### PR TITLE
feat: add activity query preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The current implementation supports:
 - deriving absolute sampled timestamps for `activity_points` in UTC and local activity time when stream offsets are available
 - loading those layers directly into QGIS
 - adding an optional Mapbox background layer through saved plugin settings
-- filtering by activity type, date range, and minimum distance
+- filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
+- previewing fetched activities with a dock-side summary and sortable recent-activity list before loading layers
 - applying visualization presets including lines, track points, heatmaps, and start-point views
 
 ## Current GeoPackage model
@@ -58,6 +59,7 @@ Visible layers:
 - `time_utils.py` — ISO timestamp parsing / offset helpers
 - `sync_repository.py` — canonical GeoPackage registry + sync metadata upserts
 - `gpkg_writer.py` — derived GeoPackage layer rebuilds via QGIS APIs
+- `activity_query.py` — reusable activity filtering, sorting, summary, preview, and subset-expression helpers
 - `layer_manager.py` — layer loading, filtering, styling, and background-map wiring
 - `mapbox_config.py` — background-map preset resolution and Mapbox XYZ URL helpers
 - `qfit_cache.py` — local cache for detailed stream bundles
@@ -77,8 +79,9 @@ Visible layers:
 6. Optionally enable a Mapbox background map and choose a preset such as Outdoor, Light, Satellite, or a custom Winter style
 7. Fetch activities from Strava
 8. Choose an output `.gpkg` file
-9. Write + load the synced result into QGIS
-10. Apply filters, style presets, and background-map updates
+9. Review the fetched-activity summary / preview and refine the query if needed
+10. Write + load the synced result into QGIS
+11. Apply filters, style presets, and background-map updates
 
 ## Background map settings
 
