### PR TITLE
Refactor atlas export coordination

### DIFF
--- a/atlas/export_coordinator.py
+++ b/atlas/export_coordinator.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class AtlasExportExecutionResult:
+    success: bool
+    page_count: int = 0
+    error: str | None = None
+
+
+class AtlasExportCoordinator:
+    """Coordinate the atlas export workflow independently from the QgsTask shell."""
+
+    def __init__(
+        self,
+        *,
+        atlas_layer,
+        output_path: str,
+        project,
+        profile_plot_style,
+        is_canceled: Callable[[], bool],
+        build_layout: Callable[..., object],
+        layout_exporter_cls,
+        build_pdf_export_settings: Callable[[], object],
+        ensure_output_directory: Callable[[], None],
+        build_page_export_runner: Callable[..., object],
+        export_cover_page: Callable[..., str | None],
+        export_toc_page: Callable[..., str | None],
+        assemble_output_pdf: Callable[..., None],
+        logger,
+    ):
+        self.atlas_layer = atlas_layer
+        self.output_path = output_path
+        self.project = project
+        self.profile_plot_style = profile_plot_style
+        self.is_canceled = is_canceled
+        self.build_layout = build_layout
+        self.layout_exporter_cls = layout_exporter_cls
+        self.build_pdf_export_settings = build_pdf_export_settings
+        self.ensure_output_directory = ensure_output_directory
+        self.build_page_export_runner = build_page_export_runner
+        self.export_cover_page = export_cover_page
+        self.export_toc_page = export_toc_page
+        self.assemble_output_pdf = assemble_output_pdf
+        self.logger = logger
+
+    def execute(self) -> AtlasExportExecutionResult:
+        try:
+            feature_count = self.atlas_layer.featureCount() if self.atlas_layer else 0
+            if feature_count == 0:
+                return AtlasExportExecutionResult(
+                    success=False,
+                    error="No atlas pages found. Store and load activity layers first.",
+                )
+
+            layout = self.build_layout(
+                self.atlas_layer,
+                project=self.project,
+                profile_plot_style=self.profile_plot_style,
+            )
+            page_count = feature_count
+
+            if self.is_canceled():
+                return AtlasExportExecutionResult(success=False, page_count=page_count)
+
+            exporter = self.layout_exporter_cls(layout)
+            settings = self.build_pdf_export_settings()
+            self.ensure_output_directory()
+
+            page_runner = self.build_page_export_runner(
+                layout=layout,
+                exporter=exporter,
+                settings=settings,
+            )
+            page_paths, page_error = page_runner.export_pages()
+            if page_error is not None:
+                return AtlasExportExecutionResult(success=False, page_count=page_count, error=page_error)
+            if self.is_canceled():
+                return AtlasExportExecutionResult(success=False, page_count=page_count)
+            if not page_paths:
+                return AtlasExportExecutionResult(
+                    success=False,
+                    page_count=page_count,
+                    error="No pages were exported.",
+                )
+
+            cover_path = self.export_cover_page(
+                self.atlas_layer,
+                self.output_path,
+                project=self.project,
+            )
+            toc_path = self.export_toc_page(
+                self.atlas_layer,
+                self.output_path,
+                project=self.project,
+            )
+            self.assemble_output_pdf(page_paths, cover_path=cover_path, toc_path=toc_path)
+            return AtlasExportExecutionResult(success=not self.is_canceled(), page_count=page_count)
+        except (RuntimeError, OSError) as exc:
+            self.logger.exception("Atlas export failed")
+            return AtlasExportExecutionResult(success=False, error=str(exc))

--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -75,6 +75,7 @@ _COVER_SUMMARY_ROW_FIELDS = (
     "extent_height_m",
     "source_activity_id",
 )
+from .export_coordinator import AtlasExportCoordinator
 from .export_document_finalizer import assemble_output_pdf, merge_pdfs
 from .export_front_matter import export_cover_page, export_toc_page
 from .export_page_runtime_builder import AtlasPageRuntimeBuilder
@@ -1349,58 +1350,25 @@ class AtlasExportTask(QgsTask):
 
     def _run_export(self) -> bool:
         """Internal export logic (called from run())."""
-        try:
-            feature_count = self._atlas_layer.featureCount() if self._atlas_layer else 0
-            if feature_count == 0:
-                self._error = "No atlas pages found. Store and load activity layers first."
-                return False
-
-            layout = build_atlas_layout(
-                self._atlas_layer,
-                project=self._project,
-                profile_plot_style=self._profile_plot_style,
-            )
-            self._page_count = feature_count
-
-            if self.isCanceled():
-                return False
-
-            exporter = QgsLayoutExporter(layout)
-            settings = self._build_pdf_export_settings()
-            self._ensure_output_directory()
-
-            page_runner = self._build_page_export_runner(
-                layout=layout,
-                exporter=exporter,
-                settings=settings,
-            )
-            page_paths, page_error = page_runner.export_pages()
-            if page_error is not None:
-                self._error = page_error
-                return False
-            if self.isCanceled():
-                return False
-            if not page_paths:
-                self._error = "No pages were exported."
-                return False
-
-            cover_path = self._export_cover_page(
-                self._atlas_layer,
-                self._output_path,
-                project=self._project,
-            )
-            toc_path = self._export_toc_page(
-                self._atlas_layer,
-                self._output_path,
-                project=self._project,
-            )
-            self._assemble_output_pdf(page_paths, cover_path=cover_path, toc_path=toc_path)
-        except (RuntimeError, OSError) as exc:
-            logger.exception("Atlas export failed")
-            self._error = str(exc)
-            return False
-
-        return not self.isCanceled()
+        result = AtlasExportCoordinator(
+            atlas_layer=self._atlas_layer,
+            output_path=self._output_path,
+            project=self._project,
+            profile_plot_style=self._profile_plot_style,
+            is_canceled=self.isCanceled,
+            build_layout=build_atlas_layout,
+            layout_exporter_cls=QgsLayoutExporter,
+            build_pdf_export_settings=self._build_pdf_export_settings,
+            ensure_output_directory=self._ensure_output_directory,
+            build_page_export_runner=self._build_page_export_runner,
+            export_cover_page=self._export_cover_page,
+            export_toc_page=self._export_toc_page,
+            assemble_output_pdf=self._assemble_output_pdf,
+            logger=logger,
+        ).execute()
+        self._page_count = result.page_count
+        self._error = result.error
+        return result.success
 
     @staticmethod
     def _build_pdf_export_settings():

