### PR TITLE
Refactor atlas export runtime behind a port

### DIFF
--- a/atlas/__init__.py
+++ b/atlas/__init__.py
@@ -6,8 +6,10 @@ rather than from individual submodules.
 """
 
 from .export_controller import AtlasExportController, AtlasExportValidationError
+from .export_runtime import AtlasExportRuntime
 from .export_service import AtlasExportResult, AtlasExportService
 from .export_use_case import AtlasExportUseCase, GenerateAtlasPdfCommand, PrepareAtlasPdfExportResult
+from .qgis_export_runtime import QgisAtlasExportRuntime
 from .publish_atlas import build_atlas_page_plans, normalize_atlas_page_settings
 
 # export_task is NOT imported here: it has top-level QGIS runtime imports that
@@ -20,6 +22,8 @@ __all__ = [
     "AtlasExportValidationError",
     "AtlasExportResult",
     "AtlasExportService",
+    "AtlasExportRuntime",
+    "QgisAtlasExportRuntime",
     "AtlasExportUseCase",
     "GenerateAtlasPdfCommand",
     "PrepareAtlasPdfExportResult",

--- a/atlas/export_runtime.py
+++ b/atlas/export_runtime.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class AtlasExportRuntime(Protocol):
+    """Application-facing runtime adapter for atlas export task details.
+
+    Keeps QGIS-heavy task construction and dependency probing behind a small
+    seam so atlas export orchestration can describe intent without directly
+    owning lazy imports into ``export_task``.
+    """
+
+    def check_pdf_export_prerequisites(self) -> str | None:
+        """Return a user-facing error when atlas PDF export cannot run."""
+
+    def build_task(self, request, *, layer_gateway):
+        """Build the runtime task object for a prepared atlas export request."""

--- a/atlas/export_service.py
+++ b/atlas/export_service.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 from ..mapbox_config import TILE_MODE_RASTER, TILE_MODE_VECTOR
 from ..visualization.application.layer_gateway import LayerGateway
+from .qgis_export_runtime import QgisAtlasExportRuntime
 
 
 @dataclass
@@ -66,8 +67,9 @@ class AtlasExportService:
     making both independently testable.
     """
 
-    def __init__(self, layer_gateway: LayerGateway) -> None:
+    def __init__(self, layer_gateway: LayerGateway, runtime=None) -> None:
         self.layer_gateway = layer_gateway
