### PR TITLE
feat: add atlas route profile metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 resources.py
 .coverage
 coverage.xml
+
+symbology-style.db

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The current implementation supports:
 - tuning atlas-page padding, minimum extent, and optional target aspect ratio directly from the plugin before rebuilding publish layers
 - generating atlas pages in a stable chronological order with page numbers and TOC-friendly labels for QGIS layouts
 - adding Web Mercator-ready atlas metadata (`center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`) for layout work in EPSG:3857
+- precomputing route-profile-ready atlas metadata (`profile_available`, sampled profile distance, min/max elevation, gain/loss) when detailed stream metrics are available
 - loading those layers directly into QGIS with EPSG:3857 as the working project/map CRS
 - adding an optional Mapbox background layer through saved plugin settings, with an explicit background-map Load button and basemap ordering kept below the activity layers
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
@@ -94,7 +95,7 @@ Visible layers:
 12. Use `Write + Load` to load the full qfit layers into QGIS without auto-applying dock subset filters to the layer tables
 13. Use `Apply filters` only when you want the current dock query to become an actual QGIS layer subset
 14. Optionally use `Load background map` to add or refresh the basemap underneath the qfit activity layers
-15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_distance_label`, `page_duration_label`, `center_x_3857`, `center_y_3857`, `extent_width_m`, and `extent_height_m` fields for layout text, overview tables, or Web Mercator layout logic
+15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_distance_label`, `page_duration_label`, `center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`, `profile_available`, `profile_distance_m`, `profile_min_altitude_m`, `profile_max_altitude_m`, `profile_elevation_gain_m`, and `profile_elevation_loss_m` fields for layout text, conditional profile frames, or Web Mercator layout logic
 
 ## Publish / atlas settings
 
@@ -105,6 +106,7 @@ The resulting atlas-page layer is intentionally more layout-ready than a raw ext
 - `page_sort_key` gives QGIS a deterministic sort field for atlas or TOC tables
 - `page_date`, `page_distance_label`, and `page_duration_label` reduce the need for layout expressions
 - `center_x_3857`, `center_y_3857`, `extent_width_m`, and `extent_height_m` make it easier to drive Web Mercator-oriented layout logic now that qfit uses EPSG:3857 as the working QGIS projection choice
+- `profile_available`, `profile_distance_m`, `profile_min_altitude_m`, `profile_max_altitude_m`, `profile_elevation_gain_m`, and `profile_elevation_loss_m` make it easier to conditionally show route-profile panels in layouts when sampled altitude/distance stream data exists
 
 Use it when you want to tune the eventual print-layout framing:
 - `Page margin (%)` adds extra space around each activity extent

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,6 +138,7 @@ Goal: configure and generate a PDF atlas with:
 ### In progress
 
 - Early atlas-generation groundwork is being explored in feature work
+- Atlas output now carries route-profile summary metadata when detailed stream metrics are available, making future profile panels/layout conditions easier to wire
 
 ### Planned
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - `activity_tracks` — one visible line feature per activity
 - `activity_starts` — one visible point per activity start
 - `activity_points` — optional sampled point layer derived from detailed stream geometry
-- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering, TOC-friendly labels, and Web Mercator-ready extent metadata
+- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering, TOC-friendly labels, Web Mercator-ready extent metadata, and route-profile summary fields when detailed streams are available
 
 ## Table: `activity_registry`
 
@@ -185,6 +185,7 @@ Primary purpose:
 - one padded extent polygon per activity with reusable title/subtitle fields
 - extent padding/minimum size controlled by the plugin's publish settings at write time
 - optional Web Mercator aspect-ratio fitting can widen/tallify the padded extent for more layout-consistent framing
+- route-profile summary fields give layouts a cheap way to decide whether to show an elevation chart and how to scale it before full PDF automation exists
 
 ### Current fields
 
@@ -207,6 +208,13 @@ Primary purpose:
 | `page_date` | TEXT | preformatted local/primary activity date for layout labels |
 | `page_distance_label` | TEXT | preformatted distance label such as `42.5 km` |
 | `page_duration_label` | TEXT | preformatted moving-time label such as `2h 00m` |
