### PR TITLE
feat: add semantic map styling presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Visible layers:
 - `gpkg_writer.py` — derived GeoPackage layer rebuilds via QGIS APIs
 - `activity_query.py` — reusable activity filtering, sorting, summary, preview, and subset-expression helpers
 - `layer_manager.py` — layer loading, filtering, styling, and background-map wiring
+- `map_style.py` — semantic activity-color mapping and basemap-aware line-style rules
 - `mapbox_config.py` — background-map preset resolution and Mapbox XYZ URL helpers
 - `temporal_config.py` — reusable temporal-playback field selection and expression helpers
 - `qfit_cache.py` — local cache for detailed stream bundles
@@ -155,6 +156,19 @@ Configure these values in the dock when you want a background basemap:
 When qfit loads the background layer, it keeps it below the qfit activity layers in the QGIS layer tree so tracks, starts, and points render on top of the basemap. qfit requests Mapbox's higher-resolution style tiles by default (`512px` with retina `@2x`) and marks the XYZ source with `tilePixelRatio=2` so QGIS treats those tiles as true high-DPI tiles instead of scaling them like standard `256px` tiles.
 
 The built-in presets intentionally keep the configuration small and predictable. The Winter slot is just a convenience label for a custom winter-themed style if you have one.
+
+## Activity styling and basemap-aware rendering
+
+qfit's `By activity type` preset now follows the semantic palette documented in `docs/map-style-guide.md`.
+
+Highlights:
+- `sport_type` is used as the preferred categorization field when it exists, with `activity_type` as a fallback
+- common Strava sports map to stable semantic color families (for example runs stay red, rides orange, winter sports blue, water sports blue/cyan, indoor fitness purple, machine/virtual grey)
+- the line palette stays semantically consistent while the rendering adapts to the active Mapbox context
+- `Outdoor` keeps the base line weights, `Light` adds a dark casing and slightly heavier lines, and `Satellite` adds a stronger white casing plus higher opacity for readability over imagery
+- unknown or future activity names fall back to a semantic family heuristic and ultimately to a neutral grey instead of failing silently
+
+The simpler `Simple lines` preset also uses the same basemap-aware width/opacity/outline rules, so switching basemaps does not require manually restyling tracks every time.
 
 ## Strava credentials
 

