### PR TITLE
refactor: add native atlas profile request helpers

### DIFF
--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -12,9 +12,13 @@ from dataclasses import dataclass
 from qgis.core import QgsLayoutItemPicture, QgsLayoutPoint, QgsLayoutSize, QgsUnitTypes
 
 try:  # pragma: no cover - availability depends on QGIS build
-    from qgis.core import QgsCoordinateReferenceSystem, QgsLayoutItemElevationProfile
+    from qgis.core import QgsCoordinateReferenceSystem
 except ImportError:  # pragma: no cover - exercised in stubbed/unit-test mode
     QgsCoordinateReferenceSystem = None
+
+try:  # pragma: no cover - availability depends on QGIS build
+    from qgis.core import QgsLayoutItemElevationProfile
+except ImportError:  # pragma: no cover - exercised in stubbed/unit-test mode
     QgsLayoutItemElevationProfile = None
 
 try:  # pragma: no cover - availability depends on QGIS build

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -240,6 +240,19 @@ class TestBuildAtlasLayout(unittest.TestCase):
         self.assertIsNotNone(adapter)
         self.assertEqual(adapter.kind, "native")
 
+    def test_native_profile_request_keeps_crs_when_native_item_class_is_missing(self):
+        curve = MagicMock(name="curve")
+        _qgis_core.QgsProfileRequest.return_value.setCrs.reset_mock()
+
+        with (
+            patch("qfit.atlas.profile_item.QgsLayoutItemElevationProfile", None),
+            patch("qfit.atlas.profile_item.QgsCoordinateReferenceSystem", _qgis_core.QgsCoordinateReferenceSystem),
+        ):
+            request = build_native_profile_request(curve)
+
+        self.assertIs(request, _qgis_core.QgsProfileRequest.return_value)
+        request.setCrs.assert_called_once()
+
     def test_build_native_profile_item_returns_native_adapter_when_available(self):
         layout = MagicMock()
         native_item = _qgis_core.QgsLayoutItemElevationProfile.return_value


### PR DESCRIPTION
## Summary
- add a small helper for building configured `QgsProfileRequest` instances when the QGIS build supports native profiles
- keep atlas export on the stable SVG/picture rendering path for now
- add focused tests for native request capability detection and request configuration

## Why
This is the next #193 slice. The adapter now has native item capability helpers and a native binding hook; this PR adds the matching native request-construction seam so a later slice can connect atlas feature geometry to a real `QgsLayoutItemElevationProfile` without mixing API discovery with export-loop changes.

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py -q --tb=short`

Refs #193
