### PR TITLE
Enforce package ownership rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,9 @@ If the change is **not** rendering-sensitive, say so briefly in the PR rather th
 Keep these rules lightweight and practical:
 
 - Prefer feature/workflow ownership over adding more unrelated top-level modules.
+- Do not add new top-level Python modules for feature-specific code; prefer the owning feature package (`activities/`, `atlas/`, `providers/`, `visualization/`, `ui/`, `validation/`).
+- Treat existing root-level modules as grandfathered transitional modules unless the code is truly shared across features.
+- If a new top-level shared module is genuinely needed, document the reason and update `tests/test_architecture_boundaries.py` in the same PR.
 - Keep `QfitDockWidget` and other UI classes focused on widget wiring, input mapping, and result rendering.
 - Put workflow orchestration into controllers/services/use cases instead of the dock widget where practical.
 - Keep provider-neutral activity logic free of direct UI imports and avoid unnecessary QGIS coupling.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,6 +170,37 @@ When adding code, ask these questions in order:
 
 If a module starts mixing two or three of those answers, that is usually a sign it wants extraction.
 
+## 5.1 Package ownership rules for new code
+
+qfit now treats a small set of packages as the default owners for new work:
+
+- `activities/` — activity import, fetch/sync/load flows, provider-neutral activity rules
+- `atlas/` — atlas/publish/export workflows and atlas-specific helpers
+- `providers/` — provider-facing contracts and provider adapters
+- `visualization/` — visualization workflows and QGIS-facing visualization adapters
+- `ui/` — dock-widget section coordination, dependency assembly, and other UI-only helpers
+- `validation/` — validation harnesses and artifact-checking helpers
+
+The flat top-level Python module layer is now effectively **frozen** except for:
+
+- plugin entrypoints / bootstrap modules (`qfit_plugin.py`, `qfit_dockwidget.py`, dialogs, package `__init__.py`)
+- a limited set of grandfathered transitional modules already in the repo
+- truly shared helpers that are both feature-neutral and small enough that creating a new package would add ceremony without improving clarity
+
+Practical rule:
+
+> **Do not add a new top-level Python module for feature-specific code.**
+
+If new code belongs to one feature or workflow, put it under that feature package even when the legacy equivalent still exists at the top level.
+
+If you think a new top-level shared module is justified, the PR should do all of the following:
+
+1. explain why the code is truly cross-feature rather than feature-owned,
+2. document that choice in this architecture guide / `CONTRIBUTING.md`, and
+3. update the architecture-boundary allowlist in `tests/test_architecture_boundaries.py`.
+
+That friction is intentional: it prevents accidental growth of the generic root layer.
+
 ## 6. Current architectural priorities
 
 The active migration priorities are tracked in issues #169 through #178. In practical terms, current high-value directions are:
@@ -214,5 +245,6 @@ Short version:
 - isolate **external dependency details** when the seam improves clarity or testability
 - favor **small incremental refactors** over large rewrites
 - preserve behavior while moving boundaries
+- treat new root-level modules as exceptions that require explicit justification and a boundary-test update
 
 If a change makes the code easier to locate, easier to test, and less coupled to the dock widget or raw QGIS details, it is probably moving in the right direction.

--- a/docs/qgis-plugin-architecture-principles.md
+++ b/docs/qgis-plugin-architecture-principles.md
@@ -190,6 +190,12 @@ When adding or refactoring code, ask these questions in order:
 5. Is correctness depending on native framework behavior that we cannot trust yet?
    - keep or add a qfit-controlled implementation/fallback
 
+Package ownership matters here too:
+
+- prefer feature-owned packages over adding more generic top-level modules
+- treat the remaining flat root-level Python modules as transitional / grandfathered unless a new shared module is explicitly justified
+- if a new top-level shared module is truly necessary, document why it is cross-feature and update the architecture guardrails in tests
+
 ## 12. What success looks like in qfit
 
 The architecture is moving in the right direction when:

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -107,5 +107,76 @@ class WorkflowBoundaryTests(unittest.TestCase):
         )
 
 
+class PackageOwnershipBoundaryTests(unittest.TestCase):
+    """Guardrails for where new code may live.
+
+    The root-level Python module layer is transitional. New feature-owned code
+    should land in packages such as ``activities/``, ``atlas/``, ``providers/``,
+    ``visualization/``, ``ui/``, or ``validation/`` rather than adding more
+    generic top-level modules.
+    """
+
+    ALLOWED_TOP_LEVEL_PYTHON_MODULES = {
+        "__init__.py",
+        "activity_classification.py",
+        "activity_query.py",
+        "activity_storage.py",
+        "background_map_controller.py",
+        "background_map_service.py",
+        "config_connection_service.py",
+        "config_status.py",
+        "contextual_help.py",
+        "credential_store.py",
+        "detailed_route_strategy.py",
+        "fetch_result_service.py",
+        "fetch_task.py",
+        "gpkg_atlas_page_builder.py",
+        "gpkg_atlas_table_builders.py",
+        "gpkg_io.py",
+        "gpkg_layer_builders.py",
+        "gpkg_point_layer_builder.py",
+        "gpkg_schema.py",
+        "gpkg_write_orchestration.py",
+        "gpkg_writer.py",
+        "layer_filter_service.py",
+        "layer_manager.py",
+        "layer_style_service.py",
+        "load_workflow.py",
+        "map_canvas_service.py",
+        "map_style.py",
+        "mapbox_config.py",
+        "models.py",
+        "polyline_utils.py",
+        "project_layer_loader.py",
+        "provider.py",
+        "qfit_cache.py",
+        "qfit_config_dialog.py",
+        "qfit_dockwidget.py",
+        "qfit_plugin.py",
+        "settings_port.py",
+        "settings_service.py",
+        "strava_client.py",
+        "strava_provider.py",
+        "sync_controller.py",
+        "sync_repository.py",
+        "temporal_config.py",
+        "temporal_service.py",
+        "time_utils.py",
+        "ui_settings_binding.py",
+        "visual_apply.py",
+    }
+
+    def test_new_root_level_python_modules_require_explicit_ownership_review(self):
+        root_modules = {path.name for path in REPO_ROOT.glob("*.py")}
+        unexpected = sorted(root_modules - self.ALLOWED_TOP_LEVEL_PYTHON_MODULES)
+        self.assertEqual(
+            [],
+            unexpected,
+            "New root-level Python modules should not be added without explicit architecture review. "
+            "Prefer feature-owned packages and update this allowlist only for justified exceptions: "
+            f"{unexpected}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- document package ownership rules so new feature-specific code goes into owning packages instead of expanding the flat root module layer
- clarify in the architecture guide and contributing guide that new top-level Python modules are exceptional and must be explicitly justified
- add an architecture boundary test that fails if a new root-level Python module is added without updating the explicit allowlist

## Testing
- `PYTHONPATH=/home/ebelo/.openclaw/workspace/worktrees python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive: docs and architecture boundary guardrails only.

Closes #265
