### PR TITLE
feat: resolve atlas profile style from settings

### DIFF
--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -7,12 +7,17 @@ profile item without rewriting the whole export loop at once.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 import math
-from types import MappingProxyType
+from collections.abc import Mapping
 
 from qgis.core import QgsLayoutItemPicture, QgsLayoutPoint, QgsLayoutSize, QgsUnitTypes
+
+from .profile_style import (
+    DEFAULT_NATIVE_PROFILE_PLOT_STYLE,
+    NativeProfilePlotAxisStyle,
+    NativeProfilePlotStyle,
+)
 
 try:  # pragma: no cover - availability depends on QGIS build
     from qgis.core import QgsCoordinateReferenceSystem
@@ -169,52 +174,6 @@ class NativeProfileRequestConfig:
     crs_auth_id: str = "EPSG:3857"
     tolerance: float | None = None
     step_distance: float | None = None
-
-
-@dataclass(frozen=True)
-class NativeProfilePlotAxisStyle:
-    """Styling defaults for one axis of a native profile plot."""
-
-    suffix: str
-    major_grid_props: Mapping[str, str]
-    minor_grid_props: Mapping[str, str]
-
-
-@dataclass(frozen=True)
-class NativeProfilePlotStyle:
-    """Styling defaults for native QGIS profile plots."""
-
-    background_fill_props: Mapping[str, str]
-    border_fill_props: Mapping[str, str]
-    x_axis: NativeProfilePlotAxisStyle
-    y_axis: NativeProfilePlotAxisStyle
-
-
-def _immutable_props(**properties: str) -> Mapping[str, str]:
-    return MappingProxyType(dict(properties))
-
-
-DEFAULT_NATIVE_PROFILE_PLOT_STYLE = NativeProfilePlotStyle(
-    background_fill_props=_immutable_props(
-        color="255,255,255,230",
-        outline_style="no",
-    ),
-    border_fill_props=_immutable_props(
-        color="255,255,255,0",
-        outline_color="160,160,160,255",
-        outline_width="0.2",
-    ),
-    x_axis=NativeProfilePlotAxisStyle(
-        suffix=" km",
-        major_grid_props=_immutable_props(color="210,210,210,255", width="0.25"),
-        minor_grid_props=_immutable_props(color="235,235,235,255", width="0.15"),
-    ),
-    y_axis=NativeProfilePlotAxisStyle(
-        suffix=" m",
-        major_grid_props=_immutable_props(color="210,210,210,255", width="0.25"),
-        minor_grid_props=_immutable_props(color="235,235,235,255", width="0.15"),
-    ),
-)
 
 
 def _build_fill_symbol(properties: Mapping[str, str]):

