### PR TITLE
feat: render SVG elevation profile chart in atlas page profile area

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -33,6 +33,7 @@ from qgis.core import (
     QgsLayoutExporter,
     QgsLayoutItemLabel,
     QgsLayoutItemMap,
+    QgsLayoutItemPicture,
     QgsLayoutPoint,
     QgsLayoutSize,
     QgsPrintLayout,
@@ -69,6 +70,16 @@ PROFILE_Y = MAP_Y + MAP_H + PROFILE_GAP_MM
 PROFILE_W = MAP_W
 PROFILE_H = (PAGE_HEIGHT_MM - MARGIN_MM - FOOTER_HEIGHT_MM
              - FOOTER_GAP_MM - PROFILE_Y)
+
+# Sub-layout within profile area: chart on top, summary text below
+PROFILE_SUMMARY_H = 10.0   # height of the text summary label
+PROFILE_SUMMARY_GAP = 2.0  # gap between chart and summary text
+PROFILE_CHART_H = PROFILE_H - PROFILE_SUMMARY_H - PROFILE_SUMMARY_GAP
+PROFILE_CHART_Y = PROFILE_Y
+PROFILE_SUMMARY_Y = PROFILE_CHART_Y + PROFILE_CHART_H + PROFILE_SUMMARY_GAP
+
+# Identifier for the profile picture item (used to find it during export)
+_PROFILE_PICTURE_ID = "qfit_profile_chart"
 
 
 def _mm(layout, value):
@@ -233,16 +244,29 @@ def build_atlas_layout(
             color=QColor(60, 60, 60),
         )
 
-    # -- Profile area: route profile summary below map ----------------------
+    # -- Profile area: chart image + summary text below map ------------------
+    # Picture item for the SVG elevation profile (source set per page during export)
+    profile_pic = QgsLayoutItemPicture(layout)
+    profile_pic.setId(_PROFILE_PICTURE_ID)
+    profile_pic.attemptMove(
+        QgsLayoutPoint(PROFILE_X, PROFILE_CHART_Y, QgsUnitTypes.LayoutMillimeters)
+    )
+    profile_pic.attemptResize(
+        QgsLayoutSize(PROFILE_W, PROFILE_CHART_H, QgsUnitTypes.LayoutMillimeters)
+    )
+    profile_pic.setResizeMode(QgsLayoutItemPicture.Zoom)
+    layout.addLayoutItem(profile_pic)
+
+    # Text summary below the chart
     profile_field = "page_profile_summary" if fields.indexOf("page_profile_summary") >= 0 else ""
     if profile_field:
         _add_label(
             layout,
             f'[% coalesce("{profile_field}", \'\') %]',
             x=PROFILE_X,
-            y=PROFILE_Y,
+            y=PROFILE_SUMMARY_Y,
             w=PROFILE_W,
-            h=min(PROFILE_H, 10.0),
+            h=PROFILE_SUMMARY_H,
             font_size=8.0,
             color=QColor(80, 80, 80),
         )
@@ -507,6 +531,27 @@ class AtlasExportTask(QgsTask):
             if output_dir and not os.path.exists(output_dir):
                 os.makedirs(output_dir, exist_ok=True)
 
+            # Locate the profile picture item so we can set its source per page.
+            profile_pic = None
+            for item in layout.items():
+                if getattr(item, "id", lambda: None)() == _PROFILE_PICTURE_ID:
+                    profile_pic = item
+                    break
+
+            # Pre-load profile samples grouped by page_sort_key.
+            profile_samples: dict[str, list[tuple[float, float]]] = {}
+            sort_key_idx = fields.indexOf("page_sort_key")
+            try:
+                source = self._atlas_layer.source()
+                gpkg_path = source.split("|")[0] if "|" in source else source
+                if gpkg_path and os.path.isfile(gpkg_path):
+                    from .atlas_profile_renderer import load_profile_samples_from_gpkg  # noqa: PLC0415
+                    profile_samples = load_profile_samples_from_gpkg(gpkg_path)
+            except Exception:  # noqa: BLE001
+                logger.debug("Could not load profile samples", exc_info=True)
+
+            profile_temp_files: list[str] = []
+
             # Collect layers with source_activity_id field for per-page filtering.
             # These are the track/start/point layers that should show only the
             # current page's activity, not the full unfiltered dataset.
@@ -550,6 +595,30 @@ class AtlasExportTask(QgsTask):
                                     layer.setSubsetString(page_filter)
                                 except RuntimeError:
                                     logger.debug("Failed to set page filter on layer", exc_info=True)
+
+                    # Render profile chart SVG for this page.
+                    if profile_pic is not None and sort_key_idx >= 0:
+                        page_sort_key = feat.attribute(sort_key_idx)
+                        page_points = profile_samples.get(page_sort_key, []) if page_sort_key else []
+                        if len(page_points) >= 2:
+                            try:
+                                from .atlas_profile_renderer import render_profile_to_file  # noqa: PLC0415
+                                svg_path = render_profile_to_file(
+                                    page_points,
+                                    width_mm=PROFILE_W,
+                                    height_mm=PROFILE_CHART_H,
+                                    directory=os.path.dirname(self._output_path) or None,
+                                )
+                                if svg_path:
+                                    profile_pic.setPicturePath(svg_path)
+                                    profile_temp_files.append(svg_path)
+                                else:
+                                    profile_pic.setPicturePath("")
+                            except Exception:  # noqa: BLE001
+                                logger.debug("Profile chart render failed", exc_info=True)
+                                profile_pic.setPicturePath("")
+                        else:
+                            profile_pic.setPicturePath("")
 
                     # Apply the stored precomputed extent to the map item.
                     if map_item is not None and has_stored_extents:
@@ -612,6 +681,13 @@ class AtlasExportTask(QgsTask):
                         os.remove(p)
                     except OSError:
                         pass
+
+            # Clean up temporary profile SVG files.
+            for svg_path in profile_temp_files:
+                try:
+                    os.remove(svg_path)
+                except OSError:
+                    pass
 
         except (RuntimeError, OSError) as exc:
             logger.exception("Atlas export failed")

--- a/atlas_profile_renderer.py
+++ b/atlas_profile_renderer.py
@@ -1,0 +1,286 @@
+"""Render a route elevation profile as an SVG image.
+
+Produces a lightweight SVG string (no external dependencies) that can be
+written to a temporary file and embedded in a QGIS print layout via
+:class:`QgsLayoutItemPicture`.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+
+
+# Layout constants for the chart within the SVG (all in viewBox units = mm)
+_PAD_LEFT = 14.0    # space for altitude labels
+_PAD_RIGHT = 3.0
+_PAD_TOP = 2.0
+_PAD_BOTTOM = 6.0   # space for distance labels
+
+# Styling
+_FILL_COLOR = "#b3cde3"       # light blue fill
+_STROKE_COLOR = "#6497b1"     # darker blue stroke
+_STROKE_WIDTH = 0.4
+_GRID_COLOR = "#d0d0d0"
+_GRID_WIDTH = 0.15
+_AXIS_COLOR = "#999999"
+_LABEL_COLOR = "#555555"
+_LABEL_FONT_SIZE = 2.2        # mm
+
+
+def _nice_step(raw_step: float) -> float:
+    """Round *raw_step* to a 'nice' interval (1, 2, 5, 10, 20, 50, …)."""
+    if raw_step <= 0:
+        return 1.0
+    exponent = math.floor(math.log10(raw_step))
+    fraction = raw_step / (10 ** exponent)
+    if fraction <= 1.5:
+        nice = 1.0
+    elif fraction <= 3.5:
+        nice = 2.0
+    elif fraction <= 7.5:
+        nice = 5.0
+    else:
+        nice = 10.0
+    return nice * (10 ** exponent)
+
+
+def _format_altitude(value: float) -> str:
+    """Format altitude for axis label."""
+    if abs(value) >= 1000:
+        return f"{value:.0f}"
+    if value == int(value):
+        return str(int(value))
+    return f"{value:.0f}"
+
+
+def _format_distance(value_m: float) -> str:
+    """Format distance for axis label."""
+    if value_m >= 1000:
+        km = value_m / 1000.0
+        if km == int(km):
+            return f"{int(km)} km"
+        return f"{km:.1f} km"
+    return f"{int(value_m)} m"
+
+
+def _xml_escape(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def render_profile_svg(
+    points: list[tuple[float, float]],
+    width_mm: float = 190.0,
+    height_mm: float = 42.0,
+) -> str | None:
+    """Render an elevation profile as an SVG string.
+
+    Parameters
+    ----------
+    points:
+        List of ``(distance_m, altitude_m)`` tuples, ordered by distance.
+    width_mm:
+        SVG width in millimetres (matches layout item width).
+    height_mm:
+        SVG height in millimetres (matches layout item height).
+
+    Returns
+    -------
+    str | None
+        SVG markup string, or ``None`` if *points* has fewer than 2 entries.
+    """
+    if len(points) < 2:
+        return None
+
+    # Data range
+    distances = [d for d, _ in points]
+    altitudes = [a for _, a in points]
+    d_min, d_max = distances[0], distances[-1]
+    a_min, a_max = min(altitudes), max(altitudes)
+
+    if d_max <= d_min:
+        return None
+
+    # Add small padding to altitude range so the line doesn't touch edges
+    a_range = a_max - a_min
+    if a_range < 1.0:
+        a_range = 1.0
+        a_min = a_min - 0.5
+        a_max = a_max + 0.5
+    else:
+        pad = a_range * 0.08
+        a_min -= pad
+        a_max += pad
+        a_range = a_max - a_min
+
+    # Chart drawing area
+    cx = _PAD_LEFT
+    cy = _PAD_TOP
+    cw = width_mm - _PAD_LEFT - _PAD_RIGHT
+    ch = height_mm - _PAD_TOP - _PAD_BOTTOM
+
+    if cw <= 0 or ch <= 0:
+        return None
+
+    def map_x(distance: float) -> float:
+        return cx + (distance - d_min) / (d_max - d_min) * cw
+
+    def map_y(altitude: float) -> float:
+        return cy + ch - (altitude - a_min) / a_range * ch
+
+    # Build SVG parts
+    parts: list[str] = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {width_mm} {height_mm}" '
+        f'width="{width_mm}mm" height="{height_mm}mm">'
+    )
+
+    # Horizontal grid lines (altitude)
+    raw_step = a_range / 4.0
+    step = _nice_step(raw_step)
+    grid_start = math.ceil(a_min / step) * step
+    grid_val = grid_start
+    while grid_val <= a_max:
+        gy = map_y(grid_val)
+        if cy <= gy <= cy + ch:
+            parts.append(
+                f'<line x1="{cx:.2f}" y1="{gy:.2f}" '
+                f'x2="{cx + cw:.2f}" y2="{gy:.2f}" '
+                f'stroke="{_GRID_COLOR}" stroke-width="{_GRID_WIDTH}" />'
+            )
+            parts.append(
+                f'<text x="{cx - 1:.2f}" y="{gy + 0.7:.2f}" '
+                f'text-anchor="end" '
+                f'font-size="{_LABEL_FONT_SIZE}" fill="{_LABEL_COLOR}" '
+                f'font-family="sans-serif">'
+                f'{_xml_escape(_format_altitude(grid_val))}</text>'
+            )
+        grid_val += step
+
+    # Altitude unit label
+    parts.append(
+        f'<text x="{cx - 1:.2f}" y="{cy - 0.3:.2f}" '
+        f'text-anchor="end" '
+        f'font-size="{_LABEL_FONT_SIZE * 0.85:.2f}" fill="{_LABEL_COLOR}" '
+        f'font-family="sans-serif">m</text>'
+    )
+
+    # Filled area polygon
+    poly_points = []
+    for d, a in points:
+        poly_points.append(f"{map_x(d):.2f},{map_y(a):.2f}")
+    # Close polygon at baseline
+    poly_points.append(f"{map_x(d_max):.2f},{map_y(a_min):.2f}")
+    poly_points.append(f"{map_x(d_min):.2f},{map_y(a_min):.2f}")
+    parts.append(
+        f'<polygon points="{" ".join(poly_points)}" '
+        f'fill="{_FILL_COLOR}" stroke="none" />'
+    )
+
+    # Profile line on top of fill
+    line_points = " ".join(
+        f"{map_x(d):.2f},{map_y(a):.2f}" for d, a in points
+    )
+    parts.append(
+        f'<polyline points="{line_points}" '
+        f'fill="none" stroke="{_STROKE_COLOR}" '
+        f'stroke-width="{_STROKE_WIDTH}" stroke-linejoin="round" />'
+    )
+
+    # Chart border (left + bottom axis lines)
+    parts.append(
+        f'<line x1="{cx:.2f}" y1="{cy:.2f}" '
+        f'x2="{cx:.2f}" y2="{cy + ch:.2f}" '
+        f'stroke="{_AXIS_COLOR}" stroke-width="{_GRID_WIDTH}" />'
+    )
+    parts.append(
+        f'<line x1="{cx:.2f}" y1="{cy + ch:.2f}" '
+        f'x2="{cx + cw:.2f}" y2="{cy + ch:.2f}" '
+        f'stroke="{_AXIS_COLOR}" stroke-width="{_GRID_WIDTH}" />'
+    )
+
+    # Distance labels along bottom axis
+    d_range = d_max - d_min
+    d_step = _nice_step(d_range / 5.0)
+    d_grid = math.ceil(d_min / d_step) * d_step
+    label_y = cy + ch + _PAD_BOTTOM * 0.7
+    while d_grid <= d_max:
+        dx = map_x(d_grid)
+        if cx <= dx <= cx + cw:
+            # Tick mark
+            parts.append(
+                f'<line x1="{dx:.2f}" y1="{cy + ch:.2f}" '
+                f'x2="{dx:.2f}" y2="{cy + ch + 1:.2f}" '
+                f'stroke="{_AXIS_COLOR}" stroke-width="{_GRID_WIDTH}" />'
+            )
+            parts.append(
+                f'<text x="{dx:.2f}" y="{label_y:.2f}" '
+                f'text-anchor="middle" '
+                f'font-size="{_LABEL_FONT_SIZE}" fill="{_LABEL_COLOR}" '
+                f'font-family="sans-serif">'
+                f'{_xml_escape(_format_distance(d_grid))}</text>'
+            )
+        d_grid += d_step
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def render_profile_to_file(
+    points: list[tuple[float, float]],
+    width_mm: float = 190.0,
+    height_mm: float = 42.0,
+    directory: str | None = None,
+) -> str | None:
+    """Render profile SVG to a temporary file and return the path.
+
+    Returns ``None`` if the profile cannot be rendered (too few points).
+    The caller is responsible for cleaning up the file.
+    """
+    svg = render_profile_svg(points, width_mm, height_mm)
+    if svg is None:
+        return None
+    fd, path = tempfile.mkstemp(suffix=".svg", prefix="qfit_profile_", dir=directory)
+    try:
+        os.write(fd, svg.encode("utf-8"))
+    finally:
+        os.close(fd)
+    return path
+
+
+def load_profile_samples_from_gpkg(
+    gpkg_path: str,
+) -> dict[str, list[tuple[float, float]]]:
+    """Load atlas profile samples from a GeoPackage, grouped by page_sort_key.
+
+    Returns a dict mapping ``page_sort_key`` to a list of
+    ``(distance_m, altitude_m)`` tuples ordered by ``profile_point_index``.
+
+    Returns an empty dict if the table does not exist or cannot be read.
+    """
+    import sqlite3  # noqa: PLC0415
+
+    result: dict[str, list[tuple[float, float]]] = {}
+    try:
+        conn = sqlite3.connect(gpkg_path)
+        try:
+            cursor = conn.execute(
+                "SELECT page_sort_key, distance_m, altitude_m "
+                "FROM atlas_profile_samples "
+                "ORDER BY page_sort_key, profile_point_index"
+            )
+            for page_sort_key, distance_m, altitude_m in cursor:
+                if page_sort_key is None:
+                    continue
+                if distance_m is None or altitude_m is None:
+                    continue
+                result.setdefault(page_sort_key, []).append(
+                    (float(distance_m), float(altitude_m))
+                )
+        finally:
+            conn.close()
+    except Exception:  # noqa: BLE001
+        pass
+    return result

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -45,6 +45,9 @@ def _make_qgis_stub():
     qgis_core.QgsCoordinateReferenceSystem = MagicMock(return_value=MagicMock())
     qgis_core.QgsRectangle = MagicMock(return_value=MagicMock())
     qgis_core.QgsLayoutItemLabel = MagicMock()
+    pic_cls = MagicMock()
+    pic_cls.Zoom = 0
+    qgis_core.QgsLayoutItemPicture = pic_cls
     qgis_core.QgsLayoutPoint = MagicMock()
     qgis_core.QgsLayoutSize = MagicMock()
     qgis_core.QgsLayoutExporter = MagicMock()
@@ -863,6 +866,28 @@ class TestLayoutGeometry(unittest.TestCase):
         profile_bottom = PROFILE_Y + PROFILE_H
         footer_y = profile_bottom + FOOTER_GAP_MM
         self.assertLessEqual(footer_y + FOOTER_HEIGHT_MM, PAGE_HEIGHT_MM - MARGIN_MM)
+
+    def test_profile_chart_and_summary_fit_within_profile_area(self):
+        from qfit.atlas_export_task import (
+            PROFILE_Y, PROFILE_H, PROFILE_CHART_Y, PROFILE_CHART_H,
+            PROFILE_SUMMARY_Y, PROFILE_SUMMARY_H, PROFILE_SUMMARY_GAP,
+        )
+
+        # Chart starts at profile area top
+        self.assertAlmostEqual(PROFILE_CHART_Y, PROFILE_Y)
+        # Summary is below chart with gap
+        self.assertAlmostEqual(
+            PROFILE_SUMMARY_Y,
+            PROFILE_CHART_Y + PROFILE_CHART_H + PROFILE_SUMMARY_GAP,
+        )
+        # Everything fits within profile area
+        total = PROFILE_CHART_H + PROFILE_SUMMARY_GAP + PROFILE_SUMMARY_H
+        self.assertAlmostEqual(total, PROFILE_H)
+
+    def test_profile_chart_has_positive_height(self):
+        from qfit.atlas_export_task import PROFILE_CHART_H
+
+        self.assertGreater(PROFILE_CHART_H, 20.0, "Profile chart should be at least 20mm tall")
 
 
 if __name__ == "__main__":

--- a/tests/test_atlas_profile_renderer.py
+++ b/tests/test_atlas_profile_renderer.py
@@ -1,0 +1,273 @@
+"""Tests for atlas_profile_renderer — SVG elevation profile generation."""
+
+import os
+import tempfile
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.atlas_profile_renderer import (
+    render_profile_svg,
+    render_profile_to_file,
+    load_profile_samples_from_gpkg,
+    _nice_step,
+    _format_altitude,
+    _format_distance,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+# Simple ascending profile: 0m → 5000m distance, 500m → 800m altitude
+SIMPLE_PROFILE = [
+    (0.0, 500.0),
+    (1000.0, 550.0),
+    (2000.0, 600.0),
+    (3000.0, 650.0),
+    (4000.0, 700.0),
+    (5000.0, 800.0),
+]
+
+# Flat profile: same altitude everywhere
+FLAT_PROFILE = [
+    (0.0, 100.0),
+    (1000.0, 100.0),
+    (2000.0, 100.0),
+]
+
+
+class TestRenderProfileSvg(unittest.TestCase):
+    """Test SVG profile rendering."""
+
+    def test_returns_svg_for_valid_profile(self):
+        svg = render_profile_svg(SIMPLE_PROFILE)
+        self.assertIsNotNone(svg)
+        self.assertIn("<svg", svg)
+        self.assertIn("</svg>", svg)
+
+    def test_returns_none_for_empty_points(self):
+        self.assertIsNone(render_profile_svg([]))
+
+    def test_returns_none_for_single_point(self):
+        self.assertIsNone(render_profile_svg([(0.0, 100.0)]))
+
+    def test_returns_none_for_zero_distance_range(self):
+        """Two points at the same distance → None."""
+        self.assertIsNone(render_profile_svg([(0.0, 100.0), (0.0, 200.0)]))
+
+    def test_flat_profile_renders(self):
+        """A flat profile (all same altitude) should still render."""
+        svg = render_profile_svg(FLAT_PROFILE)
+        self.assertIsNotNone(svg)
+        self.assertIn("<svg", svg)
+
+    def test_svg_contains_polygon(self):
+        svg = render_profile_svg(SIMPLE_PROFILE)
+        self.assertIn("<polygon", svg)
+
+    def test_svg_contains_polyline(self):
+        svg = render_profile_svg(SIMPLE_PROFILE)
+        self.assertIn("<polyline", svg)
+
+    def test_svg_viewbox_matches_dimensions(self):
+        svg = render_profile_svg(SIMPLE_PROFILE, width_mm=190.0, height_mm=42.0)
+        self.assertIn('viewBox="0 0 190.0 42.0"', svg)
+
+    def test_svg_contains_altitude_labels(self):
+        """SVG should have altitude text labels."""
+        svg = render_profile_svg(SIMPLE_PROFILE)
+        self.assertIn("<text", svg)
+        # Should contain altitude unit marker
+        self.assertIn(">m</text>", svg)
+
+    def test_svg_contains_distance_labels(self):
+        """SVG should include distance labels along the bottom axis."""
+        svg = render_profile_svg(SIMPLE_PROFILE)
+        self.assertIn("km</text>", svg)
+
+    def test_custom_dimensions(self):
+        svg = render_profile_svg(SIMPLE_PROFILE, width_mm=100.0, height_mm=30.0)
+        self.assertIsNotNone(svg)
+        self.assertIn('viewBox="0 0 100.0 30.0"', svg)
+
+    def test_very_small_dimensions_returns_none(self):
+        """If chart area is too small, returns None."""
+        svg = render_profile_svg(SIMPLE_PROFILE, width_mm=15.0, height_mm=5.0)
+        self.assertIsNone(svg)
+
+
+class TestRenderProfileToFile(unittest.TestCase):
+    """Test SVG file writing."""
+
+    def test_writes_svg_file(self):
+        path = render_profile_to_file(SIMPLE_PROFILE)
+        self.assertIsNotNone(path)
+        try:
+            self.assertTrue(os.path.isfile(path))
+            with open(path) as f:
+                content = f.read()
+            self.assertIn("<svg", content)
+        finally:
+            if path:
+                os.unlink(path)
+
+    def test_returns_none_for_insufficient_data(self):
+        self.assertIsNone(render_profile_to_file([]))
+        self.assertIsNone(render_profile_to_file([(0.0, 100.0)]))
+
+    def test_writes_to_specified_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = render_profile_to_file(SIMPLE_PROFILE, directory=tmpdir)
+            self.assertIsNotNone(path)
+            self.assertTrue(path.startswith(tmpdir))
+            os.unlink(path)
+
+    def test_file_is_valid_utf8(self):
+        path = render_profile_to_file(SIMPLE_PROFILE)
+        try:
+            with open(path, encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("<svg", content)
+        finally:
+            if path:
+                os.unlink(path)
+
+
+class TestNiceStep(unittest.TestCase):
+    """Test axis step rounding."""
+
+    def test_small_values(self):
+        self.assertAlmostEqual(_nice_step(0.3), 0.2)
+        self.assertAlmostEqual(_nice_step(0.7), 0.5)
+
+    def test_medium_values(self):
+        self.assertAlmostEqual(_nice_step(3.0), 2.0)
+        self.assertAlmostEqual(_nice_step(7.0), 5.0)
+
+    def test_large_values(self):
+        self.assertAlmostEqual(_nice_step(15.0), 10.0)
+        self.assertAlmostEqual(_nice_step(80.0), 100.0)
+
+    def test_zero_returns_one(self):
+        self.assertAlmostEqual(_nice_step(0.0), 1.0)
+
+    def test_negative_returns_one(self):
+        self.assertAlmostEqual(_nice_step(-5.0), 1.0)
+
+
+class TestFormatAltitude(unittest.TestCase):
+    def test_integer_altitude(self):
+        self.assertEqual(_format_altitude(500.0), "500")
+
+    def test_large_altitude(self):
+        self.assertEqual(_format_altitude(1234.5), "1234")
+
+    def test_zero(self):
+        self.assertEqual(_format_altitude(0.0), "0")
+
+
+class TestFormatDistance(unittest.TestCase):
+    def test_meters(self):
+        self.assertEqual(_format_distance(500.0), "500 m")
+
+    def test_kilometers(self):
+        self.assertEqual(_format_distance(3000.0), "3 km")
+
+    def test_fractional_km(self):
+        self.assertEqual(_format_distance(1500.0), "1.5 km")
+
+
+class TestLoadProfileSamplesFromGpkg(unittest.TestCase):
+    """Test loading profile samples from a GeoPackage database."""
+
+    def test_returns_empty_dict_for_nonexistent_file(self):
+        result = load_profile_samples_from_gpkg("/nonexistent/path.gpkg")
+        self.assertEqual(result, {})
+
+    def test_returns_empty_dict_for_missing_table(self):
+        """A valid SQLite DB without the atlas_profile_samples table → empty."""
+        import sqlite3
+        with tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False) as f:
+            path = f.name
+        try:
+            conn = sqlite3.connect(path)
+            conn.execute("CREATE TABLE dummy (id INTEGER)")
+            conn.close()
+            result = load_profile_samples_from_gpkg(path)
+            self.assertEqual(result, {})
+        finally:
+            os.unlink(path)
+
+    def test_loads_samples_grouped_by_page_sort_key(self):
+        import sqlite3
+        with tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False) as f:
+            path = f.name
+        try:
+            conn = sqlite3.connect(path)
+            conn.execute(
+                "CREATE TABLE atlas_profile_samples ("
+                "  page_sort_key TEXT,"
+                "  profile_point_index INTEGER,"
+                "  distance_m REAL,"
+                "  altitude_m REAL"
+                ")"
+            )
+            conn.executemany(
+                "INSERT INTO atlas_profile_samples VALUES (?, ?, ?, ?)",
+                [
+                    ("page_a", 0, 0.0, 100.0),
+                    ("page_a", 1, 1000.0, 150.0),
+                    ("page_a", 2, 2000.0, 120.0),
+                    ("page_b", 0, 0.0, 200.0),
+                    ("page_b", 1, 500.0, 250.0),
+                ],
+            )
+            conn.commit()
+            conn.close()
+
+            result = load_profile_samples_from_gpkg(path)
+            self.assertIn("page_a", result)
+            self.assertIn("page_b", result)
+            self.assertEqual(len(result["page_a"]), 3)
+            self.assertEqual(len(result["page_b"]), 2)
+            self.assertEqual(result["page_a"][0], (0.0, 100.0))
+            self.assertEqual(result["page_a"][2], (2000.0, 120.0))
+        finally:
+            os.unlink(path)
+
+    def test_skips_null_values(self):
+        import sqlite3
+        with tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False) as f:
+            path = f.name
+        try:
+            conn = sqlite3.connect(path)
+            conn.execute(
+                "CREATE TABLE atlas_profile_samples ("
+                "  page_sort_key TEXT,"
+                "  profile_point_index INTEGER,"
+                "  distance_m REAL,"
+                "  altitude_m REAL"
+                ")"
+            )
+            conn.executemany(
+                "INSERT INTO atlas_profile_samples VALUES (?, ?, ?, ?)",
+                [
+                    ("page_a", 0, 0.0, 100.0),
+                    ("page_a", 1, None, 150.0),   # null distance
+                    ("page_a", 2, 2000.0, None),   # null altitude
+                    (None, 3, 3000.0, 200.0),      # null key
+                ],
+            )
+            conn.commit()
+            conn.close()
+
+            result = load_profile_samples_from_gpkg(path)
+            self.assertEqual(len(result.get("page_a", [])), 1)
+            self.assertNotIn(None, result)
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `atlas_profile_renderer.py` module that generates lightweight SVG elevation profiles from distance/altitude sample points (no external dependencies beyond stdlib)
- During atlas PDF export, profile samples are loaded from the GeoPackage and rendered per-page as a `QgsLayoutItemPicture` in the reserved profile area below the square map
- Profile area is split into chart (~42 mm) on top and text summary (10 mm) below; pages without profile data degrade gracefully (blank area, no broken output)

## Test plan
- [x] 31 new tests for `atlas_profile_renderer` (SVG generation, file I/O, axis formatting, GeoPackage loading, edge cases)
- [x] 2 new geometry tests for profile chart/summary sub-layout within profile area
- [x] All 255 existing tests pass (including updated QGIS stubs for `QgsLayoutItemPicture`)
- [ ] SonarCloud quality gate passes