### PR TITLE
Refactor atlas export startup around a use-case boundary

### DIFF
--- a/atlas/__init__.py
+++ b/atlas/__init__.py
@@ -7,6 +7,7 @@ rather than from individual submodules.
 
 from .export_controller import AtlasExportController, AtlasExportValidationError
 from .export_service import AtlasExportResult, AtlasExportService
+from .export_use_case import AtlasExportUseCase, GenerateAtlasPdfCommand, PrepareAtlasPdfExportResult
 from .publish_atlas import build_atlas_page_plans, normalize_atlas_page_settings
 
 # export_task is NOT imported here: it has top-level QGIS runtime imports that
@@ -19,6 +20,9 @@ __all__ = [
     "AtlasExportValidationError",
     "AtlasExportResult",
     "AtlasExportService",
+    "AtlasExportUseCase",
+    "GenerateAtlasPdfCommand",
+    "PrepareAtlasPdfExportResult",
     "build_atlas_page_plans",
     "normalize_atlas_page_settings",
 ]

--- a/atlas/export_use_case.py
+++ b/atlas/export_use_case.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from .export_controller import AtlasExportValidationError
+from .export_service import AtlasExportResult, AtlasExportService, GenerateAtlasPdfRequest
+
+
+@dataclass(frozen=True)
+class GenerateAtlasPdfCommand:
+    """Application-layer command for starting atlas PDF export."""
+
+    atlas_layer: object = None
+    output_path: str = ""
+    on_finished: Callable | None = None
+    pre_export_tile_mode: str = ""
+    preset_name: str = ""
+    access_token: str = ""
+    style_owner: str = ""
+    style_id: str = ""
+    background_enabled: bool = False
+    profile_plot_style: object | None = None
+
+
+@dataclass(frozen=True)
+class PrepareAtlasPdfExportResult:
+    """Structured outcome of validating and preparing atlas export startup."""
+
+    request: GenerateAtlasPdfRequest | None = None
+    output_path: str = ""
+    path_changed: bool = False
+    error_title: str | None = None
+    error_message: str | None = None
+    pdf_status: str | None = None
+    main_status: str | None = None
+
+    @property
+    def is_ready(self) -> bool:
+        return self.request is not None and self.error_message is None
+
+
+class AtlasExportUseCase:
+    """Application-layer boundary for atlas PDF export.
+
+    Coordinates request validation, prerequisite checks, basemap preparation,
+    task construction, and completion result handling so the UI can interact
+    with atlas export through a single use-case object.
+    """
+
+    def __init__(self, controller, service: AtlasExportService) -> None:
+        self.controller = controller
+        self.service = service
+
+    @staticmethod
+    def build_command(**kwargs) -> GenerateAtlasPdfCommand:
+        return GenerateAtlasPdfCommand(**kwargs)
+
+    def prepare_export(self, command: GenerateAtlasPdfCommand) -> PrepareAtlasPdfExportResult:
+        try:
+            self.controller.validate_atlas_layer(command.atlas_layer)
+        except AtlasExportValidationError as exc:
+            return PrepareAtlasPdfExportResult(
+                error_title="Atlas export error",
+                error_message=str(exc),
+            )
+
+        try:
+            output_path, changed = self.controller.normalize_pdf_path(command.output_path)
+        except AtlasExportValidationError as exc:
+            return PrepareAtlasPdfExportResult(
+                error_title="Missing output path",
+                error_message=str(exc),
+            )
+
+        prereq_error = self.service.check_pdf_export_prerequisites()
+        if prereq_error is not None:
+            return PrepareAtlasPdfExportResult(
+                output_path=output_path,
+                path_changed=changed,
+                error_title="Atlas PDF export unavailable",
+                error_message=prereq_error,
+                pdf_status="Atlas PDF export unavailable.",
+                main_status="Atlas PDF export unavailable.",
+            )
+
+        request = self.service.build_request(
+            atlas_layer=command.atlas_layer,
+            output_path=output_path,
+            on_finished=command.on_finished,
+            pre_export_tile_mode=command.pre_export_tile_mode,
+            preset_name=command.preset_name,
+            access_token=command.access_token,
+            style_owner=command.style_owner,
+            style_id=command.style_id,
+            background_enabled=command.background_enabled,
+            profile_plot_style=command.profile_plot_style,
+        )
+        return PrepareAtlasPdfExportResult(
+            request=request,
+            output_path=output_path,
+            path_changed=changed,
+        )
+
+    def start_export(self, prepared: PrepareAtlasPdfExportResult):
+        if not prepared.is_ready or prepared.request is None:
+            raise ValueError("prepare_export() must succeed before start_export().")
+
+        self.service.prepare_basemap_for_export(prepared.request)
+        return self.service.build_task(prepared.request)
+
+    def finish_export(
+        self,
+        output_path: str | None,
+        error: str | None,
+        cancelled: bool,
+        page_count: int,
+    ) -> AtlasExportResult:
+        return self.service.build_result(output_path, error, cancelled, page_count)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -21,7 +21,6 @@ from .activities.domain.activity_query import (
     sort_activities,
     summarize_activities,
 )