+        self.runtime = runtime or QgisAtlasExportRuntime()
 
     @staticmethod
     def build_request(
@@ -121,44 +123,15 @@ class AtlasExportService:
         except RuntimeError:
             logger.warning("Vector tile mode failed, falling back to raster", exc_info=True)
 
-    @staticmethod
-    def check_pdf_export_prerequisites() -> str | None:
-        """Return a user-facing error when atlas PDF export prerequisites are missing.
-
-        Export produces one PDF per page and requires a PDF merger to assemble
-        the final multi-page document. If ``pypdf`` is unavailable, fail fast so
-        the UI can show a clear message instead of generating a misleading
-        first-page-only PDF.
-        """
-        from .export_task import _load_pdf_writer  # lazy import: QGIS runtime only
-
-        try:
-            _load_pdf_writer()
-        except ImportError:
-            return (
-                "Atlas PDF export requires the 'pypdf' runtime, but it is not available in this qfit install. "
-                "Reinstall/update the plugin so bundled dependencies are included, then try again."
-            )
-        return None
+    def check_pdf_export_prerequisites(self) -> str | None:
+        """Return a user-facing error when atlas PDF export prerequisites are missing."""
+        return self.runtime.check_pdf_export_prerequisites()
 
     def build_task(self, request: GenerateAtlasPdfRequest | None = None, **legacy_kwargs):
         """Construct an :class:`AtlasExportTask` ready to submit to the QGIS task manager."""
         if request is None:
             request = self.build_request(**legacy_kwargs)
-        from .export_task import AtlasExportTask  # lazy import: QGIS runtime only
-        return AtlasExportTask(
-            atlas_layer=request.atlas_layer,
-            output_path=request.output_path,
-            on_finished=request.on_finished,
-            restore_tile_mode=request.pre_export_tile_mode,
-            layer_manager=self.layer_gateway,
-            preset_name=request.preset_name,
-            access_token=request.access_token,
-            style_owner=request.style_owner,
-            style_id=request.style_id,
-            background_enabled=request.background_enabled,
-            profile_plot_style=request.profile_plot_style,
-        )
+        return self.runtime.build_task(request, layer_gateway=self.layer_gateway)
 
     @staticmethod
     def build_result(

--- a/atlas/qgis_export_runtime.py
+++ b/atlas/qgis_export_runtime.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from .export_runtime import AtlasExportRuntime
+
+
+class QgisAtlasExportRuntime(AtlasExportRuntime):
+    """QGIS-backed atlas export runtime adapter."""
+
+    def check_pdf_export_prerequisites(self) -> str | None:
+        from .export_task import _load_pdf_writer  # lazy import: QGIS runtime only
+
+        try:
+            _load_pdf_writer()
+        except ImportError:
+            return (
+                "Atlas PDF export requires the 'pypdf' runtime, but it is not available in this qfit install. "
+                "Reinstall/update the plugin so bundled dependencies are included, then try again."
+            )
+        return None
+
+    def build_task(self, request, *, layer_gateway):
+        from .export_task import AtlasExportTask  # lazy import: QGIS runtime only
+
+        return AtlasExportTask(
+            atlas_layer=request.atlas_layer,
+            output_path=request.output_path,
+            on_finished=request.on_finished,
+            restore_tile_mode=request.pre_export_tile_mode,
+            layer_manager=layer_gateway,
+            preset_name=request.preset_name,
+            access_token=request.access_token,
+            style_owner=request.style_owner,
+            style_id=request.style_id,
+            background_enabled=request.background_enabled,
+            profile_plot_style=request.profile_plot_style,
+        )

--- a/tests/test_atlas_export_service.py
+++ b/tests/test_atlas_export_service.py
@@ -1,12 +1,6 @@
-"""Tests for AtlasExportService and AtlasExportResult.
-
-atlas_export_service.build_task uses a lazy import of atlas.export_task (which
-requires QGIS bindings), so build_task tests patch qfit.atlas.export_task via
-patch.dict to avoid polluting sys.modules for the full test run.
-"""
-import sys
+"""Tests for AtlasExportService and AtlasExportResult."""
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
 
@@ -162,23 +156,15 @@ class PrepareBasemapTests(unittest.TestCase):
 
 
 class CheckPdfExportPrerequisitesTests(unittest.TestCase):
-    def test_returns_none_when_pdf_writer_is_available(self):
-        stub_module, _mock_task = _make_atlas_task_stub()
-        stub_module._load_pdf_writer = MagicMock(return_value=object())
+    def test_delegates_prerequisite_check_to_runtime(self):
+        runtime = MagicMock()
+        runtime.check_pdf_export_prerequisites.return_value = "missing pypdf"
+        service = AtlasExportService(MagicMock(), runtime=runtime)
 
-        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
-            self.assertIsNone(AtlasExportService.check_pdf_export_prerequisites())
+        error = service.check_pdf_export_prerequisites()
 
-    def test_returns_user_facing_error_when_pdf_writer_is_missing(self):
-        stub_module, _mock_task = _make_atlas_task_stub()
-        stub_module._load_pdf_writer = MagicMock(side_effect=ImportError("missing pypdf"))
-
-        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
-            error = AtlasExportService.check_pdf_export_prerequisites()
-
-        self.assertIsNotNone(error)
-        self.assertIn("pypdf", error)
-        self.assertIn("Reinstall/update the plugin", error)
+        self.assertEqual(error, "missing pypdf")
+        runtime.check_pdf_export_prerequisites.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------
@@ -186,90 +172,65 @@ class CheckPdfExportPrerequisitesTests(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
-def _make_atlas_task_stub():
-    """Return a (stub_module, MockTask) pair for patching qfit.atlas.export_task."""
-    stub_module = MagicMock()
-    MockTask = MagicMock()
-    stub_module.AtlasExportTask = MockTask
-    return stub_module, MockTask
-
-
 class BuildTaskTests(unittest.TestCase):
     def setUp(self):
         self.layer_manager = MagicMock()
-        self.service = AtlasExportService(self.layer_manager)
+        self.runtime = MagicMock()
+        self.service = AtlasExportService(self.layer_manager, runtime=self.runtime)
 
-    def test_constructs_atlas_export_task_with_correct_params(self):
-        stub_module, MockTask = _make_atlas_task_stub()
-        on_finished = MagicMock()
-        atlas_layer = MagicMock()
-
-        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
-            self.service.build_task(
-                atlas_layer=atlas_layer,
-                output_path="/out.pdf",
-                on_finished=on_finished,
-                pre_export_tile_mode="Raster",
-                preset_name="Dark",
-                access_token="tok",
-                style_owner="mapbox",
-                style_id="dark-v11",
-                background_enabled=True,
-            )
-
-        MockTask.assert_called_once_with(
-            atlas_layer=atlas_layer,
+    def test_build_task_delegates_request_and_gateway_to_runtime(self):
+        request = GenerateAtlasPdfRequest(
+            atlas_layer=MagicMock(),
             output_path="/out.pdf",
-            on_finished=on_finished,
-            restore_tile_mode="Raster",
-            layer_manager=self.layer_manager,
+            on_finished=MagicMock(),
+            pre_export_tile_mode="Raster",
             preset_name="Dark",
             access_token="tok",
             style_owner="mapbox",
             style_id="dark-v11",
             background_enabled=True,
-            profile_plot_style=None,
         )
 
-    def test_passes_background_enabled_false(self):
-        stub_module, MockTask = _make_atlas_task_stub()
+        self.service.build_task(request)
 
-        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
-            self.service.build_task(
-                atlas_layer=MagicMock(),
-                output_path="/out.pdf",
-                on_finished=MagicMock(),
-                pre_export_tile_mode="Vector",
-                preset_name="Light",
-                access_token="",
-                style_owner="",
-                style_id="",
-                background_enabled=False,
-            )
+        self.runtime.build_task.assert_called_once_with(request, layer_gateway=self.layer_manager)
 
-        kwargs = MockTask.call_args.kwargs
-        self.assertFalse(kwargs["background_enabled"])
-        self.assertEqual(kwargs["restore_tile_mode"], "Vector")
+    def test_build_task_constructs_request_from_legacy_kwargs_before_delegating(self):
+        self.service.build_task(
+            atlas_layer=MagicMock(),
+            output_path="/out.pdf",
+            on_finished=MagicMock(),
+            pre_export_tile_mode="Vector",
+            preset_name="Light",
+            access_token="",
+            style_owner="",
+            style_id="",
+            background_enabled=False,
+        )
 
-    def test_passes_profile_plot_style_through_to_task(self):
-        stub_module, MockTask = _make_atlas_task_stub()
+        request = self.runtime.build_task.call_args.args[0]
+        self.assertIsInstance(request, GenerateAtlasPdfRequest)
+        self.assertFalse(request.background_enabled)
+        self.assertEqual(request.pre_export_tile_mode, "Vector")
+
+    def test_build_task_preserves_profile_plot_style_in_delegated_request(self):
         style = object()
 
-        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
-            self.service.build_task(
-                atlas_layer=MagicMock(),
-                output_path="/out.pdf",
-                on_finished=MagicMock(),
-                pre_export_tile_mode="Vector",
-                preset_name="Light",
-                access_token="",
-                style_owner="",
-                style_id="",
-                background_enabled=False,
-                profile_plot_style=style,
-            )
+        self.service.build_task(
+            atlas_layer=MagicMock(),
+            output_path="/out.pdf",
+            on_finished=MagicMock(),
+            pre_export_tile_mode="Vector",
+            preset_name="Light",
+            access_token="",
+            style_owner="",
+            style_id="",
+            background_enabled=False,
+            profile_plot_style=style,
+        )
 
-        self.assertIs(MockTask.call_args.kwargs["profile_plot_style"], style)
+        request = self.runtime.build_task.call_args.args[0]
+        self.assertIs(request.profile_plot_style, style)
 
 
 class AtlasExportRequestContractTests(unittest.TestCase):

--- a/tests/test_qgis_atlas_export_runtime.py
+++ b/tests/test_qgis_atlas_export_runtime.py
@@ -1,0 +1,77 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tests import _path  # noqa: F401
+
+from qfit.atlas.export_service import GenerateAtlasPdfRequest
+from qfit.atlas.qgis_export_runtime import QgisAtlasExportRuntime
+
+
+def _make_atlas_task_stub():
+    stub_module = MagicMock()
+    mock_task = MagicMock()
+    stub_module.AtlasExportTask = mock_task
+    return stub_module, mock_task
+
+
+class QgisAtlasExportRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.runtime = QgisAtlasExportRuntime()
+
+    def test_returns_none_when_pdf_writer_is_available(self):
+        stub_module, _mock_task = _make_atlas_task_stub()
+        stub_module._load_pdf_writer = MagicMock(return_value=object())
+
+        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
+            self.assertIsNone(self.runtime.check_pdf_export_prerequisites())
+
+    def test_returns_user_facing_error_when_pdf_writer_is_missing(self):
+        stub_module, _mock_task = _make_atlas_task_stub()
+        stub_module._load_pdf_writer = MagicMock(side_effect=ImportError("missing pypdf"))
+
+        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
+            error = self.runtime.check_pdf_export_prerequisites()
+
+        self.assertIsNotNone(error)
+        self.assertIn("pypdf", error)
+        self.assertIn("Reinstall/update the plugin", error)
+
+    def test_build_task_constructs_atlas_export_task_with_correct_params(self):
+        stub_module, mock_task = _make_atlas_task_stub()
+        on_finished = MagicMock()
+        atlas_layer = MagicMock()
+        layer_gateway = MagicMock()
+        request = GenerateAtlasPdfRequest(
+            atlas_layer=atlas_layer,
+            output_path="/out.pdf",
+            on_finished=on_finished,
+            pre_export_tile_mode="Raster",
+            preset_name="Dark",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="dark-v11",
+            background_enabled=True,
+            profile_plot_style="style-override",
+        )
+
+        with patch.dict(sys.modules, {"qfit.atlas.export_task": stub_module}):
+            self.runtime.build_task(request, layer_gateway=layer_gateway)
+
+        mock_task.assert_called_once_with(
+            atlas_layer=atlas_layer,
+            output_path="/out.pdf",
+            on_finished=on_finished,
+            restore_tile_mode="Raster",
+            layer_manager=layer_gateway,
+            preset_name="Dark",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="dark-v11",
+            background_enabled=True,
+            profile_plot_style="style-override",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an atlas export runtime port for prerequisite probing and task construction
- move the QGIS-specific lazy-import behavior into a dedicated runtime adapter
- keep atlas export service focused on orchestration while preserving existing behavior

## Testing
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #247
