### PR TITLE
refactor: add settings port and QGIS adapter (#173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ See `docs/architecture.md` for the contributor-facing boundary rules and placeme
 - `background_map_controller.py` — background map wiring and basemap orchestration
 - `contextual_help.py` — reusable contextual help entries for dock widget controls
 - `fetch_task.py` — QgsTask wrapper for background Strava fetching
-- `settings_service.py` — QGIS settings storage and retrieval
+- `settings_port.py` — small application-facing settings access contract
+- `settings_service.py` — QGIS-backed settings adapter implementing that contract
 - `sync_controller.py` — fetch/sync orchestration bridging the dock widget and Strava client
 - `scripts/install_plugin.py` — install qfit into a local QGIS profile for testing
 - `scripts/uninstall_plugin.py` — remove qfit from a local QGIS profile

--- a/config_status.py
+++ b/config_status.py
@@ -4,10 +4,10 @@ These functions depend only on ``SettingsService`` and can be tested
 without a running Qt/QGIS environment.
 """
 
-from .settings_service import SettingsService
+from .settings_port import SettingsPort
 
 
-def strava_status_text(settings: SettingsService) -> str:
+def strava_status_text(settings: SettingsPort) -> str:
     """Return a human-readable Strava connection status."""
     client_id = settings.get("client_id", "")
     client_secret = settings.get("client_secret", "")
@@ -19,7 +19,7 @@ def strava_status_text(settings: SettingsService) -> str:
     return "Not configured"
 
 
-def mapbox_status_text(settings: SettingsService) -> str:
+def mapbox_status_text(settings: SettingsPort) -> str:
     """Return a human-readable Mapbox connection status."""
     token = settings.get("mapbox_access_token", "")
     if not token:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ Good candidates in qfit:
 
 - activity provider
 - activity storage
-- settings/configuration access
+- settings/configuration access (now via a small `SettingsPort` with the current QGIS-backed adapter behind it)
 - QGIS layer/visualization operations
 - atlas export orchestration boundaries
 

--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -23,6 +23,7 @@ from qgis.PyQt.QtWidgets import (
 
 from .config_connection_service import validate_mapbox_connection, validate_strava_connection
 from .config_status import mapbox_status_text, strava_status_text
+from .settings_port import SettingsPort
 from .settings_service import SettingsService
 from .strava_client import StravaClient
 from .ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
@@ -40,7 +41,7 @@ class QfitConfigDialog(QDialog):
     saving. Changes are persisted to QSettings on save.
     """
 
-    def __init__(self, settings_service: SettingsService | None = None, parent: QWidget | None = None):
+    def __init__(self, settings_service: SettingsPort | None = None, parent: QWidget | None = None):
         super().__init__(parent)
         self._settings = settings_service or SettingsService()
         self.setWindowTitle("qfit — Configuration")

--- a/settings_port.py
+++ b/settings_port.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SettingsPort(Protocol):
+    """Application-facing settings access port.
+
+    qfit workflows and UI helpers should depend on this small contract rather
+    than on QGIS-specific settings details directly.
+    """
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the stored value for *key*, or *default* when unset."""
+
+    def get_bool(self, key: str, default: bool = False) -> bool:
+        """Return the stored setting coerced to a boolean value."""
+
+    def set(self, key: str, value: Any) -> None:
+        """Persist *value* under *key*."""

--- a/settings_service.py
+++ b/settings_service.py
@@ -6,6 +6,7 @@ from .credential_store import (
     SENSITIVE_KEYS,
     make_credential_store,
 )
+from .settings_port import SettingsPort
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +14,8 @@ SETTINGS_PREFIX = "qfit"
 LEGACY_SETTINGS_PREFIX = "QFIT"
 
 
-class SettingsService:
-    """Centralised get/set wrapper around QSettings with legacy-prefix fallback.
+class QgisSettingsAdapter(SettingsPort):
+    """QGIS-backed implementation of the :class:`~qfit.settings_port.SettingsPort`.
 
     Sensitive keys (see :data:`~qfit.credential_store.SENSITIVE_KEYS`) are
     routed through a :class:`~qfit.credential_store.CredentialStore` so they
@@ -114,3 +115,8 @@ class SettingsService:
                     key,
                 )
         self._settings.setValue(f"{self._prefix}/{key}", value)
+
+
+# Backward-compatible name kept while qfit incrementally moves callers toward
+# the SettingsPort abstraction.
+SettingsService = QgisSettingsAdapter

--- a/tests/test_settings_port_usage.py
+++ b/tests/test_settings_port_usage.py
@@ -1,0 +1,65 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.config_status import mapbox_status_text, strava_status_text
+from qfit.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
+
+
+class FakeSettingsPort:
+    def __init__(self, data=None):
+        self._data = dict(data or {})
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+    def get_bool(self, key, default=False):
+        value = self._data.get(key, default)
+        if isinstance(value, str):
+            return value.lower() in ("1", "true", "yes", "on")
+        return bool(value)
+
+    def set(self, key, value):
+        self._data[key] = value
+
+
+class TextWidget:
+    def __init__(self, value=""):
+        self._value = value
+
+    def text(self):
+        return self._value
+
+    def setText(self, value):
+        self._value = value
+
+
+class SettingsPortUsageTests(unittest.TestCase):
+    def test_config_status_helpers_only_need_settings_port(self):
+        settings = FakeSettingsPort(
+            {
+                "client_id": "id123",
+                "client_secret": "sec456",
+                "refresh_token": "tok789",
+                "mapbox_access_token": "pk.test",
+            }
+        )
+
+        self.assertEqual(strava_status_text(settings), "Connected (refresh token saved)")
+        self.assertEqual(mapbox_status_text(settings), "Access token saved")
+
+    def test_ui_settings_bindings_work_with_port_contract(self):
+        widget = TextWidget("  hello  ")
+        binding = UIFieldBinding("greeting", "default", lambda: widget.text().strip(), widget.setText)
+        settings = FakeSettingsPort()
+
+        save_bindings([binding], settings)
+        self.assertEqual(settings.get("greeting"), "hello")
+
+        widget.setText("")
+        load_bindings([binding], settings)
+        self.assertEqual(widget.text(), "hello")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
 from qfit.credential_store import InMemoryCredentialStore, NullCredentialStore
-from qfit.settings_service import SettingsService
+from qfit.settings_port import SettingsPort
+from qfit.settings_service import QgisSettingsAdapter, SettingsService
 
 
 class FakeQSettings:
@@ -20,6 +21,13 @@ class FakeQSettings:
 
     def remove(self, key):
         self._data.pop(key, None)
+
+
+class SettingsPortAdapterTests(unittest.TestCase):
+    def test_qgis_settings_adapter_satisfies_settings_port(self):
+        adapter = QgisSettingsAdapter(qsettings=FakeQSettings())
+        self.assertIsInstance(adapter, SettingsPort)
+        self.assertIsInstance(SettingsService(qsettings=FakeQSettings()), SettingsPort)
 
 
 class SettingsServiceGetTests(unittest.TestCase):

--- a/ui_settings_binding.py
+++ b/ui_settings_binding.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from .settings_service import SettingsService
+from .settings_port import SettingsPort
 
 
 @dataclass
@@ -54,7 +54,7 @@ class UIFieldBinding:
 
 def load_bindings(
     bindings: list[UIFieldBinding],
-    settings: SettingsService,
+    settings: SettingsPort,
 ) -> None:
     """Populate each widget from *settings* using the explicit binding table."""
     for b in bindings:
@@ -63,7 +63,7 @@ def load_bindings(
 
 def save_bindings(
     bindings: list[UIFieldBinding],
-    settings: SettingsService,
+    settings: SettingsPort,
 ) -> None:
     """Persist each widget value to *settings* using the explicit binding table."""
     for b in bindings:


### PR DESCRIPTION
## Summary
- introduce a small SettingsPort contract for qfit settings access
- make the current QGIS-backed settings implementation the concrete adapter behind that port
- type settings consumers against the port and add coverage proving the seam works with test doubles

## Testing
- python3 -m pytest tests/test_settings_service.py tests/test_ui_settings_binding.py tests/test_settings_port_usage.py tests/test_config_dialog.py -q
- python3 -m pytest tests/ -x -q

Closes #173
