### PR TITLE
fix: atlas map extent uses Predefined scaling (activity bounding box without extra margin)

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -152,7 +152,10 @@ def build_atlas_layout(
     map_item.attemptMove(QgsLayoutPoint(MAP_X, MAP_Y, QgsUnitTypes.LayoutMillimeters))
     map_item.attemptResize(QgsLayoutSize(MAP_W, MAP_H, QgsUnitTypes.LayoutMillimeters))
     map_item.setAtlasDriven(True)
-    map_item.setAtlasScalingMode(QgsLayoutItemMap.Auto)
+    # Predefined: use the atlas feature's bounding box as the exact map extent.
+    # The activity_atlas_pages layer already stores page extents with margin applied
+    # via publish_atlas.py. Using Auto would add a second automatic margin on top.
+    map_item.setAtlasScalingMode(QgsLayoutItemMap.Predefined)
 
     # Disable tile border rendering on visible vector tile layers (debug overlay)
     try:


### PR DESCRIPTION
QgsLayoutItemMap.Auto was adding an automatic extra margin on top of the pre-calculated page extent, pushing the activity track into a small portion of the map. Switched to Predefined so the atlas feature geometry is used as-is for the map extent.