### PR TITLE
feat: add atlas page layer for publish workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The current implementation supports:
 - attaching sampled stream metrics to `activity_points` when available, including time, distance, elevation, heart rate, cadence, power, speed, temperature, grade, and moving-state flags
 - deriving absolute sampled timestamps for `activity_points` in UTC and local activity time when stream offsets are available
 - wiring loaded qfit layers into QGIS temporal playback using local or UTC timestamps when available
+- generating an `activity_atlas_pages` layer with print-ready page extents and labels for QGIS atlas layouts
 - loading those layers directly into QGIS
 - adding an optional Mapbox background layer through saved plugin settings
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
@@ -38,11 +39,13 @@ Visible layers:
 - `activity_tracks` — line layer for activity geometries
 - `activity_starts` — start-point layer
 - `activity_points` — optional sampled point layer derived from detailed streams, with per-point stream metrics and derived timestamps when available
+- `activity_atlas_pages` — polygon layer of atlas/page extents with titles/subtitles for QGIS print layouts
 
 ## Planned next expansions
 
 - provider adapters for FIT / GPX / TCX imports
 - richer temporal styling / playback presets on top of the new QGIS temporal wiring
+- PDF/layout automation on top of the new atlas-page layer
 - richer symbology and density workflows
 - better packaging and release automation
 - repeatable integration tests inside a real QGIS environment
@@ -65,6 +68,7 @@ Visible layers:
 - `mapbox_config.py` — background-map preset resolution and Mapbox XYZ URL helpers
 - `temporal_config.py` — reusable temporal-playback field selection and expression helpers
 - `qfit_cache.py` — local cache for detailed stream bundles
+- `publish_atlas.py` — atlas/page extent planning helpers for QGIS print layouts
 - `scripts/install_plugin.py` — install qfit into a local QGIS profile for testing
 - `scripts/uninstall_plugin.py` — remove qfit from a local QGIS profile
 - `docs/schema.md` — current schema design
@@ -84,6 +88,7 @@ Visible layers:
 9. Review the fetched-activity summary / preview and refine the query if needed
 10. Write + load the synced result into QGIS
 11. Apply filters, style presets, temporal-playback mode, and background-map updates
+12. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export
 
 ## Background map settings
 
@@ -137,6 +142,7 @@ python3 -m unittest discover -s tests -v
 
 The covered areas currently include:
 - activity querying, sorting, summary formatting, and layer subset expression helpers
+- atlas-page extent/label planning helpers for publish workflows
 - temporal-playback field selection / expression helpers
 - polyline decoding
 - ISO time parsing/formatting helpers

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -7,6 +7,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - keep a canonical local source of truth for synced activities
 - separate internal sync tables from visible GIS layers
 - support both lightweight line rendering and richer point-based analysis
+- create atlas-friendly page extents for publish/layout workflows
 - stay flexible for Strava first, with room for FIT / GPX / TCX providers later
 
 ## GeoPackage contents
@@ -21,6 +22,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - `activity_tracks` — one visible line feature per activity
 - `activity_starts` — one visible point per activity start
 - `activity_points` — optional sampled point layer derived from detailed stream geometry
+- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows
 
 ## Table: `activity_registry`
 
@@ -173,6 +175,34 @@ Primary purpose:
 | `geometry_source` | TEXT | usually `stream` |
 | `last_synced_at` | TEXT | last registry sync time |
 
+## Layer: `activity_atlas_pages`
+
+Geometry type:
+- `POLYGON`
+
+Primary purpose:
+- atlas/page index layer for QGIS print layouts and future PDF export workflows
+- one padded extent polygon per activity with reusable title/subtitle fields
+
+### Current fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `activity_fk` | INTEGER | local sequential reference in the derived layer |
+| `source` | TEXT | provider name |
+| `source_activity_id` | TEXT | provider activity id |
+| `name` | TEXT | activity title |
+| `activity_type` | TEXT | run, ride, etc. |
+| `start_date` | TEXT | ISO 8601 UTC |
+| `distance_m` | REAL | copied for filtering / layout text |
+| `moving_time_s` | INTEGER | copied for layout text |
+| `geometry_source` | TEXT | stream/summary/fallback source used to derive the page extent |
+| `page_name` | TEXT | atlas-friendly page label, usually `YYYY-MM-DD · Title` |
+| `page_title` | TEXT | large-title label |
+| `page_subtitle` | TEXT | compact summary such as type, distance, and moving time |
+| `extent_width_deg` | REAL | padded page width in degrees |
+| `extent_height_deg` | REAL | padded page height in degrees |
+
 ## Geometry priority
 
 When rebuilding visible layers, qfit currently prefers geometry in this order:
