### PR TITLE
feat: add atlas cover highlight table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The current implementation supports:
 - exposing publish-friendly detail labels on atlas pages (`page_toc_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, `page_profile_summary`) so layouts can show activity stats with less expression boilerplate
 - stamping atlas-document / cover-ready summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) onto every atlas page so QGIS layouts can reuse them directly
 - writing an `atlas_document_summary` helper table with the atlas-wide totals and labels as a single row for cover/TOC layouts that prefer a dedicated document summary source
+- writing an `atlas_cover_highlights` helper table with one ordered cover-metric row per highlight so QGIS cover pages can bind simple label/value cards without custom expressions
 - writing an `atlas_toc_entries` helper table with one row per atlas page so QGIS table-of-contents layouts can bind to a clean non-spatial TOC source instead of the atlas polygons
 - writing an `atlas_profile_samples` helper table with one row per sampled distance/elevation point so QGIS layouts can build route-profile charts from atlas-ready per-page data
 - loading those layers directly into QGIS with EPSG:3857 as the working project/map CRS
@@ -51,6 +52,7 @@ Visible layers:
 - `activity_points` — optional sampled point layer derived from detailed streams, with per-point stream metrics and derived timestamps when available
 - `activity_atlas_pages` — polygon layer of atlas/page extents with titles/subtitles plus page numbers and TOC-friendly labels for QGIS print layouts
 - `atlas_document_summary` — single-row helper table with atlas-wide totals/labels for cover and table-of-contents layouts
+- `atlas_cover_highlights` — ordered label/value helper rows for cover-page metric cards or summary lists
 - `atlas_toc_entries` — one-row-per-page helper table with TOC-ready labels for print-layout tables and cover/contents compositions
 - `atlas_profile_samples` — one-row-per-profile-point helper table with sampled distance/elevation values for route-profile diagrams in print layouts
 
@@ -106,8 +108,9 @@ Visible layers:
 14. Optionally use `Load / refresh background map` to add or refresh the basemap underneath the qfit activity layers
 15. Optionally use the loaded `qfit atlas pages` layer as a starting index layer for a QGIS print layout / atlas export, using its built-in `page_number`, `page_name`, `page_date`, `page_toc_label`, `page_distance_label`, `page_duration_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, `page_profile_summary`, `document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`, `center_x_3857`, `center_y_3857`, `extent_width_m`, `extent_height_m`, `profile_available`, `profile_distance_m`, `profile_distance_label`, `profile_altitude_range_label`, `profile_relief_m`, `profile_elevation_gain_m`, `profile_elevation_gain_label`, and `profile_elevation_loss_label` fields for layout text, conditional profile frames, cover/TOC summaries, or Web Mercator layout logic
 16. If you want a single atlas-wide record for a cover page or table-of-contents layout, read the `atlas_document_summary` table from the GeoPackage and reuse its `activity_count`, `date_range_label`, `total_distance_label`, `total_duration_label`, `total_elevation_gain_label`, `activity_types_label`, and `cover_summary` fields directly
-17. If you want a clean per-page table source for a QGIS contents page, use the `atlas_toc_entries` table and bind a layout table or labels to its `page_number`, `page_number_label`, `page_toc_label`, `toc_entry_label`, `page_stats_summary`, and `page_profile_summary` fields instead of reading those values from the atlas polygons
-18. If you want an atlas-ready route-profile data source, use the `atlas_profile_samples` table and chart or filter it by `page_number` / `page_sort_key`; it exposes ordered `distance_m`, `distance_label`, `altitude_m`, `profile_point_index`, `profile_point_ratio`, and `profile_distance_m` values for each page
+17. If you want a simple cover-page metric grid or highlight list, bind a layout table or labels to the ordered `atlas_cover_highlights` rows (`highlight_label`, `highlight_value`) instead of rebuilding those strings in expressions
+18. If you want a clean per-page table source for a QGIS contents page, use the `atlas_toc_entries` table and bind a layout table or labels to its `page_number`, `page_number_label`, `page_toc_label`, `toc_entry_label`, `page_stats_summary`, and `page_profile_summary` fields instead of reading those values from the atlas polygons
+19. If you want an atlas-ready route-profile data source, use the `atlas_profile_samples` table and chart or filter it by `page_number` / `page_sort_key`; it exposes ordered `distance_m`, `distance_label`, `altitude_m`, `profile_point_index`, `profile_point_ratio`, and `profile_distance_m` values for each page
 
 ## Publish / atlas settings
 
@@ -119,6 +122,7 @@ The resulting atlas-page layer is intentionally more layout-ready than a raw ext
 - `page_date`, `page_toc_label`, `page_distance_label`, `page_duration_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`, `page_stats_summary`, and `page_profile_summary` reduce the need for layout expressions
 - document-level summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) are still repeated on every atlas page for simple per-page layout expressions
 - the GeoPackage now also includes an `atlas_document_summary` table with a single atlas-wide summary row when you prefer a dedicated cover/TOC data source
