### PR TITLE
Remove native SVG fallback item path from atlas profiles

### DIFF
--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -52,7 +52,6 @@ class ProfileItemAdapter:
 
     item: object
     kind: str = "picture"
-    svg_fallback_item: object | None = None
     atlas_driven: bool = False
 
     @property
@@ -87,16 +86,12 @@ class ProfileItemAdapter:
     def clear_profile(self) -> None:
         self._clear_native_curve()
         self._set_picture_path(self.item, "")
-        self._set_picture_path(self.svg_fallback_item, "")
         self._refresh_item(self.item)
-        self._refresh_item(self.svg_fallback_item)
 
     def set_svg_profile(self, svg_path: str) -> None:
         self._clear_native_curve()
-        picture_item = self.svg_fallback_item or self.item
-        self._set_picture_path(picture_item, svg_path)
+        self._set_picture_path(self.item, svg_path)
         self._refresh_item(self.item)
-        self._refresh_item(picture_item)
 
     def configure_native_defaults(
         self,
@@ -149,9 +144,7 @@ class ProfileItemAdapter:
         if not callable(set_profile_curve) or profile_curve is None:
             return False
 
-        self._set_picture_path(self.svg_fallback_item, "")
         set_profile_curve(profile_curve)
-        self._refresh_item(self.svg_fallback_item)
         self._refresh_item(self.item)
         return True
 
@@ -327,8 +320,8 @@ def build_profile_item(
     """Create the current profile layout item and return an adapter for it.
 
     Prefer a native ``QgsLayoutItemElevationProfile`` when the QGIS build
-    exposes it, while keeping a hidden picture-backed fallback so atlas pages
-    with unusable native curve input can still render the sampled SVG chart.
+    exposes it, while still falling back to a picture-backed item when native
+    profile support is unavailable.
     """
     native_adapter = build_native_profile_item(
         layout,
@@ -340,16 +333,6 @@ def build_profile_item(
         config=native_config,
     )
     if native_adapter is not None:
-        if not native_adapter.requires_manual_page_updates:
-            return native_adapter
-
-        fallback_item = QgsLayoutItemPicture(layout)
-        fallback_item.setId(f"{item_id}_svg_fallback")
-        fallback_item.attemptMove(QgsLayoutPoint(x, y, QgsUnitTypes.LayoutMillimeters))
-        fallback_item.attemptResize(QgsLayoutSize(w, h, QgsUnitTypes.LayoutMillimeters))
-        fallback_item.setResizeMode(QgsLayoutItemPicture.Zoom)
-        layout.addLayoutItem(fallback_item)
-        native_adapter.svg_fallback_item = fallback_item
         return native_adapter
 
     profile_item = QgsLayoutItemPicture(layout)
@@ -397,35 +380,10 @@ def build_native_profile_item(
     return adapter
 
 
-def _find_svg_fallback_item(item) -> object | None:
-    """Locate the hidden SVG fallback item paired with a native profile item."""
-    item_id_getter = getattr(item, "id", None)
-    layout_getter = getattr(item, "layout", None)
-    if not callable(item_id_getter) or not callable(layout_getter):
-        return None
-
-    item_id = item_id_getter()
-    if not item_id:
-        return None
-
-    layout = layout_getter()
-    items_getter = getattr(layout, "items", None)
-    if not callable(items_getter):
-        return None
-
-    fallback_id = f"{item_id}_svg_fallback"
-    for candidate in items_getter():
-        candidate_id_getter = getattr(candidate, "id", None)
-        if callable(candidate_id_getter) and candidate_id_getter() == fallback_id:
-            return candidate
-    return None
-
-
 def build_profile_item_adapter(item) -> ProfileItemAdapter:
     """Wrap an already-created layout item in the shared adapter type."""
     item_type = type(item).__name__.lower()
     kind = "native" if "elevationprofile" in item_type else "picture"
-    fallback_item = _find_svg_fallback_item(item) if kind == "native" else None
     atlas_driven = False
     if kind == "native":
         atlas_driven_getter = getattr(item, "atlasDriven", None)
@@ -436,7 +394,7 @@ def build_profile_item_adapter(item) -> ProfileItemAdapter:
                 atlas_driven = False
             else:
                 atlas_driven = bool(atlas_driven_value) if atlas_driven_value is not None else False
-    return ProfileItemAdapter(item=item, kind=kind, svg_fallback_item=fallback_item, atlas_driven=atlas_driven)
+    return ProfileItemAdapter(item=item, kind=kind, atlas_driven=atlas_driven)
 
 
 def native_profile_item_available() -> bool:

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -364,7 +364,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
         _qgis_core.QgsLayoutItemElevationProfile.return_value.setId.assert_called_once_with("profile")
         _qgis_core.QgsLayoutItemPicture.assert_not_called()
 
-    def test_build_profile_item_keeps_svg_fallback_for_manual_native_updates(self):
+    def test_build_profile_item_does_not_create_svg_fallback_for_manual_native_updates(self):
         layout = MagicMock()
         _qgis_core.QgsLayoutItemElevationProfile.reset_mock()
         _qgis_core.QgsLayoutItemElevationProfile.return_value.reset_mock()
@@ -384,15 +384,12 @@ class TestBuildAtlasLayout(unittest.TestCase):
             )
 
         self.assertEqual(adapter.kind, "native")
-        self.assertIs(adapter.svg_fallback_item, _qgis_core.QgsLayoutItemPicture.return_value)
-        _qgis_core.QgsLayoutItemPicture.return_value.setId.assert_called_once_with("profile_svg_fallback")
+        _qgis_core.QgsLayoutItemPicture.assert_not_called()
 
-    def test_build_profile_item_keeps_svg_fallback_when_native_atlas_driven_api_is_unavailable(self):
+    def test_build_profile_item_uses_native_item_when_manual_updates_are_required(self):
         layout = MagicMock()
         native_adapter = ProfileItemAdapter(item=MagicMock(), kind="native", atlas_driven=False)
-        picture_item = _qgis_core.QgsLayoutItemPicture.return_value
         _qgis_core.QgsLayoutItemPicture.reset_mock()
-        picture_item.reset_mock()
 
         with patch("qfit.atlas.profile_item.build_native_profile_item", return_value=native_adapter):
             with patch("qfit.atlas.profile_item.QgsLayoutItemPicture", _qgis_core.QgsLayoutItemPicture):
@@ -407,26 +404,7 @@ class TestBuildAtlasLayout(unittest.TestCase):
                 )
 
         self.assertIs(adapter, native_adapter)
-        self.assertIs(adapter.svg_fallback_item, picture_item)
-        picture_item.setId.assert_called_once_with("profile_svg_fallback")
-
-    def test_build_profile_item_adapter_finds_native_svg_fallback_by_id(self):
-        layout = MagicMock()
-        native_item = MagicMock()
-        native_item.__class__.__name__ = "QgsLayoutItemElevationProfile"
-        native_item.id.return_value = "profile"
-        native_item.layout.return_value = layout
-
-        fallback_item = MagicMock()
-        fallback_item.id.return_value = "profile_svg_fallback"
-        other_item = MagicMock()
-        other_item.id.return_value = "something_else"
-        layout.items.return_value = [other_item, fallback_item]
-
-        adapter = build_profile_item_adapter(native_item)
-
-        self.assertEqual(adapter.kind, "native")
-        self.assertIs(adapter.svg_fallback_item, fallback_item)
+        _qgis_core.QgsLayoutItemPicture.assert_not_called()
 
     def test_build_profile_item_falls_back_to_picture_when_native_unavailable(self):
         layout = MagicMock()
@@ -973,22 +951,15 @@ class TestBuildAtlasLayout(unittest.TestCase):
     def test_build_profile_item_adapter_returns_picture_when_native_item_lacks_lookup_helpers(self):
         adapter = build_profile_item_adapter(object())
         self.assertEqual(adapter.kind, "picture")
-        self.assertIsNone(adapter.svg_fallback_item)
 
-    def test_build_profile_item_adapter_native_without_id_or_layout_items_has_no_fallback(self):
+    def test_build_profile_item_adapter_detects_native_without_layout_lookup_helpers(self):
         native_item = MagicMock()
         native_item.__class__.__name__ = "QgsLayoutItemElevationProfile"
-        native_item.id.return_value = ""
-        native_item.layout.return_value = object()
+        del native_item.atlasDriven
 
         adapter = build_profile_item_adapter(native_item)
         self.assertEqual(adapter.kind, "native")
-        self.assertIsNone(adapter.svg_fallback_item)
-
-        native_item.id.return_value = "profile"
-        native_item.layout.return_value = object()
-        adapter = build_profile_item_adapter(native_item)
-        self.assertIsNone(adapter.svg_fallback_item)
+        self.assertFalse(adapter.atlas_driven)
 
     def test_build_native_profile_curve_rejects_polygon_api_objects_without_curve_api(self):
         class _PolygonLike:
@@ -1114,10 +1085,6 @@ class TestBuildAtlasLayout(unittest.TestCase):
         curve.numPoints.return_value = 1
         curve.pointN.side_effect = RuntimeError("boom")
         self.assertFalse(profile_item_module._curve_points_have_z(curve))
-
-        native_item = MagicMock()
-        del native_item.id
-        self.assertIsNone(profile_item_module._find_svg_fallback_item(native_item))
 
         candidate = MagicMock()
         del candidate.wkbType


### PR DESCRIPTION
## Summary
- stop creating hidden `*_svg_fallback` picture items for native atlas profile layout items
- simplify native profile adapters so they only manage the real layout item
- update tests to cover the native-only manual update path without the extra fallback item

## Testing
- python3 -m pytest tests/ -x -q --tb=short

Advances #196.