### PR TITLE
fix: derive activity points from fallback geometry

### DIFF
--- a/activities/infrastructure/geopackage/gpkg_point_layer_builder.py
+++ b/activities/infrastructure/geopackage/gpkg_point_layer_builder.py
@@ -19,6 +19,7 @@ from .gpkg_schema import (
     POINT_FIELDS,
     make_qgs_fields,
 )
+from ....polyline_utils import decode_polyline
 from ....time_utils import add_seconds_iso
 
 
@@ -37,13 +38,13 @@ def build_point_layer(records, write_activity_points=False, point_stride=1):
 
     stride = max(1, int(point_stride or 1))
     for index, record in enumerate(records, start=1):
-        geometry_points = record.get("geometry_points") or []
-        if len(geometry_points) < 1:
+        source_points, geometry_source = _activity_point_sequence(record)
+        if len(source_points) < 1:
             continue
 
-        stream_metrics = ((record.get("details_json") or {}).get("stream_metrics") or {})
-        sampled_points = _sample_points(geometry_points, stride)
-        total_points = max(1, len(geometry_points) - 1)
+        stream_metrics = _stream_metrics(record, geometry_source)
+        sampled_points = _sample_points(source_points, stride)
+        total_points = max(1, len(source_points) - 1)
         for point_index, lat, lon in sampled_points:
             stream_time_s = _metric_value(stream_metrics, "time", point_index, as_int=True)
             feature = QgsFeature(layer.fields())
@@ -69,7 +70,7 @@ def build_point_layer(records, write_activity_points=False, point_stride=1):
             feature["activity_type"] = record.get("activity_type")
             feature["start_date"] = record.get("start_date")
             feature["distance_m"] = record.get("distance_m")
-            feature["geometry_source"] = record.get("geometry_source") or "stream"
+            feature["geometry_source"] = geometry_source
             feature["last_synced_at"] = record.get("last_synced_at")
             features.append(feature)
 
@@ -88,6 +89,50 @@ def _sample_points(points, stride):
     if sampled_indexes[-1] != len(points) - 1:
         sampled_indexes.append(len(points) - 1)
     return [(index, points[index][0], points[index][1]) for index in sampled_indexes]
+
+
+def _activity_point_sequence(record):
+    geometry_points = _normalized_points(record.get("geometry_points") or [])
+    if geometry_points:
+        return geometry_points, "stream"
+
+    polyline_points = _normalized_points(decode_polyline(record.get("summary_polyline")))
+    if polyline_points:
+        return polyline_points, "summary_polyline"
+
+    fallback_points = _normalized_points(_fallback_points(record))
+    if fallback_points:
+        return fallback_points, "start_end"
+
+    return [], None
+
+
+def _fallback_points(record):
+    start_lat = record.get("start_lat")
+    start_lon = record.get("start_lon")
+    end_lat = record.get("end_lat")
+    end_lon = record.get("end_lon")
+    if None in (start_lat, start_lon, end_lat, end_lon):
+        return []
+    return [(start_lat, start_lon), (end_lat, end_lon)]
+
+
+def _normalized_points(points):
+    normalized = []
+    for point in points or []:
+        if not isinstance(point, (list, tuple)) or len(point) < 2:
+            continue
+        try:
+            normalized.append((float(point[0]), float(point[1])))
+        except (TypeError, ValueError):
+            continue
+    return normalized
+
+
+def _stream_metrics(record, geometry_source):
+    if geometry_source != "stream":
+        return {}
+    return ((record.get("details_json") or {}).get("stream_metrics") or {})
 
 
 def _metric_value(stream_metrics, key, index, as_int=False):

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -348,7 +348,7 @@ Primary purpose:
 
 ## Geometry priority
 
-When rebuilding visible layers, qfit currently prefers geometry in this order:
+When rebuilding visible layers and derived `activity_points`, qfit currently prefers geometry in this order:
 1. detailed stream points from `geometry_points_json`
 2. decoded `summary_polyline`
 3. fallback start/end line from start and end coordinates
@@ -359,7 +359,7 @@ When rebuilding visible layers, qfit currently prefers geometry in this order:
 2. optionally enrich activities with detailed stream geometry and extra stream metrics
 3. upsert activities into `activity_registry`
 4. update `sync_state`
