### PR TITLE
fix: avoid rewriting unchanged activities in SyncRepository

### DIFF
--- a/sync_repository.py
+++ b/sync_repository.py
@@ -170,14 +170,16 @@ class SyncRepository:
                     (record.get("source"), record.get("source_activity_id")),
                 ).fetchone()
 
+                if existing is not None and existing[0] == summary_hash:
+                    unchanged += 1
+                    continue
+
                 first_seen_at = now if existing is None else (existing[1] or now)
                 registry_record = self._prepare_registry_record(record, summary_hash, first_seen_at, now)
                 self._upsert_registry_row(cursor, registry_record)
 
                 if existing is None:
                     inserted += 1
-                elif existing[0] == summary_hash:
-                    unchanged += 1
                 else:
                     updated += 1
 


### PR DESCRIPTION
Closes #66

- Skip upsert when summary hash matches existing row
- `first_seen_at` and `last_synced_at` remain stable for unchanged activities
- Counters correctly reflect inserted/updated/unchanged