### PR TITLE
refactor: centralize native profile plot style defaults

### DIFF
--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -7,8 +7,10 @@ profile item without rewriting the whole export loop at once.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 import math
+from types import MappingProxyType
 
 from qgis.core import QgsLayoutItemPicture, QgsLayoutPoint, QgsLayoutSize, QgsUnitTypes
 
@@ -173,61 +175,65 @@ class NativeProfilePlotAxisStyle:
     """Styling defaults for one axis of a native profile plot."""
 
     suffix: str
-    major_grid_props: dict[str, str]
-    minor_grid_props: dict[str, str]
+    major_grid_props: Mapping[str, str]
+    minor_grid_props: Mapping[str, str]
 
 
 @dataclass(frozen=True)
 class NativeProfilePlotStyle:
     """Styling defaults for native QGIS profile plots."""
 
-    background_fill_props: dict[str, str]
-    border_fill_props: dict[str, str]
+    background_fill_props: Mapping[str, str]
+    border_fill_props: Mapping[str, str]
     x_axis: NativeProfilePlotAxisStyle
     y_axis: NativeProfilePlotAxisStyle
 
 
+def _immutable_props(**properties: str) -> Mapping[str, str]:
+    return MappingProxyType(dict(properties))
+
+
 DEFAULT_NATIVE_PROFILE_PLOT_STYLE = NativeProfilePlotStyle(
-    background_fill_props={
-        "color": "255,255,255,230",
-        "outline_style": "no",
-    },
-    border_fill_props={
-        "color": "255,255,255,0",
-        "outline_color": "160,160,160,255",
-        "outline_width": "0.2",
-    },
+    background_fill_props=_immutable_props(
+        color="255,255,255,230",
+        outline_style="no",
+    ),
+    border_fill_props=_immutable_props(
+        color="255,255,255,0",
+        outline_color="160,160,160,255",
+        outline_width="0.2",
+    ),
     x_axis=NativeProfilePlotAxisStyle(
         suffix=" km",
-        major_grid_props={"color": "210,210,210,255", "width": "0.25"},
-        minor_grid_props={"color": "235,235,235,255", "width": "0.15"},
+        major_grid_props=_immutable_props(color="210,210,210,255", width="0.25"),
+        minor_grid_props=_immutable_props(color="235,235,235,255", width="0.15"),
     ),
     y_axis=NativeProfilePlotAxisStyle(
         suffix=" m",
-        major_grid_props={"color": "210,210,210,255", "width": "0.25"},
-        minor_grid_props={"color": "235,235,235,255", "width": "0.15"},
+        major_grid_props=_immutable_props(color="210,210,210,255", width="0.25"),
+        minor_grid_props=_immutable_props(color="235,235,235,255", width="0.15"),
     ),
 )
 
 
-def _build_fill_symbol(properties: dict[str, str]):
+def _build_fill_symbol(properties: Mapping[str, str]):
     create_simple = getattr(QgsFillSymbol, "createSimple", None)
     if QgsFillSymbol is None or not callable(create_simple):
         return None
 
     try:
-        return create_simple(properties)
+        return create_simple(dict(properties))
     except Exception:  # noqa: BLE001
         return None
 
 
-def _build_line_symbol(properties: dict[str, str]):
+def _build_line_symbol(properties: Mapping[str, str]):
     create_simple = getattr(QgsLineSymbol, "createSimple", None)
     if QgsLineSymbol is None or not callable(create_simple):
         return None
 
     try:
-        return create_simple(properties)
+        return create_simple(dict(properties))
     except Exception:  # noqa: BLE001
         return None
 
@@ -255,7 +261,7 @@ def _configure_plot_axis_style(axis, style: NativeProfilePlotAxisStyle) -> None:
 def configure_native_profile_plot_defaults(
     item,
     *,
-    style: NativeProfilePlotStyle = DEFAULT_NATIVE_PROFILE_PLOT_STYLE,
+    style: NativeProfilePlotStyle | None = None,
 ) -> None:
     """Apply conservative default styling to native profile plot items."""
     plot_getter = getattr(item, "plot", None)
@@ -270,13 +276,15 @@ def configure_native_profile_plot_defaults(
     if plot is None:
         return
 
+    resolved_style = style or DEFAULT_NATIVE_PROFILE_PLOT_STYLE
+
     set_chart_background = getattr(plot, "setChartBackgroundSymbol", None)
-    background_symbol = _build_fill_symbol(style.background_fill_props)
+    background_symbol = _build_fill_symbol(resolved_style.background_fill_props)
     if callable(set_chart_background) and background_symbol is not None:
         set_chart_background(background_symbol)
 
     set_chart_border = getattr(plot, "setChartBorderSymbol", None)
-    border_symbol = _build_fill_symbol(style.border_fill_props)
+    border_symbol = _build_fill_symbol(resolved_style.border_fill_props)
     if callable(set_chart_border) and border_symbol is not None:
         set_chart_border(border_symbol)
 
@@ -287,7 +295,7 @@ def configure_native_profile_plot_defaults(
         except Exception:  # noqa: BLE001
             x_axis = None
         if x_axis is not None:
-            _configure_plot_axis_style(x_axis, style.x_axis)
+            _configure_plot_axis_style(x_axis, resolved_style.x_axis)
 
     y_axis_getter = getattr(plot, "yAxis", None)
     if callable(y_axis_getter):
@@ -296,7 +304,7 @@ def configure_native_profile_plot_defaults(
         except Exception:  # noqa: BLE001
             y_axis = None
         if y_axis is not None:
-            _configure_plot_axis_style(y_axis, style.y_axis)
+            _configure_plot_axis_style(y_axis, resolved_style.y_axis)
 
 
 def _matches_line_geometry_type(geometry_type) -> bool:

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -606,6 +606,22 @@ class TestBuildAtlasLayout(unittest.TestCase):
         x_axis.setGridMinorSymbol.assert_called_once_with("x-minor")
         y_axis.setGridMajorSymbol.assert_called_once_with("y-major")
         y_axis.setGridMinorSymbol.assert_called_once_with("y-minor")
+        self.assertEqual(
+            fill_symbol_cls.createSimple.call_args_list[0].args[0],
+            dict(DEFAULT_NATIVE_PROFILE_PLOT_STYLE.background_fill_props),
+        )
+        self.assertIsNot(
+            fill_symbol_cls.createSimple.call_args_list[0].args[0],
+            DEFAULT_NATIVE_PROFILE_PLOT_STYLE.background_fill_props,
+        )
+        self.assertEqual(
+            line_symbol_cls.createSimple.call_args_list[0].args[0],
+            dict(DEFAULT_NATIVE_PROFILE_PLOT_STYLE.x_axis.major_grid_props),
+        )
+        self.assertIsNot(
+            line_symbol_cls.createSimple.call_args_list[0].args[0],
+            DEFAULT_NATIVE_PROFILE_PLOT_STYLE.x_axis.major_grid_props,
+        )
 
     def test_configure_native_profile_plot_defaults_accepts_custom_style(self):
         item = MagicMock(name="native_item")


### PR DESCRIPTION
## Summary
- extract the native profile plot defaults into explicit style dataclasses instead of leaving them hard-coded inside the styling helper
- keep the current visual behavior unchanged while giving the native profile path a clean seam for future settings-based overrides
- add regression coverage for both the shared default style and custom-style injection

## Why
Issue #199 is about configurable profile styling. This slice does not add UI/settings yet, but it moves the defaults into a real style configuration object so future overrides can plug in without rewriting the native-plot helper.

## Testing
- python3 -m pytest tests/test_atlas_export_task.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #199
