### PR TITLE
fix: wire native profile request during atlas export

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -172,12 +172,15 @@ def _apply_page_profile_payload(
     if getattr(profile_adapter, "atlas_driven", False):
         return
 
-    native_curve, _native_request = profile_payload.native_inputs()
+    native_curve, native_request = profile_payload.native_inputs()
     if native_curve is None:
         profile_adapter.clear_profile()
         return
 
-    if profile_adapter.bind_native_profile(profile_curve=native_curve):
+    if profile_adapter.bind_native_profile(
+        profile_curve=native_curve,
+        profile_request=native_request,
+    ):
         return
 
     profile_adapter.clear_profile()

--- a/atlas/profile_item.py
+++ b/atlas/profile_item.py
@@ -67,6 +67,37 @@ class ProfileItemAdapter:
         if callable(set_picture_path):
             set_picture_path(path)
 
+    def _copy_profile_request_setting_to_item(
+        self,
+        profile_request,
+        *,
+        setter_name: str,
+        getter_name: str,
+    ) -> None:
+        setter = getattr(self.item, setter_name, None)
+        getter = getattr(profile_request, getter_name, None)
+        if not callable(setter) or not callable(getter):
+            return
+
+        try:
+            setter(getter())
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _apply_profile_request_to_item(self, profile_request) -> None:
+        if profile_request is None:
+            return
+
+        for setter_name, getter_name in (
+            ("setCrs", "crs"),
+            ("setTolerance", "tolerance"),
+        ):
+            self._copy_profile_request_setting_to_item(
+                profile_request,
+                setter_name=setter_name,
+                getter_name=getter_name,
+            )
+
     def _clear_native_curve(self) -> None:
         if not self.supports_native_profile:
             return
@@ -122,6 +153,7 @@ class ProfileItemAdapter:
         self,
         *,
         profile_curve=None,
+        profile_request=None,
     ) -> bool:
         """Bind native profile inputs when the underlying item supports them.
 
@@ -134,6 +166,8 @@ class ProfileItemAdapter:
         """
         if not self.supports_native_profile:
             return False
+
+        self._apply_profile_request_to_item(profile_request)
 
         set_profile_curve = getattr(self.item, "setProfileCurve", None)
         if not callable(set_profile_curve) or profile_curve is None:

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -257,7 +257,10 @@ class TestBuildAtlasLayout(unittest.TestCase):
         atlas_export_task._apply_page_profile_payload(adapter, payload)
 
         payload.native_inputs.assert_called_once_with()
-        adapter.bind_native_profile.assert_called_once_with(profile_curve="curve")
+        adapter.bind_native_profile.assert_called_once_with(
+            profile_curve="curve",
+            profile_request="request",
+        )
 
     def test_apply_page_profile_payload_skips_manual_updates_for_atlas_driven_native_item(self):
         adapter = MagicMock(name="adapter")
@@ -282,7 +285,10 @@ class TestBuildAtlasLayout(unittest.TestCase):
         atlas_export_task._apply_page_profile_payload(adapter, payload)
 
         payload.native_inputs.assert_called_once_with()
-        adapter.bind_native_profile.assert_called_once_with(profile_curve="curve")
+        adapter.bind_native_profile.assert_called_once_with(
+            profile_curve="curve",
+            profile_request="request",
+        )
         adapter.clear_profile.assert_called_once_with()
 
     def test_apply_page_profile_payload_clears_native_profile_when_curve_missing(self):
@@ -875,6 +881,39 @@ class TestBuildAtlasLayout(unittest.TestCase):
         adapter.bind_native_profile(profile_curve="curve")
 
         item.setProfileCurve.assert_called_once_with("curve")
+
+    def test_native_adapter_applies_request_state_via_item_setters(self):
+        item = MagicMock()
+        profile_request = MagicMock(name="profile_request")
+        profile_request.crs.return_value = "EPSG:3857"
+        profile_request.tolerance.return_value = 25.0
+        profile_request.stepDistance.return_value = 5.0
+        adapter = ProfileItemAdapter(item=item, kind="native")
+
+        adapter.bind_native_profile(
+            profile_curve="curve",
+            profile_request=profile_request,
+        )
+
+        item.setProfileCurve.assert_called_once_with("curve")
+        item.setCrs.assert_called_once_with("EPSG:3857")
+        item.setTolerance.assert_called_once_with(25.0)
+        self.assertFalse(item.profileRequest.called)
+
+    def test_native_adapter_skips_missing_item_request_setters(self):
+        item = MagicMock()
+        del item.setTolerance
+        profile_request = MagicMock(name="profile_request")
+        del profile_request.tolerance
+        adapter = ProfileItemAdapter(item=item, kind="native")
+
+        adapter.bind_native_profile(
+            profile_curve="curve",
+            profile_request=profile_request,
+        )
+
+        item.setProfileCurve.assert_called_once_with("curve")
+        item.setCrs.assert_called_once_with(profile_request.crs.return_value)
 
     def test_native_adapter_clear_profile_swallow_set_profile_curve_errors(self):
         item = MagicMock()
@@ -1512,19 +1551,25 @@ class TestProfileChartRendering(unittest.TestCase):
             output_path="/tmp/qfit_test_profile_chart.pdf",
             on_finished=lambda **kw: None,
         )
+        native_request = MagicMock(name="native_request")
+        native_request.crs.return_value = "EPSG:3857"
+        native_request.tolerance.return_value = 25.0
+        native_request.stepDistance.return_value = 5.0
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
              patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
              patch("qfit.atlas.export_task._geometry_supports_native_profile", side_effect=lambda geometry: geometry == "track-geometry"), \
-             patch("qfit.atlas.export_task.build_native_profile_inputs", return_value=("curve", "request")) as build_native_inputs, \
+             patch("qfit.atlas.export_task.build_native_profile_inputs", return_value=("curve", native_request)) as build_native_inputs, \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
 
         build_native_inputs.assert_called_once_with("track-geometry")
         native_profile_item.setProfileCurve.assert_called_once_with("curve")
+        native_profile_item.setCrs.assert_called_once_with("EPSG:3857")
+        native_profile_item.setTolerance.assert_called_once_with(25.0)
         native_profile_item.refresh.assert_called()
 
     def test_profile_chart_changes_per_activity_page(self):


### PR DESCRIPTION
## Summary\n- propagate the per-page native profile request into the live layout elevation profile item\n- keep binding the curve directly while also updating the mutable profileRequest() object\n- add regression tests covering adapter request binding and export-loop request wiring\n\n## Testing\n- python3 -m pytest tests/test_atlas_export_task.py -x -q --tb=short\n- python3 -m pytest tests/ -x -q --tb=short