### PR TITLE
Fix #337: remove obsolete feature timestamps from Analyze

### DIFF
--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -273,6 +273,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.analysisModeComboBox.currentText(), "None")
             self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
             self.assertEqual(dock.analysisModeLabel.parentWidget().parentWidget(), dock.analysisSectionContentWidget)
+            self.assertEqual(dock.temporalModeLabel.parentWidget().parentWidget(), dock.styleSectionContentWidget)
             temporal_mode_layout = dock.temporalModeLabel.parentWidget().layout()
             self.assertEqual(temporal_mode_layout.spacing(), 6)
             self.assertGreaterEqual(dock.temporalModeComboBox.minimumContentsLength(), 10)

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -26,6 +26,7 @@ class WorkflowSectionCoordinator:
         )
         self._move_store_section_under_fetch()
         self._move_load_layers_to_visualize()
+        self._move_temporal_controls_to_visualize()
         dock.outputGroupBox.setTitle("Store / database")
         dock.publishGroupBox.setCheckable(False)
         dock.publishSettingsWidget.setVisible(True)
@@ -190,3 +191,20 @@ class WorkflowSectionCoordinator:
         output_layout.removeWidget(dock.loadLayersButton)
         dock.loadLayersButton.setParent(dock.styleGroupBox)
         style_layout.insertWidget(0, dock.loadLayersButton)
+
+    def _move_temporal_controls_to_visualize(self) -> None:
+        dock = self.dock_widget
+        analysis_layout = getattr(dock, "analysisWorkflowLayout", None)
+        style_layout = getattr(dock, "styleGroupLayout", None)
+        temporal_row = getattr(dock, "analysisTemporalModeRow", None)
+        temporal_help = getattr(dock, "temporalHelpLabel", None)
+        if analysis_layout is None or style_layout is None or temporal_row is None or temporal_help is None:
+            return
+        if temporal_row.parent() is dock.styleGroupBox:
+            return
+        analysis_layout.removeWidget(temporal_row)
+        analysis_layout.removeWidget(temporal_help)
+        temporal_row.setParent(dock.styleGroupBox)
+        temporal_help.setParent(dock.styleGroupBox)
+        style_layout.addWidget(temporal_row)
+        style_layout.addWidget(temporal_help)


### PR DESCRIPTION
## Summary
- move the temporal playback controls out of the Analyze section and into Visualize
- keep temporal playback behavior and persisted settings unchanged
- add smoke coverage that the temporal control now lives under the Visualize section

Fixes #337.

## Tests
- `python3 -m pytest tests/test_qgis_smoke.py tests/test_contextual_help.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short` *(reported 936 passed, 139 skipped before the known host-side post-run SIGSEGV)*
