### PR TITLE
refactor: return structured background workflow results

### DIFF
--- a/background_map_controller.py
+++ b/background_map_controller.py
@@ -1,9 +1,30 @@
 import logging
+from dataclasses import dataclass
 
 from .mapbox_config import preset_defaults, preset_requires_custom_style
 from .visualization.application.layer_gateway import LayerGateway
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LoadBackgroundRequest:
+    """Structured input for the background-map workflow."""
+
+    enabled: bool = False
+    preset_name: str = ""
+    access_token: str = ""
+    style_owner: str = ""
+    style_id: str = ""
+    tile_mode: str = "raster"
+
+
+@dataclass
+class LoadBackgroundResult:
+    """Structured result from loading or clearing a background map."""
+
+    layer: object = None
+    status: str = ""
 
 
 class BackgroundMapController:
@@ -23,9 +44,16 @@ class BackgroundMapController:
             return None
         return preset_defaults(preset_name)
 
-    def load_background(self, enabled, preset_name, access_token, style_owner, style_id, tile_mode):
-        """Apply the background layer via the layer gateway and return the layer (or *None*)."""
-        layer = self._layer_gateway.ensure_background_layer(
+    @staticmethod
+    def build_load_request(
+        enabled,
+        preset_name,
+        access_token,
+        style_owner,
+        style_id,
+        tile_mode,
+    ) -> LoadBackgroundRequest:
+        return LoadBackgroundRequest(
             enabled=enabled,
             preset_name=preset_name,
             access_token=access_token,
@@ -33,4 +61,30 @@ class BackgroundMapController:
             style_id=style_id,
             tile_mode=tile_mode,
         )
-        return layer
+
+    def load_background(
+        self,
+        request: LoadBackgroundRequest | None = None,
+        **legacy_kwargs,
+    ) -> LoadBackgroundResult:
+        """Apply the background layer via the layer gateway and return a structured result."""
+        if request is None:
+            request = self.build_load_request(**legacy_kwargs)
+
+        layer = self._layer_gateway.ensure_background_layer(
+            enabled=request.enabled,
+            preset_name=request.preset_name,
+            access_token=request.access_token,
+            style_owner=request.style_owner,
+            style_id=request.style_id,
+            tile_mode=request.tile_mode,
+        )
+        status = (
+            "Background map loaded below the qfit activity layers"
+            if request.enabled and layer is not None
+            else "Background map cleared"
+        )
+        return LoadBackgroundResult(layer=layer, status=status)
+
+    def load_background_request(self, request: LoadBackgroundRequest) -> LoadBackgroundResult:
+        return self.load_background(request=request)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -540,25 +540,23 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def on_load_background_clicked(self):
         self._save_settings()
-        enabled = self.backgroundMapCheckBox.isChecked()
         try:
-            self.background_layer = self.background_controller.load_background(
-                enabled=enabled,
+            request = self.background_controller.build_load_request(
+                enabled=self.backgroundMapCheckBox.isChecked(),
                 preset_name=self.backgroundPresetComboBox.currentText(),
                 access_token=self._mapbox_access_token(),
                 style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
                 style_id=self.mapboxStyleIdLineEdit.text().strip(),
                 tile_mode=self.tileModeComboBox.currentText(),
             )
+            result = self.background_controller.load_background_request(request)
+            self.background_layer = result.layer
         except (MapboxConfigError, RuntimeError) as exc:
             self._show_error("Background map failed", str(exc))
             self._set_status("Background map could not be updated")
             return
 
-        if enabled and self.background_layer is not None:
-            self._set_status("Background map loaded below the qfit activity layers")
-        else:
-            self._set_status("Background map cleared")
+        self._set_status(result.status)
 
     def _sync_background_style_fields(self, preset_name, force=False):
         result = self.background_controller.resolve_style_defaults(

--- a/tests/test_background_map_controller.py
+++ b/tests/test_background_map_controller.py
@@ -2,7 +2,11 @@ import unittest
 from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
-from qfit.background_map_controller import BackgroundMapController
+from qfit.background_map_controller import (
+    BackgroundMapController,
+    LoadBackgroundRequest,
+    LoadBackgroundResult,
+)
 
 
 class ResolveStyleDefaultsTests(unittest.TestCase):
@@ -35,6 +39,23 @@ class ResolveStyleDefaultsTests(unittest.TestCase):
 
 
 class LoadBackgroundTests(unittest.TestCase):
+    def test_build_load_request_returns_dataclass(self):
+        lm = MagicMock()
+        ctrl = BackgroundMapController(lm)
+
+        request = ctrl.build_load_request(
+            enabled=True,
+            preset_name="Mapbox Dark",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="dark-v11",
+            tile_mode="raster",
+        )
+
+        self.assertIsInstance(request, LoadBackgroundRequest)
+        self.assertTrue(request.enabled)
+        self.assertEqual(request.style_id, "dark-v11")
+
     def test_delegates_to_layer_manager(self):
         lm = MagicMock()
         sentinel = object()
@@ -48,7 +69,9 @@ class LoadBackgroundTests(unittest.TestCase):
             style_id="dark-v11",
             tile_mode="raster",
         )
-        self.assertIs(result, sentinel)
+        self.assertIsInstance(result, LoadBackgroundResult)
+        self.assertIs(result.layer, sentinel)
+        self.assertEqual(result.status, "Background map loaded below the qfit activity layers")
         lm.ensure_background_layer.assert_called_once_with(
             enabled=True,
             preset_name="Mapbox Dark",
@@ -70,4 +93,5 @@ class LoadBackgroundTests(unittest.TestCase):
             style_id="",
             tile_mode="raster",
         )
-        self.assertIsNone(result)
+        self.assertIsNone(result.layer)
+        self.assertEqual(result.status, "Background map cleared")

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -398,6 +398,35 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_load_background_clicked_uses_structured_background_workflow(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            fake_layer = MagicMock(name="background_layer")
+            dock._save_settings = MagicMock()
+            dock.backgroundMapCheckBox.setChecked(True)
+            dock.background_controller.build_load_request = MagicMock(return_value="background-request")
+            dock.background_controller.load_background_request = MagicMock(
+                return_value=MagicMock(
+                    layer=fake_layer,
+                    status="Background map loaded below the qfit activity layers",
+                )
+            )
+
+            dock.on_load_background_clicked()
+
+            dock.background_controller.build_load_request.assert_called_once()
+            dock.background_controller.load_background_request.assert_called_once_with(
+                "background-request"
+            )
+            self.assertIs(dock.background_layer, fake_layer)
+            self.assertEqual(
+                dock.statusLabel.text(),
+                "Background map loaded below the qfit activity layers",
+            )
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_fetch_preview_shows_fetched_count_even_when_visualize_filters_match_zero(self):
         dock = QfitDockWidget(self.iface)
         try:


### PR DESCRIPTION
## Summary
- add explicit request/result dataclasses for the background-map workflow
- move background status branching out of `QfitDockWidget` and into `BackgroundMapController`
- cover the controller and dock integration with focused tests

## Why
This keeps thinning `QfitDockWidget` for issue #169 by moving another small workflow decision/result mapping behind a dedicated controller seam.

## Testing
- `python3 -m pytest tests/test_background_map_controller.py tests/test_qgis_smoke.py -q --tb=short`

Refs #169
