### PR TITLE
Tighten architecture boundary guardrails

### DIFF
--- a/atlas/export_service.py
+++ b/atlas/export_service.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 from ..mapbox_config import TILE_MODE_RASTER, TILE_MODE_VECTOR
 from ..visualization.application.layer_gateway import LayerGateway
-from .qgis_export_runtime import QgisAtlasExportRuntime
 
 
 @dataclass
@@ -69,7 +68,13 @@ class AtlasExportService:
 
     def __init__(self, layer_gateway: LayerGateway, runtime=None) -> None:
         self.layer_gateway = layer_gateway
-        self.runtime = runtime or QgisAtlasExportRuntime()
+        self.runtime = runtime or self._build_default_runtime()
+
+    @staticmethod
+    def _build_default_runtime():
+        from .qgis_export_runtime import QgisAtlasExportRuntime
+
+        return QgisAtlasExportRuntime()
 
     @staticmethod
     def build_request(

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -27,6 +27,80 @@ def _import_targets(relative_path: str) -> set[str]:
     return targets
 
 
+def _module_scope_condition_value(node: ast.AST) -> bool | None:
+    """Return a statically-known boolean value for simple module-scope guards."""
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, bool):
+        return node.value
+    if isinstance(node, ast.Name) and node.id == "TYPE_CHECKING":
+        return False
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        if node.value.id == "typing" and node.attr == "TYPE_CHECKING":
+            return False
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        operand = _module_scope_condition_value(node.operand)
+        return None if operand is None else not operand
+    return None
+
+
+def _collect_module_scope_import_targets(tree: ast.AST) -> set[str]:
+    """Return imports executed at module import time.
+
+    This intentionally ignores imports nested inside functions/methods, so the
+    test can distinguish eager module-scope coupling from lazy runtime imports.
+    """
+
+    targets: set[str] = set()
+
+    def visit_statements(statements):
+        for statement in statements:
+            if isinstance(statement, ast.Import):
+                for alias in statement.names:
+                    targets.add(alias.name)
+            elif isinstance(statement, ast.ImportFrom):
+                base = ('.' * statement.level) + (statement.module or '')
+                for alias in statement.names:
+                    if alias.name == '*':
+                        targets.add(base)
+                    elif base:
+                        targets.add(f"{base}.{alias.name}")
+                    else:
+                        targets.add(alias.name)
+            elif isinstance(statement, ast.Try):
+                visit_statements(statement.body)
+                visit_statements(statement.handlers)
+                visit_statements(statement.orelse)
+                visit_statements(statement.finalbody)
+            elif isinstance(statement, ast.ExceptHandler):
+                visit_statements(statement.body)
+            elif isinstance(statement, ast.If):
+                condition_value = _module_scope_condition_value(statement.test)
+                if condition_value is True:
+                    visit_statements(statement.body)
+                elif condition_value is False:
+                    visit_statements(statement.orelse)
+                else:
+                    visit_statements(statement.body)
+                    visit_statements(statement.orelse)
+            elif isinstance(statement, (ast.With, ast.AsyncWith)):
+                visit_statements(statement.body)
+            elif isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+                visit_statements(statement.body)
+                visit_statements(statement.orelse)
+            elif isinstance(statement, ast.Match):
+                for case in statement.cases:
+                    visit_statements(case.body)
+
+    visit_statements(tree.body)
+    return targets
+
+
+def _module_scope_import_targets(relative_path: str) -> set[str]:
+    path = REPO_ROOT / relative_path
+    tree = ast.parse(path.read_text(), filename=str(path))
+    return _collect_module_scope_import_targets(tree)
+
+
 class CoreModuleBoundaryTests(unittest.TestCase):
     CORE_MODULES = [
         "activities/domain/activity_classification.py",
@@ -72,6 +146,8 @@ class WorkflowBoundaryTests(unittest.TestCase):
         "activities/application/load_workflow.py",
         "activities/application/sync_controller.py",
         "atlas/export_controller.py",
+        "atlas/export_service.py",
+        "atlas/export_use_case.py",
         "background_map_controller.py",
         "visual_apply.py",
     ]
@@ -105,6 +181,85 @@ class WorkflowBoundaryTests(unittest.TestCase):
             imports,
             "qfit.atlas package import should stay usable without pulling in QGIS-heavy export_task",
         )
+
+
+class PortBoundaryTests(unittest.TestCase):
+    PORT_MODULES = [
+        "atlas/export_runtime.py",
+        "settings_port.py",
+        "visualization/application/layer_gateway.py",
+    ]
+
+    FORBIDDEN_PREFIXES = (
+        "qgis",
+        ".qfit_dockwidget",
+        ".qfit_plugin",
+        ".qfit_config_dialog",
+    )
+
+    def test_port_modules_stay_free_of_qgis_and_ui_imports(self):
+        offenders = {}
+        for relative_path in self.PORT_MODULES:
+            forbidden = sorted(
+                target
+                for target in _import_targets(relative_path)
+                if target.startswith(self.FORBIDDEN_PREFIXES)
+            )
+            if forbidden:
+                offenders[relative_path] = forbidden
+        self.assertEqual(
+            {},
+            offenders,
+            f"Port modules should stay QGIS/UI-free: {offenders}",
+        )
+
+
+class ModuleScopeImportBoundaryTests(unittest.TestCase):
+    def test_atlas_export_service_does_not_eagerly_import_qgis_runtime_adapter(self):
+        imports = _module_scope_import_targets("atlas/export_service.py")
+        self.assertNotIn(
+            ".qgis_export_runtime.QgisAtlasExportRuntime",
+            imports,
+            "AtlasExportService should obtain the QGIS runtime adapter lazily, not via module-scope imports.",
+        )
+
+    def test_ui_dependency_builder_keeps_qgis_layer_gateway_import_lazy(self):
+        imports = _module_scope_import_targets("ui/dockwidget_dependencies.py")
+        self.assertNotIn(
+            "..visualization.infrastructure.qgis_layer_gateway.QgisLayerGateway",
+            imports,
+            "Dock-widget dependency assembly should keep the QGIS layer gateway behind a lazy import seam.",
+        )
+
+
+class ModuleScopeImportScannerTests(unittest.TestCase):
+    def _imports_from_source(self, source: str) -> set[str]:
+        return _collect_module_scope_import_targets(ast.parse(source))
+
+    def test_skips_imports_behind_type_checking_guard(self):
+        imports = self._imports_from_source(
+            "from typing import TYPE_CHECKING\n"
+            "if TYPE_CHECKING:\n"
+            "    import qgis\n"
+            "else:\n"
+            "    import pathlib\n"
+        )
+        self.assertIn("pathlib", imports)
+        self.assertNotIn("qgis", imports)
+
+    def test_tracks_imports_in_other_module_scope_blocks(self):
+        imports = self._imports_from_source(
+            "with context():\n"
+            "    import alpha\n"
+            "for _item in items:\n"
+            "    import beta\n"
+            "while ready:\n"
+            "    import gamma\n"
+            "match state:\n"
+            "    case 'x':\n"
+            "        import delta\n"
+        )
+        self.assertEqual({"alpha", "beta", "gamma", "delta"}, imports)
 
 
 class PackageOwnershipBoundaryTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- expand architecture boundary tests to cover the refactored application/port structure more explicitly
- add module-scope import checks so application-layer seams do not eagerly import QGIS-heavy adapters
- make `AtlasExportService` build its default QGIS runtime lazily so the boundary rule reflects the intended architecture

## Testing
- `PYTHONPATH=/home/ebelo/.openclaw/workspace/worktrees python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive: architecture guardrails and lazy import wiring only.

Closes #266
