### PR TITLE
fix: standardize visualize temporal playback on local time

### DIFF
--- a/docs/qgis-testing.md
+++ b/docs/qgis-testing.md
@@ -77,7 +77,7 @@ Inside the dock:
 7. in **Store data**, choose an output `.gpkg` and optionally enable sampled `activity_points`
 8. click **Store and load layers**
 9. in **Visualize**, optionally configure a basemap and click **Load basemap**
-10. in **Analyze**, optionally switch **Temporal timestamps** to `Local activity time` or `UTC time`
+10. in **Visualize**, optionally enable a basemap, then keep the default local-time temporal playback behavior
 11. click **Apply current filters to loaded layers** if you want the loaded layers and tables to follow the current dock query
 12. expand **Publish / atlas** only when you want to tune atlas framing controls
 13. hover the contextual-help tooltips / `?` buttons if you want reminders about detailed-track limits, point sampling, basemap setup, publish framing, or store/load vs filter behavior
@@ -119,4 +119,4 @@ Once qfit is loaded successfully, good manual checks are:
 - confirm `activity_points` attributes contain time / distance / HR / power where available
 - test filtering, preview sorting, style presets, and temporal playback wiring
 - when the `By activity type` preset is active, verify that runs/rides/winter activities keep their semantic colors and that line casing/opacity adapts sensibly when you switch between Outdoor, Light, and Satellite basemaps
-- open the QGIS Temporal Controller and confirm the loaded layers respond to the chosen local/UTC playback mode
+- open the QGIS Temporal Controller and confirm the loaded layers respond to local-time playback

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -103,7 +103,7 @@ Goal: map styling, data filtering, and activity querying.
   - preview sorting
   - fetched-activity preview/summary panel
 - QGIS temporal playback wiring:
-  - disabled / local activity time / UTC time
+  - local activity time by default
   - temporal layer configuration for points, tracks, and starts
 
 ### Planned

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -232,7 +232,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.temporalModeComboBox.clear()
         for label in temporal_mode_labels():
             self.temporalModeComboBox.addItem(label)
+        self.temporalModeComboBox.setCurrentText(DEFAULT_TEMPORAL_MODE_LABEL)
         self.temporalModeComboBox.setMinimumContentsLength(10)
+        self.temporalModeComboBox.hide()
+        self.temporalModeLabel.hide()
+        self.temporalHelpLabel.hide()
+        temporal_row = getattr(self, "analysisTemporalModeRow", None)
+        if temporal_row is not None:
+            temporal_row.hide()
 
     def _configure_analysis_mode_options(self):
         content_widget = getattr(self, "analysisSectionContentWidget", self.analysisWorkflowGroupBox)
@@ -451,12 +458,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 self._default_atlas_pdf_path(),
                 lambda: self.atlasPdfPathLineEdit.text().strip(),
                 self.atlasPdfPathLineEdit.setText,
-            ),
-            UIFieldBinding(
-                "temporal_mode",
-                DEFAULT_TEMPORAL_MODE_LABEL,
-                lambda: self.temporalModeComboBox.currentText(),
-                lambda value: self._set_combo_value(self.temporalModeComboBox, value, DEFAULT_TEMPORAL_MODE_LABEL),
             ),
             UIFieldBinding(
                 "analysis_mode",
@@ -913,7 +914,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             ),
             selection_state=selection_state,
             style_preset=self.stylePresetComboBox.currentText(),
