### PR TITLE
feat: clarify detailed route backfill wording

### DIFF
--- a/contextual_help.py
+++ b/contextual_help.py
@@ -18,27 +18,28 @@ class HelpEntry:
 DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
     HelpEntry(
         anchor_name="detailedStreamsCheckBox",
-        target_text="Fetch detailed Strava tracks when available",
+        target_text="Fetch detailed routes when available",
         tooltip=(
-            "Downloads higher-fidelity Strava stream data for some activities so qfit can write richer "
+            "Downloads higher-fidelity Strava route data for some activities so qfit can write richer "
             "geometry, timestamps, sampled points, and publish/profile metadata."
         ),
         helper_text=(
-            "Turn this on when you want more than start/end points. qfit caches downloaded streams locally "
-            "and may skip extra downloads when Strava quota gets tight."
+            "Turn this on when you want more than start/end points. qfit caches downloaded routes locally, "
+            "and already detailed or cached routes do not consume the per-run download budget."
         ),
     ),
     HelpEntry(
         anchor_name="maxDetailedActivitiesSpinBox",
         label_name="maxDetailedActivitiesLabel",
-        label_text="Detailed track fetch limit",
+        label_text="Max new detailed routes this run",
         tooltip=(
-            "Maximum number of fetched activities that qfit will enrich with detailed Strava streams during "
-            "this fetch. Lower values keep imports faster and burn less Strava quota."
+            "Maximum number of still-missing activities that qfit will newly enrich with detailed Strava "
+            "routes during this fetch. Lower values keep imports faster and burn less Strava quota."
         ),
         helper_text=(
-            "This limit only applies when detailed tracks are enabled. Example: with 100 fetched activities and a "
-            "limit of 25, qfit still writes all 100 activities but only enriches up to 25 with full stream detail."
+            "This limit only applies when detailed routes are enabled. Example: with 100 fetched activities and a "
+            "limit of 25, qfit still writes all 100 activities but only downloads up to 25 new detailed routes. "
+            "Already detailed or cached routes do not count against that limit."
         ),
         help_button=True,
     ),

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -240,18 +240,18 @@
                   </widget>
                  </item>
                  <item row="2" column="0" colspan="2">
-                  <widget class="QCheckBox" name="detailedStreamsCheckBox">
-                   <property name="text">
-                    <string>Fetch detailed Strava track streams when available</string>
-                   </property>
-                  </widget>
+                 <widget class="QCheckBox" name="detailedStreamsCheckBox">
+                  <property name="text">
+                    <string>Fetch detailed routes when available</string>
+                  </property>
+                 </widget>
                  </item>
                  <item row="3" column="0">
-                  <widget class="QLabel" name="maxDetailedActivitiesLabel">
-                   <property name="text">
-                    <string>Detailed tracks limit</string>
-                   </property>
-                  </widget>
+                 <widget class="QLabel" name="maxDetailedActivitiesLabel">
+                  <property name="text">
+                    <string>Max new detailed routes this run</string>
+                  </property>
+                 </widget>
                  </item>
                  <item row="3" column="1">
                   <widget class="QSpinBox" name="maxDetailedActivitiesSpinBox">

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -264,9 +264,9 @@ class ContextualHelpTests(unittest.TestCase):
         ]:
             self.assertIn(anchor_name, entries)
 
-        self.assertEqual(entries["maxDetailedActivitiesSpinBox"].label_text, "Detailed track fetch limit")
+        self.assertEqual(entries["maxDetailedActivitiesSpinBox"].label_text, "Max new detailed routes this run")
         self.assertTrue(entries["maxDetailedActivitiesSpinBox"].help_button)
-        self.assertIn("only enriches up to 25", entries["maxDetailedActivitiesSpinBox"].helper_text)
+        self.assertIn("downloads up to 25 new detailed routes", entries["maxDetailedActivitiesSpinBox"].helper_text)
         self.assertEqual(entries["pointSamplingStrideSpinBox"].label_text, "Keep every Nth point")
         self.assertEqual(entries["temporalModeComboBox"].label_text, "Temporal timestamps")
         self.assertEqual(entries["backgroundPresetComboBox"].label_text, "Basemap preset")

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -167,7 +167,7 @@ class QgisSmokeTests(unittest.TestCase):
         try:
             from qgis.PyQt.QtWidgets import QLabel, QWidget
 
-            self.assertEqual(dock.maxDetailedActivitiesLabel.text(), "Detailed track fetch limit")
+            self.assertEqual(dock.maxDetailedActivitiesLabel.text(), "Max new detailed routes this run")
             self.assertEqual(dock.pointSamplingStrideLabel.text(), "Keep every Nth point")
             self.assertEqual(dock.temporalModeLabel.text(), "Temporal timestamps")
             self.assertEqual(dock.workflowLabel.text(), "Workflow: Fetch & store → Visualize → Analyze → Publish")
@@ -350,6 +350,21 @@ class QgisSmokeTests(unittest.TestCase):
             task_manager.return_value.addTask.assert_called_once_with(fake_task)
             self.assertIs(dock._fetch_task, fake_task)
             self.assertEqual(dock.refreshButton.text(), "Cancel")
+        finally:
+            dock.close()
+            dock.deleteLater()
+
+    def test_detailed_route_controls_use_missing_route_wording(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            self.assertEqual(
+                dock.detailedStreamsCheckBox.text(),
+                "Fetch detailed routes when available",
+            )
+            self.assertEqual(
+                dock.maxDetailedActivitiesLabel.text(),
+                "Max new detailed routes this run",
+            )
         finally:
             dock.close()
             dock.deleteLater()


### PR DESCRIPTION
## Summary
- rename the detailed-stream controls to talk about detailed routes and new-route budget instead of a vague track limit
- update contextual help so it explains that already cached/detailed routes do not count against the per-run limit
- add smoke/help tests for the new wording

## Why
This is the next small slice for #168. The behavior fix in #204 makes backfill progress more predictable; this PR updates the UI copy so the controls describe that model more clearly.

## Testing
- `python3 -m pytest tests/test_contextual_help.py tests/test_qgis_smoke.py -q --tb=short`

Refs #168
