### PR TITLE
hotfix: remove stale QgsAtlasComposition import (crash on plugin load)

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import os
 
 from qgis.core import (
-    QgsAtlasComposition,
     QgsLayoutExporter,
     QgsLayoutItemLabel,
     QgsLayoutItemMap,


### PR DESCRIPTION
## Problem
Plugin crashes on load with:
```
ImportError: cannot import name 'QgsAtlasComposition' from 'qgis.core'
```
`QgsAtlasComposition` was removed in QGIS 3.x. The class is not needed since we access the atlas via `layout.atlas()`.

## Fix
Remove the dead import.

Fixes classFactory() crash reported by Emman.