### PR TITLE
refactor: move strava auth workflow into sync controller

### DIFF
--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -35,6 +35,29 @@ class BuildFetchTaskRequest:
     on_finished: object = None
 
 
+@dataclass
+class StravaAuthorizeRequest:
+    """Structured input for building a Strava authorization URL."""
+
+    client_id: str = ""
+    client_secret: str = ""
+    refresh_token: str = ""
+    cache: object = None
+    redirect_uri: str = ""
+
+
+@dataclass
+class ExchangeStravaCodeRequest:
+    """Structured input for exchanging a Strava authorization code."""
+
+    client_id: str = ""
+    client_secret: str = ""
+    refresh_token: str = ""
+    cache: object = None
+    authorization_code: str = ""
+    redirect_uri: str = ""
+
+
 class SyncController:
     """Orchestrates provider fetch/sync logic independent of the UI."""
 
@@ -144,6 +167,83 @@ class SyncController:
             max_detailed_activities=request.max_detailed_activities,
             on_finished=request.on_finished,
         )
+
+    @staticmethod
+    def build_authorize_request(
+        client_id,
+        client_secret,
+        refresh_token,
+        cache,
+        redirect_uri,
+    ) -> StravaAuthorizeRequest:
+        return StravaAuthorizeRequest(
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+            cache=cache,
+            redirect_uri=redirect_uri,
+        )
+
+    def build_authorize_url(
+        self,
+        request: StravaAuthorizeRequest | None = None,
+        **legacy_kwargs,
+    ) -> str:
+        if request is None:
+            request = self.build_authorize_request(**legacy_kwargs)
+
+        provider_request = self.build_provider_request(
+            client_id=request.client_id,
+            client_secret=request.client_secret,
+            refresh_token=request.refresh_token,
+            cache=request.cache,
+            require_refresh_token=False,
+        )
+        provider = self.build_strava_provider(provider_request)
+        return provider.build_authorize_url(redirect_uri=request.redirect_uri)
+
+    @staticmethod
+    def build_exchange_code_request(
+        client_id,
+        client_secret,
+        refresh_token,
+        cache,
+        authorization_code,
+        redirect_uri,
+    ) -> ExchangeStravaCodeRequest:
+        return ExchangeStravaCodeRequest(
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+            cache=cache,
+            authorization_code=authorization_code,
+            redirect_uri=redirect_uri,
+        )
+
+    def exchange_code_for_tokens(
+        self,
+        request: ExchangeStravaCodeRequest | None = None,
+        **legacy_kwargs,
+    ):
+        if request is None:
+            request = self.build_exchange_code_request(**legacy_kwargs)
+
+        provider_request = self.build_provider_request(
+            client_id=request.client_id,
+            client_secret=request.client_secret,
+            refresh_token=request.refresh_token,
+            cache=request.cache,
+            require_refresh_token=False,
+        )
+        provider = self.build_strava_provider(provider_request)
+        payload = provider.exchange_code_for_tokens(
+            authorization_code=request.authorization_code,
+            redirect_uri=request.redirect_uri,
+        )
+        refresh_token = payload.get("refresh_token")
+        if not refresh_token:
+            raise ProviderError("Strava returned no refresh token")
+        return payload
 
     def build_sync_metadata(self, activities, provider):
         """Return a sync-context dict from a completed fetch."""

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -575,16 +575,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def on_open_authorize_clicked(self):
         self._save_settings()
         try:
-            provider_request = self.sync_controller.build_provider_request(
+            authorize_request = self.sync_controller.build_authorize_request(
                 client_id=self.clientIdLineEdit.text().strip(),
                 client_secret=self.clientSecretLineEdit.text().strip(),
                 refresh_token=self.refreshTokenLineEdit.text().strip(),
                 cache=self.cache,
-                require_refresh_token=False,
+                redirect_uri=self._redirect_uri(),
             )
-            client = self.sync_controller.build_strava_provider(provider_request)
-            redirect_uri = self._redirect_uri()
-            url = client.build_authorize_url(redirect_uri=redirect_uri)
+            url = self.sync_controller.build_authorize_url(authorize_request)
             if not QDesktopServices.openUrl(QUrl(url)):
                 clipboard = QApplication.clipboard()
                 if clipboard is not None:
@@ -614,21 +612,16 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         try:
-            provider_request = self.sync_controller.build_provider_request(
+            exchange_request = self.sync_controller.build_exchange_code_request(
                 client_id=self.clientIdLineEdit.text().strip(),
                 client_secret=self.clientSecretLineEdit.text().strip(),
                 refresh_token=self.refreshTokenLineEdit.text().strip(),
                 cache=self.cache,
-                require_refresh_token=False,
-            )
-            client = self.sync_controller.build_strava_provider(provider_request)
-            payload = client.exchange_code_for_tokens(
                 authorization_code=authorization_code,
                 redirect_uri=self._redirect_uri(),
             )
-            refresh_token = payload.get("refresh_token")
-            if not refresh_token:
-                raise ProviderError("Strava returned no refresh token")
+            payload = self.sync_controller.exchange_code_for_tokens(exchange_request)
+            refresh_token = payload["refresh_token"]
             self.refreshTokenLineEdit.setText(refresh_token)
             self.authCodeLineEdit.clear()
             self._save_settings()

--- a/sync_controller.py
+++ b/sync_controller.py
@@ -5,9 +5,17 @@ This module remains as a stable forwarding import during the package move.
 """
 
 from .activities.application.sync_controller import (
+    ExchangeStravaCodeRequest,
     BuildFetchTaskRequest,
     BuildStravaProviderRequest,
+    StravaAuthorizeRequest,
     SyncController,
 )
 
-__all__ = ["BuildFetchTaskRequest", "BuildStravaProviderRequest", "SyncController"]
+__all__ = [
+    "BuildFetchTaskRequest",
+    "BuildStravaProviderRequest",
+    "ExchangeStravaCodeRequest",
+    "StravaAuthorizeRequest",
+    "SyncController",
+]

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -354,6 +354,50 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_open_authorize_clicked_builds_authorize_url_via_sync_controller(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            dock._save_settings = MagicMock()
+            dock.sync_controller.build_authorize_request = MagicMock(return_value="authorize-request")
+            dock.sync_controller.build_authorize_url = MagicMock(return_value="https://strava.test/auth")
+
+            with patch("qfit.qfit_dockwidget.QDesktopServices.openUrl", return_value=True) as open_url:
+                dock.on_open_authorize_clicked()
+
+            dock.sync_controller.build_authorize_request.assert_called_once()
+            dock.sync_controller.build_authorize_url.assert_called_once_with("authorize-request")
+            open_url.assert_called_once()
+            self.assertIn("Strava authorization opened", dock.statusLabel.text())
+        finally:
+            dock.close()
+            dock.deleteLater()
+
+    def test_exchange_code_clicked_uses_sync_controller_exchange_workflow(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            dock.authCodeLineEdit.setText("abc123")
+            dock._save_settings = MagicMock()
+            dock._update_connection_status = MagicMock()
+            dock.sync_controller.build_exchange_code_request = MagicMock(return_value="exchange-request")
+            dock.sync_controller.exchange_code_for_tokens = MagicMock(
+                return_value={
+                    "refresh_token": "rtok",
+                    "athlete": {"firstname": "Ada", "lastname": "Lovelace"},
+                }
+            )
+
+            dock.on_exchange_code_clicked()
+
+            dock.sync_controller.build_exchange_code_request.assert_called_once()
+            dock.sync_controller.exchange_code_for_tokens.assert_called_once_with("exchange-request")
+            self.assertEqual(dock.refreshTokenLineEdit.text(), "rtok")
+            self.assertEqual(dock.authCodeLineEdit.text(), "")
+            dock._update_connection_status.assert_called_once()
+            self.assertIn("Ada Lovelace", dock.statusLabel.text())
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_fetch_preview_shows_fetched_count_even_when_visualize_filters_match_zero(self):
         dock = QfitDockWidget(self.iface)
         try:

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -5,7 +5,13 @@ from unittest.mock import MagicMock, patch
 from tests import _path  # noqa: F401
 from qfit.provider import ProviderError
 from qfit.strava_provider import StravaProvider
-from qfit.sync_controller import BuildFetchTaskRequest, BuildStravaProviderRequest, SyncController
+from qfit.sync_controller import (
+    BuildFetchTaskRequest,
+    BuildStravaProviderRequest,
+    ExchangeStravaCodeRequest,
+    StravaAuthorizeRequest,
+    SyncController,
+)
 
 
 class BuildStravaProviderTests(unittest.TestCase):
@@ -106,6 +112,96 @@ class BuildFetchTaskTests(unittest.TestCase):
             on_finished="callback",
         )
         self.assertIs(task, fetch_task_class.return_value)
+
+
+class StravaAuthorizationWorkflowTests(unittest.TestCase):
+    def test_build_authorize_request_returns_dataclass(self):
+        ctrl = SyncController()
+
+        request = ctrl.build_authorize_request(
+            client_id="id",
+            client_secret="secret",
+            refresh_token="token",
+            cache="cache",
+            redirect_uri="https://example.com/callback",
+        )
+
+        self.assertIsInstance(request, StravaAuthorizeRequest)
+        self.assertEqual(request.redirect_uri, "https://example.com/callback")
+
+    def test_build_authorize_url_uses_validated_provider(self):
+        ctrl = SyncController()
+        provider = MagicMock(name="provider")
+        provider.build_authorize_url.return_value = "https://strava.test/auth"
+
+        with patch.object(ctrl, "build_strava_provider", return_value=provider):
+            url = ctrl.build_authorize_url(
+                client_id="id",
+                client_secret="secret",
+                refresh_token="",
+                cache="cache",
+                redirect_uri="https://example.com/callback",
+            )
+
+        provider.build_authorize_url.assert_called_once_with(
+            redirect_uri="https://example.com/callback"
+        )
+        self.assertEqual(url, "https://strava.test/auth")
+
+    def test_build_exchange_code_request_returns_dataclass(self):
+        ctrl = SyncController()
+
+        request = ctrl.build_exchange_code_request(
+            client_id="id",
+            client_secret="secret",
+            refresh_token="",
+            cache="cache",
+            authorization_code="abc123",
+            redirect_uri="https://example.com/callback",
+        )
+
+        self.assertIsInstance(request, ExchangeStravaCodeRequest)
+        self.assertEqual(request.authorization_code, "abc123")
+
+    def test_exchange_code_for_tokens_returns_payload(self):
+        ctrl = SyncController()
+        provider = MagicMock(name="provider")
+        payload = {"refresh_token": "rtok", "athlete": {"firstname": "Ada"}}
+        provider.exchange_code_for_tokens.return_value = payload
+
+        with patch.object(ctrl, "build_strava_provider", return_value=provider):
+            result = ctrl.exchange_code_for_tokens(
+                client_id="id",
+                client_secret="secret",
+                refresh_token="",
+                cache="cache",
+                authorization_code="abc123",
+                redirect_uri="https://example.com/callback",
+            )
+
+        provider.exchange_code_for_tokens.assert_called_once_with(
+            authorization_code="abc123",
+            redirect_uri="https://example.com/callback",
+        )
+        self.assertEqual(result, payload)
+
+    def test_exchange_code_for_tokens_requires_refresh_token_in_payload(self):
+        ctrl = SyncController()
+        provider = MagicMock(name="provider")
+        provider.exchange_code_for_tokens.return_value = {"athlete": {"firstname": "Ada"}}
+
+        with (
+            patch.object(ctrl, "build_strava_provider", return_value=provider),
+            self.assertRaisesRegex(ProviderError, "no refresh token"),
+        ):
+            ctrl.exchange_code_for_tokens(
+                client_id="id",
+                client_secret="secret",
+                refresh_token="",
+                cache="cache",
+                authorization_code="abc123",
+                redirect_uri="https://example.com/callback",
+            )
 
 
 class BuildSyncMetadataTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add explicit authorization/code-exchange request types to `SyncController`
- move Strava authorize URL construction and token exchange out of `QfitDockWidget`
- cover the controller seam and dock integration with focused tests

## Why
This continues the issue #169 follow-up by thinning `QfitDockWidget` and moving more Strava-specific workflow logic into the application/controller layer.

## Testing
- `python3 -m pytest tests/test_sync_controller.py tests/test_qgis_smoke.py -q --tb=short`

Refs #169
