### PR TITLE
Align architecture guide with implemented structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ Keep these rules lightweight and practical:
 - Prefer feature/workflow ownership over adding more unrelated top-level modules.
 - Do not add new top-level Python modules for feature-specific code; prefer the owning feature package (`activities/`, `atlas/`, `providers/`, `visualization/`, `ui/`, `validation/`).
 - Treat existing root-level modules as grandfathered transitional modules unless the code is truly shared across features.
+- If you touch a transitional root module that now only forwards imports, prefer moving the real implementation in the owned package and keep the root file as a thin compatibility shim instead of re-expanding it.
 - If a new top-level shared module is genuinely needed, document the reason and update `tests/test_architecture_boundaries.py` in the same PR.
 - Keep `QfitDockWidget` and other UI classes focused on widget wiring, input mapping, and result rendering.
 - Put workflow orchestration into controllers/services/use cases instead of the dock widget where practical.

--- a/README.md
+++ b/README.md
@@ -106,10 +106,12 @@ See `docs/architecture.md` for the contributor-facing boundary rules and placeme
 - `publish_atlas.py` — atlas/page extent planning helpers for QGIS print layouts
 - `atlas_export_task.py` — QgsTask-based PDF atlas export (programmatic QgsPrintLayout + QgsLayoutExporter)
 - `atlas_export_controller.py` — atlas export orchestration extracted from the dock widget
-- `background_map_controller.py` — background map wiring and basemap orchestration
+- `visualization/application/background_map_controller.py` — background map wiring and basemap orchestration
+- `background_map_controller.py` — compatibility import shim for the visualization workflow package
 - `contextual_help.py` — reusable contextual help entries for dock widget controls
 - `fetch_task.py` — QgsTask wrapper for background Strava fetching
-- `load_workflow.py` / `visual_apply.py` / `atlas/export_service.py` — workflow services with explicit request/result dataclasses to keep dock-widget calls structured during the architecture migration
+- `activities/application/load_workflow.py` / `visualization/application/visual_apply.py` / `atlas/export_service.py` — workflow services with explicit request/result dataclasses to keep dock-widget calls structured during the architecture migration
+- `load_workflow.py` / `visual_apply.py` — compatibility import shims for migrated workflow modules
 - `settings_port.py` — small application-facing settings access contract
 - `settings_service.py` — QGIS-backed settings adapter implementing that contract
 - `sync_controller.py` — fetch/sync orchestration bridging the dock widget and Strava client
@@ -123,7 +125,7 @@ See `docs/architecture.md` for the contributor-facing boundary rules and placeme
 
 ## How the current workflow works
 
-The dock is organized around the main qfit workflow. Orchestration is split across dedicated controllers: `SyncController` handles fetch/sync logic, `BackgroundMapController` manages basemap wiring, and `AtlasExportController` drives PDF atlas export — keeping the dock widget focused on UI wiring.
+The dock is organized around the main qfit workflow. Orchestration is split across dedicated controllers/services owned by feature packages: `SyncController` handles fetch/sync logic, `visualization.application.BackgroundMapController` manages basemap wiring, `visualization.application.VisualApplyService` applies styling/filter workflows, and `AtlasExportController` drives PDF atlas export — keeping the dock widget focused on UI wiring.
 
 1. **Connect** — enter your Strava app credentials and use the built-in OAuth helper if you still need a refresh token
 2. **Fetch activities** — choose paging limits and any activity filters you want to use for previewing; the fetch runs in a background `QgsTask` via `StravaFetchTask` so the QGIS UI stays responsive; the fetch always performs a full sync, and date filters apply only to the preview and loaded layers

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,20 @@ Over time, qfit should trend toward clearer feature areas such as:
 
 Not every area needs `application/`, `domain/`, and `infrastructure/` subpackages immediately. Prefer gradual, pragmatic extraction.
 
+### Current implemented package map
+
+The codebase now already reflects most of that shape:
+
+- `activities/domain/` — provider-neutral activity models, classification, and query logic
+- `activities/application/` — fetch/sync/load workflow services and request/result models
+- `providers/domain/` / `providers/infrastructure/` — provider contracts plus Strava-backed adapters
+- `visualization/application/` / `visualization/infrastructure/` — visualization/background workflows plus QGIS layer/runtime adapters
+- `atlas/` — atlas/export/publish workflows, profile handling, and atlas-owned infrastructure such as PDF assembly
+- `ui/` — dock-widget dependency assembly and workflow-section coordination
+- `validation/` — validation harnesses and scenario helpers for export-sensitive checks
+
+Some root-level modules still exist as **compatibility shims** so imports remain stable while the migration settles. Those files are transitional; new feature logic should not be added there.
+
 ## 2. Working layers
 
 Use these layers as a placement heuristic.
@@ -203,13 +217,13 @@ That friction is intentional: it prevents accidental growth of the generic root 
 
 ## 6. Current architectural priorities
 
-The active migration priorities are tracked in issues #169 through #178. In practical terms, current high-value directions are:
+The current architecture work is centered on making the implemented structure easier to understand and harder to regress. In practical terms, high-value directions are:
 
 - thin out `QfitDockWidget`
-- use clearer request/result objects for main workflows
-- isolate settings, storage, and layer operations behind pragmatic seams
-- consolidate activity-centric business logic into a clearer core
-- keep feature ownership clearer as modules move out of the flat top-level layout
+- use clearer request/result objects for user-facing workflows
+- keep ports/adapters boundaries small and explicit where they buy testability
+- preserve feature ownership by moving real implementations into owned packages and leaving only narrow compatibility shims at the root when needed
+- keep docs and architecture guardrails aligned with the code that now exists on `main`
 
 ## 7. Review checklist
 

--- a/docs/qgis-plugin-architecture-principles.md
+++ b/docs/qgis-plugin-architecture-principles.md
@@ -109,6 +109,15 @@ UI -> application/workflow -> domain + ports -> infrastructure adapters
 - **ports** = small application-facing contracts where a seam improves clarity or testability
 - **infrastructure adapters** = Strava integration, GeoPackage persistence, QGIS settings access, QGIS layer operations, Mapbox/QGIS-specific runtime behavior
 
+Concretely in the current repo, that mostly maps to:
+
+- `activities/application` + `activities/domain`
+- `providers/domain` + `providers/infrastructure`
+- `visualization/application` + `visualization/infrastructure`
+- `atlas/` for publish/export workflows and atlas-owned helpers/infrastructure
+- `ui/` for dock-widget wiring helpers
+- `validation/` for export-sensitive validation harnesses
+
 ## 7. Ports and adapters: when to use them
 
 Introduce a port/gateway when at least one of these is true:
@@ -195,6 +204,8 @@ Package ownership matters here too:
 - prefer feature-owned packages over adding more generic top-level modules
 - treat the remaining flat root-level Python modules as transitional / grandfathered unless a new shared module is explicitly justified
 - if a new top-level shared module is truly necessary, document why it is cross-feature and update the architecture guardrails in tests
+
+In other words: root-level compatibility shims may remain for import stability, but real feature logic should continue moving toward the owned package structure above.
 
 ## 12. What success looks like in qfit
 


### PR DESCRIPTION
## Summary
- update the architecture guide to describe the package structure that now exists in `main`
- clarify in the principles/contributing docs that root-level compatibility shims are transitional and real feature logic belongs in owned packages
- refresh the README structure/workflow notes so they point at the migrated visualization workflow modules instead of stale root-level homes

## Testing
- `PYTHONPATH=/home/ebelo/.openclaw/workspace/worktrees python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive: documentation-only alignment.

Closes #270
