### PR TITLE
feat: add heatmap analysis mode

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -5,12 +5,15 @@ from dataclasses import dataclass, field
 from ...activities.application.activity_selection_state import ActivitySelectionState
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
+HEATMAP_MODE = "Heatmap"
 
 
 @dataclass(frozen=True)
 class RunAnalysisRequest:
     analysis_mode: str = ""
+    activities_layer: object = None
     starts_layer: object = None
+    points_layer: object = None
     selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
 
 
@@ -28,10 +31,14 @@ class AnalysisController:
         analysis_mode: str,
         starts_layer: object,
         selection_state: ActivitySelectionState | None = None,
+        activities_layer: object = None,
+        points_layer: object = None,
     ) -> RunAnalysisRequest:
         return RunAnalysisRequest(
             analysis_mode=analysis_mode or "",
+            activities_layer=activities_layer,
             starts_layer=starts_layer,
+            points_layer=points_layer,
             selection_state=selection_state or ActivitySelectionState(),
         )
 
@@ -39,23 +46,44 @@ class AnalysisController:
         if request is None:
             request = self.build_request(**legacy_kwargs)
 
-        if request.analysis_mode != FREQUENT_STARTING_POINTS_MODE:
-            return RunAnalysisResult()
-        if request.starts_layer is None:
-            return RunAnalysisResult()
+        if request.analysis_mode == FREQUENT_STARTING_POINTS_MODE:
+            if request.starts_layer is None:
+                return RunAnalysisResult()
 
-        layer, clusters = _build_frequent_start_points_layer(request.starts_layer)
-        if layer is None or not clusters:
+            layer, clusters = _build_frequent_start_points_layer(request.starts_layer)
+            if layer is None or not clusters:
+                return RunAnalysisResult(
+                    status="No frequent starting points matched the current filters"
+                )
+
             return RunAnalysisResult(
-                status="No frequent starting points matched the current filters"
+                status="Showing top {count} frequent starting-point clusters".format(
+                    count=len(clusters)
+                ),
+                layer=layer,
             )
 
-        return RunAnalysisResult(
-            status="Showing top {count} frequent starting-point clusters".format(
-                count=len(clusters)
-            ),
-            layer=layer,
-        )
+        if request.analysis_mode == HEATMAP_MODE:
+            if request.activities_layer is None and request.points_layer is None:
+                return RunAnalysisResult()
+
+            layer, sample_count = _build_activity_heatmap_layer(
+                request.activities_layer,
+                request.points_layer,
+            )
+            if layer is None or sample_count <= 0:
+                return RunAnalysisResult(
+                    status="No activity heatmap data matched the current filters"
+                )
+
+            return RunAnalysisResult(
+                status="Showing activity heatmap from {count} sampled route points".format(
+                    count=sample_count
+                ),
+                layer=layer,
+            )
+
+        return RunAnalysisResult()
 
     def run_request(self, request: RunAnalysisRequest) -> RunAnalysisResult:
         return self.run(request=request)
@@ -67,3 +95,12 @@ def _build_frequent_start_points_layer(starts_layer):
     )
 
     return build_frequent_start_points_layer(starts_layer)
+
+
+def _build_activity_heatmap_layer(activities_layer, points_layer):
+    from ..infrastructure.activity_heatmap_layer import build_activity_heatmap_layer
+
+    return build_activity_heatmap_layer(
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+    )

--- a/analysis/infrastructure/activity_heatmap_layer.py
+++ b/analysis/infrastructure/activity_heatmap_layer.py
@@ -21,41 +21,13 @@ def build_activity_heatmap_layer(activities_layer=None, points_layer=None):
     if source_layer is None or not source_layer.isValid():
         return None, 0
 
