### PR TITLE
Move map canvas and loader services into visualization package

### DIFF
--- a/map_canvas_service.py
+++ b/map_canvas_service.py
@@ -1,82 +1,9 @@
-import logging
+"""Compatibility shim for the visualization map-canvas service.
 
-from qgis.core import (
-    QgsCoordinateReferenceSystem,
-    QgsCoordinateTransform,
-    QgsProject,
-    QgsRectangle,
-)
+Prefer importing from ``qfit.visualization.infrastructure.map_canvas_service``.
+This module remains as a stable forwarding import during the package move.
+"""
 
-logger = logging.getLogger(__name__)
+from .visualization.infrastructure.map_canvas_service import MapCanvasService, WORKING_CRS
 
-WORKING_CRS = "EPSG:3857"
-
-
-class MapCanvasService:
-    """Manages map canvas CRS setup and extent coordination.
-
-    Extracted from :class:`LayerManager` to isolate canvas-level concerns
-    (CRS switching, extent preservation, zoom-to-layers) from the
-    layer-loading orchestration.
-    """
-
-    def __init__(self, background_service):
-        self._background_service = background_service
-
-    def ensure_working_crs(self, iface, preserve_extent: bool = True):
-        """Set the project CRS to Web Mercator.
-
-        Parameters
-        ----------
-        preserve_extent : bool, default True
-            When true, transforms and reapplies the current canvas extent across
-            the CRS switch. When false, only switches the CRS and leaves extent
-            management to the caller (for example a later zoom-to-layers step).
-        """
-        project = QgsProject.instance()
-        working_crs = QgsCoordinateReferenceSystem(WORKING_CRS)
-        if not working_crs.isValid():
-            return
-
-        canvas = iface.mapCanvas() if iface is not None else None
-
-        current_extent = canvas.extent() if canvas is not None else None
-        current_crs = project.crs()
-
-        project.setCrs(working_crs)
-        if canvas is not None:
-            canvas.setDestinationCrs(working_crs)
-            if preserve_extent and current_extent is not None and current_crs.isValid() and not current_extent.isEmpty():
-                transform = QgsCoordinateTransform(current_crs, working_crs, project)
-                try:
-                    transformed = transform.transformBoundingBox(current_extent)
-                    if not transformed.isEmpty():
-                        canvas.setExtent(transformed)
-                        canvas.refresh()
-                except RuntimeError:
-                    logger.debug("Extent transform in CRS switch failed", exc_info=True)
-
-    def zoom_to_layers(self, iface, layers):
-        """Combine layer extents, snap to tile zoom, and set canvas extent."""
-        extents = None
-        for layer in layers:
-            if layer is None or not layer.isValid():
-                continue
-            layer_extent = layer.extent()
-            if layer_extent.isEmpty():
-                continue
-            if extents is None:
-                extents = QgsRectangle(layer_extent)
-            else:
-                extents.combineExtentWith(layer_extent)
-
-        if extents is None or extents.isEmpty():
-            return
-
-        canvas = iface.mapCanvas() if iface is not None else None
-        if canvas is None:
-            return
-
-        extents = self._background_service.snap_extent_to_background_tile_zoom(extents, canvas)
-        canvas.setExtent(extents)
-        canvas.refresh()
+__all__ = ["MapCanvasService", "WORKING_CRS"]

--- a/project_layer_loader.py
+++ b/project_layer_loader.py
@@ -1,52 +1,9 @@
-from qgis.core import QgsProject, QgsVectorLayer
+"""Compatibility shim for the visualization project-layer loader.
 
+Prefer importing from ``qfit.visualization.infrastructure.project_layer_loader``.
+This module remains as a stable forwarding import during the package move.
+"""
 
-class ProjectLayerLoader:
-    """Loads and replaces qfit output layers in the current QGIS project."""
+from .visualization.infrastructure.project_layer_loader import ProjectLayerLoader
 
