### PR TITLE
fix: fail fast when atlas pdf merger is unavailable

### DIFF
--- a/atlas/export_service.py
+++ b/atlas/export_service.py
@@ -118,6 +118,26 @@ class AtlasExportService:
         except RuntimeError:
             logger.warning("Vector tile mode failed, falling back to raster", exc_info=True)
 
+    @staticmethod
+    def check_pdf_export_prerequisites() -> str | None:
+        """Return a user-facing error when atlas PDF export prerequisites are missing.
+
+        Export produces one PDF per page and requires a PDF merger to assemble
+        the final multi-page document. If ``pypdf`` is unavailable, fail fast so
+        the UI can show a clear message instead of generating a misleading
+        first-page-only PDF.
+        """
+        from .export_task import _load_pdf_writer  # lazy import: QGIS runtime only
+
+        try:
+            _load_pdf_writer()
+        except ImportError:
+            return (
+                "Atlas PDF export requires the 'pypdf' runtime, but it is not available in this qfit install. "
+                "Reinstall/update the plugin so bundled dependencies are included, then try again."
+            )
+        return None
+
     def build_task(self, request: GenerateAtlasPdfRequest | None = None, **legacy_kwargs):
         """Construct an :class:`AtlasExportTask` ready to submit to the QGIS task manager."""
         if request is None:

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1060,6 +1060,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if changed:
             self.atlasPdfPathLineEdit.setText(output_path)
 
+        prereq_error = self.atlas_export_service.check_pdf_export_prerequisites()
+        if prereq_error is not None:
+            self._set_atlas_pdf_status("Atlas PDF export unavailable.")
+            self._set_status("Atlas PDF export unavailable.")
+            self._show_error("Atlas PDF export unavailable", prereq_error)
+            return
+
         self._save_settings()
 
         pre_export_tile_mode = self.tileModeComboBox.currentText()

--- a/tests/test_atlas_export_service.py
+++ b/tests/test_atlas_export_service.py
@@ -157,6 +157,31 @@ class PrepareBasemapTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# AtlasExportService.check_pdf_export_prerequisites
+# ---------------------------------------------------------------------------
+
+
+class CheckPdfExportPrerequisitesTests(unittest.TestCase):
+    def test_returns_none_when_pdf_writer_is_available(self):
+        stub_module, _mock_task = _make_atlas_task_stub()
+        stub_module._load_pdf_writer = MagicMock(return_value=object())
+
+        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
+            self.assertIsNone(AtlasExportService.check_pdf_export_prerequisites())
+
+    def test_returns_user_facing_error_when_pdf_writer_is_missing(self):
+        stub_module, _mock_task = _make_atlas_task_stub()
+        stub_module._load_pdf_writer = MagicMock(side_effect=ImportError("missing pypdf"))
+
+        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
+            error = AtlasExportService.check_pdf_export_prerequisites()
+
+        self.assertIsNotNone(error)
+        self.assertIn("pypdf", error)
+        self.assertIn("Reinstall/update the plugin", error)
+
+
+# ---------------------------------------------------------------------------
 # AtlasExportService.build_task
 # ---------------------------------------------------------------------------
 

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 
@@ -302,6 +302,36 @@ class QgisSmokeTests(unittest.TestCase):
             dock_reloaded.close()
             dock_reloaded.deleteLater()
 
+    def test_generate_atlas_pdf_shows_clear_error_when_pypdf_is_missing(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            dock.atlas_layer = MagicMock()
+            dock.atlas_layer.featureCount.return_value = 3
+            dock.atlasPdfPathLineEdit.setText("/tmp/qfit-atlas.pdf")
+
+            dock.atlas_export_controller.validate_atlas_layer = MagicMock()
+            dock.atlas_export_controller.normalize_pdf_path = MagicMock(
+                return_value=("/tmp/qfit-atlas.pdf", False)
+            )
+            dock.atlas_export_service.check_pdf_export_prerequisites = MagicMock(
+                return_value="Atlas PDF export requires the 'pypdf' runtime."
+            )
+            dock._save_settings = MagicMock()
+            dock._show_error = MagicMock()
+
+            dock.on_generate_atlas_pdf_clicked()
+
+            dock._show_error.assert_called_once_with(
+                "Atlas PDF export unavailable",
+                "Atlas PDF export requires the 'pypdf' runtime.",
+            )
+            dock._save_settings.assert_not_called()
+            self.assertIsNone(dock._atlas_export_task)
+            self.assertEqual(dock.atlasPdfStatusLabel.text(), "Atlas PDF export unavailable.")
+            self.assertEqual(dock.statusLabel.text(), "Atlas PDF export unavailable.")
+        finally:
+            dock.close()
+            dock.deleteLater()
     def test_fetch_preview_shows_fetched_count_even_when_visualize_filters_match_zero(self):
         dock = QfitDockWidget(self.iface)
         try:


### PR DESCRIPTION
## Summary
- check atlas PDF export prerequisites before starting the export task
- surface a clear user-facing error when `pypdf` is unavailable
- add regression tests for both the service-level prerequisite check and the dock-widget button flow

## Why
When the PDF merge dependency is missing, qfit should stop early and explain the problem instead of attempting export and ending up with a misleading cover-only PDF.

## Testing
- `python3 -m pytest tests/test_atlas_export_service.py tests/test_qgis_smoke.py -q --tb=short`
