### PR TITLE
feat(#125): introduce ActivityProvider protocol and StravaProvider

### DIFF
--- a/fetch_task.py
+++ b/fetch_task.py
@@ -1,4 +1,4 @@
-"""Background task for fetching Strava activities without blocking the QGIS UI.
+"""Background task for fetching activities without blocking the QGIS UI.
 
 Uses :class:`qgis.core.QgsTask` so that fetches appear in the QGIS task
 manager, show progress in the native progress bar, and can be cancelled.
@@ -10,28 +10,28 @@ from qgis.core import QgsTask
 
 logger = logging.getLogger(__name__)
 
-from .strava_client import StravaClient, StravaClientError
+from .provider import ProviderError
 
 
-class StravaFetchTask(QgsTask):
-    """Wraps :meth:`StravaClient.fetch_activities` in a ``QgsTask``.
+class FetchTask(QgsTask):
+    """Wraps an :class:`ActivityProvider`'s ``fetch_activities`` in a ``QgsTask``.
 
     The task runs in a QGIS-managed worker thread so the main thread (and
     therefore the QGIS UI) stays responsive while activities are being
-    downloaded from Strava.
+    downloaded.
 
     Parameters
     ----------
-    client:
-        A fully-configured :class:`StravaClient` instance.
+    provider:
+        A fully-configured :class:`ActivityProvider` instance.
     per_page:
         Number of activities to request per API page.
     max_pages:
         Maximum number of pages to fetch.
     before:
-        Upper bound epoch timestamp (passed to Strava API).
+        Upper bound epoch timestamp.
     after:
-        Lower bound epoch timestamp (passed to Strava API).
+        Lower bound epoch timestamp.
     use_detailed_streams:
         Whether to enrich activities with per-point stream data.
     max_detailed_activities:
@@ -40,12 +40,12 @@ class StravaFetchTask(QgsTask):
         Callable invoked **on the main thread** when the task completes.
         It receives keyword arguments:
         ``activities`` (list | None), ``error`` (str | None),
-        ``cancelled`` (bool), ``client`` (:class:`StravaClient`).
+        ``cancelled`` (bool), ``provider`` (:class:`ActivityProvider`).
     """
 
     def __init__(
         self,
-        client,
+        provider,
         per_page,
         max_pages,
         before,
@@ -54,8 +54,8 @@ class StravaFetchTask(QgsTask):
         max_detailed_activities,
         on_finished,
     ):
-        super().__init__("Fetch Strava activities", QgsTask.CanCancel)
-        self._client = client
+        super().__init__("Fetch activities", QgsTask.CanCancel)
+        self._provider = provider
         self._per_page = per_page
         self._max_pages = max_pages
         self._before = before
@@ -71,12 +71,12 @@ class StravaFetchTask(QgsTask):
     # ------------------------------------------------------------------
 
     def run(self):
-        """Execute the Strava fetch in the worker thread.
+        """Execute the fetch in the worker thread.
 
         Returns ``True`` on success, ``False`` on error or cancellation.
         """
         try:
-            self._activities = self._client.fetch_activities(
+            self._activities = self._provider.fetch_activities(
                 per_page=self._per_page,
                 max_pages=self._max_pages,
                 before=self._before,
@@ -84,11 +84,11 @@ class StravaFetchTask(QgsTask):
                 use_detailed_streams=self._use_detailed_streams,
                 max_detailed_activities=self._max_detailed_activities,
             )
-        except StravaClientError as exc:
+        except ProviderError as exc:
             self._error = str(exc)
             return False
         except Exception as exc:  # noqa: BLE001 – QgsTask worker thread safety net
-            logger.exception("Strava fetch task failed")
+            logger.exception("Fetch task failed")
             self._error = str(exc)
             return False
 
@@ -105,5 +105,5 @@ class StravaFetchTask(QgsTask):
                 activities=self._activities if result else None,
                 error=self._error,
                 cancelled=self.isCanceled(),
-                client=self._client,
+                provider=self._provider,
             )

--- a/provider.py
+++ b/provider.py
@@ -1,0 +1,38 @@
+"""Provider protocol for activity sources.
+
+Defines the contract that all activity providers (Strava, GPX, …) must
+implement, as well as the common error type they should raise.
+"""
+
+from typing import Dict, List, Optional, Protocol, runtime_checkable
+
+from .models import Activity
+
+
+class ProviderError(RuntimeError):
+    """Raised by an :class:`ActivityProvider` when a fetch or auth operation fails."""
+
+
+@runtime_checkable
+class ActivityProvider(Protocol):
+    """Protocol for objects that can fetch fitness activities.
+
+    Any class that exposes ``source_name``, ``last_stream_enrichment_stats``,
+    ``last_rate_limit``, and :meth:`fetch_activities` with the matching
+    signature satisfies this protocol — no explicit inheritance required.
+    """
+
+    source_name: str
+    last_stream_enrichment_stats: Dict
+    last_rate_limit: Optional[Dict]
+
+    def fetch_activities(
+        self,
+        per_page: int = 200,
+        max_pages: int = 0,
+        before: Optional[float] = None,
+        after: Optional[float] = None,
+        use_detailed_streams: bool = False,
+        max_detailed_activities: Optional[int] = None,
+    ) -> List[Activity]:
+        ...

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -34,10 +34,11 @@ from .mapbox_config import (
     preset_requires_custom_style,
 )
 from .visual_apply import BackgroundConfig, LayerRefs, VisualApplyService
-from .fetch_task import StravaFetchTask
+from .fetch_task import FetchTask
 from .atlas.export_task import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .qfit_cache import QfitCache
-from .strava_client import StravaClient, StravaClientError
+from .provider import ProviderError
+from .strava_provider import StravaProvider
 from .settings_service import SettingsService
 from .sync_controller import SyncController
 from .temporal_config import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
@@ -244,7 +245,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.clientIdLineEdit.setText(s.get("client_id", ""))
         self.clientSecretLineEdit.setText(s.get("client_secret", ""))
         self.redirectUriLineEdit.setText(
-            s.get("redirect_uri", StravaClient.DEFAULT_REDIRECT_URI)
+            s.get("redirect_uri", StravaProvider.DEFAULT_REDIRECT_URI)
         )
         self.authCodeLineEdit.setText("")
         self.refreshTokenLineEdit.setText(s.get("refresh_token", ""))
@@ -391,7 +392,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def on_open_authorize_clicked(self):
         self._save_settings()
         try:
-            client = self.sync_controller.build_client(
+            client = self.sync_controller.build_strava_provider(
                 client_id=self.clientIdLineEdit.text().strip(),
                 client_secret=self.clientSecretLineEdit.text().strip(),
                 refresh_token=self.refreshTokenLineEdit.text().strip(),
@@ -417,7 +418,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(
                 "Strava authorization opened in your browser. Approve access, copy the returned code, then paste it here and click Exchange code."
             )
-        except StravaClientError as exc:
+        except ProviderError as exc:
             self._show_error("Strava authorization failed", str(exc))
             self._set_status("Could not start the Strava authorization flow")
 
@@ -429,7 +430,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         try:
-            client = self.sync_controller.build_client(
+            client = self.sync_controller.build_strava_provider(
                 client_id=self.clientIdLineEdit.text().strip(),
                 client_secret=self.clientSecretLineEdit.text().strip(),
                 refresh_token=self.refreshTokenLineEdit.text().strip(),
@@ -442,7 +443,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
             refresh_token = payload.get("refresh_token")
             if not refresh_token:
-                raise StravaClientError("Strava returned no refresh token")
+                raise ProviderError("Strava returned no refresh token")
             self.refreshTokenLineEdit.setText(refresh_token)
             self.authCodeLineEdit.clear()
             self._save_settings()
@@ -459,7 +460,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 )
             else:
                 self._set_status("Strava refresh token saved locally in QGIS settings.")
-        except StravaClientError as exc:
+        except ProviderError as exc:
             self._show_error("Token exchange failed", str(exc))
             self._set_status("Could not exchange the Strava authorization code")
 
@@ -486,22 +487,22 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._save_settings()
         try:
-            client = self.sync_controller.build_client(
+            client = self.sync_controller.build_strava_provider(
                 client_id=self.clientIdLineEdit.text().strip(),
                 client_secret=self.clientSecretLineEdit.text().strip(),
                 refresh_token=self.refreshTokenLineEdit.text().strip(),
                 cache=self.cache,
                 require_refresh_token=True,
             )
-        except StravaClientError as exc:
+        except ProviderError as exc:
             self._show_error("Strava import failed", str(exc))
             self._set_status("Strava fetch failed")
             return
 
         # Issue #38: fetch all activities — no date filtering at import time.
         # Date filters are visualization-only (applied post-import to loaded layers).
-        self._fetch_task = StravaFetchTask(
-            client=client,
+        self._fetch_task = FetchTask(
+            provider=client,
             per_page=self.perPageSpinBox.value(),
             max_pages=self.maxPagesSpinBox.value(),
             before=None,
@@ -520,7 +521,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.exchangeCodeButton.setEnabled(not running)
         self.openAuthorizeButton.setEnabled(not running)
 
-    def _on_fetch_finished(self, activities, error, cancelled, client):
+    def _on_fetch_finished(self, activities, error, cancelled, provider):
         """Called on the main thread when the background fetch completes."""
         self._fetch_task = None
         self._set_fetch_running(False)
@@ -535,7 +536,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self.activities = activities
-        metadata = self.sync_controller.build_sync_metadata(activities, client)
+        metadata = self.sync_controller.build_sync_metadata(activities, provider)
         detailed_count = metadata["detailed_count"]
         today_str = metadata["today_str"]
         self.last_fetch_context = metadata
@@ -551,7 +552,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
         )
         self._refresh_activity_preview()
-        self._set_status(self.sync_controller.fetch_status_text(client, len(self.activities), detailed_count))
+        self._set_status(self.sync_controller.fetch_status_text(provider, len(self.activities), detailed_count))
 
     def on_load_clicked(self):
         self._save_settings()
@@ -766,7 +767,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
 
     def _redirect_uri(self):
-        return self.redirectUriLineEdit.text().strip() or StravaClient.DEFAULT_REDIRECT_URI
+        return self.redirectUriLineEdit.text().strip() or StravaProvider.DEFAULT_REDIRECT_URI
 
     def _qdate_to_date(self, value):
         return date(value.year(), value.month(), value.day())

--- a/strava_provider.py
+++ b/strava_provider.py
@@ -1,0 +1,95 @@
+"""Strava implementation of the :class:`ActivityProvider` protocol.
+
+Wraps :class:`StravaClient` and translates Strava-specific errors into the
+provider-neutral :class:`ProviderError`.
+"""
+
+from .provider import ProviderError
+from .strava_client import StravaClient, StravaClientError
+
+
+class StravaProvider:
+    """ActivityProvider backed by the Strava API.
+
+    Wraps :class:`StravaClient`, exposing the provider-neutral interface
+    defined by :class:`ActivityProvider` while also making Strava-specific
+    authorisation helpers available for the UI layer.
+    """
+
+    source_name = "strava"
+    DEFAULT_REDIRECT_URI = StravaClient.DEFAULT_REDIRECT_URI
+
+    def __init__(self, client_id=None, client_secret=None, refresh_token=None, cache=None):
+        self._client = StravaClient(
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+            cache=cache,
+        )
+
+    # ------------------------------------------------------------------
+    # ActivityProvider protocol
+    # ------------------------------------------------------------------
+
+    @property
+    def last_stream_enrichment_stats(self):
+        return self._client.last_stream_enrichment_stats
+
+    @property
+    def last_rate_limit(self):
+        return self._client.last_rate_limit
+
+    def fetch_activities(
+        self,
+        per_page=200,
+        max_pages=0,
+        before=None,
+        after=None,
+        use_detailed_streams=False,
+        max_detailed_activities=None,
+    ):
+        """Fetch activities from Strava.
+
+        Delegates to :meth:`StravaClient.fetch_activities` and translates any
+        :class:`StravaClientError` into a provider-neutral :class:`ProviderError`.
+        """
+        try:
+            return self._client.fetch_activities(
+                per_page=per_page,
+                max_pages=max_pages,
+                before=before,
+                after=after,
+                use_detailed_streams=use_detailed_streams,
+                max_detailed_activities=max_detailed_activities,
+            )
+        except StravaClientError as exc:
+            raise ProviderError(str(exc)) from exc
+
+    # ------------------------------------------------------------------
+    # Strava-specific: OAuth authorisation helpers
+    # ------------------------------------------------------------------
+
+    def has_client_credentials(self):
+        """Return True if both client_id and client_secret are set."""
+        return self._client.has_client_credentials()
+
+    def has_refresh_token(self):
+        """Return True if a refresh token is available."""
+        return bool(self._client.refresh_token)
+
+    def build_authorize_url(self, redirect_uri=None):
+        """Build the Strava OAuth authorisation URL."""
+        try:
+            return self._client.build_authorize_url(redirect_uri=redirect_uri)
+        except StravaClientError as exc:
+            raise ProviderError(str(exc)) from exc
+
+    def exchange_code_for_tokens(self, authorization_code, redirect_uri=None):
+        """Exchange an authorisation code for access and refresh tokens."""
+        try:
+            return self._client.exchange_code_for_tokens(
+                authorization_code=authorization_code,
+                redirect_uri=redirect_uri,
+            )
+        except StravaClientError as exc:
+            raise ProviderError(str(exc)) from exc

--- a/sync_controller.py
+++ b/sync_controller.py
@@ -1,55 +1,57 @@
 import logging
 from datetime import date
 
-from .strava_client import StravaClient, StravaClientError
+from .provider import ProviderError
+from .strava_provider import StravaProvider
 
 logger = logging.getLogger(__name__)
 
 
 class SyncController:
-    """Orchestrates Strava fetch/sync logic independent of the UI."""
+    """Orchestrates provider fetch/sync logic independent of the UI."""
 
-    def build_client(self, client_id, client_secret, refresh_token, cache=None, require_refresh_token=True):
-        """Create and validate a :class:`StravaClient`."""
-        client = StravaClient(
+    def build_strava_provider(self, client_id, client_secret, refresh_token, cache=None, require_refresh_token=True):
+        """Create and validate a :class:`StravaProvider`."""
+        provider = StravaProvider(
             client_id=client_id,
             client_secret=client_secret,
             refresh_token=refresh_token,
             cache=cache,
         )
-        if not client.has_client_credentials():
-            raise StravaClientError("Enter Strava client ID and client secret first.")
-        if require_refresh_token and not client.refresh_token:
-            raise StravaClientError(
+        if not provider.has_client_credentials():
+            raise ProviderError("Enter Strava client ID and client secret first.")
+        if require_refresh_token and not provider.has_refresh_token():
+            raise ProviderError(
                 "Enter a refresh token, or use the built-in authorization flow to generate one."
             )
-        return client
+        return provider
 
-    def build_sync_metadata(self, activities, client):
+    def build_sync_metadata(self, activities, provider):
         """Return a sync-context dict from a completed fetch."""
         detailed_count = sum(1 for a in activities if a.geometry_source == "stream")
         today_str = date.today().isoformat()
         return {
-            "provider": "strava",
+            "provider": provider.source_name,
             "before_epoch": None,
             "after_epoch": None,
             "fetched_count": len(activities),
             "detailed_count": detailed_count,
-            "stream_stats": client.last_stream_enrichment_stats,
-            "rate_limit": client.last_rate_limit,
+            "stream_stats": provider.last_stream_enrichment_stats,
+            "rate_limit": provider.last_rate_limit,
             "is_full_sync": True,
             "today_str": today_str,
         }
 
-    def fetch_status_text(self, client, activity_count, detailed_count):
+    def fetch_status_text(self, provider, activity_count, detailed_count):
         """Build a human-readable status string for a completed fetch."""
-        stream_stats = client.last_stream_enrichment_stats or {}
-        rate_limit_note = self._rate_limit_note(client.last_rate_limit)
+        stream_stats = provider.last_stream_enrichment_stats or {}
+        rate_limit_note = self._rate_limit_note(provider.last_rate_limit)
         return (
-            "Fetched {activity_count} activities from Strava, detailed tracks: {detailed_count}, "
+            "Fetched {activity_count} activities from {source}, detailed tracks: {detailed_count}, "
             "cached streams: {cached}, downloaded streams: {downloaded}, rate-limit skips: {skipped}.{rate_note}"
         ).format(
             activity_count=activity_count,
+            source=provider.source_name,
             detailed_count=detailed_count,
             cached=stream_stats.get("cached", 0),
             downloaded=stream_stats.get("downloaded", 0),

--- a/tests/test_fetch_task.py
+++ b/tests/test_fetch_task.py
@@ -1,12 +1,12 @@
-"""Tests for StravaFetchTask.
+"""Tests for FetchTask.
 
 These tests exercise the task logic without a live QGIS instance by
-subclassing StravaFetchTask and stubbing out the QgsTask infrastructure
+subclassing FetchTask and stubbing out the QgsTask infrastructure
 (``isCanceled``, ``finished``).
 """
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
 
@@ -42,7 +42,8 @@ _qgis.core = _qgis_core
 sys.modules.setdefault("qgis", _qgis)
 sys.modules.setdefault("qgis.core", _qgis_core)
 
-from qfit.fetch_task import StravaFetchTask  # noqa: E402  (import after stub)
+from qfit.fetch_task import FetchTask  # noqa: E402  (import after stub)
+from qfit.provider import ProviderError  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -60,7 +61,7 @@ def _run_task(task):
 # Tests
 # ---------------------------------------------------------------------------
 
-class TestStravaFetchTaskSuccess(unittest.TestCase):
+class TestFetchTaskSuccess(unittest.TestCase):
     def setUp(self):
         self.received = {}
 
@@ -70,13 +71,13 @@ class TestStravaFetchTaskSuccess(unittest.TestCase):
         mock_activity = MagicMock()
         mock_activity.geometry_source = "summary_polyline"
 
-        self.mock_client = MagicMock()
-        self.mock_client.fetch_activities.return_value = [mock_activity]
-        self.mock_client.last_stream_enrichment_stats = {}
-        self.mock_client.last_rate_limit = None
+        self.mock_provider = MagicMock()
+        self.mock_provider.fetch_activities.return_value = [mock_activity]
+        self.mock_provider.last_stream_enrichment_stats = {}
+        self.mock_provider.last_rate_limit = None
 
-        self.task = StravaFetchTask(
-            client=self.mock_client,
+        self.task = FetchTask(
+            provider=self.mock_provider,
             per_page=200,
             max_pages=0,
             before=None,
@@ -97,9 +98,13 @@ class TestStravaFetchTaskSuccess(unittest.TestCase):
         self.assertIsNone(self.received.get("error"))
         self.assertFalse(self.received.get("cancelled"))
 
+    def test_finished_callback_receives_provider(self):
+        _run_task(self.task)
+        self.assertIs(self.received.get("provider"), self.mock_provider)
+
     def test_fetch_activities_called_with_correct_params(self):
         _run_task(self.task)
-        self.mock_client.fetch_activities.assert_called_once_with(
+        self.mock_provider.fetch_activities.assert_called_once_with(
             per_page=200,
             max_pages=0,
             before=None,
@@ -109,20 +114,18 @@ class TestStravaFetchTaskSuccess(unittest.TestCase):
         )
 
 
-class TestStravaFetchTaskError(unittest.TestCase):
+class TestFetchTaskError(unittest.TestCase):
     def setUp(self):
         self.received = {}
 
         def on_finished(**kwargs):
             self.received.update(kwargs)
 
-        from qfit.strava_client import StravaClientError
+        self.mock_provider = MagicMock()
+        self.mock_provider.fetch_activities.side_effect = ProviderError("rate limit hit")
 
-        self.mock_client = MagicMock()
-        self.mock_client.fetch_activities.side_effect = StravaClientError("rate limit hit")
-
-        self.task = StravaFetchTask(
-            client=self.mock_client,
+        self.task = FetchTask(
+            provider=self.mock_provider,
             per_page=200,
             max_pages=0,
             before=None,
@@ -143,7 +146,7 @@ class TestStravaFetchTaskError(unittest.TestCase):
         self.assertFalse(self.received.get("cancelled"))
 
 
-class TestStravaFetchTaskCancellation(unittest.TestCase):
+class TestFetchTaskCancellation(unittest.TestCase):
     def setUp(self):
         self.received = {}
 
@@ -153,11 +156,11 @@ class TestStravaFetchTaskCancellation(unittest.TestCase):
         mock_activity = MagicMock()
         mock_activity.geometry_source = "summary_polyline"
 
-        self.mock_client = MagicMock()
-        self.mock_client.fetch_activities.return_value = [mock_activity]
+        self.mock_provider = MagicMock()
+        self.mock_provider.fetch_activities.return_value = [mock_activity]
 
-        self.task = StravaFetchTask(
-            client=self.mock_client,
+        self.task = FetchTask(
+            provider=self.mock_provider,
             per_page=200,
             max_pages=0,
             before=None,
@@ -177,14 +180,14 @@ class TestStravaFetchTaskCancellation(unittest.TestCase):
         self.assertTrue(self.received.get("cancelled"))
 
 
-class TestStravaFetchTaskNoCallback(unittest.TestCase):
+class TestFetchTaskNoCallback(unittest.TestCase):
     """finished() must not raise even if on_finished is None."""
 
     def test_finished_without_callback(self):
-        mock_client = MagicMock()
-        mock_client.fetch_activities.return_value = []
-        task = StravaFetchTask(
-            client=mock_client,
+        mock_provider = MagicMock()
+        mock_provider.fetch_activities.return_value = []
+        task = FetchTask(
+            provider=mock_provider,
             per_page=200,
             max_pages=0,
             before=None,
@@ -198,16 +201,16 @@ class TestStravaFetchTaskNoCallback(unittest.TestCase):
         task.finished(True)
 
 
-class TestStravaFetchTaskUnexpectedError(unittest.TestCase):
+class TestFetchTaskUnexpectedError(unittest.TestCase):
     """The worker-thread safety net catches unexpected errors and reports them."""
 
     def test_unexpected_exception_caught_and_reported(self):
         received = {}
-        mock_client = MagicMock()
-        mock_client.fetch_activities.side_effect = ValueError("bad data")
+        mock_provider = MagicMock()
+        mock_provider.fetch_activities.side_effect = ValueError("bad data")
 
-        task = StravaFetchTask(
-            client=mock_client,
+        task = FetchTask(
+            provider=mock_provider,
             per_page=200,
             max_pages=0,
             before=None,

--- a/tests/test_strava_provider.py
+++ b/tests/test_strava_provider.py
@@ -1,0 +1,142 @@
+"""Tests for StravaProvider and the ActivityProvider protocol."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+from qfit.provider import ActivityProvider, ProviderError
+from qfit.strava_provider import StravaProvider
+
+
+class TestStravaProviderProtocol(unittest.TestCase):
+    """StravaProvider must satisfy the ActivityProvider protocol."""
+
+    def test_strava_provider_satisfies_activity_provider(self):
+        provider = StravaProvider(client_id="id", client_secret="secret", refresh_token="token")
+        self.assertIsInstance(provider, ActivityProvider)
+
+    def test_source_name_is_strava(self):
+        provider = StravaProvider()
+        self.assertEqual(provider.source_name, "strava")
+
+    def test_default_redirect_uri_matches_strava_client(self):
+        from qfit.strava_client import StravaClient
+        self.assertEqual(StravaProvider.DEFAULT_REDIRECT_URI, StravaClient.DEFAULT_REDIRECT_URI)
+
+
+class TestStravaProviderFetchActivities(unittest.TestCase):
+    """fetch_activities delegates to StravaClient and translates errors."""
+
+    def _make_provider(self):
+        provider = StravaProvider(client_id="id", client_secret="secret", refresh_token="token")
+        provider._client = MagicMock()
+        return provider
+
+    def test_fetch_activities_delegates_to_client(self):
+        provider = self._make_provider()
+        provider._client.fetch_activities.return_value = []
+        result = provider.fetch_activities(per_page=50, max_pages=2)
+        provider._client.fetch_activities.assert_called_once_with(
+            per_page=50,
+            max_pages=2,
+            before=None,
+            after=None,
+            use_detailed_streams=False,
+            max_detailed_activities=None,
+        )
+        self.assertEqual(result, [])
+
+    def test_fetch_activities_translates_strava_client_error(self):
+        from qfit.strava_client import StravaClientError
+        provider = self._make_provider()
+        provider._client.fetch_activities.side_effect = StravaClientError("API error")
+        with self.assertRaises(ProviderError) as ctx:
+            provider.fetch_activities()
+        self.assertIn("API error", str(ctx.exception))
+
+    def test_fetch_activities_error_preserves_cause(self):
+        from qfit.strava_client import StravaClientError
+        provider = self._make_provider()
+        original = StravaClientError("original")
+        provider._client.fetch_activities.side_effect = original
+        try:
+            provider.fetch_activities()
+        except ProviderError as exc:
+            self.assertIs(exc.__cause__, original)
+
+
+class TestStravaProviderProperties(unittest.TestCase):
+    """last_stream_enrichment_stats and last_rate_limit proxy to the client."""
+
+    def _make_provider(self):
+        provider = StravaProvider()
+        provider._client = MagicMock()
+        return provider
+
+    def test_last_stream_enrichment_stats_proxied(self):
+        provider = self._make_provider()
+        provider._client.last_stream_enrichment_stats = {"cached": 3}
+        self.assertEqual(provider.last_stream_enrichment_stats, {"cached": 3})
+
+    def test_last_rate_limit_proxied(self):
+        provider = self._make_provider()
+        provider._client.last_rate_limit = {"short_remaining": 100}
+        self.assertEqual(provider.last_rate_limit, {"short_remaining": 100})
+
+
+class TestStravaProviderCredentials(unittest.TestCase):
+    def test_has_client_credentials_delegates(self):
+        provider = StravaProvider(client_id="id", client_secret="secret")
+        self.assertTrue(provider.has_client_credentials())
+
+    def test_has_client_credentials_false_when_empty(self):
+        provider = StravaProvider()
+        self.assertFalse(provider.has_client_credentials())
+
+    def test_has_refresh_token_true(self):
+        provider = StravaProvider(refresh_token="tok")
+        self.assertTrue(provider.has_refresh_token())
+
+    def test_has_refresh_token_false_when_empty(self):
+        provider = StravaProvider()
+        self.assertFalse(provider.has_refresh_token())
+
+
+class TestStravaProviderAuthMethods(unittest.TestCase):
+    """build_authorize_url and exchange_code_for_tokens translate errors."""
+
+    def _make_provider(self):
+        provider = StravaProvider(client_id="id", client_secret="secret")
+        provider._client = MagicMock()
+        return provider
+
+    def test_build_authorize_url_delegates(self):
+        provider = self._make_provider()
+        provider._client.build_authorize_url.return_value = "https://example.com/auth"
+        url = provider.build_authorize_url(redirect_uri="http://localhost/cb")
+        self.assertEqual(url, "https://example.com/auth")
+        provider._client.build_authorize_url.assert_called_once_with(redirect_uri="http://localhost/cb")
+
+    def test_build_authorize_url_translates_error(self):
+        from qfit.strava_client import StravaClientError
+        provider = self._make_provider()
+        provider._client.build_authorize_url.side_effect = StravaClientError("no client id")
+        with self.assertRaises(ProviderError):
+            provider.build_authorize_url()
+
+    def test_exchange_code_for_tokens_delegates(self):
+        provider = self._make_provider()
+        provider._client.exchange_code_for_tokens.return_value = {"access_token": "abc"}
+        payload = provider.exchange_code_for_tokens(authorization_code="code123")
+        self.assertEqual(payload["access_token"], "abc")
+
+    def test_exchange_code_for_tokens_translates_error(self):
+        from qfit.strava_client import StravaClientError
+        provider = self._make_provider()
+        provider._client.exchange_code_for_tokens.side_effect = StravaClientError("bad code")
+        with self.assertRaises(ProviderError):
+            provider.exchange_code_for_tokens(authorization_code="bad")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -1,43 +1,44 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
 
 from tests import _path  # noqa: F401
-from qfit.strava_client import StravaClient, StravaClientError
+from qfit.provider import ProviderError
+from qfit.strava_provider import StravaProvider
 from qfit.sync_controller import SyncController
 
 
-class BuildClientTests(unittest.TestCase):
-    def test_build_client_returns_strava_client(self):
+class BuildStravaProviderTests(unittest.TestCase):
+    def test_build_strava_provider_returns_strava_provider(self):
         ctrl = SyncController()
-        client = ctrl.build_client("id", "secret", "token")
-        self.assertIsInstance(client, StravaClient)
+        provider = ctrl.build_strava_provider("id", "secret", "token")
+        self.assertIsInstance(provider, StravaProvider)
 
-    def test_build_client_raises_without_credentials(self):
+    def test_build_strava_provider_raises_without_credentials(self):
         ctrl = SyncController()
-        with self.assertRaises(StravaClientError):
-            ctrl.build_client("", "", "token")
+        with self.assertRaises(ProviderError):
+            ctrl.build_strava_provider("", "", "token")
 
-    def test_build_client_raises_without_refresh_token(self):
+    def test_build_strava_provider_raises_without_refresh_token(self):
         ctrl = SyncController()
-        with self.assertRaises(StravaClientError):
-            ctrl.build_client("id", "secret", "")
+        with self.assertRaises(ProviderError):
+            ctrl.build_strava_provider("id", "secret", "")
 
-    def test_build_client_allows_missing_refresh_token_when_not_required(self):
+    def test_build_strava_provider_allows_missing_refresh_token_when_not_required(self):
         ctrl = SyncController()
-        client = ctrl.build_client("id", "secret", "", require_refresh_token=False)
-        self.assertIsInstance(client, StravaClient)
+        provider = ctrl.build_strava_provider("id", "secret", "", require_refresh_token=False)
+        self.assertIsInstance(provider, StravaProvider)
 
 
 class BuildSyncMetadataTests(unittest.TestCase):
     def test_metadata_fields(self):
         ctrl = SyncController()
         activity = SimpleNamespace(geometry_source="stream")
-        client = SimpleNamespace(
+        provider = SimpleNamespace(
+            source_name="strava",
             last_stream_enrichment_stats={"cached": 1},
             last_rate_limit={"short_remaining": 10},
         )
-        meta = ctrl.build_sync_metadata([activity], client)
+        meta = ctrl.build_sync_metadata([activity], provider)
         self.assertEqual(meta["provider"], "strava")
         self.assertEqual(meta["fetched_count"], 1)
         self.assertEqual(meta["detailed_count"], 1)
@@ -50,40 +51,67 @@ class BuildSyncMetadataTests(unittest.TestCase):
             SimpleNamespace(geometry_source="stream"),
             SimpleNamespace(geometry_source="polyline"),
         ]
-        client = SimpleNamespace(last_stream_enrichment_stats=None, last_rate_limit=None)
-        meta = ctrl.build_sync_metadata(activities, client)
+        provider = SimpleNamespace(
+            source_name="strava",
+            last_stream_enrichment_stats=None,
+            last_rate_limit=None,
+        )
+        meta = ctrl.build_sync_metadata(activities, provider)
         self.assertEqual(meta["detailed_count"], 1)
         self.assertEqual(meta["fetched_count"], 2)
+
+    def test_metadata_uses_provider_source_name(self):
+        ctrl = SyncController()
+        provider = SimpleNamespace(
+            source_name="gpx",
+            last_stream_enrichment_stats=None,
+            last_rate_limit=None,
+        )
+        meta = ctrl.build_sync_metadata([], provider)
+        self.assertEqual(meta["provider"], "gpx")
 
 
 class FetchStatusTextTests(unittest.TestCase):
     def test_basic_status_text(self):
         ctrl = SyncController()
-        client = SimpleNamespace(
+        provider = SimpleNamespace(
+            source_name="strava",
             last_stream_enrichment_stats={"cached": 2, "downloaded": 3, "skipped_rate_limit": 0},
             last_rate_limit=None,
         )
-        text = ctrl.fetch_status_text(client, 10, 5)
+        text = ctrl.fetch_status_text(provider, 10, 5)
         self.assertIn("10 activities", text)
         self.assertIn("detailed tracks: 5", text)
         self.assertIn("cached streams: 2", text)
 
+    def test_status_text_includes_source_name(self):
+        ctrl = SyncController()
+        provider = SimpleNamespace(
+            source_name="strava",
+            last_stream_enrichment_stats={},
+            last_rate_limit=None,
+        )
+        text = ctrl.fetch_status_text(provider, 3, 0)
+        self.assertIn("strava", text)
+
     def test_rate_limit_note_included(self):
         ctrl = SyncController()
-        client = SimpleNamespace(
+        provider = SimpleNamespace(
+            source_name="strava",
             last_stream_enrichment_stats={},
             last_rate_limit={"short_remaining": 50, "long_remaining": 900},
         )
-        text = ctrl.fetch_status_text(client, 1, 0)
+        text = ctrl.fetch_status_text(provider, 1, 0)
         self.assertIn("Remaining rate limit", text)
         self.assertIn("short=50", text)
         self.assertIn("long=900", text)
 
     def test_no_rate_limit(self):
         ctrl = SyncController()
-        client = SimpleNamespace(
+        provider = SimpleNamespace(
+            source_name="strava",
             last_stream_enrichment_stats=None,
             last_rate_limit=None,
         )
-        text = ctrl.fetch_status_text(client, 0, 0)
+        text = ctrl.fetch_status_text(provider, 0, 0)
         self.assertNotIn("rate limit", text.lower().replace("rate-limit", ""))


### PR DESCRIPTION
## Summary

- Adds `provider.py` with an `ActivityProvider` `Protocol` and a shared `ProviderError` exception — the canonical contract for all future activity sources
- Adds `strava_provider.py` with `StravaProvider`, which wraps the existing `StravaClient`, implements the protocol, translates `StravaClientError` → `ProviderError`, and also exposes Strava-specific OAuth helpers (`build_authorize_url`, `exchange_code_for_tokens`)
- Renames `StravaFetchTask` → `FetchTask` in `fetch_task.py`; the task now accepts any `ActivityProvider` and catches the provider-neutral `ProviderError`
- Updates `SyncController`: `build_client` → `build_strava_provider`; `build_sync_metadata` and `fetch_status_text` use `provider.source_name` instead of the hard-coded string `"strava"`
- Updates `qfit_dockwidget.py` to work entirely through the new provider boundary

Strava behaviour is unchanged; only the internal seam is new.

## Test plan

- [ ] `python3 -m pytest tests/ -x -q --tb=short` — all 394 tests pass, 127 skipped (QGIS-only)
- [ ] New `tests/test_strava_provider.py` covers: protocol conformance, `fetch_activities` delegation and error translation, property proxies, credential helpers, and OAuth auth methods
- [ ] Updated `tests/test_sync_controller.py` and `tests/test_fetch_task.py` reflect the renamed API

Closes #125 (first increment)

@codex code review please

🤖 Generated with [Claude Code](https://claude.com/claude-code)