### PR TITLE
fix: unify fetch semantics between UI, code, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ qfit is a QGIS plugin for importing and visualizing fitness activity data in a s
 The current implementation supports:
 - Strava API connection using `client_id`, `client_secret`, and `refresh_token`
 - a built-in OAuth helper to open the Strava authorize page and exchange an authorization code for a refresh token
-- downloading recent athlete activities from Strava
-- date-bounded fetches based on the selected filter window
+- downloading all athlete activities from Strava (full sync)
 - optional detailed Strava track streams for higher-fidelity geometries
 - local caching of detailed stream bundles to reduce repeated API calls
 - a simple Strava rate-limit guard for detailed-stream enrichment
@@ -100,7 +99,7 @@ Visible layers:
 The dock is now organized around the main qfit workflow:
 
 1. **Connect** — enter your Strava app credentials and use the built-in OAuth helper if you still need a refresh token
-2. **Fetch activities** — choose a date window, paging limits, and any activity filters you want to use for previewing
+2. **Fetch activities** — choose paging limits and any activity filters you want to use for previewing; the fetch always performs a full sync, and date filters apply only to the preview and loaded layers
 3. Optionally enable detailed Strava track streams; qfit keeps the detailed-track limit hidden until that mode is turned on
 4. Click **Fetch activities** to preview what qfit will work with before anything is written to disk
 5. **Store data** — choose an output `.gpkg` file and optionally enable sampled `activity_points` generation for analysis

--- a/contextual_help.py
+++ b/contextual_help.py
@@ -179,8 +179,8 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
         anchor_name="refreshButton",
         target_text="Fetch activities",
         tooltip=(
-            "Pulls activities from Strava using the current date range, paging, and detailed-track settings without "
-            "writing anything to QGIS yet."
+            "Pulls all activities from Strava using the current paging and detailed-track settings without "
+            "writing anything to QGIS yet.  Date filters apply only to the preview and loaded layers."
         ),
     ),
     HelpEntry(

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1,5 +1,5 @@
 import os
-from datetime import date, datetime, time
+from datetime import date
 
 from qgis.core import QgsApplication, QgsProject
 from qgis.PyQt import uic
@@ -585,19 +585,18 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status("Strava fetch failed")
             return
 
-        before, after = self._build_fetch_epoch_range()
         self.activities = activities
         detailed_count = sum(1 for activity in self.activities if activity.geometry_source == "stream")
         today_str = date.today().isoformat()
         self.last_fetch_context = {
             "provider": "strava",
-            "before_epoch": before,
-            "after_epoch": after,
+            "before_epoch": None,
+            "after_epoch": None,
             "fetched_count": len(self.activities),
             "detailed_count": detailed_count,
             "stream_stats": client.last_stream_enrichment_stats,
             "rate_limit": client.last_rate_limit,
-            "is_full_sync": self._is_full_sync_window(before, after),
+            "is_full_sync": True,
         }
         # Persist last sync date
         settings = QSettings()
@@ -936,28 +935,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _redirect_uri(self):
         return self.redirectUriLineEdit.text().strip() or StravaClient.DEFAULT_REDIRECT_URI
 
-    def _build_fetch_epoch_range(self):
-        local_tz = datetime.now().astimezone().tzinfo
-        after = None
-        before = None
-
-        if self.dateFromEdit.date().isValid():
-            start_date = self._qdate_to_date(self.dateFromEdit.date())
-            after = int(datetime.combine(start_date, time(0, 0, 0), tzinfo=local_tz).timestamp())
-
-        if self.dateToEdit.date().isValid():
-            end_date = self._qdate_to_date(self.dateToEdit.date())
-            before = int(datetime.combine(end_date, time(23, 59, 59), tzinfo=local_tz).timestamp())
-
-        return before, after
-
     def _qdate_to_date(self, value):
         return date(value.year(), value.month(), value.day())
-
-    def _is_full_sync_window(self, before_epoch, after_epoch):
-        if before_epoch is None or after_epoch is None:
-            return False
-        return (before_epoch - after_epoch) >= 365 * 24 * 60 * 60
 
     def _populate_activity_types(self):
         current_value = self.activityTypeComboBox.currentText() or "All"


### PR DESCRIPTION
Closes #64

- Remove `_build_fetch_epoch_range()` and `_is_full_sync_window()` (fetch always does full sync)
- Update fetch button tooltip to clarify date filters are preview/layer-only
- Update README to remove date-bounded fetch claims