### PR TITLE
feat: add temporal playback wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The current implementation supports:
 - optionally writing an `activity_points` analysis layer from detailed stream geometry
 - attaching sampled stream metrics to `activity_points` when available, including time, distance, elevation, heart rate, cadence, power, speed, temperature, grade, and moving-state flags
 - deriving absolute sampled timestamps for `activity_points` in UTC and local activity time when stream offsets are available
+- wiring loaded qfit layers into QGIS temporal playback using local or UTC timestamps when available
 - loading those layers directly into QGIS
 - adding an optional Mapbox background layer through saved plugin settings
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
@@ -40,8 +41,8 @@ Visible layers:
 
 ## Planned next expansions
 
-- more explicit QGIS temporal integration and styling on top of the new point timestamps
 - provider adapters for FIT / GPX / TCX imports
+- richer temporal styling / playback presets on top of the new QGIS temporal wiring
 - richer symbology and density workflows
 - better packaging and release automation
 - repeatable integration tests inside a real QGIS environment
@@ -62,6 +63,7 @@ Visible layers:
 - `activity_query.py` — reusable activity filtering, sorting, summary, preview, and subset-expression helpers
 - `layer_manager.py` — layer loading, filtering, styling, and background-map wiring
 - `mapbox_config.py` — background-map preset resolution and Mapbox XYZ URL helpers
+- `temporal_config.py` — reusable temporal-playback field selection and expression helpers
 - `qfit_cache.py` — local cache for detailed stream bundles
 - `scripts/install_plugin.py` — install qfit into a local QGIS profile for testing
 - `scripts/uninstall_plugin.py` — remove qfit from a local QGIS profile
@@ -81,7 +83,7 @@ Visible layers:
 8. Choose an output `.gpkg` file
 9. Review the fetched-activity summary / preview and refine the query if needed
 10. Write + load the synced result into QGIS
-11. Apply filters, style presets, and background-map updates
+11. Apply filters, style presets, temporal-playback mode, and background-map updates
 
 ## Background map settings
 
@@ -135,6 +137,7 @@ python3 -m unittest discover -s tests -v
 
 The covered areas currently include:
 - activity querying, sorting, summary formatting, and layer subset expression helpers
+- temporal-playback field selection / expression helpers
 - polyline decoding
 - ISO time parsing/formatting helpers
 - local stream-cache behavior

--- a/docs/qgis-testing.md
+++ b/docs/qgis-testing.md
@@ -57,6 +57,8 @@ Inside the dock:
 6. fetch activities
 7. review the fetched-activity preview and query summary
 8. write and load the output GeoPackage
+9. optionally switch **Temporal playback** to `Local activity time` or `UTC time`
+10. click **Apply filters** to wire the loaded layers into the QGIS temporal controller
 
 ## 5. What to expect in QGIS
 
@@ -93,4 +95,5 @@ Once qfit is loaded successfully, good manual checks are:
 - fetch detailed streams for a few activities
 - confirm `activity_tracks` geometries look right
 - confirm `activity_points` attributes contain time / distance / HR / power where available
-- test filtering, preview sorting, and style presets
+- test filtering, preview sorting, style presets, and temporal playback wiring
+- open the QGIS Temporal Controller and confirm the loaded layers respond to the chosen local/UTC playback mode

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -143,7 +143,7 @@ Geometry type:
 Primary purpose:
 - point-based analysis and visualization from detailed track streams
 - heatmaps using sampled detailed geometry rather than just activity starts
-- foundation for temporal views once QGIS temporal wiring is added
+- temporal playback in QGIS using sampled local or UTC timestamps
 
 ### Current fields
 
@@ -192,7 +192,7 @@ When rebuilding visible layers, qfit currently prefers geometry in this order:
 ## Next phase
 
 Planned next improvements:
-- more explicit QGIS temporal integration using the new sampled timestamps
+- richer temporal styling and playback presets on top of the new timestamp wiring
 - provider adapters for FIT / GPX / TCX imports using the same registry model
 - more explicit incremental sync cursors / sync policies
 - better QGIS integration testing and packaging polish

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -12,6 +12,7 @@ from qgis.core import (
     QgsSingleSymbolRenderer,
     QgsStyle,
     QgsVectorLayer,
+    QgsVectorLayerTemporalProperties,
 )
 
 from .activity_query import ActivityQuery, build_subset_string
@@ -21,6 +22,7 @@ from .mapbox_config import (
     build_xyz_layer_uri,
     resolve_background_style,
 )
+from .temporal_config import build_temporal_plan, describe_temporal_configuration, is_temporal_mode_enabled
 
 
 class LayerManager:
