### PR TITLE
refactor: extract clear database workflow

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -31,6 +31,14 @@ class LoadDatasetRequest:
     output_path: str = ""
 
 
+@dataclass
+class ClearDatabaseRequest:
+    """Structured input for clearing a qfit GeoPackage and loaded layers."""
+
+    output_path: str = ""
+    layers: list = field(default_factory=list)
+
+
 # Backward-compatible aliases while issue #175 lands incrementally.
 LoadDatabaseRequest = StoreActivitiesRequest
 LoadExistingRequest = LoadDatasetRequest
@@ -53,6 +61,15 @@ class LoadResult:
     start_count: int = 0
     point_count: int = 0
     atlas_count: int = 0
+
+
+@dataclass
+class ClearDatabaseResult:
+    """Structured result from clearing a qfit GeoPackage and loaded layers."""
+
+    output_path: str = ""
+    deleted: bool = False
+    status: str = ""
 
 
 class LoadWorkflowError(Exception):
@@ -92,6 +109,13 @@ class LoadWorkflowService:
     @staticmethod
     def build_load_existing_request(output_path) -> LoadDatasetRequest:
         return LoadDatasetRequest(output_path=output_path)
+
+    @staticmethod
+    def build_clear_database_request(output_path, layers=None) -> ClearDatabaseRequest:
+        return ClearDatabaseRequest(
+            output_path=output_path,
+            layers=list(layers or []),
+        )
 
     def _write_database(self, request: StoreActivitiesRequest) -> LoadResult:
         """Write activities to the GeoPackage without loading layers into QGIS.
@@ -226,3 +250,39 @@ class LoadWorkflowService:
 
     def load_existing_request(self, request: LoadDatasetRequest) -> LoadResult:
         return self.load_existing(request)
+
+    def clear_database(
+        self,
+        request: ClearDatabaseRequest | None = None,
+        **legacy_kwargs,
+    ) -> ClearDatabaseResult:
+        """Remove qfit layers from QGIS and delete the GeoPackage when present."""
+        if request is None:
+            request = self.build_clear_database_request(**legacy_kwargs)
+
+        if not request.output_path:
+            raise LoadWorkflowError("Set a GeoPackage output path first.")
+
+        self.layer_gateway.remove_layers(request.layers)
+
+        deleted = False
+        if os.path.exists(request.output_path):
+            os.remove(request.output_path)
+            deleted = True
+
+        if deleted:
+            status = (
+                f"Database cleared: {request.output_path} deleted. "
+                "Fetch and store activities to start fresh."
+            )
+        else:
+            status = "Layers cleared. No file to delete at the specified path."
+
+        return ClearDatabaseResult(
+            output_path=request.output_path,
+            deleted=deleted,
+            status=status,
+        )
+
+    def clear_database_request(self, request: ClearDatabaseRequest) -> ClearDatabaseResult:
+        return self.clear_database(request=request)

--- a/load_workflow.py
+++ b/load_workflow.py
@@ -5,6 +5,8 @@ This module remains as a stable forwarding import during the package move.
 """
 
 from .activities.application.load_workflow import (
+    ClearDatabaseRequest,
+    ClearDatabaseResult,
     LoadDatabaseRequest,
     LoadDatasetRequest,
     LoadExistingRequest,
@@ -15,6 +17,8 @@ from .activities.application.load_workflow import (
 )
 
 __all__ = [
+    "ClearDatabaseRequest",
+    "ClearDatabaseResult",
     "LoadDatabaseRequest",
     "LoadDatasetRequest",
     "LoadExistingRequest",

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -833,13 +833,24 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if reply != QMessageBox.Yes:
             return
 
-        # Remove layers from QGIS project
-        for layer in [self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer]:
-            if layer is not None:
-                try:
-                    QgsProject.instance().removeMapLayer(layer)
-                except RuntimeError:
-                    logger.debug("Failed to remove layer from project", exc_info=True)
+        try:
+            request = self.load_workflow.build_clear_database_request(
+                output_path=output_path,
+                layers=[
+                    self.activities_layer,
+                    self.starts_layer,
+                    self.points_layer,
+                    self.atlas_layer,
+                ],
+            )
+            result = self.load_workflow.clear_database_request(request)
+        except LoadWorkflowError as exc:
+            self._show_error("No database path", str(exc))
+            return
+        except (RuntimeError, OSError) as exc:
+            self._show_error("Could not delete database", str(exc))
+            self._set_status("Failed to delete the GeoPackage file")
+            return
 
         self.activities_layer = None
         self.starts_layer = None
@@ -849,24 +860,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.output_path = None
         self.last_fetch_context = {}
 
-        # Delete the file
-        deleted = False
-        if os.path.exists(output_path):
-            try:
-                os.remove(output_path)
-                deleted = True
-            except OSError as exc:
-                self._show_error("Could not delete database", str(exc))
-                self._set_status("Failed to delete the GeoPackage file")
-                return
-
         self.countLabel.setText("Activities fetched: 0")
-        if deleted:
-            self._set_status(
-                f"Database cleared: {output_path} deleted. Fetch and store activities to start fresh."
-            )
-        else:
-            self._set_status("Layers cleared. No file to delete at the specified path.")
+        self._set_status(result.status)
 
     def on_apply_filters_clicked(self):
         has_layers = any(layer is not None for layer in [self.activities_layer, self.starts_layer, self.points_layer, self.atlas_layer])

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -61,6 +61,24 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         )
         background.move_background_layers_to_bottom.assert_called_once_with()
 
+    def test_qgis_gateway_remove_layers_delegates_to_qgsproject(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            layer_a = MagicMock(name="layer_a")
+            layer_b = MagicMock(name="layer_b")
+
+            gateway.remove_layers([layer_a, None, layer_b])
+
+        modules["qgis.core"].QgsProject.instance.return_value.removeMapLayer.assert_any_call(layer_a)
+        modules["qgis.core"].QgsProject.instance.return_value.removeMapLayer.assert_any_call(layer_b)
+
     @staticmethod
     def _reset_qgis_gateway_imports():
         for name in [
@@ -93,7 +111,11 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         mapbox_config = ModuleType("qfit.mapbox_config")
         mapbox_config.TILE_MODE_RASTER = "raster"
 
+        qgis_core = ModuleType("qgis.core")
+        qgis_core.QgsProject = MagicMock(name="QgsProject")
+
         return {
+            "qgis.core": qgis_core,
             "qfit.background_map_service": class_module(
                 "qfit.background_map_service",
                 "BackgroundMapService",

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 from qfit.load_workflow import (
+    ClearDatabaseRequest,
+    ClearDatabaseResult,
     LoadDatabaseRequest,
     LoadExistingRequest,
     LoadResult,
@@ -296,6 +298,61 @@ class LoadExistingSuccessTests(unittest.TestCase):
         result = self.service.load_existing("/tmp/empty.gpkg")
 
         self.assertEqual(result.total_stored, 0)
+
+
+class ClearDatabaseValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.service = LoadWorkflowService(self.layer_manager)
+
+    def test_raises_when_no_output_path(self):
+        with self.assertRaises(LoadWorkflowError) as ctx:
+            self.service.clear_database(output_path="", layers=[])
+
+        self.assertIn("output path", str(ctx.exception))
+
+    def test_build_clear_database_request_returns_dataclass(self):
+        request = self.service.build_clear_database_request(
+            "/tmp/test.gpkg",
+            layers=["activities", "atlas"],
+        )
+
+        self.assertIsInstance(request, ClearDatabaseRequest)
+        self.assertEqual(request.output_path, "/tmp/test.gpkg")
+        self.assertEqual(request.layers, ["activities", "atlas"])
+
+
+class ClearDatabaseSuccessTests(unittest.TestCase):
+    def setUp(self):
+        self.layer_manager = MagicMock()
+        self.service = LoadWorkflowService(self.layer_manager)
+
+    @patch("qfit.activities.application.load_workflow.os.path.exists", return_value=True)
+    @patch("qfit.activities.application.load_workflow.os.remove")
+    def test_removes_layers_and_deletes_file_when_present(self, mock_remove, _mock_exists):
+        result = self.service.clear_database(
+            output_path="/tmp/test.gpkg",
+            layers=["activities", None, "atlas"],
+        )
+
+        self.assertIsInstance(result, ClearDatabaseResult)
+        self.assertTrue(result.deleted)
+        self.assertIn("/tmp/test.gpkg deleted", result.status)
+        self.layer_manager.remove_layers.assert_called_once_with(["activities", None, "atlas"])
+        mock_remove.assert_called_once_with("/tmp/test.gpkg")
+
+    @patch("qfit.activities.application.load_workflow.os.path.exists", return_value=False)
+    @patch("qfit.activities.application.load_workflow.os.remove")
+    def test_clears_layers_without_delete_when_file_missing(self, mock_remove, _mock_exists):
+        result = self.service.clear_database(
+            output_path="/tmp/missing.gpkg",
+            layers=["activities"],
+        )
+
+        self.assertFalse(result.deleted)
+        self.assertEqual(result.status, "Layers cleared. No file to delete at the specified path.")
+        self.layer_manager.remove_layers.assert_called_once_with(["activities"])
+        mock_remove.assert_not_called()
 
 
 class LoadResultTests(unittest.TestCase):

--- a/visualization/application/layer_gateway.py
+++ b/visualization/application/layer_gateway.py
@@ -9,6 +9,8 @@ class LayerGateway(Protocol):
 
     def load_output_layers(self, gpkg_path): ...
 
+    def remove_layers(self, layers): ...
+
     def ensure_background_layer(
         self,
         enabled,

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -1,5 +1,7 @@
 import logging
 
+from qgis.core import QgsProject
+
 logger = logging.getLogger(__name__)
 
 from ...background_map_service import BackgroundMapService
@@ -35,6 +37,15 @@ class QgisLayerGateway:
             self.iface, [activities_layer, starts_layer, points_layer, atlas_layer]
         )
         return activities_layer, starts_layer, points_layer, atlas_layer
+
+    def remove_layers(self, layers):
+        for layer in layers or []:
+            if layer is None:
+                continue
+            try:
+                QgsProject.instance().removeMapLayer(layer)
+            except RuntimeError:
+                logger.debug("Failed to remove layer from project", exc_info=True)
 
     def ensure_background_layer(self, enabled, preset_name, access_token, style_owner="", style_id="", tile_mode=TILE_MODE_RASTER):
         return self._background_service.ensure_background_layer(


### PR DESCRIPTION
## Summary
- move clear-database orchestration out of `QfitDockWidget` and into `LoadWorkflowService`
- extend the layer gateway with a dedicated `remove_layers` boundary for removing loaded qfit layers
- keep the confirmation dialog in the UI while pushing delete/reset work into an application-facing workflow

## Why
This continues the follow-up work on #169 by thinning `QfitDockWidget` a bit more and moving one more concrete workflow behind explicit service/gateway seams.

## Testing
- `python3 -m pytest tests/test_load_workflow.py tests/test_layer_gateway.py -q --tb=short`
- `python3 -m pytest tests/test_qgis_smoke.py -q --tb=short`

Refs #169
