### PR TITLE
feat: add atlas TOC-ready page fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The current implementation supports:
 - wiring loaded qfit layers into QGIS temporal playback using local or UTC timestamps when available
 - generating an `activity_atlas_pages` layer with print-ready page extents and labels for QGIS atlas layouts
 - tuning atlas-page padding and minimum extent directly from the plugin before rebuilding publish layers
+- generating atlas pages in a stable chronological order with page numbers and TOC-friendly labels for QGIS layouts
 - loading those layers directly into QGIS
 - adding an optional Mapbox background layer through saved plugin settings
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
@@ -40,7 +41,7 @@ Visible layers:
 - `activity_tracks` — line layer for activity geometries
 - `activity_starts` — start-point layer
 - `activity_points` — optional sampled point layer derived from detailed streams, with per-point stream metrics and derived timestamps when available
-- `activity_atlas_pages` — polygon layer of atlas/page extents with titles/subtitles for QGIS print layouts
+- `activity_atlas_pages` — polygon layer of atlas/page extents with titles/subtitles plus page numbers and TOC-friendly labels for QGIS print layouts
 
 ## Planned next expansions
 
@@ -90,11 +91,16 @@ Visible layers:
 10. Write + load the synced result into QGIS
 11. Optionally tune atlas-page margin and minimum extent in the Publish / atlas section
 12. Apply filters, style presets, temporal-playback mode, and background-map updates