@@ -96,6 +98,21 @@ class LayerManager:
             else:
                 self._apply_start_point_style(starts_layer, subtle=points_layer is not None)
 
+    def apply_temporal_configuration(self, activities_layer, starts_layer, points_layer, mode_label):
+        layer_specs = [
+            (activities_layer, "activity_tracks"),
+            (starts_layer, "activity_starts"),
+            (points_layer, "activity_points"),
+        ]
+        plans = []
+        for layer, layer_key in layer_specs:
+            if layer is None:
+                continue
+            plan = self._apply_temporal_plan(layer, layer_key, mode_label)
+            if plan is not None:
+                plans.append(plan)
+        return describe_temporal_configuration(plans, mode_label)
+
     def _load_first_available(self, gpkg_path, candidates):
         last_error = None
         for layer_name, display_name in candidates:
@@ -130,6 +147,29 @@ class LayerManager:
         for layer in list(project.mapLayers().values()):
             if layer.name().startswith(BACKGROUND_LAYER_PREFIX):
                 project.removeMapLayer(layer.id())
+
+    def _apply_temporal_plan(self, layer, layer_key, mode_label):
+        props = layer.temporalProperties()
+        if props is None:
+            return None
+        if not is_temporal_mode_enabled(mode_label):
+            props.setIsActive(False)
+            layer.triggerRepaint()
+            return None
+
+        available_fields = [field.name() for field in layer.fields()]
+        plan = build_temporal_plan(layer_key, available_fields, mode_label)
+        if plan is None:
+            props.setIsActive(False)
+            layer.triggerRepaint()
+            return None
+
+        props.setIsActive(True)
+        props.setMode(QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndEndFromExpressions)
+        props.setStartExpression(plan.expression)
+        props.setEndExpression(plan.expression)
+        layer.triggerRepaint()
+        return plan
 
     def _zoom_to_layers(self, layers):
         extents = None

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.11.0
+version=0.12.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -27,6 +27,7 @@ from .mapbox_config import (
 )
 from .qfit_cache import QfitCache
 from .strava_client import StravaClient, StravaClientError
+from .temporal_config import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
 
 FORM_CLASS, _ = uic.loadUiType(
     __import__("os").path.join(__import__("os").path.dirname(__file__), "qfit_dockwidget_base.ui")
@@ -52,6 +53,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.setupUi(self)
         self._configure_background_preset_options()
         self._configure_preview_sort_options()
+        self._configure_temporal_mode_options()
         self._load_settings()
         self._wire_events()
         self._set_default_dates()
@@ -88,6 +90,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.previewSortComboBox.clear()
         for label in SORT_OPTIONS:
             self.previewSortComboBox.addItem(label)
+
+    def _configure_temporal_mode_options(self):
+        self.temporalModeComboBox.clear()
+        for label in temporal_mode_labels():
+            self.temporalModeComboBox.addItem(label)
 
     def _build_cache(self):
         base_path = QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)
@@ -136,6 +143,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._setting_value(settings, "mapbox_style_owner", "mapbox")
         )
         self.mapboxStyleIdLineEdit.setText(self._setting_value(settings, "mapbox_style_id", ""))
+
+        temporal_mode = self._setting_value(settings, "temporal_mode", DEFAULT_TEMPORAL_MODE_LABEL)
+        temporal_mode_index = self.temporalModeComboBox.findText(temporal_mode)
+        if temporal_mode_index < 0:
+            temporal_mode_index = self.temporalModeComboBox.findText(DEFAULT_TEMPORAL_MODE_LABEL)
+        self.temporalModeComboBox.setCurrentIndex(max(temporal_mode_index, 0))
 
         preset_name = self._setting_value(settings, "background_preset", DEFAULT_BACKGROUND_PRESET)
         preset_index = self.backgroundPresetComboBox.findText(preset_name)
