### PR TITLE
fix: extract fetch/sync orchestration into SyncController

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -38,6 +38,7 @@ from .atlas_export_task import AtlasExportTask, BUILTIN_ATLAS_MAP_TARGET_ASPECT_
 from .qfit_cache import QfitCache
 from .strava_client import StravaClient, StravaClientError
 from .settings_service import SettingsService
+from .sync_controller import SyncController
 from .temporal_config import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
 
 FORM_CLASS, _ = uic.loadUiType(
@@ -63,6 +64,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._fetch_task = None
         self._atlas_export_task = None
         self.settings = SettingsService()
+        self.sync_controller = SyncController()
         self.layer_manager = LayerManager(iface)
         self.cache = self._build_cache()
         self.setupUi(self)
@@ -382,7 +384,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def on_open_authorize_clicked(self):
         self._save_settings()
         try:
-            client = self._build_client(require_refresh_token=False)
+            client = self.sync_controller.build_client(
+                client_id=self.clientIdLineEdit.text().strip(),
+                client_secret=self.clientSecretLineEdit.text().strip(),
+                refresh_token=self.refreshTokenLineEdit.text().strip(),
+                cache=self.cache,
+                require_refresh_token=False,
+            )
             redirect_uri = self._redirect_uri()
             url = client.build_authorize_url(redirect_uri=redirect_uri)
             if not QDesktopServices.openUrl(QUrl(url)):
@@ -414,7 +422,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         try:
-            client = self._build_client(require_refresh_token=False)
+            client = self.sync_controller.build_client(
+                client_id=self.clientIdLineEdit.text().strip(),
+                client_secret=self.clientSecretLineEdit.text().strip(),
+                refresh_token=self.refreshTokenLineEdit.text().strip(),
+                cache=self.cache,
+                require_refresh_token=False,
+            )
             payload = client.exchange_code_for_tokens(
                 authorization_code=authorization_code,
                 redirect_uri=self._redirect_uri(),
@@ -465,7 +479,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._save_settings()
         try:
-            client = self._build_client(require_refresh_token=True)
+            client = self.sync_controller.build_client(
+                client_id=self.clientIdLineEdit.text().strip(),
+                client_secret=self.clientSecretLineEdit.text().strip(),
+                refresh_token=self.refreshTokenLineEdit.text().strip(),
+                cache=self.cache,
+                require_refresh_token=True,
+            )
         except StravaClientError as exc:
             self._show_error("Strava import failed", str(exc))
             self._set_status("Strava fetch failed")
@@ -508,18 +528,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self.activities = activities
-        detailed_count = sum(1 for activity in self.activities if activity.geometry_source == "stream")
-        today_str = date.today().isoformat()
-        self.last_fetch_context = {
-            "provider": "strava",
-            "before_epoch": None,
-            "after_epoch": None,
-            "fetched_count": len(self.activities),
-            "detailed_count": detailed_count,
-            "stream_stats": client.last_stream_enrichment_stats,
-            "rate_limit": client.last_rate_limit,
-            "is_full_sync": True,
-        }
+        metadata = self.sync_controller.build_sync_metadata(activities, client)
+        detailed_count = metadata["detailed_count"]
+        today_str = metadata["today_str"]
+        self.last_fetch_context = metadata
         # Persist last sync date
         self.settings.set("last_sync_date", today_str)
 
@@ -532,7 +544,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
         )
         self._refresh_activity_preview()
-        self._set_status(self._fetch_status_text(client, len(self.activities), detailed_count))
+        self._set_status(self.sync_controller.fetch_status_text(client, len(self.activities), detailed_count))
 
     def on_load_clicked(self):
         if not self.activities:
@@ -840,20 +852,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.activityPreviewPlainTextEdit.setPlainText("\n".join(preview_lines))
         return sorted_activities
 
-    def _build_client(self, require_refresh_token=True):
-        client = StravaClient(
-            client_id=self.clientIdLineEdit.text().strip(),
-            client_secret=self.clientSecretLineEdit.text().strip(),
-            refresh_token=self.refreshTokenLineEdit.text().strip(),
-            cache=self.cache,
-        )
-        if not client.has_client_credentials():
-            raise StravaClientError("Enter Strava client ID and client secret first.")
-        if require_refresh_token and not client.refresh_token:
-            raise StravaClientError(
-                "Enter a refresh token, or use the built-in authorization flow to generate one."
-            )
-        return client
 
     def _redirect_uri(self):
         return self.redirectUriLineEdit.text().strip() or StravaClient.DEFAULT_REDIRECT_URI
@@ -900,32 +898,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         index = self.activityTypeComboBox.findText(current_value)
         self.activityTypeComboBox.setCurrentIndex(max(index, 0))
 
-    def _fetch_status_text(self, client, activity_count, detailed_count):
-        stream_stats = client.last_stream_enrichment_stats or {}
-        rate_limit_note = self._rate_limit_note(client.last_rate_limit)
-        return (
-            "Fetched {activity_count} activities from Strava, detailed tracks: {detailed_count}, "
-            "cached streams: {cached}, downloaded streams: {downloaded}, rate-limit skips: {skipped}.{rate_note}"
-        ).format(
-            activity_count=activity_count,
-            detailed_count=detailed_count,
-            cached=stream_stats.get("cached", 0),
-            downloaded=stream_stats.get("downloaded", 0),
-            skipped=stream_stats.get("skipped_rate_limit", 0),
-            rate_note=rate_limit_note,
-        )
-
-    def _rate_limit_note(self, rate_limit):
-        if not rate_limit:
-            return ""
-        short_remaining = rate_limit.get("short_remaining")
-        long_remaining = rate_limit.get("long_remaining")
-        if short_remaining is None and long_remaining is None:
-            return ""
-        return " Remaining rate limit: short={short}, long={long}.".format(
-            short=short_remaining if short_remaining is not None else "?",
-            long=long_remaining if long_remaining is not None else "?",
-        )
 
     def _update_connection_status(self):
         has_client = bool(self.clientIdLineEdit.text().strip() and self.clientSecretLineEdit.text().strip())

--- a/sync_controller.py
+++ b/sync_controller.py
@@ -1,0 +1,71 @@
+import logging
+from datetime import date
+
+from .strava_client import StravaClient, StravaClientError
+
+logger = logging.getLogger(__name__)
+
+
+class SyncController:
+    """Orchestrates Strava fetch/sync logic independent of the UI."""
+
+    def build_client(self, client_id, client_secret, refresh_token, cache=None, require_refresh_token=True):
+        """Create and validate a :class:`StravaClient`."""
+        client = StravaClient(
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+            cache=cache,
+        )
+        if not client.has_client_credentials():
+            raise StravaClientError("Enter Strava client ID and client secret first.")
+        if require_refresh_token and not client.refresh_token:
+            raise StravaClientError(
+                "Enter a refresh token, or use the built-in authorization flow to generate one."
+            )
+        return client
+
+    def build_sync_metadata(self, activities, client):
+        """Return a sync-context dict from a completed fetch."""
+        detailed_count = sum(1 for a in activities if a.geometry_source == "stream")
+        today_str = date.today().isoformat()
+        return {
+            "provider": "strava",
+            "before_epoch": None,
+            "after_epoch": None,
+            "fetched_count": len(activities),
+            "detailed_count": detailed_count,
+            "stream_stats": client.last_stream_enrichment_stats,
+            "rate_limit": client.last_rate_limit,
+            "is_full_sync": True,
+            "today_str": today_str,
+        }
+
+    def fetch_status_text(self, client, activity_count, detailed_count):
+        """Build a human-readable status string for a completed fetch."""
+        stream_stats = client.last_stream_enrichment_stats or {}
+        rate_limit_note = self._rate_limit_note(client.last_rate_limit)
+        return (
+            "Fetched {activity_count} activities from Strava, detailed tracks: {detailed_count}, "
+            "cached streams: {cached}, downloaded streams: {downloaded}, rate-limit skips: {skipped}.{rate_note}"
+        ).format(
+            activity_count=activity_count,
+            detailed_count=detailed_count,
+            cached=stream_stats.get("cached", 0),
+            downloaded=stream_stats.get("downloaded", 0),
+            skipped=stream_stats.get("skipped_rate_limit", 0),
+            rate_note=rate_limit_note,
+        )
+
+    @staticmethod
+    def _rate_limit_note(rate_limit):
+        if not rate_limit:
+            return ""
+        short_remaining = rate_limit.get("short_remaining")
+        long_remaining = rate_limit.get("long_remaining")
+        if short_remaining is None and long_remaining is None:
+            return ""
+        return " Remaining rate limit: short={short}, long={long}.".format(
+            short=short_remaining if short_remaining is not None else "?",
+            long=long_remaining if long_remaining is not None else "?",
+        )

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -1,0 +1,89 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from qfit.strava_client import StravaClient, StravaClientError
+from qfit.sync_controller import SyncController
+
+
+class BuildClientTests(unittest.TestCase):
+    def test_build_client_returns_strava_client(self):
+        ctrl = SyncController()
+        client = ctrl.build_client("id", "secret", "token")
+        self.assertIsInstance(client, StravaClient)
+
+    def test_build_client_raises_without_credentials(self):
+        ctrl = SyncController()
+        with self.assertRaises(StravaClientError):
+            ctrl.build_client("", "", "token")
+
+    def test_build_client_raises_without_refresh_token(self):
+        ctrl = SyncController()
+        with self.assertRaises(StravaClientError):
+            ctrl.build_client("id", "secret", "")
+
+    def test_build_client_allows_missing_refresh_token_when_not_required(self):
+        ctrl = SyncController()
+        client = ctrl.build_client("id", "secret", "", require_refresh_token=False)
+        self.assertIsInstance(client, StravaClient)
+
+
+class BuildSyncMetadataTests(unittest.TestCase):
+    def test_metadata_fields(self):
+        ctrl = SyncController()
+        activity = SimpleNamespace(geometry_source="stream")
+        client = SimpleNamespace(
+            last_stream_enrichment_stats={"cached": 1},
+            last_rate_limit={"short_remaining": 10},
+        )
+        meta = ctrl.build_sync_metadata([activity], client)
+        self.assertEqual(meta["provider"], "strava")
+        self.assertEqual(meta["fetched_count"], 1)
+        self.assertEqual(meta["detailed_count"], 1)
+        self.assertTrue(meta["is_full_sync"])
+        self.assertIn("today_str", meta)
+
+    def test_detailed_count_excludes_non_stream(self):
+        ctrl = SyncController()
+        activities = [
+            SimpleNamespace(geometry_source="stream"),
+            SimpleNamespace(geometry_source="polyline"),
+        ]
+        client = SimpleNamespace(last_stream_enrichment_stats=None, last_rate_limit=None)
+        meta = ctrl.build_sync_metadata(activities, client)
+        self.assertEqual(meta["detailed_count"], 1)
+        self.assertEqual(meta["fetched_count"], 2)
+
+
+class FetchStatusTextTests(unittest.TestCase):
+    def test_basic_status_text(self):
+        ctrl = SyncController()
+        client = SimpleNamespace(
+            last_stream_enrichment_stats={"cached": 2, "downloaded": 3, "skipped_rate_limit": 0},
+            last_rate_limit=None,
+        )
+        text = ctrl.fetch_status_text(client, 10, 5)
+        self.assertIn("10 activities", text)
+        self.assertIn("detailed tracks: 5", text)
+        self.assertIn("cached streams: 2", text)
+
+    def test_rate_limit_note_included(self):
+        ctrl = SyncController()
+        client = SimpleNamespace(
+            last_stream_enrichment_stats={},
+            last_rate_limit={"short_remaining": 50, "long_remaining": 900},
+        )
+        text = ctrl.fetch_status_text(client, 1, 0)
+        self.assertIn("Remaining rate limit", text)
+        self.assertIn("short=50", text)
+        self.assertIn("long=900", text)
+
+    def test_no_rate_limit(self):
+        ctrl = SyncController()
+        client = SimpleNamespace(
+            last_stream_enrichment_stats=None,
+            last_rate_limit=None,
+        )
+        text = ctrl.fetch_status_text(client, 0, 0)
+        self.assertNotIn("rate limit", text.lower().replace("rate-limit", ""))


### PR DESCRIPTION
Closes #71

- Created `SyncController` with `build_client()`, `build_sync_metadata()`, and `fetch_status_text()`
- Moved `_build_client`, `_fetch_status_text`, and `_rate_limit_note` out of `QfitDockWidget`
- Dock widget now delegates to `SyncController` for fetch/sync orchestration
- Added comprehensive unit tests for the new controller