### PR TITLE
fix: prune stale activity points on full sync

### DIFF
--- a/activities/application/fetch_task.py
+++ b/activities/application/fetch_task.py
@@ -80,6 +80,11 @@ class FetchTask(QgsTask):
         Returns ``True`` on success, ``False`` on error or cancellation.
         """
         try:
+            self._provider.last_fetch_context = {
+                "max_pages": self._max_pages,
+                "before": self._before,
+                "after": self._after,
+            }
             self._activities = self._provider.fetch_activities(
                 per_page=self._per_page,
                 max_pages=self._max_pages,

--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -244,6 +244,10 @@ class SyncController:
         """Return a sync-context dict from a completed fetch."""
         detailed_count = sum(1 for a in activities if a.geometry_source == "stream")
         today_str = date.today().isoformat()
+        fetch_context = getattr(provider, "last_fetch_context", {}) or {}
+        is_unbounded_fetch = int(fetch_context.get("max_pages") or 0) == 0
+        uses_default_bounds = fetch_context.get("before") is None and fetch_context.get("after") is None
+        is_full_sync = is_unbounded_fetch and uses_default_bounds and not getattr(provider, "last_fetch_notice", None)
         return {
             "provider": provider.source_name,
             "before_epoch": None,
@@ -252,7 +256,7 @@ class SyncController:
             "detailed_count": detailed_count,
             "stream_stats": provider.last_stream_enrichment_stats,
             "rate_limit": provider.last_rate_limit,
-            "is_full_sync": True,
+            "is_full_sync": is_full_sync,
             "today_str": today_str,
         }
 

--- a/sync_repository.py
+++ b/sync_repository.py
@@ -192,6 +192,7 @@ class SyncRepository:
                 else:
                     updated += 1
 
+            self._prune_missing_activities(cursor, activities, sync_metadata)
             total_count = cursor.execute("SELECT COUNT(*) FROM activity_registry").fetchone()[0]
             self._update_sync_state(cursor, activities, sync_metadata, now, inserted, updated, unchanged, total_count)
             connection.commit()
@@ -201,6 +202,33 @@ class SyncRepository:
             updated=updated,
             unchanged=unchanged,
             total_count=total_count,
+        )
+
+    def _prune_missing_activities(self, cursor, activities, sync_metadata):
+        if not sync_metadata.get("is_full_sync"):
+            return
+
+        provider = sync_metadata.get("provider") or (activities[0].source if activities else "strava")
+        incoming_ids = {
+            str(activity.source_activity_id if hasattr(activity, "source_activity_id") else activity.get("source_activity_id"))
+            for activity in activities
+            if (activity.source if hasattr(activity, "source") else activity.get("source")) == provider
+            and (activity.source_activity_id if hasattr(activity, "source_activity_id") else activity.get("source_activity_id")) is not None
+        }
+
+        if incoming_ids:
+            placeholders = ", ".join("?" for _ in incoming_ids)
+            cursor.execute(
+                "DELETE FROM activity_registry WHERE source = ? AND source_activity_id NOT IN ({placeholders})".format(
+                    placeholders=placeholders,
+                ),
+                [provider, *sorted(incoming_ids)],
+            )
+            return
+
+        cursor.execute(
+            "DELETE FROM activity_registry WHERE source = ?",
+            (provider,),
         )
 
     def load_all_activity_records(self):

--- a/tests/test_fetch_task.py
+++ b/tests/test_fetch_task.py
@@ -132,6 +132,13 @@ class TestFetchTaskSuccess(unittest.TestCase):
             detailed_route_strategy="Missing routes only",
         )
 
+    def test_records_fetch_context_on_provider(self):
+        _run_task(self.task)
+        self.assertEqual(
+            self.mock_provider.last_fetch_context,
+            {"max_pages": 0, "before": None, "after": None},
+        )
+
 
 class TestFetchTaskError(unittest.TestCase):
     def setUp(self):

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1066,6 +1066,38 @@ class QgisSmokeTests(unittest.TestCase):
             self.layer_manager.ensure_background_layer(False, "Outdoor", "test-token")
             self.assertNotIn(background_name, self._layer_order())
 
+    def test_full_sync_rewrite_removes_stale_activity_points(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = str(Path(temp_dir) / "qfit-prune-points.gpkg")
+            writer = GeoPackageWriter(
+                output_path,
+                write_activity_points=True,
+                point_stride=1,
+                atlas_margin_percent=10,
+                atlas_min_extent_degrees=0.01,
+                atlas_target_aspect_ratio=1.5,
+            )
+
+            writer.write_activities(
+                self._sample_activities(),
+                sync_metadata={"provider": "strava", "is_full_sync": True},
+            )
+            _activities_layer, _starts_layer, points_layer, _atlas_layer = self.layer_manager.load_output_layers(output_path)
+            initial_ids = sorted({feature["source_activity_id"] for feature in points_layer.getFeatures()})
+            initial_point_count = points_layer.featureCount()
+
+            writer.write_activities(
+                self._sample_activities()[:1],
+                sync_metadata={"provider": "strava", "is_full_sync": True},
+            )
+            activities_layer, _starts_layer, points_layer, _atlas_layer = self.layer_manager.load_output_layers(output_path)
+
+            self.assertEqual(initial_ids, ["1001", "1002"])
+            self.assertEqual(activities_layer.featureCount(), 1)
+            self.assertLess(points_layer.featureCount(), initial_point_count)
+            remaining_ids = sorted({feature["source_activity_id"] for feature in points_layer.getFeatures()})
+            self.assertEqual(remaining_ids, ["1001"])
+
     def test_heatmap_preset_renderer_and_layer_visibility(self):
         """Heatmap preset must produce a density-based renderer and suppress other layers."""
         from qgis.core import QgsHeatmapRenderer, QgsUnitTypes

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -295,6 +295,8 @@ class BuildSyncMetadataTests(unittest.TestCase):
             source_name="strava",
             last_stream_enrichment_stats={"cached": 1},
             last_rate_limit={"short_remaining": 10},
+            last_fetch_notice=None,
+            last_fetch_context={"max_pages": 0, "before": None, "after": None},
         )
         meta = ctrl.build_sync_metadata([activity], provider)
         self.assertEqual(meta["provider"], "strava")
@@ -313,6 +315,8 @@ class BuildSyncMetadataTests(unittest.TestCase):
             source_name="strava",
             last_stream_enrichment_stats=None,
             last_rate_limit=None,
+            last_fetch_notice=None,
+            last_fetch_context={"max_pages": 0, "before": None, "after": None},
         )
         meta = ctrl.build_sync_metadata(activities, provider)
         self.assertEqual(meta["detailed_count"], 1)
@@ -324,9 +328,39 @@ class BuildSyncMetadataTests(unittest.TestCase):
             source_name="gpx",
             last_stream_enrichment_stats=None,
             last_rate_limit=None,
+            last_fetch_notice=None,
+            last_fetch_context={"max_pages": 0, "before": None, "after": None},
         )
         meta = ctrl.build_sync_metadata([], provider)
         self.assertEqual(meta["provider"], "gpx")
+
+    def test_metadata_marks_bounded_fetch_as_not_full_sync(self):
+        ctrl = SyncController()
+        provider = SimpleNamespace(
+            source_name="strava",
+            last_stream_enrichment_stats=None,
+            last_rate_limit=None,
+            last_fetch_notice=None,
+            last_fetch_context={"max_pages": 1, "before": None, "after": None},
+        )
+
+        meta = ctrl.build_sync_metadata([], provider)
+
+        self.assertFalse(meta["is_full_sync"])
+
+    def test_metadata_marks_rate_limited_fetch_as_not_full_sync(self):
+        ctrl = SyncController()
+        provider = SimpleNamespace(
+            source_name="strava",
+            last_stream_enrichment_stats=None,
+            last_rate_limit={"short_remaining": 2},
+            last_fetch_notice="Stopped early to avoid hitting the Strava rate limit.",
+            last_fetch_context={"max_pages": 0, "before": None, "after": None},
+        )
+
+        meta = ctrl.build_sync_metadata([], provider)
+
+        self.assertFalse(meta["is_full_sync"])
 
 
 class FetchStatusTextTests(unittest.TestCase):

--- a/tests/test_sync_repository.py
+++ b/tests/test_sync_repository.py
@@ -279,6 +279,44 @@ class SyncUnchangedBehaviorTests(unittest.TestCase):
             self.assertEqual(stats["updated"], 0)
             self.assertEqual(stats["stored_total"], 1)
 
+    def test_full_sync_prunes_missing_activities_for_same_provider(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = SyncRepository(str(Path(tmpdir) / "qfit.sqlite"))
+            repo.ensure_schema()
+
+            repo.upsert_activities([
+                self._activity(source_activity_id="A", distance_m=100.0),
+                self._activity(source_activity_id="B", distance_m=200.0),
+            ])
+
+            result = repo.upsert_activities(
+                [self._activity(source_activity_id="A", distance_m=100.0)],
+                sync_metadata={"provider": "strava", "is_full_sync": True},
+            )
+
+            self.assertEqual(result.total_count, 1)
+            stored_ids = [activity.source_activity_id for activity in repo.load_all_activities()]
+            self.assertEqual(stored_ids, ["A"])
+
+    def test_incremental_sync_keeps_missing_activities(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = SyncRepository(str(Path(tmpdir) / "qfit.sqlite"))
+            repo.ensure_schema()
+
+            repo.upsert_activities([
+                self._activity(source_activity_id="A", distance_m=100.0),
+                self._activity(source_activity_id="B", distance_m=200.0),
+            ])
+
+            result = repo.upsert_activities(
+                [self._activity(source_activity_id="A", distance_m=100.0)],
+                sync_metadata={"provider": "strava", "is_full_sync": False},
+            )
+
+            self.assertEqual(result.total_count, 2)
+            stored_ids = sorted(activity.source_activity_id for activity in repo.load_all_activities())
+            self.assertEqual(stored_ids, ["A", "B"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Part of #346

## Summary
- prune missing activities from the canonical sync registry during full-sync writes
- let the existing GeoPackage rebuild path remove stale `activity_points` rows from activities that disappeared
- add repository and PyQGIS regression coverage for full-sync pruning versus incremental sync behavior

## Testing
- `python3 -m pytest tests/test_sync_repository.py -q`
- `python3 -m pytest tests/test_qgis_smoke.py -q -k 'full_sync_rewrite_removes_stale_activity_points or headless_qgis_smoke_covers_write_load_crs_temporal_and_background_order'`
- `python3 -m pytest tests/ -x -q --tb=short` *(completed with `957 passed, 147 skipped`, then hit the known local interpreter teardown segfault with exit 139)*