-    layer_crs = source_layer.crs()
-    authid = layer_crs.authid() if layer_crs is not None and layer_crs.isValid() else "EPSG:3857"
-    heatmap_layer = QgsVectorLayer(
-        f"Point?crs={authid}",
-        ACTIVITY_HEATMAP_LAYER_NAME,
-        "memory",
-    )
-    provider = heatmap_layer.dataProvider()
-
-    features = []
-    if points_layer is not None and points_layer.isValid() and points_layer.featureCount() > 0:
-        for source_feature in points_layer.getFeatures():
-            geometry = source_feature.geometry()
-            if geometry is None or geometry.isEmpty():
-                continue
-            point = geometry.asPoint()
-            if point.isEmpty():
-                continue
-            feature = QgsFeature()
-            feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(point.x(), point.y())))
-            features.append(feature)
-    else:
-        for source_feature in activities_layer.getFeatures():
-            geometry = source_feature.geometry()
-            if geometry is None or geometry.isEmpty():
-                continue
-            for vertex in geometry.vertices():
-                feature = QgsFeature()
-                feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(vertex.x(), vertex.y())))
-                features.append(feature)
+    heatmap_layer = _build_memory_heatmap_layer(source_layer)
+    features = _collect_heatmap_features(points_layer, activities_layer)
 
     if not features:
         return None, 0
 
-    provider.addFeatures(features)
+    heatmap_layer.dataProvider().addFeatures(features)
     heatmap_layer.updateExtents()
     heatmap_layer.setRenderer(build_qfit_visualize_heatmap_renderer())
     heatmap_layer.setOpacity(1.0)
@@ -63,9 +35,61 @@ def build_activity_heatmap_layer(activities_layer=None, points_layer=None):
     return heatmap_layer, len(features)
 
 
+def _build_memory_heatmap_layer(source_layer):
+    layer_crs = source_layer.crs()
+    authid = (
+        layer_crs.authid()
+        if layer_crs is not None and layer_crs.isValid()
+        else "EPSG:3857"
+    )
+    return QgsVectorLayer(
+        f"Point?crs={authid}",
+        ACTIVITY_HEATMAP_LAYER_NAME,
+        "memory",
+    )
+
+
+def _collect_heatmap_features(points_layer, activities_layer):
+    if _has_features(points_layer):
+        return list(_point_features_from_points_layer(points_layer))
+    if _has_features(activities_layer):
+        return list(_point_features_from_activity_layer(activities_layer))
+    return []
+
+
+def _point_features_from_points_layer(points_layer):
+    for source_feature in points_layer.getFeatures():
+        geometry = source_feature.geometry()
+        if geometry is None or geometry.isEmpty():
+            continue
+        point = geometry.asPoint()
+        if point.isEmpty():
+            continue
+        yield _build_point_feature(point.x(), point.y())
+
+
+def _point_features_from_activity_layer(activities_layer):
+    for source_feature in activities_layer.getFeatures():
+        geometry = source_feature.geometry()
+        if geometry is None or geometry.isEmpty():
+            continue
+        for vertex in geometry.vertices():
+            yield _build_point_feature(vertex.x(), vertex.y())
+
+
+def _build_point_feature(x, y):
+    feature = QgsFeature()
+    feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(x, y)))
+    return feature
+
+
+def _has_features(layer):
+    return layer is not None and layer.isValid() and layer.featureCount() > 0
+
+
 def _preferred_source_layer(points_layer, activities_layer):
-    if points_layer is not None and points_layer.isValid() and points_layer.featureCount() > 0:
+    if _has_features(points_layer):
         return points_layer
-    if activities_layer is not None and activities_layer.isValid() and activities_layer.featureCount() > 0:
+    if _has_features(activities_layer):
         return activities_layer
     return None

