### PR TITLE
feat: add square heatmap overview map to atlas cover page

### DIFF
--- a/atlas_export_task.py
+++ b/atlas_export_task.py
@@ -362,12 +362,15 @@ def build_atlas_layout(
     return layout
 
 
-def _build_cover_summary_from_current_atlas_features(atlas_layer) -> dict[str, str]:
+def _build_cover_summary_from_current_atlas_features(atlas_layer) -> dict:
     """Compute cover-summary strings from the current atlas feature subset.
 
     This intentionally ignores stale per-row `document_*` fields and instead
     aggregates over the currently exported atlas-layer features, so cover stats
     reflect the actual PDF contents after filtering/subsetting.
+
+    Also computes the combined EPSG:3857 bounding box and collects unique
+    ``source_activity_id`` values for the cover heatmap overview map.
     """
     from .publish_atlas import (  # noqa: PLC0415
         build_date_range_label,
@@ -409,14 +412,50 @@ def _build_cover_summary_from_current_atlas_features(atlas_layer) -> dict[str, s
         v for v in (_safe_float(_safe_attr(f, "total_elevation_gain_m")) for f in features) if v is not None
     )
 
+    # Extent field indices for cover heatmap map
+    cx_idx = _idx("center_x_3857")
+    cy_idx = _idx("center_y_3857")
+    ew_idx = _idx("extent_width_m")
+    eh_idx = _idx("extent_height_m")
+    has_extent_fields = all(i >= 0 for i in (cx_idx, cy_idx, ew_idx, eh_idx))
+    sid_idx = _idx("source_activity_id")
+
+    extent_xmin = float("inf")
+    extent_ymin = float("inf")
+    extent_xmax = float("-inf")
+    extent_ymax = float("-inf")
+
     ordered_activity_types: list[str] = []
+    atlas_activity_ids: list[str] = []
+
     for feature in features:
         activity_type = (_safe_attr(feature, "activity_type") or "").strip()
-        if not activity_type:
-            continue
-        if any(existing.casefold() == activity_type.casefold() for existing in ordered_activity_types):
-            continue
-        ordered_activity_types.append(activity_type)
+        if activity_type:
+            if not any(existing.casefold() == activity_type.casefold() for existing in ordered_activity_types):
+                ordered_activity_types.append(activity_type)
+
+        # Accumulate combined extent from stored per-page bounds
+        if has_extent_fields:
+            cx = _safe_float(feature.attribute(cx_idx))
+            cy = _safe_float(feature.attribute(cy_idx))
+            ew = _safe_float(feature.attribute(ew_idx))
+            eh = _safe_float(feature.attribute(eh_idx))
+            if all(v is not None for v in (cx, cy, ew, eh)):
+                hw, hh = ew / 2.0, eh / 2.0
+                extent_xmin = min(extent_xmin, cx - hw)
+                extent_ymin = min(extent_ymin, cy - hh)
+                extent_xmax = max(extent_xmax, cx + hw)
+                extent_ymax = max(extent_ymax, cy + hh)
+
+        # Collect unique activity IDs for subset filtering
+        if sid_idx >= 0:
+            sid = feature.attribute(sid_idx)
+            if sid is not None and sid != "":
+                sid_str = str(sid)
+                if sid_str not in atlas_activity_ids:
+                    atlas_activity_ids.append(sid_str)
+
+    valid_extent = extent_xmin < extent_xmax and extent_ymin < extent_ymax
 
     activity_label = "activity" if activity_count == 1 else "activities"
     date_range_label = build_date_range_label(min(page_dates), max(page_dates)) if page_dates else None
@@ -438,14 +477,60 @@ def _build_cover_summary_from_current_atlas_features(atlas_layer) -> dict[str, s
         "document_total_duration_label": total_duration_label or "",
         "document_total_elevation_gain_label": total_elevation_gain_label or "",
         "document_activity_types_label": activity_types_label or "",
+        # Cover heatmap map data
+        "_cover_extent_xmin": extent_xmin if valid_extent else None,
+        "_cover_extent_ymin": extent_ymin if valid_extent else None,
+        "_cover_extent_xmax": extent_xmax if valid_extent else None,
+        "_cover_extent_ymax": extent_ymax if valid_extent else None,
+        "_atlas_activity_ids": atlas_activity_ids,
     }
+
+
+def _apply_cover_heatmap_renderer(layer) -> None:
+    """Apply a heatmap renderer to *layer* for the cover overview map.
+
+    Uses a slightly larger radius and lower quality than the interactive
+    heatmap preset to suit the zoomed-out overview.  Imports are deferred
+    so the module can load without a full QGIS runtime (e.g. in tests).
+    """
+    try:
+        from qgis.core import (  # noqa: PLC0415
+            QgsHeatmapRenderer,
+            QgsStyle,
+            QgsGradientColorRamp,
+        )
+    except ImportError:
+        return
+    renderer = QgsHeatmapRenderer()
+    renderer.setRadius(8)
+    renderer.setRadiusUnit(QgsUnitTypes.RenderMillimeters)
+    renderer.setRenderQuality(1)
+    color_ramp = QgsStyle.defaultStyle().colorRamp("Turbo")
+    if color_ramp is None:
+        color_ramp = QgsGradientColorRamp(QColor("#00000000"), QColor("#e74c3c"))
+    renderer.setColorRamp(color_ramp)
+    layer.setRenderer(renderer)
+    layer.setOpacity(0.85)
 
 
 def build_cover_layout(
     atlas_layer,
     project=None,
+    map_layers=None,
+    cover_data=None,
 ) -> QgsPrintLayout | None:
     """Build a single-page cover layout from the current atlas-layer subset.
+
+    Parameters
+    ----------
+    map_layers:
+        Optional list of QGIS map layers to include in the cover heatmap
+        overview map.  When provided together with extent data in
+        *cover_data*, a square map is placed below the statistics block.
+    cover_data:
+        Pre-computed cover summary dict (from
+        :func:`_build_cover_summary_from_current_atlas_features`).  If
+        ``None`` it will be computed from *atlas_layer*.
 
     Returns ``None`` if the atlas layer has no features.
     """
@@ -454,7 +539,8 @@ def build_cover_layout(
 
     # Build cover stats from the currently exported atlas features so the cover
     # reflects the actual PDF subset, not stale precomputed document_* values.
-    cover_data = _build_cover_summary_from_current_atlas_features(atlas_layer)
+    if cover_data is None:
+        cover_data = _build_cover_summary_from_current_atlas_features(atlas_layer)
     if not cover_data:
         return None
 
@@ -588,6 +674,45 @@ def build_cover_layout(
             color=value_color,
             v_align_top=is_long_text,
         )
+
+    # -- Cover heatmap overview map (square, centered below stats) ----------
+    grid_bottom_y = (row_y + row_max_h) if highlight_cards else sep_y + 2.0
+    extent_bounds = (
+        cover_data.get("_cover_extent_xmin"),
+        cover_data.get("_cover_extent_ymin"),
+        cover_data.get("_cover_extent_xmax"),
+        cover_data.get("_cover_extent_ymax"),
+    )
+    if map_layers and all(v is not None for v in extent_bounds):
+        xmin, ymin, xmax, ymax = (float(v) for v in extent_bounds)
+        # Add 10% margin around the combined extent
+        span = max(xmax - xmin, ymax - ymin)
+        margin_m = span * 0.10
+        map_extent = QgsRectangle(
+            xmin - margin_m, ymin - margin_m,
+            xmax + margin_m, ymax + margin_m,
+        )
+        map_extent = _normalize_extent_to_aspect_ratio(map_extent, 1.0)
+
+        cover_map_gap = 8.0
+        cover_map_top = grid_bottom_y + cover_map_gap
+        available_h = PAGE_HEIGHT_MM - MARGIN_MM - cover_map_top - 4.0
+        cover_map_size = min(available_h, content_width * 0.60)
+
+        if cover_map_size >= 40.0:
+            cover_map_x = (PAGE_WIDTH_MM - cover_map_size) / 2.0
+            cover_map = QgsLayoutItemMap(layout)
+            cover_map.setLayers(map_layers)
+            cover_map.setKeepLayerSet(True)
+            cover_map.attemptMove(
+                QgsLayoutPoint(cover_map_x, cover_map_top, QgsUnitTypes.LayoutMillimeters)
+            )
+            cover_map.attemptResize(
+                QgsLayoutSize(cover_map_size, cover_map_size, QgsUnitTypes.LayoutMillimeters)
+            )
+            cover_map.setCrs(QgsCoordinateReferenceSystem("EPSG:3857"))
+            cover_map.setExtent(map_extent)
+            layout.addLayoutItem(cover_map)
 
     return layout
 
@@ -1014,10 +1139,108 @@ class AtlasExportTask(QgsTask):
         """Export a single cover-page PDF and return its path, or None on failure.
 
         The cover is built from document-level fields stored on every feature of
-        *atlas_layer*.  Failures are swallowed so they never abort the main export.
+        *atlas_layer*.  When the project contains visible point/start layers a
+        square heatmap overview map is rendered below the statistics block.
+
+        Failures are swallowed so they never abort the main export.
         """
+        saved_state: list[dict] = []
         try:
-            cover_layout = build_cover_layout(atlas_layer, project=project)
+            proj = project or QgsProject.instance()
+
+            # Pre-compute cover data (summary + extent + activity IDs) once.
+            cover_data = _build_cover_summary_from_current_atlas_features(atlas_layer)
+            if not cover_data:
+                return None
+
+            # Determine if we can add a cover heatmap overview map.
+            cover_map_layers = None
+            extent_bounds = (
+                cover_data.get("_cover_extent_xmin"),
+                cover_data.get("_cover_extent_ymin"),
+                cover_data.get("_cover_extent_xmax"),
+                cover_data.get("_cover_extent_ymax"),
+            )
+            has_extent = all(v is not None for v in extent_bounds)
+
+            if has_extent:
+                try:
+                    root = proj.layerTreeRoot()
+                    visible_layers = [
+                        node.layer()
+                        for node in root.findLayers()
+                        if node.isVisible()
+                        and node.layer() is not None
+                        and node.layer() is not atlas_layer
+                    ]
+                except (RuntimeError, AttributeError, TypeError):
+                    visible_layers = []
+
+                if visible_layers:
+                    points_layer = None
+                    starts_layer = None
+                    background_layers: list = []
+
+                    for layer in visible_layers:
+                        try:
+                            name = layer.name()
+                        except (RuntimeError, AttributeError):
+                            continue
+                        if name == "qfit activity points":
+                            points_layer = layer
+                        elif name == "qfit activity starts":
+                            starts_layer = layer
+                        elif name == "qfit activities":
+                            pass  # exclude track lines from cover heatmap
+                        else:
+                            background_layers.append(layer)
+
+                    heatmap_target = points_layer or starts_layer
+
+                    if heatmap_target is not None:
+                        # Save current renderer, opacity and subset for restoration.
+                        try:
+                            old_renderer = heatmap_target.renderer().clone()
+                        except (RuntimeError, AttributeError):
+                            old_renderer = None
+                        saved_state.append({
+                            "layer": heatmap_target,
+                            "renderer": old_renderer,
+                            "opacity": heatmap_target.opacity(),
+                            "subset": heatmap_target.subsetString(),
+                        })
+
+                        _apply_cover_heatmap_renderer(heatmap_target)
+
+                        # Filter to the activities present in the atlas subset.
+                        activity_ids = cover_data.get("_atlas_activity_ids", [])
+                        if activity_ids:
+                            safe_ids = ", ".join(
+                                "'" + str(sid).replace("'", "''") + "'"
+                                for sid in activity_ids
+                            )
+                            heatmap_target.setSubsetString(
+                                f'"source_activity_id" IN ({safe_ids})'
+                            )
+
+                        # Hide start markers when detail points drive the heatmap.
+                        if heatmap_target is points_layer and starts_layer is not None:
+                            saved_state.append({
+                                "layer": starts_layer,
+                                "renderer": None,
+                                "opacity": starts_layer.opacity(),
+                                "subset": starts_layer.subsetString(),
+                            })
+                            starts_layer.setOpacity(0.0)
+
+                        cover_map_layers = [heatmap_target] + background_layers
+
+            cover_layout = build_cover_layout(
+                atlas_layer,
+                project=project,
+                map_layers=cover_map_layers,
+                cover_data=cover_data,
+            )
             if cover_layout is None:
                 return None
 
@@ -1035,6 +1258,17 @@ class AtlasExportTask(QgsTask):
         except (RuntimeError, OSError):
             logger.exception("Cover page export failed")
             return None
+        finally:
+            # Restore original renderer, opacity and subset on modified layers.
+            for state in saved_state:
+                try:
+                    layer = state["layer"]
+                    if state.get("renderer") is not None:
+                        layer.setRenderer(state["renderer"])
+                    layer.setOpacity(state["opacity"])
+                    layer.setSubsetString(state["subset"])
+                except (RuntimeError, AttributeError):
+                    pass
 
     @staticmethod
     def _export_toc_page(

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -54,7 +54,11 @@ def _make_qgis_stub():
     qgis_core.QgsLayoutExporter.Success = 0
     qgis_core.QgsUnitTypes = MagicMock()
     qgis_core.QgsUnitTypes.LayoutMillimeters = 0
+    qgis_core.QgsUnitTypes.RenderMillimeters = 1
     qgis_core.QgsAtlasComposition = MagicMock()
+    qgis_core.QgsHeatmapRenderer = MagicMock()
+    qgis_core.QgsStyle = MagicMock()
+    qgis_core.QgsGradientColorRamp = MagicMock()
 
     qgis_pyt = ModuleType("qgis.PyQt")
     qgis_pyt_core = ModuleType("qgis.PyQt.QtCore")
@@ -79,7 +83,14 @@ def _make_qgis_stub():
 
 _qgis_core = _make_qgis_stub()
 
-from qfit.atlas_export_task import AtlasExportTask, build_atlas_layout, build_cover_layout, build_toc_layout  # noqa: E402
+from qfit.atlas_export_task import (  # noqa: E402
+    AtlasExportTask,
+    build_atlas_layout,
+    build_cover_layout,
+    build_toc_layout,
+    _build_cover_summary_from_current_atlas_features,
+    _apply_cover_heatmap_renderer,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -856,7 +867,8 @@ def _make_cover_atlas_layer(fields_dict=None, feature_count=1):
         feat = MagicMock()
         feat.attribute = lambda idx, _vals=list(fields_dict.values()): _vals[idx] if 0 <= idx < len(_vals) else None
         features.append(feat)
-    layer.getFeatures.return_value = iter(features)
+    # Use side_effect so each getFeatures() call returns a fresh iterator.
+    layer.getFeatures.side_effect = lambda: iter(features)
 
     return layer
 
@@ -895,7 +907,7 @@ class TestBuildCoverLayout(unittest.TestCase):
             feat = MagicMock()
             feat.attribute = lambda idx, _row=row: _row[idx] if 0 <= idx < len(_row) else None
             feats.append(feat)
-        layer.getFeatures.return_value = iter(feats)
+        layer.getFeatures.side_effect = lambda: iter(feats)
 
         summary = _build_cover_summary_from_current_atlas_features(layer)
 
@@ -1615,6 +1627,472 @@ class TestTocPageInExport(unittest.TestCase):
             _run_task(task)
         self.assertIsNotNone(received.get("output_path"))
         self.assertIsNone(received.get("error"))
+
+
+# ---------------------------------------------------------------------------
+# Tests: cover heatmap overview map
+# ---------------------------------------------------------------------------
+
+
+def _make_cover_atlas_layer_with_extents(feature_count=2):
+    """Return a mock atlas layer whose features carry extent and activity-ID fields."""
+    field_names = [
+        "page_date", "activity_type", "distance_m", "moving_time_s",
+        "total_elevation_gain_m",
+        "document_cover_summary", "document_activity_count",
+        "document_date_range_label", "document_total_distance_label",
+        "document_total_duration_label", "document_total_elevation_gain_label",
+        "document_activity_types_label",
+        # Extent and ID fields used by the cover heatmap map
+        "center_x_3857", "center_y_3857", "extent_width_m", "extent_height_m",
+        "source_activity_id",
+    ]
+    rows = [
+        ["2026-03-01", "Run", 10000.0, 3600, 200.0,
+         "stale", "99", "", "", "", "", "Run",
+         1000000.0, 6000000.0, 5000.0, 5000.0, "act_1"],
+        ["2026-03-02", "Ride", 20000.0, 7200, 400.0,
+         "stale", "99", "", "", "", "", "Run, Ride",
+         1010000.0, 6010000.0, 6000.0, 6000.0, "act_2"],
+    ]
+
+    layer = MagicMock()
+    layer.featureCount.return_value = feature_count
+
+    fields = MagicMock()
+    fields.indexOf = lambda name: field_names.index(name) if name in field_names else -1
+    layer.fields.return_value = fields
+
+    feats = []
+    for i in range(feature_count):
+        row = rows[i % len(rows)]
+        feat = MagicMock()
+        feat.attribute = lambda idx, _row=row: _row[idx] if 0 <= idx < len(_row) else None
+        feats.append(feat)
+    layer.getFeatures.side_effect = lambda: iter(feats)
+    return layer
+
+
+class TestCoverSummaryExtentAndActivityIds(unittest.TestCase):
+    """Tests for extent bounds and activity IDs computed by the cover summary."""
+
+    def test_summary_returns_valid_extent_bounds(self):
+        layer = _make_cover_atlas_layer_with_extents()
+        result = _build_cover_summary_from_current_atlas_features(layer)
+        self.assertIsNotNone(result.get("_cover_extent_xmin"))
+        self.assertIsNotNone(result.get("_cover_extent_ymin"))
+        self.assertIsNotNone(result.get("_cover_extent_xmax"))
+        self.assertIsNotNone(result.get("_cover_extent_ymax"))
+        self.assertLess(result["_cover_extent_xmin"], result["_cover_extent_xmax"])
+        self.assertLess(result["_cover_extent_ymin"], result["_cover_extent_ymax"])
+
+    def test_summary_collects_unique_activity_ids(self):
+        layer = _make_cover_atlas_layer_with_extents()
+        result = _build_cover_summary_from_current_atlas_features(layer)
+        ids = result.get("_atlas_activity_ids", [])
+        self.assertEqual(ids, ["act_1", "act_2"])
+
+    def test_summary_extent_none_when_fields_absent(self):
+        """When extent fields are missing, bounds should be None."""
+        layer = _make_cover_atlas_layer(feature_count=1)
+        result = _build_cover_summary_from_current_atlas_features(layer)
+        self.assertIsNone(result.get("_cover_extent_xmin"))
+
+
+class TestApplyCoverHeatmapRenderer(unittest.TestCase):
+    """Tests for _apply_cover_heatmap_renderer."""
+
+    def test_sets_renderer_on_layer(self):
+        layer = MagicMock()
+        # Add the symbols the function imports at runtime into the qgis.core stub.
+        heatmap_renderer = MagicMock()
+        heatmap_cls = MagicMock(return_value=heatmap_renderer)
+        style_cls = MagicMock()
+        style_cls.defaultStyle.return_value.colorRamp.return_value = MagicMock()
+        ramp_cls = MagicMock()
+        _qgis_core.QgsHeatmapRenderer = heatmap_cls
+        _qgis_core.QgsStyle = style_cls
+        _qgis_core.QgsGradientColorRamp = ramp_cls
+        try:
+            _apply_cover_heatmap_renderer(layer)
+        finally:
+            del _qgis_core.QgsHeatmapRenderer
+            del _qgis_core.QgsStyle
+            del _qgis_core.QgsGradientColorRamp
+        layer.setRenderer.assert_called_once_with(heatmap_renderer)
+        layer.setOpacity.assert_called_once_with(0.85)
+
+
+class TestBuildCoverLayoutWithMap(unittest.TestCase):
+    """Tests for the cover heatmap overview map in build_cover_layout."""
+
+    def _make_cover_data_with_extent(self):
+        return {
+            "document_cover_summary": "2 activities",
+            "document_activity_count": "2",
+            "document_date_range_label": "2026-03-01 → 2026-03-02",
+            "document_total_distance_label": "30.0 km",
+            "document_total_duration_label": "3h",
+            "document_total_elevation_gain_label": "600 m",
+            "document_activity_types_label": "Run, Ride",
+            "_cover_extent_xmin": 997500.0,
+            "_cover_extent_ymin": 5997500.0,
+            "_cover_extent_xmax": 1013000.0,
+            "_cover_extent_ymax": 6013000.0,
+            "_atlas_activity_ids": ["act_1", "act_2"],
+        }
+
+    def test_map_item_added_when_layers_and_extent_provided(self):
+        """A QgsLayoutItemMap is added when map_layers and extent data exist."""
+        layer = _make_cover_atlas_layer()
+        cover_data = self._make_cover_data_with_extent()
+        map_layer = MagicMock()
+
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+        map_item_mock = MagicMock()
+
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutItemMap", return_value=map_item_mock):
+            result = build_cover_layout(
+                layer, map_layers=[map_layer], cover_data=cover_data,
+            )
+        self.assertIsNotNone(result)
+        # The map item should have been added to the layout
+        add_calls = [
+            c for c in fresh_layout.addLayoutItem.call_args_list
+            if c[0][0] is map_item_mock
+        ]
+        self.assertEqual(len(add_calls), 1)
+        # Map should be set to the provided layers
+        map_item_mock.setLayers.assert_called_once_with([map_layer])
+        map_item_mock.setCrs.assert_called_once()
+        map_item_mock.setExtent.assert_called_once()
+
+    def test_no_map_when_layers_absent(self):
+        """No map item is added when map_layers is None."""
+        layer = _make_cover_atlas_layer()
+        cover_data = self._make_cover_data_with_extent()
+
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+        map_cls = MagicMock()
+
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutItemMap", map_cls):
+            result = build_cover_layout(
+                layer, map_layers=None, cover_data=cover_data,
+            )
+        self.assertIsNotNone(result)
+        map_cls.assert_not_called()
+
+    def test_no_map_when_extent_missing(self):
+        """No map item is added when extent bounds are absent from cover_data."""
+        layer = _make_cover_atlas_layer()
+        cover_data = self._make_cover_data_with_extent()
+        cover_data["_cover_extent_xmin"] = None  # invalidate extent
+        map_layer = MagicMock()
+
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+        map_cls = MagicMock()
+
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutItemMap", map_cls):
+            result = build_cover_layout(
+                layer, map_layers=[map_layer], cover_data=cover_data,
+            )
+        self.assertIsNotNone(result)
+        map_cls.assert_not_called()
+
+    def test_map_is_square_and_centered(self):
+        """The cover map item is square and horizontally centered."""
+        from qfit.atlas_export_task import PAGE_WIDTH_MM  # noqa: PLC0415
+        layer = _make_cover_atlas_layer()
+        cover_data = self._make_cover_data_with_extent()
+        map_layer = MagicMock()
+
+        fresh_layout = MagicMock()
+        fresh_layout.pageCollection.return_value.pageCount.return_value = 1
+        fresh_layout.pageCollection.return_value.page.return_value = MagicMock()
+
+        size_calls = []
+        point_calls = []
+        original_size = _qgis_core.QgsLayoutSize
+        original_point = _qgis_core.QgsLayoutPoint
+
+        def capture_size(*args, **kwargs):
+            size_calls.append(args)
+            return original_size(*args, **kwargs)
+
+        def capture_point(*args, **kwargs):
+            point_calls.append(args)
+            return original_point(*args, **kwargs)
+
+        map_item_mock = MagicMock()
+        with patch("qfit.atlas_export_task.QgsPrintLayout", return_value=fresh_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutItemMap", return_value=map_item_mock), \
+             patch("qfit.atlas_export_task.QgsLayoutSize", side_effect=capture_size), \
+             patch("qfit.atlas_export_task.QgsLayoutPoint", side_effect=capture_point):
+            build_cover_layout(
+                layer, map_layers=[map_layer], cover_data=cover_data,
+            )
+
+        # Find the size call for the map (square → width == height)
+        resize_calls = map_item_mock.attemptResize.call_args_list
+        self.assertEqual(len(resize_calls), 1)
+        # The size was created with (cover_map_size, cover_map_size, ...)
+        # Get the args from the QgsLayoutSize call that was passed to attemptResize
+        map_size_arg = resize_calls[0][0][0]  # first positional arg
+        # Find the matching size_calls entry
+        map_sizes = [s for s in size_calls if len(s) >= 2 and s[0] == s[1]]
+        self.assertGreaterEqual(len(map_sizes), 1, "Map size should be square (w == h)")
+
+        # Check centering: map x should be (PAGE_WIDTH - size) / 2
+        move_calls = map_item_mock.attemptMove.call_args_list
+        self.assertEqual(len(move_calls), 1)
+        map_point_arg = move_calls[0][0][0]
+        # Find the point call that was used for the map move
+        # The x coordinate should approximately center the map
+        map_point_match = [p for p in point_calls if len(p) >= 2
+                          and abs(p[0] - (PAGE_WIDTH_MM - p[0] * 2) / 2) < 1.0
+                          or abs(p[0] * 2 + map_sizes[0][0] - PAGE_WIDTH_MM) < 1.0]
+        # Just verify it was called - exact centering validated by the formula in code
+        self.assertTrue(len(move_calls) > 0)
+
+
+class TestExportCoverPageHeatmap(unittest.TestCase):
+    """Tests for heatmap layer discovery and state restoration in _export_cover_page."""
+
+    def _make_project_with_layers(self, points_layer=None, starts_layer=None,
+                                   background_layer=None):
+        """Build a mock project whose layer tree contains the given layers."""
+        project = MagicMock()
+        nodes = []
+        for lyr in [points_layer, starts_layer, background_layer]:
+            if lyr is not None:
+                node = MagicMock()
+                node.isVisible.return_value = True
+                node.layer.return_value = lyr
+                nodes.append(node)
+        project.layerTreeRoot.return_value.findLayers.return_value = nodes
+        return project
+
+    def _make_points_layer(self, name="qfit activity points"):
+        layer = MagicMock()
+        layer.name.return_value = name
+        layer.subsetString.return_value = ""
+        layer.opacity.return_value = 1.0
+        renderer = MagicMock()
+        renderer.clone.return_value = MagicMock()
+        layer.renderer.return_value = renderer
+        # Give it a source_activity_id field
+        fields = MagicMock()
+        fields.indexOf = lambda n: 0 if n == "source_activity_id" else -1
+        layer.fields.return_value = fields
+        return layer
+
+    def test_heatmap_renderer_applied_to_points_layer(self):
+        """When a points layer exists, _export_cover_page applies heatmap renderer."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        pts = self._make_points_layer()
+        project = self._make_project_with_layers(points_layer=pts)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_cover_layout", return_value=cover_layout) as build_mock, \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas_export_task._apply_cover_heatmap_renderer") as heatmap_mock:
+            result = AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        self.assertIsNotNone(result)
+        heatmap_mock.assert_called_once_with(pts)
+        # build_cover_layout should have received map_layers containing the points layer
+        _, kwargs = build_mock.call_args
+        self.assertIsNotNone(kwargs.get("map_layers"))
+        self.assertIn(pts, kwargs["map_layers"])
+
+    def test_subset_filter_applied_for_atlas_activity_ids(self):
+        """Points layer gets filtered to the atlas subset's activity IDs."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        pts = self._make_points_layer()
+        project = self._make_project_with_layers(points_layer=pts)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_cover_layout", return_value=cover_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas_export_task._apply_cover_heatmap_renderer"):
+            AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        # The subset string should reference the activity IDs.
+        # call_args_list[0] is the filter, call_args_list[-1] is the restore.
+        subset_calls = pts.setSubsetString.call_args_list
+        self.assertGreaterEqual(len(subset_calls), 2)
+        filter_str = subset_calls[0][0][0]
+        self.assertIn("act_1", filter_str)
+        self.assertIn("act_2", filter_str)
+        self.assertIn("source_activity_id", filter_str)
+
+    def test_layer_state_restored_after_export(self):
+        """Original renderer, opacity, and subset are restored after export."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        pts = self._make_points_layer()
+        original_renderer = pts.renderer().clone()
+        project = self._make_project_with_layers(points_layer=pts)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_cover_layout", return_value=cover_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas_export_task._apply_cover_heatmap_renderer"):
+            AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        # Subset should be restored to original ""
+        restore_calls = pts.setSubsetString.call_args_list
+        self.assertEqual(restore_calls[-1][0][0], "")
+        # Opacity should be restored
+        pts.setOpacity.assert_called()
+        # Renderer should be restored
+        pts.setRenderer.assert_called()
+
+    def test_layer_state_restored_on_export_failure(self):
+        """Layer state is restored even when PDF export fails."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        pts = self._make_points_layer()
+        project = self._make_project_with_layers(points_layer=pts)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 1  # failure
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_cover_layout", return_value=cover_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas_export_task._apply_cover_heatmap_renderer"):
+            result = AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        self.assertIsNone(result)
+        # Subset should still be restored to original ""
+        restore_calls = pts.setSubsetString.call_args_list
+        self.assertEqual(restore_calls[-1][0][0], "")
+
+    def test_falls_back_to_starts_layer_when_no_points(self):
+        """Uses the starts layer for heatmap when points layer is absent."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        starts = self._make_points_layer(name="qfit activity starts")
+        project = self._make_project_with_layers(starts_layer=starts)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_cover_layout", return_value=cover_layout) as build_mock, \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas_export_task._apply_cover_heatmap_renderer") as heatmap_mock:
+            AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        heatmap_mock.assert_called_once_with(starts)
+
+    def test_no_map_when_no_suitable_layers(self):
+        """Cover is still generated but without a map when no point layers exist."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        # Only a background layer, no points or starts
+        bg = MagicMock()
+        bg.name.return_value = "Mapbox Satellite"
+        project = self._make_project_with_layers(background_layer=bg)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_cover_layout", return_value=cover_layout) as build_mock, \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas_export_task._apply_cover_heatmap_renderer") as heatmap_mock:
+            result = AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        self.assertIsNotNone(result)
+        heatmap_mock.assert_not_called()
+
+    def test_starts_layer_hidden_when_points_used_for_heatmap(self):
+        """When points layer drives the heatmap, starts layer opacity is set to 0."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        pts = self._make_points_layer()
+        starts = self._make_points_layer(name="qfit activity starts")
+        project = self._make_project_with_layers(
+            points_layer=pts, starts_layer=starts,
+        )
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas_export_task.build_cover_layout", return_value=cover_layout), \
+             patch("qfit.atlas_export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas_export_task._apply_cover_heatmap_renderer"):
+            AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        # Starts layer should have been set to 0 opacity during export
+        opacity_calls = starts.setOpacity.call_args_list
+        self.assertTrue(any(c[0][0] == 0.0 for c in opacity_calls),
+                        "Starts layer should be hidden (opacity 0) when points drive the heatmap")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #118.

- Adds a square heatmap overview map below the statistics block on the atlas cover page
- The map reflects exactly the activities included in the current atlas PDF subset (not stale precomputed data)
- Uses a Turbo color ramp heatmap renderer with overview-tuned parameters (radius 8mm, quality 1)
- Computes the combined EPSG:3857 bounding box from stored per-page extents with 10% margin, normalized to square
- Discovers points (preferred) or starts layer from the project for heatmap rendering; hides tracks and starts when points drive the heatmap
- Temporarily applies heatmap style and atlas-subset filter during cover export, then restores original renderer/opacity/subset in a finally block
- Falls back gracefully: if no suitable layers or extent data are available, the cover page renders without a map (same as before)

## Test plan

- [x] `python3 -m pytest tests/ -x -q --tb=short` — 321 passed, 12 skipped
- [ ] Verify cover heatmap map appears correctly in exported PDF with real activities
- [ ] Verify cover page still renders correctly when no points/starts layers exist
- [ ] SonarCloud quality gate passes