### PR TITLE
docs: record detailed route status in persisted schema

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -72,7 +72,7 @@ Recommended unique key:
 | `summary_polyline` | TEXT | encoded summary polyline when provided |
 | `geometry_source` | TEXT | `stream`, `summary_polyline`, or `start_end` |
 | `geometry_points_json` | TEXT | JSON array of detailed geometry points when available |
-| `details_json` | TEXT | provider extras as JSON, including cached stream metrics when available |
+| `details_json` | TEXT | provider extras as JSON, including cached stream metrics and `detailed_route_status` (`cached`, `downloaded`, `empty`, `error`, `skipped_rate_limit`) when available |
 | `summary_hash` | TEXT | stable change-detection hash |
 | `first_seen_at` | TEXT | first time activity entered the registry |
 | `last_synced_at` | TEXT | last sync/update time |

--- a/tests/test_sync_repository.py
+++ b/tests/test_sync_repository.py
@@ -224,6 +224,23 @@ class SyncUnchangedBehaviorTests(unittest.TestCase):
             self.assertEqual(result.unchanged, 1)
             self.assertEqual(result.updated, 0)
 
+    def test_detailed_route_status_is_persisted_and_treated_as_meaningful(self):
+        """Detailed-route status should be stored and should trigger updates when it changes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = SyncRepository(str(Path(tmpdir) / "qfit.sqlite"))
+            repo.ensure_schema()
+
+            repo.upsert_activities([self._activity(details_json={"device_name": "Edge", "detailed_route_status": "cached"})])
+            stored = repo.load_all_activities()[0]
+            self.assertEqual(stored.details_json["detailed_route_status"], "cached")
+
+            result = repo.upsert_activities(
+                [self._activity(details_json={"device_name": "Edge", "detailed_route_status": "downloaded"})]
+            )
+
+            self.assertEqual(result.updated, 1)
+            self.assertEqual(result.unchanged, 0)
+
     def test_non_volatile_detail_change_triggers_update(self):
         """Changing a non-volatile detail key triggers an update."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- add a repository regression test showing that `detailed_route_status` is persisted and treated as meaningful state
- document `detailed_route_status` in the schema reference for `details_json`

## Why
This is another small #168 slice. The earlier PRs introduced normalized detailed-route status metadata; this one makes that persistence/documentation explicit so later filtering/reporting work has a clearer contract.

## Testing
- `python3 -m pytest tests/test_sync_repository.py -q --tb=short`

Refs #168
