### PR TITLE
fix: prevent raw template text in atlas export below profile (#108)

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -86,6 +86,19 @@ DETAIL_BLOCK_Y = PROFILE_SUMMARY_Y + PROFILE_SUMMARY_H + DETAIL_BLOCK_GAP
 
 # Identifier for the profile picture item (used to find it during export)
 _PROFILE_PICTURE_ID = "qfit_profile_chart"
+_PROFILE_SUMMARY_ID = "qfit_profile_summary"
+_DETAIL_BLOCK_ID = "qfit_detail_block"
+
+# Per-page detail item fields: (field_name, human_label).  Shared between
+# build_atlas_layout (to decide whether to create the label) and the export
+# loop (to build the plain-text content per page).
+_DETAIL_ITEM_FIELDS = [
+    ("page_distance_label", "Distance"),
+    ("page_duration_label", "Moving time"),
+    ("page_average_speed_label", "Speed"),
+    ("page_average_pace_label", "Pace"),
+    ("page_elevation_gain_label", "Climbing"),
+]
 
 
 def _mm(layout, value):
@@ -264,12 +277,14 @@ def build_atlas_layout(
     profile_pic.setResizeMode(QgsLayoutItemPicture.Zoom)
     layout.addLayoutItem(profile_pic)
 
-    # Text summaries below the chart: profile summary then stats summary
-    profile_field = "page_profile_summary" if fields.indexOf("page_profile_summary") >= 0 else ""
-    if profile_field:
-        _add_label(
+    # Text summaries below the chart — text is set per page during the export
+    # loop so that no [% %] expressions remain in the layout.  This avoids raw
+    # template syntax leaking into the final PDF when QGIS fails to evaluate
+    # inline atlas expressions (see issue #108).
+    if fields.indexOf("page_profile_summary") >= 0:
+        lbl = _add_label(
             layout,
-            f'[% coalesce("{profile_field}", \'\') %]',
+            "",
             x=PROFILE_X,
             y=PROFILE_SUMMARY_Y,
             w=PROFILE_W,
@@ -277,25 +292,17 @@ def build_atlas_layout(
             font_size=7.0,
             color=QColor(100, 100, 100),
         )
+        lbl.setId(_PROFILE_SUMMARY_ID)
 
-    # Detail block: per-page detail items (label: value lines) from individual fields
-    _DETAIL_ITEM_FIELDS = [
-        ("page_distance_label", "Distance"),
-        ("page_duration_label", "Moving time"),
-        ("page_average_speed_label", "Speed"),
-        ("page_average_pace_label", "Pace"),
-        ("page_elevation_gain_label", "Climbing"),
-    ]
-    detail_parts = []
-    for field_name, label in _DETAIL_ITEM_FIELDS:
-        if fields.indexOf(field_name) >= 0:
-            detail_parts.append(f"'{label}: ' || \"{field_name}\"")
-    if detail_parts:
-        inner = ", ".join(detail_parts)
-        detail_expr = f"[% concat_ws(char(10), {inner}) %]"
-        _add_label(
+    # Detail block: per-page detail items (label: value lines) from individual
+    # fields.  Like the profile summary the text is set per page during export.
+    has_any_detail_field = any(
+        fields.indexOf(fn) >= 0 for fn, _ in _DETAIL_ITEM_FIELDS
+    )
+    if has_any_detail_field:
+        lbl = _add_label(
             layout,
-            detail_expr,
+            "",
             x=PROFILE_X,
             y=DETAIL_BLOCK_Y,
             w=PROFILE_W,
@@ -304,6 +311,7 @@ def build_atlas_layout(
             color=QColor(100, 100, 100),
             v_align_top=True,
         )
+        lbl.setId(_DETAIL_BLOCK_ID)
 
     # -- Footer: page number -----------------------------------------------
     footer_y = PROFILE_Y + PROFILE_H + FOOTER_GAP_MM
@@ -676,12 +684,18 @@ class AtlasExportTask(QgsTask):
             if output_dir and not os.path.exists(output_dir):
                 os.makedirs(output_dir, exist_ok=True)
 
-            # Locate the profile picture item so we can set its source per page.
+            # Locate per-page layout items so we can update them each iteration.
             profile_pic = None
+            profile_summary_label = None
+            detail_block_label = None
             for item in layout.items():
-                if getattr(item, "id", lambda: None)() == _PROFILE_PICTURE_ID:
+                item_id = getattr(item, "id", lambda: None)()
+                if item_id == _PROFILE_PICTURE_ID:
                     profile_pic = item
-                    break
+                elif item_id == _PROFILE_SUMMARY_ID:
+                    profile_summary_label = item
+                elif item_id == _DETAIL_BLOCK_ID:
+                    detail_block_label = item
 
             # Pre-load profile samples grouped by page_sort_key.
             profile_samples: dict[str, list[tuple[float, float]]] = {}
@@ -713,6 +727,14 @@ class AtlasExportTask(QgsTask):
 
             # Field index for source_activity_id in the atlas layer.
             sid_atlas_idx = fields.indexOf("source_activity_id")
+
+            # Field indices for per-page text labels (profile summary + detail).
+            profile_summary_idx = fields.indexOf("page_profile_summary")
+            detail_field_indices = [
+                (fields.indexOf(fn), human_label)
+                for fn, human_label in _DETAIL_ITEM_FIELDS
+                if fields.indexOf(fn) >= 0
+            ]
 
             # Walk the atlas features in order, setting the map extent explicitly
             # from the stored center/size fields so QGIS atlas auto-fit cannot
@@ -764,6 +786,20 @@ class AtlasExportTask(QgsTask):
                                 profile_pic.setPicturePath("")
                         else:
                             profile_pic.setPicturePath("")
+
+                    # Set profile summary text directly from the feature so that
+                    # no raw [% %] template syntax can leak (issue #108).
+                    if profile_summary_label is not None and profile_summary_idx >= 0:
+                        val = feat.attribute(profile_summary_idx)
+                        profile_summary_label.setText(str(val) if val else "")
+
+                    if detail_block_label is not None and detail_field_indices:
+                        lines = []
+                        for idx, human_label in detail_field_indices:
+                            val = feat.attribute(idx)
+                            if val is not None and val != "":
+                                lines.append(f"{human_label}: {val}")
+                        detail_block_label.setText("\n".join(lines))
 
                     # Apply the stored precomputed extent to the map item.
                     if map_item is not None and has_stored_extents:

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -224,8 +224,35 @@ class TestBuildAtlasLayoutSummaryLabels(unittest.TestCase):
             texts.append(call[0][0])
         return texts
 
+    def _label_ids(self):
+        """Return the list of IDs set on label items."""
+        from qgis.core import QgsLayoutItemLabel
+        ids = []
+        for call in QgsLayoutItemLabel.return_value.setId.call_args_list:
+            ids.append(call[0][0])
+        return ids
+
     def test_both_summaries_rendered_when_fields_present(self):
-        """Both profile summary and detail block appear when fields exist."""
+        """Both profile summary and detail block labels are created when fields exist."""
+        _qgis_core.QgsLayoutItemLabel.reset_mock()
+        available = {
+            "page_sort_key", "page_title", "page_stats_summary",
+            "page_subtitle", "page_date", "page_profile_summary",
+            "page_distance_label", "page_duration_label",
+            "page_elevation_gain_label",
+        }
+        self._build_with_fields(available)
+        ids = self._label_ids()
+        from qfit.atlas_export_task import _PROFILE_SUMMARY_ID, _DETAIL_BLOCK_ID
+        self.assertIn(_PROFILE_SUMMARY_ID, ids, "profile summary label missing")
+        self.assertIn(_DETAIL_BLOCK_ID, ids, "detail block label missing")
+
+    def test_no_raw_expression_in_profile_area_labels(self):
+        """Profile summary and detail block labels must not contain [% %] syntax.
+
+        These labels are populated per-page from feature attributes during export
+        to prevent raw template syntax leaking into the PDF (issue #108).
+        """
         _qgis_core.QgsLayoutItemLabel.reset_mock()
         available = {
             "page_sort_key", "page_title", "page_stats_summary",
@@ -235,10 +262,16 @@ class TestBuildAtlasLayoutSummaryLabels(unittest.TestCase):
         }
         self._build_with_fields(available)
         texts = self._label_texts(None)
-        profile_labels = [t for t in texts if "page_profile_summary" in t]
-        detail_labels = [t for t in texts if "page_distance_label" in t]
-        self.assertTrue(len(profile_labels) >= 1, "profile summary label missing")
-        self.assertTrue(len(detail_labels) >= 1, "detail block label missing")
+        # No label text should reference profile-area field names inside [% %].
+        profile_area_fields = {"page_profile_summary", "page_distance_label",
+                               "page_duration_label", "page_elevation_gain_label"}
+        for t in texts:
+            if "[%" in t:
+                for field in profile_area_fields:
+                    self.assertNotIn(
+                        field, t,
+                        f"raw [% %] expression referencing {field} found: {t!r}",
+                    )
 
     def test_detail_block_omitted_when_fields_absent(self):
         """Detail block label is not added when no detail fields are present."""
@@ -248,25 +281,21 @@ class TestBuildAtlasLayoutSummaryLabels(unittest.TestCase):
             "page_date", "page_profile_summary",
         }
         self._build_with_fields(available)
-        texts = self._label_texts(None)
-        detail_labels = [t for t in texts if "page_distance_label" in t]
-        self.assertEqual(len(detail_labels), 0, "detail block should not be added")
+        ids = self._label_ids()
+        from qfit.atlas_export_task import _DETAIL_BLOCK_ID
+        self.assertNotIn(_DETAIL_BLOCK_ID, ids, "detail block should not be added")
 
-    def test_detail_block_includes_available_fields_only(self):
-        """Detail block expression only references fields present on the layer."""
+    def test_detail_block_created_with_subset_of_fields(self):
+        """Detail block label is created when at least some detail fields exist."""
         _qgis_core.QgsLayoutItemLabel.reset_mock()
         available = {
             "page_sort_key", "page_title", "page_subtitle", "page_date",
             "page_distance_label", "page_elevation_gain_label",
         }
         self._build_with_fields(available)
-        texts = self._label_texts(None)
-        detail_labels = [t for t in texts if "page_distance_label" in t]
-        self.assertEqual(len(detail_labels), 1)
-        expr_text = detail_labels[0]
-        self.assertIn("page_elevation_gain_label", expr_text)
-        self.assertNotIn("page_duration_label", expr_text)
-        self.assertNotIn("page_average_speed_label", expr_text)
+        ids = self._label_ids()
+        from qfit.atlas_export_task import _DETAIL_BLOCK_ID
+        self.assertIn(_DETAIL_BLOCK_ID, ids, "detail block should be created")
 
     def test_profile_summary_omitted_when_field_absent(self):
         """Profile summary label is not added when the field is missing."""
@@ -276,9 +305,126 @@ class TestBuildAtlasLayoutSummaryLabels(unittest.TestCase):
             "page_subtitle", "page_date",
         }
         self._build_with_fields(available)
-        texts = self._label_texts(None)
-        profile_labels = [t for t in texts if "page_profile_summary" in t]
-        self.assertEqual(len(profile_labels), 0, "profile summary label should not be added")
+        ids = self._label_ids()
+        from qfit.atlas_export_task import _PROFILE_SUMMARY_ID
+        self.assertNotIn(_PROFILE_SUMMARY_ID, ids, "profile summary label should not be added")
+
+
+class TestPerPageLabelTextSetting(unittest.TestCase):
+    """Verify that profile-area label text is set from feature attributes per page (issue #108)."""
+
+    def test_profile_summary_set_per_page(self):
+        """Profile summary label receives plain text from feature attribute each page."""
+        from qfit.atlas_export_task import _PROFILE_SUMMARY_ID, _DETAIL_BLOCK_ID
+
+        layout_mock, atlas_mock, exporter_cls_mock = _make_atlas_mock(feature_count=1)
+
+        # Create mock label items with IDs matching the profile-area constants.
+        summary_label = MagicMock()
+        summary_label.id.return_value = _PROFILE_SUMMARY_ID
+        detail_label = MagicMock()
+        detail_label.id.return_value = _DETAIL_BLOCK_ID
+        layout_mock.items.return_value = [summary_label, detail_label]
+
+        # Atlas layer with profile summary and detail fields present.
+        atlas_layer = _make_atlas_layer(feature_count=1)
+        field_names = [
+            "page_sort_key", "page_profile_summary",
+            "page_distance_label", "page_elevation_gain_label",
+            "center_x_3857", "center_y_3857", "extent_width_m", "extent_height_m",
+        ]
+        atlas_layer.fields.return_value.indexOf = (
+            lambda name: field_names.index(name) if name in field_names else -1
+        )
+
+        # Feature attributes: return realistic values per field index.
+        attr_values = {
+            0: "sort_key_1",               # page_sort_key
+            1: "5.2 km · 120–450 m",       # page_profile_summary
+            2: "5.2 km",                    # page_distance_label
+            3: "330 m",                     # page_elevation_gain_label
+            4: 1000.0, 5: 2000.0, 6: 500.0, 7: 500.0,  # extents
+        }
+        feat_mock = atlas_mock.layout.return_value.reportContext.return_value.feature.return_value
+        feat_mock.attribute.side_effect = lambda idx: attr_values.get(idx)
+
+        received = {}
+        task = AtlasExportTask(
+            atlas_layer=atlas_layer,
+            output_path="/tmp/qfit_test_perpage.pdf",
+            on_finished=lambda **kw: received.update(kw),
+        )
+
+        with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("os.replace"), \
+             patch("os.makedirs"):
+            _run_task(task)
+
+        # Profile summary label should have been set to the resolved attribute value.
+        summary_label.setText.assert_called()
+        summary_text = summary_label.setText.call_args[0][0]
+        self.assertEqual(summary_text, "5.2 km · 120–450 m")
+        self.assertNotIn("[%", summary_text)
+
+        # Detail block label should have resolved label:value lines.
+        detail_label.setText.assert_called()
+        detail_text = detail_label.setText.call_args[0][0]
+        self.assertIn("Distance: 5.2 km", detail_text)
+        self.assertIn("Climbing: 330 m", detail_text)
+        self.assertNotIn("[%", detail_text)
+        # Fields not in the layer should not appear.
+        self.assertNotIn("Moving time:", detail_text)
+        self.assertNotIn("Speed:", detail_text)
+
+    def test_null_attributes_produce_empty_text(self):
+        """NULL or empty feature attributes produce empty label text, not raw syntax."""
+        from qfit.atlas_export_task import _PROFILE_SUMMARY_ID, _DETAIL_BLOCK_ID
+
+        layout_mock, atlas_mock, exporter_cls_mock = _make_atlas_mock(feature_count=1)
+
+        summary_label = MagicMock()
+        summary_label.id.return_value = _PROFILE_SUMMARY_ID
+        detail_label = MagicMock()
+        detail_label.id.return_value = _DETAIL_BLOCK_ID
+        layout_mock.items.return_value = [summary_label, detail_label]
+
+        atlas_layer = _make_atlas_layer(feature_count=1)
+        field_names = [
+            "page_sort_key", "page_profile_summary",
+            "page_distance_label", "page_elevation_gain_label",
+            "center_x_3857", "center_y_3857", "extent_width_m", "extent_height_m",
+        ]
+        atlas_layer.fields.return_value.indexOf = (
+            lambda name: field_names.index(name) if name in field_names else -1
+        )
+
+        # All label attributes are None (e.g. activity with no profile data).
+        feat_mock = atlas_mock.layout.return_value.reportContext.return_value.feature.return_value
+        feat_mock.attribute.side_effect = lambda idx: {4: 1000.0, 5: 2000.0, 6: 500.0, 7: 500.0}.get(idx)
+
+        received = {}
+        task = AtlasExportTask(
+            atlas_layer=atlas_layer,
+            output_path="/tmp/qfit_test_null.pdf",
+            on_finished=lambda **kw: received.update(kw),
+        )
+
+        with patch("qfit.atlas_export_task.build_atlas_layout", return_value=layout_mock), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls_mock), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas_export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("os.replace"), \
+             patch("os.makedirs"):
+            _run_task(task)
+
+        summary_label.setText.assert_called()
+        self.assertEqual(summary_label.setText.call_args[0][0], "")
+
+        detail_label.setText.assert_called()
+        self.assertEqual(detail_label.setText.call_args[0][0], "")
 
 
 class TestAtlasExportTaskSuccess(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Replace inline QGIS `[% %]` expressions in profile summary and detail block labels with direct per-page text setting from feature attributes during export
- Profile-area labels now use IDs (`_PROFILE_SUMMARY_ID`, `_DETAIL_BLOCK_ID`) and are populated in the export loop, matching the existing pattern used for the profile picture item
- Module-level `_DETAIL_ITEM_FIELDS` constant shared between layout creation and the export loop

## Test plan
- [x] Existing 66 atlas export tests pass (updated to match new label creation pattern)
- [x] New `TestPerPageLabelTextSetting` class with 2 tests:
  - `test_profile_summary_set_per_page` — verifies resolved text, no `[%` syntax
  - `test_null_attributes_produce_empty_text` — verifies NULL attributes produce empty text
- [x] New regression test `test_no_raw_expression_in_profile_area_labels` — asserts no `[%` expression references profile-area fields
- [x] Full suite: 291 passed, 5 skipped

Closes #108