### PR TITLE
Refactor #324: add activity selection state

### DIFF
--- a/activities/application/__init__.py
+++ b/activities/application/__init__.py
@@ -1,10 +1,10 @@
-"""Activity workflow services and task helpers."""
+"""Activity workflow services and task helpers.
 
-from .activity_selection_state import ActivitySelectionState
-from .fetch_result_service import FetchActivitiesRequest, FetchResult, FetchResultService
-from .fetch_task import FetchTask
-from .load_workflow import LoadDatabaseRequest, LoadDatasetRequest, LoadExistingRequest, LoadResult, LoadWorkflowError, LoadWorkflowService, StoreActivitiesRequest
-from .sync_controller import BuildStravaProviderRequest, SyncController
+This package keeps its public re-exports lazy so pure-Python consumers can
+import lightweight application models without pulling in QGIS task modules.
+"""
+
+from importlib import import_module
 
 __all__ = [
     "ActivitySelectionState",
@@ -22,3 +22,31 @@ __all__ = [
     "StoreActivitiesRequest",
     "SyncController",
 ]
+
+_EXPORTS = {
+    "ActivitySelectionState": (".activity_selection_state", "ActivitySelectionState"),
+    "BuildStravaProviderRequest": (".sync_controller", "BuildStravaProviderRequest"),
+    "FetchActivitiesRequest": (".fetch_result_service", "FetchActivitiesRequest"),
+    "FetchResult": (".fetch_result_service", "FetchResult"),
+    "FetchResultService": (".fetch_result_service", "FetchResultService"),
+    "FetchTask": (".fetch_task", "FetchTask"),
+    "LoadDatabaseRequest": (".load_workflow", "LoadDatabaseRequest"),
+    "LoadDatasetRequest": (".load_workflow", "LoadDatasetRequest"),
+    "LoadExistingRequest": (".load_workflow", "LoadExistingRequest"),
+    "LoadResult": (".load_workflow", "LoadResult"),
+    "LoadWorkflowError": (".load_workflow", "LoadWorkflowError"),
+    "LoadWorkflowService": (".load_workflow", "LoadWorkflowService"),
+    "StoreActivitiesRequest": (".load_workflow", "StoreActivitiesRequest"),
+    "SyncController": (".sync_controller", "SyncController"),
+}
+
+
+def __getattr__(name):
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attr_name = _EXPORTS[name]
+    module = import_module(module_name, __name__)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/activities/application/__init__.py
+++ b/activities/application/__init__.py
@@ -1,11 +1,13 @@
 """Activity workflow services and task helpers."""
 
+from .activity_selection_state import ActivitySelectionState
 from .fetch_result_service import FetchActivitiesRequest, FetchResult, FetchResultService
 from .fetch_task import FetchTask
 from .load_workflow import LoadDatabaseRequest, LoadDatasetRequest, LoadExistingRequest, LoadResult, LoadWorkflowError, LoadWorkflowService, StoreActivitiesRequest
 from .sync_controller import BuildStravaProviderRequest, SyncController
 
 __all__ = [
+    "ActivitySelectionState",
     "BuildStravaProviderRequest",
     "FetchActivitiesRequest",
     "FetchResult",

--- a/activities/application/activity_selection_state.py
+++ b/activities/application/activity_selection_state.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from ..domain.activity_query import ActivityQuery, filter_activities
+
+
+@dataclass(frozen=True)
+class ActivitySelectionState:
+    """Reusable application model for the current effective activity subset."""
+
+    query: ActivityQuery = field(default_factory=ActivityQuery)
+    filtered_count: int = 0
+
+    @classmethod
+    def from_activities(
+        cls,
+        activities: Iterable[object],
+        query: ActivityQuery | None = None,
+    ) -> "ActivitySelectionState":
+        normalized_query = query if query is not None else ActivityQuery()
+        return cls(
+            query=normalized_query,
+            filtered_count=len(filter_activities(activities, normalized_query)),
+        )
+

--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from ...activities.application.activity_selection_state import ActivitySelectionState
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
 
@@ -9,6 +11,7 @@ FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
 class RunAnalysisRequest:
     analysis_mode: str = ""
     starts_layer: object = None
+    selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
 
 
 @dataclass(frozen=True)
@@ -21,10 +24,15 @@ class AnalysisController:
     """Coordinates dock-triggered analysis workflows behind a small seam."""
 
     @staticmethod
-    def build_request(analysis_mode: str, starts_layer: object) -> RunAnalysisRequest:
+    def build_request(
+        analysis_mode: str,
+        starts_layer: object,
+        selection_state: ActivitySelectionState | None = None,
+    ) -> RunAnalysisRequest:
         return RunAnalysisRequest(
             analysis_mode=analysis_mode or "",
             starts_layer=starts_layer,
+            selection_state=selection_state or ActivitySelectionState(),
         )
 
     def run(self, request: RunAnalysisRequest | None = None, **legacy_kwargs) -> RunAnalysisResult:

--- a/atlas/export_use_case.py
+++ b/atlas/export_use_case.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable
 
+from ..activities.application.activity_selection_state import ActivitySelectionState
 from .export_controller import AtlasExportValidationError
 from .export_service import (
     AtlasExportPlan,
@@ -17,6 +18,7 @@ class GenerateAtlasPdfCommand:
     """Application-layer command for starting atlas PDF export."""
 
     atlas_layer: object = None
+    selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
     output_path: str = ""
     on_finished: Callable | None = None
     pre_export_tile_mode: str = ""

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -38,6 +38,7 @@ from .activities.domain.activity_query import (
     sort_activities,
     summarize_activities,
 )
+from .activities.application.activity_selection_state import ActivitySelectionState
 from .activities.application.load_workflow import LoadWorkflowError
 from .activities.application.store_task import build_store_task
 from .analysis.infrastructure.frequent_start_points_layer import (
@@ -890,8 +891,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(result.status)
 
     def _build_visual_workflow_action(self, action_type):
-        filtered_activities = self._filtered_activities()
-        query = self._current_activity_query()
+        selection_state = self._current_activity_selection_state()
 
         return action_type(
             layers=LayerRefs(
@@ -900,7 +900,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 points=self.points_layer,
                 atlas=self.atlas_layer,
             ),
-            query=query,
+            selection_state=selection_state,
             style_preset=self.stylePresetComboBox.currentText(),
             temporal_mode=self.temporalModeComboBox.currentText(),
             background_config=BackgroundConfig(
@@ -912,15 +912,15 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 tile_mode=self.tileModeComboBox.currentText(),
             ),
             apply_subset_filters=True,
-            filtered_count=len(filtered_activities),
             analysis_mode=self.analysisModeComboBox.currentText(),
             starts_layer=self.starts_layer,
         )
 
-    def _run_selected_analysis(self, analysis_mode, starts_layer):
+    def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
         request = self.analysis_controller.build_request(
             analysis_mode=analysis_mode,
             starts_layer=starts_layer,
+            selection_state=selection_state,
         )
         result = self.analysis_controller.run_request(request)
         if result.layer is None:
@@ -950,7 +950,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         current_starts_layer = (
             starts_layer if starts_layer is not None else getattr(self, "starts_layer", None)
         )
-        return self._run_selected_analysis(current_mode, current_starts_layer)
+        return self._run_selected_analysis(
+            current_mode,
+            current_starts_layer,
+            self._current_activity_selection_state(),
+        )
 
     def _clear_analysis_layer(self):
         project = QgsProject.instance()
@@ -969,8 +973,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             except RuntimeError:
                 logger.debug("Failed to remove stale frequent-start analysis layer", exc_info=True)
 
-    def _current_activity_query(self):
-        return ActivityQuery(
+    def _current_activity_selection_state(self):
+        query = ActivityQuery(
             activity_type=self.activityTypeComboBox.currentText() or "All",
             date_from=self.dateFromEdit.date().toString("yyyy-MM-dd") if self.dateFromEdit.date().isValid() else None,
             date_to=self.dateToEdit.date().toString("yyyy-MM-dd") if self.dateToEdit.date().isValid() else None,
@@ -980,6 +984,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             detailed_route_filter=self.detailedRouteStatusComboBox.currentData(),
             sort_label=self.previewSortComboBox.currentText() or DEFAULT_SORT_LABEL,
         )
+        return ActivitySelectionState.from_activities(self.activities, query)
+
+    def _current_activity_query(self):
+        return self._current_activity_selection_state().query
 
     def _refresh_activity_preview(self):
         if not self.activities:
@@ -989,13 +997,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         fetched_activities = sort_activities(self.activities, DEFAULT_SORT_LABEL)
         summary = summarize_activities(fetched_activities)
+        selection_state = self._current_activity_selection_state()
 
         query_summary = format_summary_text(summary)
-        filtered_count = len(self._filtered_activities())
-        if filtered_count != len(self.activities):
+        if selection_state.filtered_count != len(self.activities):
             query_summary = (
                 f"{query_summary}\n"
-                f"Visualize filters currently match {filtered_count} activities."
+                f"Visualize filters currently match {selection_state.filtered_count} activities."
             )
         self.querySummaryLabel.setText(query_summary)
 
@@ -1006,7 +1014,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return fetched_activities
 
     def _filtered_activities(self):
-        return filter_activities(self.activities, self._current_activity_query())
+        return filter_activities(self.activities, self._current_activity_selection_state().query)
 
 
     def _redirect_uri(self):
@@ -1100,6 +1108,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         export_command = self.atlas_export_use_case.build_command(
             atlas_layer=self.atlas_layer,
+            selection_state=self._current_activity_selection_state(),
             output_path=self.atlasPdfPathLineEdit.text().strip(),
             on_finished=self._on_atlas_export_finished,
             pre_export_tile_mode=self.tileModeComboBox.currentText(),

--- a/tests/test_activity_selection_state.py
+++ b/tests/test_activity_selection_state.py
@@ -1,0 +1,45 @@
+import unittest
+from dataclasses import dataclass
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
+
+
+@dataclass
+class _Activity:
+    name: str
+    activity_type: str
+    sport_type: str | None = None
+    start_date_local: str = "2026-04-07T08:00:00Z"
+    distance_km: float = 10.0
+    moving_time_s: int = 3600
+    geometry_source: str = "stream"
+
+
+class TestActivitySelectionState(unittest.TestCase):
+    def test_from_activities_uses_query_to_count_matching_subset(self):
+        activities = [
+            _Activity(name="Morning Ride", activity_type="Ride"),
+            _Activity(name="Lunch Run", activity_type="Run"),
+            _Activity(name="Evening Ride", activity_type="Ride"),
+        ]
+        query = ActivityQuery(activity_type="Ride", search_text="ride")
+
+        state = ActivitySelectionState.from_activities(activities, query)
+
+        self.assertIs(state.query, query)
+        self.assertEqual(state.filtered_count, 2)
+
+    def test_from_activities_defaults_to_empty_query(self):
+        activities = [_Activity(name="Morning Ride", activity_type="Ride")]
+
+        state = ActivitySelectionState.from_activities(activities)
+
+        self.assertIsInstance(state.query, ActivityQuery)
+        self.assertEqual(state.filtered_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import patch
 
 from tests import _path  # noqa: F401
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.analysis.application.analysis_controller import (
     AnalysisController,
     FREQUENT_STARTING_POINTS_MODE,
@@ -17,6 +19,13 @@ class TestAnalysisController(unittest.TestCase):
 
         self.assertEqual(request.analysis_mode, "None")
         self.assertEqual(request.starts_layer, "starts-layer")
+
+    def test_build_request_keeps_selection_state(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
+
+        request = self.controller.build_request("None", "starts-layer", selection_state)
+
+        self.assertIs(request.selection_state, selection_state)
 
     def test_run_request_returns_empty_result_for_non_matching_mode(self):
         request = self.controller.build_request("None", object())

--- a/tests/test_atlas_export_use_case.py
+++ b/tests/test_atlas_export_use_case.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
 
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.atlas.export_controller import AtlasExportValidationError
 from qfit.atlas.export_service import AtlasExportResult
 from qfit.atlas.export_use_case import (
@@ -19,11 +21,17 @@ class AtlasExportUseCaseTests(unittest.TestCase):
         self.use_case = AtlasExportUseCase(self.controller, self.service)
 
     def test_build_command_returns_dataclass(self):
-        command = self.use_case.build_command(output_path="/tmp/atlas.pdf", background_enabled=True)
+        selection_state = ActivitySelectionState(query=ActivityQuery(search_text="ride"), filtered_count=7)
+        command = self.use_case.build_command(
+            output_path="/tmp/atlas.pdf",
+            background_enabled=True,
+            selection_state=selection_state,
+        )
 
         self.assertIsInstance(command, GenerateAtlasPdfCommand)
         self.assertEqual(command.output_path, "/tmp/atlas.pdf")
         self.assertTrue(command.background_enabled)
+        self.assertIs(command.selection_state, selection_state)
 
     def test_prepare_export_returns_validation_error_when_layer_invalid(self):
         self.controller.validate_atlas_layer.side_effect = AtlasExportValidationError("missing layer")

--- a/tests/test_dock_action_dispatcher.py
+++ b/tests/test_dock_action_dispatcher.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
 from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.ui.application import (
     ApplyVisualizationAction,
@@ -30,13 +31,13 @@ class TestDockActionDispatcher(unittest.TestCase):
             run_analysis=run_analysis,
         )
         starts_layer = object()
+        selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=3)
         action = ApplyVisualizationAction(
             layers=LayerRefs(activities=object(), starts=starts_layer),
-            query=ActivityQuery(),
+            selection_state=selection_state,
             style_preset="By activity type",
             temporal_mode="By month",
             background_config=BackgroundConfig(enabled=True, preset_name="Outdoors"),
-            filtered_count=3,
             analysis_mode="Most frequent starting points",
             starts_layer=starts_layer,
             apply_subset_filters=False,
@@ -47,17 +48,17 @@ class TestDockActionDispatcher(unittest.TestCase):
         save_settings.assert_called_once_with()
         visual_apply.build_request.assert_called_once_with(
             layers=action.layers,
-            query=action.query,
+            selection_state=selection_state,
             style_preset="By activity type",
             temporal_mode="By month",
             background_config=action.background_config,
             apply_subset_filters=False,
-            filtered_count=3,
         )
         visual_apply.apply_request.assert_called_once_with("request")
         run_analysis.assert_called_once_with(
             "Most frequent starting points",
             starts_layer,
+            selection_state,
         )
         self.assertEqual(
             result.status,
@@ -85,11 +86,10 @@ class TestDockActionDispatcher(unittest.TestCase):
         )
         action = RunAnalysisAction(
             layers=LayerRefs(activities=object()),
-            query=ActivityQuery(),
+            selection_state=ActivitySelectionState(query=ActivityQuery(), filtered_count=1),
             style_preset="By activity type",
             temporal_mode="By month",
             background_config=BackgroundConfig(),
-            filtered_count=1,
             analysis_mode="None",
             apply_subset_filters=True,
         )

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -379,9 +379,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.starts_layer = "starts"
         dock.points_layer = "points"
         dock.atlas_layer = "atlas"
-        dock._filtered_activities = MagicMock(return_value=[1, 2, 3])
-        query = object()
-        dock._current_activity_query = MagicMock(return_value=query)
+        selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=3)
+        dock._current_activity_selection_state = MagicMock(return_value=selection_state)
         dock.stylePresetComboBox = _FakeComboBox(current_text="By activity type")
         dock.temporalModeComboBox = _FakeComboBox(current_text="By month")
         dock.backgroundMapCheckBox = _FakeCheckBox(True)
@@ -400,7 +399,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIsInstance(action, self.module.ApplyVisualizationAction)
         self.assertEqual(action.layers.activities, "activities")
         self.assertEqual(action.layers.starts, "starts")
-        self.assertIs(action.query, query)
+        self.assertIs(action.selection_state, selection_state)
+        self.assertIs(action.query, selection_state.query)
         self.assertEqual(action.filtered_count, 3)
         self.assertEqual(action.analysis_mode, "Most frequent starting points")
         self.assertEqual(action.background_config.access_token, "token")
@@ -414,17 +414,20 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             status="Showing top 2 frequent starting-point clusters",
             layer=None,
         )
+        selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
         result = self.module.QfitDockWidget._run_selected_analysis(
             dock,
             "Most frequent starting points",
             "starts-layer",
+            selection_state,
         )
 
         self.assertEqual(result, "Showing top 2 frequent starting-point clusters")
         dock.analysis_controller.build_request.assert_called_once_with(
             analysis_mode="Most frequent starting points",
             starts_layer="starts-layer",
+            selection_state=selection_state,
         )
         dock.analysis_controller.run_request.assert_called_once_with("analysis-request")
 
@@ -438,12 +441,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             layer=analysis_layer,
         )
         project = _FakeProject()
+        selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
         with patch.object(self.module.QgsProject, "instance", return_value=project):
             status = self.module.QfitDockWidget._run_selected_analysis(
                 dock,
                 "Most frequent starting points",
                 "starts-layer",
+                selection_state,
             )
 
         self.assertEqual(status, "Showing top 2 frequent starting-point clusters")
@@ -455,11 +460,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock = object.__new__(self.module.QfitDockWidget)
         action = self.module.ApplyVisualizationAction(
             layers=self.module.LayerRefs(activities="activities"),
-            query=object(),
+            selection_state=self.module.ActivitySelectionState(query=object(), filtered_count=1),
             style_preset="By activity type",
             temporal_mode="By month",
             background_config=self.module.BackgroundConfig(),
-            filtered_count=1,
             analysis_mode="None",
             apply_subset_filters=True,
         )
@@ -486,6 +490,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.starts_layer = "starts-layer"
         dock._clear_analysis_layer = MagicMock()
         dock._run_selected_analysis = MagicMock(return_value="status")
+        selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
+        dock._current_activity_selection_state = MagicMock(return_value=selection_state)
 
         status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
 
@@ -494,6 +500,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._run_selected_analysis.assert_called_once_with(
             "Most frequent starting points",
             "starts-layer",
+            selection_state,
         )
 
     def test_apply_analysis_configuration_defaults_missing_starts_layer_to_none(self):
@@ -501,6 +508,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")
         dock._clear_analysis_layer = MagicMock()
         dock._run_selected_analysis = MagicMock(return_value="")
+        selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=0)
+        dock._current_activity_selection_state = MagicMock(return_value=selection_state)
 
         status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
 
@@ -508,6 +517,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._run_selected_analysis.assert_called_once_with(
             "Most frequent starting points",
             None,
+            selection_state,
         )
 
     def test_clear_analysis_layer_removes_current_and_stale_project_layers(self):

--- a/ui/application/dock_action_dispatcher.py
+++ b/ui/application/dock_action_dispatcher.py
@@ -1,21 +1,28 @@
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from ...activities.domain.activity_query import ActivityQuery
+from ...activities.application.activity_selection_state import ActivitySelectionState
 from ...visualization.application import BackgroundConfig, LayerRefs, VisualApplyService
 
 
 @dataclass(frozen=True)
 class _BaseVisualWorkflowAction:
     layers: LayerRefs
-    query: ActivityQuery
+    selection_state: ActivitySelectionState
     style_preset: str
     temporal_mode: str
     background_config: BackgroundConfig
-    filtered_count: int
     analysis_mode: str
     starts_layer: object = None
     apply_subset_filters: bool = True
+
+    @property
+    def query(self):
+        return self.selection_state.query
+
+    @property
+    def filtered_count(self):
+        return self.selection_state.filtered_count
 
 
 @dataclass(frozen=True)
@@ -47,7 +54,7 @@ class DockActionDispatcher:
         *,
         visual_apply: VisualApplyService,
         save_settings: Callable[[], None],
-        run_analysis: Callable[[str, object], str],
+        run_analysis: Callable[[str, object, ActivitySelectionState], str],
     ) -> None:
         self.visual_apply = visual_apply
         self._save_settings = save_settings
@@ -68,12 +75,11 @@ class DockActionDispatcher:
         self._save_settings()
         request = self.visual_apply.build_request(
             layers=action.layers,
-            query=action.query,
+            selection_state=action.selection_state,
             style_preset=action.style_preset,
             temporal_mode=action.temporal_mode,
             background_config=action.background_config,
             apply_subset_filters=action.apply_subset_filters,
-            filtered_count=action.filtered_count,
         )
         visual_result = self.visual_apply.apply_request(request)
 
@@ -86,6 +92,7 @@ class DockActionDispatcher:
         analysis_status = self._run_analysis(
             action.analysis_mode,
             action.starts_layer,
+            action.selection_state,
         )
         return DockActionResult(
             status=self._combine_statuses(visual_result.status, analysis_status),

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -1,6 +1,8 @@
 import logging
 from dataclasses import dataclass, field
 
+from ...activities.application.activity_selection_state import ActivitySelectionState
+from ...activities.domain.activity_query import ActivityQuery
 from ...mapbox_config import MapboxConfigError
 from .layer_gateway import LayerGateway
 
@@ -40,12 +42,19 @@ class ApplyVisualizationRequest:
     """Structured input for the visualization/apply workflow."""
 
     layers: LayerRefs = field(default_factory=LayerRefs)
-    query: object = None
+    selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
     style_preset: str = ""
     temporal_mode: str = ""
     background_config: BackgroundConfig = field(default_factory=BackgroundConfig)
     apply_subset_filters: bool = False
-    filtered_count: int = 0
+
+    @property
+    def query(self):
+        return self.selection_state.query
+
+    @property
+    def filtered_count(self):
+        return self.selection_state.filtered_count
 
 
 # Backward-compatible alias while the request-object migration lands incrementally.
@@ -79,21 +88,26 @@ class VisualApplyService:
     @staticmethod
     def build_request(
         layers,
-        query,
         style_preset,
         temporal_mode,
         background_config,
         apply_subset_filters,
-        filtered_count,
+        selection_state=None,
+        query=None,
+        filtered_count=0,
     ) -> ApplyVisualizationRequest:
+        if selection_state is None:
+            selection_state = ActivitySelectionState(
+                query=query if query is not None else ActivityQuery(),
+                filtered_count=filtered_count,
+            )
         return ApplyVisualizationRequest(
             layers=layers,
-            query=query,
+            selection_state=selection_state,
             style_preset=style_preset,
             temporal_mode=temporal_mode,
             background_config=background_config,
             apply_subset_filters=apply_subset_filters,
-            filtered_count=filtered_count,
         )
 
     def apply(self, request: ApplyVisualizationRequest | None = None, **legacy_kwargs):


### PR DESCRIPTION
## Summary
- add a reusable `ActivitySelectionState` application model for the current effective subset/query
- build that state once from the dock widget and reuse it across visualization, analysis, and atlas export request objects
- keep current behavior unchanged while adding focused regression coverage for the new shared state wiring

## Testing
- python3 -m pytest tests/test_activity_selection_state.py tests/test_dock_action_dispatcher.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_analysis_controller.py tests/test_atlas_export_use_case.py tests/test_visual_apply.py -q --tb=short
- python3 -m pytest tests/test_gpkg_atlas_page_builder.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short *(hits an existing order-dependent QGIS import harness error in `tests/test_gpkg_atlas_page_builder.py`; the same error reproduces with the #324-touched tests excluded, and that file passes in isolation)*

Closes #324