### PR TITLE
refactor: extract gpkg point layer builder

### DIFF
--- a/gpkg_layer_builders.py
+++ b/gpkg_layer_builders.py
@@ -5,6 +5,7 @@ This module provides standalone functions that build ``QgsVectorLayer`` objects
 from activity records and atlas plans.  It contains no I/O — callers are
 responsible for writing the returned layers to disk.
 
+The activity-point builder lives in :mod:`gpkg_point_layer_builder`.
 Geometry-less atlas helper-table builders (document summary, cover highlights,
 page detail items, profile samples, TOC) live in
 :mod:`gpkg_atlas_table_builders`.
@@ -22,7 +23,6 @@ from qgis.core import (
 
 from .gpkg_schema import (
     ATLAS_FIELDS,
-    POINT_FIELDS,
     START_FIELDS,
     TRACK_FIELDS,
     make_qgs_fields,
@@ -36,7 +36,7 @@ from .gpkg_atlas_table_builders import (
     build_toc_layer,
 )
 from .atlas.publish_atlas import build_atlas_page_plans
-from .time_utils import add_seconds_iso
+from .gpkg_point_layer_builder import build_point_layer
 
 
 def build_track_layer(records):
@@ -118,62 +118,6 @@ def build_start_layer(records):
         feature["distance_m"] = record.get("distance_m")
         feature["last_synced_at"] = record.get("last_synced_at")
         features.append(feature)
-
-    provider.addFeatures(features)
-    layer.updateExtents()
-    return layer
-
-
-def build_point_layer(records, write_activity_points=False, point_stride=1):
-    """Build and return a memory ``QgsVectorLayer`` of per-point stream data."""
-    layer = QgsVectorLayer("Point?crs=EPSG:4326", "activity_points", "memory")
-    provider = layer.dataProvider()
-    provider.addAttributes(make_qgs_fields(POINT_FIELDS))
-    layer.updateFields()
-
-    features = []
-    if not write_activity_points:
-        provider.addFeatures(features)
-        layer.updateExtents()
-        return layer
-
-    stride = max(1, int(point_stride or 1))
-    for index, record in enumerate(records, start=1):
-        geometry_points = record.get("geometry_points") or []
-        if len(geometry_points) < 1:
-            continue
-
-        stream_metrics = ((record.get("details_json") or {}).get("stream_metrics") or {})
-        sampled_points = _sample_points(geometry_points, stride)
-        total_points = max(1, len(geometry_points) - 1)
-        for point_index, lat, lon in sampled_points:
-            stream_time_s = _metric_value(stream_metrics, "time", point_index, as_int=True)
-            feature = QgsFeature(layer.fields())
-            feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(float(lon), float(lat))))
-            feature["activity_fk"] = index
-            feature["source"] = record.get("source")
-            feature["source_activity_id"] = record.get("source_activity_id")
-            feature["point_index"] = point_index
-            feature["point_ratio"] = float(point_index) / float(total_points)
-            feature["stream_time_s"] = stream_time_s
-            feature["point_timestamp_utc"] = add_seconds_iso(record.get("start_date"), stream_time_s)
-            feature["point_timestamp_local"] = add_seconds_iso(record.get("start_date_local"), stream_time_s)
-            feature["stream_distance_m"] = _metric_value(stream_metrics, "distance", point_index)
-            feature["altitude_m"] = _metric_value(stream_metrics, "altitude", point_index)
-            feature["heartrate_bpm"] = _metric_value(stream_metrics, "heartrate", point_index)
-            feature["cadence_rpm"] = _metric_value(stream_metrics, "cadence", point_index)
-            feature["watts"] = _metric_value(stream_metrics, "watts", point_index)
-            feature["velocity_mps"] = _metric_value(stream_metrics, "velocity_smooth", point_index)
-            feature["temp_c"] = _metric_value(stream_metrics, "temp", point_index)
-            feature["grade_smooth_pct"] = _metric_value(stream_metrics, "grade_smooth", point_index)
-            feature["moving"] = _metric_value(stream_metrics, "moving", point_index, as_int=True)
-            feature["name"] = record.get("name")
-            feature["activity_type"] = record.get("activity_type")
-            feature["start_date"] = record.get("start_date")
-            feature["distance_m"] = record.get("distance_m")
-            feature["geometry_source"] = record.get("geometry_source") or "stream"
-            feature["last_synced_at"] = record.get("last_synced_at")
-            features.append(feature)
 
     provider.addFeatures(features)
     layer.updateExtents()
