### PR TITLE
fix: ignore hidden advanced fetch settings

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -650,18 +650,22 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _start_fetch(self, detailed_route_strategy, status_text, use_detailed_streams=None):
         self._save_settings()
+        advanced_fetch_enabled = self.advancedFetchGroupBox.isChecked()
         if use_detailed_streams is None:
-            use_detailed_streams = self.detailedStreamsCheckBox.isChecked()
+            use_detailed_streams = self.detailedStreamsCheckBox.isChecked() if advanced_fetch_enabled else False
+        per_page = self.perPageSpinBox.value() if advanced_fetch_enabled else 200
+        max_pages = self.maxPagesSpinBox.value() if advanced_fetch_enabled else 0
+        max_detailed_activities = self.maxDetailedActivitiesSpinBox.value() if advanced_fetch_enabled else 25
         try:
             fetch_request = self.sync_controller.build_fetch_task_request(
                 client_id=self.clientIdLineEdit.text().strip(),
                 client_secret=self.clientSecretLineEdit.text().strip(),
                 refresh_token=self.refreshTokenLineEdit.text().strip(),
                 cache=self.cache,
-                per_page=self.perPageSpinBox.value(),
-                max_pages=self.maxPagesSpinBox.value(),
+                per_page=per_page,
+                max_pages=max_pages,
                 use_detailed_streams=use_detailed_streams,
-                max_detailed_activities=self.maxDetailedActivitiesSpinBox.value(),
+                max_detailed_activities=max_detailed_activities,
                 detailed_route_strategy=detailed_route_strategy,
                 on_finished=self._on_fetch_finished,
             )

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -510,10 +510,75 @@ class QgisSmokeTests(unittest.TestCase):
                 dock.sync_controller.build_fetch_task_request.call_args.kwargs["detailed_route_strategy"],
                 "Recent fetch only",
             )
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["per_page"], 200)
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_pages"], 0)
+            self.assertFalse(dock.sync_controller.build_fetch_task_request.call_args.kwargs["use_detailed_streams"])
             dock.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
             task_manager.return_value.addTask.assert_called_once_with(fake_task)
             self.assertIs(dock._fetch_task, fake_task)
             self.assertEqual(dock.refreshButton.text(), "Cancel")
+        finally:
+            dock.close()
+            dock.deleteLater()
+
+    def test_refresh_clicked_ignores_hidden_advanced_fetch_settings(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            fake_task = MagicMock(name="fetch_task")
+            dock._save_settings = MagicMock()
+            dock.sync_controller.build_fetch_task_request = MagicMock(return_value="fetch-request")
+            dock.sync_controller.build_fetch_task = MagicMock(return_value=fake_task)
+            dock.advancedFetchGroupBox.setChecked(False)
+            dock.perPageSpinBox.setValue(50)
+            dock.maxPagesSpinBox.setValue(1)
+            dock.maxDetailedActivitiesSpinBox.setValue(3)
+            dock.detailedStreamsCheckBox.setChecked(True)
+
+            with patch("qfit.qfit_dockwidget.QgsApplication.taskManager") as task_manager:
+                task_manager.return_value.addTask = MagicMock()
+                dock.on_refresh_clicked()
+
+            dock.sync_controller.build_fetch_task_request.assert_called_once()
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["per_page"], 200)
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_pages"], 0)
+            self.assertEqual(
+                dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_detailed_activities"],
+                25,
+            )
+            self.assertFalse(dock.sync_controller.build_fetch_task_request.call_args.kwargs["use_detailed_streams"])
+            dock.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
+            task_manager.return_value.addTask.assert_called_once_with(fake_task)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
+    def test_refresh_clicked_uses_advanced_fetch_settings_when_enabled(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            fake_task = MagicMock(name="fetch_task")
+            dock._save_settings = MagicMock()
+            dock.sync_controller.build_fetch_task_request = MagicMock(return_value="fetch-request")
+            dock.sync_controller.build_fetch_task = MagicMock(return_value=fake_task)
+            dock.advancedFetchGroupBox.setChecked(True)
+            dock.perPageSpinBox.setValue(50)
+            dock.maxPagesSpinBox.setValue(1)
+            dock.maxDetailedActivitiesSpinBox.setValue(3)
+            dock.detailedStreamsCheckBox.setChecked(True)
+
+            with patch("qfit.qfit_dockwidget.QgsApplication.taskManager") as task_manager:
+                task_manager.return_value.addTask = MagicMock()
+                dock.on_refresh_clicked()
+
+            dock.sync_controller.build_fetch_task_request.assert_called_once()
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["per_page"], 50)
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_pages"], 1)
+            self.assertEqual(
+                dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_detailed_activities"],
+                3,
+            )
+            self.assertTrue(dock.sync_controller.build_fetch_task_request.call_args.kwargs["use_detailed_streams"])
+            dock.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
+            task_manager.return_value.addTask.assert_called_once_with(fake_task)
         finally:
             dock.close()
             dock.deleteLater()


### PR DESCRIPTION
## Summary
- treat advanced fetch controls as opt-in, so a normal fetch ignores hidden advanced overrides
- keep the existing advanced settings when the advanced group is explicitly enabled
- add PyQGIS smoke coverage for both the default and advanced-enabled fetch paths

## Testing
- `python3 -m pytest tests/test_qgis_smoke.py -q`
- `python3 -m pytest tests/ -x -q --tb=short` *(all tests completed with `942 passed, 141 skipped`, but the local interpreter segfaulted during teardown afterward with exit 139; CI should confirm this is only an environment-side teardown issue)*
