### PR TITLE
Refactor #321: add atlas cover composer seam

### DIFF
--- a/atlas/cover_composer.py
+++ b/atlas/cover_composer.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+class AtlasCoverComposer:
+    """Dedicated seam for atlas cover-page composition."""
+
+    def build_layout(
+        self,
+        atlas_layer,
+        *,
+        project=None,
+        map_layers=None,
+        cover_data=None,
+    ):
+        from .export_task import build_cover_layout
+
+        return build_cover_layout(
+            atlas_layer,
+            project=project,
+            map_layers=map_layers,
+            cover_data=cover_data,
+        )

--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -29,7 +29,11 @@ import logging
 import os
 from dataclasses import dataclass
 
+from .cover_composer import AtlasCoverComposer
+
 logger = logging.getLogger(__name__)
+
+_DEFAULT_COVER_COMPOSER = AtlasCoverComposer()
 
 
 def _format_unexpected_export_error(exc: Exception) -> str:
@@ -56,6 +60,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QFont
 
 from ..activity_classification import ordered_canonical_activity_labels
+from .cover_composer import AtlasCoverComposer
 from .profile_item import (
     NativeProfileItemConfig,
     atlas_layer_supports_native_profile_atlas,
@@ -1221,6 +1226,7 @@ class AtlasExportTask(QgsTask):
         atlas_layer,
         output_path: str,
         project=None,
+        cover_composer=_DEFAULT_COVER_COMPOSER,
     ) -> str | None:
         """Export a single cover-page PDF and return its path, or None on failure."""
         return export_cover_page(
@@ -1230,7 +1236,7 @@ class AtlasExportTask(QgsTask):
             get_project_instance=QgsProject.instance,
             build_cover_data=_build_cover_summary_from_current_atlas_features,
             apply_cover_heatmap_renderer=_apply_cover_heatmap_renderer,
-            build_cover_layout_fn=build_cover_layout,
+            build_cover_layout_fn=cover_composer.build_layout,
             layout_exporter_cls=QgsLayoutExporter,
             logger=logger,
         )

--- a/tests/test_cover_composer.py
+++ b/tests/test_cover_composer.py
@@ -1,0 +1,34 @@
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+from tests import _path  # noqa: F401
+from qfit.atlas.cover_composer import AtlasCoverComposer
+
+
+class TestAtlasCoverComposer(unittest.TestCase):
+    def test_build_layout_delegates_to_export_task_builder(self):
+        fake_module = ModuleType("qfit.atlas.export_task")
+        fake_builder = MagicMock(return_value="layout")
+        fake_module.build_cover_layout = fake_builder
+
+        with patch.dict(sys.modules, {"qfit.atlas.export_task": fake_module}):
+            result = AtlasCoverComposer().build_layout(
+                "atlas-layer",
+                project="project",
+                map_layers=["layer"],
+                cover_data={"title": "Atlas"},
+            )
+
+        self.assertEqual(result, "layout")
+        fake_builder.assert_called_once_with(
+            "atlas-layer",
+            project="project",
+            map_layers=["layer"],
+            cover_data={"title": "Atlas"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated `AtlasCoverComposer` seam for cover-page composition
- route atlas cover-page export through the composer seam while preserving current cover layout behavior
- add focused tests for the new cover-composer path and revalidate the atlas export flow

## Tests
- `python3 -m pytest tests/test_cover_composer.py tests/test_atlas_export_use_case.py tests/test_qgis_smoke.py -q --tb=short -k 'cover or atlas_export or generate_atlas_pdf'`
- `python3 -m pytest tests/test_atlas_export_task.py -q --tb=short -k 'cover'`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive, but the atlas cover/export path was revalidated through focused export-task and smoke coverage.

Closes #321