### PR TITLE
refactor: add a QGIS layer gateway boundary

### DIFF
--- a/atlas/export_service.py
+++ b/atlas/export_service.py
@@ -12,6 +12,7 @@ from typing import Callable
 logger = logging.getLogger(__name__)
 
 from ..mapbox_config import TILE_MODE_RASTER, TILE_MODE_VECTOR
+from ..visualization.application.layer_gateway import LayerGateway
 
 
 @dataclass
@@ -64,8 +65,8 @@ class AtlasExportService:
     making both independently testable.
     """
 
-    def __init__(self, layer_manager) -> None:
-        self.layer_manager = layer_manager
+    def __init__(self, layer_gateway: LayerGateway) -> None:
+        self.layer_gateway = layer_gateway
 
     @staticmethod
     def build_request(
@@ -106,7 +107,7 @@ class AtlasExportService:
         if request.pre_export_tile_mode != TILE_MODE_RASTER or not request.background_enabled:
             return
         try:
-            self.layer_manager.ensure_background_layer(
+            self.layer_gateway.ensure_background_layer(
                 enabled=True,
                 preset_name=request.preset_name,
                 access_token=request.access_token,
@@ -127,7 +128,7 @@ class AtlasExportService:
             output_path=request.output_path,
             on_finished=request.on_finished,
             restore_tile_mode=request.pre_export_tile_mode,
-            layer_manager=self.layer_manager,
+            layer_manager=self.layer_gateway,
             preset_name=request.preset_name,
             access_token=request.access_token,
             style_owner=request.style_owner,

--- a/background_map_controller.py
+++ b/background_map_controller.py
@@ -1,6 +1,7 @@
 import logging
 
 from .mapbox_config import preset_defaults, preset_requires_custom_style
+from .visualization.application.layer_gateway import LayerGateway
 
 logger = logging.getLogger(__name__)
 
@@ -8,8 +9,8 @@ logger = logging.getLogger(__name__)
 class BackgroundMapController:
     """Orchestrates background map configuration and loading."""
 
-    def __init__(self, layer_manager):
-        self._layer_manager = layer_manager
+    def __init__(self, layer_gateway: LayerGateway):
+        self._layer_gateway = layer_gateway
 
     def resolve_style_defaults(self, preset_name, current_owner, current_style_id, force=False):
         """Return ``(owner, style_id)`` to apply for *preset_name*.
@@ -23,8 +24,8 @@ class BackgroundMapController:
         return preset_defaults(preset_name)
 
     def load_background(self, enabled, preset_name, access_token, style_owner, style_id, tile_mode):
