### PR TITLE
feat: add atlas document summary table

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The current implementation supports:
 - precomputing route-profile-ready atlas metadata (`profile_available`, sampled profile distance, min/max elevation, relief, gain/loss, and layout-friendly labels) when detailed stream metrics are available
 - exposing publish-friendly detail labels on atlas pages (`page_toc_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, `page_profile_summary`) so layouts can show activity stats with less expression boilerplate
 - stamping atlas-document / cover-ready summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) onto every atlas page so QGIS layouts can reuse them directly
+- writing an `atlas_document_summary` helper table with the atlas-wide totals and labels as a single row for cover/TOC layouts that prefer a dedicated document summary source
 - loading those layers directly into QGIS with EPSG:3857 as the working project/map CRS
 - adding an optional Mapbox background layer through saved plugin settings, with an explicit background-map Load button and basemap ordering kept below the activity layers
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
@@ -46,6 +47,7 @@ Visible layers:
 - `activity_starts` — start-point layer
 - `activity_points` — optional sampled point layer derived from detailed streams, with per-point stream metrics and derived timestamps when available
 - `activity_atlas_pages` — polygon layer of atlas/page extents with titles/subtitles plus page numbers and TOC-friendly labels for QGIS print layouts
+- `atlas_document_summary` — single-row helper table with atlas-wide totals/labels for cover and table-of-contents layouts
 
 ## Planned next expansions
 
@@ -97,7 +99,8 @@ Visible layers:
 12. Use `Write + Load` to load the full qfit layers into QGIS without auto-applying dock subset filters to the layer tables
 13. Use `Apply filters` only when you want the current dock query to become an actual QGIS layer subset
 14. Optionally use `Load background map` to add or refresh the basemap underneath the qfit activity layers
-15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_toc_label`, `page_distance_label`, `page_duration_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, `page_profile_summary`, `document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`, `center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`, `profile_available`, `profile_distance_m`, `profile_distance_label`, `profile_altitude_range_label`, `profile_relief_m`, `profile_elevation_gain_m`, `profile_elevation_gain_label`, `profile_elevation_loss_m`, and `profile_elevation_loss_label` fields for layout text, conditional profile frames, cover/TOC summaries, or Web Mercator layout logic
+15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_toc_label`, `page_distance_label`, `page_duration_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, `page_profile_summary`, `document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`, `center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`, `profile_available`, `profile_distance_m`, `profile_distance_label`, `profile_altitude_range_label`, `profile_relief_m`, `profile_elevation_gain_m`, `profile_elevation_gain_label`, and `profile_elevation_loss_label` fields for layout text, conditional profile frames, cover/TOC summaries, or Web Mercator layout logic
+16. If you want a single atlas-wide record for a cover page or table-of-contents layout, read the new `atlas_document_summary` table from the GeoPackage and reuse its `activity_count`, `date_range_label`, `total_distance_label`, `total_duration_label`, `total_elevation_gain_label`, `activity_types_label`, and `cover_summary` fields directly
 
 ## Publish / atlas settings
 
@@ -107,7 +110,8 @@ The resulting atlas-page layer is intentionally more layout-ready than a raw ext
 - pages are ordered chronologically with a stable `page_number`
 - `page_sort_key` gives QGIS a deterministic sort field for atlas or TOC tables
 - `page_date`, `page_toc_label`, `page_distance_label`, `page_duration_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, and `page_profile_summary` reduce the need for layout expressions
-- document-level summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) are repeated on every atlas page so cover/TOC layouts can reuse atlas-wide totals without a separate helper table
+- document-level summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) are still repeated on every atlas page for simple per-page layout expressions
+- the GeoPackage now also includes an `atlas_document_summary` table with a single atlas-wide summary row when you prefer a dedicated cover/TOC data source
 - `center_x_3857`, `center_y_3857`, `extent_width_m`, and `extent_height_m` make it easier to drive Web Mercator-oriented layout logic now that qfit uses EPSG:3857 as the working QGIS projection choice
 - `profile_available`, `profile_distance_m`, `profile_distance_label`, `profile_altitude_range_label`, `profile_relief_m`, `profile_elevation_gain_m`, `profile_elevation_gain_label`, `profile_elevation_loss_m`, and `profile_elevation_loss_label` make it easier to conditionally show route-profile panels in layouts when sampled altitude/distance stream data exists, without repeating basic label formatting in QGIS expressions
 

