### PR TITLE
Docs: add rendering-proof checklist for export-sensitive PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,30 @@ All PRs must pass the following before merging:
 ### Tests must pass
 - `python3 -m pytest tests/ -x -q` must be green before opening a PR.
 
+### Rendering-proof checklist (mandatory for export-sensitive PRs)
+For changes that affect rendered/exported output — especially atlas PDFs, cover pages, table-of-contents pages, profiles, charts, or packaging/runtime-dependent export behaviour — green CI alone is **not** enough.
+
+Include a short validation note in the PR covering the relevant items below:
+
+- **Real-data check:** validated against representative real data when the feature depends on realistic geometry/content, not only synthetic fixtures.
+- **Artifact proof:** verified the final exported artifact that users actually consume (for example PDF or PNG), not just intermediate object state or layout configuration.
+- **Interactive vs export path:** noted whether the change was checked only interactively, only in export/headless flow, or in both paths when that distinction matters.
+- **Packaging/runtime note:** if the feature depends on runtime-packaged pieces (for example `pypdf`, native profile support, SVG generation, or version-specific QGIS behavior), documented what environment/path was checked.
+- **Expected output statement:** recorded what “correct output” means for this change so reviewers know what was actually validated.
+
+Use a concise PR note such as:
+
+```markdown
+## Rendering proof
+- Data: real atlas export dataset / synthetic fixture / both
+- Artifact checked: exported PDF page(s), cover page, TOC page, profile graphic, etc.
+- Path checked: interactive / export / headless
+- Runtime note: packaged plugin dev install / local source checkout / specific QGIS version
+- Result: what was visually/functionally confirmed
+```
+
+If the change is **not** rendering-sensitive, say so briefly in the PR rather than leaving the question ambiguous.
+
 ## Architecture rules
 
 Keep these rules lightweight and practical:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,8 +190,21 @@ Use this quick checklist in PR review:
 - Is a new abstraction earning its keep, or just adding ceremony?
 - Would a future contributor know where related code belongs?
 - Are tests focused on the highest-value non-UI logic?
+- If the PR is rendering/export-sensitive, does it include explicit rendering proof instead of relying on green CI alone?
 
-## 8. Contributor rules
+## 8. Rendering-proof rule for export-sensitive changes
+
+For atlas/export/chart/rendering work, reviewers should expect a short PR note that records:
+
+- what dataset or scenario was validated
+- which final artifact was checked (PDF, PNG, generated graphic, etc.)
+- whether the validation covered interactive behavior, export/headless behavior, or both
+- any runtime/packaging assumptions that mattered
+- what output was visually/functionally confirmed as correct
+
+The contributor-facing checklist for this lives in `CONTRIBUTING.md`. This section exists to make the same rule visible during architectural review: output-sensitive changes need artifact proof, not only passing tests and apparently-correct object construction.
+
+## 9. Contributor rules
 
 Short version:
 


### PR DESCRIPTION
## Summary
- add a contributor-facing rendering-proof checklist for export-sensitive PRs
- surface the same rule in the architecture review checklist so artifact proof is expected during review
- make the required validation note explicit for atlas/export/chart/runtime-sensitive work

## Testing
- docs-only change

Closes #245
