### PR TITLE
feat: reserve profile area below square map in atlas layout

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -53,14 +53,22 @@ PAGE_HEIGHT_MM = 297.0
 MARGIN_MM = 10.0
 HEADER_HEIGHT_MM = 16.0
 FOOTER_HEIGHT_MM = 8.0
-HEADER_GAP_MM = 3.0   # gap between header and map
-FOOTER_GAP_MM = 3.0   # gap between map and footer
+HEADER_GAP_MM = 3.0    # gap between header and map
+PROFILE_GAP_MM = 3.0   # gap between map and profile area
+FOOTER_GAP_MM = 3.0    # gap between profile area and footer
 
 MAP_X = MARGIN_MM
 MAP_Y = MARGIN_MM + HEADER_HEIGHT_MM + HEADER_GAP_MM
 MAP_W = PAGE_WIDTH_MM - 2 * MARGIN_MM                   # 190 mm
 MAP_H = MAP_W                                            # square
 BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO = MAP_W / MAP_H   # 1.0
+
+# Profile area: reserved below the map for route profile content
+PROFILE_X = MARGIN_MM
+PROFILE_Y = MAP_Y + MAP_H + PROFILE_GAP_MM
+PROFILE_W = MAP_W
+PROFILE_H = (PAGE_HEIGHT_MM - MARGIN_MM - FOOTER_HEIGHT_MM
+             - FOOTER_GAP_MM - PROFILE_Y)
 
 
 def _mm(layout, value):
@@ -225,8 +233,22 @@ def build_atlas_layout(
             color=QColor(60, 60, 60),
         )
 
+    # -- Profile area: route profile summary below map ----------------------
+    profile_field = "page_profile_summary" if fields.indexOf("page_profile_summary") >= 0 else ""
+    if profile_field:
+        _add_label(
+            layout,
+            f'[% coalesce("{profile_field}", \'\') %]',
+            x=PROFILE_X,
+            y=PROFILE_Y,
+            w=PROFILE_W,
+            h=min(PROFILE_H, 10.0),
+            font_size=8.0,
+            color=QColor(80, 80, 80),
+        )
+
     # -- Footer: page number -----------------------------------------------
-    footer_y = MAP_Y + MAP_H + FOOTER_GAP_MM
+    footer_y = PROFILE_Y + PROFILE_H + FOOTER_GAP_MM
     _add_label(
         layout,
         "[% @atlas_featurenumber %] / [% @atlas_totalfeatures %]",
@@ -237,20 +259,6 @@ def build_atlas_layout(
         font_size=7.0,
         color=QColor(120, 120, 120),
     )
-
-    # -- Footer: activity type / profile summary ---------------------------
-    profile_field = "page_profile_summary" if fields.indexOf("page_profile_summary") >= 0 else ""
-    if profile_field:
-        _add_label(
-            layout,
-            f'[% coalesce("{profile_field}", \'\') %]',
-            x=MARGIN_MM + 60.0,
-            y=footer_y,
-            w=PAGE_WIDTH_MM - 2 * MARGIN_MM - 60.0,
-            h=FOOTER_HEIGHT_MM,
-            font_size=7.0,
-            color=QColor(120, 120, 120),
-        )
 
     return layout
 

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -805,15 +805,64 @@ class TestLayoutGeometry(unittest.TestCase):
 
     def test_footer_space_below_map(self):
         from qfit.atlas_export_task import (
-            MAP_Y, MAP_H, PAGE_HEIGHT_MM, MARGIN_MM, FOOTER_HEIGHT_MM, FOOTER_GAP_MM,
+            MAP_Y, MAP_H, PAGE_HEIGHT_MM, MARGIN_MM, FOOTER_HEIGHT_MM,
+            FOOTER_GAP_MM, PROFILE_GAP_MM, PROFILE_H,
         )
 
         space_below_map = PAGE_HEIGHT_MM - MARGIN_MM - (MAP_Y + MAP_H)
         self.assertGreaterEqual(
             space_below_map,
-            FOOTER_GAP_MM + FOOTER_HEIGHT_MM,
-            "Must be enough space below map for footer",
+            PROFILE_GAP_MM + PROFILE_H + FOOTER_GAP_MM + FOOTER_HEIGHT_MM,
+            "Must be enough space below map for profile area + footer",
         )
+
+    def test_profile_area_positioned_below_map(self):
+        from qfit.atlas_export_task import (
+            MAP_Y, MAP_H, PROFILE_X, PROFILE_Y, PROFILE_W, PROFILE_H, MARGIN_MM,
+        )
+
+        self.assertGreater(PROFILE_Y, MAP_Y + MAP_H, "Profile must start below map")
+        self.assertGreaterEqual(PROFILE_X, MARGIN_MM)
+        self.assertGreater(PROFILE_W, 0)
+        self.assertGreater(PROFILE_H, 0)
+
+    def test_profile_area_does_not_overlap_footer(self):
+        from qfit.atlas_export_task import (
+            PROFILE_Y, PROFILE_H, FOOTER_GAP_MM, FOOTER_HEIGHT_MM,
+            PAGE_HEIGHT_MM, MARGIN_MM,
+        )
+
+        profile_bottom = PROFILE_Y + PROFILE_H
+        footer_y = profile_bottom + FOOTER_GAP_MM
+        footer_bottom = footer_y + FOOTER_HEIGHT_MM
+        self.assertLessEqual(
+            footer_bottom,
+            PAGE_HEIGHT_MM - MARGIN_MM,
+            "Footer must not extend beyond bottom margin",
+        )
+
+    def test_profile_area_has_usable_height(self):
+        from qfit.atlas_export_task import PROFILE_H
+
+        self.assertGreaterEqual(PROFILE_H, 40.0, "Profile area should be at least 40mm tall")
+
+    def test_layout_items_do_not_overlap_vertically(self):
+        from qfit.atlas_export_task import (
+            MARGIN_MM, HEADER_HEIGHT_MM, HEADER_GAP_MM,
+            MAP_Y, MAP_H, PROFILE_GAP_MM,
+            PROFILE_Y, PROFILE_H, FOOTER_GAP_MM,
+            FOOTER_HEIGHT_MM, PAGE_HEIGHT_MM,
+        )
+
+        header_bottom = MARGIN_MM + HEADER_HEIGHT_MM
+        self.assertLessEqual(header_bottom + HEADER_GAP_MM, MAP_Y)
+
+        map_bottom = MAP_Y + MAP_H
+        self.assertLessEqual(map_bottom + PROFILE_GAP_MM, PROFILE_Y)
+
+        profile_bottom = PROFILE_Y + PROFILE_H
+        footer_y = profile_bottom + FOOTER_GAP_MM
+        self.assertLessEqual(footer_y + FOOTER_HEIGHT_MM, PAGE_HEIGHT_MM - MARGIN_MM)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add explicit `PROFILE_X/Y/W/H` constants defining a ~50mm reserved area below the square map for route profile content
- Move profile summary label from footer into the new profile area (8pt, gray)
- Pages without profile data degrade gracefully (empty area, footer still renders)
- Layout zones top-to-bottom: header → gap → square map (190mm) → gap → profile area (~50mm) → gap → footer

## Test plan
- [x] Test profile area is positioned below map with no overlap
- [x] Test profile area does not overlap footer
- [x] Test profile area has usable height (>= 40mm)
- [x] Test all layout items are vertically non-overlapping
- [x] All 222 tests pass