--- a/docs/qgis-testing.md
+++ b/docs/qgis-testing.md
@@ -11,7 +11,7 @@ python3 -m unittest tests.test_qgis_smoke -v
 ```
 
 What it checks:
-- writing a sample qfit GeoPackage with tracks, starts, points, and atlas pages
+- writing a sample qfit GeoPackage with tracks, starts, points, atlas pages, and the atlas document-summary table
 - loading those layers back into a live `QgsProject`
 - enforcing qfit's working CRS (`EPSG:3857`) on the project/canvas
 - wiring temporal playback expressions onto loaded layers

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -139,7 +139,7 @@ Goal: configure and generate a PDF atlas with:
 
 - Early atlas-generation groundwork is being explored in feature work
 - Atlas output now carries route-profile summary metadata when detailed stream metrics are available, plus layout-friendly profile labels/relief for future profile panels and print layouts
-- Atlas planning helpers now also compute cover-ready document summary totals (activity count, date span, totals, activity types, one-line summary text) to support future cover/TOC layouts
+- Atlas planning helpers now also compute cover-ready document summary totals (activity count, date span, totals, activity types, one-line summary text) and the GeoPackage now exposes them through a dedicated `atlas_document_summary` helper table for cover/TOC layouts
 
 ### Planned
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,6 +23,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - `activity_starts` — one visible point per activity start
 - `activity_points` — optional sampled point layer derived from detailed stream geometry
 - `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering, TOC-friendly labels, publish-friendly detail labels/summary text, repeated document-summary fields for cover/TOC layouts, Web Mercator-ready extent metadata, and route-profile summary/label fields when detailed streams are available
+- `atlas_document_summary` — non-spatial single-row helper table carrying atlas-wide totals and cover/TOC-ready labels for layouts that prefer a dedicated document-summary source
 
 ## Table: `activity_registry`
 
@@ -186,7 +187,8 @@ Primary purpose:
 - extent padding/minimum size controlled by the plugin's publish settings at write time
 - optional Web Mercator aspect-ratio fitting can widen/tallify the padded extent for more layout-consistent framing
 - publish-friendly detail labels (`page_toc_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`) plus `page_stats_summary` and `page_profile_summary` reduce per-layout expression boilerplate for per-activity stat blocks
-- repeated document-summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) let cover/TOC layouts reuse atlas-wide totals without introducing a separate summary table yet
+- repeated document-summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) still make it easy for per-page layout expressions to reuse atlas-wide totals
+- the companion `atlas_document_summary` table now provides the same atlas-wide totals/labels as a dedicated single-row source for cover and table-of-contents layouts
 - route-profile summary and label fields give layouts a cheap way to decide whether to show an elevation chart and to reuse publish-friendly text without extra QGIS expression boilerplate before full PDF automation exists
 
 ### Current fields
@@ -242,6 +244,32 @@ Primary purpose:
 | `extent_width_m` | REAL | padded page width in Web Mercator meters |
 | `extent_height_m` | REAL | padded page height in Web Mercator meters |
 
+## Table: `atlas_document_summary`
+
+Geometry type:
+- none
+
+Primary purpose:
+- store atlas-wide totals and cover/TOC-ready labels as a dedicated single-row helper table
+- give QGIS print layouts a clean document-summary source without forcing cover pages to read repeated values from an arbitrary atlas polygon feature
+
+### Current fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `activity_count` | INTEGER | number of atlas pages / usable activities included in the atlas summary |
+| `activity_date_start` | TEXT | first atlas activity date such as `2026-03-18` |
+| `activity_date_end` | TEXT | last atlas activity date such as `2026-03-20` |
+| `date_range_label` | TEXT | preformatted date span such as `2026-03-18 → 2026-03-20` |
+| `total_distance_m` | REAL | total atlas distance in meters |
+| `total_distance_label` | TEXT | preformatted total distance such as `82.6 km` |
+| `total_moving_time_s` | INTEGER | total atlas moving time in seconds |
+| `total_duration_label` | TEXT | preformatted total duration such as `4h 20m` |
+| `total_elevation_gain_m` | REAL | total atlas elevation gain in meters |
+| `total_elevation_gain_label` | TEXT | preformatted total climb such as `1145 m` |
+| `activity_types_label` | TEXT | ordered activity-type list such as `Ride, Run` |
+| `cover_summary` | TEXT | one-line cover summary such as `3 activities · 2026-03-18 → 2026-03-20 · 82.6 km · 4h 20m · ↑ 1145 m · Ride, Run` |
+
 ## Geometry priority
 
 When rebuilding visible layers, qfit currently prefers geometry in this order:
