### PR TITLE
fix: restore tile mode with package-relative import after atlas export

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -971,7 +971,7 @@ class AtlasExportTask(QgsTask):
             and self._background_enabled
         ):
             try:
-                from mapbox_config import TILE_MODE_RASTER  # noqa: PLC0415
+                from .mapbox_config import TILE_MODE_RASTER  # noqa: PLC0415
                 if self._restore_tile_mode == TILE_MODE_RASTER:
                     self._layer_manager.ensure_background_layer(
                         enabled=True,


### PR DESCRIPTION
## Problem\nAtlas export cleanup imported  as a top-level module in . In the installed QGIS plugin runtime, that module is inside the plugin package, so the import failed with:\n\n\n\nThat broke background tile-mode restoration after export and could leave QGIS in a bad state.\n\n## Fix\n- switch the cleanup import to package-relative form:\n  - \n\n## Test\n- ....................................................................     [100%]
68 passed in 0.16s\n- ........................................................................ [ 24%]
........................................................................ [ 48%]
...................s.................................................... [ 72%]
......................ssss.............................................. [ 97%]
........                                                                 [100%]
291 passed, 5 skipped in 0.68s\n\nFull suite: **291 passed, 5 skipped**.