### PR TITLE
fix: scope atlas cover summary to exported atlas subset

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -362,40 +362,109 @@ def build_atlas_layout(
     return layout
 
 
+def _build_cover_summary_from_current_atlas_features(atlas_layer) -> dict[str, str]:
+    """Compute cover-summary strings from the current atlas feature subset.
+
+    This intentionally ignores stale per-row `document_*` fields and instead
+    aggregates over the currently exported atlas-layer features, so cover stats
+    reflect the actual PDF contents after filtering/subsetting.
+    """
+    from .publish_atlas import (  # noqa: PLC0415
+        build_date_range_label,
+        format_distance_label,
+        format_duration_label,
+        format_elevation_label,
+    )
+
+    features = list(atlas_layer.getFeatures())
+    if not features:
+        return {}
+
+    fields = atlas_layer.fields()
+
+    def _idx(name: str) -> int:
+        return fields.indexOf(name)
+
+    def _safe_attr(feature, name: str):
+        idx = _idx(name)
+        return feature.attribute(idx) if idx >= 0 else None
+
+    def _safe_float(value):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _safe_int(value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    activity_count = len(features)
+    page_dates = [str(v) for v in (_safe_attr(f, "page_date") for f in features) if v]
+    total_distance_m = sum(v for v in (_safe_float(_safe_attr(f, "distance_m")) for f in features) if v is not None)
+    total_moving_time_s = sum(v for v in (_safe_int(_safe_attr(f, "moving_time_s")) for f in features) if v is not None)
+    total_elevation_gain_m = sum(
+        v for v in (_safe_float(_safe_attr(f, "total_elevation_gain_m")) for f in features) if v is not None
+    )
+
+    ordered_activity_types: list[str] = []
+    for feature in features:
+        activity_type = (_safe_attr(feature, "activity_type") or "").strip()
+        if not activity_type:
+            continue
+        if any(existing.casefold() == activity_type.casefold() for existing in ordered_activity_types):
+            continue
+        ordered_activity_types.append(activity_type)
+
+    activity_label = "activity" if activity_count == 1 else "activities"
+    date_range_label = build_date_range_label(min(page_dates), max(page_dates)) if page_dates else None
+    total_distance_label = format_distance_label(total_distance_m) if total_distance_m > 0 else None
+    total_duration_label = format_duration_label(total_moving_time_s) if total_moving_time_s > 0 else None
+    total_elevation_gain_label = format_elevation_label(total_elevation_gain_m) if total_elevation_gain_m > 0 else None
+    activity_types_label = ", ".join(ordered_activity_types) if ordered_activity_types else None
+
+    cover_parts = [f"{activity_count} {activity_label}"]
+    for part in [date_range_label, total_distance_label, total_duration_label, total_elevation_gain_label, activity_types_label]:
+        if part:
+            cover_parts.append(part)
+
+    return {
+        "document_cover_summary": " · ".join(cover_parts) if cover_parts else "",
+        "document_activity_count": str(activity_count),
+        "document_date_range_label": date_range_label or "",
+        "document_total_distance_label": total_distance_label or "",
+        "document_total_duration_label": total_duration_label or "",
+        "document_total_elevation_gain_label": total_elevation_gain_label or "",
+        "document_activity_types_label": activity_types_label or "",
+    }
+
+
 def build_cover_layout(
     atlas_layer,
     project=None,
 ) -> QgsPrintLayout | None:
-    """Build a single-page cover layout from document-level fields on *atlas_layer*.
+    """Build a single-page cover layout from the current atlas-layer subset.
 
-    Returns ``None`` if the atlas layer has no features or the required
-    document-level fields are absent (cover is simply skipped in that case).
+    Returns ``None`` if the atlas layer has no features.
     """
     if atlas_layer is None or atlas_layer.featureCount() == 0:
         return None
 
-    # Read the first feature — all features carry identical document-level fields.
-    feat = next(iter(atlas_layer.getFeatures()), None)
-    if feat is None:
+    # Build cover stats from the currently exported atlas features so the cover
+    # reflects the actual PDF subset, not stale precomputed document_* values.
+    cover_data = _build_cover_summary_from_current_atlas_features(atlas_layer)
+    if not cover_data:
         return None
 
-    fields = atlas_layer.fields()
-
-    def _get(name: str, default: str = "") -> str:
-        idx = fields.indexOf(name)
-        if idx < 0:
-            return default
-        val = feat.attribute(idx)
-        return str(val) if val is not None else default
-
-    cover_summary = _get("document_cover_summary")
-    activity_count = _get("document_activity_count")
-    date_range_label = _get("document_date_range_label")
-    total_distance_label = _get("document_total_distance_label")
-    total_duration_label = _get("document_total_duration_label")
-    total_elevation_gain_label = _get("document_total_elevation_gain_label")
-    activity_types_label = _get("document_activity_types_label")
-
+    cover_summary = cover_data.get("document_cover_summary", "")
+    activity_count = cover_data.get("document_activity_count", "")
+    date_range_label = cover_data.get("document_date_range_label", "")
+    total_distance_label = cover_data.get("document_total_distance_label", "")
+    total_duration_label = cover_data.get("document_total_duration_label", "")
+    total_elevation_gain_label = cover_data.get("document_total_elevation_gain_label", "")
+    activity_types_label = cover_data.get("document_activity_types_label", "")
     proj = project or QgsProject.instance()
     layout = QgsPrintLayout(proj)
     layout.initializeDefaults()

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -826,15 +826,21 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
 
 
 def _make_cover_atlas_layer(fields_dict=None, feature_count=1):
-    """Return a mock atlas layer with cover document fields populated."""
+    """Return a mock atlas layer with per-page fields populated for cover aggregation."""
     fields_dict = fields_dict or {
-        "document_cover_summary": "3 activities · 2025-01-01 → 2026-03-22 · 250.0 km",
-        "document_activity_count": "3",
-        "document_date_range_label": "2025-01-01 → 2026-03-22",
-        "document_total_distance_label": "250.0 km",
-        "document_total_duration_label": "12h 30m",
-        "document_total_elevation_gain_label": "5000 m",
-        "document_activity_types_label": "Run, Ride",
+        "page_date": "2026-03-22",
+        "activity_type": "Run",
+        "distance_m": 250000.0,
+        "moving_time_s": 45000,
+        "total_elevation_gain_m": 5000.0,
+        # Legacy/stale document fields may still exist but should be ignored by build_cover_layout
+        "document_cover_summary": "stale summary",
+        "document_activity_count": "999",
+        "document_date_range_label": "stale range",
+        "document_total_distance_label": "9999 km",
+        "document_total_duration_label": "999h",
+        "document_total_elevation_gain_label": "99999 m",
+        "document_activity_types_label": "Everything",
     }
     all_field_names = list(fields_dict.keys())
 
@@ -845,14 +851,60 @@ def _make_cover_atlas_layer(fields_dict=None, feature_count=1):
     fields.indexOf = lambda name: all_field_names.index(name) if name in all_field_names else -1
     layer.fields.return_value = fields
 
-    feat = MagicMock()
-    feat.attribute = lambda idx: list(fields_dict.values())[idx] if 0 <= idx < len(fields_dict) else None
-    layer.getFeatures.return_value = iter([feat])
+    features = []
+    for _ in range(feature_count):
+        feat = MagicMock()
+        feat.attribute = lambda idx, _vals=list(fields_dict.values()): _vals[idx] if 0 <= idx < len(_vals) else None
+        features.append(feat)
+    layer.getFeatures.return_value = iter(features)
 
     return layer
 
 
 class TestBuildCoverLayout(unittest.TestCase):
+    def test_cover_summary_is_recomputed_from_current_atlas_subset(self):
+        from qfit.atlas_export_task import _build_cover_summary_from_current_atlas_features
+
+        field_names = [
+            "page_date",
+            "activity_type",
+            "distance_m",
+            "moving_time_s",
+            "total_elevation_gain_m",
+            "document_cover_summary",
+            "document_activity_count",
+            "document_date_range_label",
+            "document_total_distance_label",
+            "document_total_duration_label",
+            "document_total_elevation_gain_label",
+            "document_activity_types_label",
+        ]
+
+        rows = [
+            ["2026-03-01", "NordicSkiing", 12000.0, 3600, 300.0, "stale all data", "99", "", "", "", "", "Run, Ride, NordicSkiing"],
+            ["2026-03-02", "NordicSkiing", 8000.0, 2400, 200.0, "stale all data", "99", "", "", "", "", "Run, Ride, NordicSkiing"],
+        ]
+
+        layer = MagicMock()
+        layer.featureCount.return_value = 2
+        fields = MagicMock()
+        fields.indexOf = lambda name: field_names.index(name) if name in field_names else -1
+        layer.fields.return_value = fields
+        feats = []
+        for row in rows:
+            feat = MagicMock()
+            feat.attribute = lambda idx, _row=row: _row[idx] if 0 <= idx < len(_row) else None
+            feats.append(feat)
+        layer.getFeatures.return_value = iter(feats)
+
+        summary = _build_cover_summary_from_current_atlas_features(layer)
+
+        self.assertEqual(summary["document_activity_count"], "2")
+        self.assertEqual(summary["document_activity_types_label"], "NordicSkiing")
+        self.assertIn("2026-03-01 → 2026-03-02", summary["document_cover_summary"])
+        self.assertIn("20.0 km", summary["document_total_distance_label"])
+        self.assertNotIn("Run, Ride", summary["document_cover_summary"])
+
     def test_build_cover_layout_returns_layout_for_populated_layer(self):
         """build_cover_layout returns a layout object when layer has features."""
         layer = _make_cover_atlas_layer()
@@ -995,12 +1047,17 @@ class TestBuildCoverLayout(unittest.TestCase):
                                 "Highlight cards should use at least two distinct x positions")
 
     def test_build_cover_layout_fewer_stats_fewer_items(self):
-        """With only 2 stats, the grid renders 2×2 = 4 highlight items."""
+        """With only activity count + distance present, the grid stays compact."""
         fields_dict = {
-            "document_cover_summary": "2 activities · 100 km",
-            "document_activity_count": "2",
+            "page_date": "",
+            "activity_type": "",
+            "distance_m": 100000.0,
+            "moving_time_s": None,
+            "total_elevation_gain_m": None,
+            "document_cover_summary": "stale summary",
+            "document_activity_count": "999",
             "document_date_range_label": "",
-            "document_total_distance_label": "100 km",
+            "document_total_distance_label": "",
             "document_total_duration_label": "",
             "document_total_elevation_gain_label": "",
             "document_activity_types_label": "",
@@ -1012,13 +1069,18 @@ class TestBuildCoverLayout(unittest.TestCase):
         with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout):
             result = build_cover_layout(layer)
         self.assertIsNotNone(result)
-        # title (1) + subtitle (1) + separator (1) + 2×2 highlight items = 7
+        # title (1) + subtitle (1) + separator (1) + 2 stats × 2 label/value items = 7
         add_calls = fresh_layout.addLayoutItem.call_args_list
         self.assertEqual(len(add_calls), 7)
 
-    def test_build_cover_layout_no_stats_no_highlight_items(self):
-        """When all stats are empty, no highlight cards are rendered."""
+    def test_build_cover_layout_minimal_subset_still_shows_activity_count(self):
+        """A non-empty subset should still show an activity-count card even if other stats are empty."""
         fields_dict = {
+            "page_date": "",
+            "activity_type": "",
+            "distance_m": None,
+            "moving_time_s": None,
+            "total_elevation_gain_m": None,
             "document_cover_summary": "",
             "document_activity_count": "0",
             "document_date_range_label": "",
@@ -1034,9 +1096,9 @@ class TestBuildCoverLayout(unittest.TestCase):
         with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout):
             result = build_cover_layout(layer)
         self.assertIsNotNone(result)
-        # title (1) + separator (1) = 2 (no subtitle since summary is empty)
+        # title + subtitle + separator + one stat card (label+value) = 5
         add_calls = fresh_layout.addLayoutItem.call_args_list
-        self.assertEqual(len(add_calls), 2)
+        self.assertEqual(len(add_calls), 5)
 
 
 class TestExportCoverPage(unittest.TestCase):


### PR DESCRIPTION
## Problem\nThe PDF cover page can still show document-wide stats from stale precomputed  fields embedded in atlas rows, even when the actual exported atlas subset is narrower (for example, only NordicSkiing pages).\n\n## Fix\n- stop trusting the first feature\'s  fields when building the cover page\n- recompute cover summary strings directly from the **current atlas-layer feature subset** being exported\n- aggregate over the current atlas rows using per-page fields already present on the atlas layer:\n  - \n  - \n  - \n  - \n  - \n- preserve existing cover layout logic, but feed it truly subset-scoped stats\n\n## Why this fixes the user-reported bug\nIf the atlas export is filtered to only NordicSkiing pages, the cover now reflects only those NordicSkiing pages, not the broader loaded dataset or old baked document summary values.\n\n## Test\n- new regression test proves stale  values are ignored in favor of the current atlas subset\n- full suite green: ........................................................................ [ 23%]
........................................................................ [ 47%]
.......................s................................................ [ 71%]
..........................ssssss........................................ [ 95%]
..............                                                           [100%]
295 passed, 7 skipped in 0.71s\n\nResult: **295 passed, 7 skipped**.