### PR TITLE
ci: build plugin ZIP artifact on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build plugin ZIP
+        id: package
+        run: |
+          python scripts/package_plugin.py
+          echo "zip=$(ls dist/*.zip)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload plugin ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: qfit-plugin
+          path: ${{ steps.package.outputs.zip }}
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yml` that triggers on push to `main`
- Runs `scripts/package_plugin.py` to build the distributable ZIP
- Uploads the ZIP as a GitHub Actions artifact via `actions/upload-artifact@v4`

## Test plan
- [ ] CI workflows (tests, SonarCloud) pass on this PR
- [ ] After merge, verify the `build` workflow runs and produces the `qfit-plugin` artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)