### PR TITLE
feat: style native atlas profile plots

### DIFF
--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -32,6 +32,12 @@ try:  # pragma: no cover - availability depends on QGIS build
 except ImportError:  # pragma: no cover - exercised in stubbed/unit-test mode
     QgsWkbTypes = None
 
+try:  # pragma: no cover - availability depends on QGIS build
+    from qgis.core import QgsFillSymbol, QgsLineSymbol
+except ImportError:  # pragma: no cover - exercised in stubbed/unit-test mode
+    QgsFillSymbol = None
+    QgsLineSymbol = None
+
 
 @dataclass
 class ProfileItemAdapter:
@@ -162,6 +168,110 @@ class NativeProfileRequestConfig:
     step_distance: float | None = None
 
 
+def _build_fill_symbol(properties: dict[str, str]):
+    create_simple = getattr(QgsFillSymbol, "createSimple", None)
+    if QgsFillSymbol is None or not callable(create_simple):
+        return None
+
+    try:
+        return create_simple(properties)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _build_line_symbol(properties: dict[str, str]):
+    create_simple = getattr(QgsLineSymbol, "createSimple", None)
+    if QgsLineSymbol is None or not callable(create_simple):
+        return None
+
+    try:
+        return create_simple(properties)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _configure_plot_axis_suffix(axis, suffix: str) -> None:
+    set_label_suffix = getattr(axis, "setLabelSuffix", None)
+    if callable(set_label_suffix):
+        set_label_suffix(suffix)
+
+
+def _configure_plot_axis_grid(axis, *, major_props: dict[str, str], minor_props: dict[str, str]) -> None:
+    set_major_symbol = getattr(axis, "setGridMajorSymbol", None)
+    major_symbol = _build_line_symbol(major_props)
+    if callable(set_major_symbol) and major_symbol is not None:
+        set_major_symbol(major_symbol)
+
+    set_minor_symbol = getattr(axis, "setGridMinorSymbol", None)
+    minor_symbol = _build_line_symbol(minor_props)
+    if callable(set_minor_symbol) and minor_symbol is not None:
+        set_minor_symbol(minor_symbol)
+
+
+def configure_native_profile_plot_defaults(item) -> None:
+    """Apply conservative default styling to native profile plot items."""
+    plot_getter = getattr(item, "plot", None)
+    if not callable(plot_getter):
+        return
+
+    try:
+        plot = plot_getter()
+    except Exception:  # noqa: BLE001
+        return
+
+    if plot is None:
+        return
+
+    set_chart_background = getattr(plot, "setChartBackgroundSymbol", None)
+    background_symbol = _build_fill_symbol(
+        {
+            "color": "255,255,255,230",
+            "outline_style": "no",
+        }
+    )
+    if callable(set_chart_background) and background_symbol is not None:
+        set_chart_background(background_symbol)
+
+    set_chart_border = getattr(plot, "setChartBorderSymbol", None)
+    border_symbol = _build_fill_symbol(
+        {
+            "color": "255,255,255,0",
+            "outline_color": "160,160,160,255",
+            "outline_width": "0.2",
+        }
+    )
+    if callable(set_chart_border) and border_symbol is not None:
+        set_chart_border(border_symbol)
+
+    x_axis_getter = getattr(plot, "xAxis", None)
+    if callable(x_axis_getter):
+        try:
+            x_axis = x_axis_getter()
+        except Exception:  # noqa: BLE001
+            x_axis = None
+        if x_axis is not None:
+            _configure_plot_axis_suffix(x_axis, " km")
+            _configure_plot_axis_grid(
+                x_axis,
+                major_props={"color": "210,210,210,255", "width": "0.25"},
+                minor_props={"color": "235,235,235,255", "width": "0.15"},
+            )
+
+    y_axis_getter = getattr(plot, "yAxis", None)
+    if callable(y_axis_getter):
+        try:
+            y_axis = y_axis_getter()
+        except Exception:  # noqa: BLE001
+            y_axis = None
+        if y_axis is not None:
+            _configure_plot_axis_suffix(y_axis, " m")
+            _configure_plot_axis_grid(
+                y_axis,
+                major_props={"color": "210,210,210,255", "width": "0.25"},
+                minor_props={"color": "235,235,235,255", "width": "0.15"},
+            )
+
+
 def _matches_line_geometry_type(geometry_type) -> bool:
     if geometry_type is None:
         return False
@@ -288,6 +398,7 @@ def build_native_profile_item(
         tolerance=cfg.tolerance,
         layers=cfg.layers,
     )
+    configure_native_profile_plot_defaults(profile_item)
     return adapter
 
 

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -97,6 +97,7 @@ from qfit.atlas.profile_item import (  # noqa: E402
     build_profile_item_adapter,
     build_native_profile_item,
     build_native_profile_request,
+    configure_native_profile_plot_defaults,
     native_profile_item_available,
     native_profile_request_available,
 )
