### PR TITLE
feat: add Mapbox background selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The current implementation supports:
 - attaching sampled stream metrics to `activity_points` when available, including time, distance, elevation, heart rate, cadence, power, speed, temperature, grade, and moving-state flags
 - deriving absolute sampled timestamps for `activity_points` in UTC and local activity time when stream offsets are available
 - loading those layers directly into QGIS
+- adding an optional Mapbox background layer through saved plugin settings
 - filtering by activity type, date range, and minimum distance
 - applying visualization presets including lines, track points, heatmaps, and start-point views
 
@@ -57,7 +58,8 @@ Visible layers:
 - `time_utils.py` — ISO timestamp parsing / offset helpers
 - `sync_repository.py` — canonical GeoPackage registry + sync metadata upserts
 - `gpkg_writer.py` — derived GeoPackage layer rebuilds via QGIS APIs
-- `layer_manager.py` — layer loading, filtering, and styling
+- `layer_manager.py` — layer loading, filtering, styling, and background-map wiring
+- `mapbox_config.py` — background-map preset resolution and Mapbox XYZ URL helpers
 - `qfit_cache.py` — local cache for detailed stream bundles
 - `scripts/install_plugin.py` — install qfit into a local QGIS profile for testing
 - `scripts/uninstall_plugin.py` — remove qfit from a local QGIS profile
@@ -72,10 +74,23 @@ Visible layers:
 3. Choose how many pages of activities to fetch
 4. Optionally enable detailed Strava track streams and set a limit
 5. Optionally enable the `activity_points` layer and choose a point sampling stride
-6. Fetch activities from Strava
-7. Choose an output `.gpkg` file
-8. Write + load the synced result into QGIS
-9. Apply filters and style presets
+6. Optionally enable a Mapbox background map and choose a preset such as Outdoor, Light, Satellite, or a custom Winter style
+7. Fetch activities from Strava
+8. Choose an output `.gpkg` file
+9. Write + load the synced result into QGIS
+10. Apply filters, style presets, and background-map updates
+
+## Background map settings
+
+qfit can also add a Mapbox background layer underneath the synced activity data.
+
+Configure these values in the dock when you want a background basemap:
+- enable the background-map toggle
+- paste a Mapbox access token
+- choose a preset such as `Outdoor`, `Light`, or `Satellite`
+- for `Winter (custom style)` or `Custom`, provide the Mapbox style owner and style ID from your own Studio style
+
+The built-in presets intentionally keep the configuration small and predictable. The Winter slot is just a convenience label for a custom winter-themed style if you have one.
 
 ## Strava credentials
 
@@ -119,6 +134,7 @@ The covered areas currently include:
 - polyline decoding
 - ISO time parsing/formatting helpers
 - local stream-cache behavior
+- Mapbox background preset/config resolution
 - Strava normalization and helper logic
 - sync repository hashing, upserts, and reload behavior
 

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -6,11 +6,19 @@ from qgis.core import (
     QgsLineSymbol,
     QgsMarkerSymbol,
     QgsProject,
+    QgsRasterLayer,
     QgsRectangle,
     QgsRendererCategory,
     QgsSingleSymbolRenderer,
     QgsStyle,
     QgsVectorLayer,
+)
+
+from .mapbox_config import (
+    BACKGROUND_LAYER_PREFIX,
+    build_background_layer_name,
+    build_xyz_layer_uri,
+    resolve_background_style,
 )
 
 
@@ -27,6 +35,24 @@ class LayerManager:
         points_layer = self._load_optional_layer(gpkg_path, "activity_points", "qfit activity points")
         self._zoom_to_layers([activities_layer, starts_layer, points_layer])
         return activities_layer, starts_layer, points_layer
