### PR TITLE
fix: align license across README and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,4 +233,4 @@ This project is now beyond the original scaffold/MVP stage and is moving toward 
 
 ## License
 
-TBD
+GPL-2.0-or-later — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Closes #69

- Replace "TBD" license in README with GPL-2.0-or-later
- LICENSE file already existed with GPL-2.0 text