### PR TITLE
fix: extract background map orchestration

### DIFF
--- a/background_map_controller.py
+++ b/background_map_controller.py
@@ -1,0 +1,35 @@
+import logging
+
+from .mapbox_config import preset_defaults, preset_requires_custom_style
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundMapController:
+    """Orchestrates background map configuration and loading."""
+
+    def __init__(self, layer_manager):
+        self._layer_manager = layer_manager
+
+    def resolve_style_defaults(self, preset_name, current_owner, current_style_id, force=False):
+        """Return ``(owner, style_id)`` to apply for *preset_name*.
+
+        Returns ``None`` when the current values should be kept.
+        """
+        if preset_requires_custom_style(preset_name):
+            return None
+        if current_owner and current_style_id and not force:
+            return None
+        return preset_defaults(preset_name)
+
+    def load_background(self, enabled, preset_name, access_token, style_owner, style_id, tile_mode):
+        """Apply the background layer via :class:`LayerManager` and return the layer (or *None*)."""
+        layer = self._layer_manager.ensure_background_layer(
+            enabled=enabled,
+            preset_name=preset_name,
+            access_token=access_token,
+            style_owner=style_owner,
+            style_id=style_id,
+            tile_mode=tile_mode,
+        )
+        return layer

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -20,6 +20,7 @@ from .activity_query import (
     sort_activities,
     summarize_activities,
 )
+from .background_map_controller import BackgroundMapController
 from .contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .gpkg_writer import GeoPackageWriter
 from .layer_manager import LayerManager
@@ -30,7 +31,6 @@ from .mapbox_config import (
     TILE_MODES,
     MapboxConfigError,
     background_preset_names,
-    preset_defaults,
     preset_requires_custom_style,
 )
 from .fetch_task import StravaFetchTask
@@ -66,6 +66,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.settings = SettingsService()
         self.sync_controller = SyncController()
         self.layer_manager = LayerManager(iface)
+        self.background_controller = BackgroundMapController(self.layer_manager)
         self.cache = self._build_cache()
         self.setupUi(self)
         self._remove_stale_qfit_layers()
@@ -352,7 +353,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._save_settings()
         enabled = self.backgroundMapCheckBox.isChecked()
         try:
-            self.background_layer = self.layer_manager.ensure_background_layer(
+            self.background_layer = self.background_controller.load_background(
                 enabled=enabled,
                 preset_name=self.backgroundPresetComboBox.currentText(),
                 access_token=self.mapboxAccessTokenLineEdit.text().strip(),
@@ -371,15 +372,16 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status("Background map cleared")
 
     def _sync_background_style_fields(self, preset_name, force=False):
-        if preset_requires_custom_style(preset_name):
-            return
-        current_owner = self.mapboxStyleOwnerLineEdit.text().strip()
-        current_style_id = self.mapboxStyleIdLineEdit.text().strip()
-        if current_owner and current_style_id and not force:
-            return
-        style_owner, style_id = preset_defaults(preset_name)
-        self.mapboxStyleOwnerLineEdit.setText(style_owner)
-        self.mapboxStyleIdLineEdit.setText(style_id)
+        result = self.background_controller.resolve_style_defaults(
+            preset_name,
+            current_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+            current_style_id=self.mapboxStyleIdLineEdit.text().strip(),
+            force=force,
+        )
+        if result is not None:
+            style_owner, style_id = result
+            self.mapboxStyleOwnerLineEdit.setText(style_owner)
+            self.mapboxStyleIdLineEdit.setText(style_id)
 
     def on_open_authorize_clicked(self):
         self._save_settings()

--- a/tests/test_background_map_controller.py
+++ b/tests/test_background_map_controller.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+from qfit.background_map_controller import BackgroundMapController
+
+
+class ResolveStyleDefaultsTests(unittest.TestCase):
+    def test_returns_defaults_when_forced(self):
+        lm = MagicMock()
+        ctrl = BackgroundMapController(lm)
+        result = ctrl.resolve_style_defaults("Mapbox Dark", "existing", "existing", force=True)
+        self.assertIsNotNone(result)
+        owner, style_id = result
+        self.assertTrue(owner)
+        self.assertTrue(style_id)
+
+    def test_returns_none_when_current_values_set_and_not_forced(self):
+        lm = MagicMock()
+        ctrl = BackgroundMapController(lm)
+        result = ctrl.resolve_style_defaults("Mapbox Dark", "mapbox", "dark-v11", force=False)
+        self.assertIsNone(result)
+
+    def test_returns_defaults_when_current_values_empty(self):
+        lm = MagicMock()
+        ctrl = BackgroundMapController(lm)
+        result = ctrl.resolve_style_defaults("Mapbox Dark", "", "", force=False)
+        self.assertIsNotNone(result)
+
+    def test_returns_none_for_custom_style_preset(self):
+        lm = MagicMock()
+        ctrl = BackgroundMapController(lm)
+        result = ctrl.resolve_style_defaults("Custom", "any", "any", force=True)
+        self.assertIsNone(result)
+
+
+class LoadBackgroundTests(unittest.TestCase):
+    def test_delegates_to_layer_manager(self):
+        lm = MagicMock()
+        sentinel = object()
+        lm.ensure_background_layer.return_value = sentinel
+        ctrl = BackgroundMapController(lm)
+        result = ctrl.load_background(
+            enabled=True,
+            preset_name="Mapbox Dark",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="dark-v11",
+            tile_mode="raster",
+        )
+        self.assertIs(result, sentinel)
+        lm.ensure_background_layer.assert_called_once_with(
+            enabled=True,
+            preset_name="Mapbox Dark",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="dark-v11",
+            tile_mode="raster",
+        )
+
+    def test_returns_none_when_disabled(self):
+        lm = MagicMock()
+        lm.ensure_background_layer.return_value = None
+        ctrl = BackgroundMapController(lm)
+        result = ctrl.load_background(
+            enabled=False,
+            preset_name="Mapbox Dark",
+            access_token="",
+            style_owner="",
+            style_id="",
+            tile_mode="raster",
+        )
+        self.assertIsNone(result)


### PR DESCRIPTION
Closes #72

- Created `BackgroundMapController` with `resolve_style_defaults()` and `load_background()`
- Moved style resolution and layer manager delegation out of `QfitDockWidget`
- Added unit tests for the new controller