### PR TITLE
feat: use vector basemap for atlas PDF export (dramatically reduces file size)

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -265,6 +265,13 @@ class AtlasExportTask(QgsTask):
         on_finished,
         project=None,
         subset_string: str | None = None,
+        restore_tile_mode: str | None = None,
+        layer_manager=None,
+        preset_name: str | None = None,
+        access_token: str = "",
+        style_owner: str = "",
+        style_id: str = "",
+        background_enabled: bool = False,
     ):
         super().__init__("Export qfit atlas PDF", QgsTask.CanCancel)
         self._atlas_layer = atlas_layer
@@ -272,6 +279,13 @@ class AtlasExportTask(QgsTask):
         self._on_finished = on_finished
         self._project = project
         self._subset_string = subset_string
+        self._restore_tile_mode = restore_tile_mode
+        self._layer_manager = layer_manager
+        self._preset_name = preset_name
+        self._access_token = access_token
+        self._style_owner = style_owner
+        self._style_id = style_id
+        self._background_enabled = background_enabled
         self._error: str | None = None
         self._page_count: int = 0
 
@@ -353,6 +367,26 @@ class AtlasExportTask(QgsTask):
 
     def finished(self, result: bool) -> None:
         """Called on the main thread after run() returns."""
+        # Restore the original tile mode (raster) on the main thread after export
+        if (
+            self._restore_tile_mode is not None
+            and self._layer_manager is not None
+            and self._background_enabled
+        ):
+            try:
+                from mapbox_config import TILE_MODE_RASTER  # noqa: PLC0415
+                if self._restore_tile_mode == TILE_MODE_RASTER:
+                    self._layer_manager.ensure_background_layer(
+                        enabled=True,
+                        preset_name=self._preset_name,
+                        access_token=self._access_token,
+                        style_owner=self._style_owner,
+                        style_id=self._style_id,
+                        tile_mode=self._restore_tile_mode,
+                    )
+            except Exception:
+                pass
+
         if self._on_finished is not None:
             self._on_finished(
                 output_path=self._output_path if result else None,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -987,6 +987,26 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         query = self._current_activity_query()
         current_subset = build_subset_string(query)
 
+        # Switch basemap to vector mode for export if currently raster — vector
+        # tiles embed as true PDF vectors, dramatically reducing file size.
+        # We reload the basemap in vector mode and restore raster after export.
+        pre_export_tile_mode = self.tileModeComboBox.currentText()
+        if (
+            pre_export_tile_mode == TILE_MODE_RASTER
+            and self.backgroundMapCheckBox.isChecked()
+        ):
+            try:
+                self.layer_manager.ensure_background_layer(
+                    enabled=True,
+                    preset_name=self.backgroundPresetComboBox.currentText(),
+                    access_token=self.mapboxAccessTokenLineEdit.text().strip(),
+                    style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+                    style_id=self.mapboxStyleIdLineEdit.text().strip(),
+                    tile_mode=TILE_MODE_VECTOR,
+                )
+            except Exception:
+                pass  # fall back to raster if vector fails
+
         self._set_atlas_export_running(True)
         self._set_atlas_pdf_status(
             f"Exporting atlas ({self.atlas_layer.featureCount()} pages)…"
@@ -998,6 +1018,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             output_path=output_path,
             on_finished=self._on_atlas_export_finished,
             subset_string=current_subset,
+            restore_tile_mode=pre_export_tile_mode,
+            layer_manager=self.layer_manager,
+            preset_name=self.backgroundPresetComboBox.currentText(),
+            access_token=self.mapboxAccessTokenLineEdit.text().strip(),
+            style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+            style_id=self.mapboxStyleIdLineEdit.text().strip(),
+            background_enabled=self.backgroundMapCheckBox.isChecked(),
         )
         QgsApplication.taskManager().addTask(self._atlas_export_task)
 


### PR DESCRIPTION
Before export, qfit automatically switches the basemap from Raster to Vector mode.
Vector tiles embed as true PDF vectors instead of raster bitmaps.
After export completes, the original Raster basemap is restored.

This should reduce the atlas PDF from ~54 MB to a few MB for the same 8 pages.