### PR TITLE
Add connection test request models

### DIFF
--- a/config_connection_service.py
+++ b/config_connection_service.py
@@ -12,9 +12,45 @@ from .providers.infrastructure.strava_client import StravaClient, StravaClientEr
 
 
 @dataclass(frozen=True)
+class StravaConnectionTestRequest:
+    client_id: str = ""
+    client_secret: str = ""
+    refresh_token: str = ""
+
+
+@dataclass(frozen=True)
+class MapboxConnectionTestRequest:
+    access_token: str = ""
+    default_preset_name: str = DEFAULT_BACKGROUND_PRESET
+
+
+@dataclass(frozen=True)
 class ConnectionTestResult:
     ok: bool
     message: str
+
+
+def build_strava_connection_test_request(
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+) -> StravaConnectionTestRequest:
+    return StravaConnectionTestRequest(
+        client_id=client_id,
+        client_secret=client_secret,
+        refresh_token=refresh_token,
+    )
+
+
+def build_mapbox_connection_test_request(
+    access_token: str,
+    *,
+    default_preset_name: str = DEFAULT_BACKGROUND_PRESET,
+) -> MapboxConnectionTestRequest:
+    return MapboxConnectionTestRequest(
+        access_token=access_token,
+        default_preset_name=default_preset_name,
+    )
 
 
 def validate_strava_connection(
@@ -24,10 +60,19 @@ def validate_strava_connection(
     *,
     client_factory=StravaClient,
 ) -> ConnectionTestResult:
+    request = build_strava_connection_test_request(client_id, client_secret, refresh_token)
+    return validate_strava_connection_request(request, client_factory=client_factory)
+
+
+def validate_strava_connection_request(
+    request: StravaConnectionTestRequest,
+    *,
+    client_factory=StravaClient,
+) -> ConnectionTestResult:
     """Validate current Strava credentials and activity-read access."""
-    resolved_client_id = (client_id or "").strip()
-    resolved_client_secret = (client_secret or "").strip()
-    resolved_refresh_token = (refresh_token or "").strip()
+    resolved_client_id = (request.client_id or "").strip()
+    resolved_client_secret = (request.client_secret or "").strip()
+    resolved_refresh_token = (request.refresh_token or "").strip()
 
     if not resolved_client_id or not resolved_client_secret:
         return ConnectionTestResult(False, "Enter a Strava client ID and client secret first.")
@@ -65,12 +110,27 @@ def validate_mapbox_connection(
     fetch_style_definition=fetch_mapbox_style_definition,
     default_preset_name: str = DEFAULT_BACKGROUND_PRESET,
 ) -> ConnectionTestResult:
+    request = build_mapbox_connection_test_request(
+        access_token,
+        default_preset_name=default_preset_name,
+    )
+    return validate_mapbox_connection_request(
+        request,
+        fetch_style_definition=fetch_style_definition,
+    )
+
+
+def validate_mapbox_connection_request(
+    request: MapboxConnectionTestRequest,
+    *,
+    fetch_style_definition=fetch_mapbox_style_definition,
+) -> ConnectionTestResult:
     """Validate the current Mapbox token using a built-in qfit preset style."""
-    token = (access_token or "").strip()
+    token = (request.access_token or "").strip()
     if not token:
         return ConnectionTestResult(False, "Enter a Mapbox access token first.")
 
-    style_owner, style_id = preset_defaults(default_preset_name)
+    style_owner, style_id = preset_defaults(request.default_preset_name)
 
     try:
         style_definition = fetch_style_definition(token, style_owner, style_id)

--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -21,7 +21,12 @@ from qgis.PyQt.QtWidgets import (
     QWidget,
 )
 
-from .config_connection_service import validate_mapbox_connection, validate_strava_connection
+from .config_connection_service import (
+    build_mapbox_connection_test_request,
+    build_strava_connection_test_request,
+    validate_mapbox_connection_request,
+    validate_strava_connection_request,
+)
 from .config_status import mapbox_status_text, strava_status_text
 from .settings_port import SettingsPort
 from .settings_service import SettingsService
@@ -185,15 +190,17 @@ class QfitConfigDialog(QDialog):
         self._mapbox_status_label.setText(mapbox_status_text(self._settings))
 
     def _test_strava(self) -> None:
-        result = validate_strava_connection(
+        request = build_strava_connection_test_request(
             self._client_id_edit.text(),
             self._client_secret_edit.text(),
             self._refresh_token_edit.text(),
         )
+        result = validate_strava_connection_request(request)
         self._strava_test_status_label.setText(result.message)
 
     def _test_mapbox(self) -> None:
-        result = validate_mapbox_connection(self._mapbox_token_edit.text())
+        request = build_mapbox_connection_test_request(self._mapbox_token_edit.text())
+        result = validate_mapbox_connection_request(request)
         self._mapbox_test_status_label.setText(result.message)
 
     # -- Visibility ----------------------------------------------------------

--- a/tests/test_config_connection_service.py
+++ b/tests/test_config_connection_service.py
@@ -3,7 +3,29 @@ from urllib.error import HTTPError, URLError
 
 from tests import _path  # noqa: F401
 
-from qfit.config_connection_service import validate_mapbox_connection, validate_strava_connection
+from qfit.config_connection_service import (
+    build_mapbox_connection_test_request,
+    build_strava_connection_test_request,
+    validate_mapbox_connection,
+    validate_mapbox_connection_request,
+    validate_strava_connection,
+    validate_strava_connection_request,
+)
+
+
+class TestConnectionRequestBuilders(unittest.TestCase):
+    def test_build_strava_connection_test_request(self):
+        request = build_strava_connection_test_request(" id ", " secret ", " tok ")
+
+        self.assertEqual(request.client_id, " id ")
+        self.assertEqual(request.client_secret, " secret ")
+        self.assertEqual(request.refresh_token, " tok ")
+
+    def test_build_mapbox_connection_test_request(self):
+        request = build_mapbox_connection_test_request(" pk.test ")
+
+        self.assertEqual(request.access_token, " pk.test ")
+        self.assertEqual(request.default_preset_name, "Outdoor")
 
 
 class TestStravaConnectionValidation(unittest.TestCase):
@@ -34,6 +56,29 @@ class TestStravaConnectionValidation(unittest.TestCase):
                 return []
 
         result = validate_strava_connection("id", "secret", "tok", client_factory=FakeClient)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.message, "Strava activity access OK")
+        self.assertEqual(captured["client"].fetch_calls, [(1, 1)])
+
+    def test_request_variant_reports_success_when_refresh_works(self):
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                captured["client"] = self
+                self.fetch_calls = []
+
+            def refresh_access_token(self):
+                return {"access_token": "ok"}
+
+            def fetch_activities(self, *, per_page, max_pages):
+                self.fetch_calls.append((per_page, max_pages))
+                return []
+
+        request = build_strava_connection_test_request("id", "secret", "tok")
+        result = validate_strava_connection_request(request, client_factory=FakeClient)
+
         self.assertTrue(result.ok)
         self.assertEqual(result.message, "Strava activity access OK")
         self.assertEqual(captured["client"].fetch_calls, [(1, 1)])
@@ -86,6 +131,19 @@ class TestMapboxConnectionValidation(unittest.TestCase):
             return {"name": "Mapbox Outdoors"}
 
         result = validate_mapbox_connection("pk.test", fetch_style_definition=fetch_style_definition)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.message, "Mapbox connection OK (Mapbox Outdoors)")
+
+    def test_request_variant_reports_success(self):
+        def fetch_style_definition(token, owner, style_id):
+            self.assertEqual(token, "pk.test")
+            self.assertEqual(owner, "mapbox")
+            self.assertEqual(style_id, "outdoors-v12")
+            return {"name": "Mapbox Outdoors"}
+
+        request = build_mapbox_connection_test_request("pk.test")
+        result = validate_mapbox_connection_request(request, fetch_style_definition=fetch_style_definition)
+
         self.assertTrue(result.ok)
         self.assertEqual(result.message, "Mapbox connection OK (Mapbox Outdoors)")
 


### PR DESCRIPTION
## Summary
- introduce explicit request models for the Strava and Mapbox connection-test workflows
- update the configuration dialog to build request objects before invoking the validation helpers
- keep the existing convenience wrappers intact while adding direct request-oriented tests

## Testing
- `PYTHONPATH=/home/ebelo/.openclaw/workspace/worktrees python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive: configuration workflow/request-model cleanup only.

Closes #267
