### PR TITLE
refactor: extract atlas profile item adapter

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -49,6 +49,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QFont
 
 from ..activity_classification import ordered_canonical_activity_labels
+from .profile_item import build_profile_item, build_profile_item_adapter
 
 # ---------------------------------------------------------------------------
 # Page geometry (mm, A4 portrait with square map)
@@ -344,18 +345,18 @@ def build_atlas_layout(
             color=QColor(60, 60, 60),
         )
 
-    # -- Profile area: chart image + summary text below map ------------------
-    # Picture item for the SVG elevation profile (source set per page during export)
-    profile_pic = QgsLayoutItemPicture(layout)
-    profile_pic.setId(_PROFILE_PICTURE_ID)
-    profile_pic.attemptMove(
-        QgsLayoutPoint(PROFILE_X, PROFILE_CHART_Y, QgsUnitTypes.LayoutMillimeters)
+    # -- Profile area: chart item + summary text below map -------------------
+    # The profile item currently wraps the legacy SVG/picture implementation,
+    # but is created through an adapter so the export loop can later swap in a
+    # native QGIS elevation-profile item without another large rewrite.
+    build_profile_item(
+        layout,
+        item_id=_PROFILE_PICTURE_ID,
+        x=PROFILE_X,
+        y=PROFILE_CHART_Y,
+        w=PROFILE_W,
+        h=PROFILE_CHART_H,
     )
-    profile_pic.attemptResize(
-        QgsLayoutSize(PROFILE_W, PROFILE_CHART_H, QgsUnitTypes.LayoutMillimeters)
-    )
-    profile_pic.setResizeMode(QgsLayoutItemPicture.Zoom)
-    layout.addLayoutItem(profile_pic)
 
     # Text summaries below the chart — text is set per page during the export
     # loop so that no [% %] expressions remain in the layout.  This avoids raw
@@ -1068,6 +1069,7 @@ class AtlasExportTask(QgsTask):
 
                     # Render profile chart SVG for this page.
                     if profile_pic is not None and sort_key_idx >= 0:
+                        profile_adapter = build_profile_item_adapter(profile_pic)
                         page_sort_key = _normalize_profile_sample_key(feat.attribute(sort_key_idx))
                         page_points = profile_samples.get(page_sort_key, []) if page_sort_key else []
                         if len(page_points) >= 2:
@@ -1080,27 +1082,15 @@ class AtlasExportTask(QgsTask):
                                     directory=os.path.dirname(self._output_path) or None,
                                 )
                                 if svg_path:
-                                    profile_pic.setPicturePath(svg_path)
-                                    refresh = getattr(profile_pic, "refresh", None)
-                                    if callable(refresh):
-                                        refresh()
+                                    profile_adapter.set_svg_profile(svg_path)
                                     profile_temp_files.append(svg_path)
                                 else:
-                                    profile_pic.setPicturePath("")
-                                    refresh = getattr(profile_pic, "refresh", None)
-                                    if callable(refresh):
-                                        refresh()
+                                    profile_adapter.clear_profile()
                             except Exception:  # noqa: BLE001
                                 logger.debug("Profile chart render failed", exc_info=True)
-                                profile_pic.setPicturePath("")
-                                refresh = getattr(profile_pic, "refresh", None)
-                                if callable(refresh):
-                                    refresh()
+                                profile_adapter.clear_profile()
                         else:
-                            profile_pic.setPicturePath("")
-                            refresh = getattr(profile_pic, "refresh", None)
-                            if callable(refresh):
-                                refresh()
+                            profile_adapter.clear_profile()
 
                     # Set profile summary text directly from the feature so that
                     # no raw [% %] template syntax can leak (issue #108).

