### PR TITLE
fix: soften atlas cover heatmap rendering

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -722,23 +722,14 @@ def _apply_cover_heatmap_renderer(layer) -> None:
     so the module can load without a full QGIS runtime (e.g. in tests).
     """
     try:
-        from qgis.core import (  # noqa: PLC0415
-            QgsHeatmapRenderer,
-            QgsStyle,
-            QgsGradientColorRamp,
+        from ..visualization.infrastructure.layer_style_service import (  # noqa: PLC0415
+            build_qfit_heatmap_renderer,
         )
     except ImportError:
         return
-    renderer = QgsHeatmapRenderer()
-    renderer.setRadius(8)
-    renderer.setRadiusUnit(QgsUnitTypes.RenderMillimeters)
-    renderer.setRenderQuality(1)
-    color_ramp = QgsStyle.defaultStyle().colorRamp("Turbo")
-    if color_ramp is None:
-        color_ramp = QgsGradientColorRamp(QColor("#00000000"), QColor("#e74c3c"))
-    renderer.setColorRamp(color_ramp)
-    layer.setRenderer(renderer)
-    layer.setOpacity(0.85)
+
+    layer.setRenderer(build_qfit_heatmap_renderer())
+    layer.setOpacity(0.7)
 
 
 def build_cover_layout(

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -4146,21 +4146,24 @@ class TestApplyCoverHeatmapRenderer(unittest.TestCase):
     def test_sets_renderer_on_layer(self):
         layer = MagicMock()
         heatmap_renderer = MagicMock()
-        heatmap_cls = MagicMock(return_value=heatmap_renderer)
-        style_cls = MagicMock()
-        style_cls.defaultStyle.return_value.colorRamp.return_value = MagicMock()
-        ramp_cls = MagicMock()
+        heatmap_builder_module = ModuleType(
+            "qfit.visualization.infrastructure.layer_style_service"
+        )
+        heatmap_builder_module.build_qfit_heatmap_renderer = MagicMock(
+            return_value=heatmap_renderer
+        )
 
-        qgis_core = ModuleType("qgis.core")
-        qgis_core.QgsHeatmapRenderer = heatmap_cls
-        qgis_core.QgsStyle = style_cls
-        qgis_core.QgsGradientColorRamp = ramp_cls
-
-        with patch.dict(sys.modules, {"qgis.core": qgis_core}):
+        with patch.dict(
+            sys.modules,
+            {
+                "qfit.visualization.infrastructure.layer_style_service": heatmap_builder_module,
+            },
+        ):
             _apply_cover_heatmap_renderer(layer)
 
+        heatmap_builder_module.build_qfit_heatmap_renderer.assert_called_once_with()
         layer.setRenderer.assert_called_once_with(heatmap_renderer)
-        layer.setOpacity.assert_called_once_with(0.85)
+        layer.setOpacity.assert_called_once_with(0.7)
 
 
 class TestBuildCoverLayoutWithMap(unittest.TestCase):

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -31,6 +31,26 @@ BY_ACTIVITY_TYPE_PRESET = "By activity type"
 OTHER_ACTIVITY_LABEL = "Other"
 
 
+def build_qfit_heatmap_renderer():
+    renderer = QgsHeatmapRenderer()
+    renderer.setRadius(12)
+    renderer.setRadiusUnit(QgsUnitTypes.RenderMillimeters)
+    renderer.setRenderQuality(2)
+    heat_ramp = QgsGradientColorRamp(
+        QColor("#00000000"),
+        QColor("#E74C3C"),
+        False,
+        [
+            QgsGradientStop(0.15, QColor("#00000000")),
+            QgsGradientStop(0.35, QColor(52, 152, 219, 90)),
+            QgsGradientStop(0.60, QColor(241, 196, 15, 160)),
+            QgsGradientStop(0.82, QColor(230, 126, 34, 220)),
+        ],
+    )
+    renderer.setColorRamp(heat_ramp)
+    return renderer
+
+
 class LayerStyleService:
     """Applies visual styles (renderers, opacity) to qfit output layers.
 
@@ -213,23 +233,7 @@ class LayerStyleService:
         layer.triggerRepaint()
 
     def _apply_heatmap_style(self, layer):
-        renderer = QgsHeatmapRenderer()
-        renderer.setRadius(12)
-        renderer.setRadiusUnit(QgsUnitTypes.RenderMillimeters)
-        renderer.setRenderQuality(2)
-        heat_ramp = QgsGradientColorRamp(
-            QColor("#00000000"),
-            QColor("#E74C3C"),
-            False,
-            [
-                QgsGradientStop(0.15, QColor("#00000000")),
-                QgsGradientStop(0.35, QColor(52, 152, 219, 90)),
-                QgsGradientStop(0.60, QColor(241, 196, 15, 160)),
-                QgsGradientStop(0.82, QColor(230, 126, 34, 220)),
-            ],
-        )
-        renderer.setColorRamp(heat_ramp)
-        layer.setRenderer(renderer)
+        layer.setRenderer(build_qfit_heatmap_renderer())
         layer.setOpacity(0.75)
         layer.triggerRepaint()
 


### PR DESCRIPTION
## Summary
- switch the atlas cover-page heatmap to qfit's shared transparent heatmap palette instead of the heavier default Turbo ramp
- lower the cover heatmap opacity so the map context stays visible and empty areas remain visually quiet
- add a regression test that verifies the cover renderer now uses the shared qfit heatmap builder

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py tests/test_layer_style_service.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short` (tests reached green locally before the known PyQGIS teardown crash at interpreter shutdown on this branch)

## Notes
- This addresses issue #292.
- The cover page now reuses qfit's existing heatmap styling instead of maintaining a second heatmap palette just for the atlas front matter.

Closes #292