@@ -530,15 +531,16 @@ class TestBuildAtlasLayout(unittest.TestCase):
         native_item = _qgis_core.QgsLayoutItemElevationProfile.return_value
         native_item.__class__.__name__ = "QgsLayoutItemElevationProfile"
 
-        adapter = build_native_profile_item(
-            layout,
-            item_id="profile",
-            x=10.0,
-            y=20.0,
-            w=30.0,
-            h=40.0,
-            config=NativeProfileItemConfig(tolerance=12.5, layers=[]),
-        )
+        with patch("qfit.atlas.profile_item.configure_native_profile_plot_defaults") as style_defaults:
+            adapter = build_native_profile_item(
+                layout,
+                item_id="profile",
+                x=10.0,
+                y=20.0,
+                w=30.0,
+                h=40.0,
+                config=NativeProfileItemConfig(tolerance=12.5, layers=[]),
+            )
 
         self.assertIsNotNone(adapter)
         self.assertEqual(adapter.kind, "native")
@@ -548,6 +550,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
         native_item.setTolerance.assert_called_once_with(12.5)
         native_item.setCrs.assert_called_once()
         layout.addLayoutItem.assert_called_once_with(native_item)
+        style_defaults.assert_called_once_with(native_item)
 
     def test_build_native_profile_item_passes_configured_layers(self):
         layout = MagicMock()
@@ -568,6 +571,58 @@ class TestBuildAtlasLayout(unittest.TestCase):
         )
 
         native_item.setLayers.assert_called_once_with([first_layer, second_layer])
+
+    def test_configure_native_profile_plot_defaults_styles_axes_and_grid(self):
+        item = MagicMock(name="native_item")
+        plot = MagicMock(name="plot")
+        x_axis = MagicMock(name="x_axis")
+        y_axis = MagicMock(name="y_axis")
+        plot.xAxis.return_value = x_axis
+        plot.yAxis.return_value = y_axis
+        item.plot.return_value = plot
+
+        with (
+            patch("qfit.atlas.profile_item.QgsFillSymbol") as fill_symbol_cls,
+            patch("qfit.atlas.profile_item.QgsLineSymbol") as line_symbol_cls,
+        ):
+            fill_symbol_cls.createSimple.side_effect = ["background-fill", "border-fill"]
+            line_symbol_cls.createSimple.side_effect = [
+                "x-major",
+                "x-minor",
+                "y-major",
+                "y-minor",
+            ]
+
+            configure_native_profile_plot_defaults(item)
+
+        plot.setChartBackgroundSymbol.assert_called_once_with("background-fill")
+        plot.setChartBorderSymbol.assert_called_once_with("border-fill")
+        x_axis.setLabelSuffix.assert_called_once_with(" km")
+        y_axis.setLabelSuffix.assert_called_once_with(" m")
+        x_axis.setGridMajorSymbol.assert_called_once_with("x-major")
+        x_axis.setGridMinorSymbol.assert_called_once_with("x-minor")
+        y_axis.setGridMajorSymbol.assert_called_once_with("y-major")
+        y_axis.setGridMinorSymbol.assert_called_once_with("y-minor")
+
+    def test_configure_native_profile_plot_defaults_tolerates_missing_plot_api(self):
+        item = MagicMock(name="native_item")
+        plot = MagicMock(name="plot")
+        del plot.setChartBackgroundSymbol
+        del plot.setChartBorderSymbol
+        del plot.xAxis
+        del plot.yAxis
+        item.plot.return_value = plot
+
+        with (
+            patch("qfit.atlas.profile_item.QgsFillSymbol") as fill_symbol_cls,
+            patch("qfit.atlas.profile_item.QgsLineSymbol") as line_symbol_cls,
+        ):
+            fill_symbol_cls.createSimple.return_value = "fill"
+            line_symbol_cls.createSimple.return_value = "line"
+
+            configure_native_profile_plot_defaults(item)
+
+        item.plot.assert_called_once_with()
 
     def test_atlas_layer_supports_native_profile_atlas_for_line_geometry(self):
         atlas_layer = MagicMock(name="atlas_layer")


### PR DESCRIPTION
## Summary
- apply conservative default styling to native layout elevation-profile plots in the unified atlas layout builder path
- set chart background/border defaults plus readable axis suffixes and grid styling when the underlying QGIS plot API is available
- add regression coverage for both the styling helper and the native-item builder wiring

## Why
Issue #197 asks for the elevation profile to behave like a standard, visually consistent part of the activity-page layout. This slice adds default native-plot styling in one place without widening scope into user-configurable settings yet.

## Testing
- python3 -m pytest tests/test_atlas_export_task.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #197
