### PR TITLE
feat: render cover stats as 2-column highlight-card grid

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -410,48 +410,57 @@ def build_cover_layout(
     sep_label.setBackgroundEnabled(True)
     layout.addLayoutItem(sep_label)
 
-    # Stats block — label/value rows
-    stats_y = sep_y + 6.0
-    row_h = 8.0
-    label_col_w = 60.0
-    value_col_w = content_width - label_col_w
-    label_color = QColor(100, 100, 100)
+    # Highlight-card grid — 2-column layout for cover stats
+    grid_y = sep_y + 8.0
+    grid_cols = 2
+    grid_gap_x = 6.0   # horizontal gap between columns
+    card_w = (content_width - grid_gap_x) / grid_cols
+    card_label_h = 5.0  # height for the label row
+    card_value_h = 8.0  # height for the value row
+    card_h = card_label_h + card_value_h
+    card_gap_y = 4.0    # vertical gap between card rows
+    label_color = QColor(120, 120, 120)
     value_color = QColor(20, 20, 20)
 
-    stats_rows: list[tuple[str, str]] = []
+    highlight_cards: list[tuple[str, str]] = []
     if activity_count and activity_count != "0":
-        stats_rows.append(("Activities", activity_count))
+        highlight_cards.append(("Activities", activity_count))
     if date_range_label:
-        stats_rows.append(("Date range", date_range_label))
+        highlight_cards.append(("Date range", date_range_label))
     if total_distance_label:
-        stats_rows.append(("Distance", total_distance_label))
+        highlight_cards.append(("Distance", total_distance_label))
     if total_duration_label:
-        stats_rows.append(("Moving time", total_duration_label))
+        highlight_cards.append(("Moving time", total_duration_label))
     if total_elevation_gain_label:
-        stats_rows.append(("Climbing", total_elevation_gain_label))
+        highlight_cards.append(("Climbing", total_elevation_gain_label))
     if activity_types_label:
-        stats_rows.append(("Activity types", activity_types_label))
+        highlight_cards.append(("Activity types", activity_types_label))
 
-    for i, (row_label, row_value) in enumerate(stats_rows):
-        row_y = stats_y + i * row_h
+    for i, (card_label, card_value) in enumerate(highlight_cards):
+        col = i % grid_cols
+        row = i // grid_cols
+        card_x = center_x + col * (card_w + grid_gap_x)
+        card_y = grid_y + row * (card_h + card_gap_y)
         _add_label(
             layout,
-            f"{row_label}:",
-            x=center_x,
-            y=row_y,
-            w=label_col_w,
-            h=row_h,
-            font_size=9.0,
+            card_label.upper(),
+            x=card_x,
+            y=card_y,
+            w=card_w,
+            h=card_label_h,
+            font_size=7.0,
             color=label_color,
+            v_align_top=True,
         )
         _add_label(
             layout,
-            row_value,
-            x=center_x + label_col_w,
-            y=row_y,
-            w=value_col_w,
-            h=row_h,
-            font_size=9.0,
+            card_value,
+            x=card_x,
+            y=card_y + card_label_h,
+            w=card_w,
+            h=card_value_h,
+            font_size=12.0,
+            bold=True,
             color=value_color,
         )
 

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -718,6 +718,105 @@ class TestBuildCoverLayout(unittest.TestCase):
         from qfit.atlas_export_task import QgsPrintLayout  # noqa: PLC0415
         QgsPrintLayout.assert_called_with(project)
 
+    def test_build_cover_layout_highlight_grid_item_count(self):
+        """Each stat produces two layout items: an uppercase label and a bold value."""
+        layer = _make_cover_atlas_layer()
+        # Use a fresh layout mock to isolate item counts from other tests.
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout):
+            result = build_cover_layout(layer)
+        self.assertIsNotNone(result)
+        # With all 6 stats present, we expect:
+        #   title (1) + subtitle (1) + separator (1) + 6×2 highlight items = 15
+        add_calls = fresh_layout.addLayoutItem.call_args_list
+        self.assertEqual(len(add_calls), 15)
+
+    def test_build_cover_layout_highlight_labels_uppercased(self):
+        """Highlight card labels are rendered in uppercase."""
+        layer = _make_cover_atlas_layer()
+        fresh_label_cls = MagicMock()
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutItemLabel", fresh_label_cls):
+            build_cover_layout(layer)
+        label_texts = [
+            call[0][0]
+            for call in fresh_label_cls.return_value.setText.call_args_list
+        ]
+        expected_upper_labels = [
+            "ACTIVITIES", "DATE RANGE", "DISTANCE",
+            "MOVING TIME", "CLIMBING", "ACTIVITY TYPES",
+        ]
+        for expected in expected_upper_labels:
+            self.assertIn(expected, label_texts)
+
+    def test_build_cover_layout_highlight_grid_two_columns(self):
+        """Highlight cards are positioned in a 2-column grid pattern."""
+        from qfit.atlas_export_task import MARGIN_MM  # noqa: PLC0415
+        layer = _make_cover_atlas_layer()
+        fresh_point_cls = MagicMock()
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutPoint", fresh_point_cls):
+            build_cover_layout(layer)
+        # Collect x-coordinates from all QgsLayoutPoint calls.
+        x_coords = sorted({call[0][0] for call in fresh_point_cls.call_args_list})
+        # There should be at least 2 distinct x positions for the grid columns
+        # (beyond the title/subtitle x position at MARGIN_MM)
+        grid_x_positions = [x for x in x_coords if x > MARGIN_MM]
+        self.assertGreaterEqual(len(grid_x_positions), 1,
+                                "Highlight cards should use at least two distinct x positions")
+
+    def test_build_cover_layout_fewer_stats_fewer_items(self):
+        """With only 2 stats, the grid renders 2×2 = 4 highlight items."""
+        fields_dict = {
+            "document_cover_summary": "2 activities · 100 km",
+            "document_activity_count": "2",
+            "document_date_range_label": "",
+            "document_total_distance_label": "100 km",
+            "document_total_duration_label": "",
+            "document_total_elevation_gain_label": "",
+            "document_activity_types_label": "",
+        }
+        layer = _make_cover_atlas_layer(fields_dict=fields_dict)
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout):
+            result = build_cover_layout(layer)
+        self.assertIsNotNone(result)
+        # title (1) + subtitle (1) + separator (1) + 2×2 highlight items = 7
+        add_calls = fresh_layout.addLayoutItem.call_args_list
+        self.assertEqual(len(add_calls), 7)
+
+    def test_build_cover_layout_no_stats_no_highlight_items(self):
+        """When all stats are empty, no highlight cards are rendered."""
+        fields_dict = {
+            "document_cover_summary": "",
+            "document_activity_count": "0",
+            "document_date_range_label": "",
+            "document_total_distance_label": "",
+            "document_total_duration_label": "",
+            "document_total_elevation_gain_label": "",
+            "document_activity_types_label": "",
+        }
+        layer = _make_cover_atlas_layer(fields_dict=fields_dict)
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout):
+            result = build_cover_layout(layer)
+        self.assertIsNotNone(result)
+        # title (1) + separator (1) = 2 (no subtitle since summary is empty)
+        add_calls = fresh_layout.addLayoutItem.call_args_list
+        self.assertEqual(len(add_calls), 2)
+
 
 class TestExportCoverPage(unittest.TestCase):
     def test_export_cover_page_returns_path_on_success(self):


### PR DESCRIPTION
## Summary
- Replaces the plain label/value row list on the portrait atlas cover page with a 2-column highlight-card grid
- Each card displays an uppercase category label (7pt, muted) above a larger bold value (12pt) — cleaner visual hierarchy
- Uses the same atlas-scoped document fields; gracefully omits cards for missing/empty values
- Adds 5 new tests covering grid item counts, uppercase labels, 2-column positioning, partial stats, and empty-stats edge case

## Test plan
- [x] `python3 -m pytest tests/ -x -q` — 288 passed, 4 skipped
- [ ] SonarCloud quality gate passes
- [ ] Visual check of exported cover PDF with full and partial stats