### PR TITLE
refactor: move fetch task construction into sync controller

### DIFF
--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass
 from datetime import date
 
+from .fetch_task import FetchTask
 from ...providers.domain.provider import ProviderError
 from ...providers.infrastructure.strava_provider import StravaProvider
 
@@ -17,6 +18,21 @@ class BuildStravaProviderRequest:
     refresh_token: str = ""
     cache: object = None
     require_refresh_token: bool = True
+
+
+@dataclass
+class BuildFetchTaskRequest:
+    """Structured input for creating a validated activity-fetch task."""
+
+    client_id: str = ""
+    client_secret: str = ""
+    refresh_token: str = ""
+    cache: object = None
+    per_page: int = 200
+    max_pages: int = 0
+    use_detailed_streams: bool = False
+    max_detailed_activities: int = 25
+    on_finished: object = None
 
 
 class SyncController:
@@ -74,6 +90,60 @@ class SyncController:
                 "Open qfit → Configuration and enter a Strava refresh token first."
             )
         return provider
+
+    @staticmethod
+    def build_fetch_task_request(
+        client_id,
+        client_secret,
+        refresh_token,
+        cache,
+        per_page,
+        max_pages,
+        use_detailed_streams,
+        max_detailed_activities,
+        on_finished,
+    ) -> BuildFetchTaskRequest:
+        """Build a structured request for creating a fetch task."""
+        return BuildFetchTaskRequest(
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+            cache=cache,
+            per_page=per_page,
+            max_pages=max_pages,
+            use_detailed_streams=use_detailed_streams,
+            max_detailed_activities=max_detailed_activities,
+            on_finished=on_finished,
+        )
+
+    def build_fetch_task(
+        self,
+        request: BuildFetchTaskRequest | None = None,
+        **legacy_kwargs,
+    ) -> FetchTask:
+        """Create a validated :class:`FetchTask` for background activity import."""
+        if request is None:
+            request = self.build_fetch_task_request(**legacy_kwargs)
+
+        provider_request = self.build_provider_request(
+            client_id=request.client_id,
+            client_secret=request.client_secret,
+            refresh_token=request.refresh_token,
+            cache=request.cache,
+            require_refresh_token=True,
+        )
+        provider = self.build_strava_provider(provider_request)
+
+        return FetchTask(
+            provider=provider,
+            per_page=request.per_page,
+            max_pages=request.max_pages,
+            before=None,
+            after=None,
+            use_detailed_streams=request.use_detailed_streams,
+            max_detailed_activities=request.max_detailed_activities,
+            on_finished=request.on_finished,
+        )
 
     def build_sync_metadata(self, activities, provider):
         """Return a sync-context dict from a completed fetch."""

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -22,7 +22,6 @@ from .activities.domain.activity_query import (
     summarize_activities,
 )
 from .atlas.export_controller import AtlasExportValidationError