-            temporal_mode=self.temporalModeComboBox.currentText(),
+            temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
             background_config=BackgroundConfig(
                 enabled=self.backgroundMapCheckBox.isChecked(),
                 preset_name=self.backgroundPresetComboBox.currentText(),

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -268,7 +268,6 @@ class ContextualHelpTests(unittest.TestCase):
             "maxDetailedActivitiesSpinBox",
             "writeActivityPointsCheckBox",
             "pointSamplingStrideSpinBox",
-            "temporalModeComboBox",
             "backgroundPresetComboBox",
             "atlasTargetAspectRatioSpinBox",
             "refreshButton",
@@ -284,7 +283,6 @@ class ContextualHelpTests(unittest.TestCase):
         self.assertTrue(entries["maxDetailedActivitiesSpinBox"].help_button)
         self.assertIn("downloads up to 25 new detailed routes", entries["maxDetailedActivitiesSpinBox"].helper_text)
         self.assertEqual(entries["pointSamplingStrideSpinBox"].label_text, "Keep every Nth point")
-        self.assertEqual(entries["temporalModeComboBox"].label_text, "Temporal timestamps")
         self.assertEqual(entries["backgroundPresetComboBox"].label_text, "Basemap preset")
         self.assertEqual(entries["atlasTargetAspectRatioSpinBox"].label_text, "Target page aspect ratio")
         self.assertEqual(entries["refreshButton"].target_text, "Fetch activities")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -406,6 +406,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIs(action.query, selection_state.query)
         self.assertEqual(action.filtered_count, 3)
         self.assertEqual(action.analysis_mode, "Most frequent starting points")
+        self.assertEqual(action.temporal_mode, self.module.DEFAULT_TEMPORAL_MODE_LABEL)
         self.assertEqual(action.background_config.access_token, "token")
         self.assertEqual(action.background_config.tile_mode, "Raster")
 

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -16,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 try:
     from qgis.core import (
         QgsApplication,
+        QgsCoordinateTransform,
         QgsFeature,
         QgsLayoutExporter,
         QgsMapRendererSequentialJob,
@@ -51,11 +52,12 @@ try:
     from qfit.layer_manager import LayerManager
     from qfit.mapbox_config import TILE_MODE_RASTER
     from qfit.activities.domain.models import Activity
-    from qfit.qfit_dockwidget import QfitDockWidget
+    from qfit.qfit_dockwidget import ApplyVisualizationAction, QfitDockWidget
     from qfit.settings_service import SettingsService
     from qfit.ui.dockwidget_dependencies import build_dockwidget_dependencies
     from qfit.ui.workflow_section_coordinator import WorkflowSectionCoordinator
     from qfit.visual_apply import VisualApplyService
+    from qfit.visualization.application.temporal_config import DEFAULT_TEMPORAL_MODE_LABEL
 
     QGIS_AVAILABLE = True
     QGIS_IMPORT_ERROR = None
@@ -235,7 +237,6 @@ class QgisSmokeTests(unittest.TestCase):
 
             self.assertEqual(dock.maxDetailedActivitiesLabel.text(), "Max new detailed routes this run")
             self.assertEqual(dock.pointSamplingStrideLabel.text(), "Keep every Nth point")
-            self.assertEqual(dock.temporalModeLabel.text(), "Temporal timestamps")
             self.assertEqual(dock.workflowLabel.text(), "Workflow: Fetch & store → Visualize → Analyze → Publish")
             self.assertFalse(dock.credentialsGroupBox.isVisible())
             self.assertTrue(bool(dock.features() & dock.DockWidgetMovable))
@@ -280,6 +281,9 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(temporal_mode_layout.spacing(), 6)
             self.assertGreaterEqual(dock.temporalModeComboBox.minimumContentsLength(), 10)
             self.assertGreaterEqual(dock.temporalHelpLabel.margin(), 2)
+            self.assertTrue(dock.temporalModeLabel.isHidden())
+            self.assertTrue(dock.temporalModeComboBox.isHidden())
+            self.assertTrue(dock.temporalHelpLabel.isHidden())
             self.assertEqual(dock.publishGroupBox.title(), "")
             self.assertEqual(dock.publishSectionToggleButton.text(), "4. Publish / atlas")
             self.assertFalse(dock.publishSectionContentWidget.isHidden())
@@ -296,8 +300,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertIsNotNone(dock.findChild(QLabel, "maxDetailedActivitiesSpinBoxContextHelpLabel"))
             self.assertIsNotNone(dock.findChild(QWidget, "maxDetailedActivitiesSpinBoxHelpField"))
             temporal_helper = dock.findChild(QLabel, "temporalModeComboBoxContextHelpLabel")
-            self.assertIsNotNone(temporal_helper)
-            self.assertEqual(temporal_helper.parentWidget(), dock.temporalModeLabel.parentWidget())
+            self.assertIsNone(temporal_helper)
             dock.activitiesSectionToggleButton.click()
             self.assertFalse(dock.activitiesSectionToggleButton.isChecked())
             self.assertEqual(dock.activitiesSectionToggleButton.arrowType(), Qt.RightArrow)
@@ -365,9 +368,6 @@ class QgisSmokeTests(unittest.TestCase):
             style_preset_text = dock.stylePresetComboBox.itemText(
                 1 if dock.stylePresetComboBox.count() > 1 else 0
             )
-            temporal_mode_text = dock.temporalModeComboBox.itemText(
-                1 if dock.temporalModeComboBox.count() > 1 else 0
-            )
             background_preset_text = dock.backgroundPresetComboBox.itemText(
                 1 if dock.backgroundPresetComboBox.count() > 1 else 0
             )
@@ -381,7 +381,6 @@ class QgisSmokeTests(unittest.TestCase):
             dock.backgroundPresetComboBox.setCurrentText(background_preset_text)
             dock.previewSortComboBox.setCurrentText(preview_sort_text)
             dock.stylePresetComboBox.setCurrentText(style_preset_text)
-            dock.temporalModeComboBox.setCurrentText(temporal_mode_text)
             dock.analysisModeComboBox.setCurrentText("Most frequent starting points")
             dock.atlasTargetAspectRatioSpinBox.setValue(1.75)
             dock.atlasPdfPathLineEdit.setText("/tmp/roundtrip.pdf")
@@ -397,7 +396,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(settings.get("background_preset"), background_preset_text)
             self.assertEqual(settings.get("preview_sort"), preview_sort_text)
             self.assertEqual(settings.get("style_preset"), style_preset_text)
-            self.assertEqual(settings.get("temporal_mode"), temporal_mode_text)
+            self.assertIsNone(settings.get("temporal_mode"))
             self.assertEqual(settings.get("analysis_mode"), "Most frequent starting points")
             self.assertAlmostEqual(float(settings.get("atlas_target_aspect_ratio")), 1.75, places=2)
             self.assertEqual(settings.get("atlas_pdf_path"), "/tmp/roundtrip.pdf")
@@ -416,13 +415,32 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock_reloaded.backgroundPresetComboBox.currentText(), background_preset_text)
             self.assertEqual(dock_reloaded.previewSortComboBox.currentText(), preview_sort_text)
             self.assertEqual(dock_reloaded.stylePresetComboBox.currentText(), style_preset_text)
-            self.assertEqual(dock_reloaded.temporalModeComboBox.currentText(), temporal_mode_text)
+            self.assertEqual(dock_reloaded.temporalModeComboBox.currentText(), DEFAULT_TEMPORAL_MODE_LABEL)
             self.assertEqual(dock_reloaded.analysisModeComboBox.currentText(), "Most frequent starting points")
             self.assertAlmostEqual(dock_reloaded.atlasTargetAspectRatioSpinBox.value(), 1.75, places=2)
             self.assertEqual(dock_reloaded.atlasPdfPathLineEdit.text(), "/tmp/roundtrip.pdf")
         finally:
             dock_reloaded.close()
             dock_reloaded.deleteLater()
+
+    def test_dock_widget_ignores_legacy_temporal_mode_settings_and_uses_local_time(self):
+        settings = SettingsService(
+            qsettings=_FakeQSettings({"qfit/temporal_mode": "UTC time"}),
+            credential_store=InMemoryCredentialStore(),
+        )
+        dependencies = replace(
+            build_dockwidget_dependencies(self.iface),
+            settings=settings,
+        )
+
+        dock = QfitDockWidget(self.iface, dependencies=dependencies)
+        try:
+            self.assertEqual(dock.temporalModeComboBox.currentText(), DEFAULT_TEMPORAL_MODE_LABEL)
+            action = dock._build_visual_workflow_action(ApplyVisualizationAction)
+            self.assertEqual(action.temporal_mode, DEFAULT_TEMPORAL_MODE_LABEL)
+        finally:
+            dock.close()
+            dock.deleteLater()
 
     def test_generate_atlas_pdf_shows_clear_error_when_pypdf_is_missing(self):
         dock = QfitDockWidget(self.iface)
@@ -1155,10 +1173,10 @@ class QgisSmokeTests(unittest.TestCase):
             # Points layer carries the heatmap renderer
             renderer = points_layer.renderer()
             self.assertIsInstance(renderer, QgsHeatmapRenderer)
-            self.assertEqual(renderer.radius(), 18)
+            self.assertEqual(renderer.radius(), 1000)
             self.assertEqual(renderer.colorRamp().color2().alpha(), 255)
             self.assertGreater(renderer.colorRamp().color2().red(), renderer.colorRamp().color2().blue())
-            self.assertEqual(renderer.radiusUnit(), QgsUnitTypes.RenderMillimeters)
+            self.assertEqual(renderer.radiusUnit(), QgsUnitTypes.RenderMapUnits)
             self.assertEqual(renderer.renderQuality(), 2)
             self.assertIsNotNone(renderer.colorRamp())
             self.assertEqual(renderer.colorRamp().color1().alpha(), 0)
@@ -1872,6 +1890,15 @@ class QgisSmokeTests(unittest.TestCase):
         settings.setLayers(layers)
         settings.setOutputSize(QImage(width, height, QImage.Format_ARGB32).size())
         settings.setBackgroundColor(Qt.white)
+
+        destination_crs = QgsProject.instance().crs()
+        if destination_crs.isValid():
+            settings.setDestinationCrs(destination_crs)
+            source_layer = next((layer for layer in layers if layer is not None and layer.isValid()), None)
+            source_crs = source_layer.crs() if source_layer is not None else None
+            if source_crs is not None and source_crs.isValid() and source_crs != destination_crs:
+                transform = QgsCoordinateTransform(source_crs, destination_crs, QgsProject.instance())
+                extent = transform.transformBoundingBox(extent)
         settings.setExtent(extent)
 
         job = QgsMapRendererSequentialJob(settings)

--- a/tests/test_temporal_config.py
+++ b/tests/test_temporal_config.py
@@ -6,6 +6,7 @@ from qfit.visualization.application.temporal_config import (
     build_temporal_plan,
     describe_temporal_configuration,
     is_temporal_mode_enabled,
+    normalize_temporal_mode,
     temporal_mode_labels,
 )
 
@@ -14,9 +15,9 @@ class TemporalConfigTests(unittest.TestCase):
     def test_temporal_mode_helpers(self):
         labels = temporal_mode_labels()
 
-        self.assertEqual(labels[0], "Disabled")
-        self.assertIn(DEFAULT_TEMPORAL_MODE_LABEL, labels)
-        self.assertFalse(is_temporal_mode_enabled("Disabled"))
+        self.assertEqual(labels, [DEFAULT_TEMPORAL_MODE_LABEL])
+        self.assertEqual(normalize_temporal_mode("UTC time"), DEFAULT_TEMPORAL_MODE_LABEL)
+        self.assertEqual(normalize_temporal_mode("Disabled"), DEFAULT_TEMPORAL_MODE_LABEL)
         self.assertTrue(is_temporal_mode_enabled(DEFAULT_TEMPORAL_MODE_LABEL))
 
     def test_build_temporal_plan_prefers_local_point_time_when_available(self):
@@ -42,9 +43,13 @@ class TemporalConfigTests(unittest.TestCase):
         self.assertEqual(plan.field_name, "start_date")
         self.assertEqual(plan.field_kind, "utc")
 
-    def test_build_temporal_plan_returns_none_when_disabled_or_missing(self):
-        self.assertIsNone(build_temporal_plan("activity_points", ["point_timestamp_utc"], "Disabled"))
-        self.assertIsNone(build_temporal_plan("activity_points", ["distance_m"], "UTC time"))
+    def test_build_temporal_plan_ignores_legacy_modes_and_still_uses_local_defaults(self):
+        plan = build_temporal_plan("activity_points", ["point_timestamp_utc"], "UTC time")
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.field_name, "point_timestamp_utc")
+        self.assertEqual(plan.field_kind, "utc")
+        self.assertIsNone(build_temporal_plan("activity_points", ["distance_m"], "Disabled"))
 
     def test_describe_temporal_configuration_is_human_readable(self):
         point_plan = build_temporal_plan("activity_points", ["point_timestamp_utc"], "UTC time")
