### PR TITLE
fix: heatmap preset produces visible density gradients

### DIFF
--- a/layer_manager.py
+++ b/layer_manager.py
@@ -137,8 +137,11 @@ class LayerManager:
         if activities_layer is not None:
             if preset in ("By activity type",):
                 self._apply_categorized_line_style(activities_layer, basemap_preset_name)
-            elif preset in ("Heatmap", "Track points"):
-                # Tracks hidden; user sees points/heatmap instead — show subtle lines
+            elif preset == "Heatmap":
+                # Hide tracks so the density surface reads clearly
+                self._apply_simple_line_style(activities_layer, basemap_preset_name, subtle=True)
+                activities_layer.setOpacity(0.0)
+            elif preset == "Track points":
                 self._apply_simple_line_style(activities_layer, basemap_preset_name, subtle=True)
             else:
                 self._apply_simple_line_style(activities_layer, basemap_preset_name)
@@ -164,7 +167,9 @@ class LayerManager:
                 if points_layer is None:
                     self._apply_heatmap_style(starts_layer)
                 else:
+                    # Hide start markers so only the density surface shows
                     self._apply_start_point_style(starts_layer, subtle=True)
+                    starts_layer.setOpacity(0.0)
             elif preset == "By activity type":
                 self._apply_categorized_point_style(starts_layer, basemap_preset_name, size="3.0")
             else:
@@ -544,14 +549,15 @@ class LayerManager:
 
     def _apply_heatmap_style(self, layer):
         renderer = QgsHeatmapRenderer()
-        renderer.setRadius(20)
-        renderer.setRadiusUnit(QgsUnitTypes.RenderPixels)
+        renderer.setRadius(12)
+        renderer.setRadiusUnit(QgsUnitTypes.RenderMillimeters)
+        renderer.setRenderQuality(2)
         renderer.setColorRamp(
             QgsStyle.defaultStyle().colorRamp("Turbo")
             or QgsGradientColorRamp(QColor("#00000000"), QColor("#e74c3c"))
         )
         layer.setRenderer(renderer)
-        layer.setOpacity(0.85)
+        layer.setOpacity(0.75)
         layer.triggerRepaint()
 
     def _apply_clusterish_style(self, layer):

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -282,6 +282,71 @@ class QgisSmokeTests(unittest.TestCase):
             self.layer_manager.ensure_background_layer(False, "Outdoor", "test-token")
             self.assertNotIn(background_name, self._layer_order())
 
+    def test_heatmap_preset_renderer_and_layer_visibility(self):
+        """Heatmap preset must produce a density-based renderer and suppress other layers."""
+        from qgis.core import QgsHeatmapRenderer, QgsUnitTypes
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = self._write_sample_gpkg(tmp)
+            activities_layer, starts_layer, points_layer, atlas_layer = (
+                self.layer_manager.load_output_layers(output_path)
+            )
+
+            self.layer_manager.apply_style(
+                activities_layer,
+                starts_layer,
+                points_layer,
+                atlas_layer,
+                "Heatmap",
+            )
+
+            # Points layer carries the heatmap renderer
+            renderer = points_layer.renderer()
+            self.assertIsInstance(renderer, QgsHeatmapRenderer)
+            self.assertEqual(renderer.radius(), 12)
+            self.assertEqual(renderer.radiusUnit(), QgsUnitTypes.RenderMillimeters)
+            self.assertEqual(renderer.renderQuality(), 2)
+            self.assertIsNotNone(renderer.colorRamp())
+            self.assertEqual(round(points_layer.opacity(), 2), 0.75)
+
+            # Tracks and start points must be fully hidden so they don't flatten the visual
+            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+            self.assertEqual(round(starts_layer.opacity(), 2), 0.0)
+
+    def test_heatmap_preset_falls_back_to_starts_layer(self):
+        """When points_layer is None the heatmap should render on starts_layer."""
+        from qgis.core import QgsHeatmapRenderer
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = self._write_sample_gpkg(tmp)
+            activities_layer, starts_layer, _points_layer, atlas_layer = (
+                self.layer_manager.load_output_layers(output_path)
+            )
+
+            self.layer_manager.apply_style(
+                activities_layer,
+                starts_layer,
+                None,  # no points layer
+                atlas_layer,
+                "Heatmap",
+            )
+
+            self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
+            self.assertEqual(round(starts_layer.opacity(), 2), 0.75)
+            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+
+    def _write_sample_gpkg(self, temp_dir):
+        output_path = str(Path(temp_dir) / "qfit-heatmap-test.gpkg")
+        GeoPackageWriter(
+            output_path,
+            write_activity_points=True,
+            point_stride=2,
+            atlas_margin_percent=10,
+            atlas_min_extent_degrees=0.01,
+            atlas_target_aspect_ratio=1.5,
+        ).write_activities(self._sample_activities(), sync_metadata={"provider": "strava"})
+        return output_path
+
     def _layer_order(self):
         names = []
         for child in QgsProject.instance().layerTreeRoot().children():


### PR DESCRIPTION
## Summary
- Increased heatmap kernel radius from 20 px to 12 mm (RenderMillimeters) so kernels overlap and density variation becomes visible
- Set render quality to 2 for smoother output
- Reduced heatmap layer opacity to 0.75 for better basemap readability
- Tracks and start-point markers are now fully hidden (opacity 0) when Heatmap preset is active
- Fallback to starts_layer when points_layer is absent is preserved

## Test plan
- [x] `test_heatmap_preset_renderer_and_layer_visibility` — verifies renderer type, radius, unit, quality, color ramp, and that tracks/starts are hidden
- [x] `test_heatmap_preset_falls_back_to_starts_layer` — verifies heatmap renders on starts_layer when points are missing
- [x] Full suite: 291 passed, 7 skipped