### PR TITLE
fix: soften atlas cover heatmap rendering

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -729,7 +729,7 @@ def _apply_cover_heatmap_renderer(layer) -> None:
         return
 
     layer.setRenderer(build_qfit_heatmap_renderer())
-    layer.setOpacity(0.7)
+    layer.setOpacity(0.55)
 
 
 def build_cover_layout(

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -4195,7 +4195,7 @@ class TestApplyCoverHeatmapRenderer(unittest.TestCase):
 
         heatmap_builder_module.build_qfit_heatmap_renderer.assert_called_once_with()
         layer.setRenderer.assert_called_once_with(heatmap_renderer)
-        layer.setOpacity.assert_called_once_with(0.7)
+        layer.setOpacity.assert_called_once_with(0.55)
 
 
 class TestBuildCoverLayoutWithMap(unittest.TestCase):

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -804,6 +804,8 @@ class QgisSmokeTests(unittest.TestCase):
             renderer = points_layer.renderer()
             self.assertIsInstance(renderer, QgsHeatmapRenderer)
             self.assertEqual(renderer.radius(), 12)
+            self.assertLessEqual(renderer.colorRamp().color2().alpha(), 215)
+            self.assertGreater(renderer.colorRamp().color2().red(), renderer.colorRamp().color2().blue())
             self.assertEqual(renderer.radiusUnit(), QgsUnitTypes.RenderMillimeters)
             self.assertEqual(renderer.renderQuality(), 2)
             self.assertIsNotNone(renderer.colorRamp())

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -38,13 +38,13 @@ def build_qfit_heatmap_renderer():
     renderer.setRenderQuality(2)
     heat_ramp = QgsGradientColorRamp(
         QColor("#00000000"),
-        QColor("#E74C3C"),
+        QColor(239, 108, 0, 215),
         False,
         [
-            QgsGradientStop(0.15, QColor("#00000000")),
-            QgsGradientStop(0.35, QColor(52, 152, 219, 90)),
-            QgsGradientStop(0.60, QColor(241, 196, 15, 160)),
-            QgsGradientStop(0.82, QColor(230, 126, 34, 220)),
+            QgsGradientStop(0.18, QColor("#00000000")),
+            QgsGradientStop(0.38, QColor(79, 195, 247, 70)),
+            QgsGradientStop(0.62, QColor(255, 183, 77, 135)),
+            QgsGradientStop(0.82, QColor(255, 138, 101, 185)),
         ],
     )
     renderer.setColorRamp(heat_ramp)


### PR DESCRIPTION
## Summary
- soften the shared qfit heatmap ramp so dense areas stay readable without turning into a dark block
- lower the atlas cover heatmap opacity so the summary map reads lighter on the cover page
- extend the cover/heatmap tests to pin the lighter rendering behaviour

## Testing
- `python3 -m pytest tests/test_atlas_export_task.py::TestApplyCoverHeatmapRenderer tests/test_qgis_smoke.py::QgisSmokeTests::test_heatmap_preset_renderer_and_layer_visibility tests/test_qgis_smoke.py::QgisSmokeTests::test_heatmap_preset_falls_back_to_starts_layer -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Notes
- This is a small follow-up slice for #292.
- The full suite completed green before the known PyQGIS teardown noise at process exit.

Part of #292