--- a/docs/map-style-guide.md
+++ b/docs/map-style-guide.md
@@ -1,0 +1,352 @@
+# 🎨 qfit Map Visualization Style Guide  
+*Strava activities — semantic colors, palette, and adaptive rendering*
+
+---
+
+## 1. Purpose
+
+This document defines how outdoor activities are visualized in qfit maps.
+
+Goals:
+- Ensure **instant readability** when many activities are displayed together  
+- Maintain **semantic consistency across activity types**  
+- Provide a **color-blind-aware palette**  
+- Ensure visibility across **different basemaps (Outdoor, Light, Satellite)**  
+
+---
+
+## 2. Core Design Principles
+
+### 2.1 Semantic Color Families (Strict Rule)
+
+Each activity type maps to a **single color family**.
+
+| Semantic meaning                     | Color family |
+|-------------------------------------|--------------|
+| Effort / cardio (running)           | Red          |
+| Speed / motion (cycling)            | Orange       |
+| Human-powered low speed (walking)   | Yellow       |
+| Winter activities                   | Blue         |
+| Water activities                    | Blue / Cyan  |
+| Mountain / rock                     | Brown        |
+| Indoor / fitness                    | Purple       |
+| Machine / virtual                   | Grey         |
+
+👉 **Rule:** One semantic = one color family (no overlap)
+
+---
+
+### 2.2 Seasonal Consistency
+
+- ❌ Yellow MUST NOT be used for winter  
+- ❌ Blue MUST NOT be used for walking activities  
+- ✅ All winter activities must stay in the **blue family**
+
+---
+
+### 2.3 Color-Blind Awareness
+
+- Avoid red–green conflicts  
+- Use clearly separated color families  
+- Do not rely on subtle hue differences  
+- Combine color with:
+  - line width
+  - opacity
+
+---
+
+### 2.4 Minimal Cognitive Load
+
+- Keep palette compact  
+- Avoid unnecessary variation  
+- Users should recognize activities **without reading a legend**
+
+---
+
+## 3. Color Palette (Reference)
+
+| Semantic | Hex |
+|----------|-----|
+| Red      | `#D62828` |
+| Orange   | `#F77F00` |
+| Yellow   | `#FFD60A` |
+| Blue     | `#0077B6` |
+| Cyan     | `#00B4D8` |
+| Teal     | `#2A9D8F` |
+| Brown    | `#8B5E34` |
+| Purple   | `#7B2CBF` |
+| Grey     | `#6C757D` |
+
+---
+
+## 4. Strava Activity Mapping
+
+### 🏃 Running (Red)
+
+| Activity   | Hex |
+|------------|-----|
+| Run        | `#D62828` |
+| TrailRun   | `#9D0208` |
+| VirtualRun | `#868E96` |
+
+---
+
+### 🚴 Cycling (Orange)
+
+| Activity            | Hex |
+|---------------------|-----|
+| Ride                | `#F77F00` |
+| MountainBikeRide    | `#D95F02` |
+| GravelRide          | `#BC6C25` |
+| EBikeRide           | `#6C757D` |
+
+---
+
+### 🚶 Walking / Hiking (Yellow)
+
+| Activity     | Hex |
+|--------------|-----|
+| Walk         | `#FFD60A` |
+| Hike         | `#F9C74F` |
+| Backpacking  | `#E9C46A` |
+
+---
+
+### ❄️ Winter Sports (Blue ONLY)
+
+| Activity          | Hex |
+|-------------------|-----|
+| AlpineSki         | `#0077B6` |
+| BackcountrySki    | `#023E8A` |
+| NordicSki         | `#0096C7` |
+| Snowboard         | `#00B4D8` |
+| Snowshoe          | `#48CAE4` |
+
+---
+
+### 🌊 Water Sports (Blue / Cyan)
+
+| Activity            | Hex |
+|---------------------|-----|
+| Swim                | `#0077B6` |
+| OpenWaterSwim       | `#023E8A` |
+| Kayaking            | `#1B9AAA` |
+| Canoeing            | `#2A9D8F` |
+| Rowing              | `#264653` |
+| StandUpPaddling     | `#48CAE4` |
+| Surfing             | `#0096C7` |
+
+---
+
+### 🏔️ Mountain / Climbing
+
+| Activity         | Hex |
+|------------------|-----|
+| RockClimbing     | `#8B5E34` |
+| Mountaineering   | `#6B4423` |
+| IceClimbing      | `#90E0EF` |
+
+---
+
+### 🏋️ Indoor / Fitness
+
+| Activity        | Hex |
+|-----------------|-----|
+| Workout         | `#7B2CBF` |
+| Crossfit        | `#5A189A` |
+| WeightTraining  | `#3C096C` |
+| Yoga            | `#C77DFF` |
+
+---
+
+### ⚫ Machine / Virtual / Other
+
+| Activity     | Hex |
+|--------------|-----|
+| VirtualRide  | `#6C757D` |
+| Commute      | `#495057` |
+| Other        | `#9E9E9E` |
+
+---
+
+## 5. Rendering Rules
+
+### 5.1 Base Style
+
+| Property | Value |
+|----------|------|
+| Width    | 1.5–2.0 px |
+| Opacity  | 0.8–0.9 |
+| Cap      | Round |
+| Join     | Round |
+
+---
+
+### 5.2 Highlighted Activity
+
+- Width: **3 px**  
+- White outer glow: **0.5–1 px**
+
+---
+
+### 5.3 Overlapping Tracks
+
+- Use **opacity < 1**  
+- Avoid fully opaque lines  
+- Prefer thickness over brightness  
+
+---
+
+## 6. Visual Encoding
+
+| Property   | Meaning |
+|------------|--------|
+| Color      | Activity type |
+| Thickness  | Selection / importance |
+| Opacity    | Density |
+
+👉 Do not rely on color alone
+
+---
+
+## 7. Basemap Adaptation
+
+### Principle
+
+> **Stable palette + adaptive rendering**
+
+Colors remain unchanged across basemaps.  
+Only rendering parameters are adjusted.
+
+---
+
+### 🗺️ Mapbox Outdoor (Reference)
+
+| Property | Value |
+|----------|------|
+| Width    | 1.5–2.0 px |
+| Opacity  | ~0.85 |
+| Outline  | Optional |
+
+---
+
+### 🤍 Mapbox Light
+
+| Property | Value |
+|----------|------|
+| Width    | ≥ 2.0 px |
+| Opacity  | ~0.9 |
+| Outline  | Yes |
+
+Outline:
+- Color: `#333333`
+- Width: `0.3–0.5 px`
+
+---
+
+### 🛰️ Satellite
+
+| Property | Value |
+|----------|------|
+| Width    | 2.0–2.5 px |
+| Opacity  | ~0.95 |
+| Outline  | Mandatory |
+
+Outline:
+- Color: `#FFFFFF`
+- Width: `0.8–1.2 px`
+
+---
+
+## 8. Color Adaptation per Basemap
+
+### Principle
+
+> **Stable hue, adaptive luminance**
+
+- Hue = semantic meaning (fixed)  
+- Lightness / saturation = adjusted for readability  
+
+---
+
+### Mapbox Outdoor
+
+- Default palette  
+- No color changes  
+
+---
+
+### Mapbox Light (Darkened Colors)
+
+| Semantic | Default | Light variant |
+|----------|--------|--------------|
+| Red      | `#D62828` | `#C1121F` |
+| Orange   | `#F77F00` | `#E85D04` |
+| Yellow   | `#FFD60A` | `#E0B000` |
+| Blue     | `#0077B6` | `#005F99` |
+
+---
+
+### Satellite (Enhanced Colors)
+
+| Semantic | Default | Satellite variant |
+|----------|--------|------------------|
+| Red      | `#D62828` | `#E63946` |
+| Orange   | `#F77F00` | `#FF7F11` |
+| Yellow   | `#FFD60A` | `#FFDD00` |
+| Blue     | `#0077B6` | `#0096C7` |
+
+---
+
+### Constraints
+
+- No hue shifts  
+- No semantic confusion  
+- Adjustments must remain subtle  
+
+---
+
+### Priority
+
+1. Outline  
+2. Line width  
+3. Opacity  
+4. Color adjustment  
+
+---
+
+## 9. QGIS Implementation
+
+### Symbology
+
+Layer Properties → Symbology → Categorized  
+Column: `sport_type`
+
+---
+
+### Recommended Styles
+
+- `qfit_outdoor.qml`
+- `qfit_light.qml`
+- `qfit_satellite.qml`
+
+---
+
+## 10. Key Takeaways
+
+- Use **one consistent palette**  
+- Do NOT change color meaning across maps  
+- Adapt rendering instead (width, outline, opacity)  
+- Prioritize **semantic clarity over visual variety**
+
+---
+
+## 11. Future Improvements
+
+- Automatic basemap detection  
+- Color-blind simulation validation  
+- User-customizable themes  
+- Speed / elevation gradients  
+- Time-based animation  
+
+---