@@ -301,33 +245,3 @@ def _fallback_geometry(record):
     ])
 
 
-def _sample_points(points, stride):
-    if not points:
-        return []
-    if stride <= 1:
-        return [(index, lat, lon) for index, (lat, lon) in enumerate(points)]
-
-    sampled_indexes = list(range(0, len(points), stride))
-    if sampled_indexes[-1] != len(points) - 1:
-        sampled_indexes.append(len(points) - 1)
-    return [(index, points[index][0], points[index][1]) for index in sampled_indexes]
-
-
-def _metric_value(stream_metrics, key, index, as_int=False):
-    values = stream_metrics.get(key) if isinstance(stream_metrics, dict) else None
-    if not isinstance(values, list) or index >= len(values):
-        return None
-    value = values[index]
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return int(value) if as_int else value
-    if as_int:
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None

--- a/gpkg_point_layer_builder.py
+++ b/gpkg_point_layer_builder.py
@@ -1,0 +1,110 @@
+"""
+GeoPackage activity-point layer builder for qfit.
+
+This module provides the standalone ``build_point_layer`` function plus the
+point-stream sampling helpers it depends on. It contains no I/O — callers are
+responsible for writing the returned layer to disk.
+
+The remaining geometry and atlas builders live in :mod:`gpkg_layer_builders`.
+"""
+
+from qgis.core import (
+    QgsFeature,
+    QgsGeometry,
+    QgsPointXY,
+    QgsVectorLayer,
+)
+
+from .gpkg_schema import (
+    POINT_FIELDS,
+    make_qgs_fields,
+)
+from .time_utils import add_seconds_iso
+
+
+def build_point_layer(records, write_activity_points=False, point_stride=1):
+    """Build and return a memory ``QgsVectorLayer`` of per-point stream data."""
+    layer = QgsVectorLayer("Point?crs=EPSG:4326", "activity_points", "memory")
+    provider = layer.dataProvider()
+    provider.addAttributes(make_qgs_fields(POINT_FIELDS))
+    layer.updateFields()
+
+    features = []
+    if not write_activity_points:
+        provider.addFeatures(features)
+        layer.updateExtents()
+        return layer
+
+    stride = max(1, int(point_stride or 1))
+    for index, record in enumerate(records, start=1):
+        geometry_points = record.get("geometry_points") or []
+        if len(geometry_points) < 1:
+            continue
+
+        stream_metrics = ((record.get("details_json") or {}).get("stream_metrics") or {})
+        sampled_points = _sample_points(geometry_points, stride)
+        total_points = max(1, len(geometry_points) - 1)
+        for point_index, lat, lon in sampled_points:
+            stream_time_s = _metric_value(stream_metrics, "time", point_index, as_int=True)
+            feature = QgsFeature(layer.fields())
+            feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(float(lon), float(lat))))
+            feature["activity_fk"] = index
+            feature["source"] = record.get("source")
+            feature["source_activity_id"] = record.get("source_activity_id")
+            feature["point_index"] = point_index
+            feature["point_ratio"] = float(point_index) / float(total_points)
+            feature["stream_time_s"] = stream_time_s
+            feature["point_timestamp_utc"] = add_seconds_iso(record.get("start_date"), stream_time_s)
+            feature["point_timestamp_local"] = add_seconds_iso(record.get("start_date_local"), stream_time_s)
+            feature["stream_distance_m"] = _metric_value(stream_metrics, "distance", point_index)
+            feature["altitude_m"] = _metric_value(stream_metrics, "altitude", point_index)
+            feature["heartrate_bpm"] = _metric_value(stream_metrics, "heartrate", point_index)
+            feature["cadence_rpm"] = _metric_value(stream_metrics, "cadence", point_index)
+            feature["watts"] = _metric_value(stream_metrics, "watts", point_index)
+            feature["velocity_mps"] = _metric_value(stream_metrics, "velocity_smooth", point_index)
+            feature["temp_c"] = _metric_value(stream_metrics, "temp", point_index)
+            feature["grade_smooth_pct"] = _metric_value(stream_metrics, "grade_smooth", point_index)
+            feature["moving"] = _metric_value(stream_metrics, "moving", point_index, as_int=True)
+            feature["name"] = record.get("name")
+            feature["activity_type"] = record.get("activity_type")
+            feature["start_date"] = record.get("start_date")
+            feature["distance_m"] = record.get("distance_m")
+            feature["geometry_source"] = record.get("geometry_source") or "stream"
+            feature["last_synced_at"] = record.get("last_synced_at")
+            features.append(feature)
+
+    provider.addFeatures(features)
+    layer.updateExtents()
+    return layer
+
+
+def _sample_points(points, stride):
+    if not points:
+        return []
+    if stride <= 1:
+        return [(index, lat, lon) for index, (lat, lon) in enumerate(points)]
+
+    sampled_indexes = list(range(0, len(points), stride))
+    if sampled_indexes[-1] != len(points) - 1:
+        sampled_indexes.append(len(points) - 1)
+    return [(index, points[index][0], points[index][1]) for index in sampled_indexes]
+
+
+def _metric_value(stream_metrics, key, index, as_int=False):
+    values = stream_metrics.get(key) if isinstance(stream_metrics, dict) else None
+    if not isinstance(values, list) or index >= len(values):
+        return None
+    value = values[index]
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value) if as_int else value
+    if as_int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/gpkg_write_orchestration.py
+++ b/gpkg_write_orchestration.py
@@ -18,10 +18,10 @@ but contains no schema definitions or repository logic.
 from .gpkg_io import write_layer_to_gpkg
 from .gpkg_layer_builders import (
     build_atlas_layer,
-    build_point_layer,
     build_start_layer,
     build_track_layer,
 )
