### PR TITLE
feat: enable native atlas profile rendering path

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -188,8 +188,7 @@ def _apply_page_profile_payload(
     """Apply per-page profile data to the active layout item backend."""
     if profile_adapter.supports_native_profile:
         native_curve, _native_request = profile_payload.native_inputs()
-        if native_curve is not None:
-            profile_adapter.bind_native_profile(profile_curve=native_curve)
+        if native_curve is not None and profile_adapter.bind_native_profile(profile_curve=native_curve):
             return
 
     page_points = profile_payload.page_points

--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -100,25 +100,28 @@ class ProfileItemAdapter:
         self,
         *,
         profile_curve=None,
-    ) -> None:
+    ) -> bool:
         """Bind native profile inputs when the underlying item supports them.
 
-        Picture-backed adapters intentionally ignore these calls so callers can
-        prepare native curve binding logic before the atlas export loop switches
-        away from the legacy SVG renderer. Native profile *request* objects are
-        prepared separately, because supported QGIS versions expose
-        ``profileRequest()`` but not a matching public setter.
+        Returns ``True`` when a native curve was actually bound. Picture-backed
+        adapters intentionally ignore these calls so callers can prepare native
+        curve binding logic before the atlas export loop switches away from the
+        legacy SVG renderer. Native profile *request* objects are prepared
+        separately, because supported QGIS versions expose ``profileRequest()``
+        but not a matching public setter.
         """
         if not self.supports_native_profile:
-            return
-
-        self._set_picture_path(self.svg_fallback_item, "")
+            return False
 
         set_profile_curve = getattr(self.item, "setProfileCurve", None)
-        if callable(set_profile_curve) and profile_curve is not None:
-            set_profile_curve(profile_curve)
+        if not callable(set_profile_curve) or profile_curve is None:
+            return False
+
+        self._set_picture_path(self.svg_fallback_item, "")
+        set_profile_curve(profile_curve)
         self._refresh_item(self.svg_fallback_item)
         self._refresh_item(self.item)
+        return True
 
 
 @dataclass

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -229,6 +229,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
     def test_apply_page_profile_payload_binds_native_curve_without_svg_render(self):
         adapter = MagicMock(name="adapter")
         adapter.supports_native_profile = True
+        adapter.bind_native_profile.return_value = True
         payload = MagicMock(name="payload")
         payload.native_inputs.return_value = ("curve", "request")
         profile_temp_files = []
@@ -245,6 +246,33 @@ class TestBuildAtlasLayout(unittest.TestCase):
         adapter.bind_native_profile.assert_called_once_with(profile_curve="curve")
         render_profile.assert_not_called()
         self.assertEqual(profile_temp_files, [])
+
+    def test_apply_page_profile_payload_falls_back_to_svg_when_native_bind_is_unavailable(self):
+        adapter = MagicMock(name="adapter")
+        adapter.supports_native_profile = True
+        adapter.bind_native_profile.return_value = False
+        payload = MagicMock(name="payload")
+        payload.native_inputs.return_value = ("curve", "request")
+        payload.page_points = [(0.0, 100.0), (1.0, 120.0)]
+        profile_temp_files = []
+
+        with patch.object(
+            atlas_export_task,
+            "_render_page_profile_svg",
+            return_value="/tmp/profile.svg",
+        ) as render_profile:
+            atlas_export_task._apply_page_profile_payload(
+                adapter,
+                payload,
+                output_path="/tmp/out.pdf",
+                profile_temp_files=profile_temp_files,
+            )
+
+        payload.native_inputs.assert_called_once_with()
+        adapter.bind_native_profile.assert_called_once_with(profile_curve="curve")
+        render_profile.assert_called_once_with(payload.page_points, output_path="/tmp/out.pdf")
+        adapter.set_svg_profile.assert_called_once_with("/tmp/profile.svg")
+        self.assertEqual(profile_temp_files, ["/tmp/profile.svg"])
 
     def test_apply_page_profile_payload_clears_native_profile_when_curve_missing(self):
         adapter = MagicMock(name="adapter")


### PR DESCRIPTION
## Summary
- let atlas export use native profile bindings when the layout item backend is native
- keep the SVG renderer as the fallback path for picture-backed profile items
- centralize backend selection in one helper so the native rollout stays incremental

## Why
This is the next #193 slice. The prior PRs built the adapter, request, curve, and payload seams; this PR is the first behavior change that actually exercises the native profile path when a native profile item exists, while preserving the current SVG rendering fallback.

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py -q --tb=short`

Refs #193