@@ -186,12 +216,13 @@ When rebuilding visible layers, qfit currently prefers geometry in this order:
 2. optionally enrich activities with detailed stream geometry and extra stream metrics
 3. upsert activities into `activity_registry`
 4. update `sync_state`
-5. rebuild `activity_tracks`, `activity_starts`, and optionally `activity_points`
+5. rebuild `activity_tracks`, `activity_starts`, `activity_atlas_pages`, and optionally `activity_points`
 6. load those layers into QGIS
 
 ## Next phase
 
 Planned next improvements:
+- PDF/layout automation on top of `activity_atlas_pages`
 - richer temporal styling and playback presets on top of the new timestamp wiring
 - provider adapters for FIT / GPX / TCX imports using the same registry model
 - more explicit incremental sync cursors / sync policies

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -10,11 +10,13 @@ from qgis.core import (
     QgsGeometry,
     QgsPointXY,
     QgsProject,
+    QgsRectangle,
     QgsVectorFileWriter,
     QgsVectorLayer,
 )
 
 from .polyline_utils import decode_polyline
+from .publish_atlas import build_atlas_page_plans
 from .sync_repository import REGISTRY_TABLE, SYNC_STATE_TABLE, SyncRepository
 from .time_utils import add_seconds_iso
 
@@ -91,6 +93,23 @@ POINT_FIELDS = [
     ("last_synced_at", QVariant.String),
 ]
 
+ATLAS_FIELDS = [
+    ("activity_fk", QVariant.Int),
+    ("source", QVariant.String),
+    ("source_activity_id", QVariant.String),
+    ("name", QVariant.String),
+    ("activity_type", QVariant.String),
+    ("start_date", QVariant.String),
+    ("distance_m", QVariant.Double),
+    ("moving_time_s", QVariant.Int),
+    ("geometry_source", QVariant.String),
+    ("page_name", QVariant.String),
+    ("page_title", QVariant.String),
+    ("page_subtitle", QVariant.String),
+    ("extent_width_deg", QVariant.Double),
+    ("extent_height_deg", QVariant.Double),
+]
+
 
 class GeoPackageWriter:
     """Persist qfit sync data to a GeoPackage and rebuild derived visualization layers."""
@@ -127,6 +146,11 @@ class GeoPackageWriter:
                 "kind": "layer",
                 "fields": [name for name, _ in POINT_FIELDS],
             },
+            "activity_atlas_pages": {
+                "geometry": "POLYGON",
+                "kind": "layer",
+                "fields": [name for name, _ in ATLAS_FIELDS],
+            },
         }
 
     def write_activities(self, activities, sync_metadata=None):
@@ -140,6 +164,7 @@ class GeoPackageWriter:
             self._write_layer(self._build_track_layer([]), "activity_tracks", overwrite_file=True)
             self._write_layer(self._build_start_layer([]), "activity_starts", overwrite_file=False)
             self._write_layer(self._build_point_layer([]), "activity_points", overwrite_file=False)
+            self._write_layer(self._build_atlas_layer([]), "activity_atlas_pages", overwrite_file=False)
 
         repository.ensure_schema()
         sync_result = repository.upsert_activities(activities, sync_metadata=sync_metadata)
@@ -148,9 +173,11 @@ class GeoPackageWriter:
         track_layer = self._build_track_layer(records)
         start_layer = self._build_start_layer(records)
         point_layer = self._build_point_layer(records)
+        atlas_layer = self._build_atlas_layer(records)
         self._write_layer(track_layer, "activity_tracks", overwrite_file=False)
         self._write_layer(start_layer, "activity_starts", overwrite_file=False)
         self._write_layer(point_layer, "activity_points", overwrite_file=False)
+        self._write_layer(atlas_layer, "activity_atlas_pages", overwrite_file=False)
 
         return {
             "schema": self.schema(),
@@ -159,6 +186,7 @@ class GeoPackageWriter:
             "track_count": track_layer.featureCount(),
             "start_count": start_layer.featureCount(),
             "point_count": point_layer.featureCount(),
+            "atlas_count": atlas_layer.featureCount(),
             "sync": sync_result,
         }
 
@@ -291,6 +319,37 @@ class GeoPackageWriter:
                 feature["geometry_source"] = record.get("geometry_source") or "stream"
                 feature["last_synced_at"] = record.get("last_synced_at")
                 features.append(feature)
