### PR TITLE
fix: align remaining missing count with empty routes

### DIFF
--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -367,7 +367,7 @@ class StravaClient:
                 stats["empty"] += 1
 
         stats["remaining_missing"] = sum(
-            1 for activity in activities if not self._activity_has_detailed_route(activity)
+            1 for activity in activities if self._activity_needs_detailed_route(activity)
         )
         self.last_stream_enrichment_stats = stats
         return activities
@@ -375,6 +375,13 @@ class StravaClient:
     @staticmethod
     def _activity_has_detailed_route(activity):
         return getattr(activity, "geometry_source", None) == "stream"
+
+    @staticmethod
+    def _activity_needs_detailed_route(activity):
+        if getattr(activity, "geometry_source", None) == "stream":
+            return False
+        status = (getattr(activity, "details_json", None) or {}).get("detailed_route_status")
+        return status not in {"cached", "downloaded", "empty"}
 
     @staticmethod
     def _set_detailed_route_status(activity, status):

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -199,6 +199,19 @@ class StravaClientTests(unittest.TestCase):
             client.enrich_activities_with_streams([activity], max_activities=1)
 
         self.assertEqual(activity.details_json["detailed_route_status"], "empty")
+        self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 0)
+
+    def test_cache_hit_empty_does_not_count_as_remaining_missing(self):
+        client = StravaClient()
+        activity = client.normalize_activity({"id": 42, "name": "Run"})
+
+        with patch.object(client, "_load_cached_stream_bundle", return_value={"latlng": []}):
+            client.enrich_activities_with_streams([activity], max_activities=1)
+
+        self.assertEqual(client.last_stream_enrichment_stats["missing_before"], 0)
+        self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 0)
+        self.assertEqual(activity.details_json["stream_cache"], "hit-empty")
+        self.assertEqual(activity.details_json["detailed_route_status"], "empty")
 
     def test_parse_rate_limit_pair_and_remaining(self):
         client = StravaClient()


### PR DESCRIPTION
## Summary
- stop counting `detailed_route_status=empty` activities as `remaining_missing`
- add regression coverage for both downloaded-empty and cache-hit-empty paths

## Why
This addresses missed Codex feedback from #204. Previously qfit could report `missing_before=0` while still reporting `remaining_missing>0` for cache-hit-empty routes, even though those routes had already been classified as empty and would not be retried in the same path.

## Testing
- `python3 -m pytest tests/test_strava_client.py -q --tb=short`

Refs #168
