### PR TITLE
Improve atlas export failure surfacing

### DIFF
--- a/atlas/export_coordinator.py
+++ b/atlas/export_coordinator.py
@@ -47,25 +47,53 @@ class AtlasExportCoordinator:
         self.assemble_output_pdf = assemble_output_pdf
         self.logger = logger
 
+    def _stage_failure(
+        self,
+        stage: str,
+        exc: Exception,
+        *,
+        page_count: int = 0,
+        user_label: str | None = None,
+    ) -> AtlasExportExecutionResult:
+        self.logger.exception(f"Atlas export {stage} failed")
+        detail = str(exc).strip() or exc.__class__.__name__
+        return AtlasExportExecutionResult(
+            success=False,
+            page_count=page_count,
+            error=f"{user_label or stage.capitalize()} failed: {detail}",
+        )
+
     def execute(self) -> AtlasExportExecutionResult:
         try:
             feature_count = self.atlas_layer.featureCount() if self.atlas_layer else 0
-            if feature_count == 0:
-                return AtlasExportExecutionResult(
-                    success=False,
-                    error="No atlas pages found. Store and load activity layers first.",
-                )
+        except (RuntimeError, OSError) as exc:
+            return self._stage_failure(
+                "atlas layer inspection",
+                exc,
+                user_label="Atlas layer inspection",
+            )
 
+        if feature_count == 0:
+            return AtlasExportExecutionResult(
+                success=False,
+                error="No atlas pages found. Store and load activity layers first.",
+            )
+
+        try:
             layout = self.build_layout(
                 self.atlas_layer,
                 project=self.project,
                 profile_plot_style=self.profile_plot_style,
             )
-            page_count = feature_count
+        except (RuntimeError, OSError) as exc:
+            return self._stage_failure("layout preparation", exc, user_label="Layout preparation")
 
-            if self.is_canceled():
-                return AtlasExportExecutionResult(success=False, page_count=page_count)
+        page_count = feature_count
 
+        if self.is_canceled():
+            return AtlasExportExecutionResult(success=False, page_count=page_count)
+
+        try:
             exporter = self.layout_exporter_cls(layout)
             settings = self.build_pdf_export_settings()
             self.ensure_output_directory()
@@ -75,18 +103,26 @@ class AtlasExportCoordinator:
                 exporter=exporter,
                 settings=settings,
             )
-            page_paths, page_error = page_runner.export_pages()
-            if page_error is not None:
-                return AtlasExportExecutionResult(success=False, page_count=page_count, error=page_error)
-            if self.is_canceled():
-                return AtlasExportExecutionResult(success=False, page_count=page_count)
-            if not page_paths:
-                return AtlasExportExecutionResult(
-                    success=False,
-                    page_count=page_count,
-                    error="No pages were exported.",
-                )
+        except (RuntimeError, OSError) as exc:
+            return self._stage_failure("export setup", exc, page_count=page_count, user_label="Export setup")
 
+        try:
+            page_paths, page_error = page_runner.export_pages()
+        except (RuntimeError, OSError) as exc:
+            return self._stage_failure("page export", exc, page_count=page_count, user_label="Page export")
+
+        if page_error is not None:
+            return AtlasExportExecutionResult(success=False, page_count=page_count, error=page_error)
+        if self.is_canceled():
+            return AtlasExportExecutionResult(success=False, page_count=page_count)
+        if not page_paths:
+            return AtlasExportExecutionResult(
+                success=False,
+                page_count=page_count,
+                error="No pages were exported.",
+            )
+
+        try:
             cover_path = self.export_cover_page(
                 self.atlas_layer,
                 self.output_path,
@@ -98,7 +134,12 @@ class AtlasExportCoordinator:
                 project=self.project,
             )
             self.assemble_output_pdf(page_paths, cover_path=cover_path, toc_path=toc_path)
-            return AtlasExportExecutionResult(success=not self.is_canceled(), page_count=page_count)
         except (RuntimeError, OSError) as exc:
-            self.logger.exception("Atlas export failed")
-            return AtlasExportExecutionResult(success=False, error=str(exc))
+            return self._stage_failure(
+                "final PDF assembly",
+                exc,
+                page_count=page_count,
+                user_label="Final PDF assembly",
+            )
+
+        return AtlasExportExecutionResult(success=not self.is_canceled(), page_count=page_count)

