### PR TITLE
feat: generate table-of-contents page in atlas PDF export

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -424,6 +424,108 @@ def build_cover_layout(
     return layout
 
 
+def build_toc_layout(
+    atlas_layer,
+    project=None,
+) -> QgsPrintLayout | None:
+    """Build a single-page table-of-contents layout from *atlas_layer* features.
+
+    Returns ``None`` if the atlas layer has no features or the required
+    fields are absent (the TOC page is simply skipped in that case).
+    """
+    if atlas_layer is None or atlas_layer.featureCount() == 0:
+        return None
+
+    fields = atlas_layer.fields()
+    pn_idx = fields.indexOf("page_number")
+    toc_idx = fields.indexOf("page_toc_label")
+    name_idx = fields.indexOf("page_name")
+    sort_idx = fields.indexOf("page_sort_key")
+
+    # We need at least page_number and one of toc_label/name to build entries.
+    if pn_idx < 0 or (toc_idx < 0 and name_idx < 0):
+        return None
+
+    # Collect TOC entries from all features, sorted by page_sort_key or page_number.
+    entries: list[tuple[str, str]] = []  # (sort_key, display_label)
+    for feat in atlas_layer.getFeatures():
+        page_num = feat.attribute(pn_idx)
+        toc_label = feat.attribute(toc_idx) if toc_idx >= 0 else None
+        page_name = feat.attribute(name_idx) if name_idx >= 0 else None
+        sort_key = feat.attribute(sort_idx) if sort_idx >= 0 else ""
+
+        label_text = toc_label or page_name or ""
+        if not label_text and page_num is None:
+            continue
+
+        display = f"{page_num}.\u2002{label_text}" if label_text else str(page_num)
+        entries.append((str(sort_key or ""), display))
+
+    if not entries:
+        return None
+
+    # Sort by the sort key to match atlas page order.
+    entries.sort(key=lambda e: e[0])
+
+    proj = project or QgsProject.instance()
+    layout = QgsPrintLayout(proj)
+    layout.initializeDefaults()
+    layout.setName("qfit Atlas Contents")
+
+    page_collection = layout.pageCollection()
+    if page_collection.pageCount() > 0:
+        page = page_collection.page(0)
+        page.setPageSize(
+            QgsLayoutSize(PAGE_WIDTH_MM, PAGE_HEIGHT_MM, QgsUnitTypes.LayoutMillimeters)
+        )
+
+    content_width = PAGE_WIDTH_MM - 2 * MARGIN_MM
+
+    # Title
+    title_y = MARGIN_MM
+    title_h = 14.0
+    _add_label(
+        layout,
+        "Contents",
+        x=MARGIN_MM,
+        y=title_y,
+        w=content_width,
+        h=title_h,
+        font_size=16.0,
+        bold=True,
+    )
+
+    # Separator line below title
+    sep_y = title_y + title_h + 2.0
+    sep_label = QgsLayoutItemLabel(layout)
+    sep_label.setText("")
+    sep_label.attemptMove(QgsLayoutPoint(MARGIN_MM, sep_y, QgsUnitTypes.LayoutMillimeters))
+    sep_label.attemptResize(QgsLayoutSize(content_width, 0.3, QgsUnitTypes.LayoutMillimeters))
+    sep_label.setBackgroundColor(QColor(180, 180, 180))
+    sep_label.setBackgroundEnabled(True)
+    layout.addLayoutItem(sep_label)
+
+    # TOC entries
+    entry_y = sep_y + 4.0
+    row_h = 7.0
+    entry_color = QColor(30, 30, 30)
+
+    for _sort_key, display in entries:
+        _add_label(
+            layout,
+            display,
+            x=MARGIN_MM,
+            y=entry_y,
+            w=content_width,
+            h=row_h,
+            font_size=9.0,
+            color=entry_color,
+        )
+        entry_y += row_h
+
+    return layout
+
+
 class AtlasExportTask(QgsTask):
     """Export the qfit atlas as a multi-page PDF via QGIS print layout.
 
@@ -669,7 +771,14 @@ class AtlasExportTask(QgsTask):
                 self._output_path,
                 project=self._project,
             )
-            all_paths = ([cover_path] if cover_path else []) + page_paths
+            # Insert a table-of-contents page (silently skipped if generation fails).
+            toc_path = self._export_toc_page(
+                self._atlas_layer,
+                self._output_path,
+                project=self._project,
+            )
+            front_pages = [p for p in (cover_path, toc_path) if p]
+            all_paths = front_pages + page_paths
 
             # Merge all per-page PDFs into a single output PDF.
             if len(all_paths) == 1:
@@ -725,6 +834,36 @@ class AtlasExportTask(QgsTask):
             return cover_path
         except (RuntimeError, OSError):
             logger.exception("Cover page export failed")
+            return None
+
+    @staticmethod
+    def _export_toc_page(
+        atlas_layer,
+        output_path: str,
+        project=None,
+    ) -> str | None:
+        """Export a single table-of-contents PDF and return its path, or None on failure.
+
+        Failures are swallowed so they never abort the main export.
+        """
+        try:
+            toc_layout = build_toc_layout(atlas_layer, project=project)
+            if toc_layout is None:
+                return None
+
+            toc_path = f"{output_path}.toc.pdf"
+            exporter = QgsLayoutExporter(toc_layout)
+            settings = QgsLayoutExporter.PdfExportSettings()
+            settings.dpi = 150
+            settings.rasterizeWholeImage = False
+            settings.forceVectorOutput = True
+
+            result = exporter.exportToPdf(toc_path, settings)
+            if result != QgsLayoutExporter.Success:
+                return None
+            return toc_path
+        except (RuntimeError, OSError):
+            logger.exception("TOC page export failed")
             return None
 
     @staticmethod

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -79,7 +79,7 @@ def _make_qgis_stub():
 
 _qgis_core = _make_qgis_stub()
 
-from qfit.atlas_export_task import AtlasExportTask, build_atlas_layout, build_cover_layout  # noqa: E402
+from qfit.atlas_export_task import AtlasExportTask, build_atlas_layout, build_cover_layout, build_toc_layout  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +205,7 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
              patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas_export_task.AtlasExportTask._merge_pdfs"), \
              patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("os.replace"), \
              patch("os.makedirs"):
             result = task.run()
@@ -222,6 +223,7 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
         with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -243,6 +245,7 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
              patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas_export_task.AtlasExportTask._merge_pdfs"), \
              patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("os.remove"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -359,6 +362,7 @@ class TestAtlasExportTaskNoCallback(unittest.TestCase):
         with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("os.replace"), \
              patch("os.makedirs"):
             task.run()
@@ -385,6 +389,7 @@ class TestAtlasExportTaskLayerSubsetHandling(unittest.TestCase):
         with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -439,6 +444,7 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
         with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -467,6 +473,7 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
              patch("qfit.atlas_export_task.AtlasExportTask._merge_pdfs",
                    side_effect=lambda pages, out: merge_calls.append((pages, out))), \
              patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("os.remove", side_effect=lambda p: remove_calls.append(p)), \
              patch("os.makedirs"):
             _run_task(task)
@@ -492,6 +499,7 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
         with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("os.replace", side_effect=lambda src, dst: replace_calls.append((src, dst))), \
              patch("qfit.atlas_export_task.AtlasExportTask._merge_pdfs") as mock_merge, \
              patch("os.makedirs"):
@@ -888,6 +896,197 @@ class TestLayoutGeometry(unittest.TestCase):
         from qfit.atlas_export_task import PROFILE_CHART_H
 
         self.assertGreater(PROFILE_CHART_H, 20.0, "Profile chart should be at least 20mm tall")
+
+
+# ---------------------------------------------------------------------------
+# Tests: table of contents page
+# ---------------------------------------------------------------------------
+
+
+def _make_toc_atlas_layer(entries=None, feature_count=None):
+    """Return a mock atlas layer with TOC-relevant fields populated.
+
+    *entries* is a list of dicts with keys: page_number, page_toc_label,
+    page_name, page_sort_key.
+    """
+    if entries is None:
+        entries = [
+            {"page_number": 1, "page_toc_label": "2025-06-01 · Morning Ride · 42 km",
+             "page_name": "Morning Ride", "page_sort_key": "2025-06-01|morning_ride"},
+            {"page_number": 2, "page_toc_label": "2025-06-02 · Afternoon Run · 10 km",
+             "page_name": "Afternoon Run", "page_sort_key": "2025-06-02|afternoon_run"},
+            {"page_number": 3, "page_toc_label": None,
+             "page_name": "Evening Walk", "page_sort_key": "2025-06-03|evening_walk"},
+        ]
+    if feature_count is None:
+        feature_count = len(entries)
+
+    all_field_names = ["page_number", "page_toc_label", "page_name", "page_sort_key"]
+    layer = MagicMock()
+    layer.featureCount.return_value = feature_count
+
+    fields = MagicMock()
+    fields.indexOf = lambda name: all_field_names.index(name) if name in all_field_names else -1
+    layer.fields.return_value = fields
+
+    feats = []
+    for entry in entries:
+        feat = MagicMock()
+        feat.attribute = lambda idx, _e=entry: list(_e.values())[idx] if 0 <= idx < len(_e) else None
+        feats.append(feat)
+    layer.getFeatures.return_value = iter(feats)
+
+    return layer
+
+
+class TestBuildTocLayout(unittest.TestCase):
+    def test_build_toc_layout_returns_layout_for_populated_layer(self):
+        layer = _make_toc_atlas_layer()
+        result = build_toc_layout(layer)
+        self.assertIsNotNone(result)
+
+    def test_build_toc_layout_sets_layout_name(self):
+        layer = _make_toc_atlas_layer()
+        layout = build_toc_layout(layer)
+        self.assertIsNotNone(layout)
+        layout.setName.assert_called_with("qfit Atlas Contents")
+
+    def test_build_toc_layout_returns_none_for_empty_layer(self):
+        layer = _make_toc_atlas_layer(entries=[], feature_count=0)
+        result = build_toc_layout(layer)
+        self.assertIsNone(result)
+
+    def test_build_toc_layout_returns_none_for_none_layer(self):
+        result = build_toc_layout(None)
+        self.assertIsNone(result)
+
+    def test_build_toc_layout_returns_none_when_fields_missing(self):
+        layer = MagicMock()
+        layer.featureCount.return_value = 1
+        fields = MagicMock()
+        fields.indexOf = lambda name: -1  # all fields missing
+        layer.fields.return_value = fields
+        result = build_toc_layout(layer)
+        self.assertIsNone(result)
+
+    def test_build_toc_layout_falls_back_to_page_name(self):
+        """When page_toc_label is None, page_name is used instead."""
+        entries = [
+            {"page_number": 1, "page_toc_label": None,
+             "page_name": "Fallback Name", "page_sort_key": "a"},
+        ]
+        layer = _make_toc_atlas_layer(entries=entries)
+        result = build_toc_layout(layer)
+        self.assertIsNotNone(result)
+
+    def test_build_toc_layout_uses_provided_project(self):
+        layer = _make_toc_atlas_layer()
+        project = MagicMock()
+        build_toc_layout(layer, project=project)
+        from qfit.atlas_export_task import QgsPrintLayout  # noqa: PLC0415
+        QgsPrintLayout.assert_called_with(project)
+
+
+class TestExportTocPage(unittest.TestCase):
+    def test_export_toc_page_returns_path_on_success(self):
+        layer = _make_toc_atlas_layer()
+        toc_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0  # Success
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_toc_layout", return_value=toc_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls):
+            result = AtlasExportTask._export_toc_page(layer, "/tmp/atlas.pdf")
+
+        self.assertEqual(result, "/tmp/atlas.pdf.toc.pdf")
+
+    def test_export_toc_page_returns_none_when_layout_is_none(self):
+        layer = _make_toc_atlas_layer(entries=[], feature_count=0)
+        with patch("qfit.atlas_export_task.build_toc_layout", return_value=None):
+            result = AtlasExportTask._export_toc_page(layer, "/tmp/atlas.pdf")
+        self.assertIsNone(result)
+
+    def test_export_toc_page_returns_none_on_exporter_failure(self):
+        layer = _make_toc_atlas_layer()
+        toc_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 1  # failure
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_toc_layout", return_value=toc_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls):
+            result = AtlasExportTask._export_toc_page(layer, "/tmp/atlas.pdf")
+
+        self.assertIsNone(result)
+
+    def test_export_toc_page_returns_none_on_exception(self):
+        layer = _make_toc_atlas_layer()
+        with patch("qfit.atlas_export_task.build_toc_layout", side_effect=RuntimeError("boom")):
+            result = AtlasExportTask._export_toc_page(layer, "/tmp/atlas.pdf")
+        self.assertIsNone(result)
+
+
+class TestTocPageInExport(unittest.TestCase):
+    def test_toc_page_inserted_between_cover_and_activity_pages(self):
+        """TOC PDF path appears after cover and before activity pages in merge."""
+        layer = _make_atlas_layer(feature_count=2)
+        received = {}
+        task = AtlasExportTask(
+            atlas_layer=layer,
+            output_path="/tmp/qfit_toc_test.pdf",
+            on_finished=lambda **kw: received.update(kw),
+        )
+        layout_mock, _, exporter_cls_mock = _make_atlas_mock(feature_count=2)
+        merge_calls = []
+        cover_path = "/tmp/qfit_toc_test.pdf.cover.pdf"
+        toc_path = "/tmp/qfit_toc_test.pdf.toc.pdf"
+        with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page",
+                   return_value=cover_path), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page",
+                   return_value=toc_path), \
+             patch("qfit.atlas_export_task.AtlasExportTask._merge_pdfs",
+                   side_effect=lambda pages, out: merge_calls.append((pages, out))), \
+             patch("os.remove"), \
+             patch("os.makedirs"):
+            _run_task(task)
+        self.assertEqual(len(merge_calls), 1)
+        all_pages = merge_calls[0][0]
+        self.assertEqual(all_pages[0], cover_path)
+        self.assertEqual(all_pages[1], toc_path)
+        self.assertEqual(len(all_pages), 4)  # cover + toc + 2 activity pages
+
+    def test_toc_page_skipped_on_failure(self):
+        """Export succeeds even when _export_toc_page returns None."""
+        layer = _make_atlas_layer(feature_count=1)
+        received = {}
+        task = AtlasExportTask(
+            atlas_layer=layer,
+            output_path="/tmp/qfit_toc_fail.pdf",
+            on_finished=lambda **kw: received.update(kw),
+        )
+        layout_mock, _, exporter_cls_mock = _make_atlas_mock(feature_count=1)
+        with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page",
+                   return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page",
+                   return_value=None), \
+             patch("os.replace"), \
+             patch("os.makedirs"):
+            _run_task(task)
+        self.assertIsNotNone(received.get("output_path"))
+        self.assertIsNone(received.get("error"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `build_toc_layout()` that reads atlas layer features to build a simple, readable contents page listing all activities with page numbers
- Add `_export_toc_page()` static method following the same resilient pattern as `_export_cover_page()` — silently skipped on failure
- Insert the TOC page between cover and activity pages in the PDF merge order: `[cover] + [toc] + [activity pages...]`
- Uses existing `page_toc_label`, `page_name`, and `page_sort_key` fields — no new data dependencies

## Test plan
- [x] `build_toc_layout` returns layout for populated layer
- [x] `build_toc_layout` returns None for empty/None layer and missing fields
- [x] `build_toc_layout` falls back to `page_name` when `page_toc_label` is None
- [x] `_export_toc_page` returns path on success, None on failure/exception
- [x] TOC page inserted between cover and activity pages in merge order
- [x] Export succeeds even when TOC generation fails
- [x] All 279 existing tests still pass