### PR TITLE
fix: ignore hidden advanced fetch settings

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -122,7 +122,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._dock_action_dispatcher = DockActionDispatcher(
             visual_apply=self.visual_apply,
             save_settings=self._save_settings,
-            run_analysis=self._run_selected_analysis,
+            run_analysis=self._apply_analysis_configuration,
         )
 
     def _remove_stale_qfit_layers(self):
@@ -947,7 +947,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self.background_layer = result.background_layer
         return result.status
 
-    def _apply_analysis_configuration(self, analysis_mode=None, starts_layer=None):
+    def _apply_analysis_configuration(
+        self,
+        analysis_mode=None,
+        starts_layer=None,
+        selection_state=None,
+    ):
         self._clear_analysis_layer()
 
         current_mode = analysis_mode or self.analysisModeComboBox.currentText()
@@ -957,14 +962,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return self._run_selected_analysis(
             current_mode,
             current_starts_layer,
-            self._current_activity_selection_state(),
+            selection_state or self._current_activity_selection_state(),
         )
 
     def _clear_analysis_layer(self):
         project = QgsProject.instance()
         if self.analysis_layer is not None:
             try:
-                project.removeMapLayer(self.analysis_layer)
+                project.removeMapLayer(self.analysis_layer.id())
             except RuntimeError:
                 logger.debug("Failed to remove analysis layer", exc_info=True)
             self.analysis_layer = None
@@ -973,7 +978,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             if layer.name() != FREQUENT_STARTING_POINTS_LAYER_NAME:
                 continue
             try:
-                project.removeMapLayer(layer)
+                project.removeMapLayer(layer.id())
             except RuntimeError:
                 logger.debug("Failed to remove stale frequent-start analysis layer", exc_info=True)
 

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -655,7 +655,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             use_detailed_streams = self.detailedStreamsCheckBox.isChecked() if advanced_fetch_enabled else False
         per_page = self.perPageSpinBox.value() if advanced_fetch_enabled else 200
         max_pages = self.maxPagesSpinBox.value() if advanced_fetch_enabled else 0
