### PR TITLE
refactor: add native atlas profile input helper

### DIFF
--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -240,3 +240,17 @@ def build_native_profile_request(
         set_step_distance(float(cfg.step_distance))
 
     return request
+
+
+def build_native_profile_inputs(
+    feature_geometry,
+    *,
+    request_config: NativeProfileRequestConfig | None = None,
+):
+    """Build the native profile curve/request pair for a feature geometry."""
+    curve = build_native_profile_curve(feature_geometry)
+    if curve is None:
+        return None, None
+
+    request = build_native_profile_request(curve, config=request_config)
+    return curve, request

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -87,6 +87,7 @@ _qgis_core = _make_qgis_stub()
 
 import qfit.atlas.export_task as atlas_export_task  # noqa: E402
 from qfit.atlas.profile_item import (  # noqa: E402
+    build_native_profile_inputs,
     NativeProfileItemConfig,
     NativeProfileRequestConfig,
     ProfileItemAdapter,
@@ -355,6 +356,32 @@ class TestBuildAtlasLayout(unittest.TestCase):
 
         self.assertIsNone(build_native_profile_curve(geometry))
         polygon.clone.assert_not_called()
+
+    def test_build_native_profile_inputs_returns_curve_and_request_together(self):
+        geometry = MagicMock(name="geometry")
+
+        with (
+            patch("qfit.atlas.profile_item.build_native_profile_curve", return_value="curve") as build_curve,
+            patch("qfit.atlas.profile_item.build_native_profile_request", return_value="request") as build_request,
+        ):
+            curve, request = build_native_profile_inputs(
+                geometry,
+                request_config=NativeProfileRequestConfig(tolerance=12.0),
+            )
+
+        self.assertEqual(curve, "curve")
+        self.assertEqual(request, "request")
+        build_curve.assert_called_once_with(geometry)
+        build_request.assert_called_once()
+
+    def test_build_native_profile_inputs_returns_none_pair_when_curve_missing(self):
+        geometry = MagicMock(name="geometry")
+
+        with patch("qfit.atlas.profile_item.build_native_profile_curve", return_value=None):
+            curve, request = build_native_profile_inputs(geometry)
+
+        self.assertIsNone(curve)
+        self.assertIsNone(request)
 
     def test_native_adapter_binds_curve_when_supported(self):
         item = MagicMock()


### PR DESCRIPTION
## Summary
- add a helper that returns the native profile `(curve, request)` pair for a feature geometry
- keep the atlas export loop unchanged for now
- add focused tests for success/fallback behavior of the combined helper

## Why
This is the next #193 slice. The adapter, native item capability helpers, request helpers, and geometry-curve helpers are already in place; this PR composes them into one backend-agnostic input builder so the eventual export-loop switch can stay small and focused.

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py -q --tb=short`

Refs #193
