### PR TITLE
refactor: add native atlas profile curve helper

### DIFF
--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -191,6 +191,23 @@ def build_native_profile_curve(feature_geometry):
     if curve is None:
         return None
 
+    type_name = type(curve).__name__.lower()
+    if "polygon" in type_name or "surface" in type_name:
+        return None
+
+    is_curve_type = any(
+        callable(getattr(curve, name, None))
+        for name in ("curveToLine", "numPoints", "pointN")
+    )
+    has_polygon_api = any(
+        callable(getattr(curve, name, None))
+        for name in ("exteriorRing", "interiorRing", "asPolygon")
+    )
+    if has_polygon_api and not is_curve_type:
+        return None
+    if not is_curve_type:
+        return None
+
     clone = getattr(curve, "clone", None)
     if callable(clone):
         return clone()

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -346,6 +346,16 @@ class TestBuildAtlasLayout(unittest.TestCase):
         self.assertIsNone(build_native_profile_curve(None))
         self.assertIsNone(build_native_profile_curve(geometry))
 
+    def test_build_native_profile_curve_rejects_polygon_like_geometries(self):
+        polygon = MagicMock(name="polygon")
+        polygon.__class__.__name__ = "QgsPolygon"
+        polygon.exteriorRing.return_value = MagicMock()
+        geometry = MagicMock(name="geometry")
+        geometry.constGet.return_value = polygon
+
+        self.assertIsNone(build_native_profile_curve(geometry))
+        polygon.clone.assert_not_called()
+
     def test_native_adapter_binds_curve_when_supported(self):
         item = MagicMock()
         adapter = ProfileItemAdapter(item=item, kind="native")


### PR DESCRIPTION
## Summary
- add a helper that extracts a native profile curve from atlas feature geometry when available
- keep the atlas export loop unchanged for now
- add focused tests for curve extraction success/fallback behavior

## Why
This is the next #193 slice. The native profile request helper is already in place; this PR adds the matching geometry-to-curve seam so the following step can wire real atlas feature geometry into the native profile path without mixing helper work with export-loop changes.

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py -q --tb=short`

Refs #193