--- a/docs/qgis-testing.md
+++ b/docs/qgis-testing.md
@@ -114,4 +114,5 @@ Once qfit is loaded successfully, good manual checks are:
 - confirm `activity_tracks` geometries look right
 - confirm `activity_points` attributes contain time / distance / HR / power where available
 - test filtering, preview sorting, style presets, and temporal playback wiring
+- when the `By activity type` preset is active, verify that runs/rides/winter activities keep their semantic colors and that line casing/opacity adapts sensibly when you switch between Outdoor, Light, and Satellite basemaps
 - open the QGIS Temporal Controller and confirm the loaded layers respond to the chosen local/UTC playback mode

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,6 +84,7 @@ Goal: map styling, data filtering, and activity querying.
   - date range
   - minimum distance
 - Style presets and layer styling basics
+- Semantic activity-type styling presets with basemap-aware rendering profiles
 - Start points / tracks / heatmap-style views
 - Auto-zoom to loaded data extents
 - Working QGIS map/project projection choice aligned to Web Mercator (`EPSG:3857`)
@@ -109,7 +110,6 @@ Goal: map styling, data filtering, and activity querying.
 
 - Better activity details panel / inspection workflow
 - More polished symbology and map presets
-- Smarter visualization presets per activity type
 - Query saving / reusable view presets
 - More explicit basemap and map-style configuration UX
 - Better separation between preview/query controls and post-load QGIS layer subsetting

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -1,3 +1,4 @@
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (
     QgsCategorizedSymbolRenderer,
@@ -11,6 +12,7 @@ from qgis.core import (
     QgsRasterLayer,
     QgsRectangle,
     QgsRendererCategory,
+    QgsSimpleLineSymbolLayer,
     QgsSingleSymbolRenderer,
     QgsStyle,
     QgsVectorLayer,
@@ -18,6 +20,12 @@ from qgis.core import (
 )
 
 from .activity_query import ActivityQuery, build_subset_string
+from .map_style import (
+    DEFAULT_SIMPLE_LINE_HEX,
+    resolve_activity_color,
+    resolve_basemap_line_style,
+    pick_activity_style_field,
+)
 from .mapbox_config import (
     BACKGROUND_LAYER_PREFIX,
     build_background_layer_name,
@@ -80,13 +88,14 @@ class LayerManager:
         layer.setSubsetString(build_subset_string(query))
         layer.triggerRepaint()
 
-    def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset):
+    def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name=None):
         preset = preset or "Simple lines"
+        basemap_preset_name = background_preset_name or self._infer_background_preset_name()
         if activities_layer is not None:
             if preset == "By activity type":
-                self._apply_categorized_line_style(activities_layer)
+                self._apply_categorized_line_style(activities_layer, basemap_preset_name)
             else:
-                self._apply_simple_line_style(activities_layer)
+                self._apply_simple_line_style(activities_layer, basemap_preset_name)
 
         if points_layer is not None:
             if preset == "Heatmap":
@@ -232,31 +241,62 @@ class LayerManager:
         canvas.setExtent(extents)
         canvas.refresh()
 
-    def _apply_simple_line_style(self, layer):
-        symbol = QgsLineSymbol.createSimple({"line_color": "39,174,96,255", "line_width": "0.8"})
+    def _apply_simple_line_style(self, layer, basemap_preset_name=None):
+        line_style = resolve_basemap_line_style(basemap_preset_name)
+        symbol = self._build_line_symbol(DEFAULT_SIMPLE_LINE_HEX, line_style)
         layer.setRenderer(QgsSingleSymbolRenderer(symbol))
-        layer.setOpacity(1.0)
+        layer.setOpacity(line_style.opacity)
         layer.triggerRepaint()
 
-    def _apply_categorized_line_style(self, layer):
-        palette = [
-            QColor("#27ae60"),
-            QColor("#2980b9"),
-            QColor("#8e44ad"),
-            QColor("#d35400"),
-            QColor("#c0392b"),
-        ]
-        field_index = layer.fields().indexOf("activity_type")
+    def _apply_categorized_line_style(self, layer, basemap_preset_name=None):
+        line_style = resolve_basemap_line_style(basemap_preset_name)
+        field_name = pick_activity_style_field(field.name() for field in layer.fields())
+        if field_name is None:
+            self._apply_simple_line_style(layer, basemap_preset_name)
+            return
+
+        field_index = layer.fields().indexOf(field_name)
         values = sorted(value for value in layer.uniqueValues(field_index) if value not in (None, ""))
         categories = []
-        for index, value in enumerate(values):
-            symbol = QgsLineSymbol.createSimple(
-                {"line_color": palette[index % len(palette)].name(), "line_width": "0.9"}
-            )
+        for value in values:
+            symbol = self._build_line_symbol(resolve_activity_color(value, basemap_preset_name), line_style)
             categories.append(QgsRendererCategory(value, symbol, value or "Unknown"))
-        layer.setRenderer(QgsCategorizedSymbolRenderer("activity_type", categories))
-        layer.setOpacity(1.0)
+
+        renderer = QgsCategorizedSymbolRenderer(field_name, categories)
+        renderer.setSourceSymbol(self._build_line_symbol(resolve_activity_color("Other", basemap_preset_name), line_style))
+        layer.setRenderer(renderer)
+        layer.setOpacity(line_style.opacity)
         layer.triggerRepaint()
+
+    def _build_line_symbol(self, color_hex, line_style):
+        symbol = QgsLineSymbol()
+        symbol.deleteSymbolLayer(0)
+
+        if line_style.outline_color and line_style.outline_width > 0:
+            outline_layer = QgsSimpleLineSymbolLayer()
+            outline_layer.setColor(QColor(line_style.outline_color))
+            outline_layer.setWidth(line_style.line_width + (line_style.outline_width * 2.0))
+            outline_layer.setPenCapStyle(Qt.RoundCap)
+            outline_layer.setPenJoinStyle(Qt.RoundJoin)
+            symbol.appendSymbolLayer(outline_layer)
+
+        line_layer = QgsSimpleLineSymbolLayer()
+        line_layer.setColor(QColor(color_hex))
+        line_layer.setWidth(line_style.line_width)
+        line_layer.setPenCapStyle(Qt.RoundCap)
+        line_layer.setPenJoinStyle(Qt.RoundJoin)
+        symbol.appendSymbolLayer(line_layer)
+        return symbol
+
+    def _infer_background_preset_name(self):
+        for layer in QgsProject.instance().mapLayers().values():
+            name = layer.name()
+            if not name.startswith(BACKGROUND_LAYER_PREFIX):
+                continue
+            if " — " not in name:
+                return None
+            return name.split(" — ", 1)[1].strip() or None
+        return None
 
     def _apply_start_point_style(self, layer, subtle=False):
         symbol = QgsMarkerSymbol.createSimple(

--- a/map_style.py
+++ b/map_style.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import colorsys
+import re
+from typing import Iterable
+
+DEFAULT_SIMPLE_LINE_HEX = "#2A9D8F"
+_DEFAULT_CONTEXT = "Outdoor"
+
+_ACTIVITY_COLORS = {
+    "run": "#D62828",
+    "trailrun": "#9D0208",
+    "virtualrun": "#868E96",
+    "ride": "#F77F00",
+    "mountainbikeride": "#D95F02",
+    "gravelride": "#BC6C25",
+    "ebikeride": "#6C757D",
+    "walk": "#FFD60A",
+    "hike": "#F9C74F",
+    "backpacking": "#E9C46A",
+    "alpineski": "#0077B6",
+    "backcountryski": "#023E8A",
+    "nordicski": "#0096C7",
+    "snowboard": "#00B4D8",
+    "snowshoe": "#48CAE4",
+    "swim": "#0077B6",
+    "openwaterswim": "#023E8A",
+    "kayaking": "#1B9AAA",
+    "canoeing": "#2A9D8F",
+    "rowing": "#264653",
+    "standuppaddling": "#48CAE4",
+    "surfing": "#0096C7",
+    "rockclimbing": "#8B5E34",
+    "mountaineering": "#6B4423",
+    "iceclimbing": "#90E0EF",
+    "workout": "#7B2CBF",
+    "crossfit": "#5A189A",
+    "weighttraining": "#3C096C",
+    "yoga": "#C77DFF",
+    "virtualride": "#6C757D",
+    "commute": "#495057",
+    "other": "#9E9E9E",
+}
+
+_FAMILY_FALLBACKS = {
+    "running": "#D62828",
+    "cycling": "#F77F00",
+    "walking": "#FFD60A",
+    "winter": "#0077B6",
+    "water": "#00B4D8",
+    "mountain": "#8B5E34",
+    "fitness": "#7B2CBF",
+    "machine": "#6C757D",
+}
+
+
+@dataclass(frozen=True)
+class BasemapLineStyle:
+    line_width: float
+    opacity: float
+    outline_color: str | None = None
+    outline_width: float = 0.0
+
+
+_BASEMAP_LINE_STYLES = {
+    "Outdoor": BasemapLineStyle(line_width=1.8, opacity=0.85),
+    "Light": BasemapLineStyle(line_width=2.1, opacity=0.9, outline_color="#333333", outline_width=0.4),
+    "Satellite": BasemapLineStyle(line_width=2.3, opacity=0.95, outline_color="#FFFFFF", outline_width=1.0),
+}
+
+
+def normalize_activity_value(value: object) -> str:
+    text = str(value or "").strip().casefold()
+    return re.sub(r"[^a-z0-9]+", "", text)
+
+
+def pick_activity_style_field(available_fields: Iterable[str]) -> str | None:
+    field_names = {str(name) for name in available_fields}
+    for candidate in ("sport_type", "activity_type"):
+        if candidate in field_names:
+            return candidate
+    return None
+
+
+def resolve_basemap_line_style(preset_name: str | None) -> BasemapLineStyle:
+    return _BASEMAP_LINE_STYLES.get((preset_name or "").strip(), _BASEMAP_LINE_STYLES[_DEFAULT_CONTEXT])
+
+
+def resolve_activity_color(activity_value: object, basemap_preset_name: str | None = None) -> str:
+    normalized = normalize_activity_value(activity_value)
+    base_hex = _ACTIVITY_COLORS.get(normalized)
+    if base_hex is None:
+        base_hex = _FAMILY_FALLBACKS[resolve_activity_family(activity_value)]
+    return adapt_color_for_basemap(base_hex, basemap_preset_name)
+
+
+def resolve_activity_family(activity_value: object) -> str:
+    normalized = normalize_activity_value(activity_value)
+    if not normalized:
+        return "machine"
+    if any(token in normalized for token in ("virtual", "trainer", "commute", "ebike", "machine")):
+        return "machine"
+    if any(token in normalized for token in ("ski", "snow", "sled")):
+        return "winter"
+    if any(token in normalized for token in ("swim", "surf", "paddle", "row", "kayak", "canoe", "sup")):
+        return "water"
+    if any(token in normalized for token in ("iceclimb", "climb", "mountain", "boulder", "alpinism")):
+        return "mountain"
+    if any(token in normalized for token in ("run", "jog")):
+        return "running"
+    if any(token in normalized for token in ("walk", "hike", "trek", "backpack")):
+        return "walking"
+    if any(token in normalized for token in ("crossfit", "workout", "yoga", "weight", "gym", "pilates")):
+        return "fitness"
+    if any(token in normalized for token in ("ride", "bike", "cycle")):
+        return "cycling"
+    return "machine"
+
+
+def adapt_color_for_basemap(color_hex: str, basemap_preset_name: str | None) -> str:
+    context = (basemap_preset_name or "").strip() or _DEFAULT_CONTEXT
+    if context not in {"Light", "Satellite"}:
+        return color_hex.upper()
+
+    red, green, blue = _hex_to_rgb(color_hex)
+    hue, lightness, saturation = colorsys.rgb_to_hls(red / 255.0, green / 255.0, blue / 255.0)
+
+    if context == "Light":
+        lightness = _clamp(lightness * 0.84)
+        saturation = _clamp(saturation * 1.05)
+    else:
+        lightness = _clamp(lightness * 1.08 + 0.02)
+        saturation = _clamp(saturation * 1.03)
+
+    red, green, blue = colorsys.hls_to_rgb(hue, lightness, saturation)
+    return _rgb_to_hex(round(red * 255), round(green * 255), round(blue * 255))
+
+
+def _hex_to_rgb(color_hex: str) -> tuple[int, int, int]:
+    value = color_hex.strip().lstrip("#")
+    if len(value) != 6:
+        raise ValueError(f"Expected a 6-digit hex color, got: {color_hex!r}")
+    return int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
+
+
+def _rgb_to_hex(red: int, green: int, blue: int) -> str:
+    return f"#{red:02X}{green:02X}{blue:02X}"
+
+
+def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
+    return max(minimum, min(maximum, value))

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.31.0
+version=0.32.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -549,6 +549,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 self.points_layer,
                 self.atlas_layer,
                 preset,
+                background_preset_name=self.backgroundPresetComboBox.currentText() if wants_background else None,
             )
             temporal_note = self.layer_manager.apply_temporal_configuration(
                 self.activities_layer,

--- a/tests/test_map_style.py
+++ b/tests/test_map_style.py
@@ -1,0 +1,55 @@
+import unittest
+
+import tests._path  # noqa: F401,E402
+
+from map_style import (  # noqa: E402
+    DEFAULT_SIMPLE_LINE_HEX,
+    adapt_color_for_basemap,
+    pick_activity_style_field,
+    resolve_activity_color,
+    resolve_activity_family,
+    resolve_basemap_line_style,
+)
+
+
+class MapStyleTests(unittest.TestCase):
+    def test_activity_color_mapping_uses_semantic_reference_palette(self):
+        self.assertEqual(resolve_activity_color("Run"), "#D62828")
+        self.assertEqual(resolve_activity_color("TrailRun"), "#9D0208")
+        self.assertEqual(resolve_activity_color("Ride"), "#F77F00")
+        self.assertEqual(resolve_activity_color("Snowshoe"), "#48CAE4")
+        self.assertEqual(resolve_activity_color("VirtualRide"), "#6C757D")
+
+    def test_unknown_activity_types_fall_back_by_semantic_family(self):
+        self.assertEqual(resolve_activity_family("EveningJog"), "running")
+        self.assertEqual(resolve_activity_family("BikeCommute"), "machine")
+        self.assertEqual(resolve_activity_family("Kitesurf"), "water")
+        self.assertEqual(resolve_activity_color("Kitesurf"), "#00B4D8")
+        self.assertEqual(resolve_activity_color(None), "#6C757D")
+
+    def test_light_and_satellite_contexts_adjust_luminance_without_changing_mapping(self):
+        self.assertEqual(resolve_activity_color("Run", "Outdoor"), "#D62828")
+        self.assertEqual(resolve_activity_color("Run", "Light"), "#B71E1E")
+        self.assertEqual(resolve_activity_color("Run", "Satellite"), "#DE3F3F")
+        self.assertEqual(adapt_color_for_basemap(DEFAULT_SIMPLE_LINE_HEX, "Light"), "#21867A")
+        self.assertEqual(adapt_color_for_basemap(DEFAULT_SIMPLE_LINE_HEX, "Satellite"), "#2EB4A3")
+
+    def test_basemap_line_profiles_follow_style_guide_ranges(self):
+        outdoor = resolve_basemap_line_style("Outdoor")
+        light = resolve_basemap_line_style("Light")
+        satellite = resolve_basemap_line_style("Satellite")
+        fallback = resolve_basemap_line_style("Winter (custom style)")
+
+        self.assertEqual((outdoor.line_width, outdoor.opacity, outdoor.outline_color), (1.8, 0.85, None))
+        self.assertEqual((light.line_width, light.opacity, light.outline_color, light.outline_width), (2.1, 0.9, "#333333", 0.4))
+        self.assertEqual((satellite.line_width, satellite.opacity, satellite.outline_color, satellite.outline_width), (2.3, 0.95, "#FFFFFF", 1.0))
+        self.assertEqual(fallback, outdoor)
+
+    def test_pick_activity_style_field_prefers_sport_type(self):
+        self.assertEqual(pick_activity_style_field(["name", "sport_type", "activity_type"]), "sport_type")
+        self.assertEqual(pick_activity_style_field(["name", "activity_type"]), "activity_type")
+        self.assertIsNone(pick_activity_style_field(["name", "distance_m"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -191,6 +191,14 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertTrue(background.isValid())
 
             activities_layer, starts_layer, points_layer, atlas_layer = self.layer_manager.load_output_layers(output_path)
+            self.layer_manager.apply_style(
+                activities_layer,
+                starts_layer,
+                points_layer,
+                atlas_layer,
+                "By activity type",
+                background_preset_name="Satellite",
+            )
 
             self.assertTrue(activities_layer.isValid())
             self.assertTrue(starts_layer.isValid())
@@ -200,6 +208,21 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(starts_layer.featureCount(), 2)
             self.assertGreaterEqual(points_layer.featureCount(), 4)
             self.assertEqual(atlas_layer.featureCount(), 2)
+
+            renderer = activities_layer.renderer()
+            self.assertEqual(renderer.classAttribute(), "sport_type")
+            categories = {category.value(): category for category in renderer.categories()}
+            self.assertEqual(set(categories), {"Ride", "Run"})
+            self.assertEqual(round(activities_layer.opacity(), 2), 0.95)
+
+            ride_symbol = categories["Ride"].symbol()
+            run_symbol = categories["Run"].symbol()
+            self.assertEqual(ride_symbol.symbolLayerCount(), 2)
+            self.assertEqual(run_symbol.symbolLayerCount(), 2)
+            self.assertEqual(ride_symbol.symbolLayer(0).color().name().upper(), "#FFFFFF")
+            self.assertEqual(run_symbol.symbolLayer(0).color().name().upper(), "#FFFFFF")
+            self.assertEqual(ride_symbol.symbolLayer(1).color().name().upper(), "#FF8E16")
+            self.assertEqual(run_symbol.symbolLayer(1).color().name().upper(), "#DE3F3F")
 
             self.assertEqual(QgsProject.instance().crs().authid(), "EPSG:3857")
             self.assertEqual(self.iface.mapCanvas().destination_crs_authid, "EPSG:3857")


### PR DESCRIPTION
## Summary
- add a semantic activity-style palette and basemap-aware line profiles for qfit map layers
- apply the new styling preset machinery in the layer manager and cover it with unit + QGIS smoke tests
- document the style guide, bump plugin metadata to 0.32.0, and refresh the roadmap/docs

## Testing
- python3 -m unittest discover -s tests -v
- QT_QPA_PLATFORM=offscreen python3 -m unittest discover -s tests -v
- python3 scripts/package_plugin.py
- python3 scripts/install_plugin.py --profile default --mode symlink