-    ACTIVITIES_CANDIDATES = [
-        ("activity_tracks", "qfit activities"),
-        ("activities", "qfit activities"),
-    ]
-    OPTIONAL_LAYERS = [
-        ("activity_starts", "qfit activity starts"),
-        ("activity_points", "qfit activity points"),
-        ("activity_atlas_pages", "qfit atlas pages"),
-    ]
-
-    def load_output_layers(self, gpkg_path):
-        activities_layer = self._load_first_available(gpkg_path, self.ACTIVITIES_CANDIDATES)
-        optional_layers = [
-            self._load_optional_layer(gpkg_path, layer_name, display_name)
-            for layer_name, display_name in self.OPTIONAL_LAYERS
-        ]
-        return (activities_layer, *optional_layers)
-
-    def _load_first_available(self, gpkg_path, candidates):
-        last_error = None
-        for layer_name, display_name in candidates:
-            try:
-                return self._load_layer(gpkg_path, layer_name, display_name)
-            except RuntimeError as exc:
-                last_error = exc
-        if last_error is not None:
-            raise last_error
-        return None
-
-    def _load_optional_layer(self, gpkg_path, layer_name, display_name):
-        try:
-            return self._load_layer(gpkg_path, layer_name, display_name)
-        except RuntimeError:
-            return None
-
-    def _load_layer(self, gpkg_path, layer_name, display_name):
-        uri = f"{gpkg_path}|layername={layer_name}"
-        layer = QgsVectorLayer(uri, display_name, "ogr")
-        if not layer.isValid():
-            raise RuntimeError(f"Could not load layer '{layer_name}' from {gpkg_path}")
-
-        project = QgsProject.instance()
-        for old_layer in project.mapLayersByName(display_name):
-            project.removeMapLayer(old_layer.id())
-        project.addMapLayer(layer)
-        return layer
+__all__ = ["ProjectLayerLoader"]

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -61,6 +61,14 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
             )
 
             gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            gateway._canvas_service = MagicMock(name="canvas_service")
+            gateway._project_layer_loader = MagicMock(name="project_layer_loader")
+            gateway._project_layer_loader.load_output_layers.return_value = (
+                MagicMock(name="activities"),
+                MagicMock(name="starts"),
+                MagicMock(name="points"),
+                MagicMock(name="atlas"),
+            )
             gateway._move_background_layers_to_bottom = MagicMock(name="move_background_layers_to_bottom")
             result = gateway.load_output_layers("/tmp/out.gpkg")
 
@@ -98,8 +106,12 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         for name in [
             "qfit.background_map_service",
             "qfit.layer_manager",
+            "qfit.map_canvas_service",
+            "qfit.project_layer_loader",
             "qfit.visualization.infrastructure",
             "qfit.visualization.infrastructure.background_map_service",
+            "qfit.visualization.infrastructure.map_canvas_service",
+            "qfit.visualization.infrastructure.project_layer_loader",
             "qfit.visualization.infrastructure.qgis_layer_gateway",
         ]:
             sys.modules.pop(name, None)
@@ -142,6 +154,8 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
 
         qgis_core = ModuleType("qgis.core")
         qgis_core.QgsProject = MagicMock(name="QgsProject")
+        qgis_core.QgsCoordinateReferenceSystem = MagicMock(name="QgsCoordinateReferenceSystem")
+        qgis_core.QgsCoordinateTransform = MagicMock(name="QgsCoordinateTransform")
         qgis_core.QgsCategorizedSymbolRenderer = MagicMock(name="QgsCategorizedSymbolRenderer")
         qgis_core.QgsFillSymbol = MagicMock(name="QgsFillSymbol")
         qgis_core.QgsGradientColorRamp = MagicMock(name="QgsGradientColorRamp")
@@ -158,6 +172,7 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         qgis_core.QgsVectorTileLayer = MagicMock(name="QgsVectorTileLayer")
         temporal_props = MagicMock(name="QgsVectorLayerTemporalProperties")
         temporal_props.ModeFeatureDateTimeStartAndEndFromExpressions = 1
+        qgis_core.QgsVectorLayer = MagicMock(name="QgsVectorLayer")
         qgis_core.QgsVectorLayerTemporalProperties = temporal_props
 
         qgis_mod = ModuleType("qgis")
@@ -192,14 +207,14 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
                 "LayerStyleService",
                 style_service,
             ),
