### PR TITLE
Move temporal helpers into visualization package

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -44,7 +44,7 @@ from .visualization.application import BackgroundConfig, LayerRefs
 from .atlas.export_task import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_provider import StravaProvider
-from .temporal_config import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
+from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
 from .ui.dockwidget_dependencies import DockWidgetDependencies, build_dockwidget_dependencies
 from .ui.workflow_section_coordinator import WorkflowSectionCoordinator
 from .ui_settings_binding import UIFieldBinding, load_bindings, save_bindings

--- a/temporal_config.py
+++ b/temporal_config.py
@@ -1,87 +1,25 @@
-from dataclasses import dataclass
+"""Compatibility shim for visualization temporal configuration helpers.
 
-TEMPORAL_MODE_LABELS = [
-    "Disabled",
-    "Local activity time",
-    "UTC time",
+Prefer importing from ``qfit.visualization.application.temporal_config``.
+This module remains as a stable forwarding import during the package move.
+"""
+
+from .visualization.application.temporal_config import (
+    DEFAULT_TEMPORAL_MODE_LABEL,
+    TEMPORAL_MODE_LABELS,
+    TemporalLayerPlan,
+    build_temporal_plan,
+    describe_temporal_configuration,
+    is_temporal_mode_enabled,
+    temporal_mode_labels,
+)
+
+__all__ = [
+    "DEFAULT_TEMPORAL_MODE_LABEL",
+    "TEMPORAL_MODE_LABELS",
+    "TemporalLayerPlan",
+    "build_temporal_plan",
+    "describe_temporal_configuration",
+    "is_temporal_mode_enabled",
+    "temporal_mode_labels",
 ]
-DEFAULT_TEMPORAL_MODE_LABEL = "Local activity time"
-
-
-@dataclass(frozen=True)
-class TemporalLayerPlan:
-    layer_key: str
-    field_name: str
-    field_kind: str
-    label: str
-
-    @property
-    def expression(self):
-        return 'to_datetime("{field}")'.format(field=self.field_name)
-
-
-_LAYER_CANDIDATES = {
-    "activity_points": {
-        "Local activity time": ["point_timestamp_local", "point_timestamp_utc"],
-        "UTC time": ["point_timestamp_utc", "point_timestamp_local"],
-    },
-    "activity_tracks": {
-        "Local activity time": ["start_date_local", "start_date"],
-        "UTC time": ["start_date", "start_date_local"],
-    },
-    "activity_starts": {
-        "Local activity time": ["start_date_local", "start_date"],
-        "UTC time": ["start_date", "start_date_local"],
-    },
-}
-
-
-def temporal_mode_labels():
-    return list(TEMPORAL_MODE_LABELS)
-
-
-def is_temporal_mode_enabled(mode_label):
-    return (mode_label or "").strip() != "Disabled"
-
-
-def build_temporal_plan(layer_key, available_fields, mode_label):
-    mode_label = (mode_label or DEFAULT_TEMPORAL_MODE_LABEL).strip() or DEFAULT_TEMPORAL_MODE_LABEL
-    if not is_temporal_mode_enabled(mode_label):
-        return None
-
-    field_names = {name for name in (available_fields or []) if name}
-    candidates = _LAYER_CANDIDATES.get(layer_key, {}).get(mode_label, [])
-    for field_name in candidates:
-        if field_name in field_names:
-            return TemporalLayerPlan(
-                layer_key=layer_key,
-                field_name=field_name,
-                field_kind=_field_kind(field_name),
-                label=_plan_label(layer_key, field_name),
-            )
-    return None
-
-
-def describe_temporal_configuration(plans, mode_label):
-    active_plans = [plan for plan in (plans or []) if plan is not None]
-    if not is_temporal_mode_enabled(mode_label):
-        return "Temporal playback disabled"
-    if not active_plans:
-        return "Temporal playback requested, but no timestamp fields were available"
-    labels = ", ".join(plan.label for plan in active_plans)
-    return "Temporal playback wired for {labels}".format(labels=labels)
-
-
-def _field_kind(field_name):
-    return "local" if field_name.endswith("_local") else "utc"
-
-
-def _plan_label(layer_key, field_name):
-    field_kind = _field_kind(field_name).upper()
-    if layer_key == "activity_points":
-        return "activity points ({kind})".format(kind=field_kind)
-    if layer_key == "activity_tracks":
-        return "activity tracks ({kind})".format(kind=field_kind)
-    if layer_key == "activity_starts":
-        return "activity starts ({kind})".format(kind=field_kind)
-    return "{layer} ({kind})".format(layer=layer_key.replace("_", " "), kind=field_kind)

