### PR TITLE
fix: align preview filtering and QGIS subset filtering

### DIFF
--- a/activity_query.py
+++ b/activity_query.py
@@ -161,7 +161,13 @@ def build_subset_string(query: ActivityQuery) -> str:
         clauses.append(f'"distance_m" <= {query.max_distance_km * 1000.0}')
     if query.search_text:
         search_text = _escape_sql_literal(query.search_text.lower())
-        clauses.append(f"lower(coalesce(\"name\", '')) LIKE '%{search_text}%'")
+        clauses.append(
+            "("
+            f"lower(coalesce(\"name\", '')) LIKE '%{search_text}%'"
+            f" OR lower(coalesce(\"activity_type\", '')) LIKE '%{search_text}%'"
+            f" OR lower(coalesce(\"sport_type\", '')) LIKE '%{search_text}%'"
+            ")"
+        )
     if query.detailed_only:
         clauses.append('"geometry_source" = \'stream\'')
     return " AND ".join(clauses)

--- a/tests/test_activity_query.py
+++ b/tests/test_activity_query.py
@@ -111,7 +111,23 @@ class ActivityQueryTests(unittest.TestCase):
         self.assertIn('"distance_m" >= 10000.0', subset)
         self.assertIn('"distance_m" <= 50000.0', subset)
         self.assertIn("lower(coalesce(\"name\", '')) LIKE '%o''brien%'", subset)
+        self.assertIn("lower(coalesce(\"activity_type\", '')) LIKE '%o''brien%'", subset)
+        self.assertIn("lower(coalesce(\"sport_type\", '')) LIKE '%o''brien%'", subset)
         self.assertIn('"geometry_source" = \'stream\'', subset)
+
+    def test_build_subset_string_search_spans_name_type_sport(self):
+        query = ActivityQuery(search_text="ride")
+        subset = build_subset_string(query)
+        self.assertIn("lower(coalesce(\"name\", ''))", subset)
+        self.assertIn("lower(coalesce(\"activity_type\", ''))", subset)
+        self.assertIn("lower(coalesce(\"sport_type\", ''))", subset)
+        self.assertIn(" OR ", subset)
+
+    def test_build_subset_string_apostrophe_escaping(self):
+        query = ActivityQuery(search_text="it's")
+        subset = build_subset_string(query)
+        self.assertIn("it''s", subset)
+        self.assertNotIn("it's", subset)
 
     def test_format_helpers_return_human_readable_text(self):
         self.assertEqual(format_duration(3725), "1h 02m")


### PR DESCRIPTION
Closes #65

- Update `build_subset_string()` to search `name`, `activity_type`, and `sport_type`
- Add tests for multi-field search and apostrophe SQL escaping