### PR TITLE
feat: add atlas publish settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The current implementation supports:
 - deriving absolute sampled timestamps for `activity_points` in UTC and local activity time when stream offsets are available
 - wiring loaded qfit layers into QGIS temporal playback using local or UTC timestamps when available
 - generating an `activity_atlas_pages` layer with print-ready page extents and labels for QGIS atlas layouts
+- tuning atlas-page padding and minimum extent directly from the plugin before rebuilding publish layers
 - loading those layers directly into QGIS
 - adding an optional Mapbox background layer through saved plugin settings
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
@@ -87,8 +88,19 @@ Visible layers:
 8. Choose an output `.gpkg` file
 9. Review the fetched-activity summary / preview and refine the query if needed
 10. Write + load the synced result into QGIS
-11. Apply filters, style presets, temporal-playback mode, and background-map updates
-12. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export
+11. Optionally tune atlas-page margin and minimum extent in the Publish / atlas section
+12. Apply filters, style presets, temporal-playback mode, and background-map updates
+13. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export
+
+## Publish / atlas settings
+
+qfit now exposes a small publish configuration block for the generated `activity_atlas_pages` layer.
+
+Use it when you want to tune the eventual print-layout framing:
+- `Page margin (%)` adds extra space around each activity extent
+- `Minimum page extent (°)` keeps very short or compact activities readable in an atlas
+
+These values are saved in QGIS settings and applied the next time you write/load the GeoPackage.
 
 ## Background map settings
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -183,6 +183,7 @@ Geometry type:
 Primary purpose:
 - atlas/page index layer for QGIS print layouts and future PDF export workflows
 - one padded extent polygon per activity with reusable title/subtitle fields
+- extent padding/minimum size controlled by the plugin's publish settings at write time
 
 ### Current fields
 
@@ -200,8 +201,8 @@ Primary purpose:
 | `page_name` | TEXT | atlas-friendly page label, usually `YYYY-MM-DD · Title` |
 | `page_title` | TEXT | large-title label |
 | `page_subtitle` | TEXT | compact summary such as type, distance, and moving time |
-| `extent_width_deg` | REAL | padded page width in degrees |
-| `extent_height_deg` | REAL | padded page height in degrees |
+| `extent_width_deg` | REAL | padded page width in degrees after the configured atlas margin/minimum extent rules |
+| `extent_height_deg` | REAL | padded page height in degrees after the configured atlas margin/minimum extent rules |
 
 ## Geometry priority
 

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -16,7 +16,7 @@ from qgis.core import (
 )
 
 from .polyline_utils import decode_polyline
-from .publish_atlas import build_atlas_page_plans
+from .publish_atlas import build_atlas_page_plans, normalize_atlas_page_settings
 from .sync_repository import REGISTRY_TABLE, SYNC_STATE_TABLE, SyncRepository
 from .time_utils import add_seconds_iso
 