@@ -54,7 +59,7 @@ class TemporalConfigTests(unittest.TestCase):
         self.assertIn("activity points (UTC)", message)
         self.assertEqual(
             describe_temporal_configuration([], "Disabled"),
-            "Temporal playback disabled",
+            "Temporal playback uses local activity time, but no timestamp fields were available",
         )
 
 

--- a/tests/test_temporal_service.py
+++ b/tests/test_temporal_service.py
@@ -110,7 +110,7 @@ class TemporalServiceRealTests(unittest.TestCase):
         atlas_props.setIsActive.assert_called_with(False)
         self.assertIn("Temporal playback wired", result)
 
-    def test_disabled_mode_deactivates_all_layers(self):
+    def test_legacy_disabled_mode_resolves_to_local_time(self):
         tracks, tracks_props = _make_layer(["start_date_local"])
         points, points_props = _make_layer(["point_timestamp_local"])
 
@@ -118,9 +118,9 @@ class TemporalServiceRealTests(unittest.TestCase):
             tracks, None, points, None, "Disabled"
         )
 
-        tracks_props.setIsActive.assert_called_with(False)
-        points_props.setIsActive.assert_called_with(False)
-        self.assertIn("disabled", result.lower())
+        tracks_props.setIsActive.assert_called_with(True)
+        points_props.setIsActive.assert_called_with(True)
+        self.assertIn("Temporal playback wired", result)
 
     def test_skips_none_layers(self):
         tracks, tracks_props = _make_layer(["start_date_local"])