+
+    def ensure_background_layer(self, enabled, preset_name, access_token, style_owner="", style_id=""):
+        if not enabled:
+            self._remove_background_layers()
+            return None
+
+        resolved_owner, resolved_style_id = resolve_background_style(preset_name, style_owner, style_id)
+        uri = build_xyz_layer_uri(access_token, resolved_owner, resolved_style_id)
+        display_name = build_background_layer_name(preset_name, resolved_owner, resolved_style_id)
+        layer = QgsRasterLayer(uri, display_name, "wms")
+        if not layer.isValid():
+            raise RuntimeError("Could not load the selected Mapbox background layer into QGIS.")
+
+        self._remove_background_layers()
+        project = QgsProject.instance()
+        project.addMapLayer(layer, False)
+        project.layerTreeRoot().insertLayer(0, layer)
+        return layer
 
     def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None):
         if layer is None:
@@ -97,6 +123,12 @@ class LayerManager:
             QgsProject.instance().removeMapLayer(old_layer.id())
         QgsProject.instance().addMapLayer(layer)
         return layer
+
+    def _remove_background_layers(self):
+        project = QgsProject.instance()
+        for layer in list(project.mapLayers().values()):
+            if layer.name().startswith(BACKGROUND_LAYER_PREFIX):
+                project.removeMapLayer(layer.id())
 
     def _zoom_to_layers(self, layers):
         extents = None

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from urllib.parse import quote
+
+
+class MapboxConfigError(ValueError):
+    """Raised when the configured Mapbox background settings are incomplete."""
+
+
+BACKGROUND_LAYER_PREFIX = "qfit background"
+DEFAULT_BACKGROUND_PRESET = "Outdoor"
+
+_BACKGROUND_PRESETS = {
+    "Outdoor": {
+        "style_owner": "mapbox",
+        "style_id": "outdoors-v12",
+        "description": "Mapbox Outdoors",
+        "requires_custom_style": False,
+    },
+    "Light": {
+        "style_owner": "mapbox",
+        "style_id": "light-v11",
+        "description": "Mapbox Light",
+        "requires_custom_style": False,
+    },
+    "Satellite": {
+        "style_owner": "mapbox",
+        "style_id": "satellite-streets-v12",
+        "description": "Mapbox Satellite Streets",
+        "requires_custom_style": False,
+    },
+    "Winter (custom style)": {
+        "style_owner": "",
+        "style_id": "",
+        "description": "Your own winter-themed Mapbox Studio style",
+        "requires_custom_style": True,
+    },
+    "Custom": {
+        "style_owner": "",
+        "style_id": "",
+        "description": "Any Mapbox Studio style owner/style_id",
+        "requires_custom_style": True,
+    },
+}
+
+
+def background_preset_names() -> list[str]:
+    return list(_BACKGROUND_PRESETS.keys())
+
+
+def get_background_preset(name: str | None) -> dict[str, object]:
+    return _BACKGROUND_PRESETS.get(name or DEFAULT_BACKGROUND_PRESET, _BACKGROUND_PRESETS[DEFAULT_BACKGROUND_PRESET])
+
+
+def preset_requires_custom_style(name: str | None) -> bool:
+    preset = get_background_preset(name)
+    return bool(preset["requires_custom_style"])
+
+
+def preset_defaults(name: str | None) -> tuple[str, str]:
+    preset = get_background_preset(name)
+    return str(preset["style_owner"]), str(preset["style_id"])
+
+
+def resolve_background_style(
+    preset_name: str | None,
+    style_owner: str = "",
+    style_id: str = "",
+) -> tuple[str, str]:
+    preset = get_background_preset(preset_name)
+    if not preset_requires_custom_style(preset_name):
+        return preset_defaults(preset_name)
+
+    owner = style_owner.strip()
+    resolved_style_id = style_id.strip()
+    if not owner or not resolved_style_id:
+        raise MapboxConfigError(
+            "Enter a Mapbox style owner and style ID for the selected background preset."
+        )
+    return owner, resolved_style_id
+
+
+def build_mapbox_tiles_url(
+    access_token: str,
+    style_owner: str,
+    style_id: str,
+    *,
+    tile_size: int = 256,
+    retina: bool = True,
+) -> str:
+    token = access_token.strip()
+    owner = style_owner.strip()
+    resolved_style_id = style_id.strip()
+
+    if not token:
+        raise MapboxConfigError("Enter a Mapbox access token to load the selected background map.")
+    if not owner or not resolved_style_id:
+        raise MapboxConfigError("Enter a Mapbox style owner and style ID first.")
+
+    retina_suffix = "@2x" if retina else ""
+    return (
+        "https://api.mapbox.com/styles/v1/{owner}/{style_id}/tiles/{tile_size}/{{z}}/{{x}}/{{y}}{retina}"
+        "?access_token={token}"
+    ).format(
+        owner=quote(owner, safe=""),
+        style_id=quote(resolved_style_id, safe=""),
+        tile_size=tile_size,
+        retina=retina_suffix,
+        token=quote(token, safe=""),
+    )
+
+
+def build_xyz_layer_uri(access_token: str, style_owner: str, style_id: str) -> str:
+    url = build_mapbox_tiles_url(access_token, style_owner, style_id)
+    return "type=xyz&url={url}&zmin=0&zmax=22".format(
+        url=quote(url, safe=":/?{}=%@"),
+    )
+
+
+def build_background_layer_name(preset_name: str | None, style_owner: str, style_id: str) -> str:
+    label = (preset_name or DEFAULT_BACKGROUND_PRESET).strip() or DEFAULT_BACKGROUND_PRESET
+    if label == "Custom":
+        if style_owner and style_id:
+            return f"{BACKGROUND_LAYER_PREFIX} — {style_owner}/{style_id}"
+        return BACKGROUND_LAYER_PREFIX
+    return f"{BACKGROUND_LAYER_PREFIX} — {label}"

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.9.0
+version=0.10.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -8,6 +8,13 @@ from qgis.PyQt.QtWidgets import QApplication, QFileDialog, QDockWidget, QMessage
 
 from .gpkg_writer import GeoPackageWriter
 from .layer_manager import LayerManager