--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -31,6 +31,13 @@ from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
+
+def _format_unexpected_export_error(exc: Exception) -> str:
+    detail = str(exc).strip()
+    if detail:
+        return f"Unexpected atlas export failure ({exc.__class__.__name__}): {detail}"
+    return f"Unexpected atlas export failure ({exc.__class__.__name__})"
+
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsLayoutExporter,
@@ -1099,7 +1106,7 @@ class AtlasExportTask(QgsTask):
             return self._run_export()
         except Exception as exc:  # noqa: BLE001 – QgsTask worker thread safety net
             logger.exception("Atlas export task failed")
-            self._error = str(exc)
+            self._error = _format_unexpected_export_error(exc)
             return False
 
     def _run_export(self) -> bool:

--- a/tests/test_atlas_export_coordinator.py
+++ b/tests/test_atlas_export_coordinator.py
@@ -72,6 +72,23 @@ class AtlasExportCoordinatorTests(unittest.TestCase):
         )
         parts["build_layout"].assert_not_called()
 
+    def test_execute_reports_atlas_layer_inspection_failure(self):
+        parts = self._make_coordinator()
+        parts["atlas_layer"].featureCount.side_effect = RuntimeError("wrapped layer deleted")
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(
+                success=False,
+                page_count=0,
+                error="Atlas layer inspection failed: wrapped layer deleted",
+            ),
+        )
+        parts["logger"].exception.assert_called_once_with("Atlas export atlas layer inspection failed")
+        parts["build_layout"].assert_not_called()
+
     def test_execute_runs_full_export_flow(self):
         parts = self._make_coordinator()
 
@@ -118,8 +135,63 @@ class AtlasExportCoordinatorTests(unittest.TestCase):
 
         result = parts["coordinator"].execute()
 
-        self.assertEqual(result, AtlasExportExecutionResult(success=False, page_count=0, error="layout failed"))
-        parts["logger"].exception.assert_called_once_with("Atlas export failed")
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(
+                success=False,
+                page_count=0,
+                error="Layout preparation failed: layout failed",
+            ),
+        )
+        parts["logger"].exception.assert_called_once_with("Atlas export layout preparation failed")
+
+    def test_execute_reports_export_setup_stage(self):
+        parts = self._make_coordinator()
+        parts["ensure_output_directory"].side_effect = OSError("disk full")
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(
+                success=False,
+                page_count=2,
+                error="Export setup failed: disk full",
+            ),
+        )
+        parts["logger"].exception.assert_called_once_with("Atlas export export setup failed")
+
+    def test_execute_reports_page_export_stage(self):
+        parts = self._make_coordinator()
+        parts["page_runner"].export_pages.side_effect = RuntimeError("renderer exploded")
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(
+                success=False,
+                page_count=2,
+                error="Page export failed: renderer exploded",
+            ),
+        )
+        parts["logger"].exception.assert_called_once_with("Atlas export page export failed")
+
+    def test_execute_reports_final_pdf_assembly_stage(self):
+        parts = self._make_coordinator()
+        parts["assemble_output_pdf"].side_effect = OSError("permission denied")
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(
+                success=False,
+                page_count=2,
+                error="Final PDF assembly failed: permission denied",
+            ),
+        )
+        parts["logger"].exception.assert_called_once_with("Atlas export final PDF assembly failed")
 
 
 if __name__ == "__main__":

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -3611,6 +3611,23 @@ class TestAtlasExportTaskNarrowedExceptions(unittest.TestCase):
             result = AtlasExportTask._export_cover_page(layer, "/tmp/atlas.pdf")
         self.assertIsNone(result)
 
+    def test_unexpected_run_failure_is_formatted_with_exception_type(self):
+        received = {}
+        layer = _make_atlas_layer(feature_count=1)
+        task = AtlasExportTask(
+            atlas_layer=layer,
+            output_path="/tmp/qfit_test_unexpected.pdf",
+            on_finished=lambda **kw: received.update(kw),
+        )
+
+        with patch.object(AtlasExportTask, "_run_export", side_effect=ValueError("bad state")):
+            _run_task(task)
+
+        self.assertEqual(
+            received.get("error"),
+            "Unexpected atlas export failure (ValueError): bad state",
+        )
+
 
 class TestExtentNormalization(unittest.TestCase):
     class _Rect:


### PR DESCRIPTION
## Summary
- replace the coordinator’s single generic atlas-export failure path with stage-specific error reporting for layout prep, export setup, page export, and final PDF assembly
- keep the task-level worker-thread safety net, but surface unexpected failures with the exception type instead of a bare string
- add regression coverage for the new stage-specific error messages and unexpected task failure formatting

## Testing
- `PYTHONPATH=/home/ebelo/.openclaw/workspace/worktrees python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive: failure surfacing/reporting only; no rendering/export output logic changed.

Closes #268
