### PR TITLE
fix: atlas map shows blank tracks when visualization filters are active

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -286,6 +286,7 @@ class AtlasExportTask(QgsTask):
         style_owner: str = "",
         style_id: str = "",
         background_enabled: bool = False,
+        data_layers_restore: dict | None = None,
     ):
         super().__init__("Export qfit atlas PDF", QgsTask.CanCancel)
         self._atlas_layer = atlas_layer
@@ -300,6 +301,7 @@ class AtlasExportTask(QgsTask):
         self._style_owner = style_owner
         self._style_id = style_id
         self._background_enabled = background_enabled
+        self._data_layers_restore = data_layers_restore or {}
         self._error: str | None = None
         self._page_count: int = 0
 
@@ -381,6 +383,14 @@ class AtlasExportTask(QgsTask):
 
     def finished(self, result: bool) -> None:
         """Called on the main thread after run() returns."""
+        # Restore visualization subset strings on data layers
+        for lyr, original_subset in self._data_layers_restore.items():
+            try:
+                if lyr is not None and lyr.isValid():
+                    lyr.setSubsetString(original_subset)
+            except Exception:
+                pass
+
         # Restore the original tile mode (raster) on the main thread after export
         if (
             self._restore_tile_mode is not None

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1110,11 +1110,21 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self._set_status("Generating atlas PDF…")
 
+        # Clear visualization filters on data layers during export so all tracks
+        # are visible in the map regardless of the active activity-type/date filter.
+        # The atlas pages already controls which activities appear via subset_string.
+        data_layers_with_original_subsets = {}
+        for lyr in [self.activities_layer, self.starts_layer, self.points_layer]:
+            if lyr is not None and lyr.isValid() and lyr.subsetString():
+                data_layers_with_original_subsets[lyr] = lyr.subsetString()
+                lyr.setSubsetString("")
+
         self._atlas_export_task = AtlasExportTask(
             atlas_layer=self.atlas_layer,
             output_path=output_path,
             on_finished=self._on_atlas_export_finished,
             subset_string=current_subset,
+            data_layers_restore=data_layers_with_original_subsets,
             restore_tile_mode=pre_export_tile_mode,
             layer_manager=self.layer_manager,
             preset_name=self.backgroundPresetComboBox.currentText(),


### PR DESCRIPTION
Activity type/date filters on the activities layer were hiding tracks during atlas export — pages that matched the atlas filter but not the visualization filter showed blank maps. Fixed by temporarily clearing subset strings on data layers before export and restoring them after.