@@ -255,7 +283,7 @@ When rebuilding visible layers, qfit currently prefers geometry in this order:
 2. optionally enrich activities with detailed stream geometry and extra stream metrics
 3. upsert activities into `activity_registry`
 4. update `sync_state`
-5. rebuild `activity_tracks`, `activity_starts`, `activity_atlas_pages`, and optionally `activity_points`
+5. rebuild `activity_tracks`, `activity_starts`, `activity_atlas_pages`, `atlas_document_summary`, and optionally `activity_points`
 6. load those layers into QGIS
 
 ## Next phase

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -16,7 +16,12 @@ from qgis.core import (
 )
 
 from .polyline_utils import decode_polyline
-from .publish_atlas import build_atlas_page_plans, normalize_atlas_page_settings
+from .publish_atlas import (
+    activity_bounds,
+    build_atlas_document_summary,
+    build_atlas_page_plans,
+    normalize_atlas_page_settings,
+)
 from .sync_repository import REGISTRY_TABLE, SYNC_STATE_TABLE, SyncRepository
 from .time_utils import add_seconds_iso
 
@@ -144,6 +149,21 @@ ATLAS_FIELDS = [
     ("extent_height_m", QVariant.Double),
 ]
 
+DOCUMENT_SUMMARY_FIELDS = [
+    ("activity_count", QVariant.Int),
+    ("activity_date_start", QVariant.String),
+    ("activity_date_end", QVariant.String),
+    ("date_range_label", QVariant.String),
+    ("total_distance_m", QVariant.Double),
+    ("total_distance_label", QVariant.String),
+    ("total_moving_time_s", QVariant.Int),
+    ("total_duration_label", QVariant.String),
+    ("total_elevation_gain_m", QVariant.Double),
+    ("total_elevation_gain_label", QVariant.String),
+    ("activity_types_label", QVariant.String),
+    ("cover_summary", QVariant.String),
+]
+
 
 class GeoPackageWriter:
     """Persist qfit sync data to a GeoPackage and rebuild derived visualization layers."""
@@ -198,6 +218,11 @@ class GeoPackageWriter:
                 "kind": "layer",
                 "fields": [name for name, _ in ATLAS_FIELDS],
             },
+            "atlas_document_summary": {
+                "geometry": None,
+                "kind": "table",
+                "fields": [name for name, _ in DOCUMENT_SUMMARY_FIELDS],
+            },
         }
 
     def write_activities(self, activities, sync_metadata=None):
@@ -212,6 +237,7 @@ class GeoPackageWriter:
             self._write_layer(self._build_start_layer([]), "activity_starts", overwrite_file=False)
             self._write_layer(self._build_point_layer([]), "activity_points", overwrite_file=False)
             self._write_layer(self._build_atlas_layer([]), "activity_atlas_pages", overwrite_file=False)
+            self._write_layer(self._build_document_summary_layer([]), "atlas_document_summary", overwrite_file=False)
 
         repository.ensure_schema()
         sync_result = repository.upsert_activities(activities, sync_metadata=sync_metadata)
@@ -221,10 +247,12 @@ class GeoPackageWriter:
         start_layer = self._build_start_layer(records)
         point_layer = self._build_point_layer(records)
         atlas_layer = self._build_atlas_layer(records)
+        document_summary_layer = self._build_document_summary_layer(records)
         self._write_layer(track_layer, "activity_tracks", overwrite_file=False)
         self._write_layer(start_layer, "activity_starts", overwrite_file=False)
         self._write_layer(point_layer, "activity_points", overwrite_file=False)
         self._write_layer(atlas_layer, "activity_atlas_pages", overwrite_file=False)