@@ -132,14 +132,14 @@ class TemporalServiceRealTests(unittest.TestCase):
         tracks_props.setIsActive.assert_called_with(True)
         self.assertIn("Temporal playback wired", result)
 
-    def test_utc_mode_prefers_utc_fields(self):
+    def test_legacy_utc_mode_still_prefers_local_display_when_available(self):
         tracks, tracks_props = _make_layer(["start_date_local", "start_date"])
 
         self.service.apply_temporal_configuration(
             tracks, None, None, None, "UTC time"
         )
 
-        tracks_props.setStartExpression.assert_called_with('to_datetime("start_date")')
+        tracks_props.setStartExpression.assert_called_with('to_datetime("start_date_local")')
 
     def test_no_temporal_properties_returns_gracefully(self):
         layer = MagicMock()
@@ -181,15 +181,15 @@ class TemporalServiceMockTests(unittest.TestCase):
         points_props.setIsActive.assert_called_with(True)
         self.assertIn("Temporal playback wired", result)
 
-    def test_disabled_mode_deactivates_layers(self):
+    def test_legacy_disabled_mode_still_applies_local_temporal_plan(self):
         tracks, tracks_props = _make_layer(["start_date_local"])
 
         result = self.service.apply_temporal_configuration(
             tracks, None, None, None, "Disabled"
         )
 
