### PR TITLE
fix: vendor pypdf in dev plugin installs

### DIFF
--- a/scripts/install_plugin.py
+++ b/scripts/install_plugin.py
@@ -4,13 +4,12 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import os
 import pathlib
 import shutil
 import sys
 
-from importlib import metadata
+from package_plugin import _vendor_runtime_dependencies
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 PLUGIN_NAME = "qfit"
@@ -37,50 +36,6 @@ def should_copy(path: pathlib.Path) -> bool:
     if path.suffix in EXCLUDED_SUFFIXES:
         return False
     return path.is_file()
-
-
-def _resolve_package_dir(package_name: str) -> pathlib.Path:
-    spec = importlib.util.find_spec(package_name)
-    origin = getattr(spec, "origin", None) if spec is not None else None
-    if not origin:
-        raise RuntimeError(
-            f"Installing qfit for local testing requires the '{package_name}' package to be installed locally. "
-            f"Run: python -m pip install {package_name}"
-        )
-    return pathlib.Path(origin).resolve().parent
-
-
-def _resolve_distribution_license(package_name: str) -> pathlib.Path | None:
-    try:
-        dist = metadata.distribution(package_name)
-    except metadata.PackageNotFoundError:
-        return None
-
-    for file in dist.files or []:
-        parts = pathlib.Path(file).parts
-        if not parts:
-            continue
-        lowered = [part.lower() for part in parts]
-        filename = lowered[-1]
-        if filename.startswith("license") or filename.startswith("copying"):
-            return pathlib.Path(dist.locate_file(file)).resolve()
-        if "licenses" in lowered:
-            return pathlib.Path(dist.locate_file(file)).resolve()
-    return None
-
-
-def _vendor_runtime_dependencies(destination: pathlib.Path) -> None:
-    vendor_dir = destination / "vendor"
-    vendor_dir.mkdir(parents=True, exist_ok=True)
-
-    pypdf_source = _resolve_package_dir("pypdf")
-    shutil.copytree(pypdf_source, vendor_dir / "pypdf", dirs_exist_ok=True)
-
-    license_path = _resolve_distribution_license("pypdf")
-    if license_path and license_path.is_file():
-        licenses_dir = vendor_dir / "licenses"
-        licenses_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(license_path, licenses_dir / "pypdf_LICENSE.txt")
 
 
 def install_copy(destination: pathlib.Path) -> None:


### PR DESCRIPTION
## Summary
- bundle the `pypdf` runtime into local dev/plugin copy installs
- copy the upstream license into the vendored dependency area when available
- fail early with a clear message if the local environment does not have `pypdf` installed

## Why
The Windows/local dev install path should match the packaged plugin closely enough that atlas PDF merge behavior can be tested reliably.

## Testing
- `python3 -m py_compile scripts/install_plugin.py`
