### PR TITLE
feat: A4 portrait atlas layout with square map frame

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -5,19 +5,20 @@ keeping the QGIS UI responsive.  The layout is constructed programmatically
 using :class:`qgis.core.QgsPrintLayout` with an atlas coverage from the
 ``activity_atlas_pages`` vector layer.
 
-Page template (A4 landscape, 297 × 210 mm):
+Page template (A4 portrait, 210 × 297 mm):
 
-    ┌──────────────────────────────────────────────────────────────────┐
-    │  [Title]                                      [Date]             │
-    │  [Subtitle / stats]                                              │
-    │  ┌────────────────────────────────────────────────────────────┐  │
-    │  │                                                            │  │
-    │  │                       MAP FRAME                            │  │
-    │  │                  (atlas-controlled extent)                  │  │
-    │  │                                                            │  │
-    │  └────────────────────────────────────────────────────────────┘  │
-    │  Page [% @atlas_featurenumber %] of [% @atlas_totalfeatures %]  │
-    └──────────────────────────────────────────────────────────────────┘
+    ┌────────────────────────────────────────┐
+    │  [Title]                       [Date]  │
+    │  [Subtitle / stats]                    │
+    │  ┌──────────────────────────────────┐  │
+    │  │                                  │  │
+    │  │         MAP FRAME (square)       │  │
+    │  │    (atlas-controlled extent)     │  │
+    │  │                                  │  │
+    │  └──────────────────────────────────┘  │
+    │  [footer / profile area reserved]      │
+    │  Page N / Total                        │
+    └────────────────────────────────────────┘
 """
 
 from __future__ import annotations
@@ -44,11 +45,11 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QFont
 
 # ---------------------------------------------------------------------------
-# Page geometry (mm, A4 landscape)
+# Page geometry (mm, A4 portrait with square map)
 # ---------------------------------------------------------------------------
 
-PAGE_WIDTH_MM = 297.0
-PAGE_HEIGHT_MM = 210.0
+PAGE_WIDTH_MM = 210.0
+PAGE_HEIGHT_MM = 297.0
 MARGIN_MM = 10.0
 HEADER_HEIGHT_MM = 16.0
 FOOTER_HEIGHT_MM = 8.0
@@ -57,10 +58,9 @@ FOOTER_GAP_MM = 3.0   # gap between map and footer
 
 MAP_X = MARGIN_MM
 MAP_Y = MARGIN_MM + HEADER_HEIGHT_MM + HEADER_GAP_MM
-MAP_W = PAGE_WIDTH_MM - 2 * MARGIN_MM
-MAP_H = (PAGE_HEIGHT_MM - MARGIN_MM - HEADER_HEIGHT_MM - HEADER_GAP_MM
-         - FOOTER_GAP_MM - FOOTER_HEIGHT_MM - MARGIN_MM)
-BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO = MAP_W / MAP_H
+MAP_W = PAGE_WIDTH_MM - 2 * MARGIN_MM                   # 190 mm
+MAP_H = MAP_W                                            # square
+BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO = MAP_W / MAP_H   # 1.0
 
 
 def _mm(layout, value):
@@ -123,7 +123,7 @@ def build_atlas_layout(
     layout.initializeDefaults()
     layout.setName("qfit Activity Atlas")
 
-    # -- Page size (A4 landscape) ------------------------------------------
+    # -- Page size (A4 portrait) -------------------------------------------
     page_collection = layout.pageCollection()
     if page_collection.pageCount() > 0:
         page = page_collection.page(0)

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -771,5 +771,50 @@ class TestAtlasExportTaskNarrowedExceptions(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestLayoutGeometry(unittest.TestCase):
+    """Verify A4 portrait layout dimensions and square map frame."""
+
+    def test_page_dimensions_are_a4_portrait(self):
+        from qfit.atlas_export_task import PAGE_WIDTH_MM, PAGE_HEIGHT_MM
+
+        self.assertAlmostEqual(PAGE_WIDTH_MM, 210.0)
+        self.assertAlmostEqual(PAGE_HEIGHT_MM, 297.0)
+        self.assertGreater(PAGE_HEIGHT_MM, PAGE_WIDTH_MM, "Page should be portrait (taller than wide)")
+
+    def test_map_frame_is_square(self):
+        from qfit.atlas_export_task import MAP_W, MAP_H
+
+        self.assertAlmostEqual(MAP_W, MAP_H, places=3, msg="Map frame should be square")
+        self.assertGreater(MAP_W, 0)
+
+    def test_map_target_aspect_ratio_is_one(self):
+        from qfit.atlas_export_task import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
+
+        self.assertAlmostEqual(BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO, 1.0, places=3)
+
+    def test_map_frame_fits_within_page(self):
+        from qfit.atlas_export_task import (
+            MAP_X, MAP_Y, MAP_W, MAP_H,
+            PAGE_WIDTH_MM, PAGE_HEIGHT_MM, MARGIN_MM,
+        )
+
+        self.assertGreaterEqual(MAP_X, MARGIN_MM)
+        self.assertLessEqual(MAP_X + MAP_W, PAGE_WIDTH_MM - MARGIN_MM)
+        self.assertGreater(MAP_Y, MARGIN_MM)
+        self.assertLess(MAP_Y + MAP_H, PAGE_HEIGHT_MM - MARGIN_MM)
+
+    def test_footer_space_below_map(self):
+        from qfit.atlas_export_task import (
+            MAP_Y, MAP_H, PAGE_HEIGHT_MM, MARGIN_MM, FOOTER_HEIGHT_MM, FOOTER_GAP_MM,
+        )
+
+        space_below_map = PAGE_HEIGHT_MM - MARGIN_MM - (MAP_Y + MAP_H)
+        self.assertGreaterEqual(
+            space_below_map,
+            FOOTER_GAP_MM + FOOTER_HEIGHT_MM,
+            "Must be enough space below map for footer",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Switch atlas page template from A4 landscape (297x210mm) to A4 portrait (210x297mm)
- Map frame is now square (190x190mm), giving `BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO = 1.0`
- Leaves ~68mm below the square map for footer and future profile/route content
- Cover layout inherits the same portrait page dimensions

## Test plan
- [x] 5 new layout geometry tests verifying portrait dimensions, square map, aspect ratio = 1.0
- [x] Existing aspect-ratio integration test still passes (uses the exported constant)
- [x] All 218 tests pass