### PR TITLE
fix: extract atlas export orchestration

### DIFF
--- a/atlas_export_controller.py
+++ b/atlas_export_controller.py
@@ -1,0 +1,33 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AtlasExportValidationError(Exception):
+    """Raised when atlas export inputs are invalid."""
+
+
+class AtlasExportController:
+    """Validates inputs and normalises paths for atlas PDF export."""
+
+    @staticmethod
+    def validate_atlas_layer(atlas_layer):
+        """Raise :class:`AtlasExportValidationError` if the layer is unusable."""
+        if atlas_layer is None:
+            raise AtlasExportValidationError(
+                "Store and load activity layers first (step 3: Store and load layers)."
+            )
+        if atlas_layer.featureCount() == 0:
+            raise AtlasExportValidationError(
+                "The atlas_pages layer has no features. "
+                "Fetch activities with geometry and store/load layers first."
+            )
+
+    @staticmethod
+    def normalize_pdf_path(path):
+        """Return *path* with a ``.pdf`` suffix and whether the path was changed."""
+        if not path:
+            raise AtlasExportValidationError("Enter or browse to an output PDF path.")
+        if not path.lower().endswith(".pdf"):
+            return f"{path}.pdf", True
+        return path, False

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -20,6 +20,7 @@ from .activity_query import (
     sort_activities,
     summarize_activities,
 )
+from .atlas_export_controller import AtlasExportController, AtlasExportValidationError
 from .background_map_controller import BackgroundMapController
 from .contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .gpkg_writer import GeoPackageWriter
@@ -65,6 +66,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._atlas_export_task = None
         self.settings = SettingsService()
         self.sync_controller = SyncController()
+        self.atlas_export_controller = AtlasExportController()
         self.layer_manager = LayerManager(iface)
         self.background_controller = BackgroundMapController(self.layer_manager)
         self.cache = self._build_cache()
@@ -933,27 +935,20 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._atlas_export_task = None
             return
 
-        if self.atlas_layer is None:
-            self._show_error(
-                "No atlas layer",
-                "Store and load activity layers first (step 3: Store and load layers).",
-            )
+        try:
+            self.atlas_export_controller.validate_atlas_layer(self.atlas_layer)
+        except AtlasExportValidationError as exc:
+            self._show_error("Atlas export error", str(exc))
             return
 
-        if self.atlas_layer.featureCount() == 0:
-            self._show_error(
-                "Atlas layer is empty",
-                "The atlas_pages layer has no features. "
-                "Fetch activities with geometry and store/load layers first.",
+        try:
+            output_path, changed = self.atlas_export_controller.normalize_pdf_path(
+                self.atlasPdfPathLineEdit.text().strip()
             )
+        except AtlasExportValidationError as exc:
+            self._show_error("Missing output path", str(exc))
             return
-
-        output_path = self.atlasPdfPathLineEdit.text().strip()
-        if not output_path:
-            self._show_error("Missing output path", "Enter or browse to an output PDF path.")
-            return
-        if not output_path.lower().endswith(".pdf"):
-            output_path = f"{output_path}.pdf"
+        if changed:
             self.atlasPdfPathLineEdit.setText(output_path)
 
         self._save_settings()

--- a/tests/test_atlas_export_controller.py
+++ b/tests/test_atlas_export_controller.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+from qfit.atlas_export_controller import AtlasExportController, AtlasExportValidationError
+
+
+class ValidateAtlasLayerTests(unittest.TestCase):
+    def test_raises_when_layer_is_none(self):
+        with self.assertRaises(AtlasExportValidationError):
+            AtlasExportController.validate_atlas_layer(None)
+
+    def test_raises_when_layer_is_empty(self):
+        layer = MagicMock()
+        layer.featureCount.return_value = 0
+        with self.assertRaises(AtlasExportValidationError):
+            AtlasExportController.validate_atlas_layer(layer)
+
+    def test_accepts_layer_with_features(self):
+        layer = MagicMock()
+        layer.featureCount.return_value = 5
+        AtlasExportController.validate_atlas_layer(layer)
+
+
+class NormalizePdfPathTests(unittest.TestCase):
+    def test_raises_when_path_is_empty(self):
+        with self.assertRaises(AtlasExportValidationError):
+            AtlasExportController.normalize_pdf_path("")
+
+    def test_appends_pdf_extension(self):
+        path, changed = AtlasExportController.normalize_pdf_path("/tmp/atlas")
+        self.assertEqual(path, "/tmp/atlas.pdf")
+        self.assertTrue(changed)
+
+    def test_keeps_existing_pdf_extension(self):
+        path, changed = AtlasExportController.normalize_pdf_path("/tmp/atlas.pdf")
+        self.assertEqual(path, "/tmp/atlas.pdf")
+        self.assertFalse(changed)
+
+    def test_case_insensitive_pdf_check(self):
+        path, changed = AtlasExportController.normalize_pdf_path("/tmp/atlas.PDF")
+        self.assertEqual(path, "/tmp/atlas.PDF")
+        self.assertFalse(changed)


### PR DESCRIPTION
Closes #73

- Created `AtlasExportController` with `validate_atlas_layer()` and `normalize_pdf_path()`
- Moved input validation and path normalization out of `QfitDockWidget`
- Added unit tests for the new controller