### PR TITLE
refactor: extract layer filter service

### DIFF
--- a/layer_filter_service.py
+++ b/layer_filter_service.py
@@ -1,0 +1,31 @@
+from .activity_query import ActivityQuery, build_subset_string
+
+
+class LayerFilterService:
+    """Applies qfit activity subset filters to loaded output layers."""
+
+    def apply_filters(
+        self,
+        layer,
+        activity_type=None,
+        date_from=None,
+        date_to=None,
+        min_distance_km=None,
+        max_distance_km=None,
+        search_text=None,
+        detailed_only=False,
+    ):
+        if layer is None or not layer.isValid():
+            return
+
+        query = ActivityQuery(
+            activity_type=activity_type,
+            date_from=date_from,
+            date_to=date_to,
+            min_distance_km=min_distance_km,
+            max_distance_km=max_distance_km,
+            search_text=search_text,
+            detailed_only=detailed_only,
+        )
+        layer.setSubsetString(build_subset_string(query))
+        layer.triggerRepaint()

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -2,8 +2,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from .activity_query import ActivityQuery, build_subset_string
 from .background_map_service import BackgroundMapService
+from .layer_filter_service import LayerFilterService
 from .layer_style_service import LayerStyleService
 from .map_canvas_service import MapCanvasService
 from .mapbox_config import TILE_MODE_RASTER
@@ -18,6 +18,7 @@ class LayerManager:
         self.iface = iface
         self._style_service = LayerStyleService()
         self._background_service = BackgroundMapService()
+        self._filter_service = LayerFilterService()
         self._project_layer_loader = ProjectLayerLoader()
         self._temporal_service = TemporalService()
         self._canvas_service = MapCanvasService(self._background_service)
@@ -44,9 +45,8 @@ class LayerManager:
         )
 
     def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None, max_distance_km=None, search_text=None, detailed_only=False):
