### PR TITLE
refactor: add native atlas profile capability helpers

### DIFF
--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -45,22 +45,43 @@ class ProfileItemAdapter:
         if callable(refresh):
             refresh()
 
-    def configure_native_defaults(self, *, crs_authid: str = "EPSG:3857", atlas_driven: bool = True) -> None:
+    def configure_native_defaults(
+        self,
+        *,
+        crs_authid: str = "EPSG:3857",
+        atlas_driven: bool = True,
+        tolerance: float | None = None,
+    ) -> None:
         if not self.supports_native_profile:
             return
+
         set_crs = getattr(self.item, "setCrs", None)
-        if callable(set_crs) and QgsCoordinateReferenceSystem is not None:
+        if callable(set_crs) and QgsCoordinateReferenceSystem is not None and crs_authid:
             set_crs(QgsCoordinateReferenceSystem(crs_authid))
+
         set_atlas_driven = getattr(self.item, "setAtlasDriven", None)
         if callable(set_atlas_driven):
-            set_atlas_driven(atlas_driven)
+            set_atlas_driven(bool(atlas_driven))
+
+        set_tolerance = getattr(self.item, "setTolerance", None)
+        if callable(set_tolerance) and tolerance is not None:
+            set_tolerance(float(tolerance))
+
+
+@dataclass
+class NativeProfileItemConfig:
+    """Configuration for a native QGIS elevation profile layout item."""
+
+    crs_auth_id: str = "EPSG:3857"
+    atlas_driven: bool = True
+    tolerance: float | None = None
 
 
 def build_profile_item(layout, *, item_id: str, x: float, y: float, w: float, h: float) -> ProfileItemAdapter:
     """Create the current profile layout item and return an adapter for it.
 
-    Today this continues to use the legacy picture-backed SVG item.  The
-    adapter exists so a future slice can switch to a native
+    Today this continues to use the legacy picture-backed SVG item. The adapter
+    exists so a future slice can switch to a native
     ``QgsLayoutItemElevationProfile`` implementation without rewriting atlas
     export again.
     """
@@ -73,17 +94,6 @@ def build_profile_item(layout, *, item_id: str, x: float, y: float, w: float, h:
     return ProfileItemAdapter(item=profile_item, kind="picture")
 
 
-def build_profile_item_adapter(item) -> ProfileItemAdapter:
-    """Wrap an already-created layout item in the shared adapter type."""
-    item_type = type(item).__name__.lower()
-    kind = "native" if "elevationprofile" in item_type else "picture"
-    return ProfileItemAdapter(item=item, kind=kind)
-
-
-def _native_profile_item_available() -> bool:
-    return QgsLayoutItemElevationProfile is not None
-
-
 def build_native_profile_item(
     layout,
     *,
@@ -92,15 +102,14 @@ def build_native_profile_item(
     y: float,
     w: float,
     h: float,
-    crs_authid: str = "EPSG:3857",
-    atlas_driven: bool = True,
+    config: NativeProfileItemConfig | None = None,
 ) -> ProfileItemAdapter | None:
     """Create a native elevation-profile item when the QGIS build supports it.
 
     Returns ``None`` when the native item class is not available, so callers
     can keep using the picture-backed fallback path.
     """
-    if not _native_profile_item_available():
+    if not native_profile_item_available():
         return None
 
     profile_item = QgsLayoutItemElevationProfile(layout)
@@ -110,5 +119,21 @@ def build_native_profile_item(
     layout.addLayoutItem(profile_item)
 
     adapter = ProfileItemAdapter(item=profile_item, kind="native")
-    adapter.configure_native_defaults(crs_authid=crs_authid, atlas_driven=atlas_driven)
+    cfg = config or NativeProfileItemConfig()
+    adapter.configure_native_defaults(
+        crs_authid=cfg.crs_auth_id,
+        atlas_driven=cfg.atlas_driven,
+        tolerance=cfg.tolerance,
+    )
     return adapter
+
+
+def build_profile_item_adapter(item) -> ProfileItemAdapter:
+    """Wrap an already-created layout item in the shared adapter type."""
+    item_type = type(item).__name__.lower()
+    kind = "native" if "elevationprofile" in item_type else "picture"
+    return ProfileItemAdapter(item=item, kind=kind)
+
+
+def native_profile_item_available() -> bool:
+    return QgsLayoutItemElevationProfile is not None

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -86,10 +86,12 @@ _qgis_core = _make_qgis_stub()
 
 import qfit.atlas.export_task as atlas_export_task  # noqa: E402
 from qfit.atlas.profile_item import (  # noqa: E402
+    NativeProfileItemConfig,
     ProfileItemAdapter,
     build_profile_item,
     build_profile_item_adapter,
     build_native_profile_item,
+    native_profile_item_available,
 )
 
 from qfit.atlas.export_task import (  # noqa: E402
@@ -208,6 +210,9 @@ class TestBuildAtlasLayout(unittest.TestCase):
         self.assertEqual(adapter.kind, "native")
         self.assertTrue(adapter.supports_native_profile)
 
+    def test_native_profile_item_available_reflects_optional_qgis_class(self):
+        self.assertTrue(native_profile_item_available())
+
     def test_build_native_profile_item_returns_native_adapter_when_available(self):
         layout = MagicMock()
         native_item = _qgis_core.QgsLayoutItemElevationProfile.return_value
@@ -220,16 +225,19 @@ class TestBuildAtlasLayout(unittest.TestCase):
             y=20.0,
             w=30.0,
             h=40.0,
+            config=NativeProfileItemConfig(tolerance=12.5),
         )
 
         self.assertIsNotNone(adapter)
         self.assertEqual(adapter.kind, "native")
         native_item.setId.assert_called_once_with("profile")
         native_item.setAtlasDriven.assert_called_once_with(True)
+        native_item.setTolerance.assert_called_once_with(12.5)
+        native_item.setCrs.assert_called_once()
         layout.addLayoutItem.assert_called_once_with(native_item)
 
     def test_build_native_profile_item_returns_none_when_unavailable(self):
-        with patch("qfit.atlas.profile_item._native_profile_item_available", return_value=False):
+        with patch("qfit.atlas.profile_item.native_profile_item_available", return_value=False):
             adapter = build_native_profile_item(
                 MagicMock(),
                 item_id="profile",
@@ -249,6 +257,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
 
         item.setCrs.assert_not_called()
         item.setAtlasDriven.assert_not_called()
+        item.setTolerance.assert_not_called()
 
     def test_export_map_excludes_atlas_coverage_layer_overlay(self):
         atlas_layer = _make_atlas_layer(feature_count=1)


### PR DESCRIPTION
## Summary
- add explicit native-profile capability helpers to the atlas profile-item adapter layer
- expose a safe `build_native_profile_item(...)` helper that returns `None` when the QGIS build lacks the native item class
- add focused tests for native capability probing/default configuration

## Why
This is the next #193 slice. It still does not switch atlas rendering to the native elevation profile item, but it prepares the adapter contract needed for the later per-feature binding work.

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py -q --tb=short`

Refs #193
