### PR TITLE
refactor: extract LoadWorkflowService from QfitDockWidget

### DIFF
--- a/load_workflow.py
+++ b/load_workflow.py
@@ -1,0 +1,145 @@
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import date
+
+from .gpkg_writer import GeoPackageWriter
+from .layer_manager import LayerManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LoadResult:
+    """Structured result from a load workflow operation."""
+
+    output_path: str = ""
+    activities_layer: object = None
+    starts_layer: object = None
+    points_layer: object = None
+    atlas_layer: object = None
+    total_stored: int = 0
+    status: str = ""
+    sync: dict = field(default_factory=dict)
+    fetched_count: int = 0
+    track_count: int = 0
+    start_count: int = 0
+    point_count: int = 0
+    atlas_count: int = 0
+
+
+class LoadWorkflowError(Exception):
+    """Raised when a load workflow step fails validation."""
+
+
+class LoadWorkflowService:
+    """Orchestrates GeoPackage write and layer-load workflows independent of UI."""
+
+    def __init__(self, layer_manager: LayerManager):
+        self.layer_manager = layer_manager
+
+    def write_and_load(
+        self,
+        activities,
+        output_path,
+        write_activity_points,
+        point_stride,
+        atlas_margin_percent,
+        atlas_min_extent_degrees,
+        atlas_target_aspect_ratio,
+        sync_metadata=None,
+        last_sync_date=None,
+    ) -> LoadResult:
+        """Write activities to GeoPackage and load layers into QGIS.
+
+        Raises ``LoadWorkflowError`` for validation failures and
+        ``RuntimeError | OSError | ValueError`` for write/load failures.
+        """
+        if not activities:
+            raise LoadWorkflowError("Fetch activities from Strava first.")
+        if not output_path:
+            raise LoadWorkflowError("Choose a GeoPackage output path first.")
+
+        writer = GeoPackageWriter(
+            output_path=output_path,
+            write_activity_points=write_activity_points,
+            point_stride=point_stride,
+            atlas_margin_percent=atlas_margin_percent,
+            atlas_min_extent_degrees=atlas_min_extent_degrees,
+            atlas_target_aspect_ratio=atlas_target_aspect_ratio,
+        )
+        write_result = writer.write_activities(activities, sync_metadata=sync_metadata)
+        resolved_path = write_result["path"]
+
+        activities_layer, starts_layer, points_layer, atlas_layer = (
+            self.layer_manager.load_output_layers(resolved_path)
+        )
+
+        sync = write_result.get("sync") or {}
+        total_stored = sync.get("total_count", 0)
+        last_sync = last_sync_date or date.today().isoformat()
+
+        status = (
+            "Synced {fetched} fetched activities into GeoPackage: "
+            "inserted {inserted}, updated {updated}, unchanged {unchanged}, "
+            "stored total {total}. "
+            "Loaded {track_count} tracks, {start_count} starts, "
+            "{point_count} activity points, and {atlas_count} atlas pages "
+            "into QGIS without auto-filtering the layer tables."
+        ).format(
+            fetched=write_result.get("fetched_count", len(activities)),
+            inserted=sync.get("inserted", 0),
+            updated=sync.get("updated", 0),
+            unchanged=sync.get("unchanged", 0),
+            total=total_stored,
+            track_count=write_result.get("track_count", 0),
+            start_count=write_result.get("start_count", 0),
+            point_count=write_result.get("point_count", 0),
+            atlas_count=write_result.get("atlas_count", 0),
+        )
+
+        return LoadResult(
+            output_path=resolved_path,
+            activities_layer=activities_layer,
+            starts_layer=starts_layer,
+            points_layer=points_layer,
+            atlas_layer=atlas_layer,
+            total_stored=total_stored,
+            status=status,
+            sync=sync,
+            fetched_count=write_result.get("fetched_count", len(activities)),
+            track_count=write_result.get("track_count", 0),
+            start_count=write_result.get("start_count", 0),
+            point_count=write_result.get("point_count", 0),
+            atlas_count=write_result.get("atlas_count", 0),
+        )
+
+    def load_existing(self, output_path) -> LoadResult:
+        """Load layers from an existing GeoPackage without writing.
+
+        Raises ``LoadWorkflowError`` for validation failures and
+        ``RuntimeError | OSError`` for load failures.
+        """
+        if not output_path:
+            raise LoadWorkflowError("Choose a GeoPackage output path first.")
+        if not os.path.exists(output_path):
+            raise LoadWorkflowError(
+                "No database found at:\n  {path}\n\n"
+                "Fetch & Store activities first to create it.".format(path=output_path)
+            )
+
+        activities_layer, starts_layer, points_layer, atlas_layer = (
+            self.layer_manager.load_output_layers(output_path)
+        )
+
+        total = activities_layer.featureCount() if activities_layer else 0
+
+        return LoadResult(
+            output_path=output_path,
+            activities_layer=activities_layer,
+            starts_layer=starts_layer,
+            points_layer=points_layer,
+            atlas_layer=atlas_layer,
+            total_stored=total,
+            status="Layers loaded from {path}.".format(path=output_path),
+        )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -25,6 +25,7 @@ from .background_map_controller import BackgroundMapController
 from .contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .gpkg_writer import GeoPackageWriter
 from .layer_manager import LayerManager
