### PR TITLE
Refactor #320: split atlas export planning

### DIFF
--- a/atlas/export_service.py
+++ b/atlas/export_service.py
@@ -16,6 +16,20 @@ from ..visualization.application.layer_gateway import LayerGateway
 
 
 @dataclass
+class AtlasExportPlan:
+    """Structured atlas export plan independent of QGIS runtime execution."""
+
+    output_path: str = ""
+    pre_export_tile_mode: str = ""
+    preset_name: str = ""
+    access_token: str = ""
+    style_owner: str = ""
+    style_id: str = ""
+    background_enabled: bool = False
+    profile_plot_style: object | None = None
+
+
+@dataclass
 class GenerateAtlasPdfRequest:
     """Structured input for the atlas PDF generation workflow."""
 
@@ -77,6 +91,28 @@ class AtlasExportService:
         return QgisAtlasExportRuntime()
 
     @staticmethod
+    def build_plan(
+        output_path: str,
+        pre_export_tile_mode: str,
+        preset_name: str,
+        access_token: str,
+        style_owner: str,
+        style_id: str,
+        background_enabled: bool,
+        profile_plot_style: object | None = None,
+    ) -> AtlasExportPlan:
+        return AtlasExportPlan(
+            output_path=output_path,
+            pre_export_tile_mode=pre_export_tile_mode,
+            preset_name=preset_name,
+            access_token=access_token,
+            style_owner=style_owner,
+            style_id=style_id,
+            background_enabled=background_enabled,
+            profile_plot_style=profile_plot_style,
+        )
+
+    @staticmethod
     def build_request(
         atlas_layer,
         output_path: str,
@@ -89,10 +125,8 @@ class AtlasExportService:
         background_enabled: bool,
         profile_plot_style: object | None = None,
     ) -> GenerateAtlasPdfRequest:
-        return GenerateAtlasPdfRequest(
-            atlas_layer=atlas_layer,
+        plan = AtlasExportService.build_plan(
             output_path=output_path,
-            on_finished=on_finished,
             pre_export_tile_mode=pre_export_tile_mode,
             preset_name=preset_name,
             access_token=access_token,
@@ -100,6 +134,31 @@ class AtlasExportService:
             style_id=style_id,
             background_enabled=background_enabled,
             profile_plot_style=profile_plot_style,
+        )
+        return AtlasExportService.build_request_from_plan(
+            plan=plan,
+            atlas_layer=atlas_layer,
+            on_finished=on_finished,
+        )
+
+    @staticmethod
+    def build_request_from_plan(
+        *,
+        plan: AtlasExportPlan,
+        atlas_layer,
+        on_finished: Callable | None,
+    ) -> GenerateAtlasPdfRequest:
+        return GenerateAtlasPdfRequest(
+            atlas_layer=atlas_layer,
+            output_path=plan.output_path,
+            on_finished=on_finished,
+            pre_export_tile_mode=plan.pre_export_tile_mode,
+            preset_name=plan.preset_name,
+            access_token=plan.access_token,
+            style_owner=plan.style_owner,
+            style_id=plan.style_id,
+            background_enabled=plan.background_enabled,
+            profile_plot_style=plan.profile_plot_style,
         )
 
     def prepare_basemap_for_export(

--- a/atlas/export_use_case.py
+++ b/atlas/export_use_case.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass
 from typing import Callable
 
 from .export_controller import AtlasExportValidationError
-from .export_service import AtlasExportResult, AtlasExportService, GenerateAtlasPdfRequest
+from .export_service import (
+    AtlasExportPlan,
+    AtlasExportResult,
+    AtlasExportService,
+    GenerateAtlasPdfRequest,
+)
 
 
 @dataclass(frozen=True)
@@ -27,7 +32,7 @@ class GenerateAtlasPdfCommand:
 class PrepareAtlasPdfExportResult:
     """Structured outcome of validating and preparing atlas export startup."""
 
-    request: GenerateAtlasPdfRequest | None = None
+    plan: AtlasExportPlan | None = None
     output_path: str = ""
     path_changed: bool = False
     error_title: str | None = None
@@ -37,7 +42,7 @@ class PrepareAtlasPdfExportResult:
 
     @property
     def is_ready(self) -> bool:
-        return self.request is not None and self.error_message is None
+        return self.plan is not None and self.error_message is None
 
 
 class AtlasExportUseCase:
@@ -84,10 +89,8 @@ class AtlasExportUseCase:
                 main_status="Atlas PDF export unavailable.",
             )
 
-        request = self.service.build_request(
-            atlas_layer=command.atlas_layer,
+        plan = self.service.build_plan(
             output_path=output_path,
-            on_finished=command.on_finished,
             pre_export_tile_mode=command.pre_export_tile_mode,
             preset_name=command.preset_name,
             access_token=command.access_token,
@@ -97,17 +100,22 @@ class AtlasExportUseCase:
             profile_plot_style=command.profile_plot_style,
         )
         return PrepareAtlasPdfExportResult(
-            request=request,
+            plan=plan,
             output_path=output_path,
             path_changed=changed,
         )
 
-    def start_export(self, prepared: PrepareAtlasPdfExportResult):
-        if not prepared.is_ready or prepared.request is None:
+    def start_export(self, prepared: PrepareAtlasPdfExportResult, command: GenerateAtlasPdfCommand):
+        if not prepared.is_ready or prepared.plan is None:
             raise ValueError("prepare_export() must succeed before start_export().")
 
-        self.service.prepare_basemap_for_export(prepared.request)
-        return self.service.build_task(prepared.request)
+        request = self.service.build_request_from_plan(
+            plan=prepared.plan,
+            atlas_layer=command.atlas_layer,
+            on_finished=command.on_finished,
+        )
+        self.service.prepare_basemap_for_export(request)
+        return self.service.build_task(request)
 
     def finish_export(
         self,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1122,7 +1122,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self._save_settings()
-        self._atlas_export_task = self.atlas_export_use_case.start_export(prepared_export)
+        self._atlas_export_task = self.atlas_export_use_case.start_export(
+            prepared_export,
+            export_command,
+        )
 
         self._set_atlas_export_running(True)
         self._set_atlas_pdf_status(

--- a/tests/test_atlas_export_service.py
+++ b/tests/test_atlas_export_service.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from tests import _path  # noqa: F401
 
 from qfit.atlas.export_service import (
+    AtlasExportPlan,
     AtlasExportResult,
     AtlasExportService,
     GenerateAtlasPdfRequest,
@@ -234,6 +235,21 @@ class BuildTaskTests(unittest.TestCase):
 
 
 class AtlasExportRequestContractTests(unittest.TestCase):
+    def test_build_plan_returns_dataclass(self):
+        plan = AtlasExportService.build_plan(
+            output_path="/tmp/atlas.pdf",
+            pre_export_tile_mode="Raster",
+            preset_name="Dark",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="dark-v11",
+            background_enabled=True,
+        )
+
+        self.assertIsInstance(plan, AtlasExportPlan)
+        self.assertEqual(plan.output_path, "/tmp/atlas.pdf")
+        self.assertTrue(plan.background_enabled)
+
     def test_build_request_returns_dataclass(self):
         request = AtlasExportService.build_request(
             atlas_layer=MagicMock(),
@@ -268,3 +284,24 @@ class AtlasExportRequestContractTests(unittest.TestCase):
         )
 
         self.assertIs(request.profile_plot_style, style)
+
+    def test_build_request_from_plan_returns_dataclass(self):
+        plan = AtlasExportService.build_plan(
+            output_path="/tmp/atlas.pdf",
+            pre_export_tile_mode="Raster",
+            preset_name="Dark",
+            access_token="tok",
+            style_owner="mapbox",
+            style_id="dark-v11",
+            background_enabled=True,
+        )
+
+        request = AtlasExportService.build_request_from_plan(
+            plan=plan,
+            atlas_layer=MagicMock(),
+            on_finished=MagicMock(),
+        )
+
+        self.assertIsInstance(request, GenerateAtlasPdfRequest)
+        self.assertEqual(request.output_path, "/tmp/atlas.pdf")
+        self.assertTrue(request.background_enabled)

--- a/tests/test_atlas_export_use_case.py
+++ b/tests/test_atlas_export_use_case.py
@@ -60,13 +60,13 @@ class AtlasExportUseCaseTests(unittest.TestCase):
         self.assertEqual(result.error_message, "pypdf missing")
         self.assertEqual(result.pdf_status, "Atlas PDF export unavailable.")
         self.assertEqual(result.main_status, "Atlas PDF export unavailable.")
-        self.service.build_request.assert_not_called()
+        self.service.build_plan.assert_not_called()
 
-    def test_prepare_export_builds_request_on_success(self):
-        request = object()
+    def test_prepare_export_builds_plan_on_success(self):
+        plan = object()
         self.controller.normalize_pdf_path.return_value = ("/tmp/atlas.pdf", True)
         self.service.check_pdf_export_prerequisites.return_value = None
-        self.service.build_request.return_value = request
+        self.service.build_plan.return_value = plan
 
         command = GenerateAtlasPdfCommand(
             atlas_layer=object(),
@@ -83,13 +83,11 @@ class AtlasExportUseCaseTests(unittest.TestCase):
         result = self.use_case.prepare_export(command)
 
         self.assertTrue(result.is_ready)
-        self.assertIs(result.request, request)
+        self.assertIs(result.plan, plan)
         self.assertEqual(result.output_path, "/tmp/atlas.pdf")
         self.assertTrue(result.path_changed)
-        self.service.build_request.assert_called_once_with(
-            atlas_layer=command.atlas_layer,
+        self.service.build_plan.assert_called_once_with(
             output_path="/tmp/atlas.pdf",
-            on_finished=command.on_finished,
             pre_export_tile_mode="Raster",
             preset_name="Outdoor",
             access_token="tok",
@@ -100,20 +98,28 @@ class AtlasExportUseCaseTests(unittest.TestCase):
         )
 
     def test_start_export_prepares_basemap_and_builds_task(self):
+        plan = object()
         request = object()
         task = object()
+        self.service.build_request_from_plan.return_value = request
         self.service.build_task.return_value = task
-        prepared = PrepareAtlasPdfExportResult(request=request, output_path="/tmp/atlas.pdf")
+        prepared = PrepareAtlasPdfExportResult(plan=plan, output_path="/tmp/atlas.pdf")
+        command = GenerateAtlasPdfCommand(atlas_layer=object(), on_finished=MagicMock())
 
-        result = self.use_case.start_export(prepared)
+        result = self.use_case.start_export(prepared, command)
 
         self.assertIs(result, task)
+        self.service.build_request_from_plan.assert_called_once_with(
+            plan=plan,
+            atlas_layer=command.atlas_layer,
+            on_finished=command.on_finished,
+        )
         self.service.prepare_basemap_for_export.assert_called_once_with(request)
         self.service.build_task.assert_called_once_with(request)
 
-    def test_start_export_requires_prepared_request(self):
+    def test_start_export_requires_prepared_plan(self):
         with self.assertRaises(ValueError):
-            self.use_case.start_export(PrepareAtlasPdfExportResult())
+            self.use_case.start_export(PrepareAtlasPdfExportResult(), GenerateAtlasPdfCommand())
 
     def test_finish_export_delegates_to_service(self):
         final_result = AtlasExportResult(output_path="/tmp/atlas.pdf", page_count=2)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -482,7 +482,10 @@ class QgisSmokeTests(unittest.TestCase):
             build_style.assert_called_once_with(dock.settings)
             export_command = dock.atlas_export_use_case.prepare_export.call_args.args[0]
             self.assertEqual(export_command.profile_plot_style, "style-override")
-            dock.atlas_export_use_case.start_export.assert_called_once_with(prepared_export)
+            dock.atlas_export_use_case.start_export.assert_called_once_with(
+                prepared_export,
+                export_command,
+            )
             task_manager.return_value.addTask.assert_called_once_with(fake_task)
         finally:
             dock.close()


### PR DESCRIPTION
## Summary
- introduce an explicit `AtlasExportPlan` so atlas export planning is separated from QGIS runtime execution
- update the atlas export use case to prepare a plan first, then build the execution request only when starting the export task
- keep the dock widget flow intact while adding focused tests for the new planning seam

## Tests
- `python3 -m pytest tests/test_atlas_export_service.py tests/test_atlas_export_use_case.py tests/test_qgis_smoke.py -q --tb=short -k 'atlas_export or generate_atlas_pdf'`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive, but export-path behavior was revalidated through atlas export smoke coverage.

Closes #320