-        """Apply the background layer via :class:`LayerManager` and return the layer (or *None*)."""
-        layer = self._layer_manager.ensure_background_layer(
+        """Apply the background layer via the layer gateway and return the layer (or *None*)."""
+        layer = self._layer_gateway.ensure_background_layer(
             enabled=enabled,
             preset_name=preset_name,
             access_token=access_token,

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -1,70 +1,7 @@
-import logging
+"""Backward-compatible import for qfit's QGIS layer gateway adapter."""
 
-logger = logging.getLogger(__name__)
+from .visualization.infrastructure.qgis_layer_gateway import QgisLayerGateway
 
-from .background_map_service import BackgroundMapService
-from .layer_filter_service import LayerFilterService
-from .layer_style_service import LayerStyleService
-from .map_canvas_service import MapCanvasService
-from .mapbox_config import TILE_MODE_RASTER
-from .project_layer_loader import ProjectLayerLoader
-from .temporal_service import TemporalService
-
-
-class LayerManager:
-    WORKING_CRS = "EPSG:3857"
-
-    def __init__(self, iface):
-        self.iface = iface
-        self._style_service = LayerStyleService()
-        self._background_service = BackgroundMapService()
-        self._filter_service = LayerFilterService()
-        self._project_layer_loader = ProjectLayerLoader()
-        self._temporal_service = TemporalService()
-        self._canvas_service = MapCanvasService(self._background_service)
-
-    def load_output_layers(self, gpkg_path):
-        self._canvas_service.ensure_working_crs(self.iface, preserve_extent=False)
-        activities_layer, starts_layer, points_layer, atlas_layer = (
-            self._project_layer_loader.load_output_layers(gpkg_path)
-        )
-        self._move_background_layers_to_bottom()
-        self._canvas_service.zoom_to_layers(
-            self.iface, [activities_layer, starts_layer, points_layer, atlas_layer]
-        )
-        return activities_layer, starts_layer, points_layer, atlas_layer
-
-    def ensure_background_layer(self, enabled, preset_name, access_token, style_owner="", style_id="", tile_mode=TILE_MODE_RASTER):
-        return self._background_service.ensure_background_layer(
-            enabled=enabled,
-            preset_name=preset_name,
-            access_token=access_token,
-            style_owner=style_owner,
-            style_id=style_id,
-            tile_mode=tile_mode,
-        )
-
-    def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None, max_distance_km=None, search_text=None, detailed_only=False):
-        self._filter_service.apply_filters(
-            layer,
-            activity_type=activity_type,
-            date_from=date_from,
-            date_to=date_to,
-            min_distance_km=min_distance_km,
-            max_distance_km=max_distance_km,
-            search_text=search_text,
-            detailed_only=detailed_only,
-        )
-
-    def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name=None):
-        self._style_service.apply_style(
-            activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name
-        )
-
-    def apply_temporal_configuration(self, activities_layer, starts_layer, points_layer, atlas_layer, mode_label):
-        return self._temporal_service.apply_temporal_configuration(
-            activities_layer, starts_layer, points_layer, atlas_layer, mode_label
-        )
-
-    def _move_background_layers_to_bottom(self):
-        self._background_service.move_background_layers_to_bottom()
+# Preserve the long-standing import path while application services migrate
+# toward the explicit layer gateway terminology.
+LayerManager = QgisLayerGateway

--- a/load_workflow.py
+++ b/load_workflow.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from datetime import date
 
 from .sync_repository import SyncStats
+from .visualization.application.layer_gateway import LayerGateway
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +62,8 @@ class LoadWorkflowError(Exception):
 class LoadWorkflowService:
     """Orchestrates GeoPackage write and layer-load workflows independent of UI."""
 
-    def __init__(self, layer_manager):
-        self.layer_manager = layer_manager
+    def __init__(self, layer_gateway: LayerGateway):
+        self.layer_gateway = layer_gateway
 
     @staticmethod
     def build_write_request(
@@ -162,7 +163,7 @@ class LoadWorkflowService:
         result = self._write_database(request)
 
         activities_layer, starts_layer, points_layer, atlas_layer = (
-            self.layer_manager.load_output_layers(result.output_path)
+            self.layer_gateway.load_output_layers(result.output_path)
         )
 
         result.activities_layer = activities_layer
@@ -208,7 +209,7 @@ class LoadWorkflowService:
             )
 
         activities_layer, starts_layer, points_layer, atlas_layer = (
-            self.layer_manager.load_output_layers(request.output_path)
+            self.layer_gateway.load_output_layers(request.output_path)
         )
 
         total = activities_layer.featureCount() if activities_layer else 0

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -28,7 +28,7 @@ from .atlas.export_service import (
 )
 from .background_map_controller import BackgroundMapController
 from .contextual_help import ContextualHelpBinder, build_dock_help_entries