-from .atlas.export_controller import AtlasExportValidationError
 from .activities.application.load_workflow import LoadWorkflowError
 from .atlas.export_service import (
     AtlasExportResult,
@@ -351,6 +350,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.settings = dependencies.settings
         self.sync_controller = dependencies.sync_controller
         self.atlas_export_controller = dependencies.atlas_export_controller
+        self.atlas_export_use_case = dependencies.atlas_export_use_case
         self.layer_gateway = dependencies.layer_gateway
         self.background_controller = dependencies.background_controller
         self.load_workflow = dependencies.load_workflow
@@ -1054,37 +1054,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._atlas_export_task = None
             return
 
-        try:
-            self.atlas_export_controller.validate_atlas_layer(self.atlas_layer)
-        except AtlasExportValidationError as exc:
-            self._show_error("Atlas export error", str(exc))
-            return
-
-        try:
-            output_path, changed = self.atlas_export_controller.normalize_pdf_path(
-                self.atlasPdfPathLineEdit.text().strip()
-            )
-        except AtlasExportValidationError as exc:
-            self._show_error("Missing output path", str(exc))
-            return
-        if changed:
-            self.atlasPdfPathLineEdit.setText(output_path)
-
-        prereq_error = self.atlas_export_service.check_pdf_export_prerequisites()
-        if prereq_error is not None:
-            self._set_atlas_pdf_status("Atlas PDF export unavailable.")
-            self._set_status("Atlas PDF export unavailable.")
-            self._show_error("Atlas PDF export unavailable", prereq_error)
-            return
-
-        self._save_settings()
-
-        pre_export_tile_mode = self.tileModeComboBox.currentText()
-        export_request = self.atlas_export_service.build_request(
+        export_command = self.atlas_export_use_case.build_command(
             atlas_layer=self.atlas_layer,
-            output_path=output_path,
+            output_path=self.atlasPdfPathLineEdit.text().strip(),
             on_finished=self._on_atlas_export_finished,
-            pre_export_tile_mode=pre_export_tile_mode,
+            pre_export_tile_mode=self.tileModeComboBox.currentText(),
             preset_name=self.backgroundPresetComboBox.currentText(),
             access_token=self._mapbox_access_token(),
             style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
@@ -1092,7 +1066,19 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             background_enabled=self.backgroundMapCheckBox.isChecked(),
             profile_plot_style=build_native_profile_plot_style_from_settings(self.settings),
         )
-        self.atlas_export_service.prepare_basemap_for_export(export_request)
+        prepared_export = self.atlas_export_use_case.prepare_export(export_command)
+        if prepared_export.path_changed:
+            self.atlasPdfPathLineEdit.setText(prepared_export.output_path)
+        if not prepared_export.is_ready:
+            if prepared_export.pdf_status is not None:
+                self._set_atlas_pdf_status(prepared_export.pdf_status)
+            if prepared_export.main_status is not None:
+                self._set_status(prepared_export.main_status)
+            self._show_error(prepared_export.error_title, prepared_export.error_message)
+            return
+
+        self._save_settings()
+        self._atlas_export_task = self.atlas_export_use_case.start_export(prepared_export)
 
         self._set_atlas_export_running(True)
         self._set_atlas_pdf_status(
@@ -1100,7 +1086,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self._set_status("Generating atlas PDF…")
 
-        self._atlas_export_task = self.atlas_export_service.build_task(export_request)
         QgsApplication.taskManager().addTask(self._atlas_export_task)
 
     def _set_atlas_export_running(self, running: bool) -> None:
@@ -1122,7 +1107,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._atlas_export_task = None
         self._set_atlas_export_running(False)
 
-        result = AtlasExportService.build_result(output_path, error, cancelled, page_count)
+        result = self.atlas_export_use_case.finish_export(output_path, error, cancelled, page_count)
         self._set_atlas_pdf_status(result.pdf_status)
         self._set_status(result.main_status)
         if result.error is not None and not result.cancelled:

--- a/tests/test_atlas_export_use_case.py
+++ b/tests/test_atlas_export_use_case.py
@@ -1,0 +1,129 @@
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+
+from qfit.atlas.export_controller import AtlasExportValidationError
+from qfit.atlas.export_service import AtlasExportResult
+from qfit.atlas.export_use_case import (
+    AtlasExportUseCase,
+    GenerateAtlasPdfCommand,
+    PrepareAtlasPdfExportResult,
+)
+
+
+class AtlasExportUseCaseTests(unittest.TestCase):
+    def setUp(self):
+        self.controller = MagicMock(name="controller")
+        self.service = MagicMock(name="service")
+        self.use_case = AtlasExportUseCase(self.controller, self.service)
+
+    def test_build_command_returns_dataclass(self):
+        command = self.use_case.build_command(output_path="/tmp/atlas.pdf", background_enabled=True)
+
+        self.assertIsInstance(command, GenerateAtlasPdfCommand)
+        self.assertEqual(command.output_path, "/tmp/atlas.pdf")
+        self.assertTrue(command.background_enabled)
+
+    def test_prepare_export_returns_validation_error_when_layer_invalid(self):
+        self.controller.validate_atlas_layer.side_effect = AtlasExportValidationError("missing layer")
+
+        result = self.use_case.prepare_export(GenerateAtlasPdfCommand(atlas_layer=None))
+
+        self.assertFalse(result.is_ready)
+        self.assertEqual(result.error_title, "Atlas export error")
+        self.assertEqual(result.error_message, "missing layer")
+        self.service.check_pdf_export_prerequisites.assert_not_called()
+
+    def test_prepare_export_returns_missing_output_path_error(self):
+        self.controller.normalize_pdf_path.side_effect = AtlasExportValidationError("missing path")
+
+        result = self.use_case.prepare_export(GenerateAtlasPdfCommand(atlas_layer=object(), output_path=""))
+
+        self.assertFalse(result.is_ready)
+        self.assertEqual(result.error_title, "Missing output path")
+        self.assertEqual(result.error_message, "missing path")
+        self.service.check_pdf_export_prerequisites.assert_not_called()
+
+    def test_prepare_export_returns_prerequisite_error_with_statuses(self):
+        self.controller.normalize_pdf_path.return_value = ("/tmp/atlas.pdf", True)
+        self.service.check_pdf_export_prerequisites.return_value = "pypdf missing"
+
+        result = self.use_case.prepare_export(
+            GenerateAtlasPdfCommand(atlas_layer=object(), output_path="/tmp/atlas")
+        )
+
+        self.assertFalse(result.is_ready)
+        self.assertEqual(result.output_path, "/tmp/atlas.pdf")
+        self.assertTrue(result.path_changed)
+        self.assertEqual(result.error_title, "Atlas PDF export unavailable")
+        self.assertEqual(result.error_message, "pypdf missing")
+        self.assertEqual(result.pdf_status, "Atlas PDF export unavailable.")
+        self.assertEqual(result.main_status, "Atlas PDF export unavailable.")
+        self.service.build_request.assert_not_called()
+
+    def test_prepare_export_builds_request_on_success(self):
+        request = object()
+        self.controller.normalize_pdf_path.return_value = ("/tmp/atlas.pdf", True)
+        self.service.check_pdf_export_prerequisites.return_value = None
+        self.service.build_request.return_value = request
+
+        command = GenerateAtlasPdfCommand(
+            atlas_layer=object(),
+            output_path="/tmp/atlas",
+            on_finished=MagicMock(),
+            pre_export_tile_mode="Raster",
+            preset_name="Outdoor",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="style",
+            background_enabled=True,
+            profile_plot_style="style-override",
+        )
+        result = self.use_case.prepare_export(command)
+
+        self.assertTrue(result.is_ready)
+        self.assertIs(result.request, request)
+        self.assertEqual(result.output_path, "/tmp/atlas.pdf")
+        self.assertTrue(result.path_changed)
+        self.service.build_request.assert_called_once_with(
+            atlas_layer=command.atlas_layer,
+            output_path="/tmp/atlas.pdf",
+            on_finished=command.on_finished,
+            pre_export_tile_mode="Raster",
+            preset_name="Outdoor",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="style",
+            background_enabled=True,
+            profile_plot_style="style-override",
+        )
+
+    def test_start_export_prepares_basemap_and_builds_task(self):
+        request = object()
+        task = object()
+        self.service.build_task.return_value = task
+        prepared = PrepareAtlasPdfExportResult(request=request, output_path="/tmp/atlas.pdf")
+
+        result = self.use_case.start_export(prepared)
+
+        self.assertIs(result, task)
+        self.service.prepare_basemap_for_export.assert_called_once_with(request)
+        self.service.build_task.assert_called_once_with(request)
+
+    def test_start_export_requires_prepared_request(self):
+        with self.assertRaises(ValueError):
+            self.use_case.start_export(PrepareAtlasPdfExportResult())
+
+    def test_finish_export_delegates_to_service(self):
+        final_result = AtlasExportResult(output_path="/tmp/atlas.pdf", page_count=2)
+        self.service.build_result.return_value = final_result
+
+        result = self.use_case.finish_export("/tmp/atlas.pdf", None, False, 2)
+
+        self.assertIs(result, final_result)
+        self.service.build_result.assert_called_once_with("/tmp/atlas.pdf", None, False, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -29,6 +29,10 @@ class DockWidgetDependenciesTests(unittest.TestCase):
                 return_value=sentinel.atlas_export_controller,
             ),
             patch(
+                "qfit.ui.dockwidget_dependencies.AtlasExportUseCase",
+                return_value=sentinel.atlas_export_use_case,
+            ) as atlas_export_use_case,
+            patch(
                 "qfit.ui.dockwidget_dependencies._build_layer_gateway",
                 return_value=sentinel.layer_gateway,
             ),
@@ -59,6 +63,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
         self.assertIs(dependencies.settings, sentinel.settings)
         self.assertIs(dependencies.sync_controller, sentinel.sync_controller)
         self.assertIs(dependencies.atlas_export_controller, sentinel.atlas_export_controller)
+        self.assertIs(dependencies.atlas_export_use_case, sentinel.atlas_export_use_case)
         self.assertIs(dependencies.layer_gateway, sentinel.layer_gateway)
         self.assertIs(dependencies.background_controller, sentinel.background_controller)
         self.assertIs(dependencies.load_workflow, sentinel.load_workflow)
@@ -71,6 +76,10 @@ class DockWidgetDependenciesTests(unittest.TestCase):
         load_workflow.assert_called_once_with(sentinel.layer_gateway)
         visual_apply.assert_called_once_with(sentinel.layer_gateway)
         atlas_export_service.assert_called_once_with(sentinel.layer_gateway)
+        atlas_export_use_case.assert_called_once_with(
+            sentinel.atlas_export_controller,
+            sentinel.atlas_export_service,
+        )
         fetch_result_service.assert_called_once_with(sentinel.sync_controller)
 
     def test_build_cache_prefers_legacy_cache_path_when_current_path_is_missing(self):

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -337,12 +337,16 @@ class QgisSmokeTests(unittest.TestCase):
             dock.atlas_layer.featureCount.return_value = 3
             dock.atlasPdfPathLineEdit.setText("/tmp/qfit-atlas.pdf")
 
-            dock.atlas_export_controller.validate_atlas_layer = MagicMock()
-            dock.atlas_export_controller.normalize_pdf_path = MagicMock(
-                return_value=("/tmp/qfit-atlas.pdf", False)
-            )
-            dock.atlas_export_service.check_pdf_export_prerequisites = MagicMock(
-                return_value="Atlas PDF export requires the 'pypdf' runtime."
+            from qfit.atlas.export_use_case import PrepareAtlasPdfExportResult
+
+            dock.atlas_export_use_case.prepare_export = MagicMock(
+                return_value=PrepareAtlasPdfExportResult(
+                    output_path="/tmp/qfit-atlas.pdf",
+                    error_title="Atlas PDF export unavailable",
+                    error_message="Atlas PDF export requires the 'pypdf' runtime.",
+                    pdf_status="Atlas PDF export unavailable.",
+                    main_status="Atlas PDF export unavailable.",
+                )
             )
             dock._save_settings = MagicMock()
             dock._show_error = MagicMock()
@@ -369,14 +373,11 @@ class QgisSmokeTests(unittest.TestCase):
             dock.atlas_layer.featureCount.return_value = 3
             dock.atlasPdfPathLineEdit.setText("/tmp/qfit-atlas.pdf")
 
-            dock.atlas_export_controller.validate_atlas_layer = MagicMock()
-            dock.atlas_export_controller.normalize_pdf_path = MagicMock(
-                return_value=("/tmp/qfit-atlas.pdf", False)
-            )
-            dock.atlas_export_service.check_pdf_export_prerequisites = MagicMock(return_value=None)
-            dock.atlas_export_service.build_request = MagicMock(return_value="atlas-request")
-            dock.atlas_export_service.prepare_basemap_for_export = MagicMock()
-            dock.atlas_export_service.build_task = MagicMock(return_value=fake_task)
+            prepared_export = MagicMock(name="prepared_export")
+            prepared_export.is_ready = True
+            prepared_export.path_changed = False
+            dock.atlas_export_use_case.prepare_export = MagicMock(return_value=prepared_export)
+            dock.atlas_export_use_case.start_export = MagicMock(return_value=fake_task)
             dock._save_settings = MagicMock()
 
             with (
@@ -388,11 +389,9 @@ class QgisSmokeTests(unittest.TestCase):
                 dock.on_generate_atlas_pdf_clicked()
 
             build_style.assert_called_once_with(dock.settings)
-            self.assertEqual(
-                dock.atlas_export_service.build_request.call_args.kwargs["profile_plot_style"],
-                "style-override",
-            )
-            dock.atlas_export_service.build_task.assert_called_once_with("atlas-request")
+            export_command = dock.atlas_export_use_case.prepare_export.call_args.args[0]
+            self.assertEqual(export_command.profile_plot_style, "style-override")
+            dock.atlas_export_use_case.start_export.assert_called_once_with(prepared_export)
             task_manager.return_value.addTask.assert_called_once_with(fake_task)
         finally:
             dock.close()

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from ..atlas.export_controller import AtlasExportController
 from ..atlas.export_service import AtlasExportService
+from ..atlas.export_use_case import AtlasExportUseCase
 from ..background_map_controller import BackgroundMapController
 from ..fetch_result_service import FetchResultService
 from ..load_workflow import LoadWorkflowService
@@ -25,6 +26,7 @@ class DockWidgetDependencies:
     settings: SettingsService
     sync_controller: SyncController
     atlas_export_controller: AtlasExportController
+    atlas_export_use_case: AtlasExportUseCase
     layer_gateway: Any
     background_controller: BackgroundMapController
     load_workflow: LoadWorkflowService
@@ -42,15 +44,17 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
     atlas_export_controller = AtlasExportController()
     layer_gateway = _build_layer_gateway(iface)
     cache = _build_cache()
+    atlas_export_service = AtlasExportService(layer_gateway)
     return DockWidgetDependencies(
         settings=settings,
         sync_controller=sync_controller,
         atlas_export_controller=atlas_export_controller,
+        atlas_export_use_case=AtlasExportUseCase(atlas_export_controller, atlas_export_service),
         layer_gateway=layer_gateway,
         background_controller=BackgroundMapController(layer_gateway),
         load_workflow=LoadWorkflowService(layer_gateway),
         visual_apply=VisualApplyService(layer_gateway),
-        atlas_export_service=AtlasExportService(layer_gateway),
+        atlas_export_service=atlas_export_service,
         fetch_result_service=FetchResultService(sync_controller),
         cache=cache,
     )


### PR DESCRIPTION
## Summary
- add a dedicated atlas export use-case boundary around prepare/start/finish orchestration
- move dock-widget atlas export startup off the controller/service pair onto that use case
- cover the new boundary with focused unit tests and keep the QGIS smoke coverage aligned

## Testing
- `python3 -m pytest tests/ -x -q --tb=short`

Closes #250
