### PR TITLE
feat: improve atlas projection and background loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The current implementation supports:
 - generating an `activity_atlas_pages` layer with print-ready page extents and labels for QGIS atlas layouts
 - tuning atlas-page padding and minimum extent directly from the plugin before rebuilding publish layers
 - generating atlas pages in a stable chronological order with page numbers and TOC-friendly labels for QGIS layouts
-- loading those layers directly into QGIS
-- adding an optional Mapbox background layer through saved plugin settings
+- adding Web Mercator-ready atlas metadata (`center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`) for layout work in EPSG:3857
+- loading those layers directly into QGIS with EPSG:3857 as the working project/map CRS
+- adding an optional Mapbox background layer through saved plugin settings, with an explicit background-map Load button and basemap ordering kept below the activity layers
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
 - previewing fetched activities with a dock-side summary and sortable recent-activity list before loading layers
 - applying visualization presets including lines, track points, heatmaps, and start-point views
@@ -90,8 +91,10 @@ Visible layers:
 9. Review the fetched-activity summary / preview and refine the query if needed
 10. Write + load the synced result into QGIS
 11. Optionally tune atlas-page margin and minimum extent in the Publish / atlas section
-12. Apply filters, style presets, temporal-playback mode, and background-map updates
-13. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_distance_label`, and `page_duration_label` fields for layout text or a table of contents
+12. Use `Write + Load` to load the full qfit layers into QGIS without auto-applying dock subset filters to the layer tables
+13. Use `Apply filters` only when you want the current dock query to become an actual QGIS layer subset
+14. Optionally use `Load background map` to add or refresh the basemap underneath the qfit activity layers
+15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_distance_label`, `page_duration_label`, `center_x_3857`, `center_y_3857`, `extent_width_m`, and `extent_height_m` fields for layout text, overview tables, or Web Mercator layout logic
 
 ## Publish / atlas settings
 
@@ -101,6 +104,7 @@ The resulting atlas-page layer is intentionally more layout-ready than a raw ext
 - pages are ordered chronologically with a stable `page_number`
 - `page_sort_key` gives QGIS a deterministic sort field for atlas or TOC tables
 - `page_date`, `page_distance_label`, and `page_duration_label` reduce the need for layout expressions
+- `center_x_3857`, `center_y_3857`, `extent_width_m`, and `extent_height_m` make it easier to drive Web Mercator-oriented layout logic now that qfit uses EPSG:3857 as the working QGIS projection choice
 
 Use it when you want to tune the eventual print-layout framing:
 - `Page margin (%)` adds extra space around each activity extent
@@ -117,6 +121,9 @@ Configure these values in the dock when you want a background basemap:
 - paste a Mapbox access token
 - choose a preset such as `Outdoor`, `Light`, or `Satellite`
 - for `Winter (custom style)` or `Custom`, provide the Mapbox style owner and style ID from your own Studio style
+- click `Load background map` when you want to add or refresh the basemap explicitly
+
+When qfit loads the background layer, it keeps it below the qfit activity layers in the QGIS layer tree so tracks, starts, and points render on top of the basemap.
 
 The built-in presets intentionally keep the configuration small and predictable. The Winter slot is just a convenience label for a custom winter-themed style if you have one.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -86,6 +86,7 @@ Goal: map styling, data filtering, and activity querying.
 - Style presets and layer styling basics
 - Start points / tracks / heatmap-style views
 - Auto-zoom to loaded data extents
+- Working QGIS map/project projection choice aligned to Web Mercator (`EPSG:3857`)
 - Background-map support via Mapbox
 - Background presets:
   - Outdoor
@@ -111,6 +112,7 @@ Goal: map styling, data filtering, and activity querying.
 - Smarter visualization presets per activity type
 - Query saving / reusable view presets
 - More explicit basemap and map-style configuration UX
+- Better separation between preview/query controls and post-load QGIS layer subsetting
 - Route/profile-linked inspection in the visualization flow
 
 ### Notes

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - `activity_tracks` — one visible line feature per activity
 - `activity_starts` — one visible point per activity start
 - `activity_points` — optional sampled point layer derived from detailed stream geometry
-- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering and TOC-friendly labels
+- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering, TOC-friendly labels, and Web Mercator-ready extent metadata
 
 ## Table: `activity_registry`
 
@@ -206,8 +206,12 @@ Primary purpose:
 | `page_date` | TEXT | preformatted local/primary activity date for layout labels |
 | `page_distance_label` | TEXT | preformatted distance label such as `42.5 km` |
 | `page_duration_label` | TEXT | preformatted moving-time label such as `2h 00m` |
+| `center_x_3857` | REAL | Web Mercator page center X for EPSG:3857 layouts |
+| `center_y_3857` | REAL | Web Mercator page center Y for EPSG:3857 layouts |
 | `extent_width_deg` | REAL | padded page width in degrees after the configured atlas margin/minimum extent rules |
 | `extent_height_deg` | REAL | padded page height in degrees after the configured atlas margin/minimum extent rules |
+| `extent_width_m` | REAL | padded page width in Web Mercator meters |
+| `extent_height_m` | REAL | padded page height in Web Mercator meters |
 
 ## Geometry priority
 

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -111,8 +111,12 @@ ATLAS_FIELDS = [
     ("page_date", QVariant.String),
     ("page_distance_label", QVariant.String),
     ("page_duration_label", QVariant.String),
+    ("center_x_3857", QVariant.Double),
+    ("center_y_3857", QVariant.Double),
     ("extent_width_deg", QVariant.Double),
     ("extent_height_deg", QVariant.Double),
+    ("extent_width_m", QVariant.Double),
+    ("extent_height_m", QVariant.Double),
 ]
 
 
@@ -368,8 +372,12 @@ class GeoPackageWriter:
             feature["page_date"] = plan.page_date
             feature["page_distance_label"] = plan.page_distance_label
             feature["page_duration_label"] = plan.page_duration_label
+            feature["center_x_3857"] = plan.center_x_3857
+            feature["center_y_3857"] = plan.center_y_3857
             feature["extent_width_deg"] = plan.extent_width_deg
             feature["extent_height_deg"] = plan.extent_height_deg