+from .load_workflow import LoadWorkflowError, LoadWorkflowService
 from .mapbox_config import (
     DEFAULT_BACKGROUND_PRESET,
     TILE_MODE_RASTER,
@@ -69,6 +70,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.atlas_export_controller = AtlasExportController()
         self.layer_manager = LayerManager(iface)
         self.background_controller = BackgroundMapController(self.layer_manager)
+        self.load_workflow = LoadWorkflowService(self.layer_manager)
         self.cache = self._build_cache()
         self.setupUi(self)
         self._remove_stale_qfit_layers()
@@ -551,108 +553,85 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._set_status(self.sync_controller.fetch_status_text(client, len(self.activities), detailed_count))
 
     def on_load_clicked(self):
-        if not self.activities:
-            self._show_error("Nothing to load", "Fetch activities from Strava first.")
-            return
-
         self._save_settings()
-        output_path = self.outputPathLineEdit.text().strip()
-        if not output_path:
-            self._show_error("Missing output path", "Choose a GeoPackage output path first.")
-            return
-
         self._set_status("Writing GeoPackage…")
         try:
-            writer = GeoPackageWriter(
-                output_path=output_path,
+            result = self.load_workflow.write_and_load(
+                activities=self.activities,
+                output_path=self.outputPathLineEdit.text().strip(),
                 write_activity_points=self.writeActivityPointsCheckBox.isChecked(),
                 point_stride=self.pointSamplingStrideSpinBox.value(),
                 atlas_margin_percent=self.atlasMarginPercentSpinBox.value(),
                 atlas_min_extent_degrees=self.atlasMinExtentSpinBox.value(),
                 atlas_target_aspect_ratio=self.atlasTargetAspectRatioSpinBox.value(),
+                sync_metadata=self.last_fetch_context,
+                last_sync_date=self.settings.get("last_sync_date", None),
             )
-            result = writer.write_activities(self.activities, sync_metadata=self.last_fetch_context)
-            self.output_path = result["path"]
-            self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer = self.layer_manager.load_output_layers(
-                self.output_path
-            )
-            visual_status = self._apply_visual_configuration(apply_subset_filters=False)
-            sync = result.get("sync") or {}
-            if visual_status:
-                visual_status = f" {visual_status}"
-
-            # Update completeness indicator with last sync date
-            last_sync = self.settings.get("last_sync_date", date.today().isoformat())
-            total_stored = sync.get("total_count", 0)
-            self.countLabel.setText(
-                "{total} activities stored (last sync: {sync_date})".format(
-                    total=total_stored,
-                    sync_date=last_sync,
-                )
-            )
-
-            self._set_status(
-                "Synced {fetched} fetched activities into GeoPackage: inserted {inserted}, updated {updated}, unchanged {unchanged}, stored total {total}. Loaded {track_count} tracks, {start_count} starts, {point_count} activity points, and {atlas_count} atlas pages into QGIS without auto-filtering the layer tables.{visual_status}".format(
-                    fetched=result.get("fetched_count", len(self.activities)),
-                    inserted=sync.get("inserted", 0),
-                    updated=sync.get("updated", 0),
-                    unchanged=sync.get("unchanged", 0),
-                    total=total_stored,
-                    track_count=result.get("track_count", 0),
-                    start_count=result.get("start_count", 0),
-                    point_count=result.get("point_count", 0),
-                    atlas_count=result.get("atlas_count", 0),
-                    visual_status=visual_status,
-                )
-            )
+        except LoadWorkflowError as exc:
+            self._show_error("Nothing to load", str(exc))
+            return
         except (RuntimeError, OSError, ValueError) as exc:
             _msg = "GeoPackage export failed"
             logger.exception(_msg)
             self._show_error(_msg, str(exc))
             self._set_status(_msg)
+            return
+
+        self.output_path = result.output_path
+        self.activities_layer = result.activities_layer
+        self.starts_layer = result.starts_layer
+        self.points_layer = result.points_layer
+        self.atlas_layer = result.atlas_layer
+
+        visual_status = self._apply_visual_configuration(apply_subset_filters=False)
+        last_sync = self.settings.get("last_sync_date", date.today().isoformat())
+        self.countLabel.setText(
+            "{total} activities stored (last sync: {sync_date})".format(
+                total=result.total_stored, sync_date=last_sync,
+            )
+        )
+        status = result.status
+        if visual_status:
+            status = "{status} {visual_status}".format(status=status, visual_status=visual_status)
+        self._set_status(status)
 
     def on_load_layers_clicked(self):
         """Load an existing GeoPackage into QGIS without fetching from Strava."""
         self._save_settings()
-        output_path = self.outputPathLineEdit.text().strip()
-        if not output_path:
-            self._show_error("Missing output path", "Choose a GeoPackage output path first.")
-            return
-        if not os.path.exists(output_path):
-            self._show_error(
-                "GeoPackage not found",
-                f"No database found at:\n  {output_path}\n\nFetch & Store activities first to create it.",
-            )
-            return
-
         self._set_status("Loading layers from GeoPackage…")
         try:
-            self.output_path = output_path
-            self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer = self.layer_manager.load_output_layers(
-                self.output_path
+            result = self.load_workflow.load_existing(
+                self.outputPathLineEdit.text().strip(),
             )
-            self._populate_activity_types_from_layer()
-            visual_status = self._apply_visual_configuration(apply_subset_filters=False)
-            if visual_status:
-                visual_status = f" {visual_status}"
-
-            last_sync = self.settings.get("last_sync_date", "unknown")
-            total = (self.activities_layer.featureCount() if self.activities_layer else 0)
-            self.countLabel.setText(
-                "{total} activities loaded (last sync: {sync_date})".format(
-                    total=total, sync_date=last_sync
-                )
-            )
-            self._set_status(
-                "Layers loaded from {path}.{visual_status}".format(
-                    path=output_path, visual_status=visual_status
-                )
-            )
+        except LoadWorkflowError as exc:
+            self._show_error("Load layers failed", str(exc))
+            return
         except (RuntimeError, OSError) as exc:
             _msg = "Load layers failed"
             logger.exception(_msg)
             self._show_error(_msg, str(exc))
             self._set_status(_msg)
+            return
+
+        self.output_path = result.output_path
+        self.activities_layer = result.activities_layer
+        self.starts_layer = result.starts_layer
+        self.points_layer = result.points_layer
+        self.atlas_layer = result.atlas_layer
+
+        self._populate_activity_types_from_layer()
+        visual_status = self._apply_visual_configuration(apply_subset_filters=False)
+
+        last_sync = self.settings.get("last_sync_date", "unknown")
+        self.countLabel.setText(
+            "{total} activities loaded (last sync: {sync_date})".format(
+                total=result.total_stored, sync_date=last_sync,
+            )
+        )
+        status = result.status
+        if visual_status:
+            status = "{status} {visual_status}".format(status=status, visual_status=visual_status)
+        self._set_status(status)
 
     def on_clear_database_clicked(self):
         """Delete the GeoPackage, clear loaded layers, and reset status."""

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -1,0 +1,246 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from tests import _path  # noqa: F401
+
+try:
+    from qgis.core import QgsApplication
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    QgsApplication = None
+
+if QgsApplication is not None:
+    from qfit.load_workflow import LoadResult, LoadWorkflowError, LoadWorkflowService
+else:  # pragma: no cover
+    LoadResult = None
+    LoadWorkflowError = None
+    LoadWorkflowService = None
+
+
+@unittest.skipIf(LoadWorkflowService is None, "QGIS Python bindings are not available")
+class WriteAndLoadValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.service = LoadWorkflowService(self.layer_manager)
+
+    def test_raises_when_no_activities(self):
+        with self.assertRaises(LoadWorkflowError) as ctx:
+            self.service.write_and_load(
+                activities=[],
+                output_path="/tmp/test.gpkg",
+                write_activity_points=False,
+                point_stride=5,
+                atlas_margin_percent=8.0,
+                atlas_min_extent_degrees=0.01,
+                atlas_target_aspect_ratio=1.5,
+            )
+        self.assertIn("Fetch activities", str(ctx.exception))
+
+    def test_raises_when_no_output_path(self):
+        with self.assertRaises(LoadWorkflowError) as ctx:
+            self.service.write_and_load(
+                activities=["activity"],
+                output_path="",
+                write_activity_points=False,
+                point_stride=5,
+                atlas_margin_percent=8.0,
+                atlas_min_extent_degrees=0.01,
+                atlas_target_aspect_ratio=1.5,
+            )
+        self.assertIn("output path", str(ctx.exception))
+
+
+@unittest.skipIf(LoadWorkflowService is None, "QGIS Python bindings are not available")
+class WriteAndLoadSuccessTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.service = LoadWorkflowService(self.layer_manager)
+
+    @patch("qfit.load_workflow.GeoPackageWriter")
+    def test_returns_load_result_with_layers(self, MockWriter):
+        mock_writer_instance = MockWriter.return_value
+        mock_writer_instance.write_activities.return_value = {
+            "path": "/tmp/out.gpkg",
+            "fetched_count": 3,
+            "track_count": 3,
+            "start_count": 3,
+            "point_count": 0,
+            "atlas_count": 3,
+            "sync": {
+                "total_count": 10,
+                "inserted": 2,
+                "updated": 1,
+                "unchanged": 0,
+            },
+        }
+        mock_layers = (
+            MagicMock(name="activities"),
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+        self.layer_manager.load_output_layers.return_value = mock_layers
+
+        activities = [SimpleNamespace(name="a1"), SimpleNamespace(name="a2"), SimpleNamespace(name="a3")]
+        result = self.service.write_and_load(
+            activities=activities,
+            output_path="/tmp/out.gpkg",
+            write_activity_points=False,
+            point_stride=5,
+            atlas_margin_percent=8.0,
+            atlas_min_extent_degrees=0.01,
+            atlas_target_aspect_ratio=1.5,
+            last_sync_date="2026-01-01",
+        )
+
+        self.assertIsInstance(result, LoadResult)
+        self.assertEqual(result.output_path, "/tmp/out.gpkg")
+        self.assertEqual(result.total_stored, 10)
+        self.assertEqual(result.fetched_count, 3)
+        self.assertEqual(result.track_count, 3)
+        self.assertEqual(result.activities_layer, mock_layers[0])
+        self.assertEqual(result.starts_layer, mock_layers[1])
+        self.assertEqual(result.points_layer, mock_layers[2])
+        self.assertEqual(result.atlas_layer, mock_layers[3])
+        self.assertIn("inserted 2", result.status)
+        self.assertIn("updated 1", result.status)
+
+    @patch("qfit.load_workflow.GeoPackageWriter")
+    def test_passes_sync_metadata_to_writer(self, MockWriter):
+        mock_writer_instance = MockWriter.return_value
+        mock_writer_instance.write_activities.return_value = {
+            "path": "/tmp/out.gpkg",
+            "fetched_count": 1,
+            "track_count": 1,
+            "start_count": 1,
+            "point_count": 0,
+            "atlas_count": 1,
+            "sync": {"total_count": 1, "inserted": 1, "updated": 0, "unchanged": 0},
+        }
+        self.layer_manager.load_output_layers.return_value = (None, None, None, None)
+
+        metadata = {"provider": "strava"}
+        self.service.write_and_load(
+            activities=["a"],
+            output_path="/tmp/out.gpkg",
+            write_activity_points=True,
+            point_stride=10,
+            atlas_margin_percent=5.0,
+            atlas_min_extent_degrees=0.02,
+            atlas_target_aspect_ratio=1.0,
+            sync_metadata=metadata,
+        )
+
+        mock_writer_instance.write_activities.assert_called_once_with(
+            ["a"], sync_metadata=metadata,
+        )
+
+    @patch("qfit.load_workflow.GeoPackageWriter")
+    def test_constructs_writer_with_correct_params(self, MockWriter):
+        mock_writer_instance = MockWriter.return_value
+        mock_writer_instance.write_activities.return_value = {
+            "path": "/tmp/out.gpkg",
+            "fetched_count": 1,
+            "track_count": 0,
+            "start_count": 0,
+            "point_count": 0,
+            "atlas_count": 0,
+            "sync": {"total_count": 1, "inserted": 1, "updated": 0, "unchanged": 0},
+        }
+        self.layer_manager.load_output_layers.return_value = (None, None, None, None)
+
+        self.service.write_and_load(
+            activities=["a"],
+            output_path="/tmp/test.gpkg",
+            write_activity_points=True,
+            point_stride=10,
+            atlas_margin_percent=5.0,
+            atlas_min_extent_degrees=0.02,
+            atlas_target_aspect_ratio=2.0,
+        )
+
+        MockWriter.assert_called_once_with(
+            output_path="/tmp/test.gpkg",
+            write_activity_points=True,
+            point_stride=10,
+            atlas_margin_percent=5.0,
+            atlas_min_extent_degrees=0.02,
+            atlas_target_aspect_ratio=2.0,
+        )
+
+
+@unittest.skipIf(LoadWorkflowService is None, "QGIS Python bindings are not available")
+class LoadExistingValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.service = LoadWorkflowService(self.layer_manager)
+
+    def test_raises_when_no_output_path(self):
+        with self.assertRaises(LoadWorkflowError) as ctx:
+            self.service.load_existing("")
+        self.assertIn("output path", str(ctx.exception))
+
+    def test_raises_when_file_not_found(self):
+        with self.assertRaises(LoadWorkflowError) as ctx:
+            self.service.load_existing("/nonexistent/path.gpkg")
+        self.assertIn("No database found", str(ctx.exception))
+
+
+@unittest.skipIf(LoadWorkflowService is None, "QGIS Python bindings are not available")
+class LoadExistingSuccessTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.service = LoadWorkflowService(self.layer_manager)
+
+    @patch("qfit.load_workflow.os.path.exists", return_value=True)
+    def test_returns_load_result(self, mock_exists):
+        mock_activities_layer = MagicMock()
+        mock_activities_layer.featureCount.return_value = 42
+        mock_layers = (
+            mock_activities_layer,
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+        self.layer_manager.load_output_layers.return_value = mock_layers
+
+        result = self.service.load_existing("/tmp/existing.gpkg")
+
+        self.assertIsInstance(result, LoadResult)
+        self.assertEqual(result.output_path, "/tmp/existing.gpkg")
+        self.assertEqual(result.total_stored, 42)
+        self.assertEqual(result.activities_layer, mock_activities_layer)
+        self.assertIn("/tmp/existing.gpkg", result.status)
+        self.layer_manager.load_output_layers.assert_called_once_with("/tmp/existing.gpkg")
+
+    @patch("qfit.load_workflow.os.path.exists", return_value=True)
+    def test_handles_none_activities_layer(self, mock_exists):
+        self.layer_manager.load_output_layers.return_value = (None, None, None, None)
+
+        result = self.service.load_existing("/tmp/empty.gpkg")
+
+        self.assertEqual(result.total_stored, 0)
+
+
+@unittest.skipIf(LoadResult is None, "QGIS Python bindings are not available")
+class LoadResultTests(unittest.TestCase):
+    def test_default_values(self):
+        result = LoadResult()
+        self.assertEqual(result.output_path, "")
+        self.assertIsNone(result.activities_layer)
+        self.assertEqual(result.total_stored, 0)
+        self.assertEqual(result.status, "")
+        self.assertEqual(result.sync, {})
+
+    def test_custom_values(self):
+        result = LoadResult(
+            output_path="/tmp/test.gpkg",
+            total_stored=5,
+            status="ok",
+        )
+        self.assertEqual(result.output_path, "/tmp/test.gpkg")
+        self.assertEqual(result.total_stored, 5)
+        self.assertEqual(result.status, "ok")


### PR DESCRIPTION
## Summary
- Introduces `LoadWorkflowService` with `write_and_load()` and `load_existing()` methods, extracting GeoPackage write/load orchestration out of `QfitDockWidget` (#122)
- Adds `LoadResult` dataclass for structured workflow results instead of inline dict unpacking and status string construction
- `QfitDockWidget.on_load_clicked()` and `on_load_layers_clicked()` now delegate to the service and only handle UI updates

## Test plan
- [x] All 321 existing tests pass (`python3 -m pytest tests/ -x -q --tb=short`)
- [x] New `tests/test_load_workflow.py` covers validation errors, success paths, writer construction, sync metadata passthrough, and `LoadResult` defaults
- [ ] SonarCloud quality gate passes
- [ ] No user-visible behavior regression

Closes #122 (first increment)

@codex code review please

🤖 Generated with [Claude Code](https://claude.com/claude-code)