+from .mapbox_config import (
+    DEFAULT_BACKGROUND_PRESET,
+    MapboxConfigError,
+    background_preset_names,
+    preset_defaults,
+    preset_requires_custom_style,
+)
 from .qfit_cache import QfitCache
 from .strava_client import StravaClient, StravaClientError
 
@@ -28,10 +35,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.activities_layer = None
         self.starts_layer = None
         self.points_layer = None
+        self.background_layer = None
         self.last_fetch_context = {}
         self.layer_manager = LayerManager(iface)
         self.cache = self._build_cache()
         self.setupUi(self)
+        self._configure_background_preset_options()
         self._load_settings()
         self._wire_events()
         self._set_default_dates()
@@ -43,6 +52,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.refreshButton.clicked.connect(self.on_refresh_clicked)
         self.loadButton.clicked.connect(self.on_load_clicked)
         self.applyFiltersButton.clicked.connect(self.on_apply_filters_clicked)
+        self.backgroundPresetComboBox.currentTextChanged.connect(self.on_background_preset_changed)
+
+    def _configure_background_preset_options(self):
+        self.backgroundPresetComboBox.clear()
+        for preset_name in background_preset_names():
+            self.backgroundPresetComboBox.addItem(preset_name)
 
     def _build_cache(self):
         base_path = QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)
@@ -82,6 +97,19 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._settings_bool(settings, "write_activity_points", False)
         )
         self.pointSamplingStrideSpinBox.setValue(int(self._setting_value(settings, "point_sampling_stride", 5)))