--- a/tests/test_atlas_export_coordinator.py
+++ b/tests/test_atlas_export_coordinator.py
@@ -1,0 +1,126 @@
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+
+from qfit.atlas.export_coordinator import AtlasExportCoordinator, AtlasExportExecutionResult
+
+
+class AtlasExportCoordinatorTests(unittest.TestCase):
+    def _make_coordinator(self, *, feature_count=2, canceled=False):
+        atlas_layer = MagicMock(name="atlas_layer")
+        atlas_layer.featureCount.return_value = feature_count
+
+        layout = object()
+        exporter_instance = object()
+        page_runner = MagicMock(name="page_runner")
+        page_runner.export_pages.return_value = (["/tmp/page-0.pdf"], None)
+
+        build_layout = MagicMock(return_value=layout)
+        layout_exporter_cls = MagicMock(return_value=exporter_instance)
+        build_pdf_export_settings = MagicMock(return_value=object())
+        ensure_output_directory = MagicMock()
+        build_page_export_runner = MagicMock(return_value=page_runner)
+        export_cover_page = MagicMock(return_value="/tmp/cover.pdf")
+        export_toc_page = MagicMock(return_value="/tmp/toc.pdf")
+        assemble_output_pdf = MagicMock()
+        logger = MagicMock()
+
+        coordinator = AtlasExportCoordinator(
+            atlas_layer=atlas_layer,
+            output_path="/tmp/out.pdf",
+            project=object(),
+            profile_plot_style="style",
+            is_canceled=MagicMock(return_value=canceled),
+            build_layout=build_layout,
+            layout_exporter_cls=layout_exporter_cls,
+            build_pdf_export_settings=build_pdf_export_settings,
+            ensure_output_directory=ensure_output_directory,
+            build_page_export_runner=build_page_export_runner,
+            export_cover_page=export_cover_page,
+            export_toc_page=export_toc_page,
+            assemble_output_pdf=assemble_output_pdf,
+            logger=logger,
+        )
+        return {
+            "coordinator": coordinator,
+            "atlas_layer": atlas_layer,
+            "build_layout": build_layout,
+            "layout_exporter_cls": layout_exporter_cls,
+            "build_pdf_export_settings": build_pdf_export_settings,
+            "ensure_output_directory": ensure_output_directory,
+            "build_page_export_runner": build_page_export_runner,
+            "page_runner": page_runner,
+            "export_cover_page": export_cover_page,
+            "export_toc_page": export_toc_page,
+            "assemble_output_pdf": assemble_output_pdf,
+            "logger": logger,
+        }
+
+    def test_execute_returns_empty_layer_error(self):
+        parts = self._make_coordinator(feature_count=0)
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(
+                success=False,
+                page_count=0,
+                error="No atlas pages found. Store and load activity layers first.",
+            ),
+        )
+        parts["build_layout"].assert_not_called()
+
+    def test_execute_runs_full_export_flow(self):
+        parts = self._make_coordinator()
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(result, AtlasExportExecutionResult(success=True, page_count=2, error=None))
+        parts["build_layout"].assert_called_once()
+        parts["layout_exporter_cls"].assert_called_once()
+        parts["build_pdf_export_settings"].assert_called_once_with()
+        parts["ensure_output_directory"].assert_called_once_with()
+        parts["build_page_export_runner"].assert_called_once()
+        parts["export_cover_page"].assert_called_once()
+        parts["export_toc_page"].assert_called_once()
+        parts["assemble_output_pdf"].assert_called_once_with(
+            ["/tmp/page-0.pdf"],
+            cover_path="/tmp/cover.pdf",
+            toc_path="/tmp/toc.pdf",
+        )
+
+    def test_execute_returns_page_runner_error(self):
+        parts = self._make_coordinator()
+        parts["page_runner"].export_pages.return_value = ([], "boom")
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(result, AtlasExportExecutionResult(success=False, page_count=2, error="boom"))
+        parts["assemble_output_pdf"].assert_not_called()
+
+    def test_execute_returns_error_when_no_pages_exported(self):
+        parts = self._make_coordinator()
+        parts["page_runner"].export_pages.return_value = ([], None)
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(success=False, page_count=2, error="No pages were exported."),
+        )
+        parts["assemble_output_pdf"].assert_not_called()
+
+    def test_execute_catches_runtime_error(self):
+        parts = self._make_coordinator()
+        parts["build_layout"].side_effect = RuntimeError("layout failed")
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(result, AtlasExportExecutionResult(success=False, page_count=0, error="layout failed"))
+        parts["logger"].exception.assert_called_once_with("Atlas export failed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract top-level atlas export orchestration into a dedicated `AtlasExportCoordinator`
- keep `AtlasExportTask` focused on task lifecycle and result/callback plumbing
- add direct unit coverage for the new coordinator while preserving existing atlas task behavior and test coverage

## Testing
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #262