+from .gpkg_point_layer_builder import build_point_layer
 from .gpkg_atlas_table_builders import (
     build_cover_highlight_layer,
     build_document_summary_layer,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,5 +6,5 @@ sonar.sources=.
 sonar.tests=tests
 sonar.exclusions=dist/**,.git/**,.github/**,__pycache__/**,*.pyc,tests/**
 sonar.test.inclusions=tests/**/*.py
-sonar.coverage.exclusions=__init__.py,gpkg_atlas_table_builders.py,gpkg_io.py,gpkg_layer_builders.py,gpkg_schema.py,gpkg_write_orchestration.py,gpkg_writer.py,layer_manager.py,layer_style_service.py,qfit_config_dialog.py,qfit_dockwidget.py,qfit_plugin.py,scripts/**/*.py
+sonar.coverage.exclusions=__init__.py,gpkg_atlas_table_builders.py,gpkg_io.py,gpkg_layer_builders.py,gpkg_point_layer_builder.py,gpkg_schema.py,gpkg_write_orchestration.py,gpkg_writer.py,layer_manager.py,layer_style_service.py,qfit_config_dialog.py,qfit_dockwidget.py,qfit_plugin.py,scripts/**/*.py
 sonar.python.coverage.reportPaths=coverage.xml

--- a/tests/test_gpkg_layer_builders.py
+++ b/tests/test_gpkg_layer_builders.py
@@ -15,9 +15,6 @@ if QgsApplication is not None:
         _activity_geometry,
         _fallback_geometry,
         _geometry_from_points,
-        _metric_value,
-        _sample_points,
-        build_point_layer,
         build_start_layer,
         build_track_layer,
     )
@@ -25,9 +22,6 @@ else:  # pragma: no cover
     _activity_geometry = None
     _fallback_geometry = None
     _geometry_from_points = None
-    _metric_value = None
-    _sample_points = None
-    build_point_layer = None
     build_start_layer = None
     build_track_layer = None
 
@@ -40,83 +34,6 @@ def _ensure_qgis_app():
         _QGIS_APP = QgsApplication([], False)
         _QGIS_APP.initQgis()
     return _QGIS_APP
