### PR TITLE
fix: reduce portrait atlas map size and center it

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -60,14 +60,14 @@ HEADER_GAP_MM = 3.0    # gap between header and map
 PROFILE_GAP_MM = 3.0   # gap between map and profile area
 FOOTER_GAP_MM = 3.0    # gap between profile area and footer
 
-MAP_X = MARGIN_MM
 MAP_Y = MARGIN_MM + HEADER_HEIGHT_MM + HEADER_GAP_MM
-MAP_W = PAGE_WIDTH_MM - 2 * MARGIN_MM                   # 190 mm
+MAP_W = (PAGE_WIDTH_MM - 2 * MARGIN_MM) * 0.90          # 10% smaller than full usable width
 MAP_H = MAP_W                                            # square
+MAP_X = (PAGE_WIDTH_MM - MAP_W) / 2.0                    # centered horizontally
 BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO = MAP_W / MAP_H   # 1.0
 
 # Profile area: reserved below the map for route profile content
-PROFILE_X = MARGIN_MM
+PROFILE_X = MAP_X
 PROFILE_Y = MAP_Y + MAP_H + PROFILE_GAP_MM
 PROFILE_W = MAP_W
 PROFILE_H = (PAGE_HEIGHT_MM - MARGIN_MM - FOOTER_HEIGHT_MM


### PR DESCRIPTION
## Problem\nThe portrait atlas page still feels cramped, with the square map block taking slightly too much horizontal space. The page would breathe better if the map were reduced a bit and centered.\n\n## Fix\n- reduce the square map frame to 90% of the full usable page width\n- center the map horizontally on the page\n- align the profile/detail area below to the same centered width\n- preserve the square-map aspect ratio and existing portrait layout structure\n\n## Test\n- .......................................................................  [100%]
71 passed in 0.18s\n- ........................................................................ [ 23%]
........................................................................ [ 47%]
......................s................................................. [ 71%]
.........................ssssss......................................... [ 95%]
.............                                                            [100%]
294 passed, 7 skipped in 0.77s\n\nFull suite: **294 passed, 7 skipped**.