@@ -131,6 +134,7 @@ python3 -m unittest discover -s tests -v
 ```
 
 The covered areas currently include:
+- activity querying, sorting, summary formatting, and layer subset expression helpers
 - polyline decoding
 - ISO time parsing/formatting helpers
 - local stream-cache behavior

--- a/activity_query.py
+++ b/activity_query.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date, datetime
+from typing import Iterable, Sequence
+
+DEFAULT_SORT_LABEL = "Start date (newest first)"
+SORT_OPTIONS = (
+    DEFAULT_SORT_LABEL,
+    "Start date (oldest first)",
+    "Distance (longest first)",
+    "Distance (shortest first)",
+    "Moving time (longest first)",
+    "Name (A–Z)",
+)
+
+
+class ActivityQuery:
+    def __init__(
+        self,
+        activity_type: str | None = "All",
+        date_from: str | None = None,
+        date_to: str | None = None,
+        min_distance_km: float | int | None = None,
+        max_distance_km: float | int | None = None,
+        search_text: str | None = None,
+        detailed_only: bool = False,
+        sort_label: str | None = DEFAULT_SORT_LABEL,
+    ):
+        self.activity_type = activity_type or "All"
+        self.date_from = date_from or None
+        self.date_to = date_to or None
+        self.min_distance_km = _safe_float(min_distance_km)
+        self.max_distance_km = _safe_float(max_distance_km)
+        self.search_text = (search_text or "").strip()
+        self.detailed_only = bool(detailed_only)
+        self.sort_label = sort_label or DEFAULT_SORT_LABEL
+
+
+def filter_activities(activities: Iterable[object], query: ActivityQuery) -> list[object]:
+    results = []
+    search_text = query.search_text.casefold()
+    date_from = _parse_iso_date(query.date_from)
+    date_to = _parse_iso_date(query.date_to)
+
+    for activity in activities:
+        if query.activity_type and query.activity_type != "All":
+            if (getattr(activity, "activity_type", None) or "") != query.activity_type:
+                continue
+
+        activity_date = _activity_date(activity)
+        if date_from is not None and (activity_date is None or activity_date < date_from):
+            continue
+        if date_to is not None and (activity_date is None or activity_date > date_to):
+            continue
+
+        distance_km = _distance_km(activity)
+        if query.min_distance_km is not None and query.min_distance_km > 0:
+            if distance_km is None or distance_km < query.min_distance_km:
+                continue
+        if query.max_distance_km is not None and query.max_distance_km > 0:
+            if distance_km is None or distance_km > query.max_distance_km:
+                continue
+
+        if search_text:
+            haystack = " ".join(
+                part
+                for part in [
+                    getattr(activity, "name", None),
+                    getattr(activity, "activity_type", None),
+                    getattr(activity, "sport_type", None),
+                ]
+                if part
+            ).casefold()
+            if search_text not in haystack:
+                continue
+
+        if query.detailed_only and getattr(activity, "geometry_source", None) != "stream":
+            continue
+
+        results.append(activity)
+
+    return results
+
+
+def sort_activities(activities: Sequence[object], sort_label: str | None) -> list[object]:
+    sort_label = sort_label or DEFAULT_SORT_LABEL
+    items = list(activities)
+
+    if sort_label == "Start date (oldest first)":
+        return sorted(items, key=lambda activity: (_sort_datetime(activity) is None, _sort_datetime(activity) or datetime.min))
+    if sort_label == "Distance (longest first)":
+        return sorted(items, key=lambda activity: _distance_sort_value(activity), reverse=True)
+    if sort_label == "Distance (shortest first)":
+        return sorted(items, key=lambda activity: (_distance_sort_value(activity) is None, _distance_sort_value(activity) or float("inf")))
+    if sort_label == "Moving time (longest first)":
+        return sorted(items, key=lambda activity: _moving_time_sort_value(activity), reverse=True)
+    if sort_label == "Name (A–Z)":
+        return sorted(items, key=lambda activity: ((getattr(activity, "name", None) or "").casefold(), _sort_datetime(activity) or datetime.min), reverse=False)
+
+    return sorted(items, key=lambda activity: (_sort_datetime(activity) or datetime.min, (getattr(activity, "name", None) or "").casefold()), reverse=True)
+
+
+def summarize_activities(activities: Sequence[object]) -> dict[str, object]:
+    total_distance_km = 0.0
+    total_moving_time_s = 0
+    detailed_count = 0
+    by_type = Counter()
+    latest_date = None
+
+    for activity in activities:
+        distance_km = _distance_km(activity)
+        if distance_km is not None:
+            total_distance_km += distance_km
+        moving_time_s = getattr(activity, "moving_time_s", None)
+        if isinstance(moving_time_s, (int, float)):
+            total_moving_time_s += int(moving_time_s)
+        if getattr(activity, "geometry_source", None) == "stream":
+            detailed_count += 1
+        activity_type = getattr(activity, "activity_type", None) or "Unknown"
+        by_type[activity_type] += 1
+        activity_date = _activity_date(activity)
+        if activity_date is not None and (latest_date is None or activity_date > latest_date):
+            latest_date = activity_date
+
+    return {
+        "count": len(activities),
+        "total_distance_km": round(total_distance_km, 1),
+        "total_moving_time_s": total_moving_time_s,
+        "detailed_count": detailed_count,
+        "by_type": dict(sorted(by_type.items())),
+        "latest_date": latest_date.isoformat() if latest_date is not None else None,
+    }
+
+
+def build_preview_lines(activities: Sequence[object], limit: int = 8) -> list[str]:
+    lines = []
+    for activity in list(activities)[: max(limit, 0)]:
+        date_label = _activity_date(activity).isoformat() if _activity_date(activity) is not None else "unknown date"
+        activity_type = getattr(activity, "activity_type", None) or "Activity"
+        distance_km = _distance_km(activity)
+        distance_label = "? km" if distance_km is None else f"{distance_km:.1f} km"
+        moving_time_label = format_duration(getattr(activity, "moving_time_s", None))
+        detail_label = "detailed" if getattr(activity, "geometry_source", None) == "stream" else "summary"
+        name = getattr(activity, "name", None) or "Untitled activity"
+        lines.append(f"{date_label} — {name} · {activity_type} · {distance_label} · {moving_time_label} · {detail_label}")
+    return lines
+
+
+def build_subset_string(query: ActivityQuery) -> str:
+    clauses = []
+    if query.activity_type and query.activity_type != "All":
+        clauses.append(f'"activity_type" = \'{_escape_sql_literal(query.activity_type)}\'')
+    if query.date_from:
+        clauses.append(f'"start_date" >= \'{_escape_sql_literal(query.date_from)}T00:00:00\'')
+    if query.date_to:
+        clauses.append(f'"start_date" <= \'{_escape_sql_literal(query.date_to)}T23:59:59\'')
+    if query.min_distance_km is not None and query.min_distance_km > 0:
+        clauses.append(f'"distance_m" >= {query.min_distance_km * 1000.0}')
+    if query.max_distance_km is not None and query.max_distance_km > 0:
+        clauses.append(f'"distance_m" <= {query.max_distance_km * 1000.0}')
+    if query.search_text:
+        search_text = _escape_sql_literal(query.search_text.lower())
+        clauses.append(f"lower(coalesce(\"name\", '')) LIKE '%{search_text}%'")
+    if query.detailed_only:
+        clauses.append('"geometry_source" = \'stream\'')
+    return " AND ".join(clauses)
+
+
+def format_duration(value: int | float | None) -> str:
+    if value is None:
+        return "?"
+    total_seconds = max(int(value), 0)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    if minutes:
+        return f"{minutes}m {seconds:02d}s"
+    return f"{seconds}s"
+
+
+def format_summary_text(summary: dict[str, object]) -> str:
+    if not summary.get("count"):
+        return "0 activities match the current filters."
+
+    type_counts = summary.get("by_type") or {}
+    top_types = ", ".join(f"{name}: {count}" for name, count in list(type_counts.items())[:3])
+    latest_date = summary.get("latest_date") or "unknown"
+    return (
+        "{count} activities · {distance:.1f} km · {duration} moving · detailed tracks: {detailed} · latest: {latest}"
+        "\nTop activity types: {top_types}"
+    ).format(
+        count=summary.get("count", 0),
+        distance=summary.get("total_distance_km", 0.0),
+        duration=format_duration(summary.get("total_moving_time_s")),
+        detailed=summary.get("detailed_count", 0),
+        latest=latest_date,
+        top_types=top_types or "n/a",
+    )
+
+
+def _activity_date(activity: object) -> date | None:
+    return _parse_iso_date(getattr(activity, "start_date_local", None) or getattr(activity, "start_date", None))
+
+
+def _parse_iso_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(str(value)[:10])
+        except ValueError:
+            return None
+
+
+def _sort_datetime(activity: object) -> datetime | None:
+    value = getattr(activity, "start_date_local", None) or getattr(activity, "start_date", None)
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _distance_km(activity: object) -> float | None:
+    distance_m = getattr(activity, "distance_m", None)
+    if not isinstance(distance_m, (int, float)):
+        return None
+    return float(distance_m) / 1000.0
+
+
+def _distance_sort_value(activity: object) -> float:
+    distance_m = getattr(activity, "distance_m", None)
+    if not isinstance(distance_m, (int, float)):
+        return -1.0
+    return float(distance_m)
+
+
+def _moving_time_sort_value(activity: object) -> int:
+    value = getattr(activity, "moving_time_s", None)
+    if not isinstance(value, (int, float)):
+        return -1
+    return int(value)
+
+
+def _escape_sql_literal(value: str) -> str:
+    return str(value).replace("'", "''")
+
+
+def _safe_float(value: float | int | str | None) -> float | None:
+    if value in (None, ""):
+        return None
+    return float(value)

--- a/docs/qgis-testing.md
+++ b/docs/qgis-testing.md
@@ -55,7 +55,8 @@ Inside the dock:
 4. optionally enable detailed streams
 5. optionally enable the `activity_points` layer
 6. fetch activities
-7. write and load the output GeoPackage
+7. review the fetched-activity preview and query summary
+8. write and load the output GeoPackage
 
 ## 5. What to expect in QGIS
 
@@ -92,4 +93,4 @@ Once qfit is loaded successfully, good manual checks are:
 - fetch detailed streams for a few activities
 - confirm `activity_tracks` geometries look right
 - confirm `activity_points` attributes contain time / distance / HR / power where available
-- test filtering and style presets
+- test filtering, preview sorting, and style presets

--- a/docs/strava-setup.md
+++ b/docs/strava-setup.md
@@ -41,9 +41,10 @@ Once the refresh token is available:
 2. Optionally enable detailed streams and choose a detailed-tracks limit.
 3. Optionally enable **Write activity_points layer from detailed stream geometry** and choose a sampling stride.
 4. Click **Fetch from Strava**.
-5. Choose an output `.gpkg` path.
-6. Click **Write + Load**.
-7. Apply filters and style presets as needed.
+5. Review the fetched-activity preview and refine filters such as name search, min/max distance, or detailed-only mode if needed.
+6. Choose an output `.gpkg` path.
+7. Click **Write + Load**.
+8. Apply filters and style presets as needed.
 
 ## Notes
 

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -14,6 +14,7 @@ from qgis.core import (
     QgsVectorLayer,
 )
 
+from .activity_query import ActivityQuery, build_subset_string
 from .mapbox_config import (
     BACKGROUND_LAYER_PREFIX,
     build_background_layer_name,
@@ -54,19 +55,19 @@ class LayerManager:
         project.layerTreeRoot().insertLayer(0, layer)
         return layer
 
-    def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None):
+    def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None, max_distance_km=None, search_text=None, detailed_only=False):
         if layer is None:
             return
-        clauses = []
-        if activity_type and activity_type != "All":
-            clauses.append(f'"activity_type" = \'{activity_type.replace("'", "''")}\'')
-        if date_from:
-            clauses.append(f'"start_date" >= \'{date_from}T00:00:00\'')
-        if date_to:
-            clauses.append(f'"start_date" <= \'{date_to}T23:59:59\'')
-        if min_distance_km and min_distance_km > 0:
-            clauses.append(f'"distance_m" >= {float(min_distance_km) * 1000.0}')
-        layer.setSubsetString(" AND ".join(clauses))
+        query = ActivityQuery(
+            activity_type=activity_type,
+            date_from=date_from,
+            date_to=date_to,
+            min_distance_km=min_distance_km,
+            max_distance_km=max_distance_km,
+            search_text=search_text,
+            detailed_only=detailed_only,
+        )
+        layer.setSubsetString(build_subset_string(query))
         layer.triggerRepaint()
 
     def apply_style(self, activities_layer, starts_layer, points_layer, preset):

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.10.0
+version=0.11.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -6,6 +6,16 @@ from qgis.PyQt.QtCore import QDate, QSettings, QStandardPaths, QUrl
 from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import QApplication, QFileDialog, QDockWidget, QMessageBox
 
+from .activity_query import (
+    DEFAULT_SORT_LABEL,
+    SORT_OPTIONS,
+    ActivityQuery,
+    build_preview_lines,
+    filter_activities,
+    format_summary_text,
+    sort_activities,
+    summarize_activities,
+)
 from .gpkg_writer import GeoPackageWriter
 from .layer_manager import LayerManager
 from .mapbox_config import (
@@ -41,9 +51,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.cache = self._build_cache()
         self.setupUi(self)
         self._configure_background_preset_options()
+        self._configure_preview_sort_options()
         self._load_settings()
         self._wire_events()
         self._set_default_dates()
+        self._refresh_activity_preview()
 
     def _wire_events(self):
         self.openAuthorizeButton.clicked.connect(self.on_open_authorize_clicked)
@@ -54,10 +66,28 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.applyFiltersButton.clicked.connect(self.on_apply_filters_clicked)
         self.backgroundPresetComboBox.currentTextChanged.connect(self.on_background_preset_changed)
 
+        preview_inputs = [
+            self.activityTypeComboBox.currentTextChanged,
+            self.activitySearchLineEdit.textChanged,
+            self.dateFromEdit.dateChanged,
+            self.dateToEdit.dateChanged,
+            self.minDistanceSpinBox.valueChanged,
+            self.maxDistanceSpinBox.valueChanged,
+            self.detailedOnlyCheckBox.toggled,
+            self.previewSortComboBox.currentTextChanged,
+        ]
+        for signal in preview_inputs:
+            signal.connect(self._refresh_activity_preview)
+
     def _configure_background_preset_options(self):
         self.backgroundPresetComboBox.clear()
         for preset_name in background_preset_names():
             self.backgroundPresetComboBox.addItem(preset_name)
+
+    def _configure_preview_sort_options(self):
+        self.previewSortComboBox.clear()
+        for label in SORT_OPTIONS:
+            self.previewSortComboBox.addItem(label)
 
     def _build_cache(self):
         base_path = QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)
@@ -97,6 +127,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._settings_bool(settings, "write_activity_points", False)
         )
         self.pointSamplingStrideSpinBox.setValue(int(self._setting_value(settings, "point_sampling_stride", 5)))
+        self.activitySearchLineEdit.setText(self._setting_value(settings, "activity_search_text", ""))
+        self.maxDistanceSpinBox.setValue(float(self._setting_value(settings, "max_distance_km", 0.0)))
+        self.detailedOnlyCheckBox.setChecked(self._settings_bool(settings, "detailed_only", False))
         self.backgroundMapCheckBox.setChecked(self._settings_bool(settings, "use_background_map", False))
         self.mapboxAccessTokenLineEdit.setText(self._setting_value(settings, "mapbox_access_token", ""))
         self.mapboxStyleOwnerLineEdit.setText(
@@ -110,6 +143,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             preset_index = self.backgroundPresetComboBox.findText(DEFAULT_BACKGROUND_PRESET)
         self.backgroundPresetComboBox.setCurrentIndex(max(preset_index, 0))
         self._sync_background_style_fields(self.backgroundPresetComboBox.currentText(), force=False)
+
+        preview_sort = self._setting_value(settings, "preview_sort", DEFAULT_SORT_LABEL)
+        preview_sort_index = self.previewSortComboBox.findText(preview_sort)
+        if preview_sort_index < 0:
+            preview_sort_index = self.previewSortComboBox.findText(DEFAULT_SORT_LABEL)
+        self.previewSortComboBox.setCurrentIndex(max(preview_sort_index, 0))
 
     def _save_settings(self):
         settings = QSettings()
@@ -132,6 +171,22 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         settings.setValue(
             f"{self.SETTINGS_PREFIX}/point_sampling_stride",
             self.pointSamplingStrideSpinBox.value(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/activity_search_text",
+            self.activitySearchLineEdit.text().strip(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/max_distance_km",
+            self.maxDistanceSpinBox.value(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/detailed_only",
+            self.detailedOnlyCheckBox.isChecked(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/preview_sort",
+            self.previewSortComboBox.currentText(),
         )
         settings.setValue(
             f"{self.SETTINGS_PREFIX}/use_background_map",
@@ -297,6 +352,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     detailed=detailed_count,
                 )
             )
+            self._refresh_activity_preview()
             self._set_status(self._fetch_status_text(client, len(self.activities), detailed_count))
         except StravaClientError as exc:
             self._show_error("Strava import failed", str(exc))
@@ -357,16 +413,41 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self._save_settings()
-        activity_type = self.activityTypeComboBox.currentText()
-        date_from = self.dateFromEdit.date().toString("yyyy-MM-dd") if self.dateFromEdit.date().isValid() else None
-        date_to = self.dateToEdit.date().toString("yyyy-MM-dd") if self.dateToEdit.date().isValid() else None
-        min_distance_km = self.minDistanceSpinBox.value()
+        query = self._current_activity_query()
         preset = self.stylePresetComboBox.currentText()
+        filtered_activities = self._refresh_activity_preview()
 
         if has_layers:
-            self.layer_manager.apply_filters(self.activities_layer, activity_type, date_from, date_to, min_distance_km)
-            self.layer_manager.apply_filters(self.starts_layer, activity_type, date_from, date_to, min_distance_km)
-            self.layer_manager.apply_filters(self.points_layer, activity_type, date_from, date_to, min_distance_km)
+            self.layer_manager.apply_filters(
+                self.activities_layer,
+                query.activity_type,
+                query.date_from,
+                query.date_to,
+                query.min_distance_km,
+                query.max_distance_km,
+                query.search_text,
+                query.detailed_only,
+            )
+            self.layer_manager.apply_filters(
+                self.starts_layer,
+                query.activity_type,
+                query.date_from,
+                query.date_to,
+                query.min_distance_km,
+                query.max_distance_km,
+                query.search_text,
+                query.detailed_only,
+            )
+            self.layer_manager.apply_filters(
+                self.points_layer,
+                query.activity_type,
+                query.date_from,
+                query.date_to,
+                query.min_distance_km,
+                query.max_distance_km,
+                query.search_text,
+                query.detailed_only,
+            )
             self.layer_manager.apply_style(self.activities_layer, self.starts_layer, self.points_layer, preset)
 
         try:
@@ -385,14 +466,45 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(failure_status)
             return
 
+        filtered_count = len(filtered_activities)
         if has_layers and wants_background and self.background_layer is not None:
-            self._set_status("Applied filters, styling, and background map")
+            self._set_status(f"Applied filters, styling, and background map ({filtered_count} matching activities)")
         elif has_layers:
-            self._set_status("Applied filters and styling")
+            self._set_status(f"Applied filters and styling ({filtered_count} matching activities)")
         elif wants_background and self.background_layer is not None:
-            self._set_status("Background map updated")
+            self._set_status(f"Background map updated ({filtered_count} matching activities)")
         else:
-            self._set_status("Background map cleared")
+            self._set_status(f"Background map cleared ({filtered_count} matching activities)")
+
+    def _current_activity_query(self):
+        return ActivityQuery(
+            activity_type=self.activityTypeComboBox.currentText() or "All",
+            date_from=self.dateFromEdit.date().toString("yyyy-MM-dd") if self.dateFromEdit.date().isValid() else None,
+            date_to=self.dateToEdit.date().toString("yyyy-MM-dd") if self.dateToEdit.date().isValid() else None,
+            min_distance_km=self.minDistanceSpinBox.value(),
+            max_distance_km=self.maxDistanceSpinBox.value(),
+            search_text=self.activitySearchLineEdit.text().strip(),
+            detailed_only=self.detailedOnlyCheckBox.isChecked(),
+            sort_label=self.previewSortComboBox.currentText() or DEFAULT_SORT_LABEL,
+        )
+
+    def _refresh_activity_preview(self):
+        if not self.activities:
+            self.querySummaryLabel.setText("Fetch activities to see a query summary.")
+            self.activityPreviewPlainTextEdit.setPlainText("")
+            return []
+
+        query = self._current_activity_query()
+        filtered = filter_activities(self.activities, query)
+        sorted_activities = sort_activities(filtered, query.sort_label)
+        summary = summarize_activities(sorted_activities)
+        self.querySummaryLabel.setText(format_summary_text(summary))
+
+        preview_lines = build_preview_lines(sorted_activities, limit=10)
+        if len(sorted_activities) > len(preview_lines):
+            preview_lines.append("… and {count} more".format(count=len(sorted_activities) - len(preview_lines)))
+        self.activityPreviewPlainTextEdit.setPlainText("\n".join(preview_lines))
+        return sorted_activities
 
     def _build_client(self, require_refresh_token=True):
         client = StravaClient(
@@ -436,11 +548,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return (before_epoch - after_epoch) >= 365 * 24 * 60 * 60
 
     def _populate_activity_types(self):
+        current_value = self.activityTypeComboBox.currentText() or "All"
         values = sorted({activity.activity_type for activity in self.activities if activity.activity_type})
         self.activityTypeComboBox.clear()
         self.activityTypeComboBox.addItem("All")
         for value in values:
             self.activityTypeComboBox.addItem(value)
+        index = self.activityTypeComboBox.findText(current_value)
+        self.activityTypeComboBox.setCurrentIndex(max(index, 0))
 
     def _fetch_status_text(self, client, activity_count, detailed_count):
         stream_stats = client.last_stream_enrichment_stats or {}

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -123,12 +123,17 @@
           <layout class="QFormLayout" name="filterLayout">
            <item row="0" column="0"><widget class="QLabel" name="activityTypeLabel"><property name="text"><string>Activity type</string></property></widget></item>
            <item row="0" column="1"><widget class="QComboBox" name="activityTypeComboBox"/></item>
-           <item row="1" column="0"><widget class="QLabel" name="dateFromLabel"><property name="text"><string>Date from</string></property></widget></item>
-           <item row="1" column="1"><widget class="QDateEdit" name="dateFromEdit"><property name="calendarPopup"><bool>true</bool></property></widget></item>
-           <item row="2" column="0"><widget class="QLabel" name="dateToLabel"><property name="text"><string>Date to</string></property></widget></item>
-           <item row="2" column="1"><widget class="QDateEdit" name="dateToEdit"><property name="calendarPopup"><bool>true</bool></property></widget></item>
-           <item row="3" column="0"><widget class="QLabel" name="distanceLabel"><property name="text"><string>Min distance (km)</string></property></widget></item>
-           <item row="3" column="1"><widget class="QDoubleSpinBox" name="minDistanceSpinBox"><property name="decimals"><number>1</number></property><property name="maximum"><double>1000.000000000000000</double></property></widget></item>
+           <item row="1" column="0"><widget class="QLabel" name="activityNameLabel"><property name="text"><string>Name contains</string></property></widget></item>
+           <item row="1" column="1"><widget class="QLineEdit" name="activitySearchLineEdit"><property name="placeholderText"><string>gravel, morning, commute…</string></property></widget></item>
+           <item row="2" column="0"><widget class="QLabel" name="dateFromLabel"><property name="text"><string>Date from</string></property></widget></item>
+           <item row="2" column="1"><widget class="QDateEdit" name="dateFromEdit"><property name="calendarPopup"><bool>true</bool></property></widget></item>
+           <item row="3" column="0"><widget class="QLabel" name="dateToLabel"><property name="text"><string>Date to</string></property></widget></item>
+           <item row="3" column="1"><widget class="QDateEdit" name="dateToEdit"><property name="calendarPopup"><bool>true</bool></property></widget></item>
+           <item row="4" column="0"><widget class="QLabel" name="distanceLabel"><property name="text"><string>Min distance (km)</string></property></widget></item>
+           <item row="4" column="1"><widget class="QDoubleSpinBox" name="minDistanceSpinBox"><property name="decimals"><number>1</number></property><property name="maximum"><double>1000.000000000000000</double></property></widget></item>
+           <item row="5" column="0"><widget class="QLabel" name="maxDistanceLabel"><property name="text"><string>Max distance (km)</string></property></widget></item>
+           <item row="5" column="1"><widget class="QDoubleSpinBox" name="maxDistanceSpinBox"><property name="decimals"><number>1</number></property><property name="maximum"><double>1000.000000000000000</double></property></widget></item>
+           <item row="6" column="0" colspan="2"><widget class="QCheckBox" name="detailedOnlyCheckBox"><property name="text"><string>Only detailed-stream activities</string></property></widget></item>
           </layout>
          </widget>
         </item>
@@ -147,6 +152,19 @@
             <item><property name="text"><string>Start points</string></property></item>
             <item><property name="text"><string>Clustered starts</string></property></item>
            </widget></item>
+           <item row="1" column="0"><widget class="QLabel" name="previewSortLabel"><property name="text"><string>Preview sort</string></property></widget></item>
+           <item row="1" column="1"><widget class="QComboBox" name="previewSortComboBox"/></item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="previewGroupBox">
+          <property name="title">
+           <string>Fetched activity preview</string>
+          </property>
+          <layout class="QVBoxLayout" name="previewLayout">
+           <item><widget class="QLabel" name="querySummaryLabel"><property name="text"><string>Fetch activities to see a query summary.</string></property><property name="wordWrap"><bool>true</bool></property></widget></item>
+           <item><widget class="QPlainTextEdit" name="activityPreviewPlainTextEdit"><property name="readOnly"><bool>true</bool></property><property name="placeholderText"><string>Recent activities will appear here after a fetch.</string></property></widget></item>
           </layout>
          </widget>
         </item>

--- a/tests/test_activity_query.py
+++ b/tests/test_activity_query.py
@@ -1,0 +1,122 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.activity_query import (
+    ActivityQuery,
+    build_preview_lines,
+    build_subset_string,
+    filter_activities,
+    format_duration,
+    format_summary_text,
+    sort_activities,
+    summarize_activities,
+)
+from qfit.models import Activity
+
+
+class ActivityQueryTests(unittest.TestCase):
+    def setUp(self):
+        self.activities = [
+            Activity(
+                source="strava",
+                source_activity_id="1",
+                name="Morning Gravel Ride",
+                activity_type="Ride",
+                sport_type="GravelRide",
+                start_date="2026-03-18T07:10:00+00:00",
+                start_date_local="2026-03-18T08:10:00+01:00",
+                distance_m=42500,
+                moving_time_s=7200,
+                geometry_source="stream",
+            ),
+            Activity(
+                source="strava",
+                source_activity_id="2",
+                name="Lunch Run",
+                activity_type="Run",
+                sport_type="Run",
+                start_date="2026-03-19T11:30:00+00:00",
+                start_date_local="2026-03-19T12:30:00+01:00",
+                distance_m=10200,
+                moving_time_s=3100,
+                geometry_source="summary_polyline",
+            ),
+            Activity(
+                source="strava",
+                source_activity_id="3",
+                name="Easy Evening Ride",
+                activity_type="Ride",
+                sport_type="Ride",
+                start_date="2026-03-20T17:45:00+00:00",
+                start_date_local="2026-03-20T18:45:00+01:00",
+                distance_m=18000,
+                moving_time_s=2800,
+                geometry_source="summary_polyline",
+            ),
+        ]
+
+    def test_filter_activities_supports_text_distance_and_detailed_filters(self):
+        query = ActivityQuery(
+            activity_type="Ride",
+            min_distance_km=20,
+            search_text="gravel",
+            detailed_only=True,
+        )
+
+        results = filter_activities(self.activities, query)
+
+        self.assertEqual([activity.source_activity_id for activity in results], ["1"])
+
+    def test_filter_activities_applies_date_window(self):
+        query = ActivityQuery(date_from="2026-03-19", date_to="2026-03-20")
+
+        results = filter_activities(self.activities, query)
+
+        self.assertEqual([activity.source_activity_id for activity in results], ["2", "3"])
+
+    def test_sort_activities_supports_distance_and_name(self):
+        by_distance = sort_activities(self.activities, "Distance (longest first)")
+        by_name = sort_activities(self.activities, "Name (A–Z)")
+
+        self.assertEqual([activity.source_activity_id for activity in by_distance], ["1", "3", "2"])
+        self.assertEqual([activity.source_activity_id for activity in by_name], ["3", "2", "1"])
+
+    def test_summarize_activities_and_preview_lines(self):
+        summary = summarize_activities(self.activities)
+        lines = build_preview_lines(sort_activities(self.activities, None), limit=2)
+
+        self.assertEqual(summary["count"], 3)
+        self.assertEqual(summary["total_distance_km"], 70.7)
+        self.assertEqual(summary["detailed_count"], 1)
+        self.assertEqual(summary["by_type"], {"Ride": 2, "Run": 1})
+        self.assertEqual(summary["latest_date"], "2026-03-20")
+        self.assertEqual(len(lines), 2)
+        self.assertIn("Easy Evening Ride", lines[0])
+        self.assertIn("detailed", build_preview_lines([self.activities[0]])[0])
+
+    def test_build_subset_string_covers_new_filter_fields(self):
+        query = ActivityQuery(
+            activity_type="Ride",
+            date_from="2026-03-01",
+            date_to="2026-03-31",
+            min_distance_km=10,
+            max_distance_km=50,
+            search_text="O'Brien",
+            detailed_only=True,
+        )
+
+        subset = build_subset_string(query)
+
+        self.assertIn('"activity_type" = \'Ride\'', subset)
+        self.assertIn('"distance_m" >= 10000.0', subset)
+        self.assertIn('"distance_m" <= 50000.0', subset)
+        self.assertIn("lower(coalesce(\"name\", '')) LIKE '%o''brien%'", subset)
+        self.assertIn('"geometry_source" = \'stream\'', subset)
+
+    def test_format_helpers_return_human_readable_text(self):
+        self.assertEqual(format_duration(3725), "1h 02m")
+        self.assertIn("3 activities", format_summary_text(summarize_activities(self.activities)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add reusable activity query helpers for filtering, sorting, summaries, and QGIS subset expressions
- expand the dock with activity-name search, max-distance and detailed-only filters, preview sorting, and a fetched-activity preview panel
- update docs/tests and bump qfit to 0.11.0

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m py_compile activity_query.py layer_manager.py qfit_dockwidget.py tests/test_activity_query.py
- python3 scripts/package_plugin.py