+- the new `atlas_cover_highlights` table gives cover layouts an ordered label/value row source for simple metric cards or summary lists without custom expressions
 - the new `atlas_toc_entries` table gives TOC layouts a clean non-spatial row source with page-number labels and preformatted entry text, so simple contents pages do not need to read from atlas polygons or rebuild numbering logic in expressions
 - the new `atlas_profile_samples` table gives route-profile layouts a clean per-page chart source with ordered sampled distance/elevation rows, so profile diagrams do not need to scrape nested JSON or activity points directly
 - `center_x_3857`, `center_y_3857`, `extent_width_m`, and `extent_height_m` make it easier to drive Web Mercator-oriented layout logic now that qfit uses EPSG:3857 as the working QGIS projection choice

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -140,6 +140,7 @@ Goal: configure and generate a PDF atlas with:
 - Early atlas-generation groundwork is being explored in feature work
 - Atlas output now carries route-profile summary metadata when detailed stream metrics are available, plus layout-friendly profile labels/relief for future profile panels and print layouts
 - Atlas planning helpers now also compute cover-ready document summary totals (activity count, date span, totals, activity types, one-line summary text) and the GeoPackage now exposes them through a dedicated `atlas_document_summary` helper table for cover/TOC layouts
+- The GeoPackage now also includes an `atlas_cover_highlights` helper table with ordered label/value rows so QGIS cover pages can bind metric cards or summary lists without layout-expression boilerplate
 - The GeoPackage now also includes an `atlas_toc_entries` helper table with one non-spatial row per atlas page so QGIS contents-page tables can bind to clean TOC data without depending on atlas polygons
 - The GeoPackage now also includes an `atlas_profile_samples` helper table with ordered distance/elevation sample rows per page so future QGIS route-profile diagrams can bind to atlas-ready chart data
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -24,6 +24,7 @@ This document describes the current qfit GeoPackage layout and the intended next
 - `activity_points` — optional sampled point layer derived from detailed stream geometry
 - `activity_atlas_pages` — polygon page/index layer for QGIS atlas or print-layout workflows, now with deterministic page ordering, TOC-friendly labels, publish-friendly detail labels/summary text, repeated document-summary fields for cover/TOC layouts, Web Mercator-ready extent metadata, and route-profile summary/label fields when detailed streams are available
 - `atlas_document_summary` — non-spatial single-row helper table carrying atlas-wide totals and cover/TOC-ready labels for layouts that prefer a dedicated document-summary source
+- `atlas_cover_highlights` — non-spatial ordered helper table carrying cover-ready label/value highlight rows for layouts that want simple metric cards or summary lists
 - `atlas_toc_entries` — non-spatial one-row-per-page helper table carrying page-number labels plus TOC-ready text/summary fields for contents layouts that should not depend on atlas polygon geometry
 
 ## Table: `activity_registry`
