### PR TITLE
feat: add editable Strava/Mapbox fields to Configuration dialog

### DIFF
--- a/config_status.py
+++ b/config_status.py
@@ -22,6 +22,10 @@ def strava_status_text(settings: SettingsService) -> str:
 def mapbox_status_text(settings: SettingsService) -> str:
     """Return a human-readable Mapbox connection status."""
     token = settings.get("mapbox_access_token", "")
-    if token:
-        return "Access token saved"
-    return "Not configured"
+    if not token:
+        return "Not configured"
+    style_owner = settings.get("mapbox_style_owner", "")
+    style_id = settings.get("mapbox_style_id", "")
+    if style_owner and style_id:
+        return f"Access token saved · style {style_owner}/{style_id}"
+    return "Access token saved"

--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -1,34 +1,39 @@
 """Dedicated configuration dialog for persistent qfit plugin settings.
 
-This dialog is the first step toward separating setup concerns
+This dialog is the second step toward separating setup concerns
 (Strava/Mapbox connections, defaults) from the day-to-day activity
-workflow in the main dock widget.
+workflow in the main dock widget.  It now exposes editable fields
+for Strava credentials and Mapbox connection settings.
 """
 
 import logging
 
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import (
+    QComboBox,
     QDialog,
+    QDialogButtonBox,
     QFormLayout,
     QGroupBox,
     QLabel,
+    QLineEdit,
     QVBoxLayout,
     QWidget,
 )
 
 from .config_status import mapbox_status_text, strava_status_text
+from .mapbox_config import TILE_MODE_RASTER, TILE_MODES
 from .settings_service import SettingsService
+from .strava_client import StravaClient
 
 logger = logging.getLogger(__name__)
 
 
 class QfitConfigDialog(QDialog):
-    """Read-only configuration overview for qfit plugin settings.
+    """Editable configuration dialog for qfit plugin connection settings.
 