-        tracks_props.setIsActive.assert_called_with(False)
-        self.assertIn("disabled", result.lower())
+        tracks_props.setIsActive.assert_called_with(True)
+        self.assertIn("Temporal playback wired", result)
 
     def test_skips_none_layers_and_handles_no_candidates(self):
         atlas, atlas_props = _make_layer(["unrelated_field"])

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -171,20 +171,6 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
         ),
     ),
     HelpEntry(
-        anchor_name="temporalModeComboBox",
-        label_name="temporalModeLabel",
-        label_text="Temporal timestamps",
-        tooltip=(
-            "Controls which timestamps qfit wires into QGIS temporal playback. Use local activity time for human-facing "
-            "day/time playback, or UTC when you need timezone-neutral timestamps."
-        ),
-        helper_text=(
-            "This only affects loaded QGIS layers, not the stored source data. Pick local time for most map playback; "
-            "pick UTC when you want a consistent cross-timezone reference."
-        ),
-        help_button=True,
-    ),
-    HelpEntry(
         anchor_name="refreshButton",
         target_text="Fetch activities",
         tooltip=(

--- a/visualization/application/temporal_config.py
+++ b/visualization/application/temporal_config.py
@@ -1,11 +1,7 @@
 from dataclasses import dataclass
 
-TEMPORAL_MODE_LABELS = [
-    "Disabled",
-    "Local activity time",
-    "UTC time",
-]
 DEFAULT_TEMPORAL_MODE_LABEL = "Local activity time"
+TEMPORAL_MODE_LABELS = [DEFAULT_TEMPORAL_MODE_LABEL]
 
 
 @dataclass(frozen=True)
@@ -40,14 +36,16 @@ def temporal_mode_labels():
     return list(TEMPORAL_MODE_LABELS)
 
 
+def normalize_temporal_mode(mode_label):
+    return DEFAULT_TEMPORAL_MODE_LABEL
+
+
 def is_temporal_mode_enabled(mode_label):
-    return (mode_label or "").strip() != "Disabled"
+    return True
 
 
 def build_temporal_plan(layer_key, available_fields, mode_label):
-    mode_label = (mode_label or DEFAULT_TEMPORAL_MODE_LABEL).strip() or DEFAULT_TEMPORAL_MODE_LABEL
-    if not is_temporal_mode_enabled(mode_label):
-        return None
+    mode_label = normalize_temporal_mode(mode_label)
 
     field_names = {name for name in (available_fields or []) if name}
     candidates = _LAYER_CANDIDATES.get(layer_key, {}).get(mode_label, [])
@@ -64,10 +62,8 @@ def build_temporal_plan(layer_key, available_fields, mode_label):
 
 def describe_temporal_configuration(plans, mode_label):
     active_plans = [plan for plan in (plans or []) if plan is not None]
-    if not is_temporal_mode_enabled(mode_label):
-        return "Temporal playback disabled"
     if not active_plans:
-        return "Temporal playback requested, but no timestamp fields were available"
+        return "Temporal playback uses local activity time, but no timestamp fields were available"
     labels = ", ".join(plan.label for plan in active_plans)
     return "Temporal playback wired for {labels}".format(labels=labels)
 

--- a/visualization/application/temporal_config.py
+++ b/visualization/application/temporal_config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 DEFAULT_TEMPORAL_MODE_LABEL = "Local activity time"
+UTC_TEMPORAL_MODE_LABEL = "UTC time"
 TEMPORAL_MODE_LABELS = [DEFAULT_TEMPORAL_MODE_LABEL]
 
 
@@ -18,16 +19,16 @@ class TemporalLayerPlan:
 
 _LAYER_CANDIDATES = {
     "activity_points": {
-        "Local activity time": ["point_timestamp_local", "point_timestamp_utc"],
-        "UTC time": ["point_timestamp_utc", "point_timestamp_local"],
+        DEFAULT_TEMPORAL_MODE_LABEL: ["point_timestamp_local", "point_timestamp_utc"],
+        UTC_TEMPORAL_MODE_LABEL: ["point_timestamp_utc", "point_timestamp_local"],
     },
     "activity_tracks": {
-        "Local activity time": ["start_date_local", "start_date"],
-        "UTC time": ["start_date", "start_date_local"],
+        DEFAULT_TEMPORAL_MODE_LABEL: ["start_date_local", "start_date"],
+        UTC_TEMPORAL_MODE_LABEL: ["start_date", "start_date_local"],
     },
     "activity_starts": {
-        "Local activity time": ["start_date_local", "start_date"],
-        "UTC time": ["start_date", "start_date_local"],
+        DEFAULT_TEMPORAL_MODE_LABEL: ["start_date_local", "start_date"],
+        UTC_TEMPORAL_MODE_LABEL: ["start_date", "start_date_local"],
     },
 }
 
@@ -37,11 +38,14 @@ def temporal_mode_labels():
 
 
 def normalize_temporal_mode(mode_label):
+    label = (mode_label or "").strip()
+    if label == UTC_TEMPORAL_MODE_LABEL:
+        return DEFAULT_TEMPORAL_MODE_LABEL
     return DEFAULT_TEMPORAL_MODE_LABEL
 
 
 def is_temporal_mode_enabled(mode_label):
-    return True
+    return normalize_temporal_mode(mode_label) == DEFAULT_TEMPORAL_MODE_LABEL
 
 
 def build_temporal_plan(layer_key, available_fields, mode_label):
@@ -61,9 +65,12 @@ def build_temporal_plan(layer_key, available_fields, mode_label):
 
 
 def describe_temporal_configuration(plans, mode_label):
+    normalized_mode = normalize_temporal_mode(mode_label)
     active_plans = [plan for plan in (plans or []) if plan is not None]
     if not active_plans:
-        return "Temporal playback uses local activity time, but no timestamp fields were available"
+        return "Temporal playback uses {mode}, but no timestamp fields were available".format(
+            mode=normalized_mode.lower()
+        )
     labels = ", ".join(plan.label for plan in active_plans)
     return "Temporal playback wired for {labels}".format(labels=labels)
 


### PR DESCRIPTION
## Summary
- remove the user-facing temporal timestamp selector from the Visualize workflow and always drive temporal playback with local activity time
- ignore legacy saved `temporal_mode` values so older settings do not change current behavior
- update temporal/configuration tests and user-facing docs around the local-time-only rule

## Testing
- python3 -m pytest tests/test_temporal_config.py tests/test_temporal_service.py tests/test_contextual_help.py tests/test_qfit_dockwidget_analysis_pure.py -q
- python3 -m pytest tests/test_qgis_smoke.py -q -k 'dock_widget_contextual_help_smoke or dock_widget_round_trips_settings_through_canonical_binding_table or dock_widget_ignores_legacy_temporal_mode_settings_and_uses_local_time'
- python3 -m pytest tests/test_visual_apply.py tests/test_dock_action_dispatcher.py tests/test_dockwidget_dependencies.py -q
- python3 -m pytest tests/ -x -q --tb=short
  - suite output completed cleanly (`968 passed, 152 skipped`) before the known local teardown segfault (`EXIT=139`)

Closes #352
