### PR TITLE
refactor: consolidate activity domain core (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ See `docs/architecture.md` for the contributor-facing boundary rules and placeme
 - `qfit_dockwidget.py` — dock widget UI logic
 - `qfit_dockwidget_base.ui` — Qt Designer UI layout
 - `strava_client.py` — Strava authentication and activity retrieval
-- `models.py` — canonical activity model
+- `activities/domain/` — provider-neutral activity core (`models.py`, `activity_classification.py`, `activity_query.py`)
+- `models.py` / `activity_query.py` / `activity_classification.py` — compatibility import shims for the activity domain core
 - `polyline_utils.py` — encoded polyline decoding
 - `time_utils.py` — ISO timestamp parsing / offset helpers
 - `activity_storage.py` — small activity storage port plus the GeoPackage-backed adapter
 - `sync_repository.py` — GeoPackage registry persistence and sync metadata upserts
 - `gpkg_writer.py` — derived GeoPackage layer rebuilds via QGIS APIs, depending on the storage port/adapter seam
-- `activity_query.py` — reusable activity filtering, sorting, summary, preview, and subset-expression helpers
 - `layer_manager.py` — layer loading, filtering, styling, and background-map wiring
 - `map_style.py` — semantic activity-color mapping and basemap-aware line-style rules
 - `mapbox_config.py` — background-map preset resolution and Mapbox XYZ URL helpers

--- a/activities/__init__.py
+++ b/activities/__init__.py
@@ -1,0 +1,1 @@
+"""Feature-oriented activity modules."""

--- a/activities/domain/__init__.py
+++ b/activities/domain/__init__.py
@@ -1,0 +1,25 @@
+"""Provider-neutral activity domain core for qfit."""
+
+from .activity_classification import (
+    ACTIVITY_LABEL_FIELDS,
+    activity_prefers_pace,
+    canonical_activity_label,
+    normalize_activity_type,
+    ordered_canonical_activity_labels,
+    preferred_activity_field,
+    resolve_activity_family,
+)
+from .activity_query import (
+    DEFAULT_SORT_LABEL,
+    SORT_OPTIONS,
+    ActivityQuery,
+    ActivitySummary,
+    build_preview_lines,
+    build_subset_string,
+    filter_activities,
+    format_duration,
+    format_summary_text,
+    sort_activities,
+    summarize_activities,
+)
+from .models import Activity

--- a/activities/domain/activity_classification.py
+++ b/activities/domain/activity_classification.py
@@ -1,0 +1,126 @@
+"""Single source of truth for activity type classification.
+
+All modules that need to classify, normalise, or compare activity types
+(filtering, styling, export, pace/speed selection) should use the helpers
+here instead of defining their own normalization or family-mapping logic.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+ACTIVITY_LABEL_FIELDS: tuple[str, ...] = ("sport_type", "activity_type")
+
+# Resolution order matters: first matching family wins.
+_FAMILY_TOKENS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("machine",  ("virtual", "trainer", "commute", "ebike", "machine")),
+    ("winter",   ("ski", "snow", "sled")),
+    ("water",    ("swim", "surf", "paddle", "row", "kayak", "canoe", "sup")),
+    ("mountain", ("iceclimb", "climb", "mountain", "boulder", "alpinism")),
+    ("running",  ("run", "jog")),
+    ("walking",  ("walk", "hike", "trek", "backpack")),
+    ("fitness",  ("crossfit", "workout", "yoga", "weight", "gym", "pilates")),
+    ("cycling",  ("ride", "bike", "cycle")),
+)
+
+
+def normalize_activity_type(value: object) -> str:
+    """Lowercase and strip non-alphanumeric characters from an activity type string.
+
+    This is the canonical normalization used across filtering, styling, and
+    classification.  ``'TrailRun'``, ``'Trail Run'``, and ``'trail-run'``
+    all normalise to ``'trailrun'``.
+    """
+    text = str(value or "").strip().casefold()
+    return re.sub(r"[^a-z0-9]+", "", text)
+
+
+def canonical_activity_label(
+    activity_type: str | None,
+    sport_type: str | None,
+) -> str | None:
+    """Return the canonical label for an activity.
+
+    Prefers the more-specific ``sport_type`` when set, otherwise falls back to
+    ``activity_type``. Blank/whitespace-only values are ignored. Returns
+    ``None`` when both are absent.
+
+    This is the agreed field-priority contract used by filtering, the UI
+    combo-box, and map styling.
+    """
+    for candidate in (sport_type, activity_type):
+        if candidate is None:
+            continue
+        label = str(candidate).strip()
+        if label:
+            return label
+    return None
+
+
+def ordered_canonical_activity_labels(
+    label_pairs: Iterable[tuple[str | None, str | None]],
+) -> list[str]:
+    """Return ordered unique canonical activity labels from ``(activity, sport)`` pairs.
+
+    Uses :func:`canonical_activity_label` for field-priority semantics and
+    deduplicates case-insensitively while preserving first-seen order.
+    """
+    ordered_labels: list[str] = []
+    seen_normalized: set[str] = set()
+    for activity_type, sport_type in label_pairs:
+        label = canonical_activity_label(activity_type, sport_type)
+        if not label:
+            continue
+        normalized = normalize_activity_type(label)
+        if normalized in seen_normalized:
+            continue
+        seen_normalized.add(normalized)
+        ordered_labels.append(label)
+    return ordered_labels
+
+
+def preferred_activity_field(available_fields: Iterable[str]) -> str | None:
+    """Return the best activity-label field from *available_fields*.
+
+    Prefers the more-specific ``sport_type`` when present, otherwise falls back
+    to ``activity_type``.  Returns ``None`` when neither is available.
+
+    This encodes the same field-priority contract as
+    :func:`canonical_activity_label` but operates on layer/table field names
+    rather than individual values.
+    """
+    field_set = {str(name) for name in available_fields}
+    for candidate in ACTIVITY_LABEL_FIELDS:
+        if candidate in field_set:
+            return candidate
+    return None
+
+
+def resolve_activity_family(activity_value: object) -> str:
+    """Map an activity type value to a broad semantic family name.
+
+    Returns one of: ``machine``, ``winter``, ``water``, ``mountain``,
+    ``running``, ``walking``, ``fitness``, ``cycling``.
+    Unknown or empty types default to ``machine``.
+    """
+    normalized = normalize_activity_type(activity_value)
+    if not normalized:
+        return "machine"
+    for family, tokens in _FAMILY_TOKENS:
+        if any(token in normalized for token in tokens):
+            return family
+    return "machine"
+
+
+def activity_prefers_pace(
+    activity_type: str | None,
+    sport_type: str | None = None,
+) -> bool:
+    """Return True when the activity should display pace (min/km) over speed (km/h).
+
+    Running, walking, and hiking activities prefer pace; all others use speed.
+    The canonical label (``sport_type`` preferred) is used for the check.
+    """
+    label = canonical_activity_label(activity_type, sport_type) or ""
+    normalized = normalize_activity_type(label)
+    return any(token in normalized for token in ("run", "walk", "hike"))

--- a/activities/domain/activity_query.py
+++ b/activities/domain/activity_query.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Iterable, Sequence
+
+from .activity_classification import (
+    ACTIVITY_LABEL_FIELDS,
+    canonical_activity_label,
+    normalize_activity_type,
+)
+
+
+@dataclass(frozen=True)
+class ActivitySummary:
+    count: int
+    total_distance_km: float
+    total_moving_time_s: int
+    detailed_count: int
+    by_type: dict[str, int]
+    latest_date: str | None
+
+DEFAULT_SORT_LABEL = "Start date (newest first)"
+SORT_OPTIONS = (
+    DEFAULT_SORT_LABEL,
+    "Start date (oldest first)",
+    "Distance (longest first)",
+    "Distance (shortest first)",
+    "Moving time (longest first)",
+    "Name (A–Z)",
+)
+
+
+class ActivityQuery:
+    def __init__(
+        self,
+        activity_type: str | None = "All",
+        date_from: str | None = None,
+        date_to: str | None = None,
+        min_distance_km: float | int | None = None,
+        max_distance_km: float | int | None = None,
+        search_text: str | None = None,
+        detailed_only: bool = False,
+        sort_label: str | None = DEFAULT_SORT_LABEL,
+    ):
+        self.activity_type = activity_type or "All"
+        self.date_from = date_from or None
+        self.date_to = date_to or None
+        self.min_distance_km = _safe_float(min_distance_km)
+        self.max_distance_km = _safe_float(max_distance_km)
+        self.search_text = (search_text or "").strip()
+        self.detailed_only = bool(detailed_only)
+        self.sort_label = sort_label or DEFAULT_SORT_LABEL
+
+
+def filter_activities(activities: Iterable[object], query: ActivityQuery) -> list[object]:
+    results = []
+    search_text = query.search_text.casefold()
+    date_from = _parse_iso_date(query.date_from)
+    date_to = _parse_iso_date(query.date_to)
+
+    for activity in activities:
+        if query.activity_type and query.activity_type != "All":
+            query_norm = normalize_activity_type(query.activity_type)
+            if not any(
+                normalize_activity_type(getattr(activity, field, None)) == query_norm
+                for field in ACTIVITY_LABEL_FIELDS
+            ):
+                continue
+
+        activity_date = _activity_date(activity)
+        if date_from is not None and (activity_date is None or activity_date < date_from):
+            continue
+        if date_to is not None and (activity_date is None or activity_date > date_to):
+            continue
+
+        distance_km = _distance_km(activity)
+        if query.min_distance_km is not None and query.min_distance_km > 0:
+            if distance_km is None or distance_km < query.min_distance_km:
+                continue
+        if query.max_distance_km is not None and query.max_distance_km > 0:
+            if distance_km is None or distance_km > query.max_distance_km:
+                continue
+
+        if search_text:
+            haystack = " ".join(
+                part
+                for part in [
+                    getattr(activity, "name", None),
+                    getattr(activity, "activity_type", None),
+                    getattr(activity, "sport_type", None),
+                ]
+                if part
+            ).casefold()
+            if search_text not in haystack:
+                continue
+
+        if query.detailed_only and getattr(activity, "geometry_source", None) != "stream":
+            continue
+
+        results.append(activity)
+
+    return results
+
+
+def sort_activities(activities: Sequence[object], sort_label: str | None) -> list[object]:
+    sort_label = sort_label or DEFAULT_SORT_LABEL
+    items = list(activities)
+
+    if sort_label == "Start date (oldest first)":
+        return sorted(items, key=lambda activity: (_sort_datetime(activity) is None, _sort_datetime(activity) or datetime.min))
+    if sort_label == "Distance (longest first)":
+        return sorted(items, key=lambda activity: _distance_sort_value(activity), reverse=True)
+    if sort_label == "Distance (shortest first)":
+        return sorted(items, key=lambda activity: (_distance_sort_value(activity) is None, _distance_sort_value(activity) or float("inf")))
+    if sort_label == "Moving time (longest first)":
+        return sorted(items, key=lambda activity: _moving_time_sort_value(activity), reverse=True)
+    if sort_label == "Name (A–Z)":
+        return sorted(items, key=lambda activity: ((getattr(activity, "name", None) or "").casefold(), _sort_datetime(activity) or datetime.min), reverse=False)
+
+    return sorted(items, key=lambda activity: (_sort_datetime(activity) or datetime.min, (getattr(activity, "name", None) or "").casefold()), reverse=True)
+
+
+def summarize_activities(activities: Sequence[object]) -> ActivitySummary:
+    total_distance_km = 0.0
+    total_moving_time_s = 0
+    detailed_count = 0
+    by_type = Counter()
+    latest_date = None
+
+    for activity in activities:
+        distance_km = _distance_km(activity)
+        if distance_km is not None:
+            total_distance_km += distance_km
+        moving_time_s = getattr(activity, "moving_time_s", None)
+        if isinstance(moving_time_s, (int, float)):
+            total_moving_time_s += int(moving_time_s)
+        if getattr(activity, "geometry_source", None) == "stream":
+            detailed_count += 1
+        activity_type = canonical_activity_label(
+            getattr(activity, "activity_type", None),
+            getattr(activity, "sport_type", None),
+        ) or "Unknown"
+        by_type[activity_type] += 1
+        activity_date = _activity_date(activity)
+        if activity_date is not None and (latest_date is None or activity_date > latest_date):
+            latest_date = activity_date
+
+    return ActivitySummary(
+        count=len(activities),
+        total_distance_km=round(total_distance_km, 1),
+        total_moving_time_s=total_moving_time_s,
+        detailed_count=detailed_count,
+        by_type=dict(sorted(by_type.items())),
+        latest_date=latest_date.isoformat() if latest_date is not None else None,
+    )
+
+
+def build_preview_lines(activities: Sequence[object], limit: int = 8) -> list[str]:
+    lines = []
+    for activity in list(activities)[: max(limit, 0)]:
+        date_label = _activity_date(activity).isoformat() if _activity_date(activity) is not None else "unknown date"
+        activity_type = canonical_activity_label(
+            getattr(activity, "activity_type", None),
+            getattr(activity, "sport_type", None),
+        ) or "Activity"
+        distance_km = _distance_km(activity)
+        distance_label = "? km" if distance_km is None else f"{distance_km:.1f} km"
+        moving_time_label = format_duration(getattr(activity, "moving_time_s", None))
+        detail_label = "detailed" if getattr(activity, "geometry_source", None) == "stream" else "summary"
+        name = getattr(activity, "name", None) or "Untitled activity"
+        lines.append(f"{date_label} — {name} · {activity_type} · {distance_label} · {moving_time_label} · {detail_label}")
+    return lines
+
+
+def build_subset_string(query: ActivityQuery) -> str:
+    clauses = []
+    if query.activity_type and query.activity_type != "All":
+        normalized = _escape_sql_literal(normalize_activity_type(query.activity_type))
+        type_matches = [
+            f"{_sql_normalize_expr(field_name)} = '{normalized}'"
+            for field_name in reversed(ACTIVITY_LABEL_FIELDS)
+        ]
+        clauses.append(f"({' OR '.join(type_matches)})")
+    if query.date_from:
+        clauses.append(f'"start_date" >= \'{_escape_sql_literal(query.date_from)}T00:00:00\'')
+    if query.date_to:
+        clauses.append(f'"start_date" <= \'{_escape_sql_literal(query.date_to)}T23:59:59\'')
+    if query.min_distance_km is not None and query.min_distance_km > 0:
+        clauses.append(f'"distance_m" >= {query.min_distance_km * 1000.0}')
+    if query.max_distance_km is not None and query.max_distance_km > 0:
+        clauses.append(f'"distance_m" <= {query.max_distance_km * 1000.0}')
+    if query.search_text:
+        search_text = _escape_sql_literal(query.search_text.lower())
+        search_clauses = [f"lower(coalesce(\"{field_name}\", '')) LIKE '%{search_text}%'" for field_name in ("name", *reversed(ACTIVITY_LABEL_FIELDS))]
+        clauses.append(f"({' OR '.join(search_clauses)})")
+    if query.detailed_only:
+        clauses.append('"geometry_source" = \'stream\'')
+    return " AND ".join(clauses)
+
+
+def format_duration(value: int | float | None) -> str:
+    if value is None:
+        return "?"
+    total_seconds = max(int(value), 0)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    if minutes:
+        return f"{minutes}m {seconds:02d}s"
+    return f"{seconds}s"
+
+
+def format_summary_text(summary: ActivitySummary) -> str:
+    if not summary.count:
+        return "0 activities match the current filters."
+
+    top_types = ", ".join(f"{name}: {count}" for name, count in list(summary.by_type.items())[:3])
+    latest_date = summary.latest_date or "unknown"
+    return (
+        "{count} activities · {distance:.1f} km · {duration} moving · detailed tracks: {detailed} · latest: {latest}"
+        "\nTop activity types: {top_types}"
+    ).format(
+        count=summary.count,
+        distance=summary.total_distance_km,
+        duration=format_duration(summary.total_moving_time_s),
+        detailed=summary.detailed_count,
+        latest=latest_date,
+        top_types=top_types or "n/a",
+    )
+
+
+def _activity_date(activity: object) -> date | None:
+    return _parse_iso_date(getattr(activity, "start_date_local", None) or getattr(activity, "start_date", None))
+
+
+def _parse_iso_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(str(value)[:10])
+        except ValueError:
+            return None
+
+
+def _sort_datetime(activity: object) -> datetime | None:
+    value = getattr(activity, "start_date_local", None) or getattr(activity, "start_date", None)
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _distance_km(activity: object) -> float | None:
+    distance_m = getattr(activity, "distance_m", None)
+    if not isinstance(distance_m, (int, float)):
+        return None
+    return float(distance_m) / 1000.0
+
+
+def _distance_sort_value(activity: object) -> float:
+    distance_m = getattr(activity, "distance_m", None)
+    if not isinstance(distance_m, (int, float)):
+        return -1.0
+    return float(distance_m)
+
+
+def _moving_time_sort_value(activity: object) -> int:
+    value = getattr(activity, "moving_time_s", None)
+    if not isinstance(value, (int, float)):
+        return -1
+    return int(value)
+
+
+def _sql_normalize_expr(field: str) -> str:
+    """SQL expression approximating normalize_activity_type for a column."""
+    return f"LOWER(REPLACE(REPLACE(REPLACE(\"{field}\", ' ', ''), '-', ''), '_', ''))"
+
+
+def _escape_sql_literal(value: str) -> str:
+    return str(value).replace("'", "''")
+
+
+def _safe_float(value: float | int | str | None) -> float | None:
+    if value in (None, ""):
+        return None
+    return float(value)

--- a/activities/domain/models.py
+++ b/activities/domain/models.py
@@ -1,0 +1,38 @@
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class Activity:
+    source: str
+    source_activity_id: str
+    external_id: Optional[str] = None
+    name: Optional[str] = None
+    activity_type: Optional[str] = None
+    sport_type: Optional[str] = None
+    start_date: Optional[str] = None
+    start_date_local: Optional[str] = None
+    timezone: Optional[str] = None
+    distance_m: Optional[float] = None
+    moving_time_s: Optional[int] = None
+    elapsed_time_s: Optional[int] = None
+    total_elevation_gain_m: Optional[float] = None
+    average_speed_mps: Optional[float] = None
+    max_speed_mps: Optional[float] = None
+    average_heartrate: Optional[float] = None
+    max_heartrate: Optional[float] = None
+    average_watts: Optional[float] = None
+    kilojoules: Optional[float] = None
+    calories: Optional[float] = None
+    suffer_score: Optional[float] = None
+    start_lat: Optional[float] = None
+    start_lon: Optional[float] = None
+    end_lat: Optional[float] = None
+    end_lon: Optional[float] = None
+    summary_polyline: Optional[str] = None
+    geometry_source: Optional[str] = None
+    geometry_points: List[Tuple[float, float]] = field(default_factory=list)
+    details_json: Dict[str, Any] = field(default_factory=dict)
+
+    def to_record(self) -> Dict[str, Any]:
+        return asdict(self)

--- a/activity_classification.py
+++ b/activity_classification.py
@@ -1,126 +1,25 @@
-"""Single source of truth for activity type classification.
+"""Compatibility wrapper for activity-domain classification helpers.
 
-All modules that need to classify, normalise, or compare activity types
-(filtering, styling, export, pace/speed selection) should use the helpers
-here instead of defining their own normalization or family-mapping logic.
+The canonical provider-neutral activity classification logic now lives in
+:mod:`qfit.activities.domain.activity_classification`.
 """
-from __future__ import annotations
 
-import re
-from typing import Iterable
-
-ACTIVITY_LABEL_FIELDS: tuple[str, ...] = ("sport_type", "activity_type")
-
-# Resolution order matters: first matching family wins.
-_FAMILY_TOKENS: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("machine",  ("virtual", "trainer", "commute", "ebike", "machine")),
-    ("winter",   ("ski", "snow", "sled")),
-    ("water",    ("swim", "surf", "paddle", "row", "kayak", "canoe", "sup")),
-    ("mountain", ("iceclimb", "climb", "mountain", "boulder", "alpinism")),
-    ("running",  ("run", "jog")),
-    ("walking",  ("walk", "hike", "trek", "backpack")),
-    ("fitness",  ("crossfit", "workout", "yoga", "weight", "gym", "pilates")),
-    ("cycling",  ("ride", "bike", "cycle")),
+from .activities.domain.activity_classification import (
+    ACTIVITY_LABEL_FIELDS,
+    activity_prefers_pace,
+    canonical_activity_label,
+    normalize_activity_type,
+    ordered_canonical_activity_labels,
+    preferred_activity_field,
+    resolve_activity_family,
 )
 
-
-def normalize_activity_type(value: object) -> str:
-    """Lowercase and strip non-alphanumeric characters from an activity type string.
-
-    This is the canonical normalization used across filtering, styling, and
-    classification.  ``'TrailRun'``, ``'Trail Run'``, and ``'trail-run'``
-    all normalise to ``'trailrun'``.
-    """
-    text = str(value or "").strip().casefold()
-    return re.sub(r"[^a-z0-9]+", "", text)
-
-
-def canonical_activity_label(
-    activity_type: str | None,
-    sport_type: str | None,
-) -> str | None:
-    """Return the canonical label for an activity.
-
-    Prefers the more-specific ``sport_type`` when set, otherwise falls back to
-    ``activity_type``. Blank/whitespace-only values are ignored. Returns
-    ``None`` when both are absent.
-
-    This is the agreed field-priority contract used by filtering, the UI
-    combo-box, and map styling.
-    """
-    for candidate in (sport_type, activity_type):
-        if candidate is None:
-            continue
-        label = str(candidate).strip()
-        if label:
-            return label
-    return None
-
-
-def ordered_canonical_activity_labels(
-    label_pairs: Iterable[tuple[str | None, str | None]],
-) -> list[str]:
-    """Return ordered unique canonical activity labels from ``(activity, sport)`` pairs.
-
-    Uses :func:`canonical_activity_label` for field-priority semantics and
-    deduplicates case-insensitively while preserving first-seen order.
-    """
-    ordered_labels: list[str] = []
-    seen_normalized: set[str] = set()
-    for activity_type, sport_type in label_pairs:
-        label = canonical_activity_label(activity_type, sport_type)
-        if not label:
-            continue
-        normalized = normalize_activity_type(label)
-        if normalized in seen_normalized:
-            continue
-        seen_normalized.add(normalized)
-        ordered_labels.append(label)
-    return ordered_labels
-
-
-def preferred_activity_field(available_fields: Iterable[str]) -> str | None:
-    """Return the best activity-label field from *available_fields*.
-
-    Prefers the more-specific ``sport_type`` when present, otherwise falls back
-    to ``activity_type``.  Returns ``None`` when neither is available.
-
-    This encodes the same field-priority contract as
-    :func:`canonical_activity_label` but operates on layer/table field names
-    rather than individual values.
-    """
-    field_set = {str(name) for name in available_fields}
-    for candidate in ACTIVITY_LABEL_FIELDS:
-        if candidate in field_set:
-            return candidate
-    return None
-
-
-def resolve_activity_family(activity_value: object) -> str:
-    """Map an activity type value to a broad semantic family name.
-
-    Returns one of: ``machine``, ``winter``, ``water``, ``mountain``,
-    ``running``, ``walking``, ``fitness``, ``cycling``.
-    Unknown or empty types default to ``machine``.
-    """
-    normalized = normalize_activity_type(activity_value)
-    if not normalized:
-        return "machine"
-    for family, tokens in _FAMILY_TOKENS:
-        if any(token in normalized for token in tokens):
-            return family
-    return "machine"
-
-
-def activity_prefers_pace(
-    activity_type: str | None,
-    sport_type: str | None = None,
-) -> bool:
-    """Return True when the activity should display pace (min/km) over speed (km/h).
-
-    Running, walking, and hiking activities prefer pace; all others use speed.
-    The canonical label (``sport_type`` preferred) is used for the check.
-    """
-    label = canonical_activity_label(activity_type, sport_type) or ""
-    normalized = normalize_activity_type(label)
-    return any(token in normalized for token in ("run", "walk", "hike"))
+__all__ = [
+    "ACTIVITY_LABEL_FIELDS",
+    "activity_prefers_pace",
+    "canonical_activity_label",
+    "normalize_activity_type",
+    "ordered_canonical_activity_labels",
+    "preferred_activity_field",
+    "resolve_activity_family",
+]

--- a/activity_query.py
+++ b/activity_query.py
@@ -1,294 +1,33 @@
-from __future__ import annotations
+"""Compatibility wrapper for activity-domain query helpers.
 
-from collections import Counter
-from dataclasses import dataclass
-from datetime import date, datetime
-from typing import Iterable, Sequence
+The canonical provider-neutral activity query/summary logic now lives in
+:mod:`qfit.activities.domain.activity_query`.
+"""
 
-from .activity_classification import (
-    ACTIVITY_LABEL_FIELDS,
-    canonical_activity_label,
-    normalize_activity_type,
-)
-
-
-@dataclass(frozen=True)
-class ActivitySummary:
-    count: int
-    total_distance_km: float
-    total_moving_time_s: int
-    detailed_count: int
-    by_type: dict[str, int]
-    latest_date: str | None
-
-DEFAULT_SORT_LABEL = "Start date (newest first)"
-SORT_OPTIONS = (
+from .activities.domain.activity_query import (
     DEFAULT_SORT_LABEL,
-    "Start date (oldest first)",
-    "Distance (longest first)",
-    "Distance (shortest first)",
-    "Moving time (longest first)",
-    "Name (A–Z)",
+    SORT_OPTIONS,
+    ActivityQuery,
+    ActivitySummary,
+    build_preview_lines,
+    build_subset_string,
+    filter_activities,
+    format_duration,
+    format_summary_text,
+    sort_activities,
+    summarize_activities,
 )
 
-
-class ActivityQuery:
-    def __init__(
-        self,
-        activity_type: str | None = "All",
-        date_from: str | None = None,
-        date_to: str | None = None,
-        min_distance_km: float | int | None = None,
-        max_distance_km: float | int | None = None,
-        search_text: str | None = None,
-        detailed_only: bool = False,
-        sort_label: str | None = DEFAULT_SORT_LABEL,
-    ):
-        self.activity_type = activity_type or "All"
-        self.date_from = date_from or None
-        self.date_to = date_to or None
-        self.min_distance_km = _safe_float(min_distance_km)
-        self.max_distance_km = _safe_float(max_distance_km)
-        self.search_text = (search_text or "").strip()
-        self.detailed_only = bool(detailed_only)
-        self.sort_label = sort_label or DEFAULT_SORT_LABEL
-
-
-def filter_activities(activities: Iterable[object], query: ActivityQuery) -> list[object]:
-    results = []
-    search_text = query.search_text.casefold()
-    date_from = _parse_iso_date(query.date_from)
-    date_to = _parse_iso_date(query.date_to)
-
-    for activity in activities:
-        if query.activity_type and query.activity_type != "All":
-            query_norm = normalize_activity_type(query.activity_type)
-            if not any(
-                normalize_activity_type(getattr(activity, field, None)) == query_norm
-                for field in ACTIVITY_LABEL_FIELDS
-            ):
-                continue
-
-        activity_date = _activity_date(activity)
-        if date_from is not None and (activity_date is None or activity_date < date_from):
-            continue
-        if date_to is not None and (activity_date is None or activity_date > date_to):
-            continue
-
-        distance_km = _distance_km(activity)
-        if query.min_distance_km is not None and query.min_distance_km > 0:
-            if distance_km is None or distance_km < query.min_distance_km:
-                continue
-        if query.max_distance_km is not None and query.max_distance_km > 0:
-            if distance_km is None or distance_km > query.max_distance_km:
-                continue
-
-        if search_text:
-            haystack = " ".join(
-                part
-                for part in [
-                    getattr(activity, "name", None),
-                    getattr(activity, "activity_type", None),
-                    getattr(activity, "sport_type", None),
-                ]
-                if part
-            ).casefold()
-            if search_text not in haystack:
-                continue
-
-        if query.detailed_only and getattr(activity, "geometry_source", None) != "stream":
-            continue
-
-        results.append(activity)
-
-    return results
-
-
-def sort_activities(activities: Sequence[object], sort_label: str | None) -> list[object]:
-    sort_label = sort_label or DEFAULT_SORT_LABEL
-    items = list(activities)
-
-    if sort_label == "Start date (oldest first)":
-        return sorted(items, key=lambda activity: (_sort_datetime(activity) is None, _sort_datetime(activity) or datetime.min))
-    if sort_label == "Distance (longest first)":
-        return sorted(items, key=lambda activity: _distance_sort_value(activity), reverse=True)
-    if sort_label == "Distance (shortest first)":
-        return sorted(items, key=lambda activity: (_distance_sort_value(activity) is None, _distance_sort_value(activity) or float("inf")))
-    if sort_label == "Moving time (longest first)":
-        return sorted(items, key=lambda activity: _moving_time_sort_value(activity), reverse=True)
-    if sort_label == "Name (A–Z)":
-        return sorted(items, key=lambda activity: ((getattr(activity, "name", None) or "").casefold(), _sort_datetime(activity) or datetime.min), reverse=False)
-
-    return sorted(items, key=lambda activity: (_sort_datetime(activity) or datetime.min, (getattr(activity, "name", None) or "").casefold()), reverse=True)
-
-
-def summarize_activities(activities: Sequence[object]) -> ActivitySummary:
-    total_distance_km = 0.0
-    total_moving_time_s = 0
-    detailed_count = 0
-    by_type = Counter()
-    latest_date = None
-
-    for activity in activities:
-        distance_km = _distance_km(activity)
-        if distance_km is not None:
-            total_distance_km += distance_km
-        moving_time_s = getattr(activity, "moving_time_s", None)
-        if isinstance(moving_time_s, (int, float)):
-            total_moving_time_s += int(moving_time_s)
-        if getattr(activity, "geometry_source", None) == "stream":
-            detailed_count += 1
-        activity_type = canonical_activity_label(
-            getattr(activity, "activity_type", None),
-            getattr(activity, "sport_type", None),
-        ) or "Unknown"
-        by_type[activity_type] += 1
-        activity_date = _activity_date(activity)
-        if activity_date is not None and (latest_date is None or activity_date > latest_date):
-            latest_date = activity_date
-
-    return ActivitySummary(
-        count=len(activities),
-        total_distance_km=round(total_distance_km, 1),
-        total_moving_time_s=total_moving_time_s,
-        detailed_count=detailed_count,
-        by_type=dict(sorted(by_type.items())),
-        latest_date=latest_date.isoformat() if latest_date is not None else None,
-    )
-
-
-def build_preview_lines(activities: Sequence[object], limit: int = 8) -> list[str]:
-    lines = []
-    for activity in list(activities)[: max(limit, 0)]:
-        date_label = _activity_date(activity).isoformat() if _activity_date(activity) is not None else "unknown date"
-        activity_type = canonical_activity_label(
-            getattr(activity, "activity_type", None),
-            getattr(activity, "sport_type", None),
-        ) or "Activity"
-        distance_km = _distance_km(activity)
-        distance_label = "? km" if distance_km is None else f"{distance_km:.1f} km"
-        moving_time_label = format_duration(getattr(activity, "moving_time_s", None))
-        detail_label = "detailed" if getattr(activity, "geometry_source", None) == "stream" else "summary"
-        name = getattr(activity, "name", None) or "Untitled activity"
-        lines.append(f"{date_label} — {name} · {activity_type} · {distance_label} · {moving_time_label} · {detail_label}")
-    return lines
-
-
-def build_subset_string(query: ActivityQuery) -> str:
-    clauses = []
-    if query.activity_type and query.activity_type != "All":
-        normalized = _escape_sql_literal(normalize_activity_type(query.activity_type))
-        type_matches = [
-            f"{_sql_normalize_expr(field_name)} = '{normalized}'"
-            for field_name in reversed(ACTIVITY_LABEL_FIELDS)
-        ]
-        clauses.append(f"({' OR '.join(type_matches)})")
-    if query.date_from:
-        clauses.append(f'"start_date" >= \'{_escape_sql_literal(query.date_from)}T00:00:00\'')
-    if query.date_to:
-        clauses.append(f'"start_date" <= \'{_escape_sql_literal(query.date_to)}T23:59:59\'')
-    if query.min_distance_km is not None and query.min_distance_km > 0:
-        clauses.append(f'"distance_m" >= {query.min_distance_km * 1000.0}')
-    if query.max_distance_km is not None and query.max_distance_km > 0:
-        clauses.append(f'"distance_m" <= {query.max_distance_km * 1000.0}')
-    if query.search_text:
-        search_text = _escape_sql_literal(query.search_text.lower())
-        search_clauses = [f"lower(coalesce(\"{field_name}\", '')) LIKE '%{search_text}%'" for field_name in ("name", *reversed(ACTIVITY_LABEL_FIELDS))]
-        clauses.append(f"({' OR '.join(search_clauses)})")
-    if query.detailed_only:
-        clauses.append('"geometry_source" = \'stream\'')
-    return " AND ".join(clauses)
-
-
-def format_duration(value: int | float | None) -> str:
-    if value is None:
-        return "?"
-    total_seconds = max(int(value), 0)
-    hours, remainder = divmod(total_seconds, 3600)
-    minutes, seconds = divmod(remainder, 60)
-    if hours:
-        return f"{hours}h {minutes:02d}m"
-    if minutes:
-        return f"{minutes}m {seconds:02d}s"
-    return f"{seconds}s"
-
-
-def format_summary_text(summary: ActivitySummary) -> str:
-    if not summary.count:
-        return "0 activities match the current filters."
-
-    top_types = ", ".join(f"{name}: {count}" for name, count in list(summary.by_type.items())[:3])
-    latest_date = summary.latest_date or "unknown"
-    return (
-        "{count} activities · {distance:.1f} km · {duration} moving · detailed tracks: {detailed} · latest: {latest}"
-        "\nTop activity types: {top_types}"
-    ).format(
-        count=summary.count,
-        distance=summary.total_distance_km,
-        duration=format_duration(summary.total_moving_time_s),
-        detailed=summary.detailed_count,
-        latest=latest_date,
-        top_types=top_types or "n/a",
-    )
-
-
-def _activity_date(activity: object) -> date | None:
-    return _parse_iso_date(getattr(activity, "start_date_local", None) or getattr(activity, "start_date", None))
-
-
-def _parse_iso_date(value: str | None) -> date | None:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
-    except ValueError:
-        try:
-            return date.fromisoformat(str(value)[:10])
-        except ValueError:
-            return None
-
-
-def _sort_datetime(activity: object) -> datetime | None:
-    value = getattr(activity, "start_date_local", None) or getattr(activity, "start_date", None)
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def _distance_km(activity: object) -> float | None:
-    distance_m = getattr(activity, "distance_m", None)
-    if not isinstance(distance_m, (int, float)):
-        return None
-    return float(distance_m) / 1000.0
-
-
-def _distance_sort_value(activity: object) -> float:
-    distance_m = getattr(activity, "distance_m", None)
-    if not isinstance(distance_m, (int, float)):
-        return -1.0
-    return float(distance_m)
-
-
-def _moving_time_sort_value(activity: object) -> int:
-    value = getattr(activity, "moving_time_s", None)
-    if not isinstance(value, (int, float)):
-        return -1
-    return int(value)
-
-
-def _sql_normalize_expr(field: str) -> str:
-    """SQL expression approximating normalize_activity_type for a column."""
-    return f"LOWER(REPLACE(REPLACE(REPLACE(\"{field}\", ' ', ''), '-', ''), '_', ''))"
-
-
-def _escape_sql_literal(value: str) -> str:
-    return str(value).replace("'", "''")
-
-
-def _safe_float(value: float | int | str | None) -> float | None:
-    if value in (None, ""):
-        return None
-    return float(value)
+__all__ = [
+    "DEFAULT_SORT_LABEL",
+    "SORT_OPTIONS",
+    "ActivityQuery",
+    "ActivitySummary",
+    "build_preview_lines",
+    "build_subset_string",
+    "filter_activities",
+    "format_duration",
+    "format_summary_text",
+    "sort_activities",
+    "summarize_activities",
+]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,9 +79,9 @@ This layer should prefer describing *what qfit wants done*, not *how QGIS or Str
 
 Examples:
 
-- canonical activity models
-- activity filtering/querying/sorting/summaries
-- activity classification and provider-neutral derived metadata
+- `activities/domain/models.py` for canonical activity models
+- `activities/domain/activity_query.py` for activity filtering/querying/sorting/summaries
+- `activities/domain/activity_classification.py` for provider-neutral classification and derived metadata
 - time/polyline utilities and similar reusable core helpers
 
 Responsibilities:

--- a/layer_filter_service.py
+++ b/layer_filter_service.py
@@ -1,4 +1,4 @@
-from .activity_query import ActivityQuery, build_subset_string
+from .activities.domain.activity_query import ActivityQuery, build_subset_string
 
 
 class LayerFilterService:

--- a/map_style.py
+++ b/map_style.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import colorsys
 from typing import Iterable
 
-from .activity_classification import (
+from .activities.domain.activity_classification import (
     normalize_activity_type as normalize_activity_value,
     preferred_activity_field,
     resolve_activity_family,

--- a/models.py
+++ b/models.py
@@ -1,38 +1,10 @@
-from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+"""Compatibility wrapper for the activity domain model.
 
+The canonical activity model now lives in :mod:`qfit.activities.domain.models`.
+Keep this module as a stable import surface while the package structure is
+refactored incrementally.
+"""
 
-@dataclass
-class Activity:
-    source: str
-    source_activity_id: str
-    external_id: Optional[str] = None
-    name: Optional[str] = None
-    activity_type: Optional[str] = None
-    sport_type: Optional[str] = None
-    start_date: Optional[str] = None
-    start_date_local: Optional[str] = None
-    timezone: Optional[str] = None
-    distance_m: Optional[float] = None
-    moving_time_s: Optional[int] = None
-    elapsed_time_s: Optional[int] = None
-    total_elevation_gain_m: Optional[float] = None
-    average_speed_mps: Optional[float] = None
-    max_speed_mps: Optional[float] = None
-    average_heartrate: Optional[float] = None
-    max_heartrate: Optional[float] = None
-    average_watts: Optional[float] = None
-    kilojoules: Optional[float] = None
-    calories: Optional[float] = None
-    suffer_score: Optional[float] = None
-    start_lat: Optional[float] = None
-    start_lon: Optional[float] = None
-    end_lat: Optional[float] = None
-    end_lon: Optional[float] = None
-    summary_polyline: Optional[str] = None
-    geometry_source: Optional[str] = None
-    geometry_points: List[Tuple[float, float]] = field(default_factory=list)
-    details_json: Dict[str, Any] = field(default_factory=dict)
+from .activities.domain.models import Activity
 
-    def to_record(self) -> Dict[str, Any]:
-        return asdict(self)
+__all__ = ["Activity"]

--- a/provider.py
+++ b/provider.py
@@ -6,7 +6,7 @@ implement, as well as the common error type they should raise.
 
 from typing import Dict, List, Optional, Protocol, runtime_checkable
 
-from .models import Activity
+from .activities.domain.models import Activity
 
 
 class ProviderError(RuntimeError):

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -10,8 +10,8 @@ from qgis.PyQt.QtCore import QDate, QStandardPaths, Qt, QUrl
 from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import QApplication, QFileDialog, QDockWidget, QMessageBox, QToolButton, QVBoxLayout, QWidget
 
-from .activity_classification import ordered_canonical_activity_labels
-from .activity_query import (
+from .activities.domain.activity_classification import ordered_canonical_activity_labels
+from .activities.domain.activity_query import (
     DEFAULT_SORT_LABEL,
     SORT_OPTIONS,
     ActivityQuery,

--- a/strava_client.py
+++ b/strava_client.py
@@ -74,7 +74,7 @@ class _RequestsCompat:
 
 requests = _RequestsCompat()
 
-from .models import Activity
+from .activities.domain.models import Activity
 
 
 class StravaClientError(RuntimeError):

--- a/sync_repository.py
+++ b/sync_repository.py
@@ -5,7 +5,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from .models import Activity
+from .activities.domain.models import Activity
 
 
 @dataclass(frozen=True)

--- a/tests/test_activity_classification.py
+++ b/tests/test_activity_classification.py
@@ -2,7 +2,7 @@ import unittest
 
 from tests import _path  # noqa: F401
 
-from qfit.activity_classification import (
+from qfit.activities.domain.activity_classification import (
     ACTIVITY_LABEL_FIELDS,
     activity_prefers_pace,
     canonical_activity_label,

--- a/tests/test_activity_domain_compatibility.py
+++ b/tests/test_activity_domain_compatibility.py
@@ -1,0 +1,26 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.activity_classification import normalize_activity_type as legacy_normalize_activity_type
+from qfit.activity_query import ActivityQuery as LegacyActivityQuery
+from qfit.activities.domain.activity_classification import normalize_activity_type
+from qfit.activities.domain.activity_query import ActivityQuery
+from qfit.activities.domain.models import Activity
+from qfit.models import Activity as LegacyActivity
+
+
+class ActivityDomainCompatibilityTests(unittest.TestCase):
+    def test_legacy_and_domain_activity_model_are_the_same_dataclass(self):
+        self.assertIs(LegacyActivity, Activity)
+
+    def test_legacy_and_domain_query_types_are_the_same_class(self):
+        self.assertIs(LegacyActivityQuery, ActivityQuery)
+
+    def test_legacy_and_domain_classification_helpers_match(self):
+        self.assertIs(legacy_normalize_activity_type, normalize_activity_type)
+        self.assertEqual(normalize_activity_type("Trail Run"), "trailrun")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_activity_query.py
+++ b/tests/test_activity_query.py
@@ -1,7 +1,7 @@
 import unittest
 
 from tests import _path  # noqa: F401
-from qfit.activity_query import (
+from qfit.activities.domain.activity_query import (
     ActivityQuery,
     build_preview_lines,
     build_subset_string,
@@ -11,7 +11,7 @@ from qfit.activity_query import (
     sort_activities,
     summarize_activities,
 )
-from qfit.models import Activity
+from qfit.activities.domain.models import Activity
 
 
 class ActivityQueryTests(unittest.TestCase):

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -29,10 +29,10 @@ def _import_targets(relative_path: str) -> set[str]:
 
 class CoreModuleBoundaryTests(unittest.TestCase):
     CORE_MODULES = [
-        "activity_classification.py",
-        "activity_query.py",
+        "activities/domain/activity_classification.py",
+        "activities/domain/activity_query.py",
+        "activities/domain/models.py",
         "map_style.py",
-        "models.py",
         "polyline_utils.py",
         "provider.py",
         "qfit_cache.py",

--- a/tests/test_layer_filter_service.py
+++ b/tests/test_layer_filter_service.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
 
-from qfit.activity_query import ActivityQuery, build_subset_string
+from qfit.activities.domain.activity_query import ActivityQuery, build_subset_string
 from qfit.layer_filter_service import LayerFilterService
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -11,12 +11,12 @@ try:
     from qgis.core import QgsApplication, QgsProject, QgsVectorLayer
     from qgis.PyQt.QtCore import QDate, Qt
 
-    from qfit.activity_query import ActivityQuery, build_subset_string
+    from qfit.activities.domain.activity_query import ActivityQuery, build_subset_string
     from qfit.gpkg_writer import GeoPackageWriter
     from qfit.layer_manager import LayerManager
     from qfit.atlas.export_task import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
     from qfit.mapbox_config import TILE_MODE_RASTER
-    from qfit.models import Activity
+    from qfit.activities.domain.models import Activity
     from qfit.qfit_dockwidget import QfitDockWidget
     from qfit.visual_apply import VisualApplyService
 

--- a/tests/test_sync_repository.py
+++ b/tests/test_sync_repository.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from tests import _path  # noqa: F401
-from qfit.models import Activity
+from qfit.activities.domain.models import Activity
 from qfit.sync_repository import SyncRepository
 
 


### PR DESCRIPTION
## Summary
- move the provider-neutral activity model, classification helpers, and query/summary helpers into a dedicated activities/domain core package
- keep the existing top-level activity modules as compatibility shims while internal imports migrate to the feature-oriented domain package
- extend architecture/docs coverage so the new domain core remains explicit and protected during future refactors

## Testing
- python3 -m pytest tests/test_activity_classification.py tests/test_activity_query.py tests/test_activity_domain_compatibility.py tests/test_layer_filter_service.py tests/test_sync_repository.py tests/test_architecture_boundaries.py -q
- python3 -m pytest tests/ -q

Closes #176