--- a/analysis/infrastructure/activity_heatmap_layer.py
+++ b/analysis/infrastructure/activity_heatmap_layer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from qgis.core import QgsFeature, QgsGeometry, QgsPointXY, QgsVectorLayer
+
+from ...visualization.infrastructure.layer_style_service import (
+    build_qfit_visualize_heatmap_renderer,
+)
+
+ACTIVITY_HEATMAP_LAYER_NAME = "qfit activity heatmap"
+
+
+def build_activity_heatmap_layer(activities_layer=None, points_layer=None):
+    """Build a memory point layer suitable for heatmap rendering.
+
+    Prefer the existing sampled route-points layer when available. When it is
+    missing, fall back to deriving sample points from the current activity-line
+    layer so Heatmap analysis still works without pre-generated points.
+    """
+
+    source_layer = _preferred_source_layer(points_layer, activities_layer)
+    if source_layer is None or not source_layer.isValid():
+        return None, 0
+
+    layer_crs = source_layer.crs()
+    authid = layer_crs.authid() if layer_crs is not None and layer_crs.isValid() else "EPSG:3857"
+    heatmap_layer = QgsVectorLayer(
+        f"Point?crs={authid}",
+        ACTIVITY_HEATMAP_LAYER_NAME,
+        "memory",
+    )
+    provider = heatmap_layer.dataProvider()
+
+    features = []
+    if points_layer is not None and points_layer.isValid() and points_layer.featureCount() > 0:
+        for source_feature in points_layer.getFeatures():
+            geometry = source_feature.geometry()
+            if geometry is None or geometry.isEmpty():
+                continue
+            point = geometry.asPoint()
+            if point.isEmpty():
+                continue
+            feature = QgsFeature()
+            feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(point.x(), point.y())))
+            features.append(feature)
+    else:
+        for source_feature in activities_layer.getFeatures():
+            geometry = source_feature.geometry()
+            if geometry is None or geometry.isEmpty():
+                continue
+            for vertex in geometry.vertices():
+                feature = QgsFeature()
+                feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(vertex.x(), vertex.y())))
+                features.append(feature)
+
+    if not features:
+        return None, 0
+
+    provider.addFeatures(features)
+    heatmap_layer.updateExtents()
+    heatmap_layer.setRenderer(build_qfit_visualize_heatmap_renderer())
+    heatmap_layer.setOpacity(1.0)
+    heatmap_layer.triggerRepaint()
+    return heatmap_layer, len(features)
+
+
+def _preferred_source_layer(points_layer, activities_layer):
+    if points_layer is not None and points_layer.isValid() and points_layer.featureCount() > 0:
+        return points_layer
+    if activities_layer is not None and activities_layer.isValid() and activities_layer.featureCount() > 0:
+        return activities_layer
+    return None

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -41,6 +41,9 @@ from .activities.domain.activity_query import (
 from .activities.application.activity_selection_state import ActivitySelectionState
 from .activities.application.load_workflow import LoadWorkflowError
 from .activities.application.store_task import build_store_task
+from .analysis.infrastructure.activity_heatmap_layer import (
+    ACTIVITY_HEATMAP_LAYER_NAME,
+)
 from .analysis.infrastructure.frequent_start_points_layer import (
     FREQUENT_STARTING_POINTS_LAYER_NAME,
 )
@@ -928,9 +931,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
         request = self.analysis_controller.build_request(
             analysis_mode=analysis_mode,
-            activities_layer=self.activities_layer,
+            activities_layer=getattr(self, "activities_layer", None),
             starts_layer=starts_layer,
-            points_layer=self.points_layer,
+            points_layer=getattr(self, "points_layer", None),
             selection_state=selection_state,
         )
         result = self.analysis_controller.run_request(request)
@@ -983,7 +986,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         analysis_layer_names = {
             FREQUENT_STARTING_POINTS_LAYER_NAME,
-            "qfit activity heatmap",
+            ACTIVITY_HEATMAP_LAYER_NAME,
         }
         for layer in tuple(project.mapLayers().values()):
             if layer.name() not in analysis_layer_names:

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -249,6 +249,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         combo.setObjectName("analysisModeComboBox")
         combo.addItem("None")
         combo.addItem("Most frequent starting points")
+        combo.addItem("Heatmap")
         layout.addWidget(combo)
 
         button = QPushButton("Run analysis", row)
@@ -927,7 +928,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
         request = self.analysis_controller.build_request(
             analysis_mode=analysis_mode,
+            activities_layer=self.activities_layer,
             starts_layer=starts_layer,
+            points_layer=self.points_layer,
             selection_state=selection_state,
         )
         result = self.analysis_controller.run_request(request)
@@ -978,13 +981,17 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 logger.debug("Failed to remove analysis layer", exc_info=True)
             self.analysis_layer = None
 
+        analysis_layer_names = {
+            FREQUENT_STARTING_POINTS_LAYER_NAME,
+            "qfit activity heatmap",
+        }
         for layer in tuple(project.mapLayers().values()):
-            if layer.name() != FREQUENT_STARTING_POINTS_LAYER_NAME:
+            if layer.name() not in analysis_layer_names:
                 continue
             try:
                 project.removeMapLayer(layer.id())
             except RuntimeError:
-                logger.debug("Failed to remove stale frequent-start analysis layer", exc_info=True)
+                logger.debug("Failed to remove stale analysis layer", exc_info=True)
 
     def _current_activity_selection_state(self):
         query = ActivityQuery(

--- a/tests/test_activity_heatmap_layer_pure.py
+++ b/tests/test_activity_heatmap_layer_pure.py
@@ -1,0 +1,253 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch, sentinel
+
+from tests import _path  # noqa: F401
+
+
+class _FakePoint:
+    def __init__(self, x=0.0, y=0.0, empty=False):
+        self._x = x
+        self._y = y
+        self._empty = empty
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+    def isEmpty(self):
+        return self._empty
+
+
+class _FakeGeometry:
+    def __init__(self, point=None, vertices=None, empty=False):
+        self._point = point
+        self._vertices = list(vertices or [])
+        self._empty = empty
+
+    def isEmpty(self):
+        return self._empty
+
+    def asPoint(self):
+        return self._point or _FakePoint(empty=True)
+
+    def vertices(self):
+        return iter(self._vertices)
+
+    @staticmethod
+    def fromPointXY(point):
+        return _FakeGeometry(point=_FakePoint(point.x(), point.y()))
+
+
+class _FakeFeature:
+    def __init__(self, geometry=None):
+        self._geometry = geometry
+
+    def geometry(self):
+        return self._geometry
+
+    def setGeometry(self, geometry):
+        self._geometry = geometry
+
+
+class _FakeProvider:
+    def __init__(self):
+        self.added = []
+
+    def addFeatures(self, features):
+        self.added.extend(features)
+
+
+class _FakeCrs:
+    def __init__(self, authid="EPSG:4326", valid=True):
+        self._authid = authid
+        self._valid = valid
+
+    def authid(self):
+        return self._authid
+
+    def isValid(self):
+        return self._valid
+
+
+class _FakeMemoryLayer:
+    def __init__(self, spec, name, provider_key):
+        self.spec = spec
+        self._name = name
+        self.provider_key = provider_key
+        self._provider = _FakeProvider()
+        self.renderer = None
+        self.opacity = None
+        self.repainted = False
+        self.extents_updated = False
+
+    def dataProvider(self):
+        return self._provider
+
+    def updateExtents(self):
+        self.extents_updated = True
+
+    def setRenderer(self, renderer):
+        self.renderer = renderer
+
+    def setOpacity(self, opacity):
+        self.opacity = opacity
+
+    def triggerRepaint(self):
+        self.repainted = True
+
+    def name(self):
+        return self._name
+
+    def featureCount(self):
+        return len(self._provider.added)
+
+
+class _FakeSourceLayer:
+    def __init__(self, features=None, valid=True, crs=None):
+        self._features = list(features or [])
+        self._valid = valid
+        self._crs = crs if crs is not None else _FakeCrs()
+
+    def isValid(self):
+        return self._valid
+
+    def featureCount(self):
+        return len(self._features)
+
+    def getFeatures(self):
+        return iter(self._features)
+
+    def crs(self):
+        return self._crs
+
+
+class ActivityHeatmapLayerPureTests(unittest.TestCase):
+    def setUp(self):
+        qgis_mod = types.ModuleType("qgis")
+        qgis_core = types.ModuleType("qgis.core")
+        qgis_core.QgsFeature = _FakeFeature
+        qgis_core.QgsGeometry = _FakeGeometry
+        qgis_core.QgsPointXY = _FakePoint
+        qgis_core.QgsVectorLayer = _FakeMemoryLayer
+
+        layer_style_service = types.ModuleType(
+            "qfit.visualization.infrastructure.layer_style_service"
+        )
+        layer_style_service.build_qfit_visualize_heatmap_renderer = (
+            lambda: sentinel.heatmap_renderer
+        )
+
+        self._modules = {
+            "qgis": qgis_mod,
+            "qgis.core": qgis_core,
+            "qfit.visualization.infrastructure.layer_style_service": layer_style_service,
+        }
+        self._patcher = patch.dict(sys.modules, self._modules, clear=False)
+        self._patcher.start()
+        sys.modules.pop("qfit.analysis.infrastructure.activity_heatmap_layer", None)
+        self.module = importlib.import_module(
+            "qfit.analysis.infrastructure.activity_heatmap_layer"
+        )
+
+    def tearDown(self):
+        self._patcher.stop()
+        sys.modules.pop("qfit.analysis.infrastructure.activity_heatmap_layer", None)
+
+    def test_returns_none_without_valid_source_layers(self):
+        layer, count = self.module.build_activity_heatmap_layer(None, None)
+
+        self.assertIsNone(layer)
+        self.assertEqual(count, 0)
+
+    def test_prefers_existing_points_layer(self):
+        points_layer = _FakeSourceLayer(
+            features=[
+                _FakeFeature(_FakeGeometry(point=_FakePoint(6.62, 46.52))),
+                _FakeFeature(_FakeGeometry(point=_FakePoint(6.63, 46.53))),
+            ]
+        )
+        activities_layer = _FakeSourceLayer(
+            features=[
+                _FakeFeature(
+                    _FakeGeometry(vertices=[_FakePoint(6.60, 46.50), _FakePoint(6.70, 46.60)])
+                )
+            ]
+        )
+
+        layer, count = self.module.build_activity_heatmap_layer(
+            activities_layer=activities_layer,
+            points_layer=points_layer,
+        )
+
+        self.assertIsNotNone(layer)
+        self.assertEqual(layer.name(), self.module.ACTIVITY_HEATMAP_LAYER_NAME)
+        self.assertEqual(layer.spec, "Point?crs=EPSG:4326")
+        self.assertEqual(count, 2)
+        self.assertEqual(layer.featureCount(), 2)
+        self.assertIs(layer.renderer, sentinel.heatmap_renderer)
+        self.assertEqual(layer.opacity, 1.0)
+        self.assertTrue(layer.repainted)
+
+    def test_falls_back_to_activity_vertices_when_points_layer_missing(self):
+        activities_layer = _FakeSourceLayer(
+            features=[
+                _FakeFeature(
+                    _FakeGeometry(
+                        vertices=[
+                            _FakePoint(6.60, 46.50),
+                            _FakePoint(6.65, 46.55),
+                            _FakePoint(6.70, 46.60),
+                        ]
+                    )
+                )
+            ]
+        )
+
+        layer, count = self.module.build_activity_heatmap_layer(
+            activities_layer=activities_layer,
+            points_layer=None,
+        )
+
+        self.assertIsNotNone(layer)
+        self.assertEqual(count, 3)
+        self.assertEqual(layer.featureCount(), 3)
+
+    def test_skips_empty_point_geometries(self):
+        points_layer = _FakeSourceLayer(
+            features=[
+                _FakeFeature(_FakeGeometry(empty=True)),
+                _FakeFeature(_FakeGeometry(point=_FakePoint(empty=True))),
+            ]
+        )
+
+        layer, count = self.module.build_activity_heatmap_layer(
+            activities_layer=None,
+            points_layer=points_layer,
+        )
+
+        self.assertIsNone(layer)
+        self.assertEqual(count, 0)
+
+    def test_defaults_output_crs_when_source_crs_is_invalid(self):
+        activities_layer = _FakeSourceLayer(
+            features=[_FakeFeature(_FakeGeometry(vertices=[_FakePoint(6.60, 46.50)]))],
+            crs=_FakeCrs(authid="", valid=False),
+        )
+
+        layer, count = self.module.build_activity_heatmap_layer(
+            activities_layer=activities_layer,
+            points_layer=None,
+        )
+
+        self.assertIsNotNone(layer)
+        self.assertEqual(layer.spec, "Point?crs=EPSG:3857")
+        self.assertEqual(count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -7,6 +7,7 @@ from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.analysis.application.analysis_controller import (
     AnalysisController,
     FREQUENT_STARTING_POINTS_MODE,
+    HEATMAP_MODE,
 )
 
 
@@ -15,10 +16,17 @@ class TestAnalysisController(unittest.TestCase):
         self.controller = AnalysisController()
 
     def test_build_request_returns_dataclass(self):
-        request = self.controller.build_request("None", "starts-layer")
+        request = self.controller.build_request(
+            "None",
+            "starts-layer",
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
 
         self.assertEqual(request.analysis_mode, "None")
+        self.assertEqual(request.activities_layer, "activities-layer")
         self.assertEqual(request.starts_layer, "starts-layer")
+        self.assertEqual(request.points_layer, "points-layer")
 
     def test_build_request_keeps_selection_state(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
@@ -80,6 +88,60 @@ class TestAnalysisController(unittest.TestCase):
         self.assertEqual(
             result.status,
             "Showing top 2 frequent starting-point clusters",
+        )
+        self.assertIs(result.layer, layer)
+
+    def test_run_request_returns_empty_result_without_heatmap_layers(self):
+        request = self.controller.build_request(
+            HEATMAP_MODE,
+            None,
+            activities_layer=None,
+            points_layer=None,
+        )
+
+        result = self.controller.run_request(request)
+
+        self.assertEqual(result.status, "")
+        self.assertIsNone(result.layer)
+
+    def test_run_request_reports_no_heatmap_matches(self):
+        request = self.controller.build_request(
+            HEATMAP_MODE,
+            None,
+            activities_layer=object(),
+            points_layer=None,
+        )
+
+        with patch(
+            "qfit.analysis.application.analysis_controller._build_activity_heatmap_layer",
+            return_value=(None, 0),
+        ):
+            result = self.controller.run_request(request)
+
+        self.assertEqual(
+            result.status,
+            "No activity heatmap data matched the current filters",
+        )
+        self.assertIsNone(result.layer)
+
+    def test_run_request_returns_heatmap_layer(self):
+        request = self.controller.build_request(
+            HEATMAP_MODE,
+            None,
+            activities_layer=object(),
+            points_layer=object(),
+        )
+        layer = object()
+
+        with patch(
+            "qfit.analysis.application.analysis_controller._build_activity_heatmap_layer",
+            return_value=(layer, 42),
+        ):
+            result = self.controller.run_request(request)
+
+        self.assertEqual(
+            result.status,
+            "Showing activity heatmap from 42 sampled route points",
         )
         self.assertIs(result.layer, layer)
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -284,7 +284,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(index, 0)
         self.assertEqual(row.objectName(), "analysisModeRow")
         self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
-        self.assertEqual(dock.analysisModeComboBox.items, ["None", "Most frequent starting points"])
+        self.assertEqual(
+            dock.analysisModeComboBox.items,
+            ["None", "Most frequent starting points", "Heatmap"],
+        )
         self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
 
     def test_remove_stale_qfit_layers_delegates_to_project_hygiene_service(self):
@@ -414,6 +417,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             status="Showing top 2 frequent starting-point clusters",
             layer=None,
         )
+        dock.activities_layer = "activities-layer"
+        dock.points_layer = "points-layer"
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
         result = self.module.QfitDockWidget._run_selected_analysis(
@@ -426,7 +431,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(result, "Showing top 2 frequent starting-point clusters")
         dock.analysis_controller.build_request.assert_called_once_with(
             analysis_mode="Most frequent starting points",
+            activities_layer="activities-layer",
             starts_layer="starts-layer",
+            points_layer="points-layer",
             selection_state=selection_state,
         )
         dock.analysis_controller.run_request.assert_called_once_with("analysis-request")
@@ -440,6 +447,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             status="Showing top 2 frequent starting-point clusters",
             layer=analysis_layer,
         )
+        dock.activities_layer = "activities-layer"
+        dock.points_layer = "points-layer"
         project = _FakeProject()
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
@@ -524,14 +533,20 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock = object.__new__(self.module.QfitDockWidget)
         current_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
         stale_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
-        project = _FakeProject({"one": stale_layer, "two": _FakeLayer("other")})
+        stale_heatmap_layer = _FakeLayer("qfit activity heatmap")
+        project = _FakeProject(
+            {"one": stale_layer, "two": _FakeLayer("other"), "three": stale_heatmap_layer}
+        )
         dock.analysis_layer = current_layer
 
         with patch.object(self.module.QgsProject, "instance", return_value=project):
             self.module.QfitDockWidget._clear_analysis_layer(dock)
 
         self.assertIsNone(dock.analysis_layer)
-        self.assertEqual(project.removed, [current_layer.id(), stale_layer.id()])
+        self.assertEqual(
+            project.removed,
+            [current_layer.id(), stale_layer.id(), stale_heatmap_layer.id()],
+        )
 
     def test_on_load_clicked_starts_background_store_task(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1399,6 +1399,68 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_heatmap_analysis_creates_renderable_density_layer(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                output_path = self._write_sample_gpkg(tmp)
+                (
+                    dock.activities_layer,
+                    dock.starts_layer,
+                    dock.points_layer,
+                    dock.atlas_layer,
+                ) = dock.layer_gateway.load_output_layers(output_path)
+
+                dock.analysisModeComboBox.setCurrentText("Heatmap")
+                status = dock._apply_analysis_configuration()
+
+                self.assertIn("activity heatmap", status)
+                self.assertIsNotNone(dock.analysis_layer)
+                self.assertEqual(dock.analysis_layer.name(), "qfit activity heatmap")
+                image = self._render_layers_to_image(
+                    [dock.analysis_layer],
+                    dock.activities_layer.extent(),
+                )
+                artifact_path = Path(tmp) / "heatmap-analysis.png"
+                self.assertTrue(image.save(str(artifact_path)))
+                non_white_pixels, strong_pixels = self._count_heatmap_pixels(image)
+                self.assertGreater(non_white_pixels, 20000)
+                self.assertGreater(strong_pixels, 10000)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
+    def test_heatmap_analysis_falls_back_to_activity_lines_without_points_layer(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                output_path = self._write_sample_gpkg(tmp)
+                (
+                    dock.activities_layer,
+                    dock.starts_layer,
+                    _points_layer,
+                    dock.atlas_layer,
+                ) = dock.layer_gateway.load_output_layers(output_path)
+                dock.points_layer = None
+
+                dock.analysisModeComboBox.setCurrentText("Heatmap")
+                status = dock._apply_analysis_configuration()
+
+                self.assertIn("activity heatmap", status)
+                self.assertIsNotNone(dock.analysis_layer)
+                image = self._render_layers_to_image(
+                    [dock.analysis_layer],
+                    dock.activities_layer.extent(),
+                )
+                artifact_path = Path(tmp) / "heatmap-analysis-lines-fallback.png"
+                self.assertTrue(image.save(str(artifact_path)))
+                non_white_pixels, strong_pixels = self._count_heatmap_pixels(image)
+                self.assertGreater(non_white_pixels, 5000)
+                self.assertGreater(strong_pixels, 1000)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_offscreen_profile_chart_export_contains_rendered_curve(self):
         """Bound profile exports should differ visibly from the same chart when cleared."""
         script = textwrap.dedent(


### PR DESCRIPTION
Closes #344

## Summary
- add a dedicated `Heatmap` analysis mode alongside frequent starting points
- build a renderable memory heatmap layer from sampled activity points, with a fallback to activity-line geometry when points are unavailable
- cover the analysis workflow with controller, dock pure, and PyQGIS smoke tests, including rendered-image assertions

## Testing
- `python3 -m pytest tests/test_analysis_controller.py tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/test_qgis_smoke.py -q -k 'test_heatmap_analysis_creates_renderable_density_layer or test_heatmap_analysis_falls_back_to_activity_lines_without_points_layer or test_run_analysis_clicked_updates_status_with_analysis_result'`
- `python3 -m pytest tests/ -x -q --tb=short` *(completed with `945 passed, 145 skipped`, but the local interpreter segfaulted during teardown afterward with exit 139; CI should confirm this remains an environment-side teardown issue)*