--- a/temporal_service.py
+++ b/temporal_service.py
@@ -1,59 +1,9 @@
-from qgis.core import QgsVectorLayerTemporalProperties
+"""Compatibility shim for the visualization temporal service.
 
-from .temporal_config import build_temporal_plan, describe_temporal_configuration, is_temporal_mode_enabled
+Prefer importing from ``qfit.visualization.infrastructure.temporal_service``.
+This module remains as a stable forwarding import during the package move.
+"""
 
+from .visualization.infrastructure.temporal_service import TemporalService
 
-class TemporalService:
-    """Applies temporal configuration to qfit output layers.
-
-    Reads temporal plans from :mod:`temporal_config` and wires them into the
-    QGIS temporal-properties API on each layer.
-    """
-
-    LAYER_SPECS = [
-        ("activities", "activity_tracks"),
-        ("starts", "activity_starts"),
-        ("points", "activity_points"),
-        ("atlas", "activity_atlas_pages"),
-    ]
-
-    def apply_temporal_configuration(self, activities_layer, starts_layer, points_layer, atlas_layer, mode_label):
-        layers_by_slot = {
-            "activities": activities_layer,
-            "starts": starts_layer,
-            "points": points_layer,
-            "atlas": atlas_layer,
-        }
-        plans = []
-        for slot, layer_key in self.LAYER_SPECS:
-            layer = layers_by_slot[slot]
-            if layer is None:
-                continue
-            plan = self._apply_temporal_plan(layer, layer_key, mode_label)
-            if plan is not None:
-                plans.append(plan)
-        return describe_temporal_configuration(plans, mode_label)
-
-    @staticmethod
-    def _apply_temporal_plan(layer, layer_key, mode_label):
-        props = layer.temporalProperties()
-        if props is None:
-            return None
-        if not is_temporal_mode_enabled(mode_label):
-            props.setIsActive(False)
-            layer.triggerRepaint()
-            return None
-
-        available_fields = [field.name() for field in layer.fields()]
-        plan = build_temporal_plan(layer_key, available_fields, mode_label)
-        if plan is None:
-            props.setIsActive(False)
-            layer.triggerRepaint()
-            return None
-
-        props.setIsActive(True)
-        props.setMode(QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndEndFromExpressions)
-        props.setStartExpression(plan.expression)
-        props.setEndExpression(plan.expression)
-        layer.triggerRepaint()
-        return plan
+__all__ = ["TemporalService"]

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -145,6 +145,9 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         qgis_core.QgsRasterLayer = MagicMock(name="QgsRasterLayer")
         qgis_core.QgsRectangle = MagicMock(name="QgsRectangle")
         qgis_core.QgsVectorTileLayer = MagicMock(name="QgsVectorTileLayer")