-        max_detailed_activities = self.maxDetailedActivitiesSpinBox.value() if advanced_fetch_enabled else 25
+        max_detailed_activities = (
+            self.maxDetailedActivitiesSpinBox.value()
+            if advanced_fetch_enabled or use_detailed_streams
+            else 25
+        )
         try:
             fetch_request = self.sync_controller.build_fetch_task_request(
                 client_id=self.clientIdLineEdit.text().strip(),

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -650,18 +650,22 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _start_fetch(self, detailed_route_strategy, status_text, use_detailed_streams=None):
         self._save_settings()
+        advanced_fetch_enabled = self.advancedFetchGroupBox.isChecked()
         if use_detailed_streams is None:
-            use_detailed_streams = self.detailedStreamsCheckBox.isChecked()
+            use_detailed_streams = self.detailedStreamsCheckBox.isChecked() if advanced_fetch_enabled else False
+        per_page = self.perPageSpinBox.value() if advanced_fetch_enabled else 200
+        max_pages = self.maxPagesSpinBox.value() if advanced_fetch_enabled else 0
+        max_detailed_activities = self.maxDetailedActivitiesSpinBox.value() if advanced_fetch_enabled else 25
         try:
             fetch_request = self.sync_controller.build_fetch_task_request(
                 client_id=self.clientIdLineEdit.text().strip(),
                 client_secret=self.clientSecretLineEdit.text().strip(),
                 refresh_token=self.refreshTokenLineEdit.text().strip(),
                 cache=self.cache,
-                per_page=self.perPageSpinBox.value(),
-                max_pages=self.maxPagesSpinBox.value(),
+                per_page=per_page,
+                max_pages=max_pages,
                 use_detailed_streams=use_detailed_streams,
-                max_detailed_activities=self.maxDetailedActivitiesSpinBox.value(),
+                max_detailed_activities=max_detailed_activities,
                 detailed_route_strategy=detailed_route_strategy,
                 on_finished=self._on_fetch_finished,
             )

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -531,7 +531,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             self.module.QfitDockWidget._clear_analysis_layer(dock)
 
         self.assertIsNone(dock.analysis_layer)
-        self.assertEqual(project.removed, [current_layer, stale_layer])
+        self.assertEqual(project.removed, [current_layer.id(), stale_layer.id()])
 
     def test_on_load_clicked_starts_background_store_task(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -679,6 +679,31 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_backfill_missing_detailed_routes_preserves_cap_when_advanced_fetch_is_hidden(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            fake_task = MagicMock(name="fetch_task")
+            dock._save_settings = MagicMock()
+            dock.sync_controller.build_fetch_task_request = MagicMock(return_value="fetch-request")
+            dock.sync_controller.build_fetch_task = MagicMock(return_value=fake_task)
+            dock.advancedFetchGroupBox.setChecked(False)
+            dock.maxDetailedActivitiesSpinBox.setValue(7)
+
+            with patch("qfit.qfit_dockwidget.QgsApplication.taskManager") as task_manager:
+                task_manager.return_value.addTask = MagicMock()
+                dock.on_backfill_missing_detailed_routes_clicked()
+
+            dock.sync_controller.build_fetch_task_request.assert_called_once()
+            self.assertTrue(dock.sync_controller.build_fetch_task_request.call_args.kwargs["use_detailed_streams"])
+            self.assertEqual(
+                dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_detailed_activities"],
+                7,
+            )
+            task_manager.return_value.addTask.assert_called_once_with(fake_task)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_backfill_missing_detailed_routes_ignores_click_while_fetch_running(self):
         dock = QfitDockWidget(self.iface)
         try:

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1220,6 +1220,33 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_load_layers_replaces_existing_frequent_starting_points_analysis_layer(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                output_path = self._write_sample_gpkg(tmp)
+                dock.outputPathLineEdit.setText(output_path)
+                dock.analysisModeComboBox.setCurrentText("Most frequent starting points")
+
+                dock.on_load_layers_clicked()
+                first_analysis_layer = dock.analysis_layer
+                self.assertIsNotNone(first_analysis_layer)
+                first_analysis_layer_id = first_analysis_layer.id()
+
+                dock.on_load_layers_clicked()
+
+                analysis_layers = [
+                    layer
+                    for layer in QgsProject.instance().mapLayers().values()
+                    if layer.name() == "qfit frequent starting points"
+                ]
+                self.assertEqual(len(analysis_layers), 1)
+                self.assertIsNotNone(dock.analysis_layer)
+                self.assertNotEqual(dock.analysis_layer.id(), first_analysis_layer_id)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_most_frequent_starting_points_analysis_creates_ranked_layer(self):
         dock = QfitDockWidget(self.iface)
         try:

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -510,10 +510,75 @@ class QgisSmokeTests(unittest.TestCase):
                 dock.sync_controller.build_fetch_task_request.call_args.kwargs["detailed_route_strategy"],
                 "Recent fetch only",
             )
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["per_page"], 200)
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_pages"], 0)
+            self.assertFalse(dock.sync_controller.build_fetch_task_request.call_args.kwargs["use_detailed_streams"])
             dock.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
             task_manager.return_value.addTask.assert_called_once_with(fake_task)
             self.assertIs(dock._fetch_task, fake_task)
             self.assertEqual(dock.refreshButton.text(), "Cancel")
+        finally:
+            dock.close()
+            dock.deleteLater()
+
+    def test_refresh_clicked_ignores_hidden_advanced_fetch_settings(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            fake_task = MagicMock(name="fetch_task")
+            dock._save_settings = MagicMock()
+            dock.sync_controller.build_fetch_task_request = MagicMock(return_value="fetch-request")
+            dock.sync_controller.build_fetch_task = MagicMock(return_value=fake_task)
+            dock.advancedFetchGroupBox.setChecked(False)
+            dock.perPageSpinBox.setValue(50)
+            dock.maxPagesSpinBox.setValue(1)
+            dock.maxDetailedActivitiesSpinBox.setValue(3)
+            dock.detailedStreamsCheckBox.setChecked(True)
+
+            with patch("qfit.qfit_dockwidget.QgsApplication.taskManager") as task_manager:
+                task_manager.return_value.addTask = MagicMock()
+                dock.on_refresh_clicked()
+
+            dock.sync_controller.build_fetch_task_request.assert_called_once()
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["per_page"], 200)
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_pages"], 0)
+            self.assertEqual(
+                dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_detailed_activities"],
+                25,
+            )
+            self.assertFalse(dock.sync_controller.build_fetch_task_request.call_args.kwargs["use_detailed_streams"])
+            dock.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
+            task_manager.return_value.addTask.assert_called_once_with(fake_task)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
+    def test_refresh_clicked_uses_advanced_fetch_settings_when_enabled(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            fake_task = MagicMock(name="fetch_task")
+            dock._save_settings = MagicMock()
+            dock.sync_controller.build_fetch_task_request = MagicMock(return_value="fetch-request")
+            dock.sync_controller.build_fetch_task = MagicMock(return_value=fake_task)
+            dock.advancedFetchGroupBox.setChecked(True)
+            dock.perPageSpinBox.setValue(50)
+            dock.maxPagesSpinBox.setValue(1)
+            dock.maxDetailedActivitiesSpinBox.setValue(3)
+            dock.detailedStreamsCheckBox.setChecked(True)
+
+            with patch("qfit.qfit_dockwidget.QgsApplication.taskManager") as task_manager:
+                task_manager.return_value.addTask = MagicMock()
+                dock.on_refresh_clicked()
+
+            dock.sync_controller.build_fetch_task_request.assert_called_once()
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["per_page"], 50)
+            self.assertEqual(dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_pages"], 1)
+            self.assertEqual(
+                dock.sync_controller.build_fetch_task_request.call_args.kwargs["max_detailed_activities"],
+                3,
+            )
+            self.assertTrue(dock.sync_controller.build_fetch_task_request.call_args.kwargs["use_detailed_streams"])
+            dock.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
+            task_manager.return_value.addTask.assert_called_once_with(fake_task)
         finally:
             dock.close()
             dock.deleteLater()


### PR DESCRIPTION
## Summary
- ignore persisted advanced fetch pagination settings when Advanced fetch is collapsed/off
- keep the current advanced behavior only when the user explicitly enables that section
- add smoke coverage for both the default and advanced fetch paths

## Testing
- python3 -m unittest tests.test_qgis_smoke.QgisSmokeTests.test_refresh_clicked_builds_fetch_task_via_sync_controller tests.test_qgis_smoke.QgisSmokeTests.test_refresh_clicked_ignores_hidden_advanced_fetch_settings tests.test_qgis_smoke.QgisSmokeTests.test_refresh_clicked_uses_advanced_fetch_settings_when_enabled -v
- manual Windows QGIS copy-install validation