--- a/atlas/profile_style.py
+++ b/atlas/profile_style.py
@@ -1,0 +1,124 @@
+"""Configuration helpers for native atlas elevation profile styling."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+@dataclass(frozen=True)
+class NativeProfilePlotAxisStyle:
+    """Styling defaults for one axis of a native profile plot."""
+
+    suffix: str
+    major_grid_props: Mapping[str, str]
+    minor_grid_props: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class NativeProfilePlotStyle:
+    """Styling defaults for native QGIS profile plots."""
+
+    background_fill_props: Mapping[str, str]
+    border_fill_props: Mapping[str, str]
+    x_axis: NativeProfilePlotAxisStyle
+    y_axis: NativeProfilePlotAxisStyle
+
+
+def _immutable_props(**properties: str) -> Mapping[str, str]:
+    return MappingProxyType(dict(properties))
+
+
+DEFAULT_NATIVE_PROFILE_PLOT_STYLE = NativeProfilePlotStyle(
+    background_fill_props=_immutable_props(
+        color="255,255,255,230",
+        outline_style="no",
+    ),
+    border_fill_props=_immutable_props(
+        color="255,255,255,0",
+        outline_color="160,160,160,255",
+        outline_width="0.2",
+    ),
+    x_axis=NativeProfilePlotAxisStyle(
+        suffix=" km",
+        major_grid_props=_immutable_props(color="210,210,210,255", width="0.25"),
+        minor_grid_props=_immutable_props(color="235,235,235,255", width="0.15"),
+    ),
+    y_axis=NativeProfilePlotAxisStyle(
+        suffix=" m",
+        major_grid_props=_immutable_props(color="210,210,210,255", width="0.25"),
+        minor_grid_props=_immutable_props(color="235,235,235,255", width="0.15"),
+    ),
+)
+
+
+def _setting_text(settings, key: str) -> str | None:
+    if settings is None or not hasattr(settings, "get"):
+        return None
+
+    value = settings.get(key, None)
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    return text or None
+
+
+def build_native_profile_plot_style_from_settings(
+    settings,
+    *,
+    default_style: NativeProfilePlotStyle = DEFAULT_NATIVE_PROFILE_PLOT_STYLE,
+) -> NativeProfilePlotStyle:
+    """Build a plot style from optional persisted settings overrides."""
+    background_fill_color = _setting_text(settings, "atlas_profile_plot_background_fill_color")
+    border_color = _setting_text(settings, "atlas_profile_plot_border_color")
+    major_grid_color = _setting_text(settings, "atlas_profile_plot_major_grid_color")
+    minor_grid_color = _setting_text(settings, "atlas_profile_plot_minor_grid_color")
+    x_axis_suffix = _setting_text(settings, "atlas_profile_plot_x_axis_suffix")
+    y_axis_suffix = _setting_text(settings, "atlas_profile_plot_y_axis_suffix")
+
+    if not any(
+        [
+            background_fill_color,
+            border_color,
+            major_grid_color,
+            minor_grid_color,
+            x_axis_suffix,
+            y_axis_suffix,
+        ]
+    ):
+        return default_style
+
+    background_fill_props = dict(default_style.background_fill_props)
+    border_fill_props = dict(default_style.border_fill_props)
+    x_axis_major_props = dict(default_style.x_axis.major_grid_props)
+    x_axis_minor_props = dict(default_style.x_axis.minor_grid_props)
+    y_axis_major_props = dict(default_style.y_axis.major_grid_props)
+    y_axis_minor_props = dict(default_style.y_axis.minor_grid_props)
+
+    if background_fill_color is not None:
+        background_fill_props["color"] = background_fill_color
+    if border_color is not None:
+        border_fill_props["outline_color"] = border_color
+    if major_grid_color is not None:
+        x_axis_major_props["color"] = major_grid_color
+        y_axis_major_props["color"] = major_grid_color
+    if minor_grid_color is not None:
+        x_axis_minor_props["color"] = minor_grid_color
+        y_axis_minor_props["color"] = minor_grid_color
+
+    return NativeProfilePlotStyle(
+        background_fill_props=_immutable_props(**background_fill_props),
+        border_fill_props=_immutable_props(**border_fill_props),
+        x_axis=NativeProfilePlotAxisStyle(
+            suffix=x_axis_suffix or default_style.x_axis.suffix,
+            major_grid_props=_immutable_props(**x_axis_major_props),
+            minor_grid_props=_immutable_props(**x_axis_minor_props),
+        ),
+        y_axis=NativeProfilePlotAxisStyle(
+            suffix=y_axis_suffix or default_style.y_axis.suffix,
+            major_grid_props=_immutable_props(**y_axis_major_props),
+            minor_grid_props=_immutable_props(**y_axis_minor_props),
+        ),
+    )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -27,6 +27,7 @@ from .atlas.export_service import (
     AtlasExportResult,
     AtlasExportService,
 )
+from .atlas.profile_style import build_native_profile_plot_style_from_settings
 from .contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import (
     DEFAULT_DETAILED_ROUTE_STRATEGY,
@@ -1089,6 +1090,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
             style_id=self.mapboxStyleIdLineEdit.text().strip(),
             background_enabled=self.backgroundMapCheckBox.isChecked(),
+            profile_plot_style=build_native_profile_plot_style_from_settings(self.settings),
         )
         self.atlas_export_service.prepare_basemap_for_export(export_request)
 

--- a/tests/test_atlas_profile_style.py
+++ b/tests/test_atlas_profile_style.py
@@ -1,0 +1,56 @@
+import unittest
+
+from qfit.atlas.profile_style import (
+    DEFAULT_NATIVE_PROFILE_PLOT_STYLE,
+    build_native_profile_plot_style_from_settings,
+)
+
+
+class _FakeSettings:
+    def __init__(self, values=None):
+        self._values = values or {}
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+class BuildNativeProfilePlotStyleFromSettingsTests(unittest.TestCase):
+    def test_returns_default_style_when_no_overrides_exist(self):
+        style = build_native_profile_plot_style_from_settings(_FakeSettings())
+
+        self.assertIs(style, DEFAULT_NATIVE_PROFILE_PLOT_STYLE)
+
+    def test_applies_settings_overrides(self):
+        style = build_native_profile_plot_style_from_settings(
+            _FakeSettings(
+                {
+                    "atlas_profile_plot_background_fill_color": "1,2,3,255",
+                    "atlas_profile_plot_border_color": "4,5,6,255",
+                    "atlas_profile_plot_major_grid_color": "7,8,9,255",
+                    "atlas_profile_plot_minor_grid_color": "10,11,12,255",
+                    "atlas_profile_plot_x_axis_suffix": " mi",
+                    "atlas_profile_plot_y_axis_suffix": " ft",
+                }
+            )
+        )
+
+        self.assertEqual(style.background_fill_props["color"], "1,2,3,255")
+        self.assertEqual(style.border_fill_props["outline_color"], "4,5,6,255")
+        self.assertEqual(style.x_axis.major_grid_props["color"], "7,8,9,255")
+        self.assertEqual(style.y_axis.major_grid_props["color"], "7,8,9,255")
+        self.assertEqual(style.x_axis.minor_grid_props["color"], "10,11,12,255")
+        self.assertEqual(style.y_axis.minor_grid_props["color"], "10,11,12,255")
+        self.assertEqual(style.x_axis.suffix, "mi")
+        self.assertEqual(style.y_axis.suffix, "ft")
+
+    def test_ignores_blank_string_overrides(self):
+        style = build_native_profile_plot_style_from_settings(
+            _FakeSettings(
+                {
+                    "atlas_profile_plot_background_fill_color": "   ",
+                    "atlas_profile_plot_x_axis_suffix": "",
+                }
+            )
+        )
+
+        self.assertIs(style, DEFAULT_NATIVE_PROFILE_PLOT_STYLE)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -339,6 +339,43 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_generate_atlas_pdf_passes_profile_plot_style_from_settings(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            fake_task = MagicMock(name="atlas_export_task")
+            dock.atlas_layer = MagicMock()
+            dock.atlas_layer.featureCount.return_value = 3
+            dock.atlasPdfPathLineEdit.setText("/tmp/qfit-atlas.pdf")
+
+            dock.atlas_export_controller.validate_atlas_layer = MagicMock()
+            dock.atlas_export_controller.normalize_pdf_path = MagicMock(
+                return_value=("/tmp/qfit-atlas.pdf", False)
+            )
+            dock.atlas_export_service.check_pdf_export_prerequisites = MagicMock(return_value=None)
+            dock.atlas_export_service.build_request = MagicMock(return_value="atlas-request")
+            dock.atlas_export_service.prepare_basemap_for_export = MagicMock()
+            dock.atlas_export_service.build_task = MagicMock(return_value=fake_task)
+            dock._save_settings = MagicMock()
+
+            with (
+                patch("qfit.qfit_dockwidget.build_native_profile_plot_style_from_settings", return_value="style-override") as build_style,
+                patch("qfit.qfit_dockwidget.QgsApplication.taskManager") as task_manager,
+            ):
+                task_manager.return_value.addTask = MagicMock()
+
+                dock.on_generate_atlas_pdf_clicked()
+
+            build_style.assert_called_once_with(dock.settings)
+            self.assertEqual(
+                dock.atlas_export_service.build_request.call_args.kwargs["profile_plot_style"],
+                "style-override",
+            )
+            dock.atlas_export_service.build_task.assert_called_once_with("atlas-request")
+            task_manager.return_value.addTask.assert_called_once_with(fake_task)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_refresh_clicked_builds_fetch_task_via_sync_controller(self):
         dock = QfitDockWidget(self.iface)
         try:


### PR DESCRIPTION
## Summary
- move native profile plot style dataclasses/defaults into a pure-Python `atlas.profile_style` module
- add a settings resolver that builds a native profile plot style from optional persisted overrides
- have the dock widget pass that settings-derived style into atlas export requests
- add unit coverage for the settings resolver and a dock-widget smoke test that the resolved style is forwarded into export

## Why
Issue #199 asks for configurable elevation-profile styling. The previous slices established defaults and threaded a style object through atlas export. This slice adds the first real settings-backed override path, without widening scope into config-dialog UI yet.

## Testing
- python3 -m pytest tests/test_atlas_profile_style.py tests/test_atlas_export_task.py tests/test_atlas_export_service.py tests/test_qgis_smoke.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #199