+        self.backgroundMapCheckBox.setChecked(self._settings_bool(settings, "use_background_map", False))
+        self.mapboxAccessTokenLineEdit.setText(self._setting_value(settings, "mapbox_access_token", ""))
+        self.mapboxStyleOwnerLineEdit.setText(
+            self._setting_value(settings, "mapbox_style_owner", "mapbox")
+        )
+        self.mapboxStyleIdLineEdit.setText(self._setting_value(settings, "mapbox_style_id", ""))
+
+        preset_name = self._setting_value(settings, "background_preset", DEFAULT_BACKGROUND_PRESET)
+        preset_index = self.backgroundPresetComboBox.findText(preset_name)
+        if preset_index < 0:
+            preset_index = self.backgroundPresetComboBox.findText(DEFAULT_BACKGROUND_PRESET)
+        self.backgroundPresetComboBox.setCurrentIndex(max(preset_index, 0))
+        self._sync_background_style_fields(self.backgroundPresetComboBox.currentText(), force=False)
 
     def _save_settings(self):
         settings = QSettings()
@@ -104,6 +132,26 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         settings.setValue(
             f"{self.SETTINGS_PREFIX}/point_sampling_stride",
             self.pointSamplingStrideSpinBox.value(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/use_background_map",
+            self.backgroundMapCheckBox.isChecked(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/background_preset",
+            self.backgroundPresetComboBox.currentText(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/mapbox_access_token",
+            self.mapboxAccessTokenLineEdit.text().strip(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/mapbox_style_owner",
+            self.mapboxStyleOwnerLineEdit.text().strip(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/mapbox_style_id",
+            self.mapboxStyleIdLineEdit.text().strip(),
         )
 
     def _setting_value(self, settings, key, default=None):
@@ -128,6 +176,20 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self.dateFromEdit.setDate(QDate.currentDate().addYears(-1))
         if not self.dateToEdit.date().isValid():
             self.dateToEdit.setDate(QDate.currentDate())
+
+    def on_background_preset_changed(self, preset_name):
+        self._sync_background_style_fields(preset_name, force=True)
+
+    def _sync_background_style_fields(self, preset_name, force=False):
+        if preset_requires_custom_style(preset_name):
+            return
+        current_owner = self.mapboxStyleOwnerLineEdit.text().strip()
+        current_style_id = self.mapboxStyleIdLineEdit.text().strip()
+        if current_owner and current_style_id and not force:
+            return
+        style_owner, style_id = preset_defaults(preset_name)
+        self.mapboxStyleOwnerLineEdit.setText(style_owner)
+        self.mapboxStyleIdLineEdit.setText(style_id)
 
     def on_open_authorize_clicked(self):
         self._save_settings()
@@ -268,8 +330,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
             self.on_apply_filters_clicked()
             sync = result.get("sync") or {}
+            background_note = ""
+            if self.backgroundMapCheckBox.isChecked() and self.background_layer is not None:
+                background_note = " Added the selected Mapbox background map."
             self._set_status(
-                "Synced {fetched} fetched activities into GeoPackage: inserted {inserted}, updated {updated}, unchanged {unchanged}, stored total {total}. Loaded {track_count} tracks, {start_count} starts, and {point_count} activity points into QGIS".format(
+                "Synced {fetched} fetched activities into GeoPackage: inserted {inserted}, updated {updated}, unchanged {unchanged}, stored total {total}. Loaded {track_count} tracks, {start_count} starts, and {point_count} activity points into QGIS.{background_note}".format(
                     fetched=result.get("fetched_count", len(self.activities)),
                     inserted=sync.get("inserted", 0),
                     updated=sync.get("updated", 0),
@@ -278,6 +343,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     track_count=result.get("track_count", 0),
                     start_count=result.get("start_count", 0),
                     point_count=result.get("point_count", 0),
+                    background_note=background_note,
                 )
             )
         except Exception as exc:  # noqa: BLE001
@@ -285,20 +351,48 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status("GeoPackage export failed")
 
     def on_apply_filters_clicked(self):
-        if self.activities_layer is None and self.starts_layer is None and self.points_layer is None:
+        has_layers = any(layer is not None for layer in [self.activities_layer, self.starts_layer, self.points_layer])
+        wants_background = self.backgroundMapCheckBox.isChecked()
+        if not has_layers and not wants_background:
             return
 
+        self._save_settings()
         activity_type = self.activityTypeComboBox.currentText()
         date_from = self.dateFromEdit.date().toString("yyyy-MM-dd") if self.dateFromEdit.date().isValid() else None
         date_to = self.dateToEdit.date().toString("yyyy-MM-dd") if self.dateToEdit.date().isValid() else None
         min_distance_km = self.minDistanceSpinBox.value()
         preset = self.stylePresetComboBox.currentText()
 
-        self.layer_manager.apply_filters(self.activities_layer, activity_type, date_from, date_to, min_distance_km)
-        self.layer_manager.apply_filters(self.starts_layer, activity_type, date_from, date_to, min_distance_km)
-        self.layer_manager.apply_filters(self.points_layer, activity_type, date_from, date_to, min_distance_km)
-        self.layer_manager.apply_style(self.activities_layer, self.starts_layer, self.points_layer, preset)
-        self._set_status("Applied filters and styling")
+        if has_layers:
+            self.layer_manager.apply_filters(self.activities_layer, activity_type, date_from, date_to, min_distance_km)
+            self.layer_manager.apply_filters(self.starts_layer, activity_type, date_from, date_to, min_distance_km)
+            self.layer_manager.apply_filters(self.points_layer, activity_type, date_from, date_to, min_distance_km)
+            self.layer_manager.apply_style(self.activities_layer, self.starts_layer, self.points_layer, preset)
+
+        try:
+            self.background_layer = self.layer_manager.ensure_background_layer(
+                enabled=wants_background,
+                preset_name=self.backgroundPresetComboBox.currentText(),
+                access_token=self.mapboxAccessTokenLineEdit.text().strip(),
+                style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+                style_id=self.mapboxStyleIdLineEdit.text().strip(),
+            )
+        except (MapboxConfigError, RuntimeError) as exc:
+            self._show_error("Background map failed", str(exc))
+            failure_status = "Applied filters and styling, but the background map could not be updated"
+            if not has_layers:
+                failure_status = "Background map could not be updated"
+            self._set_status(failure_status)
+            return
+
+        if has_layers and wants_background and self.background_layer is not None:
+            self._set_status("Applied filters, styling, and background map")
+        elif has_layers:
+            self._set_status("Applied filters and styling")
+        elif wants_background and self.background_layer is not None:
+            self._set_status("Background map updated")
+        else:
+            self._set_status("Background map cleared")
 
     def _build_client(self, require_refresh_token=True):
         client = StravaClient(

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -84,6 +84,25 @@
          </widget>
         </item>
         <item>
+         <widget class="QGroupBox" name="backgroundGroupBox">
+          <property name="title">
+           <string>Background map</string>
+          </property>
+          <layout class="QFormLayout" name="backgroundLayout">
+           <item row="0" column="0" colspan="2"><widget class="QCheckBox" name="backgroundMapCheckBox"><property name="text"><string>Load a Mapbox background map in QGIS</string></property></widget></item>
+           <item row="1" column="0"><widget class="QLabel" name="backgroundPresetLabel"><property name="text"><string>Preset</string></property></widget></item>
+           <item row="1" column="1"><widget class="QComboBox" name="backgroundPresetComboBox"/></item>
+           <item row="2" column="0"><widget class="QLabel" name="mapboxAccessTokenLabel"><property name="text"><string>Mapbox access token</string></property></widget></item>
+           <item row="2" column="1"><widget class="QLineEdit" name="mapboxAccessTokenLineEdit"><property name="echoMode"><enum>QLineEdit::Password</enum></property></widget></item>
+           <item row="3" column="0"><widget class="QLabel" name="mapboxStyleOwnerLabel"><property name="text"><string>Style owner</string></property></widget></item>
+           <item row="3" column="1"><widget class="QLineEdit" name="mapboxStyleOwnerLineEdit"><property name="placeholderText"><string>mapbox</string></property></widget></item>
+           <item row="4" column="0"><widget class="QLabel" name="mapboxStyleIdLabel"><property name="text"><string>Style ID</string></property></widget></item>
+           <item row="4" column="1"><widget class="QLineEdit" name="mapboxStyleIdLineEdit"><property name="placeholderText"><string>outdoors-v12 or your own Studio style ID</string></property></widget></item>
+           <item row="5" column="0" colspan="2"><widget class="QLabel" name="backgroundHelpLabel"><property name="text"><string>Built-in examples use Mapbox Outdoors, Light, and Satellite Streets. The Winter preset is intentionally a custom slot for your own winter-themed Mapbox Studio style.</string></property><property name="wordWrap"><bool>true</bool></property></widget></item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QGroupBox" name="analysisGroupBox">
           <property name="title">
            <string>Analysis layers</string>

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1,0 +1,69 @@
+import unittest
+
+import tests._path  # noqa: F401,E402
+
+from mapbox_config import (  # noqa: E402
+    MapboxConfigError,
+    build_background_layer_name,
+    build_mapbox_tiles_url,
+    build_xyz_layer_uri,
+    preset_defaults,
+    preset_requires_custom_style,
+    resolve_background_style,
+)
+
+
+class MapboxConfigTests(unittest.TestCase):
+    def test_builtin_preset_resolves_to_known_mapbox_style(self):
+        self.assertEqual(resolve_background_style("Outdoor"), ("mapbox", "outdoors-v12"))
+        self.assertEqual(resolve_background_style("Light"), ("mapbox", "light-v11"))
+        self.assertEqual(resolve_background_style("Satellite"), ("mapbox", "satellite-streets-v12"))
+
+    def test_custom_preset_requires_owner_and_style_id(self):
+        with self.assertRaises(MapboxConfigError):
+            resolve_background_style("Winter (custom style)", style_owner="", style_id="")
+
+        self.assertEqual(
+            resolve_background_style(
+                "Winter (custom style)",
+                style_owner="ebelo",
+                style_id="winter-wonderland",
+            ),
+            ("ebelo", "winter-wonderland"),
+        )
+
+    def test_preset_helpers_expose_expected_defaults(self):
+        self.assertEqual(preset_defaults("Light"), ("mapbox", "light-v11"))
+        self.assertFalse(preset_requires_custom_style("Outdoor"))
+        self.assertTrue(preset_requires_custom_style("Custom"))
+
+    def test_tiles_url_is_built_with_encoded_components(self):
+        url = build_mapbox_tiles_url(
+            access_token="pk.test token",
+            style_owner="my user",
+            style_id="style/id",
+            retina=False,
+        )
+        self.assertIn("styles/v1/my%20user/style%2Fid/tiles/256/{z}/{x}/{y}", url)
+        self.assertIn("access_token=pk.test%20token", url)
+        self.assertNotIn("@2x", url)
+
+    def test_xyz_uri_wraps_tiles_url(self):
+        uri = build_xyz_layer_uri("pk.123", "mapbox", "outdoors-v12")
+        self.assertTrue(uri.startswith("type=xyz&url=https://api.mapbox.com/"))
+        self.assertIn("{z}/{x}/{y}@2x", uri)
+        self.assertIn("zmin=0&zmax=22", uri)
+
+    def test_layer_name_prefers_preset_label(self):
+        self.assertEqual(
+            build_background_layer_name("Satellite", "mapbox", "satellite-streets-v12"),
+            "qfit background — Satellite",
+        )
+        self.assertEqual(
+            build_background_layer_name("Custom", "ebelo", "winter-wonderland"),
+            "qfit background — ebelo/winter-wonderland",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add saved Mapbox background-map settings and preset selection to the qfit dock
- load/replace a QGIS XYZ basemap layer for Outdoor, Light, Satellite, or custom Winter/Studio styles
- cover the non-QGIS Mapbox config helpers with unit tests and document the new workflow

## Testing
- python3 -m py_compile qfit_dockwidget.py layer_manager.py mapbox_config.py tests/test_mapbox_config.py
- python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py