### PR TITLE
Test: tighten cover composer boundary guardrail

### DIFF
--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -225,10 +225,9 @@ class ModuleScopeImportBoundaryTests(unittest.TestCase):
 
     def test_atlas_cover_composer_keeps_export_task_import_lazy(self):
         imports = _module_scope_import_targets("atlas/cover_composer.py")
-        self.assertNotIn(
-            ".export_task.build_cover_layout",
-            imports,
-            "AtlasCoverComposer should keep the heavy export_task cover-layout import lazy.",
+        self.assertFalse(
+            any(target.startswith(".export_task") for target in imports),
+            "AtlasCoverComposer should keep the heavy export_task dependency lazy at module scope.",
         )
 
     def test_dock_widget_does_not_import_qgis_export_runtime_directly(self):


### PR DESCRIPTION
## Summary
- tighten the cover-composer architecture-boundary test so it rejects any module-scope `atlas.export_task` import, not just `build_cover_layout`
- follow up on Codex review from merged PR #334

## Tests
- `python3 -m pytest tests/test_architecture_boundaries.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