+        self._write_layer(document_summary_layer, "atlas_document_summary", overwrite_file=False)
 
         return {
             "schema": self.schema(),
@@ -234,6 +262,7 @@ class GeoPackageWriter:
             "start_count": start_layer.featureCount(),
             "point_count": point_layer.featureCount(),
             "atlas_count": atlas_layer.featureCount(),
+            "document_summary_count": document_summary_layer.featureCount(),
             "sync": sync_result,
         }
 
@@ -433,6 +462,41 @@ class GeoPackageWriter:
             features.append(feature)
 
         provider.addFeatures(features)
+        layer.updateExtents()
+        return layer
+
+    def _build_document_summary_layer(self, records):
+        layer = QgsVectorLayer("None", "atlas_document_summary", "memory")
+        provider = layer.dataProvider()
+        provider.addAttributes(self._make_fields(DOCUMENT_SUMMARY_FIELDS))
+        layer.updateFields()
+
+        atlas_records = []
+        for record in records:
+            bounds, _ = activity_bounds(
+                record,
+                min_extent_degrees=self.atlas_page_settings.min_extent_degrees,
+            )
+            if bounds is not None:
+                atlas_records.append(record)
+
+        summary = build_atlas_document_summary(atlas_records)
+        if summary.activity_count > 0:
+            feature = QgsFeature(layer.fields())
+            feature["activity_count"] = summary.activity_count
+            feature["activity_date_start"] = summary.activity_date_start
+            feature["activity_date_end"] = summary.activity_date_end
+            feature["date_range_label"] = summary.date_range_label
+            feature["total_distance_m"] = summary.total_distance_m
+            feature["total_distance_label"] = summary.total_distance_label
+            feature["total_moving_time_s"] = summary.total_moving_time_s
+            feature["total_duration_label"] = summary.total_duration_label
+            feature["total_elevation_gain_m"] = summary.total_elevation_gain_m
+            feature["total_elevation_gain_label"] = summary.total_elevation_gain_label
+            feature["activity_types_label"] = summary.activity_types_label
+            feature["cover_summary"] = summary.cover_summary
+            provider.addFeature(feature)
+
         layer.updateExtents()
         return layer
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.25.0
+version=0.26.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/tests/test_gpkg_writer.py
+++ b/tests/test_gpkg_writer.py
@@ -35,32 +35,31 @@ class GeoPackageWriterAtlasTests(unittest.TestCase):
 
     def test_build_atlas_layer_includes_document_summary_fields(self):
         writer = GeoPackageWriter(output_path="/tmp/qfit-test.gpkg")
-        layer = writer._build_atlas_layer(
-            [
-                {
-                    "source": "strava",
-                    "source_activity_id": "100",
-                    "name": "Morning Ride",
-                    "activity_type": "Ride",
-                    "start_date_local": "2026-03-18T08:10:00+01:00",
-                    "distance_m": 42500,
-                    "moving_time_s": 7200,
-                    "total_elevation_gain_m": 640,
-                    "geometry_points": [(46.52, 6.62), (46.57, 6.74)],
-                },
-                {
-                    "source": "strava",
-                    "source_activity_id": "200",
-                    "name": "Lunch Run",
-                    "activity_type": "Run",
-                    "start_date_local": "2026-03-19T12:00:00+01:00",
-                    "distance_m": 10100,
-                    "moving_time_s": 3000,
-                    "total_elevation_gain_m": 85,
-                    "geometry_points": [(46.50, 6.60), (46.51, 6.62)],
-                },
-            ]
-        )
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "100",
+                "name": "Morning Ride",
+                "activity_type": "Ride",
+                "start_date_local": "2026-03-18T08:10:00+01:00",
+                "distance_m": 42500,
+                "moving_time_s": 7200,
+                "total_elevation_gain_m": 640,
+                "geometry_points": [(46.52, 6.62), (46.57, 6.74)],
+            },
+            {
+                "source": "strava",
+                "source_activity_id": "200",
+                "name": "Lunch Run",
+                "activity_type": "Run",
+                "start_date_local": "2026-03-19T12:00:00+01:00",
+                "distance_m": 10100,
+                "moving_time_s": 3000,
+                "total_elevation_gain_m": 85,
+                "geometry_points": [(46.50, 6.60), (46.51, 6.62)],
+            },
+        ]
+        layer = writer._build_atlas_layer(records)
 
         self.assertTrue(layer.isValid())
         self.assertEqual(layer.featureCount(), 2)
