### PR TITLE
Refactor #318: add analysis controller

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
+
+
+@dataclass(frozen=True)
+class RunAnalysisRequest:
+    analysis_mode: str = ""
+    starts_layer: object = None
+
+
+@dataclass(frozen=True)
+class RunAnalysisResult:
+    status: str = ""
+    layer: object = None
+
+
+class AnalysisController:
+    """Coordinates dock-triggered analysis workflows behind a small seam."""
+
+    @staticmethod
+    def build_request(analysis_mode: str, starts_layer: object) -> RunAnalysisRequest:
+        return RunAnalysisRequest(
+            analysis_mode=analysis_mode or "",
+            starts_layer=starts_layer,
+        )
+
+    def run(self, request: RunAnalysisRequest | None = None, **legacy_kwargs) -> RunAnalysisResult:
+        if request is None:
+            request = self.build_request(**legacy_kwargs)
+
+        if request.analysis_mode != FREQUENT_STARTING_POINTS_MODE:
+            return RunAnalysisResult()
+        if request.starts_layer is None:
+            return RunAnalysisResult()
+
+        layer, clusters = _build_frequent_start_points_layer(request.starts_layer)
+        if layer is None or not clusters:
+            return RunAnalysisResult(
+                status="No frequent starting points matched the current filters"
+            )
+
+        return RunAnalysisResult(
+            status="Showing top {count} frequent starting-point clusters".format(
+                count=len(clusters)
+            ),
+            layer=layer,
+        )
+
+    def run_request(self, request: RunAnalysisRequest) -> RunAnalysisResult:
+        return self.run(request=request)
+
+
+def _build_frequent_start_points_layer(starts_layer):
+    from ..infrastructure.frequent_start_points_layer import (
+        build_frequent_start_points_layer,
+    )
+
+    return build_frequent_start_points_layer(starts_layer)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -42,7 +42,6 @@ from .activities.application.load_workflow import LoadWorkflowError
 from .activities.application.store_task import build_store_task
 from .analysis.infrastructure.frequent_start_points_layer import (
     FREQUENT_STARTING_POINTS_LAYER_NAME,
-    build_frequent_start_points_layer,
 )
 from .atlas.export_service import (
     AtlasExportResult,
@@ -267,6 +266,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _bind_dependencies(self, dependencies: DockWidgetDependencies) -> None:
         self.settings = dependencies.settings
         self.sync_controller = dependencies.sync_controller
+        self.analysis_controller = dependencies.analysis_controller
         self.atlas_export_controller = dependencies.atlas_export_controller
         self.atlas_export_use_case = dependencies.atlas_export_use_case
         self.layer_gateway = dependencies.layer_gateway
@@ -918,10 +918,18 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
 
     def _run_selected_analysis(self, analysis_mode, starts_layer):
-        return self._apply_analysis_configuration(
+        request = self.analysis_controller.build_request(
             analysis_mode=analysis_mode,
             starts_layer=starts_layer,
         )
+        result = self.analysis_controller.run_request(request)
+        if result.layer is None:
+            return result.status
+
+        QgsProject.instance().addMapLayer(result.layer, False)
+        QgsProject.instance().layerTreeRoot().insertLayer(0, result.layer)
+        self.analysis_layer = result.layer
+        return result.status
 
     def _apply_visual_configuration(self, apply_subset_filters):
         action = replace(
@@ -942,19 +950,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         current_starts_layer = (
             starts_layer if starts_layer is not None else getattr(self, "starts_layer", None)
         )
-        if current_mode != "Most frequent starting points":
-            return ""
-        if current_starts_layer is None:
-            return ""
-
-        layer, clusters = build_frequent_start_points_layer(current_starts_layer)
-        if layer is None or not clusters:
-            return "No frequent starting points matched the current filters"
-
-        QgsProject.instance().addMapLayer(layer, False)
-        QgsProject.instance().layerTreeRoot().insertLayer(0, layer)
-        self.analysis_layer = layer
-        return "Showing top {count} frequent starting-point clusters".format(count=len(clusters))
+        return self._run_selected_analysis(current_mode, current_starts_layer)
 
     def _clear_analysis_layer(self):
         project = QgsProject.instance()

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from qfit.analysis.application.analysis_controller import (
+    AnalysisController,
+    FREQUENT_STARTING_POINTS_MODE,
+)
+
+
+class TestAnalysisController(unittest.TestCase):
+    def setUp(self):
+        self.controller = AnalysisController()
+
+    def test_build_request_returns_dataclass(self):
+        request = self.controller.build_request("None", "starts-layer")
+
+        self.assertEqual(request.analysis_mode, "None")
+        self.assertEqual(request.starts_layer, "starts-layer")
+
+    def test_run_request_returns_empty_result_for_non_matching_mode(self):
+        request = self.controller.build_request("None", object())
+
+        result = self.controller.run_request(request)
+
+        self.assertEqual(result.status, "")
+        self.assertIsNone(result.layer)
+
+    def test_run_request_returns_empty_result_without_starts_layer(self):
+        request = self.controller.build_request(
+            FREQUENT_STARTING_POINTS_MODE,
+            None,
+        )
+
+        result = self.controller.run_request(request)
+
+        self.assertEqual(result.status, "")
+        self.assertIsNone(result.layer)
+
+    def test_run_request_reports_no_matches(self):
+        request = self.controller.build_request(
+            FREQUENT_STARTING_POINTS_MODE,
+            object(),
+        )
+
+        with patch(
+            "qfit.analysis.application.analysis_controller._build_frequent_start_points_layer",
+            return_value=(None, []),
+        ):
+            result = self.controller.run_request(request)
+
+        self.assertEqual(
+            result.status,
+            "No frequent starting points matched the current filters",
+        )
+        self.assertIsNone(result.layer)
+
+    def test_run_request_returns_layer_for_matching_mode(self):
+        request = self.controller.build_request(
+            FREQUENT_STARTING_POINTS_MODE,
+            object(),
+        )
+        layer = object()
+
+        with patch(
+            "qfit.analysis.application.analysis_controller._build_frequent_start_points_layer",
+            return_value=(layer, [object(), object()]),
+        ):
+            result = self.controller.run_request(request)
+
+        self.assertEqual(
+            result.status,
+            "Showing top 2 frequent starting-point clusters",
+        )
+        self.assertIs(result.layer, layer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -32,6 +32,10 @@ class DockWidgetDependenciesTests(unittest.TestCase):
             patch("qfit.ui.dockwidget_dependencies.SettingsService", return_value=sentinel.settings),
             patch("qfit.ui.dockwidget_dependencies.SyncController", return_value=sentinel.sync_controller),
             patch(
+                "qfit.ui.dockwidget_dependencies.AnalysisController",
+                return_value=sentinel.analysis_controller,
+            ),
+            patch(
                 "qfit.ui.dockwidget_dependencies.AtlasExportController",
                 return_value=sentinel.atlas_export_controller,
             ),
@@ -73,6 +77,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
 
         self.assertIs(dependencies.settings, sentinel.settings)
         self.assertIs(dependencies.sync_controller, sentinel.sync_controller)
+        self.assertIs(dependencies.analysis_controller, sentinel.analysis_controller)
         self.assertIs(dependencies.atlas_export_controller, sentinel.atlas_export_controller)
         self.assertIs(dependencies.atlas_export_use_case, sentinel.atlas_export_use_case)
         self.assertIs(dependencies.layer_gateway, sentinel.layer_gateway)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -406,9 +406,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(action.background_config.access_token, "token")
         self.assertEqual(action.background_config.tile_mode, "Raster")
 
-    def test_run_selected_analysis_delegates_with_explicit_inputs(self):
+    def test_run_selected_analysis_delegates_to_analysis_controller(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock._apply_analysis_configuration = MagicMock(return_value="status")
+        dock.analysis_controller = MagicMock()
+        dock.analysis_controller.build_request.return_value = "analysis-request"
+        dock.analysis_controller.run_request.return_value = SimpleNamespace(
+            status="Showing top 2 frequent starting-point clusters",
+            layer=None,
+        )
 
         result = self.module.QfitDockWidget._run_selected_analysis(
             dock,
@@ -416,11 +421,35 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "starts-layer",
         )
 
-        self.assertEqual(result, "status")
-        dock._apply_analysis_configuration.assert_called_once_with(
+        self.assertEqual(result, "Showing top 2 frequent starting-point clusters")
+        dock.analysis_controller.build_request.assert_called_once_with(
             analysis_mode="Most frequent starting points",
             starts_layer="starts-layer",
         )
+        dock.analysis_controller.run_request.assert_called_once_with("analysis-request")
+
+    def test_run_selected_analysis_adds_returned_layer_to_project(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.analysis_controller = MagicMock()
+        dock.analysis_controller.build_request.return_value = "analysis-request"
+        analysis_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
+        dock.analysis_controller.run_request.return_value = SimpleNamespace(
+            status="Showing top 2 frequent starting-point clusters",
+            layer=analysis_layer,
+        )
+        project = _FakeProject()
+
+        with patch.object(self.module.QgsProject, "instance", return_value=project):
+            status = self.module.QfitDockWidget._run_selected_analysis(
+                dock,
+                "Most frequent starting points",
+                "starts-layer",
+            )
+
+        self.assertEqual(status, "Showing top 2 frequent starting-point clusters")
+        self.assertIs(dock.analysis_layer, analysis_layer)
+        self.assertEqual(project.added, [(analysis_layer, False)])
+        self.assertEqual(project.layer_tree_root.inserted, [(0, analysis_layer)])
 
     def test_apply_visual_configuration_dispatches_apply_action(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -451,60 +480,35 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.background_layer, "background-layer")
         dock._show_error.assert_not_called()
 
-    def test_apply_analysis_configuration_returns_status_for_non_matching_mode(self):
+    def test_apply_analysis_configuration_delegates_current_mode_and_layer(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock.analysisModeComboBox = _FakeComboBox(current_text="None")
+        dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")
+        dock.starts_layer = "starts-layer"
         dock._clear_analysis_layer = MagicMock()
+        dock._run_selected_analysis = MagicMock(return_value="status")
 
         status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
 
-        self.assertEqual(status, "")
+        self.assertEqual(status, "status")
         dock._clear_analysis_layer.assert_called_once_with()
+        dock._run_selected_analysis.assert_called_once_with(
+            "Most frequent starting points",
+            "starts-layer",
+        )
 
-    def test_apply_analysis_configuration_handles_missing_starts_layer(self):
+    def test_apply_analysis_configuration_defaults_missing_starts_layer_to_none(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")
-        dock.starts_layer = None
         dock._clear_analysis_layer = MagicMock()
+        dock._run_selected_analysis = MagicMock(return_value="")
 
         status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
 
         self.assertEqual(status, "")
-
-    def test_apply_analysis_configuration_handles_empty_analysis_result(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")
-        dock.starts_layer = object()
-        dock._clear_analysis_layer = MagicMock()
-
-        with patch.object(
-            self.module,
-            "build_frequent_start_points_layer",
-            return_value=(None, []),
-        ):
-            status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
-
-        self.assertEqual(status, "No frequent starting points matched the current filters")
-
-    def test_apply_analysis_configuration_adds_new_analysis_layer(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")
-        dock.starts_layer = object()
-        dock._clear_analysis_layer = MagicMock()
-        project = _FakeProject()
-        analysis_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
-
-        with patch.object(self.module.QgsProject, "instance", return_value=project), patch.object(
-            self.module,
-            "build_frequent_start_points_layer",
-            return_value=(analysis_layer, [object(), object()]),
-        ):
-            status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
-
-        self.assertEqual(status, "Showing top 2 frequent starting-point clusters")
-        self.assertIs(dock.analysis_layer, analysis_layer)
-        self.assertEqual(project.added, [(analysis_layer, False)])
-        self.assertEqual(project.layer_tree_root.inserted, [(0, analysis_layer)])
+        dock._run_selected_analysis.assert_called_once_with(
+            "Most frequent starting points",
+            None,
+        )
 
     def test_clear_analysis_layer_removes_current_and_stale_project_layers(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
+from ..analysis.application.analysis_controller import AnalysisController
 from ..atlas.export_controller import AtlasExportController
 from ..atlas.export_service import AtlasExportService
 from ..atlas.export_use_case import AtlasExportUseCase
@@ -24,6 +25,7 @@ class DockWidgetDependencies:
 
     settings: SettingsService
     sync_controller: SyncController
+    analysis_controller: AnalysisController
     atlas_export_controller: AtlasExportController
     atlas_export_use_case: AtlasExportUseCase
     layer_gateway: Any
@@ -48,6 +50,7 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
     return DockWidgetDependencies(
         settings=settings,
         sync_controller=sync_controller,
+        analysis_controller=AnalysisController(),
         atlas_export_controller=atlas_export_controller,
         atlas_export_use_case=AtlasExportUseCase(atlas_export_controller, atlas_export_service),
         layer_gateway=layer_gateway,


### PR DESCRIPTION
## Summary
- add an `AnalysisController` seam for dock-triggered analysis workflows
- move the current most-frequent-starting-points analysis dispatch behind structured request and result objects
- keep the dock widget focused on UI state and project-layer application, with updated unit coverage

## Tests
- `python3 -m pytest tests/test_analysis_controller.py tests/test_dockwidget_dependencies.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/test_qgis_smoke.py -q --tb=short -k 'test_run_analysis_clicked_updates_status_with_analysis_result or test_apply_analysis_configuration_returns_empty_status_without_starts_layer or test_apply_analysis_configuration_reports_no_matches_for_empty_starts_layer'`
- `python3 -m pytest tests/test_architecture_boundaries.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive.