-
-
-@unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
-class SamplePointsTests(unittest.TestCase):
-    """Tests for _sample_points (pure logic, no QGIS geometry)."""
-
-    @classmethod
-    def setUpClass(cls):
-        _ensure_qgis_app()
-
-    def test_empty_points_returns_empty(self):
-        self.assertEqual(_sample_points([], 1), [])
-
-    def test_stride_one_returns_all(self):
-        points = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
-        result = _sample_points(points, 1)
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0], (0, 1.0, 2.0))
-        self.assertEqual(result[2], (2, 5.0, 6.0))
-
-    def test_stride_two_includes_last(self):
-        points = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (7.0, 8.0), (9.0, 10.0)]
-        result = _sample_points(points, 2)
-        indexes = [r[0] for r in result]
-        self.assertIn(0, indexes)
-        self.assertIn(4, indexes)  # last point always included
-
-    def test_stride_larger_than_list(self):
-        points = [(1.0, 2.0), (3.0, 4.0)]
-        result = _sample_points(points, 10)
-        indexes = [r[0] for r in result]
-        self.assertIn(0, indexes)
-        self.assertIn(1, indexes)  # last point always included
-
-    def test_single_point(self):
-        points = [(5.0, 6.0)]
-        result = _sample_points(points, 1)
-        self.assertEqual(result, [(0, 5.0, 6.0)])
-
-
-@unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
-class MetricValueTests(unittest.TestCase):
-    """Tests for _metric_value (pure logic)."""
-
-    @classmethod
-    def setUpClass(cls):
-        _ensure_qgis_app()
-
-    def test_returns_float_by_default(self):
-        self.assertEqual(_metric_value({"speed": [1.5, 2.5]}, "speed", 0), 1.5)
-
-    def test_returns_int_when_as_int(self):
-        self.assertEqual(_metric_value({"time": [10, 20]}, "time", 1, as_int=True), 20)
-
-    def test_missing_key_returns_none(self):
-        self.assertIsNone(_metric_value({"speed": [1.0]}, "missing", 0))
-
-    def test_index_out_of_range_returns_none(self):
-        self.assertIsNone(_metric_value({"speed": [1.0]}, "speed", 5))
-
-    def test_none_value_returns_none(self):
-        self.assertIsNone(_metric_value({"speed": [None]}, "speed", 0))
-
-    def test_bool_true_as_int(self):
-        self.assertEqual(_metric_value({"moving": [True]}, "moving", 0, as_int=True), 1)
-
-    def test_bool_false_as_int(self):
-        self.assertEqual(_metric_value({"moving": [False]}, "moving", 0, as_int=True), 0)
-
-    def test_non_dict_metrics_returns_none(self):
-        self.assertIsNone(_metric_value(None, "speed", 0))
-
-    def test_invalid_float_returns_none(self):
-        self.assertIsNone(_metric_value({"speed": ["bad"]}, "speed", 0))
-
-    def test_invalid_int_returns_none(self):
-        self.assertIsNone(_metric_value({"time": ["bad"]}, "time", 0, as_int=True))
 
 
 @unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
@@ -258,73 +175,6 @@ class BuildStartLayerTests(unittest.TestCase):
         layer = build_start_layer(records)
         fks = sorted(f["activity_fk"] for f in layer.getFeatures())
         self.assertEqual(fks, [1, 2])