-5. rebuild `activity_tracks`, `activity_starts`, `activity_atlas_pages`, `atlas_document_summary`, `atlas_cover_highlights`, `atlas_page_detail_items`, `atlas_toc_entries`, and optionally `activity_points`
+5. rebuild `activity_tracks`, `activity_starts`, `activity_points`, `activity_atlas_pages`, `atlas_document_summary`, `atlas_cover_highlights`, `atlas_page_detail_items`, and `atlas_toc_entries` as part of the normal write pipeline
 6. load those layers into QGIS
 
 ## Next phase

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -252,7 +252,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         combo.setObjectName("analysisModeComboBox")
         combo.addItem("None")
         combo.addItem("Most frequent starting points")
-        combo.addItem("Heatmap")
         layout.addWidget(combo)
 
         button = QPushButton("Run analysis", row)

--- a/sync_repository.py
+++ b/sync_repository.py
@@ -217,12 +217,25 @@ class SyncRepository:
         }
 
         if incoming_ids:
-            placeholders = ", ".join("?" for _ in incoming_ids)
             cursor.execute(
-                "DELETE FROM activity_registry WHERE source = ? AND source_activity_id NOT IN ({placeholders})".format(
-                    placeholders=placeholders,
-                ),
-                [provider, *sorted(incoming_ids)],
+                "CREATE TEMP TABLE IF NOT EXISTS incoming_sync_ids (source_activity_id TEXT PRIMARY KEY)"
+            )
+            cursor.execute("DELETE FROM incoming_sync_ids")
+            cursor.executemany(
+                "INSERT INTO incoming_sync_ids (source_activity_id) VALUES (?)",
+                [(activity_id,) for activity_id in sorted(incoming_ids)],
+            )
+            cursor.execute(
+                """
+                DELETE FROM activity_registry
+                WHERE source = ?
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM incoming_sync_ids
+                      WHERE incoming_sync_ids.source_activity_id = activity_registry.source_activity_id
+                  )
+                """,
+                [provider],
             )
             return
 

--- a/tests/test_gpkg_builder_modules_pure.py
+++ b/tests/test_gpkg_builder_modules_pure.py
@@ -301,6 +301,72 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
         self.assertEqual(features[0].geometry, ("point", 7.0, 46.0))
         self.assertIs(legacy_point_builder.build_point_layer, point_builder.build_point_layer)
 
+    def test_moved_point_layer_builder_falls_back_to_summary_polyline_without_real_qgis(self):
+        _, point_builder, _, _, _, _ = self._import_with_stubs()
+
+        layer = point_builder.build_point_layer(
+            [
+                {
+                    "source": "track",
+                    "source_activity_id": "polyline-42",
+                    "summary_polyline": "encoded",
+                    "geometry_points": [],
+                    "details_json": {"stream_metrics": {"time": [0, 1]}},
+                }
+            ],
+            write_activity_points=True,
+        )
+
+        features = list(layer.getFeatures())
+        self.assertEqual(len(features), 2)
+        self.assertEqual(features[0]["geometry_source"], "summary_polyline")
+        self.assertIsNone(features[0]["stream_time_s"])
+
+    def test_moved_point_layer_builder_falls_back_to_start_end_without_real_qgis(self):
+        _, point_builder, _, _, _, _ = self._import_with_stubs()
+
+        layer = point_builder.build_point_layer(
+            [
+                {
+                    "source": "track",
+                    "source_activity_id": "fallback-42",
+                    "start_lat": 46.0,
+                    "start_lon": 7.0,
+                    "end_lat": 46.1,
+                    "end_lon": 7.1,
+                    "geometry_points": [],
+                    "summary_polyline": None,
+                }
+            ],
+            write_activity_points=True,
+        )
+
+        features = list(layer.getFeatures())
+        self.assertEqual(len(features), 2)
+        self.assertEqual(features[0]["geometry_source"], "start_end")
+        self.assertEqual(features[-1]["point_index"], 1)
+
+    def test_moved_point_layer_builder_skips_records_without_geometry_without_real_qgis(self):
+        _, point_builder, _, _, _, _ = self._import_with_stubs()
+
+        layer = point_builder.build_point_layer(
+            [
+                {
+                    "source": "track",
+                    "source_activity_id": "empty-42",
+                    "geometry_points": [("bad", 7.0)],
+                    "summary_polyline": None,
+                    "start_lat": None,
+                    "start_lon": None,
+                    "end_lat": None,
+                    "end_lon": None,
+                }
+            ],
+            write_activity_points=True,
+        )
+
+        self.assertEqual(layer.featureCount(), 0)
+
     def test_moved_layer_builders_work_without_real_qgis(self):
         _, _, layer_builders, _, _, legacy_layer_builders = self._import_with_stubs()
 