+            feature["extent_width_m"] = plan.extent_width_m
+            feature["extent_height_m"] = plan.extent_height_m
             features.append(feature)
 
         provider.addFeatures(features)

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -1,6 +1,7 @@
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (
     QgsCategorizedSymbolRenderer,
+    QgsCoordinateReferenceSystem,
     QgsFillSymbol,
     QgsGradientColorRamp,
     QgsHeatmapRenderer,
@@ -27,10 +28,13 @@ from .temporal_config import build_temporal_plan, describe_temporal_configuratio
 
 
 class LayerManager:
+    WORKING_CRS = "EPSG:3857"
+
     def __init__(self, iface):
         self.iface = iface
 
     def load_output_layers(self, gpkg_path):
+        self._ensure_working_crs()
         activities_layer = self._load_first_available(
             gpkg_path,
             [("activity_tracks", "qfit activities"), ("activities", "qfit activities")],
@@ -38,6 +42,7 @@ class LayerManager:
         starts_layer = self._load_optional_layer(gpkg_path, "activity_starts", "qfit activity starts")
         points_layer = self._load_optional_layer(gpkg_path, "activity_points", "qfit activity points")
         atlas_layer = self._load_optional_layer(gpkg_path, "activity_atlas_pages", "qfit atlas pages")
+        self._move_background_layers_to_bottom()
         self._zoom_to_layers([activities_layer, starts_layer, points_layer, atlas_layer])
         return activities_layer, starts_layer, points_layer, atlas_layer
 
@@ -56,7 +61,8 @@ class LayerManager:
         self._remove_background_layers()
         project = QgsProject.instance()
         project.addMapLayer(layer, False)
-        project.layerTreeRoot().insertLayer(0, layer)
+        project.layerTreeRoot().addLayer(layer)
+        self._move_background_layers_to_bottom()
         return layer
 
     def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None, max_distance_km=None, search_text=None, detailed_only=False):
@@ -153,6 +159,32 @@ class LayerManager:
         for layer in list(project.mapLayers().values()):
             if layer.name().startswith(BACKGROUND_LAYER_PREFIX):
                 project.removeMapLayer(layer.id())
+
+    def _ensure_working_crs(self):
+        project = QgsProject.instance()
+        working_crs = QgsCoordinateReferenceSystem(self.WORKING_CRS)
+        if not working_crs.isValid():
+            return
+
+        project.setCrs(working_crs)
+        canvas = self.iface.mapCanvas() if self.iface is not None else None
+        if canvas is not None:
+            canvas.setDestinationCrs(working_crs)
+
+    def _move_background_layers_to_bottom(self):
+        root = QgsProject.instance().layerTreeRoot()
+        background_nodes = []
+        other_nodes = []
+        for child in list(root.children()):
+            layer = child.layer() if hasattr(child, "layer") else None
+            if layer is not None and layer.name().startswith(BACKGROUND_LAYER_PREFIX):
+                background_nodes.append(child)
+            else:
+                other_nodes.append(child)
+
+        desired_order = other_nodes + background_nodes
+        if desired_order and desired_order != list(root.children()):
+            root.reorderChildren(desired_order)
 
     def _apply_temporal_plan(self, layer, layer_key, mode_label):
         props = layer.temporalProperties()

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.15.0
+version=0.16.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/publish_atlas.py
+++ b/publish_atlas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from math import atan, exp, log, pi, tan
 from typing import Iterable
 
 from .activity_query import format_duration
@@ -11,6 +12,9 @@ DEFAULT_ATLAS_MARGIN_PERCENT = 8.0
 DEFAULT_MIN_EXTENT_DEGREES = 0.01
 MIN_ALLOWED_ATLAS_MARGIN_PERCENT = 0.0
 MIN_ALLOWED_ATLAS_MIN_EXTENT_DEGREES = 0.0001
+WEB_MERCATOR_EPSG = "EPSG:3857"
+WEB_MERCATOR_HALF_WORLD_M = 20037508.342789244
+WEB_MERCATOR_MAX_LAT = 85.05112878
 
 
 @dataclass(frozen=True)
@@ -43,6 +47,10 @@ class AtlasPagePlan:
     max_lat: float
     extent_width_deg: float
     extent_height_deg: float
+    center_x_3857: float
+    center_y_3857: float
+    extent_width_m: float
+    extent_height_m: float
 
 
 def normalize_atlas_page_settings(
@@ -92,6 +100,9 @@ def build_atlas_page_plans(
             margin_percent=atlas_settings.margin_percent,
             min_extent_degrees=atlas_settings.min_extent_degrees,
         )
+        projected_bounds = lonlat_bounds_to_web_mercator(min_lon, min_lat, max_lon, max_lat)
+        center_x_3857 = (projected_bounds[0] + projected_bounds[2]) / 2.0
+        center_y_3857 = (projected_bounds[1] + projected_bounds[3]) / 2.0
         page_title = (record.get("name") or "Untitled activity").strip()
         page_name = build_page_name(record)
         page_subtitle = build_page_subtitle(record)
@@ -119,6 +130,10 @@ def build_atlas_page_plans(
                 max_lat=max_lat,
                 extent_width_deg=max_lon - min_lon,
                 extent_height_deg=max_lat - min_lat,
+                center_x_3857=center_x_3857,
+                center_y_3857=center_y_3857,
+                extent_width_m=projected_bounds[2] - projected_bounds[0],
+                extent_height_m=projected_bounds[3] - projected_bounds[1],
             )
         )
     return plans
@@ -221,6 +236,43 @@ def expand_bounds(
     pad_x = width * margin_ratio
     pad_y = height * margin_ratio
     return min_lon - pad_x, min_lat - pad_y, max_lon + pad_x, max_lat + pad_y
+
+
+def lonlat_to_web_mercator(lon: float, lat: float) -> tuple[float, float]:
+    lon_value = _safe_float(lon)
+    lat_value = _safe_float(lat)
+    if lon_value is None or lat_value is None:
+        raise ValueError("lon and lat must be valid numeric values")
+
+    clamped_lon = max(min(lon_value, 180.0), -180.0)
+    clamped_lat = max(min(lat_value, WEB_MERCATOR_MAX_LAT), -WEB_MERCATOR_MAX_LAT)
+    x = WEB_MERCATOR_HALF_WORLD_M * clamped_lon / 180.0
+    y = WEB_MERCATOR_HALF_WORLD_M * log(tan(pi / 4.0 + (clamped_lat * pi / 180.0) / 2.0)) / pi
+    return x, y
+
+
+def web_mercator_to_lonlat(x: float, y: float) -> tuple[float, float]:
+    x_value = _safe_float(x)
+    y_value = _safe_float(y)
+    if x_value is None or y_value is None:
+        raise ValueError("x and y must be valid numeric values")
+
+    clamped_x = max(min(x_value, WEB_MERCATOR_HALF_WORLD_M), -WEB_MERCATOR_HALF_WORLD_M)
+    clamped_y = max(min(y_value, WEB_MERCATOR_HALF_WORLD_M), -WEB_MERCATOR_HALF_WORLD_M)
+    lon = (clamped_x / WEB_MERCATOR_HALF_WORLD_M) * 180.0
+    lat = (2.0 * atan(exp((clamped_y / WEB_MERCATOR_HALF_WORLD_M) * pi)) - pi / 2.0) * 180.0 / pi
+    return lon, lat
+
+
+def lonlat_bounds_to_web_mercator(
+    min_lon: float,
+    min_lat: float,
+    max_lon: float,
+    max_lat: float,
+) -> tuple[float, float, float, float]:
+    min_x, min_y = lonlat_to_web_mercator(min_lon, min_lat)
+    max_x, max_y = lonlat_to_web_mercator(max_lon, max_lat)
+    return min(min_x, max_x), min(min_y, max_y), max(min_x, max_x), max(min_y, max_y)
 
 
 def build_page_name(record: dict) -> str:

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -67,6 +67,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.refreshButton.clicked.connect(self.on_refresh_clicked)
         self.loadButton.clicked.connect(self.on_load_clicked)
         self.applyFiltersButton.clicked.connect(self.on_apply_filters_clicked)
+        self.loadBackgroundButton.clicked.connect(self.on_load_background_clicked)
         self.backgroundPresetComboBox.currentTextChanged.connect(self.on_background_preset_changed)
 
         preview_inputs = [
@@ -263,6 +264,27 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def on_background_preset_changed(self, preset_name):
         self._sync_background_style_fields(preset_name, force=True)
 
+    def on_load_background_clicked(self):
+        self._save_settings()
+        enabled = self.backgroundMapCheckBox.isChecked()
+        try:
+            self.background_layer = self.layer_manager.ensure_background_layer(
+                enabled=enabled,
+                preset_name=self.backgroundPresetComboBox.currentText(),
+                access_token=self.mapboxAccessTokenLineEdit.text().strip(),
+                style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+                style_id=self.mapboxStyleIdLineEdit.text().strip(),
+            )
+        except (MapboxConfigError, RuntimeError) as exc:
+            self._show_error("Background map failed", str(exc))
+            self._set_status("Background map could not be updated")
+            return
+
+        if enabled and self.background_layer is not None:
+            self._set_status("Background map loaded below the qfit activity layers")
+        else:
+            self._set_status("Background map cleared")
+
     def _sync_background_style_fields(self, preset_name, force=False):
         if preset_requires_custom_style(preset_name):
             return
@@ -414,13 +436,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer = self.layer_manager.load_output_layers(
                 self.output_path
             )
-            self.on_apply_filters_clicked()
+            visual_status = self._apply_visual_configuration(apply_subset_filters=False)
             sync = result.get("sync") or {}
-            background_note = ""
-            if self.backgroundMapCheckBox.isChecked() and self.background_layer is not None:
-                background_note = " Added the selected Mapbox background map."
+            if visual_status:
+                visual_status = f" {visual_status}"
             self._set_status(
-                "Synced {fetched} fetched activities into GeoPackage: inserted {inserted}, updated {updated}, unchanged {unchanged}, stored total {total}. Loaded {track_count} tracks, {start_count} starts, {point_count} activity points, and {atlas_count} atlas pages into QGIS.{background_note}".format(
+                "Synced {fetched} fetched activities into GeoPackage: inserted {inserted}, updated {updated}, unchanged {unchanged}, stored total {total}. Loaded {track_count} tracks, {start_count} starts, {point_count} activity points, and {atlas_count} atlas pages into QGIS without auto-filtering the layer tables.{visual_status}".format(
                     fetched=result.get("fetched_count", len(self.activities)),
                     inserted=sync.get("inserted", 0),
                     updated=sync.get("updated", 0),
@@ -430,7 +451,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     start_count=result.get("start_count", 0),
                     point_count=result.get("point_count", 0),
                     atlas_count=result.get("atlas_count", 0),
-                    background_note=background_note,
+                    visual_status=visual_status,
                 )
             )
         except Exception as exc:  # noqa: BLE001
@@ -444,12 +465,19 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self._save_settings()
+        status = self._apply_visual_configuration(apply_subset_filters=True)
+        if status:
+            self._set_status(status)
+
+    def _apply_visual_configuration(self, apply_subset_filters):
+        has_layers = any(layer is not None for layer in [self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer])
+        wants_background = self.backgroundMapCheckBox.isChecked()
+        filtered_activities = self._refresh_activity_preview()
         query = self._current_activity_query()
         preset = self.stylePresetComboBox.currentText()
-        filtered_activities = self._refresh_activity_preview()
         temporal_note = ""
 
-        if has_layers:
+        if has_layers and apply_subset_filters:
             self.layer_manager.apply_filters(
                 self.activities_layer,
                 query.activity_type,
@@ -490,6 +518,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 query.search_text,
                 query.detailed_only,
             )
+
+        if has_layers:
             self.layer_manager.apply_style(
                 self.activities_layer,
                 self.starts_layer,
@@ -515,27 +545,32 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
         except (MapboxConfigError, RuntimeError) as exc:
             self._show_error("Background map failed", str(exc))
-            failure_status = "Applied filters and styling, but the background map could not be updated"
             if not has_layers:
                 failure_status = "Background map could not be updated"
+            elif apply_subset_filters:
+                failure_status = "Applied filters and styling, but the background map could not be updated"
+            else:
+                failure_status = "Loaded layers with styling, but the background map could not be updated"
             if temporal_note:
                 failure_status = f"{failure_status}. {temporal_note}."
-            self._set_status(failure_status)
-            return
+            return failure_status
 
         filtered_count = len(filtered_activities)
         if has_layers and wants_background and self.background_layer is not None:
-            status = f"Applied filters, styling, and background map ({filtered_count} matching activities)"
+            if apply_subset_filters:
+                status = f"Applied filters, styling, and background map ({filtered_count} matching activities)"
+            else:
+                status = "Applied styling and loaded the background map below the qfit activity layers"
         elif has_layers:
-            status = f"Applied filters and styling ({filtered_count} matching activities)"
+            status = f"Applied filters and styling ({filtered_count} matching activities)" if apply_subset_filters else "Applied styling to the loaded qfit layers"
         elif wants_background and self.background_layer is not None:
-            status = f"Background map updated ({filtered_count} matching activities)"
+            status = f"Background map updated ({filtered_count} matching activities)" if apply_subset_filters else "Background map loaded below the qfit activity layers"
         else:
-            status = f"Background map cleared ({filtered_count} matching activities)"
+            status = f"Background map cleared ({filtered_count} matching activities)" if apply_subset_filters else "Background map cleared"
 
         if temporal_note:
             status = f"{status}. {temporal_note}."
-        self._set_status(status)
+        return status
 
     def _current_activity_query(self):
         return ActivityQuery(

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -98,7 +98,8 @@
            <item row="3" column="1"><widget class="QLineEdit" name="mapboxStyleOwnerLineEdit"><property name="placeholderText"><string>mapbox</string></property></widget></item>
            <item row="4" column="0"><widget class="QLabel" name="mapboxStyleIdLabel"><property name="text"><string>Style ID</string></property></widget></item>
            <item row="4" column="1"><widget class="QLineEdit" name="mapboxStyleIdLineEdit"><property name="placeholderText"><string>outdoors-v12 or your own Studio style ID</string></property></widget></item>
-           <item row="5" column="0" colspan="2"><widget class="QLabel" name="backgroundHelpLabel"><property name="text"><string>Built-in examples use Mapbox Outdoors, Light, and Satellite Streets. The Winter preset is intentionally a custom slot for your own winter-themed Mapbox Studio style.</string></property><property name="wordWrap"><bool>true</bool></property></widget></item>
+           <item row="5" column="0" colspan="2"><widget class="QPushButton" name="loadBackgroundButton"><property name="text"><string>Load background map</string></property></widget></item>
+           <item row="6" column="0" colspan="2"><widget class="QLabel" name="backgroundHelpLabel"><property name="text"><string>Built-in examples use Mapbox Outdoors, Light, and Satellite Streets. The Winter preset is intentionally a custom slot for your own winter-themed Mapbox Studio style.</string></property><property name="wordWrap"><bool>true</bool></property></widget></item>
           </layout>
          </widget>
         </item>

--- a/tests/test_publish_atlas.py
+++ b/tests/test_publish_atlas.py
@@ -4,6 +4,7 @@ from tests import _path  # noqa: F401
 from qfit.publish_atlas import (
     DEFAULT_MIN_EXTENT_DEGREES,
     MIN_ALLOWED_ATLAS_MIN_EXTENT_DEGREES,
+    WEB_MERCATOR_EPSG,
     activity_bounds,
     atlas_sort_key,
     build_atlas_page_plans,
@@ -13,7 +14,9 @@ from qfit.publish_atlas import (
     expand_bounds,
     format_distance_label,
     format_duration_label,
+    lonlat_to_web_mercator,
     normalize_atlas_page_settings,
+    web_mercator_to_lonlat,
 )
 
 
@@ -48,6 +51,8 @@ class PublishAtlasTests(unittest.TestCase):
         self.assertTrue(plan.page_sort_key.startswith("2026-03-18T08:10:00+01:00|morning gravel ride|strava|101"))
         self.assertGreater(plan.extent_width_deg, 0.12)
         self.assertGreater(plan.extent_height_deg, 0.05)
+        self.assertGreater(plan.extent_width_m, 9000)
+        self.assertGreater(plan.extent_height_m, 7000)
 
     def test_build_atlas_page_plans_sorts_chronologically_and_assigns_page_numbers(self):
         records = [
@@ -105,6 +110,8 @@ class PublishAtlasTests(unittest.TestCase):
         self.assertGreater(custom_plan.extent_height_deg, default_plan.extent_height_deg)
         self.assertAlmostEqual(custom_plan.extent_width_deg, 0.03)
         self.assertAlmostEqual(custom_plan.extent_height_deg, 0.03)
+        self.assertGreater(custom_plan.extent_width_m, default_plan.extent_width_m)
+        self.assertGreater(custom_plan.extent_height_m, default_plan.extent_height_m)
 
     def test_normalize_atlas_page_settings_clamps_invalid_values(self):
         settings = normalize_atlas_page_settings(margin_percent=-5, min_extent_degrees=0)
@@ -160,6 +167,20 @@ class PublishAtlasTests(unittest.TestCase):
         key = atlas_sort_key({"name": "  Lunch   Walk  "})
 
         self.assertEqual(key, "9999-12-31T23:59:59|lunch walk||")
+
+    def test_web_mercator_helpers_round_trip_reasonably(self):
+        x, y = lonlat_to_web_mercator(6.6323, 46.5197)
+        lon, lat = web_mercator_to_lonlat(x, y)
+
+        self.assertEqual(WEB_MERCATOR_EPSG, "EPSG:3857")
+        self.assertAlmostEqual(lon, 6.6323, places=5)
+        self.assertAlmostEqual(lat, 46.5197, places=5)
+
+    def test_web_mercator_helpers_clamp_polar_latitudes(self):
+        _, y = lonlat_to_web_mercator(0.0, 90.0)
+        _, lat = web_mercator_to_lonlat(0.0, y)
+
+        self.assertLessEqual(abs(lat), 85.05112878)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Web Mercator-ready atlas metadata for publish/layout workflows and align qfit's working QGIS CRS with EPSG:3857
- add an explicit background-map Load button and keep the basemap below qfit activity layers in the layer tree
- stop auto-applying dock subset filters during Write + Load so layer tables show the full synced dataset unless the user explicitly clicks Apply filters

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m py_compile publish_atlas.py gpkg_writer.py layer_manager.py qfit_dockwidget.py
- python3 scripts/package_plugin.py