### PR TITLE
Fix #339: prefer vendored atlas export installs

### DIFF
--- a/atlas/qgis_export_runtime.py
+++ b/atlas/qgis_export_runtime.py
@@ -12,8 +12,8 @@ class QgisAtlasExportRuntime(AtlasExportRuntime):
             load_pdf_writer()
         except ImportError:
             return (
-                "Atlas PDF export requires the 'pypdf' runtime, but it is not available in this qfit install. "
-                "Reinstall/update the plugin so bundled dependencies are included, then try again."
+                "Atlas PDF export requires the bundled 'pypdf' runtime for qfit's current PDF assembly pipeline. "
+                "Install qfit with scripts/install_plugin.py --mode copy or use the packaged plugin zip so runtime dependencies are vendored."
             )
         return None
 

--- a/docs/qgis-testing.md
+++ b/docs/qgis-testing.md
@@ -21,17 +21,19 @@ If PyQGIS is not available in the current Python environment, the smoke test ski
 
 ## 1. Install the plugin into your QGIS profile
 
-For development, the easiest option is a symlinked install:
+For development and manual testing, use a copied install so qfit vendors runtime-only Python dependencies like `pypdf`:
+
+```bash
+python3 scripts/install_plugin.py --profile default --mode copy
+```
+
+If you specifically want a live symlinked install while iterating on UI code, you can still use:
 
 ```bash
 python3 scripts/install_plugin.py --profile default --mode symlink
 ```
 
-If you prefer a copied install instead of a symlink:
-
-```bash
-python3 scripts/install_plugin.py --profile default --mode copy
-```
+Note that symlink mode does **not** vendor runtime-only dependencies, so atlas PDF export may be unavailable there.
 
 Default Linux plugin target:
 - `~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/qfit`

--- a/scripts/install_plugin.py
+++ b/scripts/install_plugin.py
@@ -104,13 +104,22 @@ def main() -> int:
             print(f"Nothing to remove at {destination}")
         return 0
 
+    installed_mode = args.mode
     if args.mode == "copy":
-        install_copy(destination)
+        try:
+            install_copy(destination)
+        except RuntimeError as exc:
+            install_symlink(destination)
+            installed_mode = "symlink"
+            print(
+                "Warning: copy mode could not vendor runtime-only Python dependencies "
+                f"({exc}). Falling back to symlink mode."
+            )
     else:
         install_symlink(destination)
 
