### PR TITLE
Test #323: add dock and atlas boundary coverage

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -60,7 +60,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QFont
 
 from ..activity_classification import ordered_canonical_activity_labels
-from .cover_composer import AtlasCoverComposer
+from .layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .profile_item import (
     NativeProfileItemConfig,
     atlas_layer_supports_native_profile_atlas,
@@ -141,7 +141,6 @@ MAP_Y = MARGIN_MM + HEADER_HEIGHT_MM + HEADER_GAP_MM
 MAP_W = (PAGE_WIDTH_MM - 2 * MARGIN_MM) * 0.90          # 10% smaller than full usable width
 MAP_H = MAP_W                                            # square
 MAP_X = (PAGE_WIDTH_MM - MAP_W) / 2.0                    # centered horizontally
-BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO = MAP_W / MAP_H   # 1.0
 
 # Profile area: reserved below the map for route profile content
 PROFILE_X = MAP_X

--- a/atlas/layout_metrics.py
+++ b/atlas/layout_metrics.py
@@ -1,0 +1,3 @@
+"""Lightweight atlas layout metrics shared across planning and UI code."""
+
+BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO = 1.0

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -68,7 +68,7 @@ from .mapbox_config import (
     preset_requires_custom_style,
 )
 from .visualization.application import BackgroundConfig, LayerRefs
-from .atlas.export_task import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
+from .atlas.layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_provider import StravaProvider
 from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -238,10 +238,9 @@ class ModuleScopeImportBoundaryTests(unittest.TestCase):
             imports,
             "QfitDockWidget should stay on the atlas use-case boundary instead of importing the QGIS export runtime directly.",
         )
-        self.assertNotIn(
-            ".atlas.export_task.AtlasExportTask",
-            imports,
-            "QfitDockWidget should not depend directly on the QGIS-heavy atlas export task.",
+        self.assertFalse(
+            any(target.startswith(".atlas.export_task") for target in imports),
+            "QfitDockWidget should not import from the QGIS-heavy atlas export task module at import time.",
         )
 
     def test_ui_dependency_builder_keeps_qgis_layer_gateway_import_lazy(self):


### PR DESCRIPTION
## Summary
- strengthen architecture-boundary tests around the dock widget and atlas planning/runtime seams
- assert that the new atlas cover composer keeps its export-task dependency lazy
- update the top-level Python module allowlist to match the retired provider root shims

## Tests
- `python3 -m pytest tests/test_architecture_boundaries.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive.

Closes #323