### PR TITLE
refactor: extract VisualApplyService from QfitDockWidget (#122)

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -23,7 +23,6 @@ from .activity_query import (
 from .atlas_export_controller import AtlasExportController, AtlasExportValidationError
 from .background_map_controller import BackgroundMapController
 from .contextual_help import ContextualHelpBinder, build_dock_help_entries
-from .gpkg_writer import GeoPackageWriter
 from .layer_manager import LayerManager
 from .load_workflow import LoadWorkflowError, LoadWorkflowService
 from .mapbox_config import (
@@ -35,6 +34,7 @@ from .mapbox_config import (
     background_preset_names,
     preset_requires_custom_style,
 )
+from .visual_apply import BackgroundConfig, LayerRefs, VisualApplyService
 from .fetch_task import StravaFetchTask
 from .atlas_export_task import AtlasExportTask, BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .qfit_cache import QfitCache
@@ -71,6 +71,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.layer_manager = LayerManager(iface)
         self.background_controller = BackgroundMapController(self.layer_manager)
         self.load_workflow = LoadWorkflowService(self.layer_manager)
+        self.visual_apply = VisualApplyService(self.layer_manager)
         self.cache = self._build_cache()
         self.setupUi(self)
         self._remove_stale_qfit_layers()
@@ -697,112 +698,41 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if status:
             self._set_status(status)
 
-    @staticmethod
-    def _should_update_background_layer(apply_subset_filters):
-        return not apply_subset_filters
-
     def _apply_visual_configuration(self, apply_subset_filters):
-        has_layers = any(layer is not None for layer in [self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer])
-        wants_background = self.backgroundMapCheckBox.isChecked()
         filtered_activities = self._refresh_activity_preview()
         query = self._current_activity_query()
-        preset = self.stylePresetComboBox.currentText()
-        temporal_note = ""
 
-        if has_layers and apply_subset_filters:
-            self.layer_manager.apply_filters(
-                self.activities_layer,
-                query.activity_type,
-                query.date_from,
-                query.date_to,
-                query.min_distance_km,
-                query.max_distance_km,
-                query.search_text,
-                query.detailed_only,
-            )
-            self.layer_manager.apply_filters(
-                self.starts_layer,
-                query.activity_type,
-                query.date_from,
-                query.date_to,
-                query.min_distance_km,
-                query.max_distance_km,
-                query.search_text,
-                query.detailed_only,
-            )
-            self.layer_manager.apply_filters(
-                self.points_layer,
-                query.activity_type,
-                query.date_from,
-                query.date_to,
-                query.min_distance_km,
-                query.max_distance_km,
-                query.search_text,
-                query.detailed_only,
-            )
-            self.layer_manager.apply_filters(
-                self.atlas_layer,
-                query.activity_type,
-                query.date_from,
-                query.date_to,
-                query.min_distance_km,
-                query.max_distance_km,
-                query.search_text,
-                query.detailed_only,
-            )
+        layers = LayerRefs(
+            activities=self.activities_layer,
+            starts=self.starts_layer,
+            points=self.points_layer,
+            atlas=self.atlas_layer,
+        )
+        bg_config = BackgroundConfig(
+            enabled=self.backgroundMapCheckBox.isChecked(),
+            preset_name=self.backgroundPresetComboBox.currentText(),
+            access_token=self.mapboxAccessTokenLineEdit.text().strip(),
+            style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+            style_id=self.mapboxStyleIdLineEdit.text().strip(),
+            tile_mode=self.tileModeComboBox.currentText(),
+        )
 
-        if has_layers:
-            self.layer_manager.apply_style(
-                self.activities_layer,
-                self.starts_layer,
-                self.points_layer,
-                self.atlas_layer,
-                preset,
-                background_preset_name=self.backgroundPresetComboBox.currentText() if wants_background else None,
-            )
-            temporal_note = self.layer_manager.apply_temporal_configuration(
-                self.activities_layer,
-                self.starts_layer,
-                self.points_layer,
-                self.atlas_layer,
-                self.temporalModeComboBox.currentText(),
-            )
+        result = self.visual_apply.apply(
+            layers=layers,
+            query=query,
+            style_preset=self.stylePresetComboBox.currentText(),
+            temporal_mode=self.temporalModeComboBox.currentText(),
+            background_config=bg_config,
+            apply_subset_filters=apply_subset_filters,
+            filtered_count=len(filtered_activities),
+        )
 
-        if self._should_update_background_layer(apply_subset_filters):
-            try:
-                self.background_layer = self.layer_manager.ensure_background_layer(
-                    enabled=wants_background,
-                    preset_name=self.backgroundPresetComboBox.currentText(),
-                    access_token=self.mapboxAccessTokenLineEdit.text().strip(),
-                    style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
-                    style_id=self.mapboxStyleIdLineEdit.text().strip(),
-                    tile_mode=self.tileModeComboBox.currentText(),
-                )
-            except (MapboxConfigError, RuntimeError) as exc:
-                self._show_error("Background map failed", str(exc))
-                if not has_layers:
-                    failure_status = "Background map could not be updated"
-                else:
-                    failure_status = "Loaded layers with styling, but the background map could not be updated"
-                if temporal_note:
-                    failure_status = f"{failure_status}. {temporal_note}."
-                return failure_status
+        if self.visual_apply.should_update_background(apply_subset_filters):
+            if result.background_error:
+                self._show_error("Background map failed", result.background_error)
+            self.background_layer = result.background_layer
 
-        filtered_count = len(filtered_activities)
-        if apply_subset_filters and has_layers:
-            status = f"Applied filters and styling ({filtered_count} matching activities)"
-        elif has_layers and wants_background and self.background_layer is not None:
-            status = "Applied styling and loaded the background map below the qfit activity layers"
-        elif has_layers:
-            status = "Applied styling to the loaded qfit layers"
-        elif wants_background and self.background_layer is not None:
-            status = "Background map loaded below the qfit activity layers"
-        else:
-            status = "Background map cleared"
-
-        if temporal_note:
-            status = f"{status}. {temporal_note}."
-        return status
+        return result.status
 
     def _current_activity_query(self):
         return ActivityQuery(

--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -1,0 +1,402 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+from tests import _path  # noqa: F401
+from qfit.visual_apply import (
+    BackgroundConfig,
+    LayerRefs,
+    VisualApplyResult,
+    VisualApplyService,
+)
+
+
+def _make_query(**overrides):
+    defaults = dict(
+        activity_type="All",
+        date_from=None,
+        date_to=None,
+        min_distance_km=0,
+        max_distance_km=0,
+        search_text="",
+        detailed_only=False,
+        sort_label="Date (newest first)",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_bg_config(**overrides):
+    defaults = dict(
+        enabled=False,
+        preset_name="Dark",
+        access_token="tok",
+        style_owner="mapbox",
+        style_id="dark-v11",
+        tile_mode="raster",
+    )
+    defaults.update(overrides)
+    return BackgroundConfig(**defaults)
+
+
+class LayerRefsTests(unittest.TestCase):
+    def test_has_any_false_when_all_none(self):
+        self.assertFalse(LayerRefs().has_any())
+
+    def test_has_any_true_with_one_layer(self):
+        self.assertTrue(LayerRefs(activities=MagicMock()).has_any())
+
+    def test_has_any_true_with_atlas_only(self):
+        self.assertTrue(LayerRefs(atlas=MagicMock()).has_any())
+
+
+class ShouldUpdateBackgroundTests(unittest.TestCase):
+    def test_returns_true_when_not_applying_subset_filters(self):
+        self.assertTrue(VisualApplyService.should_update_background(False))
+
+    def test_returns_false_when_applying_subset_filters(self):
+        self.assertFalse(VisualApplyService.should_update_background(True))
+
+
+class ApplyWithSubsetFiltersTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.layer_manager.apply_temporal_configuration.return_value = ""
+        self.service = VisualApplyService(self.layer_manager)
+        self.layers = LayerRefs(
+            activities=MagicMock(name="activities"),
+            starts=MagicMock(name="starts"),
+            points=MagicMock(name="points"),
+            atlas=MagicMock(name="atlas"),
+        )
+
+    def test_applies_filters_to_all_four_layers(self):
+        query = _make_query(activity_type="Run", search_text="trail")
+
+        self.service.apply(
+            layers=self.layers,
+            query=query,
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(),
+            apply_subset_filters=True,
+            filtered_count=5,
+        )
+
+        self.assertEqual(self.layer_manager.apply_filters.call_count, 4)
+        for c in self.layer_manager.apply_filters.call_args_list:
+            self.assertEqual(c[0][1], "Run")
+            self.assertEqual(c[0][6], "trail")
+
+    def test_applies_style_when_layers_present(self):
+        self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="Speed gradient",
+            temporal_mode="Off",
+            background_config=_make_bg_config(),
+            apply_subset_filters=True,
+            filtered_count=3,
+        )
+
+        self.layer_manager.apply_style.assert_called_once()
+        args = self.layer_manager.apply_style.call_args
+        self.assertEqual(args[0][4], "Speed gradient")
+
+    def test_status_includes_filtered_count(self):
+        result = self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(),
+            apply_subset_filters=True,
+            filtered_count=42,
+        )
+
+        self.assertIn("42", result.status)
+        self.assertIn("filters", result.status.lower())
+
+    def test_does_not_update_background_on_filter_apply(self):
+        self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=True),
+            apply_subset_filters=True,
+            filtered_count=0,
+        )
+
+        self.layer_manager.ensure_background_layer.assert_not_called()
+
+
+class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.layer_manager.apply_temporal_configuration.return_value = ""
+        self.layer_manager.ensure_background_layer.return_value = MagicMock(name="bg")
+        self.service = VisualApplyService(self.layer_manager)
+        self.layers = LayerRefs(
+            activities=MagicMock(name="activities"),
+            starts=MagicMock(name="starts"),
+            points=MagicMock(name="points"),
+            atlas=MagicMock(name="atlas"),
+        )
+
+    def test_does_not_apply_filters(self):
+        self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.layer_manager.apply_filters.assert_not_called()
+
+    def test_applies_style_and_temporal(self):
+        self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Monthly",
+            background_config=_make_bg_config(),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.layer_manager.apply_style.assert_called_once()
+        self.layer_manager.apply_temporal_configuration.assert_called_once()
+        args = self.layer_manager.apply_temporal_configuration.call_args
+        self.assertEqual(args[0][4], "Monthly")
+
+    def test_updates_background_layer(self):
+        bg = _make_bg_config(enabled=True)
+        result = self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=bg,
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.layer_manager.ensure_background_layer.assert_called_once_with(
+            enabled=True,
+            preset_name="Dark",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="dark-v11",
+            tile_mode="raster",
+        )
+        self.assertIsNotNone(result.background_layer)
+
+    def test_status_mentions_styling_and_background(self):
+        bg = _make_bg_config(enabled=True)
+        result = self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=bg,
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.assertIn("styling", result.status.lower())
+        self.assertIn("background", result.status.lower())
+
+    def test_status_without_background(self):
+        result = self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=False),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.assertIn("styling", result.status.lower())
+
+
+class BackgroundFailureTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.layer_manager.apply_temporal_configuration.return_value = ""
+        self.layer_manager.ensure_background_layer.side_effect = RuntimeError("no tiles")
+        self.service = VisualApplyService(self.layer_manager)
+
+    def test_returns_error_status_on_background_failure(self):
+        layers = LayerRefs(activities=MagicMock())
+        result = self.service.apply(
+            layers=layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=True),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.assertIn("could not be updated", result.status.lower())
+        self.assertIsNone(result.background_layer)
+        self.assertEqual(result.background_error, "no tiles")
+
+    def test_error_status_with_layers(self):
+        layers = LayerRefs(activities=MagicMock())
+        result = self.service.apply(
+            layers=layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=True),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.assertIn("loaded layers", result.status.lower())
+
+    def test_error_status_without_layers(self):
+        layers = LayerRefs()
+        result = self.service.apply(
+            layers=layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=True),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.assertNotIn("loaded layers", result.status.lower())
+        self.assertIn("could not be updated", result.status.lower())
+
+
+class NoLayersTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.layer_manager.apply_temporal_configuration.return_value = ""
+        self.layer_manager.ensure_background_layer.return_value = None
+        self.service = VisualApplyService(self.layer_manager)
+
+    def test_no_filters_or_style_applied(self):
+        result = self.service.apply(
+            layers=LayerRefs(),
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(),
+            apply_subset_filters=True,
+            filtered_count=0,
+        )
+
+        self.layer_manager.apply_filters.assert_not_called()
+        self.layer_manager.apply_style.assert_not_called()
+        self.layer_manager.apply_temporal_configuration.assert_not_called()
+
+    def test_background_cleared_status(self):
+        result = self.service.apply(
+            layers=LayerRefs(),
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=False),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.assertIn("cleared", result.status.lower())
+
+
+class TemporalNoteTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.layer_manager.apply_temporal_configuration.return_value = "Temporal mode: Monthly"
+        self.layer_manager.ensure_background_layer.return_value = None
+        self.service = VisualApplyService(self.layer_manager)
+        self.layers = LayerRefs(activities=MagicMock())
+
+    def test_temporal_note_appended_to_status(self):
+        result = self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Monthly",
+            background_config=_make_bg_config(),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.assertIn("Temporal mode: Monthly", result.status)
+
+    def test_temporal_note_appended_to_failure_status(self):
+        self.layer_manager.ensure_background_layer.side_effect = RuntimeError("fail")
+        result = self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Monthly",
+            background_config=_make_bg_config(enabled=True),
+            apply_subset_filters=False,
+            filtered_count=0,
+        )
+
+        self.assertIn("Temporal mode: Monthly", result.status)
+        self.assertIn("could not be updated", result.status.lower())
+
+
+class BackgroundPresetPassthroughTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.layer_manager.apply_temporal_configuration.return_value = ""
+        self.service = VisualApplyService(self.layer_manager)
+        self.layers = LayerRefs(activities=MagicMock())
+
+    def test_passes_preset_name_to_style_when_enabled(self):
+        self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=True, preset_name="Satellite"),
+            apply_subset_filters=True,
+            filtered_count=0,
+        )
+
+        kwargs = self.layer_manager.apply_style.call_args[1]
+        self.assertEqual(kwargs["background_preset_name"], "Satellite")
+
+    def test_passes_none_to_style_when_disabled(self):
+        self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=False),
+            apply_subset_filters=True,
+            filtered_count=0,
+        )
+
+        kwargs = self.layer_manager.apply_style.call_args[1]
+        self.assertIsNone(kwargs["background_preset_name"])
+
+
+class VisualApplyResultTests(unittest.TestCase):
+    def test_default_values(self):
+        result = VisualApplyResult()
+        self.assertEqual(result.status, "")
+        self.assertIsNone(result.background_layer)
+        self.assertEqual(result.background_error, "")
+
+    def test_custom_values(self):
+        result = VisualApplyResult(
+            status="ok", background_layer="layer", background_error="err"
+        )
+        self.assertEqual(result.status, "ok")
+        self.assertEqual(result.background_layer, "layer")
+        self.assertEqual(result.background_error, "err")

