### PR TITLE
fix: keep heatmap visible when points are empty

### DIFF
--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -332,7 +332,7 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
     # Helpers
     # ------------------------------------------------------------------
 
-    def _make_layer(self, activity_types=None):
+    def _make_layer(self, activity_types=None, feature_count=2):
         """Return a mock QGIS vector layer for style tests."""
         field = MagicMock()
         field.name.return_value = "activity_type"
@@ -346,6 +346,7 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         layer.uniqueValues.return_value = (
             activity_types if activity_types is not None else ["Ride", "Run"]
         )
+        layer.featureCount.return_value = feature_count
         return layer
 
     # ------------------------------------------------------------------
@@ -379,6 +380,16 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         self.service.apply_style(acts, starts, None, None, "Heatmap")
         acts.setOpacity.assert_called_with(0.0)
         starts.setRenderer.assert_called_once()
+
+    def test_heatmap_uses_starts_when_points_layer_is_empty(self):
+        acts = self._make_layer()
+        starts = self._make_layer()
+        points = self._make_layer(feature_count=0)
+        self.service.apply_style(acts, starts, points, None, "Heatmap")
+        acts.setOpacity.assert_called_with(0.0)
+        starts.setRenderer.assert_called_once()
+        starts.setOpacity.assert_called_with(1.0)
+        points.setOpacity.assert_called_with(0.0)
 
     def test_track_points_sets_renderer_on_tracks_and_points(self):
         acts = self._make_layer()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1139,6 +1139,38 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(round(starts_layer.opacity(), 2), 1.0)
             self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
 
+    def test_heatmap_preset_falls_back_to_starts_layer_when_points_layer_is_empty(self):
+        """An empty points layer should not blank the map in Heatmap preset."""
+        from qgis.core import QgsHeatmapRenderer
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = self._write_sample_gpkg_without_points(tmp)
+            activities_layer, starts_layer, points_layer, atlas_layer = (
+                self.layer_manager.load_output_layers(output_path)
+            )
+
+            self.assertIsNotNone(points_layer)
+            self.assertEqual(points_layer.featureCount(), 0)
+
+            self.layer_manager.apply_style(
+                activities_layer,
+                starts_layer,
+                points_layer,
+                atlas_layer,
+                "Heatmap",
+            )
+
+            self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
+            self.assertEqual(round(starts_layer.opacity(), 2), 1.0)
+            self.assertEqual(round(points_layer.opacity(), 2), 0.0)
+
+            image = self._render_layers_to_image([starts_layer], starts_layer.extent())
+            non_white_pixels, strong_pixels = self._count_heatmap_pixels(image)
+
+            self.assertGreater(non_white_pixels, 1000)
+            self.assertGreater(strong_pixels, 100)
+            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+
     def test_build_frequent_start_points_layer_rejects_invalid_layer(self):
         layer, clusters = build_frequent_start_points_layer(None)
 
@@ -1681,17 +1713,39 @@ class QgisSmokeTests(unittest.TestCase):
         )
 
     def _write_sample_gpkg(self, temp_dir):
-        output_path = str(Path(temp_dir) / "qfit-heatmap-test.gpkg")
-        GeoPackageWriter(
-            output_path,
+        return self._write_sample_gpkg_with_options(
+            temp_dir,
+            filename="qfit-heatmap-test.gpkg",
             write_activity_points=True,
             point_stride=2,
+        )
+
+    def _write_sample_gpkg_without_points(self, temp_dir):
+        return self._write_sample_gpkg_with_options(
+            temp_dir,
+            filename="qfit-heatmap-no-points.gpkg",
+            write_activity_points=False,
+            point_stride=2,
+        )
+
+    def _write_sample_gpkg_with_options(
+        self,
+        temp_dir,
+        *,
+        filename,
+        write_activity_points,
+        point_stride,
+    ):
+        output_path = str(Path(temp_dir) / filename)
+        GeoPackageWriter(
+            output_path,
+            write_activity_points=write_activity_points,
+            point_stride=point_stride,
             atlas_margin_percent=10,
             atlas_min_extent_degrees=0.01,
             atlas_target_aspect_ratio=1.5,
         ).write_activities(self._sample_activities(), sync_metadata={"provider": "strava"})
         return output_path
-
 
     def _render_layers_to_image(self, layers, extent, width=800, height=800):
         settings = QgsMapSettings()

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -81,15 +81,39 @@ class LayerStyleService:
     def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name=None):
         preset = preset or "Simple lines"
         basemap_preset_name = background_preset_name or self._infer_background_preset_name()
