### PR TITLE
refactor: drop page sort key dependency for native profiles

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -1091,7 +1091,7 @@ class AtlasExportTask(QgsTask):
 
             # Pre-load profile samples grouped by page_sort_key.
             profile_samples: dict[str, list[tuple[float, float]]] = {}
-            sort_key_idx = fields.indexOf("page_sort_key")
+            sort_key_idx = fields.indexOf("page_sort_key") if manual_profile_updates_enabled else -1
             if manual_profile_updates_enabled:
                 try:
                     source = self._atlas_layer.source()

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -1613,6 +1613,59 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
         load_samples.assert_not_called()
         render_profile.assert_not_called()
 
+    def test_atlas_driven_native_profile_does_not_require_page_sort_key_field(self):
+        from qfit.atlas.export_task import _PROFILE_PICTURE_ID
+
+        atlas_layer = _make_atlas_layer(feature_count=1)
+        field_names = [
+            "source_activity_id",
+            "center_x_3857",
+            "center_y_3857",
+            "extent_width_m",
+            "extent_height_m",
+        ]
+        atlas_layer.fields.return_value.indexOf = (
+            lambda name: field_names.index(name) if name in field_names else -1
+        )
+        atlas_layer.source.return_value = "/tmp/fake.gpkg|layername=activity_atlas_pages"
+
+        layout_mock, atlas_mock, exporter_cls_mock = _make_atlas_mock(feature_count=1)
+        native_profile_item = MagicMock(name="native_profile_item")
+        native_profile_item.__class__.__name__ = "QgsLayoutItemElevationProfile"
+        native_profile_item.id.return_value = _PROFILE_PICTURE_ID
+        native_profile_item.atlasDriven.return_value = True
+        native_profile_item.layout.return_value = layout_mock
+        layout_mock.items.return_value = [native_profile_item]
+
+        feat_mock = atlas_mock.layout.return_value.reportContext.return_value.feature.return_value
+        feat_mock.attribute.side_effect = lambda idx: {
+            0: "activity-1",
+            1: 10.0,
+            2: 20.0,
+            3: 30.0,
+            4: 40.0,
+        }.get(idx)
+
+        task = AtlasExportTask(
+            atlas_layer=atlas_layer,
+            output_path="/tmp/qfit_native_without_sort_key.pdf",
+            on_finished=lambda **_: None,
+        )
+
+        with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
+             patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.profile_renderer.load_profile_samples_from_gpkg") as load_samples, \
+             patch("qfit.atlas.profile_renderer.render_profile_to_file") as render_profile, \
+             patch("qfit.atlas.export_task.AtlasExportTask._merge_pdfs"), \
+             patch("os.replace"), \
+             patch("os.makedirs"):
+            self.assertTrue(_run_task(task))
+
+        load_samples.assert_not_called()
+        render_profile.assert_not_called()
+
     def test_run_returns_true_on_success(self):
         layer = _make_atlas_layer(feature_count=3)
         received = {}


### PR DESCRIPTION
## Summary
- remove the `page_sort_key` field dependency from the true native atlas-driven export path
- keep `page_sort_key` lookup only for the legacy/manual per-page SVG profile branch
- add regression coverage that native atlas-driven export still succeeds when `page_sort_key` is absent

## Why
Issue #196 is about removing profile image handling and file-system-era dependencies. Once the native profile item is atlas-driven, the export loop should not still require legacy page-sample bookkeeping fields like `page_sort_key`.

## Testing
- python3 -m pytest tests/test_atlas_export_task.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #196
