### PR TITLE
fix: invalid layer errors from stale QGIS layers on filter operations

### DIFF
--- a/layer_manager.py
+++ b/layer_manager.py
@@ -109,7 +109,7 @@ class LayerManager:
         return layer
 
     def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None, max_distance_km=None, search_text=None, detailed_only=False):
-        if layer is None:
+        if layer is None or not layer.isValid():
             return
         query = ActivityQuery(
             activity_type=activity_type,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -947,7 +947,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         Used when layers are loaded directly (without fetching), so the combo
         box shows the correct activity types from the existing GeoPackage.
         """
-        if self.activities_layer is None:
+        if self.activities_layer is None or not self.activities_layer.isValid():
             return
         current_value = self.activityTypeComboBox.currentText() or "All"
         try:


### PR DESCRIPTION
apply_filters() and _populate_activity_types_from_layer() now check layer.isValid() before querying. Prevents SQLite 'unable to open database file' errors from stale layers left in the QGIS project from a previous session.