--- a/visual_apply.py
+++ b/visual_apply.py
@@ -1,0 +1,206 @@
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LayerRefs:
+    """References to the four qfit output layers."""
+
+    activities: object = None
+    starts: object = None
+    points: object = None
+    atlas: object = None
+
+    def has_any(self):
+        return any(
+            layer is not None
+            for layer in [self.activities, self.starts, self.points, self.atlas]
+        )
+
+
+@dataclass
+class BackgroundConfig:
+    """Settings needed to manage the background map layer."""
+
+    enabled: bool = False
+    preset_name: str = ""
+    access_token: str = ""
+    style_owner: str = ""
+    style_id: str = ""
+    tile_mode: str = ""
+
+
+@dataclass
+class VisualApplyResult:
+    """Structured result from a visual-apply operation."""
+
+    status: str = ""
+    background_layer: object = None
+    background_error: str = ""
+
+
+class VisualApplyService:
+    """Applies filters, styling, temporal config, and background to qfit layers.
+
+    Extracted from ``QfitDockWidget._apply_visual_configuration`` so the
+    orchestration logic can be tested without a live UI.
+    """
+
+    def __init__(self, layer_manager):
+        self.layer_manager = layer_manager
+
+    @staticmethod
+    def should_update_background(apply_subset_filters):
+        """Background layer is only updated on initial load, not on filter-only applies."""
+        return not apply_subset_filters
+
+    def apply(
+        self,
+        layers,
+        query,
+        style_preset,
+        temporal_mode,
+        background_config,
+        apply_subset_filters,
+        filtered_count,
+    ):
+        """Apply visual configuration to layers and return a result.
+
+        Parameters
+        ----------
+        layers : LayerRefs
+            References to the four qfit output layers.
+        query : ActivityQuery
+            Current filter/sort query built from UI state.
+        style_preset : str
+            Name of the selected style preset.
+        temporal_mode : str
+            Name of the selected temporal mode.
+        background_config : BackgroundConfig
+            Background map settings.
+        apply_subset_filters : bool
+            Whether to apply subset filters to layers.
+        filtered_count : int
+            Number of activities matching the current query (for status text).
+        """
+        has_layers = layers.has_any()
+        temporal_note = ""
+
+        if has_layers and apply_subset_filters:
+            self._apply_filters_to_all_layers(layers, query)
+
+        if has_layers:
+            self.layer_manager.apply_style(
+                layers.activities,
+                layers.starts,
+                layers.points,
+                layers.atlas,
+                style_preset,
+                background_preset_name=(
+                    background_config.preset_name if background_config.enabled else None
+                ),
+            )
+            temporal_note = self.layer_manager.apply_temporal_configuration(
+                layers.activities,
+                layers.starts,
+                layers.points,
+                layers.atlas,
+                temporal_mode,
+            )
+
+        background_layer = None
+        if self.should_update_background(apply_subset_filters):
+            background_layer, bg_error = self._ensure_background(background_config)
+            if bg_error is not None:
+                failure_status = self._background_failure_status(
+                    has_layers, temporal_note, bg_error
+                )
+                return VisualApplyResult(
+                    status=failure_status,
+                    background_layer=None,
+                    background_error=bg_error,
+                )
+
+        status = self._build_status(
+            has_layers=has_layers,
+            apply_subset_filters=apply_subset_filters,
+            filtered_count=filtered_count,
+            wants_background=background_config.enabled,
+            background_layer=background_layer,
+            temporal_note=temporal_note,
+        )
+        return VisualApplyResult(status=status, background_layer=background_layer)
+
+    def _apply_filters_to_all_layers(self, layers, query):
+        for layer in [layers.activities, layers.starts, layers.points, layers.atlas]:
+            self.layer_manager.apply_filters(
+                layer,
+                query.activity_type,
+                query.date_from,
+                query.date_to,
+                query.min_distance_km,
+                query.max_distance_km,
+                query.search_text,
+                query.detailed_only,
+            )
+
+    def _ensure_background(self, config):
+        """Try to load/update the background layer.
+
+        Returns ``(layer, None)`` on success or ``(None, error_message)`` on
+        failure.
+        """
+        try:
+            layer = self.layer_manager.ensure_background_layer(
+                enabled=config.enabled,
+                preset_name=config.preset_name,
+                access_token=config.access_token,
+                style_owner=config.style_owner,
+                style_id=config.style_id,
+                tile_mode=config.tile_mode,
+            )
+            return layer, None
+        except (RuntimeError, Exception) as exc:
+            return None, str(exc)
+
+    @staticmethod
+    def _background_failure_status(has_layers, temporal_note, error):
+        if not has_layers:
+            status = "Background map could not be updated"
+        else:
+            status = "Loaded layers with styling, but the background map could not be updated"
+        if temporal_note:
+            status = "{status}. {temporal_note}.".format(
+                status=status, temporal_note=temporal_note
+            )
+        return status
+
+    @staticmethod
+    def _build_status(
+        has_layers,
+        apply_subset_filters,
+        filtered_count,
+        wants_background,
+        background_layer,
+        temporal_note,
+    ):
+        if apply_subset_filters and has_layers:
+            status = "Applied filters and styling ({count} matching activities)".format(
+                count=filtered_count
+            )
+        elif has_layers and wants_background and background_layer is not None:
+            status = "Applied styling and loaded the background map below the qfit activity layers"
+        elif has_layers:
+            status = "Applied styling to the loaded qfit layers"
+        elif wants_background and background_layer is not None:
+            status = "Background map loaded below the qfit activity layers"
+        else:
+            status = "Background map cleared"
+
+        if temporal_note:
+            status = "{status}. {temporal_note}.".format(
+                status=status, temporal_note=temporal_note
+            )
+        return status


### PR DESCRIPTION
## Summary

Second incremental PR for #122, following the LoadWorkflowService extraction in #132.

- Extracts `_apply_visual_configuration` orchestration into a standalone `VisualApplyService` in `visual_apply.py`
- Introduces `LayerRefs`, `BackgroundConfig`, and `VisualApplyResult` dataclasses to carry data cleanly across the boundary
- `QfitDockWidget._apply_visual_configuration` is reduced to UI-layer assembly (collect widget state → call service → update widget state)
- Service is importable without QGIS bindings, enabling fast unit tests
- Reduces `QfitDockWidget` by ~70 net lines

## Test plan

- [ ] 25 new unit tests in `tests/test_visual_apply.py` covering: filter application, styling, temporal config, background success/failure, status text variants, no-layers path
- [ ] Run: `python3 -m pytest tests/ -x -q --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)