### PR TITLE
feat: persist normalized detailed route status metadata

### DIFF
--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -317,15 +317,18 @@ class StravaClient:
         for activity in activities:
             if self._activity_has_detailed_route(activity):
                 stats["already_detailed"] += 1
+                self._set_detailed_route_status(activity, "downloaded")
                 continue
 
             cached_bundle = self._load_cached_stream_bundle(activity)
             if cached_bundle is not None:
                 if self._apply_stream_bundle_to_activity(activity, cached_bundle):
                     activity.details_json["stream_cache"] = "hit"
+                    self._set_detailed_route_status(activity, "cached")
                     stats["cached"] += 1
                 else:
                     activity.details_json["stream_cache"] = "hit-empty"
+                    self._set_detailed_route_status(activity, "empty")
                     stats["empty"] += 1
                 continue
 
@@ -341,6 +344,7 @@ class StravaClient:
         for activity in candidates[:limit]:
             if self._approaching_rate_limit():
                 activity.details_json["stream_skipped_reason"] = "rate_limit_guard"
+                self._set_detailed_route_status(activity, "skipped_rate_limit")
                 stats["skipped_rate_limit"] += 1
                 continue
 
@@ -348,15 +352,18 @@ class StravaClient:
                 stream_bundle = self.fetch_activity_stream_bundle(activity.source_activity_id)
             except StravaClientError as exc:
                 activity.details_json["stream_error"] = str(exc)
+                self._set_detailed_route_status(activity, "error")
                 stats["errors"] += 1
                 continue
 
             self._save_cached_stream_bundle(activity, stream_bundle)
             if self._apply_stream_bundle_to_activity(activity, stream_bundle):
                 activity.details_json["stream_cache"] = "miss"
+                self._set_detailed_route_status(activity, "downloaded")
                 stats["downloaded"] += 1
             else:
                 activity.details_json["stream_cache"] = "miss-empty"
+                self._set_detailed_route_status(activity, "empty")
                 stats["empty"] += 1
 
         stats["remaining_missing"] = sum(
@@ -368,6 +375,10 @@ class StravaClient:
     @staticmethod
     def _activity_has_detailed_route(activity):
         return getattr(activity, "geometry_source", None) == "stream"
+
+    @staticmethod
+    def _set_detailed_route_status(activity, status):
+        activity.details_json["detailed_route_status"] = status
 
     def fetch_activity_stream_points(self, activity_id):
         stream_bundle = self.fetch_activity_stream_bundle(activity_id)

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -110,6 +110,7 @@ class StravaClientTests(unittest.TestCase):
         fetch_mock.assert_not_called()
         self.assertEqual(client.last_stream_enrichment_stats["cached"], 1)
         self.assertEqual(activity.details_json["stream_cache"], "hit")
+        self.assertEqual(activity.details_json["detailed_route_status"], "cached")
 
     def test_enrich_activities_only_spends_limit_on_missing_routes(self):
         client = StravaClient()
@@ -139,6 +140,7 @@ class StravaClientTests(unittest.TestCase):
 
         fetch_mock.assert_called_once_with("3")
         self.assertEqual(client.last_stream_enrichment_stats["already_detailed"], 1)
+        self.assertEqual(already_detailed.details_json["detailed_route_status"], "downloaded")
         self.assertEqual(client.last_stream_enrichment_stats["cached"], 1)
         self.assertEqual(client.last_stream_enrichment_stats["requested"], 1)
         self.assertEqual(client.last_stream_enrichment_stats["missing_before"], 2)
@@ -158,6 +160,45 @@ class StravaClientTests(unittest.TestCase):
         self.assertEqual(client.last_stream_enrichment_stats["missing_before"], 1)
         self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 1)
         self.assertEqual(activity.details_json["stream_skipped_reason"], "rate_limit_guard")
+        self.assertEqual(activity.details_json["detailed_route_status"], "skipped_rate_limit")
+
+    def test_enrich_activities_marks_downloaded_route_status(self):
+        client = StravaClient()
+        activity = client.normalize_activity({"id": 42, "name": "Run"})
+
+        with (
+            patch.object(client, "_load_cached_stream_bundle", return_value=None),
+            patch.object(client, "fetch_activity_stream_bundle", return_value={"latlng": [[46.5, 6.6], [46.6, 6.7]]}),
+            patch.object(client, "_save_cached_stream_bundle"),
+        ):
+            client.enrich_activities_with_streams([activity], max_activities=1)
+
+        self.assertEqual(activity.details_json["detailed_route_status"], "downloaded")
+
+    def test_enrich_activities_marks_error_route_status(self):
+        client = StravaClient()
+        activity = client.normalize_activity({"id": 42, "name": "Run"})
+
+        with (
+            patch.object(client, "_load_cached_stream_bundle", return_value=None),
+            patch.object(client, "fetch_activity_stream_bundle", side_effect=StravaClientError("boom")),
+        ):
+            client.enrich_activities_with_streams([activity], max_activities=1)
+
+        self.assertEqual(activity.details_json["detailed_route_status"], "error")
+
+    def test_enrich_activities_marks_empty_route_status(self):
+        client = StravaClient()
+        activity = client.normalize_activity({"id": 42, "name": "Run"})
+
+        with (
+            patch.object(client, "_load_cached_stream_bundle", return_value=None),
+            patch.object(client, "fetch_activity_stream_bundle", return_value={"latlng": []}),
+            patch.object(client, "_save_cached_stream_bundle"),
+        ):
+            client.enrich_activities_with_streams([activity], max_activities=1)
+
+        self.assertEqual(activity.details_json["detailed_route_status"], "empty")
 
     def test_parse_rate_limit_pair_and_remaining(self):
         client = StravaClient()


### PR DESCRIPTION
## Summary
- write a normalized `detailed_route_status` into activity metadata during stream enrichment
- mark cached/downloaded/empty/error/rate-limit outcomes consistently
- add regression tests for the new status values

## Why
This is another small slice for #168. A stable per-activity detailed-route status makes future filtering, reporting, and backfill UX work much easier without changing the database schema yet.

## Testing
- `python3 -m pytest tests/test_strava_client.py -q --tb=short`

Refs #168
