### PR TITLE
docs: add architecture guide and contributor rules (#177)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,11 @@
 
 ## Code Quality Rules
 
+Before making non-trivial structural changes, also read:
+
+- `docs/architecture.md` — architectural boundaries, dependency direction, and placement rules
+
+
 All PRs must pass the following before merging:
 
 ### SonarCloud (mandatory gate)
@@ -24,6 +29,24 @@ All PRs must pass the following before merging:
 
 ### Tests must pass
 - `python3 -m pytest tests/ -x -q` must be green before opening a PR.
+
+## Architecture rules
+
+Keep these rules lightweight and practical:
+
+- Prefer feature/workflow ownership over adding more unrelated top-level modules.
+- Keep `QfitDockWidget` and other UI classes focused on widget wiring, input mapping, and result rendering.
+- Put workflow orchestration into controllers/services/use cases instead of the dock widget where practical.
+- Keep provider-neutral activity logic free of direct UI imports and avoid unnecessary QGIS coupling.
+- Isolate Strava, GeoPackage, QGIS settings, and QGIS layer details behind clearer seams when that improves clarity or testability.
+- Do not add interface/adapter boilerplate unless it solves a real workflow or testing problem.
+- Favor small, behavior-preserving refactors over big-bang rewrites.
+
+Preferred dependency direction:
+
+```text
+UI -> application/workflow -> domain + ports -> infrastructure adapters
+```
 
 ### Commit style
 - `fix: <description> (#<issue>)` for bug fixes

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ Visible layers:
 - better packaging and release automation
 - broader scripted integration coverage inside a real QGIS environment
 
+## Architecture
+
+qfit is being evolved as a **modular monolith** with pragmatic **ports-and-adapters** boundaries.
+
+In practice, that means:
+- keep qfit as one plugin/package
+- prefer feature/workflow ownership over a flat pile of technical modules
+- keep `QfitDockWidget` focused on UI glue
+- move orchestration into controllers/services/use cases
+- keep provider-neutral logic easier to test than QGIS-heavy adapters
+- introduce ports/gateways only when they clarify workflows or reduce coupling
+
+See `docs/architecture.md` for the contributor-facing boundary rules and placement guide.
+
 ## Plugin structure
 
 - `metadata.txt` — QGIS plugin metadata
@@ -225,6 +239,13 @@ That gives two distribution paths:
 2. **Versioned release build**
    - create and push a tag like `v0.43.0`
    - GitHub will create a release and attach the generated plugin ZIP automatically
+
+## Contributing and architecture
+
+If you are changing internals, read these first:
+
+- `CONTRIBUTING.md` — workflow, tests, SonarCloud, and PR quality gates
+- `docs/architecture.md` — intended module boundaries, dependency direction, and placement rules
 
 ## Testing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,197 @@
+# qfit architecture guide
+
+qfit is evolving toward a **modular monolith** with pragmatic **ports-and-adapters** boundaries.
+
+That sounds grander than it is.
+
+The intent is simple:
+
+- keep qfit as **one plugin / one repository / one deployable unit**
+- organize code by **feature and workflow ownership** instead of a flat pile of technical helpers
+- keep the **dock widget thin**
+- keep **provider-neutral logic** easier to test than QGIS-heavy code
+- isolate external dependencies such as **Strava, GeoPackage persistence, QGIS settings, and QGIS layer operations** behind clearer seams when that buys maintainability
+
+This document is short on purpose. It is meant to guide placement and review decisions, not turn qfit into architecture theater.
+
+## 1. Target shape
+
+The target shape is a modular monolith:
+
+- **single plugin package**
+- **single runtime** inside QGIS
+- **internally separated responsibilities**
+
+Over time, qfit should trend toward clearer feature areas such as:
+
+- **activities/import**
+- **providers**
+- **visualization**
+- **atlas/publish**
+- **settings/configuration**
+- **shared/core helpers**
+
+Not every area needs `application/`, `domain/`, and `infrastructure/` subpackages immediately. Prefer gradual, pragmatic extraction.
+
+## 2. Working layers
+
+Use these layers as a placement heuristic.
+
+### UI layer
+
+Examples:
+
+- `qfit_dockwidget.py`
+- dialogs, widget bindings, message rendering, signal wiring
+
+Responsibilities:
+
+- read widget state
+- call use cases / controllers / services
+- render results, warnings, and errors
+- keep immediate UI state coherent
+
+Avoid putting these here unless there is a strong reason:
+
+- Strava orchestration details
+- GeoPackage write/load rules
+- QGIS layer-manipulation algorithms
+- derived activity business rules
+- long parameter-mapping chains that really belong in a request object or service
+
+### Application / workflow layer
+
+Examples:
+
+- controllers and orchestration services such as sync/load/export/background-map flows
+- request/result objects for main workflows
+
+Responsibilities:
+
+- coordinate a user-facing workflow
+- translate UI intent into application steps
+- depend on ports/gateways where useful
+- return structured results the UI can render
+
+This layer should prefer describing *what qfit wants done*, not *how QGIS or Strava does it internally*.
+
+### Domain / core layer
+
+Examples:
+
+- canonical activity models
+- activity filtering/querying/sorting/summaries
+- activity classification and provider-neutral derived metadata
+- time/polyline utilities and similar reusable core helpers
+
+Responsibilities:
+
+- hold provider-neutral business rules
+- stay easy to test without QGIS
+- avoid direct dependency on dock widget code or heavy infrastructure details
+
+### Infrastructure / adapters layer
+
+Examples:
+
+- Strava client/provider adapter
+- GeoPackage persistence helpers
+- QGIS settings adapter
+- QGIS layer loading/styling/temporal wiring
+- Mapbox/QGIS-specific basemap integration
+
+Responsibilities:
+
+- talk to external systems and frameworks
+- implement ports/gateways when the application layer benefits from a seam
+- keep low-level QGIS/GeoPackage/provider details out of provider-neutral logic
+
+## 3. Dependency direction
+
+Preferred direction:
+
+```text
+UI -> application/workflow -> domain + ports -> infrastructure adapters
+```
+
+Practical rules:
+
+- **UI may depend on application services.**
+- **Application code may depend on domain code and small protocols/ports.**
+- **Infrastructure may depend on domain types and application contracts when needed.**
+- **Domain/core code should not depend on UI modules.**
+- **Provider-neutral logic should avoid direct QGIS imports.**
+- **Application workflows should not reach deep into Strava/QGIS implementation details when a small seam would make intent clearer.**
+
+This is guidance, not dogma. Small plugins do not benefit from abstracting every function call.
+
+## 4. When to introduce a port or adapter
+
+Introduce a port/gateway when at least one of these is true:
+
+- the workflow needs to be tested without the real external dependency
+- the implementation detail is noisy enough to obscure the workflow
+- qfit may reasonably gain another implementation later
+- a QGIS-specific or provider-specific dependency is leaking into otherwise provider-neutral code
+
+Good candidates in qfit:
+
+- activity provider
+- activity storage
+- settings/configuration access
+- QGIS layer/visualization operations
+- atlas export orchestration boundaries
+
+Do **not** introduce a new abstraction just to satisfy a pattern name.
+
+A direct helper call is still fine when:
+
+- there is only one obvious implementation
+- the code is tiny and stable
+- adding an interface would make the workflow harder to read
+
+## 5. Placement rules for new code
+
+When adding code, ask these questions in order:
+
+1. **Is this UI glue?** Put it near the widget/dialog layer.
+2. **Is this a user-facing workflow or orchestration step?** Put it in an application/controller/service area.
+3. **Is this provider-neutral business logic?** Put it in a domain/core-oriented module.
+4. **Is this talking directly to QGIS, Strava, GeoPackage, or settings storage?** Put it in an infrastructure/adapter-oriented module.
+5. **Is this shared across features without being business logic?** Put it in a small shared helper area.
+
+If a module starts mixing two or three of those answers, that is usually a sign it wants extraction.
+
+## 6. Current architectural priorities
+
+The active migration priorities are tracked in issues #169 through #178. In practical terms, current high-value directions are:
+
+- thin out `QfitDockWidget`
+- use clearer request/result objects for main workflows
+- isolate settings, storage, and layer operations behind pragmatic seams
+- consolidate activity-centric business logic into a clearer core
+- keep feature ownership clearer as modules move out of the flat top-level layout
+
+## 7. Review checklist
+
+Use this quick checklist in PR review:
+
+- Does this change make `QfitDockWidget` heavier or thinner?
+- Is provider-neutral logic staying free of unnecessary QGIS coupling?
+- Is new workflow logic placed outside the UI when practical?
+- Is a new abstraction earning its keep, or just adding ceremony?
+- Would a future contributor know where related code belongs?
+- Are tests focused on the highest-value non-UI logic?
+
+## 8. Contributor rules
+
+Short version:
+
+- prefer **feature/workflow ownership** over more flat top-level sprawl
+- keep **UI glue in the UI**
+- keep **business rules out of QGIS-heavy modules** where practical
+- isolate **external dependency details** when the seam improves clarity or testability
+- favor **small incremental refactors** over large rewrites
+- preserve behavior while moving boundaries
+
+If a change makes the code easier to locate, easier to test, and less coupled to the dock widget or raw QGIS details, it is probably moving in the right direction.


### PR DESCRIPTION
## Summary
- add a concise architecture guide for qfit's modular-monolith / ports-and-adapters direction
- link the architecture guide from the README for contributor discoverability
- add lightweight architecture placement and dependency-direction rules to CONTRIBUTING

## Testing
- python3 -m pytest tests/ -x -q

Closes #177
