### PR TITLE
feat: prioritize missing detailed routes in stream enrichment

### DIFF
--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -266,9 +266,17 @@ class SyncController:
         stream_stats = provider.last_stream_enrichment_stats or {}
         rate_limit_note = self._rate_limit_note(provider.last_rate_limit)
         fetch_notice = self._fetch_notice(provider)
+        progress_note = ""
+        if "missing_before" in stream_stats or "remaining_missing" in stream_stats:
+            progress_note = (
+                ", missing detailed routes before run: {before}, remaining missing: {after}"
+            ).format(
+                before=stream_stats.get("missing_before", 0),
+                after=stream_stats.get("remaining_missing", 0),
+            )
         return (
             "Fetched {activity_count} activities from {source}, detailed tracks: {detailed_count}, "
-            "cached streams: {cached}, downloaded streams: {downloaded}, rate-limit skips: {skipped}.{rate_note}{fetch_notice}"
+            "cached streams: {cached}, downloaded streams: {downloaded}, rate-limit skips: {skipped}{progress}.{rate_note}{fetch_notice}"
         ).format(
             activity_count=activity_count,
             source=provider.source_name,
@@ -276,6 +284,7 @@ class SyncController:
             cached=stream_stats.get("cached", 0),
             downloaded=stream_stats.get("downloaded", 0),
             skipped=stream_stats.get("skipped_rate_limit", 0),
+            progress=progress_note,
             rate_note=rate_limit_note,
             fetch_notice=fetch_notice,
         )

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -301,21 +301,24 @@ class StravaClient:
         return payload
 
     def enrich_activities_with_streams(self, activities, max_activities=None):
-        if max_activities is None or max_activities <= 0:
-            limit = len(activities)
-        else:
-            limit = min(int(max_activities), len(activities))
-
         stats = {
-            "requested": limit,
+            "requested": 0,
+            "already_detailed": 0,
+            "missing_before": 0,
             "cached": 0,
             "downloaded": 0,
             "skipped_rate_limit": 0,
             "errors": 0,
             "empty": 0,
+            "remaining_missing": 0,
         }
 
-        for activity in activities[:limit]:
+        candidates = []
+        for activity in activities:
+            if self._activity_has_detailed_route(activity):
+                stats["already_detailed"] += 1
+                continue
+
             cached_bundle = self._load_cached_stream_bundle(activity)
             if cached_bundle is not None:
                 if self._apply_stream_bundle_to_activity(activity, cached_bundle):
@@ -326,6 +329,16 @@ class StravaClient:
                     stats["empty"] += 1
                 continue
 
+            candidates.append(activity)
+
+        stats["missing_before"] = len(candidates)
+        if max_activities is None or max_activities <= 0:
+            limit = len(candidates)
+        else:
+            limit = min(int(max_activities), len(candidates))
+        stats["requested"] = limit
+
+        for activity in candidates[:limit]:
             if self._approaching_rate_limit():
                 activity.details_json["stream_skipped_reason"] = "rate_limit_guard"
                 stats["skipped_rate_limit"] += 1
@@ -346,8 +359,15 @@ class StravaClient:
                 activity.details_json["stream_cache"] = "miss-empty"
                 stats["empty"] += 1
 
+        stats["remaining_missing"] = sum(
+            1 for activity in activities if not self._activity_has_detailed_route(activity)
+        )
         self.last_stream_enrichment_stats = stats
         return activities
+
+    @staticmethod
+    def _activity_has_detailed_route(activity):
+        return getattr(activity, "geometry_source", None) == "stream"
 
     def fetch_activity_stream_points(self, activity_id):
         stream_bundle = self.fetch_activity_stream_bundle(activity_id)

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -111,6 +111,54 @@ class StravaClientTests(unittest.TestCase):
         self.assertEqual(client.last_stream_enrichment_stats["cached"], 1)
         self.assertEqual(activity.details_json["stream_cache"], "hit")
 