-    print(f"Installed {PLUGIN_NAME} to {destination} using mode={args.mode}")
-    if args.mode == "symlink":
+    print(f"Installed {PLUGIN_NAME} to {destination} using mode={installed_mode}")
+    if installed_mode == "symlink":
         print(
             "Warning: symlink mode does not vendor runtime-only Python dependencies like pypdf. "
             "Use --mode copy or the packaged plugin zip when you need atlas PDF export."

--- a/scripts/install_plugin.py
+++ b/scripts/install_plugin.py
@@ -80,8 +80,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--mode",
         choices=("symlink", "copy"),
-        default="symlink",
-        help="Install mode (default: symlink)",
+        default="copy",
+        help="Install mode (default: copy)",
     )
     parser.add_argument(
         "--remove",
@@ -110,6 +110,11 @@ def main() -> int:
         install_symlink(destination)
 
     print(f"Installed {PLUGIN_NAME} to {destination} using mode={args.mode}")
+    if args.mode == "symlink":
+        print(
+            "Warning: symlink mode does not vendor runtime-only Python dependencies like pypdf. "
+            "Use --mode copy or the packaged plugin zip when you need atlas PDF export."
+        )
     return 0
 
 

--- a/tests/test_install_plugin.py
+++ b/tests/test_install_plugin.py
@@ -43,6 +43,30 @@ class InstallPluginTests(unittest.TestCase):
             self.assertTrue((destination / "atlas" / "export_task.py").exists())
             vendor_runtime_dependencies.assert_called_once_with(destination)
 
+    def test_main_falls_back_to_symlink_when_copy_mode_cannot_vendor_dependencies(self):
+        plugins_dir = Path("/tmp/qgis-plugins")
+        destination = plugins_dir / install_plugin.PLUGIN_NAME
+        args = SimpleNamespace(profile="default", mode="copy", plugins_dir=None, remove=False)
+
+        with patch.object(install_plugin, "parse_args", return_value=args), patch.object(
+            install_plugin, "default_plugins_dir", return_value=plugins_dir
+        ), patch.object(install_plugin, "install_copy", side_effect=RuntimeError("missing pypdf dist")), patch.object(
+            install_plugin, "install_symlink"
+        ) as install_symlink, patch("builtins.print") as mock_print:
+            exit_code = install_plugin.main()
+
+        self.assertEqual(exit_code, 0)
+        install_symlink.assert_called_once_with(destination)
+        mock_print.assert_any_call(
+            "Warning: copy mode could not vendor runtime-only Python dependencies "
+            "(missing pypdf dist). Falling back to symlink mode."
+        )
+        mock_print.assert_any_call(f"Installed {install_plugin.PLUGIN_NAME} to {destination} using mode=symlink")
+        mock_print.assert_any_call(
+            "Warning: symlink mode does not vendor runtime-only Python dependencies like pypdf. "
+            "Use --mode copy or the packaged plugin zip when you need atlas PDF export."
+        )
+
     def test_main_warns_when_symlink_mode_skips_runtime_dependencies(self):
         plugins_dir = Path("/tmp/qgis-plugins")
         destination = plugins_dir / install_plugin.PLUGIN_NAME

--- a/tests/test_install_plugin.py
+++ b/tests/test_install_plugin.py
@@ -1,0 +1,68 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_SPEC = importlib.util.spec_from_file_location("qfit_install_plugin", _SCRIPTS_DIR / "install_plugin.py")
+install_plugin = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(install_plugin)
+
+
+class InstallPluginTests(unittest.TestCase):
+    def test_parse_args_defaults_to_copy_mode(self):
+        with patch.object(sys, "argv", ["install_plugin.py"]):
+            args = install_plugin.parse_args()
+
+        self.assertEqual(args.mode, "copy")
+        self.assertEqual(args.profile, "default")
+
+    def test_install_copy_vendors_runtime_dependencies(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "src"
+            destination = Path(temp_dir) / "dest"
+            root.mkdir()
+            (root / "metadata.txt").write_text("name=qfit\n", encoding="utf-8")
+            (root / "atlas").mkdir()
+            (root / "atlas" / "export_task.py").write_text("# atlas\n", encoding="utf-8")
+
+            with patch.object(install_plugin, "ROOT", root), patch.object(
+                install_plugin, "_vendor_runtime_dependencies"
+            ) as vendor_runtime_dependencies:
+                install_plugin.install_copy(destination)
+
+            self.assertTrue((destination / "metadata.txt").exists())
+            self.assertTrue((destination / "atlas" / "export_task.py").exists())
+            vendor_runtime_dependencies.assert_called_once_with(destination)
+
+    def test_main_warns_when_symlink_mode_skips_runtime_dependencies(self):
+        plugins_dir = Path("/tmp/qgis-plugins")
+        destination = plugins_dir / install_plugin.PLUGIN_NAME
+        args = SimpleNamespace(profile="default", mode="symlink", plugins_dir=None, remove=False)
+
+        with patch.object(install_plugin, "parse_args", return_value=args), patch.object(
+            install_plugin, "default_plugins_dir", return_value=plugins_dir
+        ), patch.object(install_plugin, "install_symlink") as install_symlink, patch(
+            "builtins.print"
+        ) as mock_print:
+            exit_code = install_plugin.main()
+
+        self.assertEqual(exit_code, 0)
+        install_symlink.assert_called_once_with(destination)
+        mock_print.assert_any_call(f"Installed {install_plugin.PLUGIN_NAME} to {destination} using mode=symlink")
+        mock_print.assert_any_call(
+            "Warning: symlink mode does not vendor runtime-only Python dependencies like pypdf. "
+            "Use --mode copy or the packaged plugin zip when you need atlas PDF export."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qgis_atlas_export_runtime.py
+++ b/tests/test_qgis_atlas_export_runtime.py
@@ -29,7 +29,8 @@ class QgisAtlasExportRuntimeTests(unittest.TestCase):
 
         self.assertIsNotNone(error)
         self.assertIn("pypdf", error)
-        self.assertIn("Reinstall/update the plugin", error)
+        self.assertIn("install_plugin.py --mode copy", error)
+        self.assertIn("packaged plugin zip", error)
 
     def test_build_task_constructs_atlas_export_task_with_correct_params(self):
         stub_module, mock_task = _make_atlas_task_stub()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -273,6 +273,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.analysisModeComboBox.currentText(), "None")
             self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
             self.assertEqual(dock.analysisModeLabel.parentWidget().parentWidget(), dock.analysisSectionContentWidget)
+            self.assertEqual(dock.temporalModeLabel.parentWidget().parentWidget(), dock.styleSectionContentWidget)
             temporal_mode_layout = dock.temporalModeLabel.parentWidget().layout()
             self.assertEqual(temporal_mode_layout.spacing(), 6)
             self.assertGreaterEqual(dock.temporalModeComboBox.minimumContentsLength(), 10)

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -26,6 +26,7 @@ class WorkflowSectionCoordinator:
         )
         self._move_store_section_under_fetch()
         self._move_load_layers_to_visualize()
+        self._move_temporal_controls_to_visualize()
         dock.outputGroupBox.setTitle("Store / database")
         dock.publishGroupBox.setCheckable(False)
         dock.publishSettingsWidget.setVisible(True)
@@ -190,3 +191,20 @@ class WorkflowSectionCoordinator:
         output_layout.removeWidget(dock.loadLayersButton)
         dock.loadLayersButton.setParent(dock.styleGroupBox)
         style_layout.insertWidget(0, dock.loadLayersButton)
+
+    def _move_temporal_controls_to_visualize(self) -> None:
+        dock = self.dock_widget
+        analysis_layout = getattr(dock, "analysisWorkflowLayout", None)
+        style_layout = getattr(dock, "styleGroupLayout", None)
+        temporal_row = getattr(dock, "analysisTemporalModeRow", None)
+        temporal_help = getattr(dock, "temporalHelpLabel", None)
+        if analysis_layout is None or style_layout is None or temporal_row is None or temporal_help is None:
+            return
+        if temporal_row.parent() is dock.styleGroupBox:
+            return
+        analysis_layout.removeWidget(temporal_row)
+        analysis_layout.removeWidget(temporal_help)
+        temporal_row.setParent(dock.styleGroupBox)
+        temporal_help.setParent(dock.styleGroupBox)
+        style_layout.addWidget(temporal_row)
+        style_layout.addWidget(temporal_help)


### PR DESCRIPTION
## Summary
- switch local development installs to prefer copy mode so runtime-only deps like `pypdf` are vendored by default
- warn explicitly when using symlink mode, which does not vendor atlas PDF runtime deps
- make the missing-`pypdf` atlas export error point users to the supported install paths

Fixes #339.

## Tests
- `python3 -m pytest tests/test_install_plugin.py tests/test_qgis_atlas_export_runtime.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short` *(reported 939 passed, 139 skipped before the known host-side post-run SIGSEGV)*