@@ -114,10 +114,21 @@ ATLAS_FIELDS = [
 class GeoPackageWriter:
     """Persist qfit sync data to a GeoPackage and rebuild derived visualization layers."""
 
-    def __init__(self, output_path=None, write_activity_points=False, point_stride=5):
+    def __init__(
+        self,
+        output_path=None,
+        write_activity_points=False,
+        point_stride=5,
+        atlas_margin_percent=None,
+        atlas_min_extent_degrees=None,
+    ):
         self.output_path = output_path
         self.write_activity_points = bool(write_activity_points)
         self.point_stride = max(1, int(point_stride or 1))
+        self.atlas_page_settings = normalize_atlas_page_settings(
+            margin_percent=atlas_margin_percent,
+            min_extent_degrees=atlas_min_extent_degrees,
+        )
 
     def schema(self):
         return {
@@ -331,7 +342,10 @@ class GeoPackageWriter:
         layer.updateFields()
 
         features = []
-        for index, plan in enumerate(build_atlas_page_plans(records), start=1):
+        for index, plan in enumerate(
+            build_atlas_page_plans(records, settings=self.atlas_page_settings),
+            start=1,
+        ):
             rect = QgsRectangle(plan.min_lon, plan.min_lat, plan.max_lon, plan.max_lat)
             feature = QgsFeature(layer.fields())
             feature.setGeometry(QgsGeometry.fromRect(rect))

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.13.0
+version=0.14.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/publish_atlas.py
+++ b/publish_atlas.py
@@ -9,6 +9,14 @@ from .polyline_utils import decode_polyline
 
 DEFAULT_ATLAS_MARGIN_PERCENT = 8.0
 DEFAULT_MIN_EXTENT_DEGREES = 0.01
+MIN_ALLOWED_ATLAS_MARGIN_PERCENT = 0.0
+MIN_ALLOWED_ATLAS_MIN_EXTENT_DEGREES = 0.0001
+
+
+@dataclass(frozen=True)
+class AtlasPageSettings:
+    margin_percent: float = DEFAULT_ATLAS_MARGIN_PERCENT
+    min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES
 
 
 @dataclass(frozen=True)
@@ -32,21 +40,49 @@ class AtlasPagePlan:
     extent_height_deg: float
 
 
+def normalize_atlas_page_settings(
+    margin_percent: float | None = None,
+    min_extent_degrees: float | None = None,
+) -> AtlasPageSettings:
+    normalized_margin = _safe_float(margin_percent)
+    if normalized_margin is None:
+        normalized_margin = DEFAULT_ATLAS_MARGIN_PERCENT
+    normalized_margin = max(normalized_margin, MIN_ALLOWED_ATLAS_MARGIN_PERCENT)
+
+    normalized_min_extent = _safe_float(min_extent_degrees)
+    if normalized_min_extent is None:
+        normalized_min_extent = DEFAULT_MIN_EXTENT_DEGREES
+    normalized_min_extent = max(normalized_min_extent, MIN_ALLOWED_ATLAS_MIN_EXTENT_DEGREES)
+
+    return AtlasPageSettings(
+        margin_percent=normalized_margin,
+        min_extent_degrees=normalized_min_extent,
+    )
+
+
 def build_atlas_page_plans(
     records: Iterable[dict],
     margin_percent: float = DEFAULT_ATLAS_MARGIN_PERCENT,
     min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES,
+    settings: AtlasPageSettings | None = None,
 ) -> list[AtlasPagePlan]:
+    atlas_settings = settings or normalize_atlas_page_settings(
+        margin_percent=margin_percent,
+        min_extent_degrees=min_extent_degrees,
+    )
     plans = []
     for record in records:
-        bounds, geometry_source = activity_bounds(record, min_extent_degrees=min_extent_degrees)
+        bounds, geometry_source = activity_bounds(
+            record,
+            min_extent_degrees=atlas_settings.min_extent_degrees,
+        )
         if bounds is None:
             continue
 
         min_lon, min_lat, max_lon, max_lat = expand_bounds(
             bounds,
-            margin_percent=margin_percent,
-            min_extent_degrees=min_extent_degrees,
+            margin_percent=atlas_settings.margin_percent,
+            min_extent_degrees=atlas_settings.min_extent_degrees,
         )
         page_title = (record.get("name") or "Untitled activity").strip()
         page_name = build_page_name(record)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -144,6 +144,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._setting_value(settings, "mapbox_style_owner", "mapbox")
         )
         self.mapboxStyleIdLineEdit.setText(self._setting_value(settings, "mapbox_style_id", ""))
+        self.atlasMarginPercentSpinBox.setValue(float(self._setting_value(settings, "atlas_margin_percent", 8.0)))
+        self.atlasMinExtentSpinBox.setValue(float(self._setting_value(settings, "atlas_min_extent_degrees", 0.01)))
 
         temporal_mode = self._setting_value(settings, "temporal_mode", DEFAULT_TEMPORAL_MODE_LABEL)
         temporal_mode_index = self.temporalModeComboBox.findText(temporal_mode)
@@ -225,6 +227,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         settings.setValue(
             f"{self.SETTINGS_PREFIX}/mapbox_style_id",
             self.mapboxStyleIdLineEdit.text().strip(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/atlas_margin_percent",
+            self.atlasMarginPercentSpinBox.value(),
+        )
+        settings.setValue(
+            f"{self.SETTINGS_PREFIX}/atlas_min_extent_degrees",
+            self.atlasMinExtentSpinBox.value(),
         )
 
     def _setting_value(self, settings, key, default=None):
@@ -396,6 +406,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 output_path=output_path,
                 write_activity_points=self.writeActivityPointsCheckBox.isChecked(),
                 point_stride=self.pointSamplingStrideSpinBox.value(),
+                atlas_margin_percent=self.atlasMarginPercentSpinBox.value(),
+                atlas_min_extent_degrees=self.atlasMinExtentSpinBox.value(),
             )
             result = writer.write_activities(self.activities, sync_metadata=self.last_fetch_context)
             self.output_path = result["path"]

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -116,6 +116,20 @@
          </widget>
         </item>
         <item>
+         <widget class="QGroupBox" name="publishGroupBox">
+          <property name="title">
+           <string>Publish / atlas</string>
+          </property>
+          <layout class="QFormLayout" name="publishLayout">
+           <item row="0" column="0"><widget class="QLabel" name="atlasMarginPercentLabel"><property name="text"><string>Page margin (%)</string></property></widget></item>
+           <item row="0" column="1"><widget class="QDoubleSpinBox" name="atlasMarginPercentSpinBox"><property name="decimals"><number>1</number></property><property name="maximum"><double>1000.000000000000000</double></property><property name="singleStep"><double>1.000000000000000</double></property><property name="value"><double>8.000000000000000</double></property></widget></item>
+           <item row="1" column="0"><widget class="QLabel" name="atlasMinExtentLabel"><property name="text"><string>Minimum page extent (°)</string></property></widget></item>
+           <item row="1" column="1"><widget class="QDoubleSpinBox" name="atlasMinExtentSpinBox"><property name="decimals"><number>4</number></property><property name="minimum"><double>0.000100000000000</double></property><property name="maximum"><double>10.000000000000000</double></property><property name="singleStep"><double>0.001000000000000</double></property><property name="value"><double>0.010000000000000</double></property></widget></item>
+           <item row="2" column="0" colspan="2"><widget class="QLabel" name="publishHelpLabel"><property name="text"><string>These controls tune the generated activity_atlas_pages layer. Increase the margin when layouts need more surrounding context, or raise the minimum extent so short activities still get readable atlas pages.</string></property><property name="wordWrap"><bool>true</bool></property></widget></item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QGroupBox" name="filterGroupBox">
           <property name="title">
            <string>Filters</string>

--- a/tests/test_publish_atlas.py
+++ b/tests/test_publish_atlas.py
@@ -3,12 +3,14 @@ import unittest
 from tests import _path  # noqa: F401
 from qfit.publish_atlas import (
     DEFAULT_MIN_EXTENT_DEGREES,
+    MIN_ALLOWED_ATLAS_MIN_EXTENT_DEGREES,
     activity_bounds,
     build_atlas_page_plans,
     build_page_name,
     build_page_subtitle,
     ensure_minimum_extent,
     expand_bounds,
+    normalize_atlas_page_settings,
 )
 
 
@@ -38,6 +40,35 @@ class PublishAtlasTests(unittest.TestCase):
         self.assertEqual(plan.page_subtitle, "Ride · 42.5 km · 2h 00m")
         self.assertGreater(plan.extent_width_deg, 0.12)
         self.assertGreater(plan.extent_height_deg, 0.05)
+
+    def test_build_atlas_page_plans_respects_custom_publish_settings(self):
+        records = [
+            {
+                "name": "Lunch Walk",
+                "activity_type": "Walk",
+                "geometry_points": [(46.5000, 6.6000), (46.5002, 6.6002)],
+            }
+        ]
+
+        default_plan = build_atlas_page_plans(records)[0]
+        custom_plan = build_atlas_page_plans(records, margin_percent=25, min_extent_degrees=0.02)[0]
+
+        self.assertGreater(custom_plan.extent_width_deg, default_plan.extent_width_deg)
+        self.assertGreater(custom_plan.extent_height_deg, default_plan.extent_height_deg)
+        self.assertAlmostEqual(custom_plan.extent_width_deg, 0.03)
+        self.assertAlmostEqual(custom_plan.extent_height_deg, 0.03)
+
+    def test_normalize_atlas_page_settings_clamps_invalid_values(self):
+        settings = normalize_atlas_page_settings(margin_percent=-5, min_extent_degrees=0)
+
+        self.assertEqual(settings.margin_percent, 0.0)
+        self.assertEqual(settings.min_extent_degrees, MIN_ALLOWED_ATLAS_MIN_EXTENT_DEGREES)
+
+    def test_normalize_atlas_page_settings_uses_defaults_for_missing_values(self):
+        settings = normalize_atlas_page_settings(margin_percent=None, min_extent_degrees=None)
+
+        self.assertEqual(settings.margin_percent, 8.0)
+        self.assertEqual(settings.min_extent_degrees, DEFAULT_MIN_EXTENT_DEGREES)
 
     def test_activity_bounds_falls_back_to_start_end_coordinates(self):
         bounds, geometry_source = activity_bounds(


### PR DESCRIPTION
## Summary
- add publish/atlas controls for atlas page margin and minimum extent in the dock
- normalize atlas settings in reusable publish helpers and apply them when rebuilding `activity_atlas_pages`
- cover the new atlas-setting behavior in unit tests and document the new publish configuration

## Testing
- python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py