-from .activities.application.fetch_task import FetchTask
 from .activities.application.load_workflow import LoadWorkflowError
 from .atlas.export_service import (
     AtlasExportResult,
@@ -673,31 +672,23 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._save_settings()
         try:
-            provider_request = self.sync_controller.build_provider_request(
+            fetch_request = self.sync_controller.build_fetch_task_request(
                 client_id=self.clientIdLineEdit.text().strip(),
                 client_secret=self.clientSecretLineEdit.text().strip(),
                 refresh_token=self.refreshTokenLineEdit.text().strip(),
                 cache=self.cache,
-                require_refresh_token=True,
+                per_page=self.perPageSpinBox.value(),
+                max_pages=self.maxPagesSpinBox.value(),
+                use_detailed_streams=self.detailedStreamsCheckBox.isChecked(),
+                max_detailed_activities=self.maxDetailedActivitiesSpinBox.value(),
+                on_finished=self._on_fetch_finished,
             )
-            client = self.sync_controller.build_strava_provider(provider_request)
+            self._fetch_task = self.sync_controller.build_fetch_task(fetch_request)
         except ProviderError as exc:
             self._show_error("Strava import failed", str(exc))
             self._set_status("Strava fetch failed")
             return
 
-        # Issue #38: fetch all activities — no date filtering at import time.
-        # Date filters are visualization-only (applied post-import to loaded layers).
-        self._fetch_task = FetchTask(
-            provider=client,
-            per_page=self.perPageSpinBox.value(),
-            max_pages=self.maxPagesSpinBox.value(),
-            before=None,
-            after=None,
-            use_detailed_streams=self.detailedStreamsCheckBox.isChecked(),
-            max_detailed_activities=self.maxDetailedActivitiesSpinBox.value(),
-            on_finished=self._on_fetch_finished,
-        )
         self._set_fetch_running(True)
         self._set_status("Fetching activities from Strava…")
         QgsApplication.taskManager().addTask(self._fetch_task)

--- a/sync_controller.py
+++ b/sync_controller.py
@@ -4,6 +4,10 @@ Prefer importing from ``qfit.activities.application.sync_controller``.
 This module remains as a stable forwarding import during the package move.
 """
 
-from .activities.application.sync_controller import BuildStravaProviderRequest, SyncController
+from .activities.application.sync_controller import (
+    BuildFetchTaskRequest,
+    BuildStravaProviderRequest,
+    SyncController,
+)
 
-__all__ = ["BuildStravaProviderRequest", "SyncController"]
+__all__ = ["BuildFetchTaskRequest", "BuildStravaProviderRequest", "SyncController"]

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -332,6 +332,28 @@ class QgisSmokeTests(unittest.TestCase):
         finally:
             dock.close()
             dock.deleteLater()
+
+    def test_refresh_clicked_builds_fetch_task_via_sync_controller(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            fake_task = MagicMock(name="fetch_task")
+            dock._save_settings = MagicMock()
+            dock.sync_controller.build_fetch_task_request = MagicMock(return_value="fetch-request")
+            dock.sync_controller.build_fetch_task = MagicMock(return_value=fake_task)
+
+            with patch("qfit.qfit_dockwidget.QgsApplication.taskManager") as task_manager:
+                task_manager.return_value.addTask = MagicMock()
+                dock.on_refresh_clicked()
+
+            dock.sync_controller.build_fetch_task_request.assert_called_once()
+            dock.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
+            task_manager.return_value.addTask.assert_called_once_with(fake_task)
+            self.assertIs(dock._fetch_task, fake_task)
+            self.assertEqual(dock.refreshButton.text(), "Cancel")
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_fetch_preview_shows_fetched_count_even_when_visualize_filters_match_zero(self):
         dock = QfitDockWidget(self.iface)
         try:

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -1,10 +1,11 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 from qfit.provider import ProviderError
 from qfit.strava_provider import StravaProvider
-from qfit.sync_controller import BuildStravaProviderRequest, SyncController
+from qfit.sync_controller import BuildFetchTaskRequest, BuildStravaProviderRequest, SyncController
 
 
 class BuildStravaProviderTests(unittest.TestCase):
@@ -50,6 +51,61 @@ class BuildStravaProviderTests(unittest.TestCase):
         ctrl = SyncController()
         provider = ctrl.build_strava_provider("id", "secret", "", require_refresh_token=False)
         self.assertIsInstance(provider, StravaProvider)
+
+
+class BuildFetchTaskTests(unittest.TestCase):
+    def test_build_fetch_task_request_returns_structured_request(self):
+        ctrl = SyncController()
+
+        request = ctrl.build_fetch_task_request(
+            client_id="id",
+            client_secret="secret",
+            refresh_token="token",
+            cache="cache",
+            per_page=123,
+            max_pages=4,
+            use_detailed_streams=True,
+            max_detailed_activities=9,
+            on_finished="callback",
+        )
+
+        self.assertIsInstance(request, BuildFetchTaskRequest)
+        self.assertEqual(request.client_id, "id")
+        self.assertEqual(request.per_page, 123)
+        self.assertTrue(request.use_detailed_streams)
+
+    def test_build_fetch_task_validates_provider_and_constructs_fetch_task(self):
+        ctrl = SyncController()
+        provider = MagicMock(name="provider")
+
+        with (
+            patch.object(ctrl, "build_strava_provider", return_value=provider) as build_provider,
+            patch("qfit.activities.application.sync_controller.FetchTask") as fetch_task_class,
+        ):
+            task = ctrl.build_fetch_task(
+                client_id="id",
+                client_secret="secret",
+                refresh_token="token",
+                cache="cache",
+                per_page=50,
+                max_pages=2,
+                use_detailed_streams=True,
+                max_detailed_activities=7,
+                on_finished="callback",
+            )
+
+        build_provider.assert_called_once()
+        fetch_task_class.assert_called_once_with(
+            provider=provider,
+            per_page=50,
+            max_pages=2,
+            before=None,
+            after=None,
+            use_detailed_streams=True,
+            max_detailed_activities=7,
+            on_finished="callback",
+        )
+        self.assertIs(task, fetch_task_class.return_value)
 
 
 class BuildSyncMetadataTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add an explicit fetch-task request/type to `SyncController`
- move validated `FetchTask` construction out of `QfitDockWidget`
- cover the new controller seam and the dock-widget integration with tests

## Why
This continues the issue #169 follow-up by thinning `QfitDockWidget` and moving another concrete workflow step behind an application-layer controller.

## Testing
- `python3 -m pytest tests/test_sync_controller.py tests/test_qgis_smoke.py -q --tb=short`

Refs #169