@@ -187,6 +200,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         settings.setValue(
             f"{self.SETTINGS_PREFIX}/preview_sort",
             self.previewSortComboBox.currentText(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/temporal_mode",
+            self.temporalModeComboBox.currentText(),
         )
         settings.setValue(
             f"{self.SETTINGS_PREFIX}/use_background_map",
@@ -416,6 +433,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         query = self._current_activity_query()
         preset = self.stylePresetComboBox.currentText()
         filtered_activities = self._refresh_activity_preview()
+        temporal_note = ""
 
         if has_layers:
             self.layer_manager.apply_filters(
@@ -449,6 +467,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 query.detailed_only,
             )
             self.layer_manager.apply_style(self.activities_layer, self.starts_layer, self.points_layer, preset)
+            temporal_note = self.layer_manager.apply_temporal_configuration(
+                self.activities_layer,
+                self.starts_layer,
+                self.points_layer,
+                self.temporalModeComboBox.currentText(),
+            )
 
         try:
             self.background_layer = self.layer_manager.ensure_background_layer(
@@ -463,18 +487,24 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             failure_status = "Applied filters and styling, but the background map could not be updated"
             if not has_layers:
                 failure_status = "Background map could not be updated"
+            if temporal_note:
+                failure_status = f"{failure_status}. {temporal_note}."
             self._set_status(failure_status)
             return
 
         filtered_count = len(filtered_activities)
         if has_layers and wants_background and self.background_layer is not None:
-            self._set_status(f"Applied filters, styling, and background map ({filtered_count} matching activities)")
+            status = f"Applied filters, styling, and background map ({filtered_count} matching activities)"
         elif has_layers:
-            self._set_status(f"Applied filters and styling ({filtered_count} matching activities)")
+            status = f"Applied filters and styling ({filtered_count} matching activities)"
         elif wants_background and self.background_layer is not None:
-            self._set_status(f"Background map updated ({filtered_count} matching activities)")
+            status = f"Background map updated ({filtered_count} matching activities)"
         else:
-            self._set_status(f"Background map cleared ({filtered_count} matching activities)")
+            status = f"Background map cleared ({filtered_count} matching activities)"
+
+        if temporal_note:
+            status = f"{status}. {temporal_note}."
+        self._set_status(status)
 
     def _current_activity_query(self):
         return ActivityQuery(

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -152,8 +152,11 @@
             <item><property name="text"><string>Start points</string></property></item>
             <item><property name="text"><string>Clustered starts</string></property></item>
            </widget></item>
-           <item row="1" column="0"><widget class="QLabel" name="previewSortLabel"><property name="text"><string>Preview sort</string></property></widget></item>
-           <item row="1" column="1"><widget class="QComboBox" name="previewSortComboBox"/></item>
+           <item row="1" column="0"><widget class="QLabel" name="temporalModeLabel"><property name="text"><string>Temporal playback</string></property></widget></item>
+           <item row="1" column="1"><widget class="QComboBox" name="temporalModeComboBox"/></item>
+           <item row="2" column="0" colspan="2"><widget class="QLabel" name="temporalHelpLabel"><property name="text"><string>When enabled, qfit wires loaded layers into QGIS temporal playback using local or UTC timestamps when available.</string></property><property name="wordWrap"><bool>true</bool></property></widget></item>
+           <item row="3" column="0"><widget class="QLabel" name="previewSortLabel"><property name="text"><string>Preview sort</string></property></widget></item>
+           <item row="3" column="1"><widget class="QComboBox" name="previewSortComboBox"/></item>
           </layout>
          </widget>
         </item>

--- a/temporal_config.py
+++ b/temporal_config.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+TEMPORAL_MODE_LABELS = [
+    "Disabled",
+    "Local activity time",
+    "UTC time",
+]
+DEFAULT_TEMPORAL_MODE_LABEL = "Local activity time"
+
+
+@dataclass(frozen=True)
+class TemporalLayerPlan:
+    layer_key: str
+    field_name: str
+    field_kind: str
+    label: str
+
+    @property
+    def expression(self):
+        return 'to_datetime("{field}")'.format(field=self.field_name)
+
+
+_LAYER_CANDIDATES = {
+    "activity_points": {
+        "Local activity time": ["point_timestamp_local", "point_timestamp_utc"],
+        "UTC time": ["point_timestamp_utc", "point_timestamp_local"],
+    },
+    "activity_tracks": {
+        "Local activity time": ["start_date_local", "start_date"],
+        "UTC time": ["start_date", "start_date_local"],
+    },
+    "activity_starts": {
+        "Local activity time": ["start_date_local", "start_date"],
+        "UTC time": ["start_date", "start_date_local"],
+    },
+}
+
+
+def temporal_mode_labels():
+    return list(TEMPORAL_MODE_LABELS)
+
+
+def is_temporal_mode_enabled(mode_label):
+    return (mode_label or "").strip() != "Disabled"
+
+
+def build_temporal_plan(layer_key, available_fields, mode_label):
+    mode_label = (mode_label or DEFAULT_TEMPORAL_MODE_LABEL).strip() or DEFAULT_TEMPORAL_MODE_LABEL
+    if not is_temporal_mode_enabled(mode_label):
+        return None
+
+    field_names = {name for name in (available_fields or []) if name}
+    candidates = _LAYER_CANDIDATES.get(layer_key, {}).get(mode_label, [])
+    for field_name in candidates:
+        if field_name in field_names:
+            return TemporalLayerPlan(
+                layer_key=layer_key,
+                field_name=field_name,
+                field_kind=_field_kind(field_name),
+                label=_plan_label(layer_key, field_name),
+            )
+    return None
+
+
+def describe_temporal_configuration(plans, mode_label):
+    active_plans = [plan for plan in (plans or []) if plan is not None]
+    if not is_temporal_mode_enabled(mode_label):
+        return "Temporal playback disabled"
+    if not active_plans:
+        return "Temporal playback requested, but no timestamp fields were available"
+    labels = ", ".join(plan.label for plan in active_plans)
+    return "Temporal playback wired for {labels}".format(labels=labels)
+
+
+def _field_kind(field_name):
+    return "local" if field_name.endswith("_local") else "utc"
+
+
+def _plan_label(layer_key, field_name):
+    field_kind = _field_kind(field_name).upper()
+    if layer_key == "activity_points":
+        return "activity points ({kind})".format(kind=field_kind)
+    if layer_key == "activity_tracks":
+        return "activity tracks ({kind})".format(kind=field_kind)
+    if layer_key == "activity_starts":
+        return "activity starts ({kind})".format(kind=field_kind)
+    return "{layer} ({kind})".format(layer=layer_key.replace("_", " "), kind=field_kind)

--- a/tests/test_temporal_config.py
+++ b/tests/test_temporal_config.py
@@ -1,0 +1,62 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.temporal_config import (
+    DEFAULT_TEMPORAL_MODE_LABEL,
+    build_temporal_plan,
+    describe_temporal_configuration,
+    is_temporal_mode_enabled,
+    temporal_mode_labels,
+)
+
+
+class TemporalConfigTests(unittest.TestCase):
+    def test_temporal_mode_helpers(self):
+        labels = temporal_mode_labels()
+
+        self.assertEqual(labels[0], "Disabled")
+        self.assertIn(DEFAULT_TEMPORAL_MODE_LABEL, labels)
+        self.assertFalse(is_temporal_mode_enabled("Disabled"))
+        self.assertTrue(is_temporal_mode_enabled(DEFAULT_TEMPORAL_MODE_LABEL))
+
+    def test_build_temporal_plan_prefers_local_point_time_when_available(self):
+        plan = build_temporal_plan(
+            "activity_points",
+            ["point_timestamp_utc", "point_timestamp_local", "distance_m"],
+            "Local activity time",
+        )
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.field_name, "point_timestamp_local")
+        self.assertEqual(plan.field_kind, "local")
+        self.assertEqual(plan.expression, 'to_datetime("point_timestamp_local")')
+
+    def test_build_temporal_plan_falls_back_to_utc_when_local_is_missing(self):
+        plan = build_temporal_plan(
+            "activity_tracks",
+            ["start_date", "distance_m"],
+            "Local activity time",
+        )
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.field_name, "start_date")
+        self.assertEqual(plan.field_kind, "utc")
+
+    def test_build_temporal_plan_returns_none_when_disabled_or_missing(self):
+        self.assertIsNone(build_temporal_plan("activity_points", ["point_timestamp_utc"], "Disabled"))
+        self.assertIsNone(build_temporal_plan("activity_points", ["distance_m"], "UTC time"))
+
+    def test_describe_temporal_configuration_is_human_readable(self):
+        point_plan = build_temporal_plan("activity_points", ["point_timestamp_utc"], "UTC time")
+        message = describe_temporal_configuration([point_plan], "UTC time")
+
+        self.assertIn("Temporal playback wired", message)
+        self.assertIn("activity points (UTC)", message)
+        self.assertEqual(
+            describe_temporal_configuration([], "Disabled"),
+            "Temporal playback disabled",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a temporal playback mode selector to the qfit dock
- wire loaded qfit layers into QGIS temporal playback using local or UTC timestamps when available
- cover the timestamp field-selection logic with unit tests and update docs/versioning

## Testing
- python3 -m unittest discover -s tests -v
- PYTHONPATH=/home/ebelo/.openclaw/workspace python3 - <<'PY'
from qgis.core import QgsVectorLayer, QgsField
from qgis.PyQt.QtCore import QVariant
from qfit.layer_manager import LayerManager

layer = QgsVectorLayer('Point?crs=EPSG:4326', 'points', 'memory')
pr = layer.dataProvider()
pr.addAttributes([QgsField('point_timestamp_local', QVariant.String)])
layer.updateFields()
manager = LayerManager(None)
msg = manager.apply_temporal_configuration(None, None, layer, 'Local activity time')
props = layer.temporalProperties()
print(msg)
print(props.isActive(), props.mode(), props.startExpression(), props.endExpression())
PY