### PR TITLE
refactor: extract dock startup coordination

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -68,6 +68,7 @@ from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_provider import StravaProvider
 from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
 from .ui.dockwidget_dependencies import DockWidgetDependencies, build_dockwidget_dependencies
+from .ui.dock_startup_coordinator import DockStartupCoordinator
 from .ui.workflow_section_coordinator import WorkflowSectionCoordinator
 from .configuration.application.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
 
@@ -84,6 +85,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         | QDockWidget.DockWidgetMovable
         | QDockWidget.DockWidgetFloatable
     )
+    STARTUP_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
 
     def __init__(self, iface, parent=None, dependencies: DockWidgetDependencies | None = None):
         if parent is None and iface is not None and hasattr(iface, "mainWindow"):
@@ -106,23 +108,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._bind_dependencies(self._dependencies)
         self.setupUi(self)
         self._workflow_section_coordinator = WorkflowSectionCoordinator(self)
-        self.setFeatures(self.DEFAULT_DOCK_FEATURES)
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
-        self._workflow_section_coordinator.configure_starting_sections()
-        self._remove_stale_qfit_layers()
-        self._apply_contextual_help()
-        self._configure_background_preset_options()
-        self._configure_detailed_route_filter_options()
-        self._configure_detailed_route_strategy_options()
-        self._configure_preview_sort_options()
-        self._configure_temporal_mode_options()
-        self._configure_analysis_mode_options()
-        self._load_settings()
-        self._wire_events()
-        self._set_default_dates()
-        self._workflow_section_coordinator.configure_workflow_sections()
-        self._refresh_activity_preview()
-        self._update_connection_status()
+        self._dock_startup_coordinator = DockStartupCoordinator(
+            self,
+            workflow_section_coordinator=self._workflow_section_coordinator,
+        )
+        self._startup_result = self._dock_startup_coordinator.run()
 
     def _remove_stale_qfit_layers(self):
         """Remove qfit layers from the project whose source file no longer exists.

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -2,13 +2,14 @@ import os
 import sys
 import unittest
 from types import ModuleType
-from unittest.mock import patch, sentinel
+from unittest.mock import MagicMock, call, patch, sentinel
 
 from tests import _path  # noqa: F401
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from qfit.ui.dockwidget_dependencies import build_dockwidget_dependencies, _build_cache
+from qfit.ui.dock_startup_coordinator import DockStartupCoordinator, DockStartupResult
 
 
 class _FakeIface:
@@ -424,3 +425,70 @@ class WorkflowSectionCoordinatorVisibilityTests(unittest.TestCase):
         self.assertTrue(dock.advancedFetchSettingsWidget.visible)
         self.assertTrue(dock.mapboxStyleOwnerLineEdit.visible)
         self.assertTrue(dock.mapboxStyleIdLineEdit.visible)
+
+
+class DockStartupCoordinatorTests(unittest.TestCase):
+    def test_run_orchestrates_startup_in_constructor_order(self):
+        dock = MagicMock()
+        dock.DEFAULT_DOCK_FEATURES = sentinel.features
+        dock.STARTUP_ALLOWED_AREAS = sentinel.allowed_areas
+        workflow_section_coordinator = MagicMock()
+
+        coordinator = DockStartupCoordinator(
+            dock,
+            workflow_section_coordinator=workflow_section_coordinator,
+        )
+
+        result = coordinator.run()
+
+        self.assertEqual(
+            result,
+            DockStartupResult(
+                performed_steps=(
+                    "set_features",
+                    "set_allowed_areas",
+                    "configure_starting_sections",
+                    "remove_stale_qfit_layers",
+                    "apply_contextual_help",
+                    "configure_background_preset_options",
+                    "configure_detailed_route_filter_options",
+                    "configure_detailed_route_strategy_options",
+                    "configure_preview_sort_options",
+                    "configure_temporal_mode_options",
+                    "configure_analysis_mode_options",
+                    "load_settings",
+                    "wire_events",
+                    "set_default_dates",
+                    "configure_workflow_sections",
+                    "refresh_activity_preview",
+                    "update_connection_status",
+                ),
+            ),
+        )
+        self.assertEqual(
+            dock.mock_calls,
+            [
+                call.setFeatures(sentinel.features),
+                call.setAllowedAreas(sentinel.allowed_areas),
+                call._remove_stale_qfit_layers(),
+                call._apply_contextual_help(),
+                call._configure_background_preset_options(),
+                call._configure_detailed_route_filter_options(),
+                call._configure_detailed_route_strategy_options(),
+                call._configure_preview_sort_options(),
+                call._configure_temporal_mode_options(),
+                call._configure_analysis_mode_options(),
+                call._load_settings(),
+                call._wire_events(),
+                call._set_default_dates(),
+                call._refresh_activity_preview(),
+                call._update_connection_status(),
+            ],
+        )
+        self.assertEqual(
+            workflow_section_coordinator.mock_calls,
+            [
+                call.configure_starting_sections(),
+                call.configure_workflow_sections(),
+            ],
+        )

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -202,6 +202,24 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_dock_widget_delegates_startup_to_coordinator(self):
+        dependencies = build_dockwidget_dependencies(self.iface)
+
+        with patch("qfit.qfit_dockwidget.DockStartupCoordinator") as startup_coordinator:
+            startup_coordinator.return_value.run.return_value = MagicMock()
+            dock = QfitDockWidget(self.iface, dependencies=dependencies)
+        try:
+            startup_coordinator.assert_called_once_with(
+                dock,
+                workflow_section_coordinator=dock._workflow_section_coordinator,
+            )
+            startup_coordinator.return_value.run.assert_called_once_with()
+            self.assertIs(dock._dock_startup_coordinator, startup_coordinator.return_value)
+            self.assertIs(dock._startup_result, startup_coordinator.return_value.run.return_value)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_dock_widget_contextual_help_smoke(self):
         dependencies = replace(
             build_dockwidget_dependencies(self.iface),

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DockStartupResult:
+    performed_steps: tuple[str, ...]
+
+
+class DockStartupCoordinator:
+    """Coordinate top-level dock-widget startup without moving lower-level UI methods."""
+
+    def __init__(self, dock_widget, *, workflow_section_coordinator):
+        self.dock_widget = dock_widget
+        self.workflow_section_coordinator = workflow_section_coordinator
+
+    def run(self) -> DockStartupResult:
+        dock = self.dock_widget
+        performed_steps: list[str] = []
+
+        dock.setFeatures(dock.DEFAULT_DOCK_FEATURES)
+        performed_steps.append("set_features")
+
+        dock.setAllowedAreas(dock.STARTUP_ALLOWED_AREAS)
+        performed_steps.append("set_allowed_areas")
+
+        self.workflow_section_coordinator.configure_starting_sections()
+        performed_steps.append("configure_starting_sections")
+
+        dock._remove_stale_qfit_layers()
+        performed_steps.append("remove_stale_qfit_layers")
+
+        dock._apply_contextual_help()
+        performed_steps.append("apply_contextual_help")
+
+        dock._configure_background_preset_options()
+        performed_steps.append("configure_background_preset_options")
+
+        dock._configure_detailed_route_filter_options()
+        performed_steps.append("configure_detailed_route_filter_options")
+
+        dock._configure_detailed_route_strategy_options()
+        performed_steps.append("configure_detailed_route_strategy_options")
+
+        dock._configure_preview_sort_options()
+        performed_steps.append("configure_preview_sort_options")
+
+        dock._configure_temporal_mode_options()
+        performed_steps.append("configure_temporal_mode_options")
+
+        dock._configure_analysis_mode_options()
+        performed_steps.append("configure_analysis_mode_options")
+
+        dock._load_settings()
+        performed_steps.append("load_settings")
+
+        dock._wire_events()
+        performed_steps.append("wire_events")
+
+        dock._set_default_dates()
+        performed_steps.append("set_default_dates")
+
+        self.workflow_section_coordinator.configure_workflow_sections()
+        performed_steps.append("configure_workflow_sections")
+
+        dock._refresh_activity_preview()
+        performed_steps.append("refresh_activity_preview")
+
+        dock._update_connection_status()
+        performed_steps.append("update_connection_status")
+
+        return DockStartupResult(performed_steps=tuple(performed_steps))


### PR DESCRIPTION
## Summary
- extract dock widget startup orchestration into a dedicated `DockStartupCoordinator`
- keep the lower-level startup helpers on `QfitDockWidget` unchanged for this small slice
- add coordinator and delegation coverage for the startup sequence

Closes #315

## Testing
- python3 -m pytest tests/test_dockwidget_dependencies.py tests/test_qgis_smoke.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
