### PR TITLE
fix: mark Mapbox XYZ tiles as high DPI in QGIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Configure these values in the dock when you want a background basemap:
 - for `Winter (custom style)` or `Custom`, provide the Mapbox style owner and style ID from your own Studio style
 - click `Load background map` when you want to add or refresh the basemap explicitly
 
-When qfit loads the background layer, it keeps it below the qfit activity layers in the QGIS layer tree so tracks, starts, and points render on top of the basemap. qfit requests Mapbox's higher-resolution style tiles by default (`512px` with retina `@2x`) so the basemap stays sharper in QGIS.
+When qfit loads the background layer, it keeps it below the qfit activity layers in the QGIS layer tree so tracks, starts, and points render on top of the basemap. qfit requests Mapbox's higher-resolution style tiles by default (`512px` with retina `@2x`) and marks the XYZ source with `tilePixelRatio=2` so QGIS treats those tiles as true high-DPI tiles instead of scaling them like standard `256px` tiles.
 
 The built-in presets intentionally keep the configuration small and predictable. The Winter slot is just a convenience label for a custom winter-themed style if you have one.
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -11,6 +11,7 @@ BACKGROUND_LAYER_PREFIX = "qfit background"
 DEFAULT_BACKGROUND_PRESET = "Outdoor"
 DEFAULT_MAPBOX_TILE_SIZE = 512
 DEFAULT_MAPBOX_RETINA = True
+DEFAULT_MAPBOX_TILE_PIXEL_RATIO = 2
 
 _BACKGROUND_PRESETS = {
     "Outdoor": {
@@ -114,8 +115,9 @@ def build_mapbox_tiles_url(
 
 def build_xyz_layer_uri(access_token: str, style_owner: str, style_id: str) -> str:
     url = build_mapbox_tiles_url(access_token, style_owner, style_id)
-    return "type=xyz&url={url}&zmin=0&zmax=22".format(
+    return "type=xyz&url={url}&zmin=0&zmax=22&tilePixelRatio={tile_pixel_ratio}".format(
         url=quote(url, safe=":/?{}=%@"),
+        tile_pixel_ratio=DEFAULT_MAPBOX_TILE_PIXEL_RATIO,
     )
 
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.30.0
+version=0.30.1
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4,6 +4,7 @@ import tests._path  # noqa: F401,E402
 
 from mapbox_config import (  # noqa: E402
     DEFAULT_MAPBOX_RETINA,
+    DEFAULT_MAPBOX_TILE_PIXEL_RATIO,
     DEFAULT_MAPBOX_TILE_SIZE,
     MapboxConfigError,
     build_background_layer_name,
@@ -47,6 +48,7 @@ class MapboxConfigTests(unittest.TestCase):
             retina=False,
         )
         self.assertEqual(DEFAULT_MAPBOX_TILE_SIZE, 512)
+        self.assertEqual(DEFAULT_MAPBOX_TILE_PIXEL_RATIO, 2)
         self.assertTrue(DEFAULT_MAPBOX_RETINA)
         self.assertIn("styles/v1/my%20user/style%2Fid/tiles/512/{z}/{x}/{y}", url)
         self.assertIn("access_token=pk.test%20token", url)
@@ -57,6 +59,7 @@ class MapboxConfigTests(unittest.TestCase):
         self.assertTrue(uri.startswith("type=xyz&url=https://api.mapbox.com/"))
         self.assertIn("tiles/512/{z}/{x}/{y}@2x", uri)
         self.assertIn("zmin=0&zmax=22", uri)
+        self.assertIn(f"tilePixelRatio={DEFAULT_MAPBOX_TILE_PIXEL_RATIO}", uri)
 
     def test_layer_name_prefers_preset_label(self):
         self.assertEqual(

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -100,6 +100,12 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_background_layer_source_uses_high_dpi_xyz_uri(self):
+        background = self.layer_manager.ensure_background_layer(True, "Outdoor", "test-token")
+        self.assertTrue(background.isValid())
+        self.assertIn("tiles/512/{z}/{x}/{y}@2x", background.source())
+        self.assertIn("tilePixelRatio=2", background.source())
+
     def test_headless_qgis_smoke_covers_write_load_crs_temporal_and_background_order(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = str(Path(temp_dir) / "qfit-smoke.gpkg")


### PR DESCRIPTION
## Summary
- add `tilePixelRatio=2` to qfit's Mapbox XYZ datasource URI
- keep the existing 512px retina Mapbox tile requests, but also tell QGIS these are high-DPI tiles
- add tests/docs for the generated URI and bump plugin metadata to `0.30.1`

## Why
qfit was already requesting Mapbox `512` / `@2x` raster style tiles, but QGIS's XYZ/WMS provider only treats those as true high-DPI tiles when the datasource URI includes `tilePixelRatio`.

Without that flag, QGIS still assumes standard `256px` tile semantics, so the sharper Mapbox tiles do not render as crisply as expected.

I verified this against QGIS upstream source:
- `QgsWmsSettings::parseUri()` reads `tilePixelRatio` for tiled sources
- `QgsWmsProvider::setupXyzCapabilities()` uses it to size XYZ tile matrices and set DPI behavior

## Validation
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=/home/ebelo/.openclaw/workspace/worktrees/qfit-mapbox-xyz-tile-pixel-ratio python3 -m unittest tests.test_mapbox_config tests.test_qgis_smoke.QgisSmokeTests.test_background_layer_source_uses_high_dpi_xyz_uri -v`
- `python3 scripts/package_plugin.py`

## Notes
- I did **not** repoint Emman's existing live plugin symlink during this follow-up, to avoid trampling the current local setup while the fix is under review.
- There is an older broader smoke test on `main` whose expectations around atlas cover-highlight output appear stale in this worktree; I left that unrelated issue untouched.