+| `profile_available` | INTEGER | `1` when the activity has enough sampled distance + altitude stream data for a route profile |
+| `profile_point_count` | INTEGER | number of usable sampled profile points contributing to the summary |
+| `profile_distance_m` | REAL | sampled profile length in meters based on the usable distance stream |
+| `profile_min_altitude_m` | REAL | minimum sampled elevation available to a future profile diagram |
+| `profile_max_altitude_m` | REAL | maximum sampled elevation available to a future profile diagram |
+| `profile_elevation_gain_m` | REAL | cumulative sampled climbing derived from consecutive altitude deltas |
+| `profile_elevation_loss_m` | REAL | cumulative sampled descent derived from consecutive altitude deltas |
 | `center_x_3857` | REAL | Web Mercator page center X for EPSG:3857 layouts |
 | `center_y_3857` | REAL | Web Mercator page center Y for EPSG:3857 layouts |
 | `extent_width_deg` | REAL | padded page width in degrees after the configured atlas margin/minimum extent rules |

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -111,6 +111,13 @@ ATLAS_FIELDS = [
     ("page_date", QVariant.String),
     ("page_distance_label", QVariant.String),
     ("page_duration_label", QVariant.String),
+    ("profile_available", QVariant.Int),
+    ("profile_point_count", QVariant.Int),
+    ("profile_distance_m", QVariant.Double),
+    ("profile_min_altitude_m", QVariant.Double),
+    ("profile_max_altitude_m", QVariant.Double),
+    ("profile_elevation_gain_m", QVariant.Double),
+    ("profile_elevation_loss_m", QVariant.Double),
     ("center_x_3857", QVariant.Double),
     ("center_y_3857", QVariant.Double),
     ("extent_width_deg", QVariant.Double),
@@ -374,6 +381,13 @@ class GeoPackageWriter:
             feature["page_date"] = plan.page_date
             feature["page_distance_label"] = plan.page_distance_label
             feature["page_duration_label"] = plan.page_duration_label
+            feature["profile_available"] = int(plan.profile_available)
+            feature["profile_point_count"] = plan.profile_point_count
+            feature["profile_distance_m"] = plan.profile_distance_m
+            feature["profile_min_altitude_m"] = plan.profile_min_altitude_m
+            feature["profile_max_altitude_m"] = plan.profile_max_altitude_m
+            feature["profile_elevation_gain_m"] = plan.profile_elevation_gain_m
+            feature["profile_elevation_loss_m"] = plan.profile_elevation_loss_m
             feature["center_x_3857"] = plan.center_x_3857
             feature["center_y_3857"] = plan.center_y_3857
             feature["extent_width_deg"] = plan.extent_width_deg

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.17.0
+version=0.18.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/publish_atlas.py
+++ b/publish_atlas.py
@@ -44,6 +44,13 @@ class AtlasPagePlan:
     page_date: str | None
     page_distance_label: str | None
     page_duration_label: str | None
+    profile_available: bool
+    profile_point_count: int
+    profile_distance_m: float | None
+    profile_min_altitude_m: float | None
+    profile_max_altitude_m: float | None
+    profile_elevation_gain_m: float | None
+    profile_elevation_loss_m: float | None
     min_lon: float
     min_lat: float
     max_lon: float
@@ -131,6 +138,7 @@ def build_atlas_page_plans(
         page_title = (record.get("name") or "Untitled activity").strip()
         page_name = build_page_name(record)
         page_subtitle = build_page_subtitle(record)
+        profile_summary = build_profile_summary(record)
         plans.append(
             AtlasPagePlan(
                 source=record.get("source"),
@@ -149,6 +157,13 @@ def build_atlas_page_plans(
                 page_date=format_activity_date(record.get("start_date_local") or record.get("start_date")),
                 page_distance_label=format_distance_label(record.get("distance_m")),
                 page_duration_label=format_duration_label(record.get("moving_time_s")),
+                profile_available=profile_summary.available,
+                profile_point_count=profile_summary.point_count,
+                profile_distance_m=profile_summary.distance_m,
+                profile_min_altitude_m=profile_summary.min_altitude_m,
+                profile_max_altitude_m=profile_summary.max_altitude_m,
+                profile_elevation_gain_m=profile_summary.elevation_gain_m,
+                profile_elevation_loss_m=profile_summary.elevation_loss_m,
                 min_lon=min_lon,
                 min_lat=min_lat,
                 max_lon=max_lon,
@@ -359,6 +374,64 @@ def build_page_subtitle(record: dict) -> str:
         parts.append(duration_label)
 
     return " · ".join(parts)
+
+
+@dataclass(frozen=True)
+class AtlasProfileSummary:
+    available: bool = False
+    point_count: int = 0
+    distance_m: float | None = None
+    min_altitude_m: float | None = None
+    max_altitude_m: float | None = None
+    elevation_gain_m: float | None = None
+    elevation_loss_m: float | None = None
+
+
+def build_profile_summary(record: dict) -> AtlasProfileSummary:
+    details_json = record.get("details_json") or {}
+    stream_metrics = details_json.get("stream_metrics") if isinstance(details_json, dict) else None
+    if not isinstance(stream_metrics, dict):
+        return AtlasProfileSummary()
+
+    altitude_values = stream_metrics.get("altitude")
+    distance_values = stream_metrics.get("distance")
+    if not isinstance(altitude_values, list) or not isinstance(distance_values, list):
+        return AtlasProfileSummary()
+
+    profile_points = []
+    for distance_value, altitude_value in zip(distance_values, altitude_values):
+        distance_m = _safe_float(distance_value)
+        altitude_m = _safe_float(altitude_value)
+        if distance_m is None or altitude_m is None:
+            continue
+        profile_points.append((distance_m, altitude_m))
+
+    if len(profile_points) < 2:
+        return AtlasProfileSummary()
+
+    profile_distance_m = profile_points[-1][0] - profile_points[0][0]
+    if profile_distance_m <= 0:
+        return AtlasProfileSummary()
+
+    altitudes = [altitude for _, altitude in profile_points]
+    elevation_gain_m = 0.0
+    elevation_loss_m = 0.0
+    for (_, previous_altitude), (_, current_altitude) in zip(profile_points, profile_points[1:]):
+        delta = current_altitude - previous_altitude
+        if delta > 0:
+            elevation_gain_m += delta
+        elif delta < 0:
+            elevation_loss_m += abs(delta)
+
+    return AtlasProfileSummary(
+        available=True,
+        point_count=len(profile_points),
+        distance_m=profile_distance_m,
+        min_altitude_m=min(altitudes),
+        max_altitude_m=max(altitudes),
+        elevation_gain_m=elevation_gain_m,
+        elevation_loss_m=elevation_loss_m,
+    )
 
 
 def format_activity_date(value: str | None) -> str | None:

--- a/scripts/package_plugin.py
+++ b/scripts/package_plugin.py
@@ -11,7 +11,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 DIST_DIR = ROOT / "dist"
 EXCLUDED_DIRS = {".git", "dist", "scripts", "docs", "__pycache__"}
 EXCLUDED_SUFFIXES = {".pyc", ".pyo", ".zip"}
-EXCLUDED_FILES = {".gitignore"}
+EXCLUDED_FILES = {".gitignore", "symbology-style.db"}
 
 
 def read_metadata() -> tuple[str, str]:

--- a/tests/test_publish_atlas.py
+++ b/tests/test_publish_atlas.py
@@ -7,6 +7,7 @@ from qfit.publish_atlas import (
     MIN_ALLOWED_ATLAS_TARGET_ASPECT_RATIO,
     WEB_MERCATOR_EPSG,
     activity_bounds,
+    build_profile_summary,
     atlas_sort_key,
     build_atlas_page_plans,
     build_page_name,
@@ -51,6 +52,9 @@ class PublishAtlasTests(unittest.TestCase):
         self.assertEqual(plan.page_date, "2026-03-18")
         self.assertEqual(plan.page_distance_label, "42.5 km")
         self.assertEqual(plan.page_duration_label, "2h 00m")
+        self.assertFalse(plan.profile_available)
+        self.assertEqual(plan.profile_point_count, 0)
+        self.assertIsNone(plan.profile_distance_m)
         self.assertTrue(plan.page_sort_key.startswith("2026-03-18T08:10:00+01:00|morning gravel ride|strava|101"))
         self.assertGreater(plan.extent_width_deg, 0.12)
         self.assertGreater(plan.extent_height_deg, 0.05)
@@ -130,6 +134,49 @@ class PublishAtlasTests(unittest.TestCase):
         self.assertAlmostEqual(plan.extent_width_m / plan.extent_height_m, 2.0, places=3)
         self.assertGreater(plan.extent_width_m, 0)
         self.assertGreater(plan.extent_height_m, 0)
+
+    def test_build_atlas_page_plans_includes_route_profile_metadata_when_stream_metrics_are_available(self):
+        records = [
+            {
+                "name": "Alpine Ride",
+                "activity_type": "Ride",
+                "distance_m": 34000,
+                "geometry_points": [(46.5000, 6.6000), (46.5300, 6.6600)],
+                "details_json": {
+                    "stream_metrics": {
+                        "distance": [0, 1000, 2000, 3000],
+                        "altitude": [500, 525, 510, 560],
+                    }
+                },
+            }
+        ]
+
+        plan = build_atlas_page_plans(records)[0]
+
+        self.assertTrue(plan.profile_available)
+        self.assertEqual(plan.profile_point_count, 4)
+        self.assertEqual(plan.profile_distance_m, 3000)
+        self.assertEqual(plan.profile_min_altitude_m, 500)
+        self.assertEqual(plan.profile_max_altitude_m, 560)
+        self.assertEqual(plan.profile_elevation_gain_m, 75)
+        self.assertEqual(plan.profile_elevation_loss_m, 15)
+
+    def test_build_profile_summary_ignores_invalid_or_incomplete_stream_metrics(self):
+        summary = build_profile_summary(
+            {
+                "details_json": {
+                    "stream_metrics": {
+                        "distance": [0, None, 500],
+                        "altitude": [400, 405, None],
+                    }
+                }
+            }
+        )
+
+        self.assertFalse(summary.available)
+        self.assertEqual(summary.point_count, 0)
+        self.assertIsNone(summary.distance_m)
+
 
     def test_normalize_atlas_page_settings_clamps_invalid_values(self):
         settings = normalize_atlas_page_settings(margin_percent=-5, min_extent_degrees=0, target_aspect_ratio=0.05)


### PR DESCRIPTION
## Summary
- add pure-Python atlas profile summarization from sampled distance/altitude stream metrics
- expose profile availability and elevation summary fields on `activity_atlas_pages` for future layout/profile wiring
- document the new publish metadata, bump qfit to 0.18.0, and keep packaging from scooping up local `symbology-style.db` artifacts

## Testing
- python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py