### PR TITLE
refactor: add activity storage port and gpkg adapter (#172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ See `docs/architecture.md` for the contributor-facing boundary rules and placeme
 - `models.py` — canonical activity model
 - `polyline_utils.py` — encoded polyline decoding
 - `time_utils.py` — ISO timestamp parsing / offset helpers
-- `sync_repository.py` — canonical GeoPackage registry + sync metadata upserts
-- `gpkg_writer.py` — derived GeoPackage layer rebuilds via QGIS APIs
+- `activity_storage.py` — small activity storage port plus the GeoPackage-backed adapter
+- `sync_repository.py` — GeoPackage registry persistence and sync metadata upserts
+- `gpkg_writer.py` — derived GeoPackage layer rebuilds via QGIS APIs, depending on the storage port/adapter seam
 - `activity_query.py` — reusable activity filtering, sorting, summary, preview, and subset-expression helpers
 - `layer_manager.py` — layer loading, filtering, styling, and background-map wiring
 - `map_style.py` — semantic activity-color mapping and basemap-aware line-style rules

--- a/activity_storage.py
+++ b/activity_storage.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .sync_repository import SyncRepository, SyncStats
+
+
+@runtime_checkable
+class ActivityStore(Protocol):
+    """Application-facing port for persisted qfit activity storage."""
+
+    def ensure_schema(self) -> None:
+        """Create or update storage metadata/schema as needed."""
+
+    def upsert_activities(self, activities, sync_metadata=None) -> SyncStats:
+        """Persist fetched activities and return sync counters."""
+
+    def load_all_activity_records(self) -> list[dict]:
+        """Return all stored activity records in canonical registry form."""
+
+    def load_all_activities(self):
+        """Return all stored activities as domain objects."""
+
+
+class GeoPackageActivityStore(SyncRepository):
+    """GeoPackage-backed adapter implementing the ActivityStore port."""

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,7 +137,7 @@ Introduce a port/gateway when at least one of these is true:
 Good candidates in qfit:
 
 - activity provider
-- activity storage
+- activity storage (now starting to take shape through a small storage port plus the GeoPackage-backed adapter)
 - settings/configuration access (now via a small `SettingsPort` with the current QGIS-backed adapter behind it)
 - QGIS layer/visualization operations
 - atlas export orchestration boundaries

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -1,12 +1,12 @@
 import os
 
+from .activity_storage import GeoPackageActivityStore
 from .gpkg_schema import GPKG_LAYER_SCHEMA
 from .gpkg_write_orchestration import (
     bootstrap_empty_gpkg,
     build_and_write_all_layers,
 )
 from .atlas.publish_atlas import normalize_atlas_page_settings
-from .sync_repository import SyncRepository
 
 
 class GeoPackageWriter:
@@ -20,6 +20,7 @@ class GeoPackageWriter:
         atlas_margin_percent=None,
         atlas_min_extent_degrees=None,
         atlas_target_aspect_ratio=None,
+        activity_store_factory=GeoPackageActivityStore,
     ):
         self.output_path = output_path
         self.write_activity_points = bool(write_activity_points)
@@ -29,6 +30,7 @@ class GeoPackageWriter:
             min_extent_degrees=atlas_min_extent_degrees,
             target_aspect_ratio=atlas_target_aspect_ratio,
         )
+        self.activity_store_factory = activity_store_factory
 
     def schema(self):
         return dict(GPKG_LAYER_SCHEMA)
@@ -38,14 +40,14 @@ class GeoPackageWriter:
             raise ValueError("output_path is required")
         os.makedirs(os.path.dirname(self.output_path) or ".", exist_ok=True)
 
-        repository = SyncRepository(self.output_path)
+        activity_store = self.activity_store_factory(self.output_path)
         new_file = not os.path.exists(self.output_path) or os.path.getsize(self.output_path) == 0
         if new_file:
             bootstrap_empty_gpkg(self.output_path, self.atlas_page_settings)
 
