### PR TITLE
feat: render per-page detail items in portrait atlas detail area

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -17,7 +17,8 @@ Page template (A4 portrait, 210 × 297 mm):
     │  │                                  │  │
     │  └──────────────────────────────────┘  │
     │  [elevation profile chart]              │
-    │  [profile summary · stats summary]     │
+    │  [profile summary]                     │
+    │  [detail block: per-page metric items] │
     │  Page N / Total                        │
     └────────────────────────────────────────┘
 """
@@ -72,16 +73,16 @@ PROFILE_W = MAP_W
 PROFILE_H = (PAGE_HEIGHT_MM - MARGIN_MM - FOOTER_HEIGHT_MM
              - FOOTER_GAP_MM - PROFILE_Y)
 
-# Sub-layout within profile area: chart on top, two summary lines below
-PROFILE_SUMMARY_H = 5.0    # height of the profile summary label
-STATS_SUMMARY_H = 5.0      # height of the stats summary label
-PROFILE_SUMMARY_GAP = 2.0  # gap between chart and first summary line
-STATS_SUMMARY_GAP = 1.0    # gap between the two summary lines
-PROFILE_CHART_H = (PROFILE_H - PROFILE_SUMMARY_H - STATS_SUMMARY_H
-                   - PROFILE_SUMMARY_GAP - STATS_SUMMARY_GAP)
+# Sub-layout within profile area: chart on top, profile summary, detail block
+PROFILE_SUMMARY_H = 5.0     # height of the profile summary label
+DETAIL_BLOCK_H = 12.0       # height of the per-page detail item block
+PROFILE_SUMMARY_GAP = 2.0   # gap between chart and profile summary line
+DETAIL_BLOCK_GAP = 1.0      # gap between profile summary and detail block
+PROFILE_CHART_H = (PROFILE_H - PROFILE_SUMMARY_H - DETAIL_BLOCK_H
+                   - PROFILE_SUMMARY_GAP - DETAIL_BLOCK_GAP)
 PROFILE_CHART_Y = PROFILE_Y
 PROFILE_SUMMARY_Y = PROFILE_CHART_Y + PROFILE_CHART_H + PROFILE_SUMMARY_GAP
-STATS_SUMMARY_Y = PROFILE_SUMMARY_Y + PROFILE_SUMMARY_H + STATS_SUMMARY_GAP
+DETAIL_BLOCK_Y = PROFILE_SUMMARY_Y + PROFILE_SUMMARY_H + DETAIL_BLOCK_GAP
 
 # Identifier for the profile picture item (used to find it during export)
 _PROFILE_PICTURE_ID = "qfit_profile_chart"
@@ -103,6 +104,7 @@ def _add_label(
     bold: bool = False,
     align_right: bool = False,
     color: QColor | None = None,
+    v_align_top: bool = False,
 ) -> QgsLayoutItemLabel:
     """Add a text label item to *layout* at mm coordinates."""
     label = QgsLayoutItemLabel(layout)
@@ -115,7 +117,7 @@ def _add_label(
         label.setFontColor(color)
     h_align = Qt.AlignRight if align_right else Qt.AlignLeft
     label.setHAlign(h_align)
-    label.setVAlign(Qt.AlignVCenter)
+    label.setVAlign(Qt.AlignTop if v_align_top else Qt.AlignVCenter)
     label.attemptMove(QgsLayoutPoint(x, y, QgsUnitTypes.LayoutMillimeters))
     label.attemptResize(QgsLayoutSize(w, h, QgsUnitTypes.LayoutMillimeters))
     layout.addLayoutItem(label)
@@ -276,17 +278,31 @@ def build_atlas_layout(
             color=QColor(100, 100, 100),
         )
 
-    stats_field = "page_stats_summary" if fields.indexOf("page_stats_summary") >= 0 else ""
-    if stats_field:
+    # Detail block: per-page detail items (label: value lines) from individual fields
+    _DETAIL_ITEM_FIELDS = [
+        ("page_distance_label", "Distance"),
+        ("page_duration_label", "Moving time"),
+        ("page_average_speed_label", "Speed"),
+        ("page_average_pace_label", "Pace"),
+        ("page_elevation_gain_label", "Climbing"),
+    ]
+    detail_parts = []
+    for field_name, label in _DETAIL_ITEM_FIELDS:
+        if fields.indexOf(field_name) >= 0:
+            detail_parts.append(f"'{label}: ' || \"{field_name}\"")
+    if detail_parts:
+        inner = ", ".join(detail_parts)
+        detail_expr = f"[% concat_ws(char(10), {inner}) %]"
         _add_label(
             layout,
-            f'[% coalesce("{stats_field}", \'\') %]',
+            detail_expr,
             x=PROFILE_X,
-            y=STATS_SUMMARY_Y,
+            y=DETAIL_BLOCK_Y,
             w=PROFILE_W,
-            h=STATS_SUMMARY_H,
+            h=DETAIL_BLOCK_H,
             font_size=7.0,
             color=QColor(100, 100, 100),
+            v_align_top=True,
         )
 
     # -- Footer: page number -----------------------------------------------

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -225,21 +225,23 @@ class TestBuildAtlasLayoutSummaryLabels(unittest.TestCase):
         return texts
 
     def test_both_summaries_rendered_when_fields_present(self):
-        """Both profile and stats summaries appear when fields exist."""
+        """Both profile summary and detail block appear when fields exist."""
         _qgis_core.QgsLayoutItemLabel.reset_mock()
         available = {
             "page_sort_key", "page_title", "page_stats_summary",
             "page_subtitle", "page_date", "page_profile_summary",
+            "page_distance_label", "page_duration_label",
+            "page_elevation_gain_label",
         }
         self._build_with_fields(available)
         texts = self._label_texts(None)
         profile_labels = [t for t in texts if "page_profile_summary" in t]
-        stats_labels = [t for t in texts if "page_stats_summary" in t]
+        detail_labels = [t for t in texts if "page_distance_label" in t]
         self.assertTrue(len(profile_labels) >= 1, "profile summary label missing")
-        self.assertTrue(len(stats_labels) >= 1, "stats summary label missing in detail area")
+        self.assertTrue(len(detail_labels) >= 1, "detail block label missing")
 
-    def test_stats_summary_omitted_when_field_absent(self):
-        """Stats summary label is not added when the field is missing."""
+    def test_detail_block_omitted_when_fields_absent(self):
+        """Detail block label is not added when no detail fields are present."""
         _qgis_core.QgsLayoutItemLabel.reset_mock()
         available = {
             "page_sort_key", "page_title", "page_subtitle",
@@ -247,8 +249,24 @@ class TestBuildAtlasLayoutSummaryLabels(unittest.TestCase):
         }
         self._build_with_fields(available)
         texts = self._label_texts(None)
-        stats_labels = [t for t in texts if "page_stats_summary" in t]
-        self.assertEqual(len(stats_labels), 0, "stats summary label should not be added")
+        detail_labels = [t for t in texts if "page_distance_label" in t]
+        self.assertEqual(len(detail_labels), 0, "detail block should not be added")
+
+    def test_detail_block_includes_available_fields_only(self):
+        """Detail block expression only references fields present on the layer."""
+        _qgis_core.QgsLayoutItemLabel.reset_mock()
+        available = {
+            "page_sort_key", "page_title", "page_subtitle", "page_date",
+            "page_distance_label", "page_elevation_gain_label",
+        }
+        self._build_with_fields(available)
+        texts = self._label_texts(None)
+        detail_labels = [t for t in texts if "page_distance_label" in t]
+        self.assertEqual(len(detail_labels), 1)
+        expr_text = detail_labels[0]
+        self.assertIn("page_elevation_gain_label", expr_text)
+        self.assertNotIn("page_duration_label", expr_text)
+        self.assertNotIn("page_average_speed_label", expr_text)
 
     def test_profile_summary_omitted_when_field_absent(self):
         """Profile summary label is not added when the field is missing."""
@@ -951,7 +969,7 @@ class TestLayoutGeometry(unittest.TestCase):
         from qfit.atlas_export_task import (
             PROFILE_Y, PROFILE_H, PROFILE_CHART_Y, PROFILE_CHART_H,
             PROFILE_SUMMARY_Y, PROFILE_SUMMARY_H, PROFILE_SUMMARY_GAP,
-            STATS_SUMMARY_Y, STATS_SUMMARY_H, STATS_SUMMARY_GAP,
+            DETAIL_BLOCK_Y, DETAIL_BLOCK_H, DETAIL_BLOCK_GAP,
         )
 
         # Chart starts at profile area top
@@ -961,14 +979,14 @@ class TestLayoutGeometry(unittest.TestCase):
             PROFILE_SUMMARY_Y,
             PROFILE_CHART_Y + PROFILE_CHART_H + PROFILE_SUMMARY_GAP,
         )
-        # Stats summary is below profile summary with gap
+        # Detail block is below profile summary with gap
         self.assertAlmostEqual(
-            STATS_SUMMARY_Y,
-            PROFILE_SUMMARY_Y + PROFILE_SUMMARY_H + STATS_SUMMARY_GAP,
+            DETAIL_BLOCK_Y,
+            PROFILE_SUMMARY_Y + PROFILE_SUMMARY_H + DETAIL_BLOCK_GAP,
         )
         # Everything fits within profile area
         total = (PROFILE_CHART_H + PROFILE_SUMMARY_GAP + PROFILE_SUMMARY_H
-                 + STATS_SUMMARY_GAP + STATS_SUMMARY_H)
+                 + DETAIL_BLOCK_GAP + DETAIL_BLOCK_H)
         self.assertAlmostEqual(total, PROFILE_H)
 
     def test_profile_chart_has_positive_height(self):


### PR DESCRIPTION
## Summary

- Replace the single-line stats summary in the portrait atlas detail area with a multi-line detail block that renders individual per-page metric items (Distance, Moving time, Speed, Pace, Climbing) using the `atlas_page_detail_items` helper field data
- Detail block uses a QGIS `concat_ws(char(10), ...)` expression to build label:value lines, gracefully skipping fields that are absent or NULL on the atlas layer
- Layout adjusts detail block height to 12mm (from 5mm) with profile chart reduced accordingly (~34mm, well above 20mm minimum)
- `_add_label` helper gains `v_align_top` parameter for multi-line block readability

## Test plan

- [x] All 283 existing tests pass (`python3 -m pytest tests/ -x -q`)
- [x] New `test_detail_block_includes_available_fields_only` validates selective field inclusion
- [x] `test_detail_block_omitted_when_fields_absent` validates graceful degradation
- [x] `test_both_summaries_rendered_when_fields_present` updated for detail block
- [x] Geometry tests updated for renamed constants (DETAIL_BLOCK_H/GAP/Y)
- [ ] SonarCloud quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)