### PR TITLE
refactor: sync native profile layers with map

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -435,6 +435,7 @@ def build_atlas_layout(
         h=PROFILE_CHART_H,
         native_config=NativeProfileItemConfig(
             atlas_driven=atlas_layer_supports_native_profile_atlas(atlas_layer),
+            layers=visible_layers,
         ),
     )
 

--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -86,9 +86,14 @@ class ProfileItemAdapter:
         crs_authid: str = "EPSG:3857",
         atlas_driven: bool = True,
         tolerance: float | None = None,
+        layers: list[object] | None = None,
     ) -> None:
         if not self.supports_native_profile:
             return
+
+        set_layers = getattr(self.item, "setLayers", None)
+        if callable(set_layers) and layers is not None:
+            set_layers(list(layers))
 
         set_crs = getattr(self.item, "setCrs", None)
         if callable(set_crs) and QgsCoordinateReferenceSystem is not None and crs_authid:
@@ -137,6 +142,7 @@ class NativeProfileItemConfig:
     crs_auth_id: str = "EPSG:3857"
     atlas_driven: bool = True
     tolerance: float | None = None
+    layers: list[object] | None = None
 
 
 @dataclass
@@ -269,6 +275,7 @@ def build_native_profile_item(
         crs_authid=cfg.crs_auth_id,
         atlas_driven=cfg.atlas_driven,
         tolerance=cfg.tolerance,
+        layers=cfg.layers,
     )
     return adapter
 

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -444,16 +444,37 @@ class TestBuildAtlasLayout(unittest.TestCase):
             y=20.0,
             w=30.0,
             h=40.0,
-            config=NativeProfileItemConfig(tolerance=12.5),
+            config=NativeProfileItemConfig(tolerance=12.5, layers=[]),
         )
 
         self.assertIsNotNone(adapter)
         self.assertEqual(adapter.kind, "native")
         native_item.setId.assert_called_once_with("profile")
+        native_item.setLayers.assert_called_once_with([])
         native_item.setAtlasDriven.assert_called_once_with(True)
         native_item.setTolerance.assert_called_once_with(12.5)
         native_item.setCrs.assert_called_once()
         layout.addLayoutItem.assert_called_once_with(native_item)
+
+    def test_build_native_profile_item_passes_configured_layers(self):
+        layout = MagicMock()
+        native_item = _qgis_core.QgsLayoutItemElevationProfile.return_value
+        native_item.reset_mock()
+
+        first_layer = MagicMock(name="first_layer")
+        second_layer = MagicMock(name="second_layer")
+
+        build_native_profile_item(
+            layout,
+            item_id="profile",
+            x=10.0,
+            y=20.0,
+            w=30.0,
+            h=40.0,
+            config=NativeProfileItemConfig(layers=[first_layer, second_layer]),
+        )
+
+        native_item.setLayers.assert_called_once_with([first_layer, second_layer])
 
     def test_atlas_layer_supports_native_profile_atlas_for_line_geometry(self):
         atlas_layer = MagicMock(name="atlas_layer")
@@ -491,6 +512,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
 
         adapter.configure_native_defaults()
 
+        item.setLayers.assert_not_called()
         item.setCrs.assert_not_called()
         item.setAtlasDriven.assert_not_called()
         item.setTolerance.assert_not_called()
@@ -944,6 +966,49 @@ class TestBuildAtlasLayout(unittest.TestCase):
         native_config = build_profile_item_mock.call_args.kwargs["native_config"]
         self.assertIsInstance(native_config, NativeProfileItemConfig)
         self.assertFalse(native_config.atlas_driven)
+        self.assertEqual(native_config.layers, [])
+
+    def test_build_atlas_layout_passes_visible_layers_to_native_profile_config(self):
+        atlas_layer = _make_atlas_layer(feature_count=1)
+        atlas_layer.geometryType.return_value = "LineGeometry"
+
+        visible_track_layer = MagicMock(name="visible_track_layer")
+        visible_background_layer = MagicMock(name="visible_background_layer")
+
+        track_node = MagicMock()
+        track_node.isVisible.return_value = True
+        track_node.layer.return_value = visible_track_layer
+
+        background_node = MagicMock()
+        background_node.isVisible.return_value = True
+        background_node.layer.return_value = visible_background_layer
+
+        atlas_node = MagicMock()
+        atlas_node.isVisible.return_value = True
+        atlas_node.layer.return_value = atlas_layer
+
+        project = MagicMock()
+        project.layerTreeRoot.return_value.findLayers.return_value = [atlas_node, track_node, background_node]
+
+        with (
+            patch("qfit.atlas.export_task.QgsPrintLayout") as mock_layout_cls,
+            patch("qfit.atlas.export_task.QgsLayoutItemMap"),
+            patch("qfit.atlas.export_task.build_profile_item") as build_profile_item_mock,
+            patch("qfit.atlas.export_task.QgsCoordinateReferenceSystem"),
+            patch("qfit.atlas.export_task.QgsLayoutItemLabel"),
+            patch("qfit.atlas.export_task._add_label", return_value=MagicMock()),
+        ):
+            layout = MagicMock()
+            layout.atlas.return_value = MagicMock()
+            layout.pageCollection.return_value.pageCount.return_value = 1
+            layout.pageCollection.return_value.page.return_value = MagicMock()
+            mock_layout_cls.return_value = layout
+
+            build_atlas_layout(atlas_layer, project=project)
+
+        native_config = build_profile_item_mock.call_args.kwargs["native_config"]
+        self.assertIsInstance(native_config, NativeProfileItemConfig)
+        self.assertEqual(native_config.layers, [visible_track_layer, visible_background_layer])
 
 
 class TestBuildAtlasLayoutSummaryLabels(unittest.TestCase):


### PR DESCRIPTION
## Summary
- configure native layout elevation-profile items with the same visible layer set used by the atlas map item
- thread that participating layer list through the native profile config helper instead of leaving native profile layers implicit
- add regression tests for native item layer wiring and layout-level synchronization

## Why
Issue #198 is about keeping the map and elevation profile in sync. The atlas map already uses the current visible layer set, but the native profile item was not being configured with those same layers. This small slice closes that gap without widening the scope to broader atlas/profile behavior changes.

## Testing
- python3 -m pytest tests/test_atlas_export_task.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #198
