### PR TITLE
fix: use high-resolution mapbox tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Configure these values in the dock when you want a background basemap:
 - for `Winter (custom style)` or `Custom`, provide the Mapbox style owner and style ID from your own Studio style
 - click `Load background map` when you want to add or refresh the basemap explicitly
 
-When qfit loads the background layer, it keeps it below the qfit activity layers in the QGIS layer tree so tracks, starts, and points render on top of the basemap.
+When qfit loads the background layer, it keeps it below the qfit activity layers in the QGIS layer tree so tracks, starts, and points render on top of the basemap. qfit requests Mapbox's higher-resolution style tiles by default (`512px` with retina `@2x`) so the basemap stays sharper in QGIS.
 
 The built-in presets intentionally keep the configuration small and predictable. The Winter slot is just a convenience label for a custom winter-themed style if you have one.
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -9,6 +9,8 @@ class MapboxConfigError(ValueError):
 
 BACKGROUND_LAYER_PREFIX = "qfit background"
 DEFAULT_BACKGROUND_PRESET = "Outdoor"
+DEFAULT_MAPBOX_TILE_SIZE = 512
+DEFAULT_MAPBOX_RETINA = True
 
 _BACKGROUND_PRESETS = {
     "Outdoor": {
@@ -85,8 +87,8 @@ def build_mapbox_tiles_url(
     style_owner: str,
     style_id: str,
     *,
-    tile_size: int = 256,
-    retina: bool = True,
+    tile_size: int = DEFAULT_MAPBOX_TILE_SIZE,
+    retina: bool = DEFAULT_MAPBOX_RETINA,
 ) -> str:
     token = access_token.strip()
     owner = style_owner.strip()

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.27.0
+version=0.28.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3,6 +3,8 @@ import unittest
 import tests._path  # noqa: F401,E402
 
 from mapbox_config import (  # noqa: E402
+    DEFAULT_MAPBOX_RETINA,
+    DEFAULT_MAPBOX_TILE_SIZE,
     MapboxConfigError,
     build_background_layer_name,
     build_mapbox_tiles_url,
@@ -44,14 +46,16 @@ class MapboxConfigTests(unittest.TestCase):
             style_id="style/id",
             retina=False,
         )
-        self.assertIn("styles/v1/my%20user/style%2Fid/tiles/256/{z}/{x}/{y}", url)
+        self.assertEqual(DEFAULT_MAPBOX_TILE_SIZE, 512)
+        self.assertTrue(DEFAULT_MAPBOX_RETINA)
+        self.assertIn("styles/v1/my%20user/style%2Fid/tiles/512/{z}/{x}/{y}", url)
         self.assertIn("access_token=pk.test%20token", url)
         self.assertNotIn("@2x", url)
 
     def test_xyz_uri_wraps_tiles_url(self):
         uri = build_xyz_layer_uri("pk.123", "mapbox", "outdoors-v12")
         self.assertTrue(uri.startswith("type=xyz&url=https://api.mapbox.com/"))
-        self.assertIn("{z}/{x}/{y}@2x", uri)
+        self.assertIn("tiles/512/{z}/{x}/{y}@2x", uri)
         self.assertIn("zmin=0&zmax=22", uri)
 
     def test_layer_name_prefers_preset_label(self):


### PR DESCRIPTION
## Summary
- switch Mapbox style tile URLs from 256px defaults to 512px high-resolution tiles
- keep retina tile requests enabled for sharper XYZ basemaps in QGIS
- update tests, README background-map docs, and plugin metadata version

## Testing
- python3 -m unittest discover -s tests -v
- QT_QPA_PLATFORM=offscreen python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py
- python3 scripts/install_plugin.py --profile default --mode symlink