-13. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export
+13. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_distance_label`, and `page_duration_label` fields for layout text or a table of contents
 
 ## Publish / atlas settings
 
 qfit now exposes a small publish configuration block for the generated `activity_atlas_pages` layer.
+
+The resulting atlas-page layer is intentionally more layout-ready than a raw extent index:
+- pages are ordered chronologically with a stable `page_number`
+- `page_sort_key` gives QGIS a deterministic sort field for atlas or TOC tables
+- `page_date`, `page_distance_label`, and `page_duration_label` reduce the need for layout expressions
 
 Use it when you want to tune the eventual print-layout framing:
 - `Page margin (%)` adds extra space around each activity extent

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - `activity_tracks` — one visible line feature per activity
 - `activity_starts` — one visible point per activity start
 - `activity_points` — optional sampled point layer derived from detailed stream geometry
-- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows
+- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering and TOC-friendly labels
 
 ## Table: `activity_registry`
 
@@ -198,9 +198,14 @@ Primary purpose:
 | `distance_m` | REAL | copied for filtering / layout text |
 | `moving_time_s` | INTEGER | copied for layout text |
 | `geometry_source` | TEXT | stream/summary/fallback source used to derive the page extent |
+| `page_number` | INTEGER | stable chronological page number for layouts / table-of-contents workflows |
+| `page_sort_key` | TEXT | deterministic sort key combining activity datetime, name, source, and source id |
 | `page_name` | TEXT | atlas-friendly page label, usually `YYYY-MM-DD · Title` |
 | `page_title` | TEXT | large-title label |
 | `page_subtitle` | TEXT | compact summary such as type, distance, and moving time |
+| `page_date` | TEXT | preformatted local/primary activity date for layout labels |
+| `page_distance_label` | TEXT | preformatted distance label such as `42.5 km` |
+| `page_duration_label` | TEXT | preformatted moving-time label such as `2h 00m` |
 | `extent_width_deg` | REAL | padded page width in degrees after the configured atlas margin/minimum extent rules |
 | `extent_height_deg` | REAL | padded page height in degrees after the configured atlas margin/minimum extent rules |
 

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -103,9 +103,14 @@ ATLAS_FIELDS = [
     ("distance_m", QVariant.Double),
     ("moving_time_s", QVariant.Int),
     ("geometry_source", QVariant.String),
+    ("page_number", QVariant.Int),
+    ("page_sort_key", QVariant.String),
     ("page_name", QVariant.String),
     ("page_title", QVariant.String),
     ("page_subtitle", QVariant.String),
+    ("page_date", QVariant.String),
+    ("page_distance_label", QVariant.String),
+    ("page_duration_label", QVariant.String),
     ("extent_width_deg", QVariant.Double),
     ("extent_height_deg", QVariant.Double),
 ]
@@ -342,14 +347,11 @@ class GeoPackageWriter:
         layer.updateFields()
 
         features = []
-        for index, plan in enumerate(
-            build_atlas_page_plans(records, settings=self.atlas_page_settings),
-            start=1,
-        ):
+        for plan in build_atlas_page_plans(records, settings=self.atlas_page_settings):
             rect = QgsRectangle(plan.min_lon, plan.min_lat, plan.max_lon, plan.max_lat)
             feature = QgsFeature(layer.fields())
             feature.setGeometry(QgsGeometry.fromRect(rect))
-            feature["activity_fk"] = index
+            feature["activity_fk"] = plan.page_number
             feature["source"] = plan.source
             feature["source_activity_id"] = plan.source_activity_id
             feature["name"] = plan.name
@@ -358,9 +360,14 @@ class GeoPackageWriter:
             feature["distance_m"] = plan.distance_m
             feature["moving_time_s"] = plan.moving_time_s
             feature["geometry_source"] = plan.geometry_source
+            feature["page_number"] = plan.page_number
+            feature["page_sort_key"] = plan.page_sort_key
             feature["page_name"] = plan.page_name
             feature["page_title"] = plan.page_title
             feature["page_subtitle"] = plan.page_subtitle
+            feature["page_date"] = plan.page_date
+            feature["page_distance_label"] = plan.page_distance_label
+            feature["page_duration_label"] = plan.page_duration_label
             feature["extent_width_deg"] = plan.extent_width_deg
             feature["extent_height_deg"] = plan.extent_height_deg
             features.append(feature)

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.14.0
+version=0.15.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/publish_atlas.py
+++ b/publish_atlas.py
@@ -29,9 +29,14 @@ class AtlasPagePlan:
     distance_m: float | None
     moving_time_s: int | None
     geometry_source: str
+    page_number: int
+    page_sort_key: str
     page_name: str
     page_title: str
     page_subtitle: str
+    page_date: str | None
+    page_distance_label: str | None
+    page_duration_label: str | None
     min_lon: float
     min_lat: float
     max_lon: float
@@ -70,7 +75,7 @@ def build_atlas_page_plans(
         margin_percent=margin_percent,
         min_extent_degrees=min_extent_degrees,
     )
-    plans = []
+    candidates = []
     for record in records:
         bounds, geometry_source = activity_bounds(
             record,
@@ -78,7 +83,10 @@ def build_atlas_page_plans(
         )
         if bounds is None:
             continue
+        candidates.append((atlas_sort_key(record), record, geometry_source, bounds))
 
+    plans = []
+    for page_number, (sort_key, record, geometry_source, bounds) in enumerate(sorted(candidates, key=lambda item: item[0]), start=1):
         min_lon, min_lat, max_lon, max_lat = expand_bounds(
             bounds,
             margin_percent=atlas_settings.margin_percent,
@@ -97,9 +105,14 @@ def build_atlas_page_plans(
                 distance_m=_safe_float(record.get("distance_m")),
                 moving_time_s=_safe_int(record.get("moving_time_s")),
                 geometry_source=geometry_source,
+                page_number=page_number,
+                page_sort_key=sort_key,
                 page_name=page_name,
                 page_title=page_title,
                 page_subtitle=page_subtitle,
+                page_date=format_activity_date(record.get("start_date_local") or record.get("start_date")),
+                page_distance_label=format_distance_label(record.get("distance_m")),
+                page_duration_label=format_duration_label(record.get("moving_time_s")),
                 min_lon=min_lon,
                 min_lat=min_lat,
                 max_lon=max_lon,
@@ -109,6 +122,31 @@ def build_atlas_page_plans(
             )
         )
     return plans
+
+
+def atlas_sort_key(record: dict) -> str:
+    activity_date = format_sortable_activity_datetime(record.get("start_date_local") or record.get("start_date"))
+    title = normalize_sort_text(record.get("name") or "Untitled activity")
+    source = normalize_sort_text(record.get("source") or "")
+    source_activity_id = normalize_sort_text(record.get("source_activity_id") or "")
+    return "|".join([activity_date, title, source, source_activity_id])
+
+
+def format_sortable_activity_datetime(value: str | None) -> str:
+    if not value:
+        return "9999-12-31T23:59:59"
+    text = str(value).strip()
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).isoformat()
+    except ValueError:
+        if len(text) >= 19:
+            return text[:19]
+        return text or "9999-12-31T23:59:59"
+
+
+def normalize_sort_text(value: str | None) -> str:
+    text = (value or "").strip().casefold()
+    return " ".join(text.split())
 
 
 def activity_bounds(record: dict, min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES) -> tuple[tuple[float, float, float, float] | None, str]:
@@ -198,13 +236,13 @@ def build_page_subtitle(record: dict) -> str:
     activity_type = (record.get("activity_type") or "Activity").strip() or "Activity"
     parts.append(activity_type)
 
-    distance_m = _safe_float(record.get("distance_m"))
-    if distance_m is not None:
-        parts.append(f"{distance_m / 1000.0:.1f} km")
+    distance_label = format_distance_label(record.get("distance_m"))
+    if distance_label:
+        parts.append(distance_label)
 
-    moving_time_s = _safe_int(record.get("moving_time_s"))
-    if moving_time_s is not None:
-        parts.append(format_duration(moving_time_s))
+    duration_label = format_duration_label(record.get("moving_time_s"))
+    if duration_label:
+        parts.append(duration_label)
 
     return " · ".join(parts)
 
@@ -216,6 +254,20 @@ def format_activity_date(value: str | None) -> str | None:
         return datetime.fromisoformat(str(value).replace("Z", "+00:00")).date().isoformat()
     except ValueError:
         return str(value)[:10] or None
+
+
+def format_distance_label(value) -> str | None:
+    distance_m = _safe_float(value)
+    if distance_m is None:
+        return None
+    return f"{distance_m / 1000.0:.1f} km"
+
+
+def format_duration_label(value) -> str | None:
+    moving_time_s = _safe_int(value)
+    if moving_time_s is None:
+        return None
+    return format_duration(moving_time_s)
 
 
 def _safe_float(value) -> float | None:

--- a/tests/test_publish_atlas.py
+++ b/tests/test_publish_atlas.py
@@ -5,11 +5,14 @@ from qfit.publish_atlas import (
     DEFAULT_MIN_EXTENT_DEGREES,
     MIN_ALLOWED_ATLAS_MIN_EXTENT_DEGREES,
     activity_bounds,
+    atlas_sort_key,
     build_atlas_page_plans,
     build_page_name,
     build_page_subtitle,
     ensure_minimum_extent,
     expand_bounds,
+    format_distance_label,
+    format_duration_label,
     normalize_atlas_page_settings,
 )
 
@@ -36,10 +39,55 @@ class PublishAtlasTests(unittest.TestCase):
         self.assertEqual(len(plans), 1)
         plan = plans[0]
         self.assertEqual(plan.geometry_source, "stream")
+        self.assertEqual(plan.page_number, 1)
         self.assertEqual(plan.page_name, "2026-03-18 · Morning Gravel Ride")
         self.assertEqual(plan.page_subtitle, "Ride · 42.5 km · 2h 00m")
+        self.assertEqual(plan.page_date, "2026-03-18")
+        self.assertEqual(plan.page_distance_label, "42.5 km")
+        self.assertEqual(plan.page_duration_label, "2h 00m")
+        self.assertTrue(plan.page_sort_key.startswith("2026-03-18T08:10:00+01:00|morning gravel ride|strava|101"))
         self.assertGreater(plan.extent_width_deg, 0.12)
         self.assertGreater(plan.extent_height_deg, 0.05)
+
+    def test_build_atlas_page_plans_sorts_chronologically_and_assigns_page_numbers(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "300",
+                "name": "Evening Run",
+                "activity_type": "Run",
+                "start_date_local": "2026-03-19T18:30:00+01:00",
+                "geometry_points": [(46.51, 6.62), (46.52, 6.63)],
+            },
+            {
+                "source": "strava",
+                "source_activity_id": "100",
+                "name": "Morning Ride",
+                "activity_type": "Ride",
+                "start_date_local": "2026-03-18T08:10:00+01:00",
+                "geometry_points": [(46.52, 6.62), (46.57, 6.74)],
+            },
+            {
+                "source": "strava",
+                "source_activity_id": "200",
+                "name": "Morning Ride",
+                "activity_type": "Ride",
+                "start_date_local": "2026-03-18T08:10:00+01:00",
+                "geometry_points": [(46.42, 6.52), (46.47, 6.54)],
+            },
+        ]
+
+        plans = build_atlas_page_plans(records)
+
+        self.assertEqual([plan.page_number for plan in plans], [1, 2, 3])
+        self.assertEqual(
+            [(plan.source_activity_id, plan.page_name) for plan in plans],
+            [
+                ("100", "2026-03-18 · Morning Ride"),
+                ("200", "2026-03-18 · Morning Ride"),
+                ("300", "2026-03-19 · Evening Run"),
+            ],
+        )
 
     def test_build_atlas_page_plans_respects_custom_publish_settings(self):
         records = [
@@ -105,6 +153,13 @@ class PublishAtlasTests(unittest.TestCase):
 
         self.assertEqual(build_page_name(record), "2026-03-11 · Recovery Walk")
         self.assertEqual(build_page_subtitle(record), "Walk")
+        self.assertIsNone(format_distance_label(None))
+        self.assertIsNone(format_duration_label(None))
+
+    def test_atlas_sort_key_normalizes_missing_values(self):
+        key = atlas_sort_key({"name": "  Lunch   Walk  "})
+
+        self.assertEqual(key, "9999-12-31T23:59:59|lunch walk||")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add stable chronological atlas page ordering plus TOC-friendly label fields
- write the new atlas fields into `activity_atlas_pages` for QGIS layouts
- extend publish-atlas tests and bump plugin metadata/package version to 0.15.0

## Testing
- python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py