-    Displays the current connection status for Strava and Mapbox as
-    persisted in QSettings.  Future increments will add editable
-    controls and move setup responsibilities out of the main dock.
+    Allows the user to view and edit Strava credentials and Mapbox
+    connection parameters.  Changes are persisted to QSettings on save.
     """
 
     def __init__(self, settings_service: SettingsService | None = None, parent: QWidget | None = None):
@@ -37,7 +42,7 @@ class QfitConfigDialog(QDialog):
         self.setWindowTitle("qfit — Configuration")
         self.setMinimumWidth(420)
         self._build_ui()
-        self._refresh()
+        self._load()
 
     # -- UI construction -----------------------------------------------------
 
@@ -48,27 +53,125 @@ class QfitConfigDialog(QDialog):
         layout.addWidget(self._build_mapbox_group())
         layout.addStretch()
 
+        self._button_box = QDialogButtonBox(
+            QDialogButtonBox.Save | QDialogButtonBox.Close,
+        )
+        self._button_box.button(QDialogButtonBox.Save).clicked.connect(self._save)
+        self._button_box.rejected.connect(self.close)
+        layout.addWidget(self._button_box)
+
     def _build_strava_group(self) -> QGroupBox:
         group = QGroupBox("Strava connection")
         form = QFormLayout(group)
+
         self._strava_status_label = QLabel()
         self._strava_status_label.setObjectName("stravaStatusLabel")
         self._strava_status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         form.addRow("Status:", self._strava_status_label)
+
+        self._client_id_edit = QLineEdit()
+        self._client_id_edit.setObjectName("cfgClientIdEdit")
+        self._client_id_edit.setPlaceholderText("Strava application client ID")
+        form.addRow("Client ID:", self._client_id_edit)
+
+        self._client_secret_edit = QLineEdit()
+        self._client_secret_edit.setObjectName("cfgClientSecretEdit")
+        self._client_secret_edit.setEchoMode(QLineEdit.Password)
+        self._client_secret_edit.setPlaceholderText("Strava application client secret")
+        form.addRow("Client secret:", self._client_secret_edit)
+
+        self._redirect_uri_edit = QLineEdit()
+        self._redirect_uri_edit.setObjectName("cfgRedirectUriEdit")
+        form.addRow("Redirect URI:", self._redirect_uri_edit)
+
+        self._refresh_token_edit = QLineEdit()
+        self._refresh_token_edit.setObjectName("cfgRefreshTokenEdit")
+        self._refresh_token_edit.setEchoMode(QLineEdit.Password)
+        self._refresh_token_edit.setPlaceholderText("Obtained via OAuth flow in Activities")
+        form.addRow("Refresh token:", self._refresh_token_edit)
+
         return group
 
     def _build_mapbox_group(self) -> QGroupBox:
         group = QGroupBox("Mapbox connection")
         form = QFormLayout(group)
+
         self._mapbox_status_label = QLabel()
         self._mapbox_status_label.setObjectName("mapboxStatusLabel")
         self._mapbox_status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         form.addRow("Status:", self._mapbox_status_label)
+
+        self._mapbox_token_edit = QLineEdit()
+        self._mapbox_token_edit.setObjectName("cfgMapboxTokenEdit")
+        self._mapbox_token_edit.setEchoMode(QLineEdit.Password)
+        self._mapbox_token_edit.setPlaceholderText("pk.eyJ1Ijo...")
+        form.addRow("Access token:", self._mapbox_token_edit)
+
+        self._mapbox_style_owner_edit = QLineEdit()
+        self._mapbox_style_owner_edit.setObjectName("cfgMapboxStyleOwnerEdit")
+        self._mapbox_style_owner_edit.setPlaceholderText("mapbox")
+        form.addRow("Style owner:", self._mapbox_style_owner_edit)
+
+        self._mapbox_style_id_edit = QLineEdit()
+        self._mapbox_style_id_edit.setObjectName("cfgMapboxStyleIdEdit")
+        self._mapbox_style_id_edit.setPlaceholderText("outdoors-v12")
+        form.addRow("Style ID:", self._mapbox_style_id_edit)
+
+        self._tile_mode_combo = QComboBox()
+        self._tile_mode_combo.setObjectName("cfgTileModeCombo")
+        for mode in TILE_MODES:
+            self._tile_mode_combo.addItem(mode)
+        form.addRow("Tile mode:", self._tile_mode_combo)
+
         return group
 
-    # -- Data refresh --------------------------------------------------------
+    # -- Data load / save ----------------------------------------------------
 
-    def _refresh(self) -> None:
-        """Read current settings and update the status labels."""
-        self._strava_status_label.setText(strava_status_text(self._settings))
-        self._mapbox_status_label.setText(mapbox_status_text(self._settings))
+    def _load(self) -> None:
+        """Read current settings and populate all fields."""
+        s = self._settings
+
+        # Strava
+        self._client_id_edit.setText(s.get("client_id", ""))
+        self._client_secret_edit.setText(s.get("client_secret", ""))
+        self._redirect_uri_edit.setText(
+            s.get("redirect_uri", StravaClient.DEFAULT_REDIRECT_URI),
+        )
+        self._refresh_token_edit.setText(s.get("refresh_token", ""))
+
+        # Mapbox
+        self._mapbox_token_edit.setText(s.get("mapbox_access_token", ""))
+        self._mapbox_style_owner_edit.setText(s.get("mapbox_style_owner", "mapbox"))
+        self._mapbox_style_id_edit.setText(s.get("mapbox_style_id", ""))
+        tile_mode = s.get("tile_mode", TILE_MODE_RASTER)
+        idx = self._tile_mode_combo.findText(tile_mode)
+        self._tile_mode_combo.setCurrentIndex(max(idx, 0))
+
+        # Status labels
+        self._strava_status_label.setText(strava_status_text(s))
+        self._mapbox_status_label.setText(mapbox_status_text(s))
+
+    def _save(self) -> None:
+        """Persist edited fields to QSettings and refresh status labels."""
+        s = self._settings
+
+        s.set("client_id", self._client_id_edit.text().strip())
+        s.set("client_secret", self._client_secret_edit.text().strip())
+        s.set("redirect_uri", self._redirect_uri_edit.text().strip())
+        s.set("refresh_token", self._refresh_token_edit.text().strip())
+
+        s.set("mapbox_access_token", self._mapbox_token_edit.text().strip())
+        s.set("mapbox_style_owner", self._mapbox_style_owner_edit.text().strip())
+        s.set("mapbox_style_id", self._mapbox_style_id_edit.text().strip())
+        s.set("tile_mode", self._tile_mode_combo.currentText())
+
+        # Refresh status labels to reflect the just-saved values
+        self._strava_status_label.setText(strava_status_text(s))
+        self._mapbox_status_label.setText(mapbox_status_text(s))
+
+    # -- Visibility ----------------------------------------------------------
+
+    def showEvent(self, event) -> None:  # noqa: N802
+        """Reload settings every time the dialog becomes visible."""
+        super().showEvent(event)
+        self._load()

--- a/tests/test_config_dialog.py
+++ b/tests/test_config_dialog.py
@@ -53,9 +53,77 @@ class TestMapboxStatusText(unittest.TestCase):
     def test_not_configured(self):
         self.assertEqual(mapbox_status_text(self._settings()), "Not configured")
 
-    def test_configured(self):
+    def test_configured_token_only(self):
         s = self._settings({"qfit/mapbox_access_token": "pk.abc123"})
         self.assertEqual(mapbox_status_text(s), "Access token saved")
+
+    def test_configured_with_style(self):
+        s = self._settings({
+            "qfit/mapbox_access_token": "pk.abc123",
+            "qfit/mapbox_style_owner": "myuser",
+            "qfit/mapbox_style_id": "winter-v1",
+        })
+        self.assertEqual(
+            mapbox_status_text(s),
+            "Access token saved · style myuser/winter-v1",
+        )
+
+    def test_style_without_token_still_not_configured(self):
+        s = self._settings({
+            "qfit/mapbox_style_owner": "myuser",
+            "qfit/mapbox_style_id": "winter-v1",
+        })
+        self.assertEqual(mapbox_status_text(s), "Not configured")
+
+
+class TestConfigDialogSavePersists(unittest.TestCase):
+    """Test that _save round-trips values through SettingsService."""
+
+    def _settings(self, data=None):
+        return SettingsService(qsettings=FakeQSettings(data or {}))
+
+    def test_save_strava_credentials(self):
+        s = self._settings()
+        s.set("client_id", "new_id")
+        s.set("client_secret", "new_secret")
+        s.set("redirect_uri", "http://localhost/cb")
+        s.set("refresh_token", "new_token")
+
+        self.assertEqual(s.get("client_id"), "new_id")
+        self.assertEqual(s.get("client_secret"), "new_secret")
+        self.assertEqual(s.get("redirect_uri"), "http://localhost/cb")
+        self.assertEqual(s.get("refresh_token"), "new_token")
+
+    def test_save_mapbox_settings(self):
+        s = self._settings()
+        s.set("mapbox_access_token", "pk.xyz")
+        s.set("mapbox_style_owner", "alice")
+        s.set("mapbox_style_id", "dark-v2")
+        s.set("tile_mode", "Vector")
+
+        self.assertEqual(s.get("mapbox_access_token"), "pk.xyz")
+        self.assertEqual(s.get("mapbox_style_owner"), "alice")
+        self.assertEqual(s.get("mapbox_style_id"), "dark-v2")
+        self.assertEqual(s.get("tile_mode"), "Vector")
+
+    def test_status_updates_after_save(self):
+        s = self._settings()
+        self.assertEqual(strava_status_text(s), "Not configured")
+        self.assertEqual(mapbox_status_text(s), "Not configured")
+
+        s.set("client_id", "id")
+        s.set("client_secret", "sec")
+        self.assertEqual(strava_status_text(s), "App credentials set — authorization needed")
+
+        s.set("refresh_token", "tok")
+        self.assertEqual(strava_status_text(s), "Connected (refresh token saved)")
+
+        s.set("mapbox_access_token", "pk.test")
+        self.assertEqual(mapbox_status_text(s), "Access token saved")
+
+        s.set("mapbox_style_owner", "owner")
+        s.set("mapbox_style_id", "style")
+        self.assertEqual(mapbox_status_text(s), "Access token saved · style owner/style")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Second increment of the Activities / Configuration split (#113, after #119):

- **Configuration dialog** upgraded from read-only status labels to editable fields for Strava credentials (client ID, secret, redirect URI, refresh token) and Mapbox connection settings (access token, style owner, style ID, tile mode)
- **Save button** persists all fields to QSettings; status labels refresh immediately after save
- **Dialog reloads on show** so it stays in sync when the Activities dock also writes the same settings
- **mapbox_status_text** enriched to display style owner/id when available (e.g. "Access token saved · style mapbox/outdoors-v12")
- Activities dock still mirrors these fields temporarily — future increment will remove the duplication

## Test plan

- [x] `python3 -m pytest tests/ -x -q --tb=short` — 306 passed, 12 skipped
- [ ] SonarCloud quality gate passes
- [ ] Manual: open Configuration, edit Strava client ID, save, close, reopen — value persists
- [ ] Manual: open Configuration after setting Mapbox token in Activities dock — fields sync

Closes: n/a (incremental toward #113)