--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -1,0 +1,61 @@
+"""Helpers for atlas elevation profile layout items.
+
+This module introduces a small abstraction layer so atlas export can swap the
+legacy picture/SVG profile implementation for a future native QGIS elevation
+profile item without rewriting the whole export loop at once.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qgis.core import (
+    QgsLayoutItemPicture,
+    QgsLayoutPoint,
+    QgsLayoutSize,
+    QgsUnitTypes,
+)
+
+
+@dataclass
+class ProfileItemAdapter:
+    """Thin wrapper around the current layout item used for atlas profiles."""
+
+    item: object
+
+    def clear_profile(self) -> None:
+        set_picture_path = getattr(self.item, "setPicturePath", None)
+        if callable(set_picture_path):
+            set_picture_path("")
+        refresh = getattr(self.item, "refresh", None)
+        if callable(refresh):
+            refresh()
+
+    def set_svg_profile(self, svg_path: str) -> None:
+        set_picture_path = getattr(self.item, "setPicturePath", None)
+        if callable(set_picture_path):
+            set_picture_path(svg_path)
+        refresh = getattr(self.item, "refresh", None)
+        if callable(refresh):
+            refresh()
+
+
+def build_profile_item(layout, *, item_id: str, x: float, y: float, w: float, h: float) -> ProfileItemAdapter:
+    """Create the current profile layout item and return an adapter for it.
+
+    Today this still uses :class:`QgsLayoutItemPicture`, but callers interact
+    with the returned adapter so the rendering backend can be replaced later by
+    a native QGIS elevation profile item.
+    """
+    profile_item = QgsLayoutItemPicture(layout)
+    profile_item.setId(item_id)
+    profile_item.attemptMove(QgsLayoutPoint(x, y, QgsUnitTypes.LayoutMillimeters))
+    profile_item.attemptResize(QgsLayoutSize(w, h, QgsUnitTypes.LayoutMillimeters))
+    profile_item.setResizeMode(QgsLayoutItemPicture.Zoom)
+    layout.addLayoutItem(profile_item)
+    return ProfileItemAdapter(item=profile_item)
+
+
+def build_profile_item_adapter(item) -> ProfileItemAdapter:
+    """Wrap an already-created layout item in the shared adapter type."""
+    return ProfileItemAdapter(item=item)

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -84,6 +84,11 @@ def _make_qgis_stub():
 _qgis_core = _make_qgis_stub()
 
 import qfit.atlas.export_task as atlas_export_task  # noqa: E402
+from qfit.atlas.profile_item import (  # noqa: E402
+    ProfileItemAdapter,
+    build_profile_item,
+    build_profile_item_adapter,
+)
 
 from qfit.atlas.export_task import (  # noqa: E402
     AtlasExportTask,
@@ -164,6 +169,33 @@ def _make_atlas_mock(feature_count=3):
 
 
 class TestBuildAtlasLayout(unittest.TestCase):
+    def test_build_profile_item_creates_adapter_wrapped_picture_item(self):
+        layout = MagicMock()
+
+        adapter = build_profile_item(
+            layout,
+            item_id="profile",
+            x=10.0,
+            y=20.0,
+            w=30.0,
+            h=40.0,
+        )
+
+        self.assertIsInstance(adapter, ProfileItemAdapter)
+        self.assertIs(adapter.item, _qgis_core.QgsLayoutItemPicture.return_value)
+        _qgis_core.QgsLayoutItemPicture.return_value.setId.assert_called_once_with("profile")
+        layout.addLayoutItem.assert_called_once_with(_qgis_core.QgsLayoutItemPicture.return_value)
+
+    def test_build_profile_item_adapter_can_clear_and_set_svg(self):
+        item = MagicMock()
+        adapter = build_profile_item_adapter(item)
+
+        adapter.set_svg_profile("/tmp/profile.svg")
+        adapter.clear_profile()
+
+        self.assertEqual(item.setPicturePath.call_args_list[0][0][0], "/tmp/profile.svg")
+        self.assertEqual(item.setPicturePath.call_args_list[1][0][0], "")
+
     def test_export_map_excludes_atlas_coverage_layer_overlay(self):
         atlas_layer = _make_atlas_layer(feature_count=1)
         visible_track_layer = MagicMock(name="visible_track_layer")


### PR DESCRIPTION
## Summary
- extract the atlas profile layout item creation/updates behind a small adapter
- keep the current SVG/picture implementation, but stop hard-coding it directly throughout the export task
- add focused tests for the new adapter seam

## Why
This is the first #193 slice. It does not switch to `QgsLayoutItemElevationProfile` yet, but it creates the seam needed to replace the current picture/SVG profile implementation without rewriting the whole atlas export loop in one shot.

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py -q --tb=short`

Refs #193
