### PR TITLE
fix: validate Strava activity access in configuration

### DIFF
--- a/config_connection_service.py
+++ b/config_connection_service.py
@@ -24,7 +24,7 @@ def validate_strava_connection(
     *,
     client_factory=StravaClient,
 ) -> ConnectionTestResult:
-    """Validate the current Strava credentials by refreshing the access token."""
+    """Validate current Strava credentials and activity-read access."""
     resolved_client_id = (client_id or "").strip()
     resolved_client_secret = (client_secret or "").strip()
     resolved_refresh_token = (refresh_token or "").strip()
@@ -41,12 +41,22 @@ def validate_strava_connection(
             refresh_token=resolved_refresh_token,
         )
         client.refresh_access_token()
+        client.fetch_activities(per_page=1, max_pages=1)
     except StravaClientError as exc:
-        return ConnectionTestResult(False, f"Strava connection failed: {exc}")
+        return ConnectionTestResult(False, _format_strava_validation_error(str(exc)))
     except Exception as exc:  # noqa: BLE001
-        return ConnectionTestResult(False, f"Strava connection failed: {exc}")
+        return ConnectionTestResult(False, _format_strava_validation_error(str(exc)))
 
-    return ConnectionTestResult(True, "Strava connection OK")
+    return ConnectionTestResult(True, "Strava activity access OK")
+
+
+def _format_strava_validation_error(message: str) -> str:
+    if "activity.read_permission" in message:
+        return (
+            "Strava connection failed: token refresh succeeded, but activity-read permission is missing. "
+            "Re-authorize Strava and save a refresh token with activity:read_all scope."
+        )
+    return f"Strava connection failed: {message}"
 
 
 def validate_mapbox_connection(

--- a/tests/test_config_connection_service.py
+++ b/tests/test_config_connection_service.py
@@ -18,16 +18,25 @@ class TestStravaConnectionValidation(unittest.TestCase):
         self.assertEqual(result.message, "Enter a Strava refresh token first.")
 
     def test_reports_success_when_refresh_works(self):
+        captured = {}
+
         class FakeClient:
             def __init__(self, **kwargs):
                 self.kwargs = kwargs
+                captured["client"] = self
+                self.fetch_calls = []
 
             def refresh_access_token(self):
                 return {"access_token": "ok"}
 
+            def fetch_activities(self, *, per_page, max_pages):
+                self.fetch_calls.append((per_page, max_pages))
+                return []
+
         result = validate_strava_connection("id", "secret", "tok", client_factory=FakeClient)
         self.assertTrue(result.ok)
-        self.assertEqual(result.message, "Strava connection OK")
+        self.assertEqual(result.message, "Strava activity access OK")
+        self.assertEqual(captured["client"].fetch_calls, [(1, 1)])
 
     def test_reports_client_errors(self):
         class FakeClient:
@@ -37,9 +46,30 @@ class TestStravaConnectionValidation(unittest.TestCase):
             def refresh_access_token(self):
                 raise RuntimeError("bad token")
 
+            def fetch_activities(self, *, per_page, max_pages):
+                raise AssertionError("should not fetch after refresh failure")
+
         result = validate_strava_connection("id", "secret", "tok", client_factory=FakeClient)
         self.assertFalse(result.ok)
         self.assertEqual(result.message, "Strava connection failed: bad token")
+
+    def test_reports_missing_activity_scope(self):
+        class FakeClient:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def refresh_access_token(self):
+                return {"access_token": "ok"}
+
+            def fetch_activities(self, *, per_page, max_pages):
+                raise RuntimeError(
+                    'Strava API error 401: {"message":"Authorization Error","errors":[{"resource":"Activity","field":"activity.read_permission","code":"missing"}]}'
+                )
+
+        result = validate_strava_connection("id", "secret", "tok", client_factory=FakeClient)
+        self.assertFalse(result.ok)
+        self.assertIn("activity-read permission is missing", result.message)
+        self.assertIn("activity:read_all", result.message)
 
 
 class TestMapboxConnectionValidation(unittest.TestCase):


### PR DESCRIPTION
## What this changes\n- makes **Test connection** for Strava verify a tiny activity-read request instead of only refreshing the token\n- reports a clear error when the token is valid but missing the required activity-read scope\n- keeps the success case explicit: the configuration can actually read Strava activities\n\n## Why\nThe previous validation could report success even when the refresh token could not read activities. That led to a misleading green status in Configuration followed by a fetch failure later in the Activities workflow.\n\n## Testing\n- ......................................                                   [100%]
38 passed in 0.06s