### PR TITLE
feat: add atlas toc helper table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The current implementation supports:
 - exposing publish-friendly detail labels on atlas pages (`page_toc_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, `page_profile_summary`) so layouts can show activity stats with less expression boilerplate
 - stamping atlas-document / cover-ready summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) onto every atlas page so QGIS layouts can reuse them directly
 - writing an `atlas_document_summary` helper table with the atlas-wide totals and labels as a single row for cover/TOC layouts that prefer a dedicated document summary source
+- writing an `atlas_toc_entries` helper table with one row per atlas page so QGIS table-of-contents layouts can bind to a clean non-spatial TOC source instead of the atlas polygons
 - loading those layers directly into QGIS with EPSG:3857 as the working project/map CRS
 - adding an optional Mapbox background layer through saved plugin settings, with an explicit background-map Load button and basemap ordering kept below the activity layers
 - filtering by activity type, activity-name search, date range, minimum/maximum distance, and detailed-stream availability
@@ -48,6 +49,7 @@ Visible layers:
 - `activity_points` — optional sampled point layer derived from detailed streams, with per-point stream metrics and derived timestamps when available
 - `activity_atlas_pages` — polygon layer of atlas/page extents with titles/subtitles plus page numbers and TOC-friendly labels for QGIS print layouts
 - `atlas_document_summary` — single-row helper table with atlas-wide totals/labels for cover and table-of-contents layouts
+- `atlas_toc_entries` — one-row-per-page helper table with TOC-ready labels for print-layout tables and cover/contents compositions
 
 ## Planned next expansions
 
@@ -100,7 +102,8 @@ Visible layers:
 13. Use `Apply filters` only when you want the current dock query to become an actual QGIS layer subset
 14. Optionally use `Load background map` to add or refresh the basemap underneath the qfit activity layers
 15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_toc_label`, `page_distance_label`, `page_duration_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, `page_profile_summary`, `document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`, `center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`, `profile_available`, `profile_distance_m`, `profile_distance_label`, `profile_altitude_range_label`, `profile_relief_m`, `profile_elevation_gain_m`, `profile_elevation_gain_label`, and `profile_elevation_loss_label` fields for layout text, conditional profile frames, cover/TOC summaries, or Web Mercator layout logic
-16. If you want a single atlas-wide record for a cover page or table-of-contents layout, read the new `atlas_document_summary` table from the GeoPackage and reuse its `activity_count`, `date_range_label`, `total_distance_label`, `total_duration_label`, `total_elevation_gain_label`, `activity_types_label`, and `cover_summary` fields directly
+16. If you want a single atlas-wide record for a cover page or table-of-contents layout, read the `atlas_document_summary` table from the GeoPackage and reuse its `activity_count`, `date_range_label`, `total_distance_label`, `total_duration_label`, `total_elevation_gain_label`, `activity_types_label`, and `cover_summary` fields directly
+17. If you want a clean per-page table source for a QGIS contents page, use the `atlas_toc_entries` table and bind a layout table or labels to its `page_number`, `page_number_label`, `page_toc_label`, `toc_entry_label`, `page_stats_summary`, and `page_profile_summary` fields instead of reading those values from the atlas polygons
 
 ## Publish / atlas settings
 
@@ -112,6 +115,7 @@ The resulting atlas-page layer is intentionally more layout-ready than a raw ext
 - `page_date`, `page_toc_label`, `page_distance_label`, `page_duration_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, and `page_profile_summary` reduce the need for layout expressions
 - document-level summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) are still repeated on every atlas page for simple per-page layout expressions
 - the GeoPackage now also includes an `atlas_document_summary` table with a single atlas-wide summary row when you prefer a dedicated cover/TOC data source
+- the new `atlas_toc_entries` table gives TOC layouts a clean non-spatial row source with page-number labels and preformatted entry text, so simple contents pages do not need to read from atlas polygons or rebuild numbering logic in expressions
 - `center_x_3857`, `center_y_3857`, `extent_width_m`, and `extent_height_m` make it easier to drive Web Mercator-oriented layout logic now that qfit uses EPSG:3857 as the working QGIS projection choice
 - `profile_available`, `profile_distance_m`, `profile_distance_label`, `profile_altitude_range_label`, `profile_relief_m`, `profile_elevation_gain_m`, `profile_elevation_gain_label`, `profile_elevation_loss_m`, and `profile_elevation_loss_label` make it easier to conditionally show route-profile panels in layouts when sampled altitude/distance stream data exists, without repeating basic label formatting in QGIS expressions
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -140,6 +140,7 @@ Goal: configure and generate a PDF atlas with:
 - Early atlas-generation groundwork is being explored in feature work
 - Atlas output now carries route-profile summary metadata when detailed stream metrics are available, plus layout-friendly profile labels/relief for future profile panels and print layouts
 - Atlas planning helpers now also compute cover-ready document summary totals (activity count, date span, totals, activity types, one-line summary text) and the GeoPackage now exposes them through a dedicated `atlas_document_summary` helper table for cover/TOC layouts
