### PR TITLE
fix: write activity points by default

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -15,8 +15,8 @@ class StoreActivitiesRequest:
 
     activities: list = field(default_factory=list)
     output_path: str = ""
-    write_activity_points: bool = False
-    point_stride: int = 0
+    write_activity_points: bool = True
+    point_stride: int = 5
     atlas_margin_percent: float = 0.0
     atlas_min_extent_degrees: float = 0.0
     atlas_target_aspect_ratio: float = 0.0
@@ -86,11 +86,11 @@ class LoadWorkflowService:
     def build_write_request(
         activities,
         output_path,
-        write_activity_points,
-        point_stride,
-        atlas_margin_percent,
-        atlas_min_extent_degrees,
-        atlas_target_aspect_ratio,
+        write_activity_points=True,
+        point_stride=5,
+        atlas_margin_percent=0.0,
+        atlas_min_extent_degrees=0.0,
+        atlas_target_aspect_ratio=0.0,
         sync_metadata=None,
         last_sync_date=None,
     ) -> StoreActivitiesRequest:

--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -54,7 +54,7 @@ def bootstrap_empty_gpkg(output_path, atlas_page_settings):
 
 def build_and_write_all_layers(
     records, output_path, atlas_page_settings,
-    write_activity_points=False, point_stride=1,
+    write_activity_points=True, point_stride=5,
 ):
     """Build all visualization layers from *records* and write them to *output_path*.
 

--- a/activities/infrastructure/geopackage/gpkg_writer.py
+++ b/activities/infrastructure/geopackage/gpkg_writer.py
@@ -15,7 +15,7 @@ class GeoPackageWriter:
     def __init__(
         self,
         output_path=None,
-        write_activity_points=False,
+        write_activity_points=True,
         point_stride=5,
         atlas_margin_percent=None,
         atlas_min_extent_degrees=None,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -379,9 +379,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             ),
             UIFieldBinding(
                 "write_activity_points",
-                False,
+                True,
                 lambda: self.writeActivityPointsCheckBox.isChecked(),
-                lambda value: self._set_bool_value(self.writeActivityPointsCheckBox, value, False),
+                lambda value: self._set_bool_value(self.writeActivityPointsCheckBox, value, True),
             ),
             UIFieldBinding(
                 "point_sampling_stride",

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -100,6 +100,71 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
             self.assertEqual(result["path"], "/tmp/qfit-unit.gpkg")
             self.assertEqual(result["sync"], {"added": 1})
 
+    def test_gpkg_writer_defaults_to_writing_activity_points(self):
+        normalize_settings = MagicMock(return_value={"margin_percent": 12})
+        bootstrap_empty_gpkg = MagicMock()
+        build_and_write_all_layers = MagicMock()
+
+        module_overrides = {
+            "qfit.activities.infrastructure.geopackage.gpkg_schema": self._module(
+                "qfit.activities.infrastructure.geopackage.gpkg_schema",
+                GPKG_LAYER_SCHEMA={"activity_tracks": [("name", "String")]},
+            ),
+            "qfit.activities.infrastructure.geopackage.gpkg_write_orchestration": self._module(
+                "qfit.activities.infrastructure.geopackage.gpkg_write_orchestration",
+                bootstrap_empty_gpkg=bootstrap_empty_gpkg,
+                build_and_write_all_layers=build_and_write_all_layers,
+            ),
+            "qfit.atlas.publish_atlas": self._module(
+                "qfit.atlas.publish_atlas",
+                normalize_atlas_page_settings=normalize_settings,
+            ),
+        }
+
+        with patch.dict(sys.modules, module_overrides):
+            sys.modules.pop("qfit.activities.infrastructure.geopackage.gpkg_writer", None)
+
+            moved = importlib.import_module(
+                "qfit.activities.infrastructure.geopackage.gpkg_writer"
+            )
+
+            activity_store = MagicMock()
+            activity_store.upsert_activities.return_value = {"added": 1}
+            activity_store.load_all_activity_records.return_value = [{"name": "Morning Ride"}]
+            layer = MagicMock()
+            layer.featureCount.return_value = 1
+            build_and_write_all_layers.return_value = {
+                "activity_tracks": layer,
+                "activity_starts": layer,
+                "activity_points": layer,
+                "activity_atlas_pages": layer,
+                "atlas_document_summary": layer,
+                "atlas_cover_highlight_count": layer,
+                "atlas_page_detail_items": layer,
+                "atlas_profile_samples": layer,
+                "atlas_toc_entries": layer,
+                "atlas_cover_highlights": layer,
+            }
+
+            writer = moved.GeoPackageWriter(
+                output_path="/tmp/qfit-unit.gpkg",
+                activity_store_factory=lambda _path: activity_store,
+            )
+
+            with patch("os.path.exists", return_value=False), patch("os.path.getsize", return_value=0):
+                writer.write_activities(
+                    [{"name": "Morning Ride"}],
+                    sync_metadata={"provider": "strava"},
+                )
+
+            build_and_write_all_layers.assert_called_once_with(
+                [{"name": "Morning Ride"}],
+                "/tmp/qfit-unit.gpkg",
+                {"margin_percent": 12},
+                write_activity_points=True,
+                point_stride=5,
+            )
+
     def test_moved_gpkg_write_orchestration_and_root_shim_share_same_functions(self):
         write_layer_to_gpkg = MagicMock()
         build_track_layer = MagicMock(side_effect=lambda records: ("tracks", tuple(records)))

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -377,6 +377,12 @@ class LoadResultTests(unittest.TestCase):
 
 
 class LoadRequestContractTests(unittest.TestCase):
+    def test_store_activities_request_defaults_keep_points_enabled(self):
+        request = LoadDatabaseRequest()
+
+        self.assertTrue(request.write_activity_points)
+        self.assertEqual(request.point_stride, 5)
+
     def test_build_write_request_returns_dataclass(self):
         request = LoadWorkflowService.build_write_request(
             activities=["a"],
@@ -394,6 +400,15 @@ class LoadRequestContractTests(unittest.TestCase):
         self.assertEqual(request.output_path, "/tmp/test.gpkg")
         self.assertTrue(request.write_activity_points)
         self.assertEqual(request.sync_metadata["provider"], "strava")
+
+    def test_build_write_request_defaults_to_activity_points(self):
+        request = LoadWorkflowService.build_write_request(
+            activities=["a"],
+            output_path="/tmp/test.gpkg",
+        )
+
+        self.assertTrue(request.write_activity_points)
+        self.assertEqual(request.point_stride, 5)
 
     def test_build_load_existing_request_returns_dataclass(self):
         request = LoadWorkflowService.build_load_existing_request("/tmp/existing.gpkg")

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -252,6 +252,8 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.loadLayersButton.text(), "Load activity layers")
             self.assertEqual(dock.clearDatabaseButton.text(), "Clear database")
             self.assertEqual(dock.applyFiltersButton.text(), "Apply current filters to loaded layers")
+            self.assertTrue(dock.writeActivityPointsCheckBox.isChecked())
+            self.assertFalse(dock.pointSamplingStrideSpinBox.isHidden())
             self.assertFalse(dock.backgroundHelpLabel.isVisible())
             self.assertFalse(dock.analysisHelpLabel.isVisible())
             self.assertFalse(dock.publishHelpLabel.isVisible())


### PR DESCRIPTION
Part of #346

## Summary
- default the GeoPackage write pipeline to maintain `activity_points`
- default fresh store requests and fresh dock settings to keep point generation enabled
- add persistence, workflow, and dock smoke coverage around the new defaults

## Testing
- `python3 -m pytest tests/test_load_workflow.py tests/test_gpkg_geopackage_unit.py -q`
- `python3 -m pytest tests/test_qgis_smoke.py -q -k 'dock_widget_contextual_help_smoke or workflow_section_coordinator_updates_visibility_rules'`
- `python3 -m pytest tests/ -x -q --tb=short` *(completed with `954 passed, 146 skipped`, then hit the known local interpreter teardown segfault with exit 139)*
