### PR TITLE
fix: keep activity points enabled on writes

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -132,7 +132,7 @@ class LoadWorkflowService:
 
         writer = GeoPackageWriter(
             output_path=request.output_path,
-            write_activity_points=request.write_activity_points,
+            write_activity_points=True,
             point_stride=request.point_stride,
             atlas_margin_percent=request.atlas_margin_percent,
             atlas_min_extent_degrees=request.atlas_min_extent_degrees,

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -200,6 +200,39 @@ class WriteAndLoadSuccessTests(unittest.TestCase):
             atlas_target_aspect_ratio=2.0,
         )
 
+    def test_write_and_load_ignores_legacy_request_to_disable_activity_points(self):
+        write_result = {
+            "path": "/tmp/out.gpkg",
+            "fetched_count": 1,
+            "track_count": 0,
+            "start_count": 0,
+            "point_count": 0,
+            "atlas_count": 0,
+            "sync": SyncStats(total_count=1, inserted=1, updated=0, unchanged=0),
+        }
+        mock_gpkg = self._make_writer_mock(write_result)
+        self.layer_manager.load_output_layers.return_value = (None, None, None, None)
+
+        with patch(f"{_GPKG_WRITER_MODULE}.GeoPackageWriter", mock_gpkg.GeoPackageWriter):
+            self.service.write_and_load(
+                activities=["a"],
+                output_path="/tmp/test.gpkg",
+                write_activity_points=False,
+                point_stride=10,
+                atlas_margin_percent=5.0,
+                atlas_min_extent_degrees=0.02,
+                atlas_target_aspect_ratio=2.0,
+            )
+
+        mock_gpkg.GeoPackageWriter.assert_called_once_with(
+            output_path="/tmp/test.gpkg",
+            write_activity_points=True,
+            point_stride=10,
+            atlas_margin_percent=5.0,
+            atlas_min_extent_degrees=0.02,
+            atlas_target_aspect_ratio=2.0,
+        )
+
 
 class WriteDatabaseSuccessTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Part of #346

## Summary
- make the store workflow treat `activity_points` as a managed derivative of activity writes
- ignore legacy requests that try to disable point generation in the normal qfit write path
- add regression coverage so old saved settings cannot silently produce stale or missing points

## Testing
- `python3 -m pytest tests/test_load_workflow.py -q`
- `python3 -m pytest tests/ -x -q --tb=short` *(completed with `955 passed, 146 skipped`, then hit the known local interpreter teardown segfault with exit 139)*
