### PR TITLE
refactor: centralize atlas page profile payloads

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -160,8 +160,10 @@ class PageProfilePayload:
 
     sample_key: str | None
     page_points: list
-    native_curve: object | None
-    native_request: object | None
+    feature_geometry: object | None
+
+    def native_inputs(self):
+        return build_native_profile_inputs(self.feature_geometry)
 
 
 def _build_page_profile_payload(feat, sort_key_idx, profile_samples) -> PageProfilePayload:
@@ -173,13 +175,10 @@ def _build_page_profile_payload(feat, sort_key_idx, profile_samples) -> PageProf
 
     geometry_getter = getattr(feat, "geometry", None)
     geometry = geometry_getter() if callable(geometry_getter) else None
-    native_curve, native_request = build_native_profile_inputs(geometry)
-
     return PageProfilePayload(
         sample_key=sample_key,
         page_points=page_points,
-        native_curve=native_curve,
-        native_request=native_request,
+        feature_geometry=geometry,
     )
 
 

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -184,38 +184,46 @@ class TestBuildAtlasLayout(unittest.TestCase):
         feat.attribute.return_value = "activity-1"
         feat.geometry.return_value = "feature-geometry"
 
+        payload = atlas_export_task._build_page_profile_payload(
+            feat,
+            0,
+            {"activity-1": [(0.0, 100.0), (1.0, 120.0)]},
+        )
+
+        self.assertEqual(payload.sample_key, "activity-1")
+        self.assertEqual(payload.page_points, [(0.0, 100.0), (1.0, 120.0)])
+        self.assertEqual(payload.feature_geometry, "feature-geometry")
+
         with patch.object(
             atlas_export_task,
             "build_native_profile_inputs",
             return_value=("curve", "request"),
         ) as build_native_inputs:
-            payload = atlas_export_task._build_page_profile_payload(
-                feat,
-                0,
-                {"activity-1": [(0.0, 100.0), (1.0, 120.0)]},
-            )
+            native_curve, native_request = payload.native_inputs()
 
-        self.assertEqual(payload.sample_key, "activity-1")
-        self.assertEqual(payload.page_points, [(0.0, 100.0), (1.0, 120.0)])
-        self.assertEqual(payload.native_curve, "curve")
-        self.assertEqual(payload.native_request, "request")
+        self.assertEqual(native_curve, "curve")
+        self.assertEqual(native_request, "request")
         build_native_inputs.assert_called_once_with("feature-geometry")
 
     def test_build_page_profile_payload_handles_missing_sort_key_and_geometry(self):
         feat = MagicMock(name="feature")
         feat.geometry.return_value = None
 
+        payload = atlas_export_task._build_page_profile_payload(feat, -1, {})
+
+        self.assertIsNone(payload.sample_key)
+        self.assertEqual(payload.page_points, [])
+        self.assertIsNone(payload.feature_geometry)
+
         with patch.object(
             atlas_export_task,
             "build_native_profile_inputs",
             return_value=(None, None),
         ) as build_native_inputs:
-            payload = atlas_export_task._build_page_profile_payload(feat, -1, {})
+            native_curve, native_request = payload.native_inputs()
 
-        self.assertIsNone(payload.sample_key)
-        self.assertEqual(payload.page_points, [])
-        self.assertIsNone(payload.native_curve)
-        self.assertIsNone(payload.native_request)
+        self.assertIsNone(native_curve)
+        self.assertIsNone(native_request)
         build_native_inputs.assert_called_once_with(None)
 
     def test_build_profile_item_creates_picture_backed_adapter(self):


### PR DESCRIPTION
## Summary
- add a small helper that collects all per-page profile inputs in one place
- have atlas export use that helper for the current SVG-backed profile path
- include the future native `(curve, request)` inputs in the same payload without changing export behavior yet

## Why
This is the next #193 slice. The native profile item, request, and curve helpers already exist; this PR centralizes per-page profile data preparation so the eventual switch from SVG rendering to native QGIS elevation profile rendering can stay small and focused.

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py -q --tb=short`

Refs #193