+        temporal_props = MagicMock(name="QgsVectorLayerTemporalProperties")
+        temporal_props.ModeFeatureDateTimeStartAndEndFromExpressions = 1
+        qgis_core.QgsVectorLayerTemporalProperties = temporal_props
 
         return {
             "qgis.core": qgis_core,

--- a/tests/test_temporal_config.py
+++ b/tests/test_temporal_config.py
@@ -1,7 +1,7 @@
 import unittest
 
 from tests import _path  # noqa: F401
-from qfit.temporal_config import (
+from qfit.visualization.application.temporal_config import (
     DEFAULT_TEMPORAL_MODE_LABEL,
     build_temporal_plan,
     describe_temporal_configuration,

--- a/tests/test_temporal_service.py
+++ b/tests/test_temporal_service.py
@@ -17,7 +17,7 @@ except ValueError:
     )
 
 try:
-    from qfit.temporal_service import TemporalService
+    from qfit.visualization.infrastructure.temporal_service import TemporalService
 
     QGIS_AVAILABLE = True
     QGIS_IMPORT_ERROR = None
@@ -36,14 +36,14 @@ def _load_service_with_mock_qgis():
     qgis_modules = ["qgis", "qgis.core"]
 
     saved_qgis = {name: sys.modules.get(name) for name in qgis_modules}
-    saved_module = sys.modules.get("qfit.temporal_service")
+    saved_module = sys.modules.get("qfit.visualization.infrastructure.temporal_service")
 
     for name in qgis_modules:
         sys.modules[name] = qstub
-    sys.modules.pop("qfit.temporal_service", None)
+    sys.modules.pop("qfit.visualization.infrastructure.temporal_service", None)
 
     try:
-        module = importlib.import_module("qfit.temporal_service")
+        module = importlib.import_module("qfit.visualization.infrastructure.temporal_service")
         return module.TemporalService, module
     except Exception:  # pragma: no cover
         return None, None
@@ -54,9 +54,9 @@ def _load_service_with_mock_qgis():
             else:
                 sys.modules[name] = original
         if saved_module is None:
-            sys.modules.pop("qfit.temporal_service", None)
+            sys.modules.pop("qfit.visualization.infrastructure.temporal_service", None)
         else:
-            sys.modules["qfit.temporal_service"] = saved_module
+            sys.modules["qfit.visualization.infrastructure.temporal_service"] = saved_module
 
 
 if not QGIS_AVAILABLE:

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -6,6 +6,15 @@ from .background_map_controller import (
     LoadBackgroundResult,
 )
 from .layer_gateway import LayerGateway
+from .temporal_config import (
+    DEFAULT_TEMPORAL_MODE_LABEL,
+    TEMPORAL_MODE_LABELS,
+    TemporalLayerPlan,
+    build_temporal_plan,
+    describe_temporal_configuration,
+    is_temporal_mode_enabled,
+    temporal_mode_labels,
+)
 from .visual_apply import (
     ApplyVisualizationRequest,
     BackgroundConfig,
@@ -19,11 +28,18 @@ __all__ = [
     "ApplyVisualizationRequest",
     "BackgroundConfig",
     "BackgroundMapController",
+    "DEFAULT_TEMPORAL_MODE_LABEL",
     "LayerGateway",
     "LayerRefs",
     "LoadBackgroundRequest",
     "LoadBackgroundResult",
+    "TEMPORAL_MODE_LABELS",
+    "TemporalLayerPlan",
     "VisualApplyRequest",
     "VisualApplyResult",
     "VisualApplyService",
+    "build_temporal_plan",
+    "describe_temporal_configuration",
+    "is_temporal_mode_enabled",
+    "temporal_mode_labels",
 ]

--- a/visualization/application/temporal_config.py
+++ b/visualization/application/temporal_config.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+TEMPORAL_MODE_LABELS = [
+    "Disabled",
+    "Local activity time",
+    "UTC time",
+]
+DEFAULT_TEMPORAL_MODE_LABEL = "Local activity time"
+
+
+@dataclass(frozen=True)
+class TemporalLayerPlan:
+    layer_key: str
+    field_name: str
+    field_kind: str
+    label: str
+
+    @property
+    def expression(self):
+        return 'to_datetime("{field}")'.format(field=self.field_name)
+
+
+_LAYER_CANDIDATES = {
+    "activity_points": {
+        "Local activity time": ["point_timestamp_local", "point_timestamp_utc"],
+        "UTC time": ["point_timestamp_utc", "point_timestamp_local"],
+    },
+    "activity_tracks": {
+        "Local activity time": ["start_date_local", "start_date"],
+        "UTC time": ["start_date", "start_date_local"],
+    },
+    "activity_starts": {
+        "Local activity time": ["start_date_local", "start_date"],
+        "UTC time": ["start_date", "start_date_local"],
+    },
+}
+
+
+def temporal_mode_labels():
+    return list(TEMPORAL_MODE_LABELS)
+
+
+def is_temporal_mode_enabled(mode_label):
+    return (mode_label or "").strip() != "Disabled"
+
+
+def build_temporal_plan(layer_key, available_fields, mode_label):
+    mode_label = (mode_label or DEFAULT_TEMPORAL_MODE_LABEL).strip() or DEFAULT_TEMPORAL_MODE_LABEL
+    if not is_temporal_mode_enabled(mode_label):
+        return None
+
+    field_names = {name for name in (available_fields or []) if name}
+    candidates = _LAYER_CANDIDATES.get(layer_key, {}).get(mode_label, [])
+    for field_name in candidates:
+        if field_name in field_names:
+            return TemporalLayerPlan(
+                layer_key=layer_key,
+                field_name=field_name,
+                field_kind=_field_kind(field_name),
+                label=_plan_label(layer_key, field_name),
+            )
+    return None
+
+
+def describe_temporal_configuration(plans, mode_label):
+    active_plans = [plan for plan in (plans or []) if plan is not None]
+    if not is_temporal_mode_enabled(mode_label):
+        return "Temporal playback disabled"
+    if not active_plans:
+        return "Temporal playback requested, but no timestamp fields were available"
+    labels = ", ".join(plan.label for plan in active_plans)
+    return "Temporal playback wired for {labels}".format(labels=labels)
+
+
+def _field_kind(field_name):
+    return "local" if field_name.endswith("_local") else "utc"
+
+
+def _plan_label(layer_key, field_name):
+    field_kind = _field_kind(field_name).upper()
+    if layer_key == "activity_points":
+        return "activity points ({kind})".format(kind=field_kind)
+    if layer_key == "activity_tracks":
+        return "activity tracks ({kind})".format(kind=field_kind)
+    if layer_key == "activity_starts":
+        return "activity starts ({kind})".format(kind=field_kind)
+    return "{layer} ({kind})".format(layer=layer_key.replace("_", " "), kind=field_kind)

--- a/visualization/infrastructure/__init__.py
+++ b/visualization/infrastructure/__init__.py
@@ -1,6 +1,6 @@
 """QGIS-backed adapters for visualization workflows."""
 
-__all__ = ["BackgroundMapService", "LayerManager", "QgisLayerGateway"]
+__all__ = ["BackgroundMapService", "LayerManager", "QgisLayerGateway", "TemporalService"]
 
 
 def __getattr__(name):
@@ -12,4 +12,8 @@ def __getattr__(name):
         from .qgis_layer_gateway import QgisLayerGateway
 
         return QgisLayerGateway
+    if name == "TemporalService":
+        from .temporal_service import TemporalService
+
+        return TemporalService
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -9,8 +9,8 @@ from ...layer_style_service import LayerStyleService
 from ...map_canvas_service import MapCanvasService
 from ...mapbox_config import TILE_MODE_RASTER
 from ...project_layer_loader import ProjectLayerLoader
-from ...temporal_service import TemporalService
 from .background_map_service import BackgroundMapService
+from .temporal_service import TemporalService
 
 
 class QgisLayerGateway:

--- a/visualization/infrastructure/temporal_service.py
+++ b/visualization/infrastructure/temporal_service.py
@@ -1,0 +1,63 @@
+from qgis.core import QgsVectorLayerTemporalProperties
+
+from ..application.temporal_config import (
+    build_temporal_plan,
+    describe_temporal_configuration,
+    is_temporal_mode_enabled,
+)
+
+
+class TemporalService:
+    """Applies temporal configuration to qfit output layers.
+
+    Reads temporal plans from :mod:`visualization.application.temporal_config`
+    and wires them into the QGIS temporal-properties API on each layer.
+    """
+
+    LAYER_SPECS = [
+        ("activities", "activity_tracks"),
+        ("starts", "activity_starts"),
+        ("points", "activity_points"),
+        ("atlas", "activity_atlas_pages"),
+    ]
+
+    def apply_temporal_configuration(self, activities_layer, starts_layer, points_layer, atlas_layer, mode_label):
+        layers_by_slot = {
+            "activities": activities_layer,
+            "starts": starts_layer,
+            "points": points_layer,
+            "atlas": atlas_layer,
+        }
+        plans = []
+        for slot, layer_key in self.LAYER_SPECS:
+            layer = layers_by_slot[slot]
+            if layer is None:
+                continue
+            plan = self._apply_temporal_plan(layer, layer_key, mode_label)
+            if plan is not None:
+                plans.append(plan)
+        return describe_temporal_configuration(plans, mode_label)
+
+    @staticmethod
+    def _apply_temporal_plan(layer, layer_key, mode_label):
+        props = layer.temporalProperties()
+        if props is None:
+            return None
+        if not is_temporal_mode_enabled(mode_label):
+            props.setIsActive(False)
+            layer.triggerRepaint()
+            return None
+
+        available_fields = [field.name() for field in layer.fields()]
+        plan = build_temporal_plan(layer_key, available_fields, mode_label)
+        if plan is None:
+            props.setIsActive(False)
+            layer.triggerRepaint()
+            return None
+
+        props.setIsActive(True)
+        props.setMode(QgsVectorLayerTemporalProperties.ModeFeatureDateTimeStartAndEndFromExpressions)
+        props.setStartExpression(plan.expression)
+        props.setEndExpression(plan.expression)
+        layer.triggerRepaint()
+        return plan


### PR DESCRIPTION
## Summary
- move `temporal_config.py` into `visualization/application/temporal_config.py`
- move `TemporalService` into `visualization/infrastructure/temporal_service.py`
- keep root-level `temporal_config.py` and `temporal_service.py` as compatibility shims while callers migrate
- update visualization package exports, dock-widget imports, and tests to prefer the feature-owned paths

## Testing
- `PYTHONPATH=/home/ebelo/.openclaw/workspace/worktrees python3 -m pytest tests/ -x -q --tb=short`

## Notes
- This is another PR-sized slice for #286.
- Remaining visualization-owned root modules can continue in follow-up PRs.

Part of #286