-
-
-@unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
-class BuildPointLayerTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        _ensure_qgis_app()
-
-    def test_write_activity_points_false_returns_empty(self):
-        records = [
-            {
-                "source": "strava",
-                "source_activity_id": "1",
-                "geometry_points": [(46.5, 6.6), (46.6, 6.7)],
-            }
-        ]
-        layer = build_point_layer(records, write_activity_points=False)
-        self.assertTrue(layer.isValid())
-        self.assertEqual(layer.featureCount(), 0)
-
-    def test_write_activity_points_true_builds_features(self):
-        records = [
-            {
-                "source": "strava",
-                "source_activity_id": "1",
-                "name": "Ride",
-                "activity_type": "Ride",
-                "start_date": "2026-03-25T08:00:00Z",
-                "start_date_local": "2026-03-25T09:00:00+01:00",
-                "distance_m": 10000.0,
-                "geometry_points": [(46.5, 6.6), (46.55, 6.65), (46.6, 6.7)],
-                "details_json": {
-                    "stream_metrics": {
-                        "time": [0, 300, 600],
-                        "distance": [0.0, 5000.0, 10000.0],
-                        "altitude": [400.0, 420.0, 410.0],
-                    }
-                },
-            }
-        ]
-        layer = build_point_layer(records, write_activity_points=True, point_stride=1)
-        self.assertTrue(layer.isValid())
-        self.assertEqual(layer.featureCount(), 3)
-        features = list(layer.getFeatures())
-        self.assertEqual(features[0]["activity_fk"], 1)
-        self.assertEqual(features[0]["point_index"], 0)
-        self.assertEqual(features[0]["altitude_m"], 400.0)
-        self.assertEqual(features[-1]["point_index"], 2)
-        self.assertEqual(features[-1]["altitude_m"], 410.0)
-        self.assertEqual(features[-1]["point_ratio"], 1.0)
-
-    def test_stride_reduces_feature_count(self):
-        points = [(46.0 + i * 0.01, 6.0 + i * 0.01) for i in range(10)]
-        records = [
-            {
-                "source": "strava",
-                "source_activity_id": "1",
-                "geometry_points": points,
-            }
-        ]
-        layer_all = build_point_layer(records, write_activity_points=True, point_stride=1)
-        layer_strided = build_point_layer(records, write_activity_points=True, point_stride=3)
-        self.assertEqual(layer_all.featureCount(), 10)
-        self.assertLess(layer_strided.featureCount(), 10)
-        # last point must still be included
-        strided_indexes = sorted(f["point_index"] for f in layer_strided.getFeatures())
-        self.assertEqual(strided_indexes[-1], 9)
 
 
 if __name__ == "__main__":

