### PR TITLE
feat: add atlas profile labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The current implementation supports:
 - tuning atlas-page padding, minimum extent, and optional target aspect ratio directly from the plugin before rebuilding publish layers
 - generating atlas pages in a stable chronological order with page numbers and TOC-friendly labels for QGIS layouts
 - adding Web Mercator-ready atlas metadata (`center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`) for layout work in EPSG:3857
-- precomputing route-profile-ready atlas metadata (`profile_available`, sampled profile distance, min/max elevation, gain/loss) when detailed stream metrics are available
+- precomputing route-profile-ready atlas metadata (`profile_available`, sampled profile distance, min/max elevation, relief, gain/loss, and layout-friendly labels) when detailed stream metrics are available
 - loading those layers directly into QGIS with EPSG:3857 as the working project/map CRS
 - adding an optional Mapbox background layer through saved plugin settings, with an explicit background-map Load button and basemap ordering kept below the activity layers
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
@@ -95,7 +95,7 @@ Visible layers:
 12. Use `Write + Load` to load the full qfit layers into QGIS without auto-applying dock subset filters to the layer tables
 13. Use `Apply filters` only when you want the current dock query to become an actual QGIS layer subset
 14. Optionally use `Load background map` to add or refresh the basemap underneath the qfit activity layers
-15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_distance_label`, `page_duration_label`, `center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`, `profile_available`, `profile_distance_m`, `profile_min_altitude_m`, `profile_max_altitude_m`, `profile_elevation_gain_m`, and `profile_elevation_loss_m` fields for layout text, conditional profile frames, or Web Mercator layout logic
+15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_distance_label`, `page_duration_label`, `center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`, `profile_available`, `profile_distance_m`, `profile_distance_label`, `profile_altitude_range_label`, `profile_relief_m`, `profile_elevation_gain_m`, `profile_elevation_gain_label`, `profile_elevation_loss_m`, and `profile_elevation_loss_label` fields for layout text, conditional profile frames, or Web Mercator layout logic
 
 ## Publish / atlas settings
 
@@ -106,7 +106,7 @@ The resulting atlas-page layer is intentionally more layout-ready than a raw ext
 - `page_sort_key` gives QGIS a deterministic sort field for atlas or TOC tables
 - `page_date`, `page_distance_label`, and `page_duration_label` reduce the need for layout expressions
 - `center_x_3857`, `center_y_3857`, `extent_width_m`, and `extent_height_m` make it easier to drive Web Mercator-oriented layout logic now that qfit uses EPSG:3857 as the working QGIS projection choice
-- `profile_available`, `profile_distance_m`, `profile_min_altitude_m`, `profile_max_altitude_m`, `profile_elevation_gain_m`, and `profile_elevation_loss_m` make it easier to conditionally show route-profile panels in layouts when sampled altitude/distance stream data exists
+- `profile_available`, `profile_distance_m`, `profile_distance_label`, `profile_altitude_range_label`, `profile_relief_m`, `profile_elevation_gain_m`, `profile_elevation_gain_label`, `profile_elevation_loss_m`, and `profile_elevation_loss_label` make it easier to conditionally show route-profile panels in layouts when sampled altitude/distance stream data exists, without repeating basic label formatting in QGIS expressions
 
 Use it when you want to tune the eventual print-layout framing:
 - `Page margin (%)` adds extra space around each activity extent

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,7 +138,7 @@ Goal: configure and generate a PDF atlas with:
 ### In progress
 
 - Early atlas-generation groundwork is being explored in feature work
-- Atlas output now carries route-profile summary metadata when detailed stream metrics are available, making future profile panels/layout conditions easier to wire
+- Atlas output now carries route-profile summary metadata when detailed stream metrics are available, plus layout-friendly profile labels/relief for future profile panels and print layouts
 
 ### Planned
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - `activity_tracks` — one visible line feature per activity
 - `activity_starts` — one visible point per activity start
 - `activity_points` — optional sampled point layer derived from detailed stream geometry
-- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering, TOC-friendly labels, Web Mercator-ready extent metadata, and route-profile summary fields when detailed streams are available
+- `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering, TOC-friendly labels, Web Mercator-ready extent metadata, and route-profile summary/label fields when detailed streams are available
 
 ## Table: `activity_registry`
 
@@ -185,7 +185,7 @@ Primary purpose:
 - one padded extent polygon per activity with reusable title/subtitle fields
 - extent padding/minimum size controlled by the plugin's publish settings at write time
 - optional Web Mercator aspect-ratio fitting can widen/tallify the padded extent for more layout-consistent framing
-- route-profile summary fields give layouts a cheap way to decide whether to show an elevation chart and how to scale it before full PDF automation exists
+- route-profile summary and label fields give layouts a cheap way to decide whether to show an elevation chart and to reuse publish-friendly text without extra QGIS expression boilerplate before full PDF automation exists
 
 ### Current fields
 
@@ -211,10 +211,15 @@ Primary purpose:
 | `profile_available` | INTEGER | `1` when the activity has enough sampled distance + altitude stream data for a route profile |
 | `profile_point_count` | INTEGER | number of usable sampled profile points contributing to the summary |
 | `profile_distance_m` | REAL | sampled profile length in meters based on the usable distance stream |
+| `profile_distance_label` | TEXT | preformatted profile length such as `3.0 km` for layout text |
 | `profile_min_altitude_m` | REAL | minimum sampled elevation available to a future profile diagram |
 | `profile_max_altitude_m` | REAL | maximum sampled elevation available to a future profile diagram |
+| `profile_altitude_range_label` | TEXT | preformatted altitude span such as `500–560 m` |
+| `profile_relief_m` | REAL | simple max-minus-min altitude relief for profile scaling or legends |
 | `profile_elevation_gain_m` | REAL | cumulative sampled climbing derived from consecutive altitude deltas |
+| `profile_elevation_gain_label` | TEXT | preformatted climb label such as `75 m` |
 | `profile_elevation_loss_m` | REAL | cumulative sampled descent derived from consecutive altitude deltas |
+| `profile_elevation_loss_label` | TEXT | preformatted descent label such as `15 m` |
 | `center_x_3857` | REAL | Web Mercator page center X for EPSG:3857 layouts |
 | `center_y_3857` | REAL | Web Mercator page center Y for EPSG:3857 layouts |
 | `extent_width_deg` | REAL | padded page width in degrees after the configured atlas margin/minimum extent rules |

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -114,10 +114,15 @@ ATLAS_FIELDS = [
     ("profile_available", QVariant.Int),
     ("profile_point_count", QVariant.Int),
     ("profile_distance_m", QVariant.Double),
+    ("profile_distance_label", QVariant.String),
     ("profile_min_altitude_m", QVariant.Double),
     ("profile_max_altitude_m", QVariant.Double),
+    ("profile_altitude_range_label", QVariant.String),
+    ("profile_relief_m", QVariant.Double),
     ("profile_elevation_gain_m", QVariant.Double),
+    ("profile_elevation_gain_label", QVariant.String),
     ("profile_elevation_loss_m", QVariant.Double),
+    ("profile_elevation_loss_label", QVariant.String),
     ("center_x_3857", QVariant.Double),
     ("center_y_3857", QVariant.Double),
     ("extent_width_deg", QVariant.Double),
@@ -384,10 +389,15 @@ class GeoPackageWriter:
             feature["profile_available"] = int(plan.profile_available)
             feature["profile_point_count"] = plan.profile_point_count
             feature["profile_distance_m"] = plan.profile_distance_m
+            feature["profile_distance_label"] = plan.profile_distance_label
             feature["profile_min_altitude_m"] = plan.profile_min_altitude_m
             feature["profile_max_altitude_m"] = plan.profile_max_altitude_m
+            feature["profile_altitude_range_label"] = plan.profile_altitude_range_label
+            feature["profile_relief_m"] = plan.profile_relief_m
             feature["profile_elevation_gain_m"] = plan.profile_elevation_gain_m
+            feature["profile_elevation_gain_label"] = plan.profile_elevation_gain_label
             feature["profile_elevation_loss_m"] = plan.profile_elevation_loss_m
+            feature["profile_elevation_loss_label"] = plan.profile_elevation_loss_label
             feature["center_x_3857"] = plan.center_x_3857
             feature["center_y_3857"] = plan.center_y_3857
             feature["extent_width_deg"] = plan.extent_width_deg

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.18.0
+version=0.19.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/publish_atlas.py
+++ b/publish_atlas.py
@@ -47,10 +47,15 @@ class AtlasPagePlan:
     profile_available: bool
     profile_point_count: int
     profile_distance_m: float | None
+    profile_distance_label: str | None
     profile_min_altitude_m: float | None
     profile_max_altitude_m: float | None
+    profile_altitude_range_label: str | None
+    profile_relief_m: float | None
     profile_elevation_gain_m: float | None
+    profile_elevation_gain_label: str | None
     profile_elevation_loss_m: float | None
+    profile_elevation_loss_label: str | None
     min_lon: float
     min_lat: float
     max_lon: float
@@ -160,10 +165,18 @@ def build_atlas_page_plans(
                 profile_available=profile_summary.available,
                 profile_point_count=profile_summary.point_count,
                 profile_distance_m=profile_summary.distance_m,
+                profile_distance_label=format_distance_label(profile_summary.distance_m),
                 profile_min_altitude_m=profile_summary.min_altitude_m,
                 profile_max_altitude_m=profile_summary.max_altitude_m,
+                profile_altitude_range_label=format_altitude_range_label(
+                    profile_summary.min_altitude_m,
+                    profile_summary.max_altitude_m,
+                ),
+                profile_relief_m=profile_summary.relief_m,
                 profile_elevation_gain_m=profile_summary.elevation_gain_m,
+                profile_elevation_gain_label=format_elevation_label(profile_summary.elevation_gain_m),
                 profile_elevation_loss_m=profile_summary.elevation_loss_m,
+                profile_elevation_loss_label=format_elevation_label(profile_summary.elevation_loss_m),
                 min_lon=min_lon,
                 min_lat=min_lat,
                 max_lon=max_lon,
@@ -383,6 +396,7 @@ class AtlasProfileSummary:
     distance_m: float | None = None
     min_altitude_m: float | None = None
     max_altitude_m: float | None = None
+    relief_m: float | None = None
     elevation_gain_m: float | None = None
     elevation_loss_m: float | None = None
 
@@ -423,12 +437,15 @@ def build_profile_summary(record: dict) -> AtlasProfileSummary:
         elif delta < 0:
             elevation_loss_m += abs(delta)
 
+    min_altitude_m = min(altitudes)
+    max_altitude_m = max(altitudes)
     return AtlasProfileSummary(
         available=True,
         point_count=len(profile_points),
         distance_m=profile_distance_m,
-        min_altitude_m=min(altitudes),
-        max_altitude_m=max(altitudes),
+        min_altitude_m=min_altitude_m,
+        max_altitude_m=max_altitude_m,
+        relief_m=max_altitude_m - min_altitude_m,
         elevation_gain_m=elevation_gain_m,
         elevation_loss_m=elevation_loss_m,
     )
@@ -455,6 +472,21 @@ def format_duration_label(value) -> str | None:
     if moving_time_s is None:
         return None
     return format_duration(moving_time_s)
+
+
+def format_elevation_label(value) -> str | None:
+    elevation_m = _safe_float(value)
+    if elevation_m is None:
+        return None
+    return f"{round(elevation_m):.0f} m"
+
+
+def format_altitude_range_label(min_value, max_value) -> str | None:
+    min_altitude_m = _safe_float(min_value)
+    max_altitude_m = _safe_float(max_value)
+    if min_altitude_m is None or max_altitude_m is None:
+        return None
+    return f"{round(min_altitude_m):.0f}–{round(max_altitude_m):.0f} m"
 
 
 def _safe_float(value) -> float | None:

--- a/tests/test_publish_atlas.py
+++ b/tests/test_publish_atlas.py
@@ -15,8 +15,10 @@ from qfit.publish_atlas import (
     ensure_minimum_extent,
     expand_bounds,
     fit_bounds_to_target_aspect_ratio,
+    format_altitude_range_label,
     format_distance_label,
     format_duration_label,
+    format_elevation_label,
     lonlat_bounds_to_web_mercator,
     lonlat_to_web_mercator,
     normalize_atlas_page_settings,
@@ -156,10 +158,15 @@ class PublishAtlasTests(unittest.TestCase):
         self.assertTrue(plan.profile_available)
         self.assertEqual(plan.profile_point_count, 4)
         self.assertEqual(plan.profile_distance_m, 3000)
+        self.assertEqual(plan.profile_distance_label, "3.0 km")
         self.assertEqual(plan.profile_min_altitude_m, 500)
         self.assertEqual(plan.profile_max_altitude_m, 560)
+        self.assertEqual(plan.profile_altitude_range_label, "500–560 m")
+        self.assertEqual(plan.profile_relief_m, 60)
         self.assertEqual(plan.profile_elevation_gain_m, 75)
+        self.assertEqual(plan.profile_elevation_gain_label, "75 m")
         self.assertEqual(plan.profile_elevation_loss_m, 15)
+        self.assertEqual(plan.profile_elevation_loss_label, "15 m")
 
     def test_build_profile_summary_ignores_invalid_or_incomplete_stream_metrics(self):
         summary = build_profile_summary(
@@ -235,6 +242,12 @@ class PublishAtlasTests(unittest.TestCase):
         self.assertEqual(build_page_subtitle(record), "Walk")
         self.assertIsNone(format_distance_label(None))
         self.assertIsNone(format_duration_label(None))
+        self.assertIsNone(format_elevation_label(None))
+        self.assertIsNone(format_altitude_range_label(None, 550))
+
+    def test_profile_label_helpers_round_values_for_layout_text(self):
+        self.assertEqual(format_elevation_label(123.6), "124 m")
+        self.assertEqual(format_altitude_range_label(501.2, 559.8), "501–560 m")
 
     def test_atlas_sort_key_normalizes_missing_values(self):
         key = atlas_sort_key({"name": "  Lunch   Walk  "})


### PR DESCRIPTION
## Summary
- add layout-friendly route profile labels and relief metadata to atlas page plans
- persist the new profile label fields into `activity_atlas_pages`
- document the new atlas fields, bump plugin version to 0.19.0, and cover the formatting helpers with unit tests

## Testing
- python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py