@@ -76,6 +75,28 @@ class GeoPackageWriterAtlasTests(unittest.TestCase):
         self.assertEqual(first_feature["document_activity_types_label"], "Ride, Run")
         self.assertEqual(
             first_feature["document_cover_summary"],
+            "2 activities · 2026-03-18 → 2026-03-19 · 52.6 km · 2h 50m · ↑ 725 m · Ride, Run",
+        )
+
+        summary_layer = writer._build_document_summary_layer(records)
+        self.assertTrue(summary_layer.isValid())
+        self.assertEqual(summary_layer.featureCount(), 1)
+        self.assertGreaterEqual(summary_layer.fields().indexOf("cover_summary"), 0)
+
+        summary_feature = next(summary_layer.getFeatures())
+        self.assertEqual(summary_feature["activity_count"], 2)
+        self.assertEqual(summary_feature["activity_date_start"], "2026-03-18")
+        self.assertEqual(summary_feature["activity_date_end"], "2026-03-19")
+        self.assertEqual(summary_feature["date_range_label"], "2026-03-18 → 2026-03-19")
+        self.assertEqual(summary_feature["total_distance_m"], 52600.0)
+        self.assertEqual(summary_feature["total_distance_label"], "52.6 km")
+        self.assertEqual(summary_feature["total_moving_time_s"], 10200)
+        self.assertEqual(summary_feature["total_duration_label"], "2h 50m")
+        self.assertEqual(summary_feature["total_elevation_gain_m"], 725.0)
+        self.assertEqual(summary_feature["total_elevation_gain_label"], "725 m")
+        self.assertEqual(summary_feature["activity_types_label"], "Ride, Run")
+        self.assertEqual(
+            summary_feature["cover_summary"],
             "2 activities · 2026-03-18 → 2026-03-19 · 52.6 km · 2h 50m · ↑ 725 m · Ride, Run",
         )
 

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -8,7 +8,7 @@ from tests import _path  # noqa: F401
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
-    from qgis.core import QgsApplication, QgsProject
+    from qgis.core import QgsApplication, QgsProject, QgsVectorLayer
 
     from qfit.gpkg_writer import GeoPackageWriter
     from qfit.layer_manager import LayerManager
@@ -18,6 +18,7 @@ try:
 except Exception as exc:  # pragma: no cover - exercised only when QGIS is unavailable
     QgsApplication = None
     QgsProject = None
+    QgsVectorLayer = None
     GeoPackageWriter = None
     LayerManager = None
     QGIS_AVAILABLE = False
@@ -93,6 +94,20 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(result["start_count"], 2)
             self.assertGreaterEqual(result["point_count"], 4)
             self.assertEqual(result["atlas_count"], 2)
+            self.assertEqual(result["document_summary_count"], 1)
+
+            document_summary_layer = QgsVectorLayer(
+                f"{output_path}|layername=atlas_document_summary",
+                "qfit atlas document summary",
+                "ogr",
+            )
+            self.assertTrue(document_summary_layer.isValid())
+            self.assertEqual(document_summary_layer.featureCount(), 1)
+            document_summary_feature = next(document_summary_layer.getFeatures())
+            self.assertEqual(document_summary_feature["activity_count"], 2)
+            self.assertEqual(document_summary_feature["date_range_label"], "2026-03-20 → 2026-03-21")
+            self.assertEqual(document_summary_feature["total_distance_label"], "35.3 km")
+            self.assertIn("2 activities · 2026-03-20 → 2026-03-21 · 35.3 km · 1h 50m · ↑ 405 m", document_summary_feature["cover_summary"])
 
             background = self.layer_manager.ensure_background_layer(True, "Outdoor", "test-token")
             background_name = background.name()


### PR DESCRIPTION
## Summary
- add an `atlas_document_summary` GeoPackage table with a single atlas-wide cover/TOC summary row
- keep `activity_atlas_pages` as-is while giving layouts a dedicated non-spatial summary source
- cover the new table in PyQGIS tests, update docs, and bump plugin metadata to 0.26.0

## Testing
- python3 -m unittest discover -s tests -v
- QT_QPA_PLATFORM=offscreen python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py
- python3 scripts/install_plugin.py --profile default --mode symlink