--- a/tests/test_gpkg_point_layer_builder.py
+++ b/tests/test_gpkg_point_layer_builder.py
@@ -1,0 +1,175 @@
+import os
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from tests import _path  # noqa: F401
+
+try:
+    from qgis.core import QgsApplication
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    QgsApplication = None
+
+if QgsApplication is not None:
+    from qfit.gpkg_point_layer_builder import (
+        _metric_value,
+        _sample_points,
+        build_point_layer,
+    )
+else:  # pragma: no cover
+    _metric_value = None
+    _sample_points = None
+    build_point_layer = None
+
+_QGIS_APP = None
+
+
+def _ensure_qgis_app():
+    global _QGIS_APP
+    if _QGIS_APP is None:
+        _QGIS_APP = QgsApplication([], False)
+        _QGIS_APP.initQgis()
+    return _QGIS_APP
+
+
+@unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
+class SamplePointsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_qgis_app()
+
+    def test_empty_points_returns_empty(self):
+        self.assertEqual(_sample_points([], 1), [])
+
+    def test_stride_one_returns_all(self):
+        points = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+        result = _sample_points(points, 1)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], (0, 1.0, 2.0))
+        self.assertEqual(result[2], (2, 5.0, 6.0))
+
+    def test_stride_two_includes_last(self):
+        points = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (7.0, 8.0), (9.0, 10.0)]
+        result = _sample_points(points, 2)
+        indexes = [r[0] for r in result]
+        self.assertIn(0, indexes)
+        self.assertIn(4, indexes)
+
+    def test_stride_larger_than_list(self):
+        points = [(1.0, 2.0), (3.0, 4.0)]
+        result = _sample_points(points, 10)
+        indexes = [r[0] for r in result]
+        self.assertIn(0, indexes)
+        self.assertIn(1, indexes)
+
+    def test_single_point(self):
+        points = [(5.0, 6.0)]
+        result = _sample_points(points, 1)
+        self.assertEqual(result, [(0, 5.0, 6.0)])
+
+
+@unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
+class MetricValueTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_qgis_app()
+
+    def test_returns_float_by_default(self):
+        self.assertEqual(_metric_value({"speed": [1.5, 2.5]}, "speed", 0), 1.5)
+
+    def test_returns_int_when_as_int(self):
+        self.assertEqual(_metric_value({"time": [10, 20]}, "time", 1, as_int=True), 20)
+
+    def test_missing_key_returns_none(self):
+        self.assertIsNone(_metric_value({"speed": [1.0]}, "missing", 0))
+
+    def test_index_out_of_range_returns_none(self):
+        self.assertIsNone(_metric_value({"speed": [1.0]}, "speed", 5))
+
+    def test_none_value_returns_none(self):
+        self.assertIsNone(_metric_value({"speed": [None]}, "speed", 0))
+
+    def test_bool_true_as_int(self):
+        self.assertEqual(_metric_value({"moving": [True]}, "moving", 0, as_int=True), 1)
+
+    def test_bool_false_as_int(self):
+        self.assertEqual(_metric_value({"moving": [False]}, "moving", 0, as_int=True), 0)
+
+    def test_non_dict_metrics_returns_none(self):
+        self.assertIsNone(_metric_value(None, "speed", 0))
+
+    def test_invalid_float_returns_none(self):
+        self.assertIsNone(_metric_value({"speed": ["bad"]}, "speed", 0))
+
+    def test_invalid_int_returns_none(self):
+        self.assertIsNone(_metric_value({"time": ["bad"]}, "time", 0, as_int=True))
+
+
+@unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
+class BuildPointLayerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_qgis_app()
+
+    def test_write_activity_points_false_returns_empty(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "1",
+                "geometry_points": [(46.5, 6.6), (46.6, 6.7)],
+            }
+        ]
+        layer = build_point_layer(records, write_activity_points=False)
+        self.assertTrue(layer.isValid())
+        self.assertEqual(layer.featureCount(), 0)
+
+    def test_write_activity_points_true_builds_features(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "1",
+                "name": "Ride",
+                "activity_type": "Ride",
+                "start_date": "2026-03-25T08:00:00Z",
+                "start_date_local": "2026-03-25T09:00:00+01:00",
+                "distance_m": 10000.0,
+                "geometry_points": [(46.5, 6.6), (46.55, 6.65), (46.6, 6.7)],
+                "details_json": {
+                    "stream_metrics": {
+                        "time": [0, 300, 600],
+                        "distance": [0.0, 5000.0, 10000.0],
+                        "altitude": [400.0, 420.0, 410.0],
+                    }
+                },
+            }
+        ]
+        layer = build_point_layer(records, write_activity_points=True, point_stride=1)
+        self.assertTrue(layer.isValid())
+        self.assertEqual(layer.featureCount(), 3)
+        features = list(layer.getFeatures())
+        self.assertEqual(features[0]["activity_fk"], 1)
+        self.assertEqual(features[0]["point_index"], 0)
+        self.assertEqual(features[0]["altitude_m"], 400.0)
+        self.assertEqual(features[-1]["point_index"], 2)
+        self.assertEqual(features[-1]["altitude_m"], 410.0)
+        self.assertEqual(features[-1]["point_ratio"], 1.0)
+
+    def test_stride_reduces_feature_count(self):
+        points = [(46.0 + i * 0.01, 6.0 + i * 0.01) for i in range(10)]
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "1",
+                "geometry_points": points,
+            }
+        ]
+        layer_all = build_point_layer(records, write_activity_points=True, point_stride=1)
+        layer_strided = build_point_layer(records, write_activity_points=True, point_stride=3)
+        self.assertEqual(layer_all.featureCount(), 10)
+        self.assertLess(layer_strided.featureCount(), 10)
+        strided_indexes = sorted(f["point_index"] for f in layer_strided.getFeatures())
+        self.assertEqual(strided_indexes[-1], 9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract the activity-point GeoPackage layer builder into `gpkg_point_layer_builder.py`
- move point-stream sampling helpers alongside that builder, while keeping write orchestration wired to the new module
- split the focused point-layer tests into their own module so the extraction stays covered without changing behavior

## Testing
- python3 -m pytest tests/test_gpkg_point_layer_builder.py tests/test_gpkg_layer_builders.py tests/test_gpkg_atlas_table_builders.py tests/test_gpkg_write_orchestration.py tests/test_gpkg_writer.py -q --tb=short