-            "qfit.map_canvas_service": class_module(
-                "qfit.map_canvas_service",
+            "qfit.visualization.infrastructure.map_canvas_service": class_module(
+                "qfit.visualization.infrastructure.map_canvas_service",
                 "MapCanvasService",
                 map_canvas_service,
             ),
             "qfit.mapbox_config": mapbox_config,
-            "qfit.project_layer_loader": class_module(
-                "qfit.project_layer_loader",
+            "qfit.visualization.infrastructure.project_layer_loader": class_module(
+                "qfit.visualization.infrastructure.project_layer_loader",
                 "ProjectLayerLoader",
                 project_layer_loader,
             ),

--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -497,6 +497,8 @@ class VisualizationInfrastructureExportTests(unittest.TestCase):
         module_specs = {
             f"{package_name}.background_map_service": ("BackgroundMapService", type("BackgroundMapService", (), {})),
             f"{package_name}.layer_filter_service": ("LayerFilterService", type("LayerFilterService", (), {})),
+            f"{package_name}.map_canvas_service": ("MapCanvasService", type("MapCanvasService", (), {})),
+            f"{package_name}.project_layer_loader": ("ProjectLayerLoader", type("ProjectLayerLoader", (), {})),
             f"{package_name}.qgis_layer_gateway": ("QgisLayerGateway", type("QgisLayerGateway", (), {})),
             f"{package_name}.layer_style_service": ("LayerStyleService", type("LayerStyleService", (), {})),
             f"{package_name}.temporal_service": ("TemporalService", type("TemporalService", (), {})),
@@ -516,6 +518,8 @@ class VisualizationInfrastructureExportTests(unittest.TestCase):
             self.assertIs(package.BackgroundMapService, module_specs[f"{package_name}.background_map_service"][1])
             self.assertIs(package.LayerFilterService, module_specs[f"{package_name}.layer_filter_service"][1])
             self.assertIs(package.LayerManager, module_specs[f"{package_name}.qgis_layer_gateway"][1])
+            self.assertIs(package.MapCanvasService, module_specs[f"{package_name}.map_canvas_service"][1])
+            self.assertIs(package.ProjectLayerLoader, module_specs[f"{package_name}.project_layer_loader"][1])
             self.assertIs(package.QgisLayerGateway, module_specs[f"{package_name}.qgis_layer_gateway"][1])
             self.assertIs(package.LayerStyleService, module_specs[f"{package_name}.layer_style_service"][1])
             self.assertIs(package.TemporalService, module_specs[f"{package_name}.temporal_service"][1])

--- a/tests/test_map_canvas_service.py
+++ b/tests/test_map_canvas_service.py
@@ -17,11 +17,16 @@ except ValueError:
     )
 
 try:
-    from qfit.map_canvas_service import MapCanvasService, WORKING_CRS
+    from qfit.map_canvas_service import MapCanvasService as LegacyMapCanvasService
+    from qfit.visualization.infrastructure.map_canvas_service import (
+        MapCanvasService,
+        WORKING_CRS,
+    )
 
     QGIS_AVAILABLE = True
     QGIS_IMPORT_ERROR = None
 except Exception as exc:  # pragma: no cover
+    LegacyMapCanvasService = None
     MapCanvasService = None
     QGIS_AVAILABLE = False
     QGIS_IMPORT_ERROR = exc
@@ -37,15 +42,15 @@ def _load_service_with_mock_qgis():
     qgis_modules = ["qgis", "qgis.core"]
 
     saved_qgis = {name: sys.modules.get(name) for name in qgis_modules}
-    saved_module = sys.modules.get("qfit.map_canvas_service")
+    saved_module = sys.modules.get("qfit.visualization.infrastructure.map_canvas_service")
 
     for name in qgis_modules:
         sys.modules[name] = qstub
 
-    sys.modules.pop("qfit.map_canvas_service", None)
+    sys.modules.pop("qfit.visualization.infrastructure.map_canvas_service", None)
 
     try:
-        module = importlib.import_module("qfit.map_canvas_service")
+        module = importlib.import_module("qfit.visualization.infrastructure.map_canvas_service")
         return module.MapCanvasService, module
     except Exception:  # pragma: no cover
         return None, None
@@ -56,9 +61,9 @@ def _load_service_with_mock_qgis():
             else:
                 sys.modules[name] = original
         if saved_module is None:
-            sys.modules.pop("qfit.map_canvas_service", None)
+            sys.modules.pop("qfit.visualization.infrastructure.map_canvas_service", None)
         else:
-            sys.modules["qfit.map_canvas_service"] = saved_module
+            sys.modules["qfit.visualization.infrastructure.map_canvas_service"] = saved_module
 
 
 if not QGIS_AVAILABLE:
@@ -115,13 +120,16 @@ def _make_layer(extent_vals=None, valid=True):
 class MapCanvasServiceRealTests(unittest.TestCase):
     """Tests that run when real QGIS bindings are available."""
 
+    def test_root_shim_exports_visualization_map_canvas_service(self):
+        self.assertIs(LegacyMapCanvasService, MapCanvasService)
+
     def setUp(self):
         self._bg = MagicMock()
         self.service = MapCanvasService(self._bg)
 
     # -- ensure_working_crs -------------------------------------------------
 
-    @patch("qfit.map_canvas_service.QgsProject")
+    @patch("qfit.visualization.infrastructure.map_canvas_service.QgsProject")
     def test_ensure_working_crs_sets_project_and_canvas_crs(self, mock_project_cls):
         project = MagicMock()
         project.crs.return_value = MagicMock(isValid=MagicMock(return_value=False))
@@ -135,8 +143,8 @@ class MapCanvasServiceRealTests(unittest.TestCase):
         project.setCrs.assert_called_once()
         canvas.setDestinationCrs.assert_called_once()
 
-    @patch("qfit.map_canvas_service.QgsCoordinateTransform")
-    @patch("qfit.map_canvas_service.QgsProject")
+    @patch("qfit.visualization.infrastructure.map_canvas_service.QgsCoordinateTransform")
+    @patch("qfit.visualization.infrastructure.map_canvas_service.QgsProject")
     def test_ensure_working_crs_preserves_extent_on_crs_change(
         self, mock_project_cls, mock_transform_cls
     ):
@@ -161,8 +169,8 @@ class MapCanvasServiceRealTests(unittest.TestCase):
         canvas.setDestinationCrs.assert_called_once()
         canvas.setExtent.assert_called_once_with(transformed_extent)
 
-    @patch("qfit.map_canvas_service.QgsCoordinateTransform")
-    @patch("qfit.map_canvas_service.QgsProject")
+    @patch("qfit.visualization.infrastructure.map_canvas_service.QgsCoordinateTransform")
+    @patch("qfit.visualization.infrastructure.map_canvas_service.QgsProject")
     def test_ensure_working_crs_can_skip_extent_preservation(
         self, mock_project_cls, mock_transform_cls
     ):
@@ -183,7 +191,7 @@ class MapCanvasServiceRealTests(unittest.TestCase):
         mock_transform_cls.assert_not_called()
         canvas.setExtent.assert_not_called()
 
-    @patch("qfit.map_canvas_service.QgsProject")
+    @patch("qfit.visualization.infrastructure.map_canvas_service.QgsProject")
     def test_ensure_working_crs_noop_when_iface_is_none(self, mock_project_cls):
         project = MagicMock()
         mock_project_cls.instance.return_value = project

--- a/tests/test_project_layer_loader.py
+++ b/tests/test_project_layer_loader.py
@@ -17,11 +17,13 @@ except ValueError:
     )
 
 try:
-    from qfit.project_layer_loader import ProjectLayerLoader
+    from qfit.project_layer_loader import ProjectLayerLoader as LegacyProjectLayerLoader
+    from qfit.visualization.infrastructure.project_layer_loader import ProjectLayerLoader
 
     QGIS_AVAILABLE = True
     QGIS_IMPORT_ERROR = None
 except Exception as exc:  # pragma: no cover
+    LegacyProjectLayerLoader = None
     ProjectLayerLoader = None
     QGIS_AVAILABLE = False
     QGIS_IMPORT_ERROR = exc
@@ -38,14 +40,14 @@ def _load_service_with_mock_qgis():
     qgis_modules = ["qgis", "qgis.core"]
 
     saved_qgis = {name: sys.modules.get(name) for name in qgis_modules}
-    saved_module = sys.modules.get("qfit.project_layer_loader")
+    saved_module = sys.modules.get("qfit.visualization.infrastructure.project_layer_loader")
 
     for name in qgis_modules:
         sys.modules[name] = qstub
-    sys.modules.pop("qfit.project_layer_loader", None)
+    sys.modules.pop("qfit.visualization.infrastructure.project_layer_loader", None)
 
     try:
-        module = importlib.import_module("qfit.project_layer_loader")
+        module = importlib.import_module("qfit.visualization.infrastructure.project_layer_loader")
         return module.ProjectLayerLoader, module
     except Exception:  # pragma: no cover
         return None, None
@@ -56,9 +58,9 @@ def _load_service_with_mock_qgis():
             else:
                 sys.modules[name] = original
         if saved_module is None:
-            sys.modules.pop("qfit.project_layer_loader", None)
+            sys.modules.pop("qfit.visualization.infrastructure.project_layer_loader", None)
         else:
-            sys.modules["qfit.project_layer_loader"] = saved_module
+            sys.modules["qfit.visualization.infrastructure.project_layer_loader"] = saved_module
 
 
 if not QGIS_AVAILABLE:
@@ -74,6 +76,9 @@ SKIP_MOCK_LOAD = (
 
 @unittest.skipUnless(QGIS_AVAILABLE, SKIP_REAL)
 class ProjectLayerLoaderRealTests(unittest.TestCase):
+    def test_root_shim_exports_visualization_project_layer_loader(self):
+        self.assertIs(LegacyProjectLayerLoader, ProjectLayerLoader)
+
     def test_load_output_layers_uses_current_and_legacy_activity_names(self):
         loader = ProjectLayerLoader()
 
@@ -91,8 +96,8 @@ class ProjectLayerLoaderRealTests(unittest.TestCase):
         project = MagicMock()
         project.mapLayersByName.return_value = []
 
-        with patch("qfit.project_layer_loader.QgsVectorLayer", side_effect=[primary, legacy, starts, points, atlas]) as vector_layer, \
-             patch("qfit.project_layer_loader.QgsProject") as qgs_project:
+        with patch("qfit.visualization.infrastructure.project_layer_loader.QgsVectorLayer", side_effect=[primary, legacy, starts, points, atlas]) as vector_layer, \
+             patch("qfit.visualization.infrastructure.project_layer_loader.QgsProject") as qgs_project:
             qgs_project.instance.return_value = project
             layers = loader.load_output_layers("/tmp/out.gpkg")
 
@@ -119,8 +124,8 @@ class ProjectLayerLoaderRealTests(unittest.TestCase):
         project = MagicMock()
         project.mapLayersByName.return_value = [old_layer]
 
-        with patch("qfit.project_layer_loader.QgsVectorLayer", return_value=new_layer), \
-             patch("qfit.project_layer_loader.QgsProject") as qgs_project:
+        with patch("qfit.visualization.infrastructure.project_layer_loader.QgsVectorLayer", return_value=new_layer), \
+             patch("qfit.visualization.infrastructure.project_layer_loader.QgsProject") as qgs_project:
             qgs_project.instance.return_value = project
             loaded = loader._load_layer("/tmp/out.gpkg", "activity_tracks", "qfit activities")
 

--- a/visualization/infrastructure/__init__.py
+++ b/visualization/infrastructure/__init__.py
@@ -5,6 +5,8 @@ __all__ = [
     "LayerFilterService",
     "LayerManager",
     "LayerStyleService",
+    "MapCanvasService",
+    "ProjectLayerLoader",
     "QgisLayerGateway",
     "TemporalService",
 ]
@@ -27,6 +29,14 @@ def __getattr__(name):
         from .layer_style_service import LayerStyleService
 
         return LayerStyleService
+    if name == "MapCanvasService":
+        from .map_canvas_service import MapCanvasService
+
+        return MapCanvasService
+    if name == "ProjectLayerLoader":
+        from .project_layer_loader import ProjectLayerLoader
+
+        return ProjectLayerLoader
     if name == "TemporalService":
         from .temporal_service import TemporalService
 

--- a/visualization/infrastructure/map_canvas_service.py
+++ b/visualization/infrastructure/map_canvas_service.py
@@ -1,0 +1,82 @@
+import logging
+
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsProject,
+    QgsRectangle,
+)
+
+logger = logging.getLogger(__name__)
+
+WORKING_CRS = "EPSG:3857"
+
+
+class MapCanvasService:
+    """Manages map canvas CRS setup and extent coordination.
+
+    Extracted from :class:`QgisLayerGateway` to isolate canvas-level concerns
+    (CRS switching, extent preservation, zoom-to-layers) from the
+    layer-loading orchestration.
+    """
+
+    def __init__(self, background_service):
+        self._background_service = background_service
+
+    def ensure_working_crs(self, iface, preserve_extent: bool = True):
+        """Set the project CRS to Web Mercator.
+
+        Parameters
+        ----------
+        preserve_extent : bool, default True
+            When true, transforms and reapplies the current canvas extent across
+            the CRS switch. When false, only switches the CRS and leaves extent
+            management to the caller (for example a later zoom-to-layers step).
+        """
+        project = QgsProject.instance()
+        working_crs = QgsCoordinateReferenceSystem(WORKING_CRS)
+        if not working_crs.isValid():
+            return
+
+        canvas = iface.mapCanvas() if iface is not None else None
+
+        current_extent = canvas.extent() if canvas is not None else None
+        current_crs = project.crs()
+
+        project.setCrs(working_crs)
+        if canvas is not None:
+            canvas.setDestinationCrs(working_crs)
+            if preserve_extent and current_extent is not None and current_crs.isValid() and not current_extent.isEmpty():
+                transform = QgsCoordinateTransform(current_crs, working_crs, project)
+                try:
+                    transformed = transform.transformBoundingBox(current_extent)
+                    if not transformed.isEmpty():
+                        canvas.setExtent(transformed)
+                        canvas.refresh()
+                except RuntimeError:
+                    logger.debug("Extent transform in CRS switch failed", exc_info=True)
+
+    def zoom_to_layers(self, iface, layers):
+        """Combine layer extents, snap to tile zoom, and set canvas extent."""
+        extents = None
+        for layer in layers:
+            if layer is None or not layer.isValid():
+                continue
+            layer_extent = layer.extent()
+            if layer_extent.isEmpty():
+                continue
+            if extents is None:
+                extents = QgsRectangle(layer_extent)
+            else:
+                extents.combineExtentWith(layer_extent)
+
+        if extents is None or extents.isEmpty():
+            return
+
+        canvas = iface.mapCanvas() if iface is not None else None
+        if canvas is None:
+            return
+
+        extents = self._background_service.snap_extent_to_background_tile_zoom(extents, canvas)
+        canvas.setExtent(extents)
+        canvas.refresh()

--- a/visualization/infrastructure/project_layer_loader.py
+++ b/visualization/infrastructure/project_layer_loader.py
@@ -1,0 +1,52 @@
+from qgis.core import QgsProject, QgsVectorLayer
+
+
+class ProjectLayerLoader:
+    """Loads and replaces qfit output layers in the current QGIS project."""
+
+    ACTIVITIES_CANDIDATES = [
+        ("activity_tracks", "qfit activities"),
+        ("activities", "qfit activities"),
+    ]
+    OPTIONAL_LAYERS = [
+        ("activity_starts", "qfit activity starts"),
+        ("activity_points", "qfit activity points"),
+        ("activity_atlas_pages", "qfit atlas pages"),
+    ]
+
+    def load_output_layers(self, gpkg_path):
+        activities_layer = self._load_first_available(gpkg_path, self.ACTIVITIES_CANDIDATES)
+        optional_layers = [
+            self._load_optional_layer(gpkg_path, layer_name, display_name)
+            for layer_name, display_name in self.OPTIONAL_LAYERS
+        ]
+        return (activities_layer, *optional_layers)
+
+    def _load_first_available(self, gpkg_path, candidates):
+        last_error = None
+        for layer_name, display_name in candidates:
+            try:
+                return self._load_layer(gpkg_path, layer_name, display_name)
+            except RuntimeError as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+        return None
+
+    def _load_optional_layer(self, gpkg_path, layer_name, display_name):
+        try:
+            return self._load_layer(gpkg_path, layer_name, display_name)
+        except RuntimeError:
+            return None
+
+    def _load_layer(self, gpkg_path, layer_name, display_name):
+        uri = f"{gpkg_path}|layername={layer_name}"
+        layer = QgsVectorLayer(uri, display_name, "ogr")
+        if not layer.isValid():
+            raise RuntimeError(f"Could not load layer '{layer_name}' from {gpkg_path}")
+
+        project = QgsProject.instance()
+        for old_layer in project.mapLayersByName(display_name):
+            project.removeMapLayer(old_layer.id())
+        project.addMapLayer(layer)
+        return layer

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -4,10 +4,10 @@ from qgis.core import QgsProject
 
 logger = logging.getLogger(__name__)
 
-from ...map_canvas_service import MapCanvasService
 from ...mapbox_config import TILE_MODE_RASTER
-from ...project_layer_loader import ProjectLayerLoader
 from .background_map_service import BackgroundMapService
+from .map_canvas_service import MapCanvasService
+from .project_layer_loader import ProjectLayerLoader
 from .temporal_service import TemporalService
 
 


### PR DESCRIPTION
## Summary
- move `MapCanvasService` and `ProjectLayerLoader` into `visualization/infrastructure/`
- keep the root-level modules as compatibility shims
- update the QGIS layer gateway and tests to prefer the feature-owned package paths

## Testing
- `PYTHONPATH=/home/ebelo/.openclaw/workspace/worktrees python3 -m pytest tests/ -x -q --tb=short`

## Notes
- This is another PR-sized slice for #286.
- Remaining visualization-owned root modules can continue in follow-up PRs.

Part of #286