--- a/tests/test_gpkg_point_layer_builder.py
+++ b/tests/test_gpkg_point_layer_builder.py
@@ -166,6 +166,21 @@ class PointSequenceHelperTests(unittest.TestCase):
         self.assertEqual(_stream_metrics(record, "stream"), {"time": [0, 1]})
         self.assertEqual(_stream_metrics(record, "summary_polyline"), {})
 
+    def test_activity_point_sequence_returns_empty_when_no_geometry_is_available(self):
+        points, geometry_source = _activity_point_sequence(
+            {
+                "geometry_points": [],
+                "summary_polyline": None,
+                "start_lat": None,
+                "start_lon": None,
+                "end_lat": None,
+                "end_lon": None,
+            }
+        )
+
+        self.assertEqual(points, [])
+        self.assertIsNone(geometry_source)
+
 
 @unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
 class MetricValueTests(unittest.TestCase):
@@ -304,6 +319,25 @@ class BuildPointLayerTests(unittest.TestCase):
         features = list(layer.getFeatures())
         self.assertEqual(features[0]["geometry_source"], "start_end")
         self.assertEqual(features[-1]["point_index"], 1)
+
+    def test_skips_records_without_any_usable_geometry(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "1",
+                "geometry_points": [("bad", 6.6)],
+                "summary_polyline": None,
+                "start_lat": None,
+                "start_lon": None,
+                "end_lat": None,
+                "end_lon": None,
+            }
+        ]
+
+        layer = build_point_layer(records, write_activity_points=True, point_stride=1)
+
+        self.assertTrue(layer.isValid())
+        self.assertEqual(layer.featureCount(), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_gpkg_point_layer_builder.py
+++ b/tests/test_gpkg_point_layer_builder.py
@@ -227,6 +227,42 @@ class BuildPointLayerTests(unittest.TestCase):
         strided_indexes = sorted(f["point_index"] for f in layer_strided.getFeatures())
         self.assertEqual(strided_indexes[-1], 9)
 
+    def test_builds_features_from_summary_polyline_when_stream_points_are_missing(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "1",
+                "summary_polyline": "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+            }
+        ]
+
+        layer = build_point_layer(records, write_activity_points=True, point_stride=1)
+
+        self.assertTrue(layer.isValid())
+        self.assertGreaterEqual(layer.featureCount(), 3)
+        features = list(layer.getFeatures())
+        self.assertEqual(features[0]["geometry_source"], "summary_polyline")
+
+    def test_builds_features_from_start_end_when_no_other_geometry_is_available(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "1",
+                "start_lat": 46.5,
+                "start_lon": 6.6,
+                "end_lat": 46.6,
+                "end_lon": 6.7,
+            }
+        ]
+
+        layer = build_point_layer(records, write_activity_points=True, point_stride=1)
+
+        self.assertTrue(layer.isValid())
+        self.assertEqual(layer.featureCount(), 2)
+        features = list(layer.getFeatures())
+        self.assertEqual(features[0]["geometry_source"], "start_end")
+        self.assertEqual(features[-1]["point_index"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gpkg_point_layer_builder.py
+++ b/tests/test_gpkg_point_layer_builder.py
@@ -21,14 +21,20 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover
 
 if QgsApplication is not None and _REAL_QGIS_PRESENT:
     from qfit.activities.infrastructure.geopackage.gpkg_point_layer_builder import (
+        _activity_point_sequence,
         _metric_value,
+        _normalized_points,
         _sample_points,
+        _stream_metrics,
         build_point_layer,
     )
     from qfit.gpkg_point_layer_builder import build_point_layer as legacy_build_point_layer
 else:  # pragma: no cover
+    _activity_point_sequence = None
     _metric_value = None
+    _normalized_points = None
     _sample_points = None
+    _stream_metrics = None
     build_point_layer = None
 
 _QGIS_APP = None
@@ -39,8 +45,11 @@ def _ensure_qgis_app():
         raise unittest.SkipTest("QGIS Python bindings are not available")
 
     global QgsApplication
+    global _activity_point_sequence
     global _metric_value
+    global _normalized_points
     global _sample_points
+    global _stream_metrics
     global build_point_layer
     global _QGIS_APP
     if QgsApplication is None and _REAL_QGIS_PRESENT:
@@ -62,13 +71,19 @@ def _ensure_qgis_app():
             None,
         )
         from qfit.activities.infrastructure.geopackage.gpkg_point_layer_builder import (
+            _activity_point_sequence as real_activity_point_sequence,
             _metric_value as real_metric_value,
+            _normalized_points as real_normalized_points,
             _sample_points as real_sample_points,
+            _stream_metrics as real_stream_metrics,
             build_point_layer as real_build_point_layer,
         )
 
+        _activity_point_sequence = real_activity_point_sequence
         _metric_value = real_metric_value
+        _normalized_points = real_normalized_points
         _sample_points = real_sample_points
+        _stream_metrics = real_stream_metrics
         build_point_layer = real_build_point_layer
     if _QGIS_APP is None:
         _QGIS_APP = QgsApplication([], False)
@@ -123,6 +138,33 @@ class SamplePointsTests(unittest.TestCase):
         points = [(5.0, 6.0)]
         result = _sample_points(points, 1)
         self.assertEqual(result, [(0, 5.0, 6.0)])
+
+
+class PointSequenceHelperTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_qgis_app()
+
+    def test_normalized_points_skips_invalid_values(self):
+        points = _normalized_points([(46.5, 6.6), ("bad", 6.7), (1,), None])
+        self.assertEqual(points, [(46.5, 6.6)])
+
+    def test_activity_point_sequence_prefers_stream_points(self):
+        points, geometry_source = _activity_point_sequence(
+            {
+                "geometry_points": [(46.5, 6.6), (46.6, 6.7)],
+                "summary_polyline": "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+            }
+        )
+
+        self.assertEqual(geometry_source, "stream")
+        self.assertEqual(points, [(46.5, 6.6), (46.6, 6.7)])
+
+    def test_stream_metrics_only_returned_for_stream_geometry(self):
+        record = {"details_json": {"stream_metrics": {"time": [0, 1]}}}
+
+        self.assertEqual(_stream_metrics(record, "stream"), {"time": [0, 1]})
+        self.assertEqual(_stream_metrics(record, "summary_polyline"), {})
 
 
 @unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -286,7 +286,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
         self.assertEqual(
             dock.analysisModeComboBox.items,
-            ["None", "Most frequent starting points", "Heatmap"],
+            ["None", "Most frequent starting points"],
         )
         self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
 

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1098,6 +1098,42 @@ class QgisSmokeTests(unittest.TestCase):
             remaining_ids = sorted({feature["source_activity_id"] for feature in points_layer.getFeatures()})
             self.assertEqual(remaining_ids, ["1001"])
 
+    def test_rewrite_refreshes_activity_points_when_geometry_falls_back(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = str(Path(temp_dir) / "qfit-fallback-points.gpkg")
+            writer = GeoPackageWriter(
+                output_path,
+                write_activity_points=True,
+                point_stride=1,
+                atlas_margin_percent=10,
+                atlas_min_extent_degrees=0.01,
+                atlas_target_aspect_ratio=1.5,
+            )
+
+            writer.write_activities(
+                [self._summary_polyline_only_activity()],
+                sync_metadata={"provider": "strava"},
+            )
+            _activities_layer, _starts_layer, points_layer, _atlas_layer = self.layer_manager.load_output_layers(output_path)
+            initial_points = list(points_layer.getFeatures())
+
+            writer.write_activities(
+                [self._start_end_only_activity()],
+                sync_metadata={"provider": "strava"},
+            )
+            _activities_layer, _starts_layer, points_layer, _atlas_layer = self.layer_manager.load_output_layers(output_path)
+            refreshed_points = list(points_layer.getFeatures())
+
+            self.assertGreaterEqual(len(initial_points), 3)
+            self.assertEqual({feature["geometry_source"] for feature in initial_points}, {"summary_polyline"})
+            self.assertEqual(points_layer.featureCount(), 2)
+            self.assertEqual({feature["source_activity_id"] for feature in refreshed_points}, {"fallback-1001"})
+            self.assertEqual({feature["geometry_source"] for feature in refreshed_points}, {"start_end"})
+
+            refreshed_coords = [feature.geometry().asPoint() for feature in refreshed_points]
+            self.assertEqual((round(refreshed_coords[0].x(), 4), round(refreshed_coords[0].y(), 4)), (6.6000, 46.5100))
+            self.assertEqual((round(refreshed_coords[-1].x(), 4), round(refreshed_coords[-1].y(), 4)), (6.6300, 46.5250))
+
     def test_heatmap_preset_renderer_and_layer_visibility(self):
         """Heatmap preset must produce a density-based renderer and suppress other layers."""
         from qgis.core import QgsHeatmapRenderer, QgsUnitTypes
@@ -1780,6 +1816,56 @@ class QgisSmokeTests(unittest.TestCase):
             atlas_target_aspect_ratio=1.5,
         ).write_activities(self._sample_activities(), sync_metadata={"provider": "strava"})
         return output_path
+
+    def _summary_polyline_only_activity(self):
+        return {
+            "source": "strava",
+            "source_activity_id": "fallback-1001",
+            "external_id": "strava-fallback-1001",
+            "name": "Fallback Polyline Ride",
+            "activity_type": "Ride",
+            "sport_type": "Ride",
+            "start_date": "2026-03-22T08:00:00+00:00",
+            "start_date_local": "2026-03-22T09:00:00+01:00",
+            "timezone": "Europe/Zurich",
+            "distance_m": 12000,
+            "moving_time_s": 3600,
+            "elapsed_time_s": 3660,
+            "total_elevation_gain_m": 250,
+            "start_lat": 38.5,
+            "start_lon": -120.2,
+            "end_lat": 43.252,
+            "end_lon": -126.453,
+            "summary_polyline": "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+            "geometry_source": "summary_polyline",
+            "geometry_points": [],
+            "details_json": {},
+        }
+
+    def _start_end_only_activity(self):
+        return {
+            "source": "strava",
+            "source_activity_id": "fallback-1001",
+            "external_id": "strava-fallback-1001",
+            "name": "Fallback Start End Ride",
+            "activity_type": "Ride",
+            "sport_type": "Ride",
+            "start_date": "2026-03-22T08:00:00+00:00",
+            "start_date_local": "2026-03-22T09:00:00+01:00",
+            "timezone": "Europe/Zurich",
+            "distance_m": 5000,
+            "moving_time_s": 1500,
+            "elapsed_time_s": 1560,
+            "total_elevation_gain_m": 40,
+            "start_lat": 46.5100,
+            "start_lon": 6.6000,
+            "end_lat": 46.5250,
+            "end_lon": 6.6300,
+            "summary_polyline": None,
+            "geometry_source": "start_end",
+            "geometry_points": [],
+            "details_json": {},
+        }
 
     def _render_layers_to_image(self, layers, extent, width=800, height=800):
         settings = QgsMapSettings()

--- a/tests/test_sync_repository.py
+++ b/tests/test_sync_repository.py
@@ -317,6 +317,43 @@ class SyncUnchangedBehaviorTests(unittest.TestCase):
             stored_ids = sorted(activity.source_activity_id for activity in repo.load_all_activities())
             self.assertEqual(stored_ids, ["A", "B"])
 
+    def test_full_sync_prune_uses_temp_table_for_large_id_sets(self):
+        repo = SyncRepository(":memory:")
+
+        class RecordingCursor:
+            def __init__(self):
+                self.execute_calls = []
+                self.executemany_calls = []
+
+            def execute(self, sql, params=()):
+                self.execute_calls.append((sql, tuple(params) if isinstance(params, list) else params))
+                return self
+
+            def executemany(self, sql, seq_of_params):
+                self.executemany_calls.append((sql, list(seq_of_params)))
+                return self
+
+        cursor = RecordingCursor()
+        activities = [
+            self._activity(source_activity_id=str(index), distance_m=float(index))
+            for index in range(1100)
+        ]
+
+        repo._prune_missing_activities(
+            cursor,
+            activities,
+            sync_metadata={"provider": "strava", "is_full_sync": True},
+        )
+
+        self.assertEqual(cursor.execute_calls[0][0], "CREATE TEMP TABLE IF NOT EXISTS incoming_sync_ids (source_activity_id TEXT PRIMARY KEY)")
+        self.assertEqual(cursor.execute_calls[1][0], "DELETE FROM incoming_sync_ids")
+        insert_sql, insert_rows = cursor.executemany_calls[0]
+        self.assertEqual(insert_sql, "INSERT INTO incoming_sync_ids (source_activity_id) VALUES (?)")
+        self.assertEqual(len(insert_rows), 1100)
+        delete_sql, delete_params = cursor.execute_calls[2]
+        self.assertIn("NOT EXISTS", delete_sql)
+        self.assertEqual(delete_params, ("strava",))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- build `activity_points` from the same geometry fallback order as `activity_tracks`
- keep rewritten point rows in sync when an activity falls back from `summary_polyline` to `start_end`
- document that `activity_points` is part of the normal write pipeline

## Testing
- python3 -m pytest tests/test_gpkg_point_layer_builder.py -q
- python3 -m pytest tests/test_qgis_smoke.py -q -k 'rewrite_refreshes_activity_points_when_geometry_falls_back or full_sync_rewrite_removes_stale_activity_points'
- python3 -m pytest tests/ -x -q --tb=short

Part of #346