+
+        provider.addFeatures(features)
+        layer.updateExtents()
+        return layer
+
+    def _build_atlas_layer(self, records):
+        layer = QgsVectorLayer("Polygon?crs=EPSG:4326", "activity_atlas_pages", "memory")
+        provider = layer.dataProvider()
+        provider.addAttributes(self._make_fields(ATLAS_FIELDS))
+        layer.updateFields()
+
+        features = []
+        for index, plan in enumerate(build_atlas_page_plans(records), start=1):
+            rect = QgsRectangle(plan.min_lon, plan.min_lat, plan.max_lon, plan.max_lat)
+            feature = QgsFeature(layer.fields())
+            feature.setGeometry(QgsGeometry.fromRect(rect))
+            feature["activity_fk"] = index
+            feature["source"] = plan.source
+            feature["source_activity_id"] = plan.source_activity_id
+            feature["name"] = plan.name
+            feature["activity_type"] = plan.activity_type
+            feature["start_date"] = plan.start_date
+            feature["distance_m"] = plan.distance_m
+            feature["moving_time_s"] = plan.moving_time_s
+            feature["geometry_source"] = plan.geometry_source
+            feature["page_name"] = plan.page_name
+            feature["page_title"] = plan.page_title
+            feature["page_subtitle"] = plan.page_subtitle
+            feature["extent_width_deg"] = plan.extent_width_deg
+            feature["extent_height_deg"] = plan.extent_height_deg
+            features.append(feature)
 
         provider.addFeatures(features)
         layer.updateExtents()

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -1,6 +1,7 @@
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (
     QgsCategorizedSymbolRenderer,
+    QgsFillSymbol,
     QgsGradientColorRamp,
     QgsHeatmapRenderer,
     QgsLineSymbol,
@@ -36,8 +37,9 @@ class LayerManager:
         )
         starts_layer = self._load_optional_layer(gpkg_path, "activity_starts", "qfit activity starts")
         points_layer = self._load_optional_layer(gpkg_path, "activity_points", "qfit activity points")
-        self._zoom_to_layers([activities_layer, starts_layer, points_layer])
-        return activities_layer, starts_layer, points_layer
+        atlas_layer = self._load_optional_layer(gpkg_path, "activity_atlas_pages", "qfit atlas pages")
+        self._zoom_to_layers([activities_layer, starts_layer, points_layer, atlas_layer])
+        return activities_layer, starts_layer, points_layer, atlas_layer
 
     def ensure_background_layer(self, enabled, preset_name, access_token, style_owner="", style_id=""):
         if not enabled:
@@ -72,7 +74,7 @@ class LayerManager:
         layer.setSubsetString(build_subset_string(query))
         layer.triggerRepaint()
 
-    def apply_style(self, activities_layer, starts_layer, points_layer, preset):
+    def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset):
         preset = preset or "Simple lines"
         if activities_layer is not None:
             if preset == "By activity type":
@@ -98,11 +100,15 @@ class LayerManager:
             else:
                 self._apply_start_point_style(starts_layer, subtle=points_layer is not None)
 
-    def apply_temporal_configuration(self, activities_layer, starts_layer, points_layer, mode_label):
+        if atlas_layer is not None:
+            self._apply_atlas_page_style(atlas_layer)
+
+    def apply_temporal_configuration(self, activities_layer, starts_layer, points_layer, atlas_layer, mode_label):
         layer_specs = [
             (activities_layer, "activity_tracks"),
             (starts_layer, "activity_starts"),
             (points_layer, "activity_points"),
+            (atlas_layer, "activity_atlas_pages"),
         ]
         plans = []
         for layer, layer_key in layer_specs:
@@ -268,4 +274,17 @@ class LayerManager:
         )
         layer.setRenderer(QgsSingleSymbolRenderer(symbol))
         layer.setOpacity(0.75)