@@ -190,6 +191,7 @@ Primary purpose:
 - publish-friendly detail labels (`page_toc_label`, `page_average_speed_label`, `page_average_pace_label`, `page_elevation_gain_label`) plus `page_stats_summary` and `page_profile_summary` reduce per-layout expression boilerplate for per-activity stat blocks
 - repeated document-summary fields (`document_activity_count`, `document_date_range_label`, `document_total_distance_label`, `document_total_duration_label`, `document_total_elevation_gain_label`, `document_activity_types_label`, `document_cover_summary`) still make it easy for per-page layout expressions to reuse atlas-wide totals
 - the companion `atlas_document_summary` table now provides the same atlas-wide totals/labels as a dedicated single-row source for cover and table-of-contents layouts
+- the companion `atlas_cover_highlights` table now provides ordered cover-metric label/value rows for simple cover-page cards or summary lists
 - the companion `atlas_toc_entries` table now provides one clean non-spatial row per atlas page, with page-number labels and preformatted TOC entry text for contents-page tables
 - route-profile summary and label fields give layouts a cheap way to decide whether to show an elevation chart and to reuse publish-friendly text without extra QGIS expression boilerplate before full PDF automation exists
 
@@ -272,6 +274,24 @@ Primary purpose:
 | `activity_types_label` | TEXT | ordered activity-type list such as `Ride, Run` |
 | `cover_summary` | TEXT | one-line cover summary such as `3 activities · 2026-03-18 → 2026-03-20 · 82.6 km · 4h 20m · ↑ 1145 m · Ride, Run` |
 
+## Table: `atlas_cover_highlights`
+
+Geometry type:
+- none
+
+Primary purpose:
+- store ordered cover-page highlight rows as simple label/value pairs
+- let QGIS print layouts bind cover metric cards or summary lists without rebuilding those strings in expressions
+
+### Current fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `highlight_order` | INTEGER | stable display order for a cover layout table or repeated card frame |
+| `highlight_key` | TEXT | stable metric key such as `activity_count` or `total_distance` |
+| `highlight_label` | TEXT | layout-ready label such as `Activities` or `Distance` |
+| `highlight_value` | TEXT | formatted value such as `12 activities` or `420.7 km` |
+
 ## Table: `atlas_toc_entries`
 
 Geometry type:
@@ -313,7 +333,7 @@ When rebuilding visible layers, qfit currently prefers geometry in this order:
 2. optionally enrich activities with detailed stream geometry and extra stream metrics
 3. upsert activities into `activity_registry`
 4. update `sync_state`