-        if layer is None or not layer.isValid():
-            return
-        query = ActivityQuery(
+        self._filter_service.apply_filters(
+            layer,
             activity_type=activity_type,
             date_from=date_from,
             date_to=date_to,
@@ -55,8 +55,6 @@ class LayerManager:
             search_text=search_text,
             detailed_only=detailed_only,
         )
-        layer.setSubsetString(build_subset_string(query))
-        layer.triggerRepaint()
 
     def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name=None):
         self._style_service.apply_style(

--- a/tests/test_layer_filter_service.py
+++ b/tests/test_layer_filter_service.py
@@ -1,0 +1,112 @@
+import importlib
+import importlib.util
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+
+from qfit.activity_query import ActivityQuery, build_subset_string
+from qfit.layer_filter_service import LayerFilterService
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    _REAL_QGIS_PRESENT = importlib.util.find_spec("qgis") is not None
+except ValueError:
+    _REAL_QGIS_PRESENT = any(
+        os.path.isdir(os.path.join(p, "qgis")) for p in sys.path if p
+    )
+
+try:
+    from qfit.layer_manager import LayerManager
+
+    QGIS_AVAILABLE = True
+    QGIS_IMPORT_ERROR = None
+except Exception as exc:  # pragma: no cover
+    LayerManager = None
+    QGIS_AVAILABLE = False
+    QGIS_IMPORT_ERROR = exc
+
+SKIP_REAL = f"QGIS not available: {QGIS_IMPORT_ERROR}" if not QGIS_AVAILABLE else ""
+
+
+class LayerFilterServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.service = LayerFilterService()
+
+    def test_apply_filters_sets_subset_string_and_repaints(self):
+        layer = MagicMock()
+        layer.isValid.return_value = True
+
+        self.service.apply_filters(
+            layer,
+            activity_type="Ride",
+            date_from="2026-03-01",
+            date_to="2026-03-31",
+            min_distance_km=10,
+            max_distance_km=50,
+            search_text="alps",
+            detailed_only=True,
+        )
+
+        expected = build_subset_string(
+            ActivityQuery(
+                activity_type="Ride",
+                date_from="2026-03-01",
+                date_to="2026-03-31",
+                min_distance_km=10,
+                max_distance_km=50,
+                search_text="alps",
+                detailed_only=True,
+            )
+        )
+        layer.setSubsetString.assert_called_once_with(expected)
+        layer.triggerRepaint.assert_called_once_with()
+
+    def test_apply_filters_ignores_none_layer(self):
+        self.service.apply_filters(None, activity_type="Ride")
+
+    def test_apply_filters_ignores_invalid_layer(self):
+        layer = MagicMock()
+        layer.isValid.return_value = False
+
+        self.service.apply_filters(layer, activity_type="Ride")
+
+        layer.setSubsetString.assert_not_called()
+        layer.triggerRepaint.assert_not_called()
+
+
+@unittest.skipUnless(QGIS_AVAILABLE, SKIP_REAL)
+class LayerManagerFilterDelegationTests(unittest.TestCase):
+    def test_apply_filters_delegates_to_filter_service(self):
+        manager = LayerManager(iface=MagicMock())
+        manager._filter_service = MagicMock()
+        layer = MagicMock()
+
+        manager.apply_filters(
+            layer,
+            activity_type="Run",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            min_distance_km=5,
+            max_distance_km=15,
+            search_text="tempo",
+            detailed_only=True,
+        )
+
+        manager._filter_service.apply_filters.assert_called_once_with(
+            layer,
+            activity_type="Run",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            min_distance_km=5,
+            max_distance_km=15,
+            search_text="tempo",
+            detailed_only=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -10,6 +10,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 try:
     from qgis.core import QgsApplication, QgsProject, QgsVectorLayer
 
+    from qfit.activity_query import ActivityQuery, build_subset_string
     from qfit.gpkg_writer import GeoPackageWriter
     from qfit.layer_manager import LayerManager
     from qfit.atlas.export_task import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
@@ -22,6 +23,8 @@ except Exception as exc:  # pragma: no cover - exercised only when QGIS is unava
     QgsApplication = None
     QgsProject = None
     QgsVectorLayer = None
+    ActivityQuery = None
+    build_subset_string = None
     GeoPackageWriter = None
     LayerManager = None
     QfitDockWidget = None
@@ -141,6 +144,47 @@ class QgisSmokeTests(unittest.TestCase):
     def test_apply_filters_path_does_not_update_background_layer(self):
         self.assertFalse(VisualApplyService.should_update_background(True))
         self.assertTrue(VisualApplyService.should_update_background(False))
+
+    def test_apply_filters_updates_activity_subset_string(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = str(Path(temp_dir) / "qfit-filters.gpkg")
+            GeoPackageWriter(
+                output_path,
+                write_activity_points=True,
+                point_stride=2,
+                atlas_margin_percent=10,
+                atlas_min_extent_degrees=0.01,
+                atlas_target_aspect_ratio=1.5,
+            ).write_activities(self._sample_activities(), sync_metadata={"provider": "strava"})
+
+            activities_layer, _starts_layer, _points_layer, _atlas_layer = (
+                self.layer_manager.load_output_layers(output_path)
+            )
+            self.layer_manager.apply_filters(
+                activities_layer,
+                activity_type="Run",
+                date_from="2026-03-21",
+                date_to="2026-03-21",
+                min_distance_km=5,
+                max_distance_km=10,
+                search_text="Run",
+                detailed_only=True,
+            )
+
+            self.assertEqual(
+                activities_layer.subsetString(),
+                build_subset_string(
+                    ActivityQuery(
+                        activity_type="Run",
+                        date_from="2026-03-21",
+                        date_to="2026-03-21",
+                        min_distance_km=5,
+                        max_distance_km=10,
+                        search_text="Run",
+                        detailed_only=True,
+                    )
+                ),
+            )
 
     def test_headless_qgis_smoke_covers_write_load_crs_temporal_and_background_order(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- extract subset-string application from `LayerManager` into a focused `LayerFilterService`
- keep `LayerManager.apply_filters()` as delegation-only orchestration
- add focused service tests plus a QGIS smoke test covering the delegated subset-string path

## Testing
- python3 -m pytest /tmp/qfit/tests/test_layer_filter_service.py /tmp/qfit/tests/test_visual_apply.py /tmp/qfit/tests/test_qgis_smoke.py -q --tb=short -k 'layer_filter_service or apply_filters_updates_activity_subset_string or apply_filters_path_does_not_update_background_layer or ApplyWithSubsetFiltersTests or ApplyWithoutSubsetFiltersTests or NoLayersTests'