+        has_point_features = self._has_features(points_layer)
 
-        self._apply_activities_layer_style(activities_layer, preset, basemap_preset_name)
-        self._apply_points_layer_style(points_layer, preset, basemap_preset_name)
-        self._apply_starts_layer_style(starts_layer, points_layer, preset, basemap_preset_name)
+        self._apply_activities_layer_style(
+            activities_layer,
+            preset,
+            basemap_preset_name,
+            has_point_features=has_point_features,
+        )
+        self._apply_points_layer_style(
+            points_layer,
+            preset,
+            basemap_preset_name,
+            has_point_features=has_point_features,
+        )
+        self._apply_starts_layer_style(
+            starts_layer,
+            points_layer,
+            preset,
+            basemap_preset_name,
+            has_point_features=has_point_features,
+        )
 
         if atlas_layer is not None:
             self._apply_atlas_page_style(atlas_layer)
 
-    def _apply_activities_layer_style(self, activities_layer, preset, basemap_preset_name):
+    def _apply_activities_layer_style(
+        self,
+        activities_layer,
+        preset,
+        basemap_preset_name,
+        *,
+        has_point_features=False,
+    ):
         if activities_layer is None:
             return
         if preset == BY_ACTIVITY_TYPE_PRESET:
@@ -104,11 +128,22 @@ class LayerStyleService:
             return
         self._apply_simple_line_style(activities_layer, basemap_preset_name)
 
-    def _apply_points_layer_style(self, points_layer, preset, basemap_preset_name):
+    def _apply_points_layer_style(
+        self,
+        points_layer,
+        preset,
+        basemap_preset_name,
+        *,
+        has_point_features=False,
+    ):
         if points_layer is None:
             return
         if preset == "Heatmap":
-            self._apply_heatmap_style(points_layer)
+            if has_point_features:
+                self._apply_heatmap_style(points_layer)
+                return
+            self._apply_track_point_style(points_layer, subtle=True)
+            points_layer.setOpacity(0.0)
             return
         if preset == "Track points":
             self._apply_track_point_style(points_layer, subtle=False)
@@ -118,7 +153,15 @@ class LayerStyleService:
             return
         self._apply_track_point_style(points_layer, subtle=True)
 
-    def _apply_starts_layer_style(self, starts_layer, points_layer, preset, basemap_preset_name):
+    def _apply_starts_layer_style(
+        self,
+        starts_layer,
+        points_layer,
+        preset,
+        basemap_preset_name,
+        *,
+        has_point_features=False,
+    ):
         if starts_layer is None:
             return
         if preset == "Clustered starts":
@@ -128,7 +171,7 @@ class LayerStyleService:
             self._apply_start_point_style(starts_layer, subtle=False)
             return
         if preset == "Heatmap":
-            if points_layer is None:
+            if not has_point_features:
                 self._apply_heatmap_style(starts_layer)
             else:
                 self._apply_start_point_style(starts_layer, subtle=True)
@@ -256,6 +299,9 @@ class LayerStyleService:
         layer.setRenderer(build_qfit_visualize_heatmap_renderer())
         layer.setOpacity(1.0)
         layer.triggerRepaint()
+
+    def _has_features(self, layer):
+        return layer is not None and layer.featureCount() > 0
 
     def _apply_clusterish_style(self, layer):
         symbol = QgsMarkerSymbol.createSimple(


### PR DESCRIPTION
Part of #346

## Summary
- make the Heatmap style preset fall back to start points when the `activity_points` layer exists but has no features
- keep the empty points layer hidden so it does not blank the map
- add unit and PyQGIS smoke coverage for the empty-points fallback path

## Testing
- `python3 -m pytest tests/test_layer_style_service.py -q`
- `python3 -m pytest tests/test_qgis_smoke.py -q -k 'heatmap_preset_falls_back_to_starts_layer_when_points_layer_is_empty or heatmap_preset_falls_back_to_starts_layer or heatmap_preset_renders_visible_output'`
- `python3 -m pytest tests/ -x -q --tb=short` *(completed with `951 passed, 146 skipped`, but the local interpreter segfaulted during teardown afterward with exit 139; CI should confirm this remains the known environment-side teardown issue)*