+        layer.triggerRepaint()
+
+    def _apply_atlas_page_style(self, layer):
+        symbol = QgsFillSymbol.createSimple(
+            {
+                "color": "255,255,255,0",
+                "outline_color": "230,126,34,230",
+                "outline_width": "0.6",
+                "outline_style": "dash",
+            }
+        )
+        layer.setRenderer(QgsSingleSymbolRenderer(symbol))
+        layer.setOpacity(1.0)
         layer.triggerRepaint()

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.12.0
+version=0.13.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/publish_atlas.py
+++ b/publish_atlas.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable
+
+from .activity_query import format_duration
+from .polyline_utils import decode_polyline
+
+DEFAULT_ATLAS_MARGIN_PERCENT = 8.0
+DEFAULT_MIN_EXTENT_DEGREES = 0.01
+
+
+@dataclass(frozen=True)
+class AtlasPagePlan:
+    source: str | None
+    source_activity_id: str | None
+    name: str
+    activity_type: str
+    start_date: str | None
+    distance_m: float | None
+    moving_time_s: int | None
+    geometry_source: str
+    page_name: str
+    page_title: str
+    page_subtitle: str
+    min_lon: float
+    min_lat: float
+    max_lon: float
+    max_lat: float
+    extent_width_deg: float
+    extent_height_deg: float
+
+
+def build_atlas_page_plans(
+    records: Iterable[dict],
+    margin_percent: float = DEFAULT_ATLAS_MARGIN_PERCENT,
+    min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES,
+) -> list[AtlasPagePlan]:
+    plans = []
+    for record in records:
+        bounds, geometry_source = activity_bounds(record, min_extent_degrees=min_extent_degrees)
+        if bounds is None:
+            continue
+
+        min_lon, min_lat, max_lon, max_lat = expand_bounds(
+            bounds,
+            margin_percent=margin_percent,
+            min_extent_degrees=min_extent_degrees,
+        )
+        page_title = (record.get("name") or "Untitled activity").strip()
+        page_name = build_page_name(record)
+        page_subtitle = build_page_subtitle(record)
+        plans.append(
+            AtlasPagePlan(
+                source=record.get("source"),
+                source_activity_id=record.get("source_activity_id"),
+                name=page_title,
+                activity_type=(record.get("activity_type") or "Activity").strip() or "Activity",
+                start_date=record.get("start_date"),
+                distance_m=_safe_float(record.get("distance_m")),
+                moving_time_s=_safe_int(record.get("moving_time_s")),
+                geometry_source=geometry_source,
+                page_name=page_name,
+                page_title=page_title,
+                page_subtitle=page_subtitle,
+                min_lon=min_lon,
+                min_lat=min_lat,
+                max_lon=max_lon,
+                max_lat=max_lat,
+                extent_width_deg=max_lon - min_lon,
+                extent_height_deg=max_lat - min_lat,
+            )
+        )
+    return plans
+
+
+def activity_bounds(record: dict, min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES) -> tuple[tuple[float, float, float, float] | None, str]:
+    points = record.get("geometry_points") or []
+    if len(points) >= 2:
+        return bounds_from_points(points, min_extent_degrees=min_extent_degrees), (record.get("geometry_source") or "stream")
+
+    polyline_points = decode_polyline(record.get("summary_polyline"))
+    if len(polyline_points) >= 2:
+        return bounds_from_points(polyline_points, min_extent_degrees=min_extent_degrees), (record.get("geometry_source") or "summary_polyline")
+
+    start_lat = _safe_float(record.get("start_lat"))
+    start_lon = _safe_float(record.get("start_lon"))
+    end_lat = _safe_float(record.get("end_lat"))
+    end_lon = _safe_float(record.get("end_lon"))
+    if None not in (start_lat, start_lon, end_lat, end_lon):
+        return bounds_from_points([(start_lat, start_lon), (end_lat, end_lon)], min_extent_degrees=min_extent_degrees), (record.get("geometry_source") or "start_end")
+
+    return None, record.get("geometry_source") or "unknown"
+
+
+def bounds_from_points(points: Iterable[tuple[float, float]], min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES) -> tuple[float, float, float, float]:
+    lats = []
+    lons = []
+    for lat, lon in points:
+        lat_value = _safe_float(lat)
+        lon_value = _safe_float(lon)
+        if lat_value is None or lon_value is None:
+            continue
+        lats.append(lat_value)
+        lons.append(lon_value)
+
+    if not lats or not lons:
+        raise ValueError("points must contain at least one valid coordinate pair")
+
+    min_lat = min(lats)
+    max_lat = max(lats)
+    min_lon = min(lons)
+    max_lon = max(lons)
+    return ensure_minimum_extent((min_lon, min_lat, max_lon, max_lat), min_extent_degrees=min_extent_degrees)
+
+
+def ensure_minimum_extent(
+    bounds: tuple[float, float, float, float],
+    min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES,
+) -> tuple[float, float, float, float]:
+    min_lon, min_lat, max_lon, max_lat = bounds
+    width = max(max_lon - min_lon, 0.0)
+    height = max(max_lat - min_lat, 0.0)
+
+    if width < min_extent_degrees:
+        expand = (min_extent_degrees - width) / 2.0
+        min_lon -= expand
+        max_lon += expand
+    if height < min_extent_degrees:
+        expand = (min_extent_degrees - height) / 2.0
+        min_lat -= expand
+        max_lat += expand
+
+    return min_lon, min_lat, max_lon, max_lat
+
+
+def expand_bounds(
+    bounds: tuple[float, float, float, float],
+    margin_percent: float = DEFAULT_ATLAS_MARGIN_PERCENT,
+    min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES,
+) -> tuple[float, float, float, float]:
+    min_lon, min_lat, max_lon, max_lat = ensure_minimum_extent(bounds, min_extent_degrees=min_extent_degrees)
+    margin_ratio = max(float(margin_percent or 0.0), 0.0) / 100.0
+    width = max(max_lon - min_lon, min_extent_degrees)
+    height = max(max_lat - min_lat, min_extent_degrees)
+    pad_x = width * margin_ratio
+    pad_y = height * margin_ratio
+    return min_lon - pad_x, min_lat - pad_y, max_lon + pad_x, max_lat + pad_y
+
+
+def build_page_name(record: dict) -> str:
+    title = (record.get("name") or "Untitled activity").strip()
+    activity_date = format_activity_date(record.get("start_date_local") or record.get("start_date"))
+    if activity_date:
+        return f"{activity_date} · {title}"
+    return title
+
+
+def build_page_subtitle(record: dict) -> str:
+    parts = []
+    activity_type = (record.get("activity_type") or "Activity").strip() or "Activity"
+    parts.append(activity_type)
+
+    distance_m = _safe_float(record.get("distance_m"))
+    if distance_m is not None:
+        parts.append(f"{distance_m / 1000.0:.1f} km")
+
+    moving_time_s = _safe_int(record.get("moving_time_s"))
+    if moving_time_s is not None:
+        parts.append(format_duration(moving_time_s))
+
+    return " · ".join(parts)
+
+
+def format_activity_date(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        return str(value)[:10] or None
+
+
+def _safe_float(value) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -46,6 +46,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.activities_layer = None
         self.starts_layer = None
         self.points_layer = None
+        self.atlas_layer = None
         self.background_layer = None
         self.last_fetch_context = {}
         self.layer_manager = LayerManager(iface)
@@ -398,7 +399,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
             result = writer.write_activities(self.activities, sync_metadata=self.last_fetch_context)
             self.output_path = result["path"]
-            self.activities_layer, self.starts_layer, self.points_layer = self.layer_manager.load_output_layers(
+            self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer = self.layer_manager.load_output_layers(
                 self.output_path
             )
             self.on_apply_filters_clicked()
@@ -407,7 +408,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             if self.backgroundMapCheckBox.isChecked() and self.background_layer is not None:
                 background_note = " Added the selected Mapbox background map."
             self._set_status(
-                "Synced {fetched} fetched activities into GeoPackage: inserted {inserted}, updated {updated}, unchanged {unchanged}, stored total {total}. Loaded {track_count} tracks, {start_count} starts, and {point_count} activity points into QGIS.{background_note}".format(
+                "Synced {fetched} fetched activities into GeoPackage: inserted {inserted}, updated {updated}, unchanged {unchanged}, stored total {total}. Loaded {track_count} tracks, {start_count} starts, {point_count} activity points, and {atlas_count} atlas pages into QGIS.{background_note}".format(
                     fetched=result.get("fetched_count", len(self.activities)),
                     inserted=sync.get("inserted", 0),
                     updated=sync.get("updated", 0),
@@ -416,6 +417,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     track_count=result.get("track_count", 0),
                     start_count=result.get("start_count", 0),
                     point_count=result.get("point_count", 0),
+                    atlas_count=result.get("atlas_count", 0),
                     background_note=background_note,
                 )
             )
@@ -424,7 +426,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status("GeoPackage export failed")
 
     def on_apply_filters_clicked(self):
-        has_layers = any(layer is not None for layer in [self.activities_layer, self.starts_layer, self.points_layer])
+        has_layers = any(layer is not None for layer in [self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer])
         wants_background = self.backgroundMapCheckBox.isChecked()
         if not has_layers and not wants_background:
             return
@@ -466,11 +468,28 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 query.search_text,
                 query.detailed_only,
             )
-            self.layer_manager.apply_style(self.activities_layer, self.starts_layer, self.points_layer, preset)
+            self.layer_manager.apply_filters(
+                self.atlas_layer,
+                query.activity_type,
+                query.date_from,
+                query.date_to,
+                query.min_distance_km,
+                query.max_distance_km,
+                query.search_text,
+                query.detailed_only,
+            )
+            self.layer_manager.apply_style(
+                self.activities_layer,
+                self.starts_layer,
+                self.points_layer,
+                self.atlas_layer,
+                preset,
+            )
             temporal_note = self.layer_manager.apply_temporal_configuration(
                 self.activities_layer,
                 self.starts_layer,
                 self.points_layer,
+                self.atlas_layer,
                 self.temporalModeComboBox.currentText(),
             )
 

--- a/tests/test_publish_atlas.py
+++ b/tests/test_publish_atlas.py
@@ -1,0 +1,80 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.publish_atlas import (
+    DEFAULT_MIN_EXTENT_DEGREES,
+    activity_bounds,
+    build_atlas_page_plans,
+    build_page_name,
+    build_page_subtitle,
+    ensure_minimum_extent,
+    expand_bounds,
+)
+
+
+class PublishAtlasTests(unittest.TestCase):
+    def test_build_atlas_page_plans_prefers_stream_geometry_and_formats_labels(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "101",
+                "name": "Morning Gravel Ride",
+                "activity_type": "Ride",
+                "start_date": "2026-03-18T07:10:00+00:00",
+                "start_date_local": "2026-03-18T08:10:00+01:00",
+                "distance_m": 42500,
+                "moving_time_s": 7200,
+                "geometry_source": "stream",
+                "geometry_points": [(46.52, 6.62), (46.55, 6.7), (46.57, 6.74)],
+            }
+        ]
+
+        plans = build_atlas_page_plans(records, margin_percent=10, min_extent_degrees=0.01)
+
+        self.assertEqual(len(plans), 1)
+        plan = plans[0]
+        self.assertEqual(plan.geometry_source, "stream")
+        self.assertEqual(plan.page_name, "2026-03-18 · Morning Gravel Ride")
+        self.assertEqual(plan.page_subtitle, "Ride · 42.5 km · 2h 00m")
+        self.assertGreater(plan.extent_width_deg, 0.12)
+        self.assertGreater(plan.extent_height_deg, 0.05)
+
+    def test_activity_bounds_falls_back_to_start_end_coordinates(self):
+        bounds, geometry_source = activity_bounds(
+            {
+                "geometry_source": None,
+                "start_lat": 46.5,
+                "start_lon": 6.6,
+                "end_lat": 46.6,
+                "end_lon": 6.8,
+            }
+        )
+
+        self.assertEqual(geometry_source, "start_end")
+        self.assertEqual(bounds, (6.6, 46.5, 6.8, 46.6))
+
+    def test_ensure_minimum_extent_expands_tiny_tracks(self):
+        bounds = ensure_minimum_extent((6.7, 46.5, 6.7, 46.5), min_extent_degrees=DEFAULT_MIN_EXTENT_DEGREES)
+
+        self.assertAlmostEqual(bounds[2] - bounds[0], DEFAULT_MIN_EXTENT_DEGREES)
+        self.assertAlmostEqual(bounds[3] - bounds[1], DEFAULT_MIN_EXTENT_DEGREES)
+
+    def test_expand_bounds_applies_margin_after_minimum_extent(self):
+        expanded = expand_bounds((6.7, 46.5, 6.7, 46.5), margin_percent=20, min_extent_degrees=0.01)
+
+        self.assertAlmostEqual(expanded[2] - expanded[0], 0.014)
+        self.assertAlmostEqual(expanded[3] - expanded[1], 0.014)
+
+    def test_page_helpers_handle_missing_optional_values(self):
+        record = {
+            "name": "Recovery Walk",
+            "activity_type": "Walk",
+            "start_date": "2026-03-11T18:20:00+00:00",
+        }
+
+        self.assertEqual(build_page_name(record), "2026-03-11 · Recovery Walk")
+        self.assertEqual(build_page_subtitle(record), "Walk")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a derived `activity_atlas_pages` GeoPackage layer with padded activity extents and atlas-friendly labels
- load/style/filter the atlas pages in QGIS so they can seed print layouts immediately
- add publish-atlas unit tests and bump plugin packaging metadata to 0.13.0

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m py_compile publish_atlas.py gpkg_writer.py layer_manager.py qfit_dockwidget.py
- python3 scripts/package_plugin.py
