### PR TITLE
refactor: skip atlas sample loading for native profiles

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -1084,17 +1084,23 @@ class AtlasExportTask(QgsTask):
                 elif item_id == _DETAIL_BLOCK_ID:
                     detail_block_label = item
 
+            profile_adapter = build_profile_item_adapter(profile_pic) if profile_pic is not None else None
+            manual_profile_updates_enabled = bool(
+                profile_adapter is not None and profile_adapter.requires_manual_page_updates
+            )
+
             # Pre-load profile samples grouped by page_sort_key.
             profile_samples: dict[str, list[tuple[float, float]]] = {}
             sort_key_idx = fields.indexOf("page_sort_key")
-            try:
-                source = self._atlas_layer.source()
-                gpkg_path = source.split("|")[0] if "|" in source else source
-                if gpkg_path and os.path.isfile(gpkg_path):
-                    from .profile_renderer import load_profile_samples_from_gpkg  # noqa: PLC0415
-                    profile_samples = load_profile_samples_from_gpkg(gpkg_path)
-            except Exception:  # noqa: BLE001
-                logger.debug("Could not load profile samples", exc_info=True)
+            if manual_profile_updates_enabled:
+                try:
+                    source = self._atlas_layer.source()
+                    gpkg_path = source.split("|")[0] if "|" in source else source
+                    if gpkg_path and os.path.isfile(gpkg_path):
+                        from .profile_renderer import load_profile_samples_from_gpkg  # noqa: PLC0415
+                        profile_samples = load_profile_samples_from_gpkg(gpkg_path)
+                except Exception:  # noqa: BLE001
+                    logger.debug("Could not load profile samples", exc_info=True)
 
             profile_temp_files: list[str] = []
 
@@ -1151,8 +1157,7 @@ class AtlasExportTask(QgsTask):
                                     logger.debug("Failed to set page filter on layer", exc_info=True)
 
                     # Render profile chart SVG for this page.
-                    if profile_pic is not None and sort_key_idx >= 0:
-                        profile_adapter = build_profile_item_adapter(profile_pic)
+                    if manual_profile_updates_enabled and profile_adapter is not None and sort_key_idx >= 0:
                         profile_payload = _build_page_profile_payload(
                             feat,
                             sort_key_idx,

--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -46,6 +46,10 @@ class ProfileItemAdapter:
     def supports_native_profile(self) -> bool:
         return self.kind == "native"
 
+    @property
+    def requires_manual_page_updates(self) -> bool:
+        return not (self.supports_native_profile and self.atlas_driven)
+
     def _refresh_item(self, item: object | None) -> None:
         refresh = getattr(item, "refresh", None)
         if callable(refresh):

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -428,6 +428,16 @@ class TestBuildAtlasLayout(unittest.TestCase):
         self.assertTrue(adapter.supports_native_profile)
         self.assertTrue(adapter.atlas_driven)
 
+    def test_native_adapter_requires_no_manual_page_updates_when_atlas_driven(self):
+        adapter = ProfileItemAdapter(item=MagicMock(), kind="native", atlas_driven=True)
+
+        self.assertFalse(adapter.requires_manual_page_updates)
+
+    def test_picture_adapter_still_requires_manual_page_updates(self):
+        adapter = ProfileItemAdapter(item=MagicMock(), kind="picture", atlas_driven=False)
+
+        self.assertTrue(adapter.requires_manual_page_updates)
+
     def test_native_profile_item_available_reflects_optional_qgis_class(self):
         self.assertTrue(native_profile_item_available())
 
@@ -1363,6 +1373,61 @@ class TestProfileChartRendering(unittest.TestCase):
 
 
 class TestAtlasExportTaskSuccess(unittest.TestCase):
+    def test_atlas_driven_native_profile_skips_manual_sample_loading(self):
+        from qfit.atlas.export_task import _PROFILE_PICTURE_ID
+
+        atlas_layer = _make_atlas_layer(feature_count=1)
+        field_names = [
+            "page_sort_key",
+            "source_activity_id",
+            "center_x_3857",
+            "center_y_3857",
+            "extent_width_m",
+            "extent_height_m",
+        ]
+        atlas_layer.fields.return_value.indexOf = (
+            lambda name: field_names.index(name) if name in field_names else -1
+        )
+        atlas_layer.source.return_value = "/tmp/fake.gpkg|layername=activity_atlas_pages"
+
+        layout_mock, atlas_mock, exporter_cls_mock = _make_atlas_mock(feature_count=1)
+        native_profile_item = MagicMock(name="native_profile_item")
+        native_profile_item.__class__.__name__ = "QgsLayoutItemElevationProfile"
+        native_profile_item.id.return_value = _PROFILE_PICTURE_ID
+        native_profile_item.atlasDriven.return_value = True
+        native_profile_item.layout.return_value = layout_mock
+        layout_mock.items.return_value = [native_profile_item]
+
+        feat_mock = atlas_mock.layout.return_value.reportContext.return_value.feature.return_value
+        feat_mock.attribute.side_effect = lambda idx: {
+            0: "page-1",
+            1: "activity-1",
+            2: 10.0,
+            3: 20.0,
+            4: 30.0,
+            5: 40.0,
+        }.get(idx)
+
+        task = AtlasExportTask(
+            atlas_layer=atlas_layer,
+            output_path="/tmp/qfit_native_atlas_driven.pdf",
+            on_finished=lambda **_: None,
+        )
+
+        with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
+             patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.profile_renderer.load_profile_samples_from_gpkg") as load_samples, \
+             patch("qfit.atlas.profile_renderer.render_profile_to_file") as render_profile, \
+             patch("qfit.atlas.export_task.AtlasExportTask._merge_pdfs"), \
+             patch("os.replace"), \
+             patch("os.makedirs"):
+            _run_task(task)
+
+        load_samples.assert_not_called()
+        render_profile.assert_not_called()
+
     def test_run_returns_true_on_success(self):
         layer = _make_atlas_layer(feature_count=3)
         received = {}


### PR DESCRIPTION
## Summary
- stop preloading atlas profile sample data when the active profile item is already native and atlas-driven
- reuse the profile adapter's manual-update capability to skip the old SVG/temp-file path entirely on that native atlas-driven branch
- add regression coverage for both the adapter flag and the export-task behavior

## Why
Issue #196 is about removing profile image handling and filesystem dependencies. qfit still needed the GeoPackage-backed SVG sample path for picture/manual profile rendering, but it should not keep touching that filesystem path once a native profile item is already being driven directly by atlas.

## Testing
- python3 -m pytest tests/test_atlas_export_task.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #196
