### PR TITLE
refactor: skip manual atlas-driven native updates

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -189,6 +189,8 @@ def _apply_page_profile_payload(
 ) -> None:
     """Apply per-page profile data to the active layout item backend."""
     if profile_adapter.supports_native_profile:
+        if getattr(profile_adapter, "atlas_driven", False):
+            return
         native_curve, _native_request = profile_payload.native_inputs()
         if native_curve is not None and profile_adapter.bind_native_profile(profile_curve=native_curve):
             return

--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -40,6 +40,7 @@ class ProfileItemAdapter:
     item: object
     kind: str = "picture"
     svg_fallback_item: object | None = None
+    atlas_driven: bool = False
 
     @property
     def supports_native_profile(self) -> bool:
@@ -102,6 +103,7 @@ class ProfileItemAdapter:
         set_atlas_driven = getattr(self.item, "setAtlasDriven", None)
         if callable(set_atlas_driven):
             set_atlas_driven(bool(atlas_driven))
+        self.atlas_driven = bool(atlas_driven)
 
         set_tolerance = getattr(self.item, "setTolerance", None)
         if callable(set_tolerance) and tolerance is not None:
@@ -309,7 +311,17 @@ def build_profile_item_adapter(item) -> ProfileItemAdapter:
     item_type = type(item).__name__.lower()
     kind = "native" if "elevationprofile" in item_type else "picture"
     fallback_item = _find_svg_fallback_item(item) if kind == "native" else None
-    return ProfileItemAdapter(item=item, kind=kind, svg_fallback_item=fallback_item)
+    atlas_driven = False
+    if kind == "native":
+        atlas_driven_getter = getattr(item, "atlasDriven", None)
+        if callable(atlas_driven_getter):
+            try:
+                atlas_driven_value = _coerce_boolish(atlas_driven_getter())
+            except Exception:  # noqa: BLE001
+                atlas_driven = False
+            else:
+                atlas_driven = bool(atlas_driven_value) if atlas_driven_value is not None else False
+    return ProfileItemAdapter(item=item, kind=kind, svg_fallback_item=fallback_item, atlas_driven=atlas_driven)
 
 
 def native_profile_item_available() -> bool:

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -230,6 +230,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
     def test_apply_page_profile_payload_binds_native_curve_without_svg_render(self):
         adapter = MagicMock(name="adapter")
         adapter.supports_native_profile = True
+        adapter.atlas_driven = False
         adapter.bind_native_profile.return_value = True
         payload = MagicMock(name="payload")
         payload.native_inputs.return_value = ("curve", "request")
@@ -248,9 +249,31 @@ class TestBuildAtlasLayout(unittest.TestCase):
         render_profile.assert_not_called()
         self.assertEqual(profile_temp_files, [])
 
+    def test_apply_page_profile_payload_skips_manual_updates_for_atlas_driven_native_item(self):
+        adapter = MagicMock(name="adapter")
+        adapter.supports_native_profile = True
+        adapter.atlas_driven = True
+        payload = MagicMock(name="payload")
+        profile_temp_files = []
+
+        with patch.object(atlas_export_task, "_render_page_profile_svg") as render_profile:
+            atlas_export_task._apply_page_profile_payload(
+                adapter,
+                payload,
+                output_path="/tmp/out.pdf",
+                profile_temp_files=profile_temp_files,
+            )
+
+        payload.native_inputs.assert_not_called()
+        adapter.bind_native_profile.assert_not_called()
+        adapter.clear_profile.assert_not_called()
+        render_profile.assert_not_called()
+        self.assertEqual(profile_temp_files, [])
+
     def test_apply_page_profile_payload_falls_back_to_svg_when_native_bind_is_unavailable(self):
         adapter = MagicMock(name="adapter")
         adapter.supports_native_profile = True
+        adapter.atlas_driven = False
         adapter.bind_native_profile.return_value = False
         payload = MagicMock(name="payload")
         payload.native_inputs.return_value = ("curve", "request")
@@ -278,6 +301,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
     def test_apply_page_profile_payload_clears_native_profile_when_curve_missing(self):
         adapter = MagicMock(name="adapter")
         adapter.supports_native_profile = True
+        adapter.atlas_driven = False
         payload = MagicMock(name="payload")
         payload.native_inputs.return_value = (None, None)
 
@@ -390,6 +414,19 @@ class TestBuildAtlasLayout(unittest.TestCase):
 
         self.assertEqual(adapter.kind, "native")
         self.assertTrue(adapter.supports_native_profile)
+        self.assertFalse(adapter.atlas_driven)
+
+    def test_build_profile_item_adapter_reads_native_atlas_driven_flag(self):
+        native_item = MagicMock()
+        native_item.__class__.__name__ = "QgsLayoutItemElevationProfile"
+        native_item.id.return_value = "profile"
+        native_item.layout.return_value = MagicMock(items=MagicMock(return_value=[]))
+        native_item.atlasDriven.return_value = True
+
+        adapter = build_profile_item_adapter(native_item)
+
+        self.assertTrue(adapter.supports_native_profile)
+        self.assertTrue(adapter.atlas_driven)
 
     def test_native_profile_item_available_reflects_optional_qgis_class(self):
         self.assertTrue(native_profile_item_available())
@@ -516,6 +553,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
         item.setCrs.assert_not_called()
         item.setAtlasDriven.assert_not_called()
         item.setTolerance.assert_not_called()
+        self.assertFalse(adapter.atlas_driven)
 
     def test_native_adapter_clear_profile_resets_native_curve_when_supported(self):
         item = MagicMock()


### PR DESCRIPTION
## Summary
- teach the native profile adapter whether the underlying QGIS layout item is atlas-driven
- skip the export loop's manual per-page profile binding/rendering when a native profile item is already being driven by atlas
- add regression tests for the new atlas-driven short-circuit and adapter reconstruction path

## Why
Issue #195 is about making the native profile path fully atlas-driven. qfit's current polygon atlas coverage still keeps that mode disabled in practice, but this slice removes one more piece of manual switching logic from the native-atlas path so a future line-based coverage layer can rely on QGIS atlas control directly.

## Testing
- python3 -m pytest tests/test_atlas_export_task.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #195