-5. rebuild `activity_tracks`, `activity_starts`, `activity_atlas_pages`, `atlas_document_summary`, `atlas_toc_entries`, and optionally `activity_points`
+5. rebuild `activity_tracks`, `activity_starts`, `activity_atlas_pages`, `atlas_document_summary`, `atlas_cover_highlights`, `atlas_toc_entries`, and optionally `activity_points`
 6. load those layers into QGIS
 
 ## Next phase

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -18,6 +18,7 @@ from qgis.core import (
 from .polyline_utils import decode_polyline
 from .publish_atlas import (
     activity_bounds,
+    build_atlas_cover_highlights,
     build_atlas_document_summary,
     build_atlas_page_plans,
     build_atlas_profile_samples,
@@ -166,6 +167,13 @@ DOCUMENT_SUMMARY_FIELDS = [
     ("cover_summary", QVariant.String),
 ]
 
+COVER_HIGHLIGHT_FIELDS = [
+    ("highlight_order", QVariant.Int),
+    ("highlight_key", QVariant.String),
+    ("highlight_label", QVariant.String),
+    ("highlight_value", QVariant.String),
+]
+
 PROFILE_SAMPLE_FIELDS = [
     ("page_number", QVariant.Int),
     ("page_sort_key", QVariant.String),
@@ -260,6 +268,11 @@ class GeoPackageWriter:
                 "kind": "table",
                 "fields": [name for name, _ in DOCUMENT_SUMMARY_FIELDS],
             },
+            "atlas_cover_highlights": {
+                "geometry": None,
+                "kind": "table",
+                "fields": [name for name, _ in COVER_HIGHLIGHT_FIELDS],
+            },
             "atlas_profile_samples": {
                 "geometry": None,
                 "kind": "table",
@@ -285,6 +298,7 @@ class GeoPackageWriter:
             self._write_layer(self._build_point_layer([]), "activity_points", overwrite_file=False)
             self._write_layer(self._build_atlas_layer([]), "activity_atlas_pages", overwrite_file=False)
             self._write_layer(self._build_document_summary_layer([]), "atlas_document_summary", overwrite_file=False)
+            self._write_layer(self._build_cover_highlight_layer([]), "atlas_cover_highlights", overwrite_file=False)
             self._write_layer(self._build_profile_sample_layer([]), "atlas_profile_samples", overwrite_file=False)
             self._write_layer(self._build_toc_layer([]), "atlas_toc_entries", overwrite_file=False)
 
@@ -297,6 +311,7 @@ class GeoPackageWriter:
         point_layer = self._build_point_layer(records)
         atlas_layer = self._build_atlas_layer(records)
         document_summary_layer = self._build_document_summary_layer(records)
+        cover_highlight_layer = self._build_cover_highlight_layer(records)
         profile_sample_layer = self._build_profile_sample_layer(records)
         toc_layer = self._build_toc_layer(records)
         self._write_layer(track_layer, "activity_tracks", overwrite_file=False)
@@ -304,6 +319,7 @@ class GeoPackageWriter:
         self._write_layer(point_layer, "activity_points", overwrite_file=False)
         self._write_layer(atlas_layer, "activity_atlas_pages", overwrite_file=False)
         self._write_layer(document_summary_layer, "atlas_document_summary", overwrite_file=False)
+        self._write_layer(cover_highlight_layer, "atlas_cover_highlights", overwrite_file=False)
         self._write_layer(profile_sample_layer, "atlas_profile_samples", overwrite_file=False)
         self._write_layer(toc_layer, "atlas_toc_entries", overwrite_file=False)
 
@@ -316,6 +332,7 @@ class GeoPackageWriter:
             "point_count": point_layer.featureCount(),
             "atlas_count": atlas_layer.featureCount(),
             "document_summary_count": document_summary_layer.featureCount(),
+            "cover_highlight_count": cover_highlight_layer.featureCount(),
             "profile_sample_count": profile_sample_layer.featureCount(),
             "toc_count": toc_layer.featureCount(),
             "sync": sync_result,
@@ -552,6 +569,34 @@ class GeoPackageWriter:
             feature["cover_summary"] = summary.cover_summary
             provider.addFeature(feature)
 
+        layer.updateExtents()
+        return layer
+
+    def _build_cover_highlight_layer(self, records):
+        layer = QgsVectorLayer("None", "atlas_cover_highlights", "memory")
+        provider = layer.dataProvider()
+        provider.addAttributes(self._make_fields(COVER_HIGHLIGHT_FIELDS))
+        layer.updateFields()
+
+        atlas_records = []
+        for record in records:
+            bounds, _ = activity_bounds(
+                record,
+                min_extent_degrees=self.atlas_page_settings.min_extent_degrees,
+            )
+            if bounds is not None:
+                atlas_records.append(record)
+
+        features = []
+        for highlight in build_atlas_cover_highlights(atlas_records):
+            feature = QgsFeature(layer.fields())
+            feature["highlight_order"] = highlight.highlight_order
+            feature["highlight_key"] = highlight.highlight_key
+            feature["highlight_label"] = highlight.highlight_label
+            feature["highlight_value"] = highlight.highlight_value
+            features.append(feature)
+
+        provider.addFeatures(features)
         layer.updateExtents()
         return layer
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.29.0
+version=0.30.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/publish_atlas.py
+++ b/publish_atlas.py
@@ -61,6 +61,14 @@ class AtlasTocEntry:
 
 
 @dataclass(frozen=True)
+class AtlasCoverHighlight:
+    highlight_order: int
+    highlight_key: str
+    highlight_label: str
+    highlight_value: str
+
+
+@dataclass(frozen=True)
 class AtlasProfileSample:
     page_number: int
     page_sort_key: str
@@ -316,6 +324,35 @@ def build_atlas_toc_entries(
             )
         )
     return entries
+
+
+def build_atlas_cover_highlights(records: Iterable[dict]) -> list[AtlasCoverHighlight]:
+    summary = build_atlas_document_summary(records)
+    if summary.activity_count <= 0:
+        return []
+
+    highlights: list[AtlasCoverHighlight] = []
+
+    def add_highlight(key: str, label: str, value: str | None):
+        if not value:
+            return
+        highlights.append(
+            AtlasCoverHighlight(
+                highlight_order=len(highlights) + 1,
+                highlight_key=key,
+                highlight_label=label,
+                highlight_value=value,
+            )
+        )
+
+    activity_label = "activity" if summary.activity_count == 1 else "activities"
+    add_highlight("activity_count", "Activities", f"{summary.activity_count} {activity_label}")
+    add_highlight("date_range", "Date range", summary.date_range_label)
+    add_highlight("total_distance", "Distance", summary.total_distance_label)
+    add_highlight("total_duration", "Moving time", summary.total_duration_label)
+    add_highlight("total_elevation_gain", "Climbing", summary.total_elevation_gain_label)
+    add_highlight("activity_types", "Activity types", summary.activity_types_label)
+    return highlights
 
 
 def build_atlas_profile_samples(

--- a/tests/test_gpkg_writer.py
+++ b/tests/test_gpkg_writer.py
@@ -100,6 +100,17 @@ class GeoPackageWriterAtlasTests(unittest.TestCase):
             "2 activities · 2026-03-18 → 2026-03-19 · 52.6 km · 2h 50m · ↑ 725 m · Ride, Run",
         )
 
+        cover_highlight_layer = writer._build_cover_highlight_layer(records)
+        self.assertTrue(cover_highlight_layer.isValid())
+        self.assertEqual(cover_highlight_layer.featureCount(), 6)
+        self.assertGreaterEqual(cover_highlight_layer.fields().indexOf("highlight_value"), 0)
+        cover_highlight_features = list(cover_highlight_layer.getFeatures())
+        self.assertEqual(cover_highlight_features[0]["highlight_key"], "activity_count")
+        self.assertEqual(cover_highlight_features[0]["highlight_label"], "Activities")
+        self.assertEqual(cover_highlight_features[0]["highlight_value"], "2 activities")
+        self.assertEqual(cover_highlight_features[-1]["highlight_key"], "activity_types")
+        self.assertEqual(cover_highlight_features[-1]["highlight_value"], "Ride, Run")
+
         profile_sample_layer = writer._build_profile_sample_layer(records)
         self.assertTrue(profile_sample_layer.isValid())
         self.assertEqual(profile_sample_layer.featureCount(), 0)

--- a/tests/test_publish_atlas.py
+++ b/tests/test_publish_atlas.py
@@ -8,6 +8,7 @@ from qfit.publish_atlas import (
     WEB_MERCATOR_EPSG,
     activity_bounds,
     atlas_sort_key,
+    build_atlas_cover_highlights,
     build_atlas_document_summary,
     build_atlas_page_plans,
     build_atlas_profile_samples,
@@ -128,6 +129,46 @@ class PublishAtlasTests(unittest.TestCase):
         )
         self.assertTrue(all(plan.document_activity_count == 3 for plan in plans))
         self.assertTrue(all(plan.document_date_range_label == "2026-03-18 → 2026-03-19" for plan in plans))
+
+    def test_build_atlas_cover_highlights_create_layout_ready_rows(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "100",
+                "name": "Morning Ride",
+                "activity_type": "Ride",
+                "start_date_local": "2026-03-18T08:10:00+01:00",
+                "distance_m": 42500,
+                "moving_time_s": 7200,
+                "total_elevation_gain_m": 640,
+                "geometry_points": [(46.52, 6.62), (46.57, 6.74)],
+            },
+            {
+                "source": "strava",
+                "source_activity_id": "200",
+                "name": "Lunch Run",
+                "activity_type": "Run",
+                "start_date_local": "2026-03-19T12:00:00+01:00",
+                "distance_m": 10100,
+                "moving_time_s": 3000,
+                "total_elevation_gain_m": 85,
+                "geometry_points": [(46.50, 6.60), (46.51, 6.62)],
+            },
+        ]
+
+        highlights = build_atlas_cover_highlights(records)
+
+        self.assertEqual(len(highlights), 6)
+        self.assertEqual(highlights[0].highlight_order, 1)
+        self.assertEqual(highlights[0].highlight_key, "activity_count")
+        self.assertEqual(highlights[0].highlight_label, "Activities")
+        self.assertEqual(highlights[0].highlight_value, "2 activities")
+        self.assertEqual(highlights[1].highlight_value, "2026-03-18 → 2026-03-19")
+        self.assertEqual(highlights[2].highlight_value, "52.6 km")
+        self.assertEqual(highlights[3].highlight_value, "2h 50m")
+        self.assertEqual(highlights[4].highlight_value, "725 m")
+        self.assertEqual(highlights[5].highlight_key, "activity_types")
+        self.assertEqual(highlights[5].highlight_value, "Ride, Run")
 
     def test_build_atlas_profile_samples_create_chart_ready_rows(self):
         records = [

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -117,6 +117,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertGreaterEqual(result["point_count"], 4)
             self.assertEqual(result["atlas_count"], 2)
             self.assertEqual(result["document_summary_count"], 1)
+            self.assertEqual(result["cover_highlight_count"], 6)
             self.assertEqual(result["profile_sample_count"], 8)
             self.assertEqual(result["toc_count"], 2)
 
@@ -132,6 +133,17 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(document_summary_feature["date_range_label"], "2026-03-20 → 2026-03-21")
             self.assertEqual(document_summary_feature["total_distance_label"], "35.3 km")
             self.assertIn("2 activities · 2026-03-20 → 2026-03-21 · 35.3 km · 1h 50m · ↑ 405 m", document_summary_feature["cover_summary"])
+
+            cover_highlight_layer = QgsVectorLayer(
+                f"{output_path}|layername=atlas_cover_highlights",
+                "qfit atlas cover highlights",
+                "ogr",
+            )
+            self.assertTrue(cover_highlight_layer.isValid())
+            self.assertEqual(cover_highlight_layer.featureCount(), 6)
+            cover_highlight_feature = next(cover_highlight_layer.getFeatures())
+            self.assertEqual(cover_highlight_feature["highlight_key"], "activity_count")
+            self.assertEqual(cover_highlight_feature["highlight_value"], "2 activities")
 
             profile_layer = QgsVectorLayer(
                 f"{output_path}|layername=atlas_profile_samples",


### PR DESCRIPTION
## Summary
- add an `atlas_cover_highlights` helper table with ordered cover-page label/value rows
- write the new helper table into the GeoPackage alongside the existing document summary / TOC / profile helper tables
- cover the new helper with unit tests, PyQGIS smoke coverage, and docs/version updates

## Testing
- python3 -m unittest discover -s tests -v
- QT_QPA_PLATFORM=offscreen python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py
- python3 scripts/install_plugin.py --profile default --mode symlink