+- The GeoPackage now also includes an `atlas_toc_entries` helper table with one non-spatial row per atlas page so QGIS contents-page tables can bind to clean TOC data without depending on atlas polygons
 
 ### Planned
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -24,6 +24,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - `activity_points` — optional sampled point layer derived from detailed stream geometry
 - `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering, TOC-friendly labels, publish-friendly detail labels/summary text, repeated document-summary fields for cover/TOC layouts, Web Mercator-ready extent metadata, and route-profile summary/label fields when detailed streams are available
 - `atlas_document_summary` — non-spatial single-row helper table carrying atlas-wide totals and cover/TOC-ready labels for layouts that prefer a dedicated document-summary source
+- `atlas_toc_entries` — non-spatial one-row-per-page helper table carrying page-number labels plus TOC-ready text/summary fields for contents layouts that should not depend on atlas polygon geometry
 
 ## Table: `activity_registry`
 
@@ -189,6 +190,7 @@ Primary purpose:
 - publish-friendly detail labels (`page_toc_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`) plus `page_stats_summary` and `page_profile_summary` reduce per-layout expression boilerplate for per-activity stat blocks
 - repeated document-summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) still make it easy for per-page layout expressions to reuse atlas-wide totals
 - the companion `atlas_document_summary` table now provides the same atlas-wide totals/labels as a dedicated single-row source for cover and table-of-contents layouts
+- the companion `atlas_toc_entries` table now provides one clean non-spatial row per atlas page, with page-number labels and preformatted TOC entry text for contents-page tables
 - route-profile summary and label fields give layouts a cheap way to decide whether to show an elevation chart and to reuse publish-friendly text without extra QGIS expression boilerplate before full PDF automation exists
 
 ### Current fields
@@ -270,6 +272,34 @@ Primary purpose:
 | `activity_types_label` | TEXT | ordered activity-type list such as `Ride, Run` |
 | `cover_summary` | TEXT | one-line cover summary such as `3 activities · 2026-03-18 → 2026-03-20 · 82.6 km · 4h 20m · ↑ 1145 m · Ride, Run` |
 
+## Table: `atlas_toc_entries`
+
+Geometry type:
+- none
+
+Primary purpose:
+- store one row per atlas page for TOC/layout tables without depending on atlas polygon geometry
+- give QGIS print layouts page-number labels plus preformatted TOC entry text and per-page summary fields
+
+### Current fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `page_number` | INTEGER | stable chronological page number matching `activity_atlas_pages.page_number` |
+| `page_number_label` | TEXT | preformatted page number label such as `1` |
+| `page_sort_key` | TEXT | deterministic sort key matching the atlas-page layer |
+| `page_name` | TEXT | atlas-friendly page label such as `2026-03-18 · Morning Ride` |
+| `page_title` | TEXT | large-title label copied from the atlas page |
+| `page_subtitle` | TEXT | compact detail line copied from the atlas page |
+| `page_date` | TEXT | preformatted page date for contents layouts |
+| `page_toc_label` | TEXT | preformatted TOC-ready line such as `2026-03-18 · Morning Ride · 42.5 km · 2h 00m` |
+| `toc_entry_label` | TEXT | page-number-prefixed TOC line such as `1. 2026-03-18 · Morning Ride · 42.5 km · 2h 00m` |
+| `page_distance_label` | TEXT | preformatted page distance label |
+| `page_duration_label` | TEXT | preformatted page duration label |
+| `page_stats_summary` | TEXT | one-line page stats summary for compact contents layouts |
+| `profile_available` | INTEGER | `1` when route-profile metadata is available for the page |
+| `page_profile_summary` | TEXT | one-line route-profile summary for richer contents/detail tables |
+
 ## Geometry priority
 
 When rebuilding visible layers, qfit currently prefers geometry in this order:
@@ -283,7 +313,7 @@ When rebuilding visible layers, qfit currently prefers geometry in this order:
 2. optionally enrich activities with detailed stream geometry and extra stream metrics
 3. upsert activities into `activity_registry`
 4. update `sync_state`
-5. rebuild `activity_tracks`, `activity_starts`, `activity_atlas_pages`, `atlas_document_summary`, and optionally `activity_points`
+5. rebuild `activity_tracks`, `activity_starts`, `activity_atlas_pages`, `atlas_document_summary`, `atlas_toc_entries`, and optionally `activity_points`
 6. load those layers into QGIS
 
 ## Next phase

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -20,6 +20,7 @@ from .publish_atlas import (
     activity_bounds,
     build_atlas_document_summary,
     build_atlas_page_plans,
+    build_atlas_toc_entries,
     normalize_atlas_page_settings,
 )
 from .sync_repository import REGISTRY_TABLE, SYNC_STATE_TABLE, SyncRepository
@@ -164,6 +165,23 @@ DOCUMENT_SUMMARY_FIELDS = [
     ("cover_summary", QVariant.String),
 ]
 
+TOC_FIELDS = [
+    ("page_number", QVariant.Int),
+    ("page_number_label", QVariant.String),
+    ("page_sort_key", QVariant.String),
+    ("page_name", QVariant.String),
+    ("page_title", QVariant.String),
+    ("page_subtitle", QVariant.String),
+    ("page_date", QVariant.String),
+    ("page_toc_label", QVariant.String),
+    ("toc_entry_label", QVariant.String),
+    ("page_distance_label", QVariant.String),
+    ("page_duration_label", QVariant.String),
+    ("page_stats_summary", QVariant.String),
+    ("profile_available", QVariant.Int),
+    ("page_profile_summary", QVariant.String),
+]
+
 
 class GeoPackageWriter:
     """Persist qfit sync data to a GeoPackage and rebuild derived visualization layers."""
@@ -223,6 +241,11 @@ class GeoPackageWriter:
                 "kind": "table",
                 "fields": [name for name, _ in DOCUMENT_SUMMARY_FIELDS],
             },
+            "atlas_toc_entries": {
+                "geometry": None,
+                "kind": "table",
+                "fields": [name for name, _ in TOC_FIELDS],
+            },
         }
 
     def write_activities(self, activities, sync_metadata=None):
@@ -238,6 +261,7 @@ class GeoPackageWriter:
             self._write_layer(self._build_point_layer([]), "activity_points", overwrite_file=False)
             self._write_layer(self._build_atlas_layer([]), "activity_atlas_pages", overwrite_file=False)
             self._write_layer(self._build_document_summary_layer([]), "atlas_document_summary", overwrite_file=False)
+            self._write_layer(self._build_toc_layer([]), "atlas_toc_entries", overwrite_file=False)
 
         repository.ensure_schema()
         sync_result = repository.upsert_activities(activities, sync_metadata=sync_metadata)
@@ -248,11 +272,13 @@ class GeoPackageWriter:
         point_layer = self._build_point_layer(records)
         atlas_layer = self._build_atlas_layer(records)
         document_summary_layer = self._build_document_summary_layer(records)
+        toc_layer = self._build_toc_layer(records)
         self._write_layer(track_layer, "activity_tracks", overwrite_file=False)
         self._write_layer(start_layer, "activity_starts", overwrite_file=False)
         self._write_layer(point_layer, "activity_points", overwrite_file=False)
         self._write_layer(atlas_layer, "activity_atlas_pages", overwrite_file=False)
         self._write_layer(document_summary_layer, "atlas_document_summary", overwrite_file=False)
+        self._write_layer(toc_layer, "atlas_toc_entries", overwrite_file=False)
 
         return {
             "schema": self.schema(),
@@ -263,6 +289,7 @@ class GeoPackageWriter:
             "point_count": point_layer.featureCount(),
             "atlas_count": atlas_layer.featureCount(),
             "document_summary_count": document_summary_layer.featureCount(),
+            "toc_count": toc_layer.featureCount(),
             "sync": sync_result,
         }
 
@@ -497,6 +524,35 @@ class GeoPackageWriter:
             feature["cover_summary"] = summary.cover_summary
             provider.addFeature(feature)
 
+        layer.updateExtents()
+        return layer
+
+    def _build_toc_layer(self, records):
+        layer = QgsVectorLayer("None", "atlas_toc_entries", "memory")
+        provider = layer.dataProvider()
+        provider.addAttributes(self._make_fields(TOC_FIELDS))
+        layer.updateFields()
+
+        features = []
+        for entry in build_atlas_toc_entries(records, settings=self.atlas_page_settings):
+            feature = QgsFeature(layer.fields())
+            feature["page_number"] = entry.page_number
+            feature["page_number_label"] = entry.page_number_label
+            feature["page_sort_key"] = entry.page_sort_key
+            feature["page_name"] = entry.page_name
+            feature["page_title"] = entry.page_title
+            feature["page_subtitle"] = entry.page_subtitle
+            feature["page_date"] = entry.page_date
+            feature["page_toc_label"] = entry.page_toc_label
+            feature["toc_entry_label"] = entry.toc_entry_label
+            feature["page_distance_label"] = entry.page_distance_label
+            feature["page_duration_label"] = entry.page_duration_label
+            feature["page_stats_summary"] = entry.page_stats_summary
+            feature["profile_available"] = int(entry.profile_available)
+            feature["page_profile_summary"] = entry.page_profile_summary
+            features.append(feature)
+
+        provider.addFeatures(features)
         layer.updateExtents()
         return layer
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.26.0
+version=0.27.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/publish_atlas.py
+++ b/publish_atlas.py
@@ -43,6 +43,24 @@ class AtlasDocumentSummary:
 
 
 @dataclass(frozen=True)
+class AtlasTocEntry:
+    page_number: int
+    page_number_label: str
+    page_sort_key: str
+    page_name: str
+    page_title: str
+    page_subtitle: str
+    page_date: str | None
+    page_toc_label: str | None
+    toc_entry_label: str
+    page_distance_label: str | None
+    page_duration_label: str | None
+    page_stats_summary: str | None
+    profile_available: bool
+    page_profile_summary: str | None
+
+
+@dataclass(frozen=True)
 class AtlasPagePlan:
     source: str | None
     source_activity_id: str | None
@@ -241,6 +259,44 @@ def build_atlas_page_plans(
             )
         )
     return plans
+
+
+def build_atlas_toc_entries(
+    records: Iterable[dict],
+    margin_percent: float = DEFAULT_ATLAS_MARGIN_PERCENT,
+    min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES,
+    target_aspect_ratio: float | None = None,
+    settings: AtlasPageSettings | None = None,
+) -> list[AtlasTocEntry]:
+    entries = []
+    for plan in build_atlas_page_plans(
+        records,
+        margin_percent=margin_percent,
+        min_extent_degrees=min_extent_degrees,
+        target_aspect_ratio=target_aspect_ratio,
+        settings=settings,
+    ):
+        page_number_label = str(plan.page_number)
+        toc_entry_label = f"{page_number_label}. {plan.page_toc_label or plan.page_name}"
+        entries.append(
+            AtlasTocEntry(
+                page_number=plan.page_number,
+                page_number_label=page_number_label,
+                page_sort_key=plan.page_sort_key,
+                page_name=plan.page_name,
+                page_title=plan.page_title,
+                page_subtitle=plan.page_subtitle,
+                page_date=plan.page_date,
+                page_toc_label=plan.page_toc_label,
+                toc_entry_label=toc_entry_label,
+                page_distance_label=plan.page_distance_label,
+                page_duration_label=plan.page_duration_label,
+                page_stats_summary=plan.page_stats_summary,
+                profile_available=plan.profile_available,
+                page_profile_summary=plan.page_profile_summary,
+            )
+        )
+    return entries
 
 
 def build_atlas_document_summary(records: Iterable[dict]) -> AtlasDocumentSummary:

--- a/tests/test_gpkg_writer.py
+++ b/tests/test_gpkg_writer.py
@@ -100,6 +100,20 @@ class GeoPackageWriterAtlasTests(unittest.TestCase):
             "2 activities · 2026-03-18 → 2026-03-19 · 52.6 km · 2h 50m · ↑ 725 m · Ride, Run",
         )
 
+        toc_layer = writer._build_toc_layer(records)
+        self.assertTrue(toc_layer.isValid())
+        self.assertEqual(toc_layer.featureCount(), 2)
+        self.assertGreaterEqual(toc_layer.fields().indexOf("toc_entry_label"), 0)
+
+        toc_features = list(toc_layer.getFeatures())
+        self.assertEqual(toc_features[0]["page_number"], 1)
+        self.assertEqual(toc_features[0]["page_number_label"], "1")
+        self.assertEqual(toc_features[0]["page_toc_label"], "2026-03-18 · Morning Ride · 42.5 km · 2h 00m")
+        self.assertEqual(toc_features[0]["toc_entry_label"], "1. 2026-03-18 · Morning Ride · 42.5 km · 2h 00m")
+        self.assertEqual(toc_features[1]["page_number"], 2)
+        self.assertEqual(toc_features[1]["page_duration_label"], "50m 00s")
+        self.assertEqual(toc_features[1]["page_stats_summary"], "10.1 km · 50m 00s · 4m 57s/km · ↑ 85 m")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_publish_atlas.py
+++ b/tests/test_publish_atlas.py
@@ -10,6 +10,7 @@ from qfit.publish_atlas import (
     atlas_sort_key,
     build_atlas_document_summary,
     build_atlas_page_plans,
+    build_atlas_toc_entries,
     build_cover_summary,
     build_date_range_label,
     build_page_name,
@@ -126,6 +127,53 @@ class PublishAtlasTests(unittest.TestCase):
         )
         self.assertTrue(all(plan.document_activity_count == 3 for plan in plans))
         self.assertTrue(all(plan.document_date_range_label == "2026-03-18 → 2026-03-19" for plan in plans))
+
+    def test_build_atlas_toc_entries_create_layout_ready_table_rows(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "100",
+                "name": "Morning Ride",
+                "activity_type": "Ride",
+                "start_date_local": "2026-03-18T08:10:00+01:00",
+                "distance_m": 42500,
+                "moving_time_s": 7200,
+                "total_elevation_gain_m": 640,
+                "geometry_points": [(46.52, 6.62), (46.57, 6.74)],
+            },
+            {
+                "source": "strava",
+                "source_activity_id": "200",
+                "name": "Lunch Run",
+                "activity_type": "Run",
+                "start_date_local": "2026-03-19T12:00:00+01:00",
+                "distance_m": 10100,
+                "moving_time_s": 3000,
+                "total_elevation_gain_m": 85,
+                "geometry_points": [(46.50, 6.60), (46.51, 6.62)],
+                "details_json": {
+                    "stream_metrics": {
+                        "distance": [0, 3300, 6700, 10100],
+                        "altitude": [430, 445, 438, 452],
+                    }
+                },
+            },
+        ]
+
+        entries = build_atlas_toc_entries(records)
+
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0].page_number, 1)
+        self.assertEqual(entries[0].page_number_label, "1")
+        self.assertEqual(entries[0].page_title, "Morning Ride")
+        self.assertEqual(entries[0].page_toc_label, "2026-03-18 · Morning Ride · 42.5 km · 2h 00m")
+        self.assertEqual(entries[0].toc_entry_label, "1. 2026-03-18 · Morning Ride · 42.5 km · 2h 00m")
+        self.assertFalse(entries[0].profile_available)
+        self.assertEqual(entries[1].page_number, 2)
+        self.assertEqual(entries[1].page_number_label, "2")
+        self.assertEqual(entries[1].page_stats_summary, "10.1 km · 50m 00s · 4m 57s/km · ↑ 85 m")
+        self.assertTrue(entries[1].profile_available)
+        self.assertEqual(entries[1].page_profile_summary, "10.1 km · 430–452 m · relief 22 m · ↑ 29 m · ↓ 7 m")
 
     def test_build_atlas_page_plans_respects_custom_publish_settings(self):
         records = [

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -95,6 +95,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertGreaterEqual(result["point_count"], 4)
             self.assertEqual(result["atlas_count"], 2)
             self.assertEqual(result["document_summary_count"], 1)
+            self.assertEqual(result["toc_count"], 2)
 
             document_summary_layer = QgsVectorLayer(
                 f"{output_path}|layername=atlas_document_summary",
@@ -108,6 +109,17 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(document_summary_feature["date_range_label"], "2026-03-20 → 2026-03-21")
             self.assertEqual(document_summary_feature["total_distance_label"], "35.3 km")
             self.assertIn("2 activities · 2026-03-20 → 2026-03-21 · 35.3 km · 1h 50m · ↑ 405 m", document_summary_feature["cover_summary"])
+
+            toc_layer = QgsVectorLayer(
+                f"{output_path}|layername=atlas_toc_entries",
+                "qfit atlas toc entries",
+                "ogr",
+            )
+            self.assertTrue(toc_layer.isValid())
+            self.assertEqual(toc_layer.featureCount(), 2)
+            toc_feature = next(toc_layer.getFeatures())
+            self.assertEqual(toc_feature["page_number"], 1)
+            self.assertEqual(toc_feature["toc_entry_label"], "1. 2026-03-20 · Morning Ride · 25.2 km · 1h 00m")
 
             background = self.layer_manager.ensure_background_layer(True, "Outdoor", "test-token")
             background_name = background.name()


### PR DESCRIPTION
## Summary
- add a dedicated `atlas_toc_entries` helper table with one non-spatial row per atlas page
- expose page-number labels plus TOC-ready text/stat/profile fields for simpler QGIS contents layouts
- cover the new TOC helper table in atlas/unit/headless-QGIS tests and document the schema/workflow updates

## Testing
- python3 -m unittest discover -s tests -v
- QT_QPA_PLATFORM=offscreen python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py
- python3 scripts/install_plugin.py --profile default --mode symlink