### PR TITLE
feat: expand detailed route progress reporting

### DIFF
--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -269,10 +269,14 @@ class SyncController:
         progress_note = ""
         if "missing_before" in stream_stats or "remaining_missing" in stream_stats:
             progress_note = (
-                ", missing detailed routes before run: {before}, remaining missing: {after}"
+                ", already detailed before run: {already}, missing detailed routes before run: {before}, "
+                "remaining missing: {after}, empty detailed-route responses: {empty}, errors: {errors}"
             ).format(
+                already=stream_stats.get("already_detailed", 0),
                 before=stream_stats.get("missing_before", 0),
                 after=stream_stats.get("remaining_missing", 0),
+                empty=stream_stats.get("empty", 0),
+                errors=stream_stats.get("errors", 0),
             )
         return (
             "Fetched {activity_count} activities from {source}, detailed tracks: {detailed_count}, "

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -252,11 +252,14 @@ class FetchStatusTextTests(unittest.TestCase):
         provider = SimpleNamespace(
             source_name="strava",
             last_stream_enrichment_stats={
+                "already_detailed": 6,
                 "cached": 2,
                 "downloaded": 3,
                 "skipped_rate_limit": 0,
                 "missing_before": 4,
                 "remaining_missing": 1,
+                "empty": 1,
+                "errors": 0,
             },
             last_rate_limit=None,
             last_fetch_notice=None,
@@ -265,8 +268,11 @@ class FetchStatusTextTests(unittest.TestCase):
         self.assertIn("10 activities", text)
         self.assertIn("detailed tracks: 5", text)
         self.assertIn("cached streams: 2", text)
+        self.assertIn("already detailed before run: 6", text)
         self.assertIn("missing detailed routes before run: 4", text)
         self.assertIn("remaining missing: 1", text)
+        self.assertIn("empty detailed-route responses: 1", text)
+        self.assertIn("errors: 0", text)
 
     def test_status_text_includes_source_name(self):
         ctrl = SyncController()


### PR DESCRIPTION
## Summary
- expand the fetch summary to report already-detailed count, remaining missing count, empty detailed-route responses, and errors
- keep the new missing-route progress wording introduced in the earlier #168 slices
- cover the richer summary output with focused controller tests

## Why
This continues #168 by making repeated backfill runs easier to understand. Users can now see not just cached/downloaded counts, but also how much work was already done, how much remains, and whether empty/error outcomes occurred.

## Testing
- `python3 -m pytest tests/test_sync_controller.py -q --tb=short`

Refs #168