-from .layer_manager import LayerManager
+from .visualization.infrastructure.qgis_layer_gateway import QgisLayerGateway
 from .load_workflow import (
     LoadWorkflowError,
     LoadWorkflowService,
@@ -88,11 +88,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.settings = SettingsService()
         self.sync_controller = SyncController()
         self.atlas_export_controller = AtlasExportController()
-        self.layer_manager = LayerManager(iface)
-        self.background_controller = BackgroundMapController(self.layer_manager)
-        self.load_workflow = LoadWorkflowService(self.layer_manager)
-        self.visual_apply = VisualApplyService(self.layer_manager)
-        self.atlas_export_service = AtlasExportService(self.layer_manager)
+        self.layer_gateway = QgisLayerGateway(iface)
+        self.background_controller = BackgroundMapController(self.layer_gateway)
+        self.load_workflow = LoadWorkflowService(self.layer_gateway)
+        self.visual_apply = VisualApplyService(self.layer_gateway)
+        self.atlas_export_service = AtlasExportService(self.layer_gateway)
         self.fetch_result_service = FetchResultService(self.sync_controller)
         self.cache = self._build_cache()
         self.setupUi(self)

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -1,0 +1,128 @@
+import importlib
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+from tests import _path  # noqa: F401
+from qfit.visualization.application.layer_gateway import LayerGateway
+
+
+class LayerGatewayBoundaryTests(unittest.TestCase):
+    def test_load_workflow_service_accepts_gateway_protocol_instance(self):
+        from qfit.load_workflow import LoadWorkflowService
+
+        gateway = MagicMock(spec=LayerGateway)
+        service = LoadWorkflowService(gateway)
+
+        self.assertIs(service.layer_gateway, gateway)
+
+    def test_visual_apply_service_accepts_gateway_protocol_instance(self):
+        from qfit.visual_apply import VisualApplyService
+
+        gateway = MagicMock(spec=LayerGateway)
+        service = VisualApplyService(gateway)
+
+        self.assertIs(service.layer_gateway, gateway)
+
+    def test_qgis_gateway_adapter_and_legacy_import_share_same_class(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+            layer_manager_module = importlib.import_module("qfit.layer_manager")
+
+        self.assertIs(layer_manager_module.LayerManager, adapter_module.QgisLayerGateway)
+
+    def test_qgis_gateway_satisfies_protocol_and_delegates_to_services(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            result = gateway.load_output_layers("/tmp/out.gpkg")
+
+        self.assertIsInstance(gateway, LayerGateway)
+        canvas = gateway._canvas_service
+        loader = gateway._project_layer_loader
+        background = gateway._background_service
+        canvas.ensure_working_crs.assert_called_once_with(gateway.iface, preserve_extent=False)
+        loader.load_output_layers.assert_called_once_with("/tmp/out.gpkg")
+        canvas.zoom_to_layers.assert_called_once_with(
+            gateway.iface,
+            [result[0], result[1], result[2], result[3]],
+        )
+        background.move_background_layers_to_bottom.assert_called_once_with()
+
+    @staticmethod
+    def _reset_qgis_gateway_imports():
+        for name in [
+            "qfit.layer_manager",
+            "qfit.visualization.infrastructure.qgis_layer_gateway",
+        ]:
+            sys.modules.pop(name, None)
+
+    @staticmethod
+    def _qgis_gateway_modules():
+        def class_module(name, class_name, instance):
+            module = ModuleType(name)
+            setattr(module, class_name, MagicMock(return_value=instance))
+            return module
+
+        style_service = MagicMock(name="style_service")
+        background_service = MagicMock(name="background_service")
+        filter_service = MagicMock(name="filter_service")
+        project_layer_loader = MagicMock(name="project_layer_loader")
+        temporal_service = MagicMock(name="temporal_service")
+        map_canvas_service = MagicMock(name="map_canvas_service")
+
+        project_layer_loader.load_output_layers.return_value = (
+            MagicMock(name="activities"),
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+
+        mapbox_config = ModuleType("qfit.mapbox_config")
+        mapbox_config.TILE_MODE_RASTER = "raster"
+
+        return {
+            "qfit.background_map_service": class_module(
+                "qfit.background_map_service",
+                "BackgroundMapService",
+                background_service,
+            ),
+            "qfit.layer_filter_service": class_module(
+                "qfit.layer_filter_service",
+                "LayerFilterService",
+                filter_service,
+            ),
+            "qfit.layer_style_service": class_module(
+                "qfit.layer_style_service",
+                "LayerStyleService",
+                style_service,
+            ),
+            "qfit.map_canvas_service": class_module(
+                "qfit.map_canvas_service",
+                "MapCanvasService",
+                map_canvas_service,
+            ),
+            "qfit.mapbox_config": mapbox_config,
+            "qfit.project_layer_loader": class_module(
+                "qfit.project_layer_loader",
+                "ProjectLayerLoader",
+                project_layer_loader,
+            ),
+            "qfit.temporal_service": class_module(
+                "qfit.temporal_service",
+                "TemporalService",
+                temporal_service,
+            ),
+        }

--- a/visual_apply.py
+++ b/visual_apply.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass, field
 
 from .mapbox_config import MapboxConfigError
+from .visualization.application.layer_gateway import LayerGateway
 
 logger = logging.getLogger(__name__)
 
@@ -67,8 +68,8 @@ class VisualApplyService:
     orchestration logic can be tested without a live UI.
     """
 
-    def __init__(self, layer_manager):
-        self.layer_manager = layer_manager
+    def __init__(self, layer_gateway: LayerGateway):
+        self.layer_gateway = layer_gateway
 
     @staticmethod
     def should_update_background(apply_subset_filters):
@@ -107,7 +108,7 @@ class VisualApplyService:
             self._apply_filters_to_all_layers(request.layers, request.query)
 
         if has_layers:
-            self.layer_manager.apply_style(
+            self.layer_gateway.apply_style(
                 request.layers.activities,
                 request.layers.starts,
                 request.layers.points,
@@ -119,7 +120,7 @@ class VisualApplyService:
                     else None
                 ),
             )
-            temporal_note = self.layer_manager.apply_temporal_configuration(
+            temporal_note = self.layer_gateway.apply_temporal_configuration(
                 request.layers.activities,
                 request.layers.starts,
                 request.layers.points,
@@ -155,7 +156,7 @@ class VisualApplyService:
 
     def _apply_filters_to_all_layers(self, layers, query):
         for layer in [layers.activities, layers.starts, layers.points, layers.atlas]:
-            self.layer_manager.apply_filters(
+            self.layer_gateway.apply_filters(
                 layer,
                 query.activity_type,
                 query.date_from,
@@ -173,7 +174,7 @@ class VisualApplyService:
         failure.
         """
         try:
-            layer = self.layer_manager.ensure_background_layer(
+            layer = self.layer_gateway.ensure_background_layer(
                 enabled=config.enabled,
                 preset_name=config.preset_name,
                 access_token=config.access_token,

--- a/visualization/__init__.py
+++ b/visualization/__init__.py
@@ -1,0 +1,1 @@
+"""Visualization feature package."""

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application services and ports for visualization workflows."""

--- a/visualization/application/layer_gateway.py
+++ b/visualization/application/layer_gateway.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LayerGateway(Protocol):
+    """Application-facing boundary for qfit layer and map operations."""
+
+    def load_output_layers(self, gpkg_path): ...
+
+    def ensure_background_layer(
+        self,
+        enabled,
+        preset_name,
+        access_token,
+        style_owner="",
+        style_id="",
+        tile_mode="raster",
+    ): ...
+
+    def apply_filters(
+        self,
+        layer,
+        activity_type=None,
+        date_from=None,
+        date_to=None,
+        min_distance_km=None,
+        max_distance_km=None,
+        search_text=None,
+        detailed_only=False,
+    ): ...
+
+    def apply_style(
+        self,
+        activities_layer,
+        starts_layer,
+        points_layer,
+        atlas_layer,
+        preset,
+        background_preset_name=None,
+    ): ...
+
+    def apply_temporal_configuration(
+        self,
+        activities_layer,
+        starts_layer,
+        points_layer,
+        atlas_layer,
+        mode_label,
+    ): ...

--- a/visualization/infrastructure/__init__.py
+++ b/visualization/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""QGIS-backed adapters for visualization workflows."""

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -1,0 +1,72 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+from ...background_map_service import BackgroundMapService
+from ...layer_filter_service import LayerFilterService
+from ...layer_style_service import LayerStyleService
+from ...map_canvas_service import MapCanvasService
+from ...mapbox_config import TILE_MODE_RASTER
+from ...project_layer_loader import ProjectLayerLoader
+from ...temporal_service import TemporalService
+
+
+class QgisLayerGateway:
+    """QGIS-backed adapter for loading, filtering, styling, and map wiring."""
+
+    WORKING_CRS = "EPSG:3857"
+
+    def __init__(self, iface):
+        self.iface = iface
+        self._style_service = LayerStyleService()
+        self._background_service = BackgroundMapService()
+        self._filter_service = LayerFilterService()
+        self._project_layer_loader = ProjectLayerLoader()
+        self._temporal_service = TemporalService()
+        self._canvas_service = MapCanvasService(self._background_service)
+
+    def load_output_layers(self, gpkg_path):
+        self._canvas_service.ensure_working_crs(self.iface, preserve_extent=False)
+        activities_layer, starts_layer, points_layer, atlas_layer = (
+            self._project_layer_loader.load_output_layers(gpkg_path)
+        )
+        self._move_background_layers_to_bottom()
+        self._canvas_service.zoom_to_layers(
+            self.iface, [activities_layer, starts_layer, points_layer, atlas_layer]
+        )
+        return activities_layer, starts_layer, points_layer, atlas_layer
+
+    def ensure_background_layer(self, enabled, preset_name, access_token, style_owner="", style_id="", tile_mode=TILE_MODE_RASTER):
+        return self._background_service.ensure_background_layer(
+            enabled=enabled,
+            preset_name=preset_name,
+            access_token=access_token,
+            style_owner=style_owner,
+            style_id=style_id,
+            tile_mode=tile_mode,
+        )
+
+    def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None, max_distance_km=None, search_text=None, detailed_only=False):
+        self._filter_service.apply_filters(
+            layer,
+            activity_type=activity_type,
+            date_from=date_from,
+            date_to=date_to,
+            min_distance_km=min_distance_km,
+            max_distance_km=max_distance_km,
+            search_text=search_text,
+            detailed_only=detailed_only,
+        )
+
+    def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name=None):
+        self._style_service.apply_style(
+            activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name
+        )
+
+    def apply_temporal_configuration(self, activities_layer, starts_layer, points_layer, atlas_layer, mode_label):
+        return self._temporal_service.apply_temporal_configuration(
+            activities_layer, starts_layer, points_layer, atlas_layer, mode_label
+        )
+
+    def _move_background_layers_to_bottom(self):
+        self._background_service.move_background_layers_to_bottom()


### PR DESCRIPTION
## Summary
- add an explicit `LayerGateway` application port for visualization workflows
- move the QGIS-backed implementation into `visualization/infrastructure/qgis_layer_gateway.py`
- keep `layer_manager.py` as a compatibility import while the rest of the package migrates
- update workflow services and the dock widget to depend on the gateway boundary
- add regression tests for the new adapter boundary

## Testing
- `python3 -m pytest tests/test_load_workflow.py tests/test_visual_apply.py tests/test_background_map_controller.py tests/test_atlas_export_service.py tests/test_layer_gateway.py`
- `python3 -m pytest` *(currently segfaults during collection in this environment because the QGIS/PyQt stack crashes before test execution; targeted suites above pass)*

Part of #174. Also nudges #170 by moving visualization infrastructure under a feature package.