-        repository.ensure_schema()
-        sync_result = repository.upsert_activities(activities, sync_metadata=sync_metadata)
-        records = repository.load_all_activity_records()
+        activity_store.ensure_schema()
+        sync_result = activity_store.upsert_activities(activities, sync_metadata=sync_metadata)
+        records = activity_store.load_all_activity_records()
 
         layers = build_and_write_all_layers(
             records, self.output_path, self.atlas_page_settings,

--- a/tests/test_activity_storage.py
+++ b/tests/test_activity_storage.py
@@ -1,0 +1,49 @@
+import ast
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests import _path  # noqa: F401
+from qfit.activity_storage import ActivityStore, GeoPackageActivityStore
+
+
+class ActivityStoreAdapterTests(unittest.TestCase):
+    def test_geopackage_activity_store_satisfies_port(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = GeoPackageActivityStore(str(Path(tmpdir) / "qfit.sqlite"))
+            self.assertIsInstance(store, ActivityStore)
+
+
+class GeoPackageWriterStoragePortTests(unittest.TestCase):
+    def test_writer_accepts_and_stores_activity_store_factory(self):
+        module_path = Path(__file__).resolve().parents[1] / "gpkg_writer.py"
+        tree = ast.parse(module_path.read_text(), filename=str(module_path))
+
+        geo_writer = next(
+            node for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "GeoPackageWriter"
+        )
+        init_fn = next(
+            node for node in geo_writer.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+        )
+
+        param_names = [arg.arg for arg in init_fn.args.args]
+        self.assertIn("activity_store_factory", param_names)
+
+        assigns_factory = False
+        for node in ast.walk(init_fn):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Attribute)
+                        and isinstance(target.value, ast.Name)
+                        and target.value.id == "self"
+                        and target.attr == "activity_store_factory"
+                    ):
+                        assigns_factory = True
+        self.assertTrue(assigns_factory)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -78,7 +78,7 @@ class WriteAndLoadSuccessTests(unittest.TestCase):
         self.layer_manager.load_output_layers.return_value = mock_layers
 
         activities = [SimpleNamespace(name="a1"), SimpleNamespace(name="a2"), SimpleNamespace(name="a3")]
-        with patch.dict(sys.modules, {"qfit.gpkg_writer": mock_gpkg}):
+        with patch("qfit.gpkg_writer.GeoPackageWriter", mock_gpkg.GeoPackageWriter):
             result = self.service.write_and_load(
                 activities=activities,
                 output_path="/tmp/out.gpkg",
@@ -116,7 +116,7 @@ class WriteAndLoadSuccessTests(unittest.TestCase):
         self.layer_manager.load_output_layers.return_value = (None, None, None, None)
 
         metadata = {"provider": "strava"}
-        with patch.dict(sys.modules, {"qfit.gpkg_writer": mock_gpkg}):
+        with patch("qfit.gpkg_writer.GeoPackageWriter", mock_gpkg.GeoPackageWriter):
             self.service.write_and_load(
                 activities=["a"],
                 output_path="/tmp/out.gpkg",
@@ -145,7 +145,7 @@ class WriteAndLoadSuccessTests(unittest.TestCase):
         mock_gpkg = self._make_writer_mock(write_result)
         self.layer_manager.load_output_layers.return_value = (None, None, None, None)
 
-        with patch.dict(sys.modules, {"qfit.gpkg_writer": mock_gpkg}):
+        with patch("qfit.gpkg_writer.GeoPackageWriter", mock_gpkg.GeoPackageWriter):
             self.service.write_and_load(
                 activities=["a"],
                 output_path="/tmp/test.gpkg",
@@ -189,7 +189,7 @@ class WriteDatabaseSuccessTests(unittest.TestCase):
         }
         mock_gpkg = self._make_writer_mock(write_result)
 
-        with patch.dict(sys.modules, {"qfit.gpkg_writer": mock_gpkg}):
+        with patch("qfit.gpkg_writer.GeoPackageWriter", mock_gpkg.GeoPackageWriter):
             result = self.service.write_database(
                 activities=["a", "b"],
                 output_path="/tmp/out.gpkg",


### PR DESCRIPTION
## Summary
- introduce a small `ActivityStore` port and make the GeoPackage-backed store explicit
- let `GeoPackageWriter` depend on an injectable activity-store factory instead of reaching directly into the GeoPackage repository implementation
- add focused tests around the new storage seam and keep the load-workflow tests robust against import-order leakage

## Testing
- python3 -m pytest tests/test_activity_storage.py tests/test_sync_repository.py tests/test_load_workflow.py -q
- python3 -m pytest tests/ -x -q

Closes #172