+    def test_enrich_activities_only_spends_limit_on_missing_routes(self):
+        client = StravaClient()
+        already_detailed = client.normalize_activity({"id": 1, "name": "Detailed"})
+        already_detailed.geometry_source = "stream"
+        cached = client.normalize_activity({"id": 2, "name": "Cached"})
+        missing_a = client.normalize_activity({"id": 3, "name": "Missing A"})
+        missing_b = client.normalize_activity({"id": 4, "name": "Missing B"})
+
+        def fake_cache_lookup(activity):
+            if activity.source_activity_id == "2":
+                return {"latlng": [[46.5, 6.6], [46.6, 6.7]]}
+            return None
+
+        def fake_fetch(activity_id):
+            return {"latlng": [[46.0, 6.0], [46.1, 6.1]], "time": [0, 1]}
+
+        with (
+            patch.object(client, "_load_cached_stream_bundle", side_effect=fake_cache_lookup),
+            patch.object(client, "fetch_activity_stream_bundle", side_effect=fake_fetch) as fetch_mock,
+            patch.object(client, "_save_cached_stream_bundle"),
+        ):
+            client.enrich_activities_with_streams(
+                [already_detailed, cached, missing_a, missing_b],
+                max_activities=1,
+            )
+
+        fetch_mock.assert_called_once_with("3")
+        self.assertEqual(client.last_stream_enrichment_stats["already_detailed"], 1)
+        self.assertEqual(client.last_stream_enrichment_stats["cached"], 1)
+        self.assertEqual(client.last_stream_enrichment_stats["requested"], 1)
+        self.assertEqual(client.last_stream_enrichment_stats["missing_before"], 2)
+        self.assertEqual(client.last_stream_enrichment_stats["downloaded"], 1)
+        self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 1)
+
+    def test_enrich_activities_reports_remaining_missing_after_rate_limit_skip(self):
+        client = StravaClient()
+        activity = client.normalize_activity({"id": 42, "name": "Run"})
+
+        with (
+            patch.object(client, "_load_cached_stream_bundle", return_value=None),
+            patch.object(client, "_approaching_rate_limit", return_value=True),
+        ):
+            client.enrich_activities_with_streams([activity], max_activities=1)
+
+        self.assertEqual(client.last_stream_enrichment_stats["missing_before"], 1)
+        self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 1)
+        self.assertEqual(activity.details_json["stream_skipped_reason"], "rate_limit_guard")
+
     def test_parse_rate_limit_pair_and_remaining(self):
         client = StravaClient()
         self.assertEqual(client._parse_rate_limit_pair("200, 2000"), (200, 2000))

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -251,7 +251,13 @@ class FetchStatusTextTests(unittest.TestCase):
         ctrl = SyncController()
         provider = SimpleNamespace(
             source_name="strava",
-            last_stream_enrichment_stats={"cached": 2, "downloaded": 3, "skipped_rate_limit": 0},
+            last_stream_enrichment_stats={
+                "cached": 2,
+                "downloaded": 3,
+                "skipped_rate_limit": 0,
+                "missing_before": 4,
+                "remaining_missing": 1,
+            },
             last_rate_limit=None,
             last_fetch_notice=None,
         )
@@ -259,6 +265,8 @@ class FetchStatusTextTests(unittest.TestCase):
         self.assertIn("10 activities", text)
         self.assertIn("detailed tracks: 5", text)
         self.assertIn("cached streams: 2", text)
+        self.assertIn("missing detailed routes before run: 4", text)
+        self.assertIn("remaining missing: 1", text)
 
     def test_status_text_includes_source_name(self):
         ctrl = SyncController()


### PR DESCRIPTION
## Summary
- stop spending the detailed-stream run limit on activities that are already detailed or satisfied from cache
- treat the current detailed-stream limit as a budget for newly missing routes in the current fetch result set
- surface missing-before / remaining-missing counts in the fetch summary text

## Why
This is the first slice for #168. It does not introduce the full new UI yet, but it fixes the most confusing current behavior: repeated runs now make predictable forward progress on activities that are still missing detailed routes, instead of burning the limit on already-detailed or cached activities.

## Testing
- `python3 -m pytest tests/test_strava_client.py tests/test_sync_controller.py -q --tb=short`

Refs #168
