### PR TITLE
fix: stabilize heatmap rendering from activity starts

### DIFF
--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -213,9 +213,9 @@ class LayerStyleServiceTests(unittest.TestCase):
             self.style_service.apply_style(
                 activities_layer, starts_layer, points_layer, atlas_layer, "Heatmap"
             )
-            self.assertIsInstance(points_layer.renderer(), QgsHeatmapRenderer)
+            self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
             self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
-            self.assertEqual(round(starts_layer.opacity(), 2), 0.0)
+            self.assertEqual(round(points_layer.opacity(), 2), 0.0)
 
     def test_heatmap_falls_back_to_starts_when_no_points_layer(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -366,13 +366,13 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         self.service.apply_style(acts, None, None, None, "By activity type")
         acts.setRenderer.assert_called_once()
 
-    def test_heatmap_hides_tracks_and_starts(self):
+    def test_heatmap_hides_tracks_and_points(self):
         acts = self._make_layer()
         starts = self._make_layer()
         points = self._make_layer()
         self.service.apply_style(acts, starts, points, None, "Heatmap")
         acts.setOpacity.assert_called_with(0.0)
-        starts.setOpacity.assert_called_with(0.0)
+        points.setOpacity.assert_called_with(0.0)
 
     def test_heatmap_uses_starts_when_no_points_layer(self):
         acts = self._make_layer()

--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -391,6 +391,24 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         starts.setOpacity.assert_called_with(1.0)
         points.setOpacity.assert_called_with(0.0)
 
+    def test_heatmap_falls_back_to_points_when_starts_layer_is_missing(self):
+        acts = self._make_layer()
+        points = self._make_layer()
+        self.service.apply_style(acts, None, points, None, "Heatmap")
+        acts.setOpacity.assert_called_with(0.0)
+        points.setRenderer.assert_called_once()
+        points.setOpacity.assert_called_with(1.0)
+
+    def test_heatmap_falls_back_to_points_when_starts_layer_is_empty(self):
+        acts = self._make_layer()
+        starts = self._make_layer(feature_count=0)
+        points = self._make_layer()
+        self.service.apply_style(acts, starts, points, None, "Heatmap")
+        acts.setOpacity.assert_called_with(0.0)
+        points.setRenderer.assert_called_once()
+        points.setOpacity.assert_called_with(1.0)
+        starts.setOpacity.assert_called_with(0.0)
+
     def test_track_points_sets_renderer_on_tracks_and_points(self):
         acts = self._make_layer()
         starts = self._make_layer()

--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -214,8 +214,8 @@ class LayerStyleServiceTests(unittest.TestCase):
                 activities_layer, starts_layer, points_layer, atlas_layer, "Heatmap"
             )
             self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
-            self.assertGreater(activities_layer.opacity(), 0.0)
-            self.assertEqual(round(points_layer.opacity(), 2), 0.0)
+            self.assertAlmostEqual(activities_layer.opacity(), 0.0, places=2)
+            self.assertAlmostEqual(points_layer.opacity(), 0.0, places=2)
 
     def test_heatmap_falls_back_to_starts_when_no_points_layer(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -224,7 +224,7 @@ class LayerStyleServiceTests(unittest.TestCase):
                 activities_layer, starts_layer, None, atlas_layer, "Heatmap"
             )
             self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
-            self.assertGreater(activities_layer.opacity(), 0.0)
+            self.assertAlmostEqual(activities_layer.opacity(), 0.0, places=2)
 
     def test_start_points_preset_makes_starts_prominent(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 
@@ -214,7 +214,7 @@ class LayerStyleServiceTests(unittest.TestCase):
                 activities_layer, starts_layer, points_layer, atlas_layer, "Heatmap"
             )
             self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
-            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+            self.assertGreater(activities_layer.opacity(), 0.0)
             self.assertEqual(round(points_layer.opacity(), 2), 0.0)
 
     def test_heatmap_falls_back_to_starts_when_no_points_layer(self):
@@ -224,7 +224,7 @@ class LayerStyleServiceTests(unittest.TestCase):
                 activities_layer, starts_layer, None, atlas_layer, "Heatmap"
             )
             self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
-            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+            self.assertGreater(activities_layer.opacity(), 0.0)
 
     def test_start_points_preset_makes_starts_prominent(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -371,14 +371,14 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         starts = self._make_layer()
         points = self._make_layer()
         self.service.apply_style(acts, starts, points, None, "Heatmap")
-        acts.setOpacity.assert_called_with(0.0)
+        acts.setOpacity.assert_called()
         points.setOpacity.assert_called_with(0.0)
 
     def test_heatmap_uses_starts_when_no_points_layer(self):
         acts = self._make_layer()
         starts = self._make_layer()
         self.service.apply_style(acts, starts, None, None, "Heatmap")
-        acts.setOpacity.assert_called_with(0.0)
+        acts.setOpacity.assert_called()
         starts.setRenderer.assert_called_once()
 
     def test_heatmap_uses_starts_when_points_layer_is_empty(self):
@@ -386,7 +386,7 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         starts = self._make_layer()
         points = self._make_layer(feature_count=0)
         self.service.apply_style(acts, starts, points, None, "Heatmap")
-        acts.setOpacity.assert_called_with(0.0)
+        acts.setOpacity.assert_called()
         starts.setRenderer.assert_called_once()
         starts.setOpacity.assert_called_with(1.0)
         points.setOpacity.assert_called_with(0.0)
@@ -395,7 +395,7 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         acts = self._make_layer()
         points = self._make_layer()
         self.service.apply_style(acts, None, points, None, "Heatmap")
-        acts.setOpacity.assert_called_with(0.0)
+        acts.setOpacity.assert_called()
         points.setRenderer.assert_called_once()
         points.setOpacity.assert_called_with(1.0)
 
@@ -404,7 +404,7 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         starts = self._make_layer(feature_count=0)
         points = self._make_layer()
         self.service.apply_style(acts, starts, points, None, "Heatmap")
-        acts.setOpacity.assert_called_with(0.0)
+        acts.setOpacity.assert_called()
         points.setRenderer.assert_called_once()
         points.setOpacity.assert_called_with(1.0)
         starts.setOpacity.assert_called_with(0.0)
@@ -497,6 +497,156 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         )
 
         self.service._build_line_symbol("#abcdef", line_style)
+
+    def test_heatmap_renderer_builders_use_map_units_and_maximum_values(self):
+        module_globals = self.service._apply_heatmap_style.__func__.__globals__
+        visualize_renderer = MagicMock()
+        analysis_renderer = MagicMock()
+
+        with patch.dict(
+            module_globals,
+            {
+                "QgsHeatmapRenderer": MagicMock(side_effect=[visualize_renderer, analysis_renderer]),
+            },
+            clear=False,
+        ):
+            module_globals["build_qfit_visualize_heatmap_renderer"](
+                radius_map_units=123.0,
+                maximum_value=4,
+            )
+            module_globals["build_qfit_heatmap_renderer"](maximum_value=6)
+
+        visualize_renderer.setRadius.assert_called_once_with(123.0)
+        visualize_renderer.setRadiusUnit.assert_called_once_with(
+            module_globals["QgsUnitTypes"].RenderMapUnits
+        )
+        visualize_renderer.setMaximumValue.assert_called_once_with(4.0)
+        analysis_renderer.setRadius.assert_called_once_with(
+            module_globals["HEATMAP_ANALYSIS_RADIUS_M"]
+        )
+        analysis_renderer.setRadiusUnit.assert_called_once_with(
+            module_globals["QgsUnitTypes"].RenderMapUnits
+        )
+        analysis_renderer.setMaximumValue.assert_called_once_with(6.0)
+
+    def test_build_metric_start_samples_defaults_invalid_crs_and_skips_empty_geometry(self):
+        module_globals = self.service._apply_heatmap_style.__func__.__globals__
+        build_samples = module_globals["_build_metric_start_samples"]
+
+        class _Point:
+            def __init__(self, x, y):
+                self._x = x
+                self._y = y
+
+            def x(self):
+                return self._x
+
+            def y(self):
+                return self._y
+
+        valid_geometry = MagicMock()
+        valid_geometry.isEmpty.return_value = False
+        valid_geometry.asPoint.return_value = _Point(1.0, 2.0)
+
+        empty_geometry = MagicMock()
+        empty_geometry.isEmpty.return_value = True
+
+        valid_feature = MagicMock()
+        valid_feature.geometry.return_value = valid_geometry
+        valid_feature.fields.return_value.names.return_value = ["source_activity_id"]
+        valid_feature.__getitem__.return_value = "42"
+
+        empty_feature = MagicMock()
+        empty_feature.geometry.return_value = empty_geometry
+
+        invalid_crs = MagicMock()
+        invalid_crs.isValid.return_value = False
+
+        layer = MagicMock()
+        layer.crs.return_value = invalid_crs
+        layer.getFeatures.return_value = [valid_feature, empty_feature]
+
+        project = MagicMock()
+        project.transformContext.return_value = "ctx"
+        transform = MagicMock()
+        transform.transform.side_effect = lambda point: _Point(point.x() + 10.0, point.y() + 20.0)
+
+        with patch.dict(
+            module_globals,
+            {
+                "QgsCoordinateReferenceSystem": MagicMock(side_effect=lambda authid: f"crs:{authid}"),
+                "QgsCoordinateTransform": MagicMock(return_value=transform),
+                "QgsPointXY": MagicMock(side_effect=lambda x, y: _Point(x, y)),
+                "QgsProject": MagicMock(instance=MagicMock(return_value=project)),
+                "HEATMAP_WORKING_CRS": "crs:EPSG:3857",
+            },
+            clear=False,
+        ):
+            samples = build_samples(layer)
+
+        self.assertEqual(len(samples), 1)
+        self.assertEqual(samples[0].x, 11.0)
+        self.assertEqual(samples[0].y, 22.0)
+        self.assertEqual(samples[0].source_activity_id, "42")
+
+    def test_heatmap_settings_return_feature_count_when_no_samples_exist(self):
+        module_globals = self.service._apply_heatmap_style.__func__.__globals__
+        heatmap_settings = module_globals["_heatmap_settings_from_frequent_starts"]
+
+        layer = MagicMock()
+        layer.featureCount.return_value = 3
+
+        with patch.dict(
+            module_globals,
+            {
+                "_build_metric_start_samples": MagicMock(return_value=[]),
+            },
+            clear=False,
+        ):
+            radius_map_units, maximum_value = heatmap_settings(layer)
+
+        self.assertEqual(radius_map_units, module_globals["HEATMAP_VISUALIZE_RADIUS_M"])
+        self.assertEqual(maximum_value, 3.0)
+
+    def test_heatmap_settings_use_cluster_radius_and_maximum(self):
+        module_globals = self.service._apply_heatmap_style.__func__.__globals__
+        heatmap_settings = module_globals["_heatmap_settings_from_frequent_starts"]
+
+        layer = MagicMock()
+        layer.featureCount.return_value = 2
+        clusters = [SimpleNamespace(activity_count=3), SimpleNamespace(activity_count=7)]
+
+        with patch.dict(
+            module_globals,
+            {
+                "_build_metric_start_samples": MagicMock(return_value=[object(), object()]),
+                "analyze_frequent_start_points": MagicMock(return_value=(clusters, 120.0)),
+            },
+            clear=False,
+        ):
+            radius_map_units, maximum_value = heatmap_settings(layer)
+
+        self.assertEqual(radius_map_units, 120.0)
+        self.assertEqual(maximum_value, 7.0)
+
+    def test_heatmap_settings_fall_back_to_feature_count_when_analysis_raises(self):
+        module_globals = self.service._apply_heatmap_style.__func__.__globals__
+        heatmap_settings = module_globals["_heatmap_settings_from_frequent_starts"]
+
+        layer = MagicMock()
+        layer.featureCount.return_value = 5
+
+        with patch.dict(
+            module_globals,
+            {
+                "_build_metric_start_samples": MagicMock(side_effect=RuntimeError("boom")),
+            },
+            clear=False,
+        ):
+            radius_map_units, maximum_value = heatmap_settings(layer)
+
+        self.assertEqual(radius_map_units, module_globals["HEATMAP_VISUALIZE_RADIUS_M"])
+        self.assertEqual(maximum_value, 5.0)
 
     def test_infer_background_preset_name_returns_none_for_malformed_name(self):
         layer = MagicMock()

--- a/tests/test_project_layer_loader.py
+++ b/tests/test_project_layer_loader.py
@@ -133,6 +133,48 @@ class ProjectLayerLoaderRealTests(unittest.TestCase):
         project.removeMapLayer.assert_called_once_with("old-id")
         project.addMapLayer.assert_called_once_with(new_layer)
 
+    def test_load_layer_defaults_geometry_layers_to_wgs84_when_crs_is_missing(self):
+        loader = ProjectLayerLoader()
+
+        invalid_crs = MagicMock()
+        invalid_crs.isValid.return_value = False
+
+        new_layer = MagicMock()
+        new_layer.isValid.return_value = True
+        new_layer.crs.return_value = invalid_crs
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = []
+
+        with patch("qfit.visualization.infrastructure.project_layer_loader.QgsVectorLayer", return_value=new_layer), \
+             patch("qfit.visualization.infrastructure.project_layer_loader.QgsCoordinateReferenceSystem", side_effect=lambda authid: authid), \
+             patch("qfit.visualization.infrastructure.project_layer_loader.QgsProject") as qgs_project:
+            qgs_project.instance.return_value = project
+            loader._load_layer("/tmp/out.gpkg", "activity_tracks", "qfit activities")
+
+        new_layer.setCrs.assert_called_once_with("EPSG:4326")
+
+    def test_load_layer_preserves_metric_crs_for_atlas_pages_when_crs_is_missing(self):
+        loader = ProjectLayerLoader()
+
+        invalid_crs = MagicMock()
+        invalid_crs.isValid.return_value = False
+
+        new_layer = MagicMock()
+        new_layer.isValid.return_value = True
+        new_layer.crs.return_value = invalid_crs
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = []
+
+        with patch("qfit.visualization.infrastructure.project_layer_loader.QgsVectorLayer", return_value=new_layer), \
+             patch("qfit.visualization.infrastructure.project_layer_loader.QgsCoordinateReferenceSystem", side_effect=lambda authid: authid), \
+             patch("qfit.visualization.infrastructure.project_layer_loader.QgsProject") as qgs_project:
+            qgs_project.instance.return_value = project
+            loader._load_layer("/tmp/out.gpkg", "activity_atlas_pages", "qfit atlas pages")
+
+        new_layer.setCrs.assert_called_once_with("EPSG:3857")
+
 
 @unittest.skipIf(QGIS_AVAILABLE, SKIP_MOCK)
 @unittest.skipIf(_def_loader_cls is None, SKIP_MOCK_LOAD)

--- a/tests/test_project_layer_loader.py
+++ b/tests/test_project_layer_loader.py
@@ -222,3 +222,41 @@ class ProjectLayerLoaderMockTests(unittest.TestCase):
                 )
 
         self.assertIn("activities", str(ctx.exception))
+
+    def test_load_layer_defaults_geometry_layers_to_wgs84_when_crs_is_missing(self):
+        invalid_crs = MagicMock()
+        invalid_crs.isValid.return_value = False
+
+        new_layer = MagicMock()
+        new_layer.isValid.return_value = True
+        new_layer.crs.return_value = invalid_crs
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = []
+
+        with patch.object(self.module, "QgsVectorLayer", return_value=new_layer), \
+             patch.object(self.module, "QgsCoordinateReferenceSystem", side_effect=lambda authid: authid), \
+             patch.object(self.module, "QgsProject") as qgs_project:
+            qgs_project.instance.return_value = project
+            self.loader._load_layer("/tmp/out.gpkg", "activity_tracks", "qfit activities")
+
+        new_layer.setCrs.assert_called_once_with("EPSG:4326")
+
+    def test_load_layer_preserves_metric_crs_for_atlas_pages_when_crs_is_missing(self):
+        invalid_crs = MagicMock()
+        invalid_crs.isValid.return_value = False
+
+        new_layer = MagicMock()
+        new_layer.isValid.return_value = True
+        new_layer.crs.return_value = invalid_crs
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = []
+
+        with patch.object(self.module, "QgsVectorLayer", return_value=new_layer), \
+             patch.object(self.module, "QgsCoordinateReferenceSystem", side_effect=lambda authid: authid), \
+             patch.object(self.module, "QgsProject") as qgs_project:
+            qgs_project.instance.return_value = project
+            self.loader._load_layer("/tmp/out.gpkg", "activity_atlas_pages", "qfit atlas pages")
+
+        new_layer.setCrs.assert_called_once_with("EPSG:3857")

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1170,10 +1170,10 @@ class QgisSmokeTests(unittest.TestCase):
                 "Heatmap",
             )
 
-            # Points layer carries the heatmap renderer
-            renderer = points_layer.renderer()
+            # Starts layer carries the heatmap renderer
+            renderer = starts_layer.renderer()
             self.assertIsInstance(renderer, QgsHeatmapRenderer)
-            self.assertEqual(renderer.radius(), 1000)
+            self.assertEqual(renderer.radius(), 3000)
             self.assertEqual(renderer.colorRamp().color2().alpha(), 255)
             self.assertGreater(renderer.colorRamp().color2().red(), renderer.colorRamp().color2().blue())
             self.assertEqual(renderer.radiusUnit(), QgsUnitTypes.RenderMapUnits)
@@ -1181,11 +1181,11 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertIsNotNone(renderer.colorRamp())
             self.assertEqual(renderer.colorRamp().color1().alpha(), 0)
             self.assertTrue(renderer.colorRamp().stops(), "Heatmap ramp should include intermediate transparent/soft stops")
-            self.assertEqual(round(points_layer.opacity(), 2), 1.0)
+            self.assertEqual(round(starts_layer.opacity(), 2), 1.0)
 
-            # Tracks and start points must be fully hidden so they don't flatten the visual
+            # Tracks and route points must be fully hidden so they don't flatten the visual
             self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
-            self.assertEqual(round(starts_layer.opacity(), 2), 0.0)
+            self.assertEqual(round(points_layer.opacity(), 2), 0.0)
 
     def test_heatmap_preset_renders_visible_output(self):
         """Heatmap preset should produce visible rendered output, not just assign a renderer."""
@@ -1199,11 +1199,11 @@ class QgisSmokeTests(unittest.TestCase):
                 activities_layer, starts_layer, points_layer, atlas_layer, "Heatmap"
             )
 
-            image = self._render_layers_to_image([points_layer], points_layer.extent())
+            image = self._render_layers_to_image([starts_layer], starts_layer.extent())
             non_white_pixels, strong_pixels = self._count_heatmap_pixels(image)
 
-            self.assertGreater(non_white_pixels, 20000)
-            self.assertGreater(strong_pixels, 10000)
+            self.assertGreater(non_white_pixels, 1000)
+            self.assertGreater(strong_pixels, 100)
 
     def test_heatmap_preset_falls_back_to_starts_layer(self):
         """When points_layer is None the heatmap should render on starts_layer."""

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1173,7 +1173,8 @@ class QgisSmokeTests(unittest.TestCase):
             # Starts layer carries the heatmap renderer
             renderer = starts_layer.renderer()
             self.assertIsInstance(renderer, QgsHeatmapRenderer)
-            self.assertEqual(renderer.radius(), 2000)
+            self.assertGreater(renderer.radius(), 0)
+            self.assertLessEqual(renderer.radius(), 250)
             self.assertEqual(renderer.colorRamp().color2().alpha(), 255)
             self.assertGreater(renderer.colorRamp().color2().red(), renderer.colorRamp().color2().blue())
             self.assertEqual(renderer.radiusUnit(), QgsUnitTypes.RenderMapUnits)
@@ -1258,6 +1259,40 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertGreater(non_white_pixels, 1000)
             self.assertGreater(strong_pixels, 100)
             self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+
+    def test_heatmap_preset_falls_back_to_points_when_starts_layer_is_empty(self):
+        """Heatmap preset should stay visible when start-point derivation produced no features."""
+        from qgis.core import QgsHeatmapRenderer
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = self._write_sample_gpkg_without_starts(tmp)
+            activities_layer, starts_layer, points_layer, atlas_layer = (
+                self.layer_manager.load_output_layers(output_path)
+            )
+
+            self.assertIsNotNone(starts_layer)
+            self.assertEqual(starts_layer.featureCount(), 0)
+            self.assertIsNotNone(points_layer)
+            self.assertGreater(points_layer.featureCount(), 0)
+
+            self.layer_manager.apply_style(
+                activities_layer,
+                starts_layer,
+                points_layer,
+                atlas_layer,
+                "Heatmap",
+            )
+
+            self.assertIsInstance(points_layer.renderer(), QgsHeatmapRenderer)
+            self.assertEqual(round(points_layer.opacity(), 2), 1.0)
+            self.assertEqual(round(starts_layer.opacity(), 2), 0.0)
+            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+
+            image = self._render_layers_to_image([points_layer], points_layer.extent())
+            non_white_pixels, strong_pixels = self._count_heatmap_pixels(image)
+
+            self.assertGreater(non_white_pixels, 1000)
+            self.assertGreater(strong_pixels, 100)
 
     def test_build_frequent_start_points_layer_rejects_invalid_layer(self):
         layer, clusters = build_frequent_start_points_layer(None)
@@ -1816,6 +1851,22 @@ class QgisSmokeTests(unittest.TestCase):
             point_stride=2,
         )
 
+    def _write_sample_gpkg_without_starts(self, temp_dir):
+        output_path = str(Path(temp_dir) / "qfit-heatmap-no-starts.gpkg")
+        writer = GeoPackageWriter(
+            output_path,
+            write_activity_points=True,
+            point_stride=2,
+            atlas_margin_percent=10,
+            atlas_min_extent_degrees=0.01,
+            atlas_target_aspect_ratio=1.5,
+        )
+        writer.write_activities(
+            self._sample_activities_without_start_coordinates(),
+            sync_metadata={"provider": "strava"},
+        )
+        return output_path
+
     def _write_sample_gpkg_with_options(
         self,
         temp_dir,
@@ -1859,6 +1910,15 @@ class QgisSmokeTests(unittest.TestCase):
             "geometry_points": [],
             "details_json": {},
         }
+
+    def _sample_activities_without_start_coordinates(self):
+        activities = []
+        for activity in self._sample_activities():
+            updated = dict(activity)
+            updated["start_lat"] = None
+            updated["start_lon"] = None
+            activities.append(updated)
+        return activities
 
     def _start_end_only_activity(self):
         return {

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1173,7 +1173,7 @@ class QgisSmokeTests(unittest.TestCase):
             # Starts layer carries the heatmap renderer
             renderer = starts_layer.renderer()
             self.assertIsInstance(renderer, QgsHeatmapRenderer)
-            self.assertEqual(renderer.radius(), 3000)
+            self.assertEqual(renderer.radius(), 2000)
             self.assertEqual(renderer.colorRamp().color2().alpha(), 255)
             self.assertGreater(renderer.colorRamp().color2().red(), renderer.colorRamp().color2().blue())
             self.assertEqual(renderer.radiusUnit(), QgsUnitTypes.RenderMapUnits)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1182,11 +1182,11 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertIsNotNone(renderer.colorRamp())
             self.assertEqual(renderer.colorRamp().color1().alpha(), 0)
             self.assertTrue(renderer.colorRamp().stops(), "Heatmap ramp should include intermediate transparent/soft stops")
-            self.assertEqual(round(starts_layer.opacity(), 2), 1.0)
+            self.assertAlmostEqual(starts_layer.opacity(), 1.0, places=2)
 
-            # Tracks and route points must be fully hidden so they don't flatten the visual
-            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
-            self.assertEqual(round(points_layer.opacity(), 2), 0.0)
+            # Tracks stay faintly visible underneath, route points stay hidden
+            self.assertGreater(activities_layer.opacity(), 0.0)
+            self.assertAlmostEqual(points_layer.opacity(), 0.0, places=2)
 
     def test_heatmap_preset_renders_visible_output(self):
         """Heatmap preset should produce visible rendered output, not just assign a renderer."""
@@ -1225,8 +1225,8 @@ class QgisSmokeTests(unittest.TestCase):
             )
 
             self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
-            self.assertEqual(round(starts_layer.opacity(), 2), 1.0)
-            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+            self.assertAlmostEqual(starts_layer.opacity(), 1.0, places=2)
+            self.assertGreater(activities_layer.opacity(), 0.0)
 
     def test_heatmap_preset_falls_back_to_starts_layer_when_points_layer_is_empty(self):
         """An empty points layer should not blank the map in Heatmap preset."""
@@ -1250,15 +1250,15 @@ class QgisSmokeTests(unittest.TestCase):
             )
 
             self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
-            self.assertEqual(round(starts_layer.opacity(), 2), 1.0)
-            self.assertEqual(round(points_layer.opacity(), 2), 0.0)
+            self.assertAlmostEqual(starts_layer.opacity(), 1.0, places=2)
+            self.assertAlmostEqual(points_layer.opacity(), 0.0, places=2)
 
             image = self._render_layers_to_image([starts_layer], starts_layer.extent())
             non_white_pixels, strong_pixels = self._count_heatmap_pixels(image)
 
             self.assertGreater(non_white_pixels, 1000)
             self.assertGreater(strong_pixels, 100)
-            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+            self.assertGreater(activities_layer.opacity(), 0.0)
 
     def test_heatmap_preset_falls_back_to_points_when_starts_layer_is_empty(self):
         """Heatmap preset should stay visible when start-point derivation produced no features."""
@@ -1284,9 +1284,9 @@ class QgisSmokeTests(unittest.TestCase):
             )
 
             self.assertIsInstance(points_layer.renderer(), QgsHeatmapRenderer)
-            self.assertEqual(round(points_layer.opacity(), 2), 1.0)
-            self.assertEqual(round(starts_layer.opacity(), 2), 0.0)
-            self.assertEqual(round(activities_layer.opacity(), 2), 0.0)
+            self.assertAlmostEqual(points_layer.opacity(), 1.0, places=2)
+            self.assertAlmostEqual(starts_layer.opacity(), 0.0, places=2)
+            self.assertGreater(activities_layer.opacity(), 0.0)
 
             image = self._render_layers_to_image([points_layer], points_layer.extent())
             non_white_pixels, strong_pixels = self._count_heatmap_pixels(image)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1184,8 +1184,8 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertTrue(renderer.colorRamp().stops(), "Heatmap ramp should include intermediate transparent/soft stops")
             self.assertAlmostEqual(starts_layer.opacity(), 1.0, places=2)
 
-            # Tracks stay faintly visible underneath, route points stay hidden
-            self.assertGreater(activities_layer.opacity(), 0.0)
+            # Tracks and route points stay hidden so the heatmap remains readable
+            self.assertAlmostEqual(activities_layer.opacity(), 0.0, places=2)
             self.assertAlmostEqual(points_layer.opacity(), 0.0, places=2)
 
     def test_heatmap_preset_renders_visible_output(self):
@@ -1226,7 +1226,7 @@ class QgisSmokeTests(unittest.TestCase):
 
             self.assertIsInstance(starts_layer.renderer(), QgsHeatmapRenderer)
             self.assertAlmostEqual(starts_layer.opacity(), 1.0, places=2)
-            self.assertGreater(activities_layer.opacity(), 0.0)
+            self.assertAlmostEqual(activities_layer.opacity(), 0.0, places=2)
 
     def test_heatmap_preset_falls_back_to_starts_layer_when_points_layer_is_empty(self):
         """An empty points layer should not blank the map in Heatmap preset."""
@@ -1258,7 +1258,7 @@ class QgisSmokeTests(unittest.TestCase):
 
             self.assertGreater(non_white_pixels, 1000)
             self.assertGreater(strong_pixels, 100)
-            self.assertGreater(activities_layer.opacity(), 0.0)
+            self.assertAlmostEqual(activities_layer.opacity(), 0.0, places=2)
 
     def test_heatmap_preset_falls_back_to_points_when_starts_layer_is_empty(self):
         """Heatmap preset should stay visible when start-point derivation produced no features."""
@@ -1286,7 +1286,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertIsInstance(points_layer.renderer(), QgsHeatmapRenderer)
             self.assertAlmostEqual(points_layer.opacity(), 1.0, places=2)
             self.assertAlmostEqual(starts_layer.opacity(), 0.0, places=2)
-            self.assertGreater(activities_layer.opacity(), 0.0)
+            self.assertAlmostEqual(activities_layer.opacity(), 0.0, places=2)
 
             image = self._render_layers_to_image([points_layer], points_layer.extent())
             non_white_pixels, strong_pixels = self._count_heatmap_pixels(image)

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -1,4 +1,5 @@
 import logging
+from math import floor
 
 logger = logging.getLogger(__name__)
 
@@ -6,6 +7,8 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (
     QgsCategorizedSymbolRenderer,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
     QgsFillSymbol,
     QgsGradientColorRamp,
     QgsGradientStop,
@@ -29,12 +32,64 @@ from ...mapbox_config import BACKGROUND_LAYER_PREFIX
 
 BY_ACTIVITY_TYPE_PRESET = "By activity type"
 OTHER_ACTIVITY_LABEL = "Other"
+HEATMAP_ANALYSIS_RADIUS_M = 750
+HEATMAP_VISUALIZE_RADIUS_M = 3000
+HEATMAP_WORKING_CRS = QgsCoordinateReferenceSystem("EPSG:3857")
 
 
-def build_qfit_heatmap_renderer():
+def _estimate_heatmap_maximum(layer, radius_map_units):
+    if layer is None:
+        return None
+
+    feature_count = layer.featureCount()
+    if feature_count <= 0:
+        return None
+
+    try:
+        source_crs = layer.crs()
+        if source_crs is None or not source_crs.isValid():
+            source_crs = QgsCoordinateReferenceSystem("EPSG:4326")
+
+        transform = None
+        if source_crs != HEATMAP_WORKING_CRS:
+            transform = QgsCoordinateTransform(
+                source_crs,
+                HEATMAP_WORKING_CRS,
+                QgsProject.instance().transformContext(),
+            )
+
+        cell_size = max(radius_map_units / 2.0, 1.0)
+        counts = {}
+        for feature in layer.getFeatures():
+            geometry = feature.geometry()
+            if geometry is None or geometry.isEmpty():
+                continue
+            point = geometry.asPoint()
+            if transform is not None:
+                point = transform.transform(point)
+            key = (floor(point.x() / cell_size), floor(point.y() / cell_size))
+            counts[key] = counts.get(key, 0) + 1
+
+        if not counts:
+            return float(feature_count)
+
+        maximum = 1
+        for x, y in counts:
+            local_total = 0
+            for dx in (-1, 0, 1):
+                for dy in (-1, 0, 1):
+                    local_total += counts.get((x + dx, y + dy), 0)
+            maximum = max(maximum, local_total)
+        return float(maximum)
+    except Exception:
+        logger.debug("Failed to estimate heatmap maximum, falling back to feature count", exc_info=True)
+        return float(feature_count)
+
+
+def build_qfit_heatmap_renderer(*, maximum_value=None):
     renderer = QgsHeatmapRenderer()
-    renderer.setRadius(12)
-    renderer.setRadiusUnit(QgsUnitTypes.RenderMillimeters)
+    renderer.setRadius(HEATMAP_ANALYSIS_RADIUS_M)
+    renderer.setRadiusUnit(QgsUnitTypes.RenderMapUnits)
     renderer.setRenderQuality(2)
     heat_ramp = QgsGradientColorRamp(
         QColor("#00000000"),
@@ -48,13 +103,15 @@ def build_qfit_heatmap_renderer():
         ],
     )
     renderer.setColorRamp(heat_ramp)
+    if maximum_value is not None and maximum_value > 0:
+        renderer.setMaximumValue(float(maximum_value))
     return renderer
 
 
-def build_qfit_visualize_heatmap_renderer():
+def build_qfit_visualize_heatmap_renderer(*, maximum_value=None):
     renderer = QgsHeatmapRenderer()
-    renderer.setRadius(18)
-    renderer.setRadiusUnit(QgsUnitTypes.RenderMillimeters)
+    renderer.setRadius(HEATMAP_VISUALIZE_RADIUS_M)
+    renderer.setRadiusUnit(QgsUnitTypes.RenderMapUnits)
     renderer.setRenderQuality(2)
     heat_ramp = QgsGradientColorRamp(
         QColor("#00000000"),
@@ -68,6 +125,8 @@ def build_qfit_visualize_heatmap_renderer():
         ],
     )
     renderer.setColorRamp(heat_ramp)
+    if maximum_value is not None and maximum_value > 0:
+        renderer.setMaximumValue(float(maximum_value))
     return renderer
 
 
@@ -139,9 +198,6 @@ class LayerStyleService:
         if points_layer is None:
             return
         if preset == "Heatmap":
-            if has_point_features:
-                self._apply_heatmap_style(points_layer)
-                return
             self._apply_track_point_style(points_layer, subtle=True)
             points_layer.setOpacity(0.0)
             return
@@ -171,11 +227,7 @@ class LayerStyleService:
             self._apply_start_point_style(starts_layer, subtle=False)
             return
         if preset == "Heatmap":
-            if not has_point_features:
-                self._apply_heatmap_style(starts_layer)
-            else:
-                self._apply_start_point_style(starts_layer, subtle=True)
-                starts_layer.setOpacity(0.0)
+            self._apply_heatmap_style(starts_layer)
             return
         if preset == BY_ACTIVITY_TYPE_PRESET:
             self._apply_categorized_point_style(starts_layer, basemap_preset_name, size="3.0")
@@ -296,7 +348,11 @@ class LayerStyleService:
         layer.triggerRepaint()
 
     def _apply_heatmap_style(self, layer):
-        layer.setRenderer(build_qfit_visualize_heatmap_renderer())
+        layer.setRenderer(
+            build_qfit_visualize_heatmap_renderer(
+                maximum_value=_estimate_heatmap_maximum(layer, HEATMAP_VISUALIZE_RADIUS_M)
+            )
+        )
         layer.setOpacity(1.0)
         layer.triggerRepaint()
 

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -33,8 +33,52 @@ from ...mapbox_config import BACKGROUND_LAYER_PREFIX
 BY_ACTIVITY_TYPE_PRESET = "By activity type"
 OTHER_ACTIVITY_LABEL = "Other"
 HEATMAP_ANALYSIS_RADIUS_M = 750
-HEATMAP_VISUALIZE_RADIUS_M = 3000
+HEATMAP_VISUALIZE_RADIUS_M = 2000
 HEATMAP_WORKING_CRS = QgsCoordinateReferenceSystem("EPSG:3857")
+
+
+def _resolve_heatmap_transform(layer):
+    source_crs = layer.crs()
+    if source_crs is None or not source_crs.isValid():
+        source_crs = QgsCoordinateReferenceSystem("EPSG:4326")
+    if source_crs == HEATMAP_WORKING_CRS:
+        return None
+    return QgsCoordinateTransform(
+        source_crs,
+        HEATMAP_WORKING_CRS,
+        QgsProject.instance().transformContext(),
+    )
+
+
+def _collect_heatmap_points(layer, cell_size):
+    transform = _resolve_heatmap_transform(layer)
+    points = []
+    buckets = {}
+    for feature in layer.getFeatures():
+        geometry = feature.geometry()
+        if geometry is None or geometry.isEmpty():
+            continue
+        point = geometry.asPoint()
+        if transform is not None:
+            point = transform.transform(point)
+        point_xy = (point.x(), point.y())
+        points.append(point_xy)
+        key = (floor(point_xy[0] / cell_size), floor(point_xy[1] / cell_size))
+        buckets.setdefault(key, []).append(point_xy)
+    return points, buckets
+
+
+def _count_nearby_points(origin, buckets, cell_size, radius_squared):
+    x, y = origin
+    bucket_x = floor(x / cell_size)
+    bucket_y = floor(y / cell_size)
+    local_total = 0
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            for candidate_x, candidate_y in buckets.get((bucket_x + dx, bucket_y + dy), []):
+                if ((candidate_x - x) * (candidate_x - x)) + ((candidate_y - y) * (candidate_y - y)) <= radius_squared:
+                    local_total += 1
+    return local_total
 
 
 def _estimate_heatmap_maximum(layer, radius_map_units):
@@ -46,40 +90,16 @@ def _estimate_heatmap_maximum(layer, radius_map_units):
         return None
 
     try:
-        source_crs = layer.crs()
-        if source_crs is None or not source_crs.isValid():
-            source_crs = QgsCoordinateReferenceSystem("EPSG:4326")
-
-        transform = None
-        if source_crs != HEATMAP_WORKING_CRS:
-            transform = QgsCoordinateTransform(
-                source_crs,
-                HEATMAP_WORKING_CRS,
-                QgsProject.instance().transformContext(),
-            )
-
-        cell_size = max(radius_map_units / 2.0, 1.0)
-        counts = {}
-        for feature in layer.getFeatures():
-            geometry = feature.geometry()
-            if geometry is None or geometry.isEmpty():
-                continue
-            point = geometry.asPoint()
-            if transform is not None:
-                point = transform.transform(point)
-            key = (floor(point.x() / cell_size), floor(point.y() / cell_size))
-            counts[key] = counts.get(key, 0) + 1
-
-        if not counts:
+        cell_size = max(radius_map_units, 1.0)
+        points, buckets = _collect_heatmap_points(layer, cell_size)
+        if not points:
             return float(feature_count)
 
-        maximum = 1
-        for x, y in counts:
-            local_total = 0
-            for dx in (-1, 0, 1):
-                for dy in (-1, 0, 1):
-                    local_total += counts.get((x + dx, y + dy), 0)
-            maximum = max(maximum, local_total)
+        radius_squared = radius_map_units * radius_map_units
+        maximum = max(
+            _count_nearby_points(point, buckets, cell_size, radius_squared)
+            for point in points
+        )
         return float(maximum)
     except Exception:
         logger.debug("Failed to estimate heatmap maximum, falling back to feature count", exc_info=True)
@@ -140,26 +160,22 @@ class LayerStyleService:
     def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name=None):
         preset = preset or "Simple lines"
         basemap_preset_name = background_preset_name or self._infer_background_preset_name()
-        has_point_features = self._has_features(points_layer)
 
         self._apply_activities_layer_style(
             activities_layer,
             preset,
             basemap_preset_name,
-            has_point_features=has_point_features,
         )
         self._apply_points_layer_style(
             points_layer,
             preset,
             basemap_preset_name,
-            has_point_features=has_point_features,
         )
         self._apply_starts_layer_style(
             starts_layer,
             points_layer,
             preset,
             basemap_preset_name,
-            has_point_features=has_point_features,
         )
 
         if atlas_layer is not None:
@@ -170,8 +186,6 @@ class LayerStyleService:
         activities_layer,
         preset,
         basemap_preset_name,
-        *,
-        has_point_features=False,
     ):
         if activities_layer is None:
             return
@@ -192,8 +206,6 @@ class LayerStyleService:
         points_layer,
         preset,
         basemap_preset_name,
-        *,
-        has_point_features=False,
     ):
         if points_layer is None:
             return
@@ -215,8 +227,6 @@ class LayerStyleService:
         points_layer,
         preset,
         basemap_preset_name,
-        *,
-        has_point_features=False,
     ):
         if starts_layer is None:
             return
@@ -355,9 +365,6 @@ class LayerStyleService:
         )
         layer.setOpacity(1.0)
         layer.triggerRepaint()
-
-    def _has_features(self, layer):
-        return layer is not None and layer.featureCount() > 0
 
     def _apply_clusterish_style(self, layer):
         symbol = QgsMarkerSymbol.createSimple(

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -1,5 +1,4 @@
 import logging
-from math import floor
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +14,7 @@ from qgis.core import (
     QgsHeatmapRenderer,
     QgsLineSymbol,
     QgsMarkerSymbol,
+    QgsPointXY,
     QgsProject,
     QgsRendererCategory,
     QgsSimpleLineSymbolLayer,
@@ -22,88 +22,78 @@ from qgis.core import (
     QgsUnitTypes,
 )
 
+from ...analysis.application.frequent_start_points import (
+    StartPointSample,
+    analyze_frequent_start_points,
+)
+from ...mapbox_config import BACKGROUND_LAYER_PREFIX
 from ..map_style import (
     DEFAULT_SIMPLE_LINE_HEX,
     pick_activity_style_field,
     resolve_activity_color,
     resolve_basemap_line_style,
 )
-from ...mapbox_config import BACKGROUND_LAYER_PREFIX
 
 BY_ACTIVITY_TYPE_PRESET = "By activity type"
 OTHER_ACTIVITY_LABEL = "Other"
 HEATMAP_ANALYSIS_RADIUS_M = 750
-HEATMAP_VISUALIZE_RADIUS_M = 2000
+HEATMAP_VISUALIZE_RADIUS_M = 250
 HEATMAP_WORKING_CRS = QgsCoordinateReferenceSystem("EPSG:3857")
 
 
-def _resolve_heatmap_transform(layer):
+def _build_metric_start_samples(layer):
+    if layer is None:
+        return []
+
     source_crs = layer.crs()
     if source_crs is None or not source_crs.isValid():
         source_crs = QgsCoordinateReferenceSystem("EPSG:4326")
-    if source_crs == HEATMAP_WORKING_CRS:
-        return None
-    return QgsCoordinateTransform(
-        source_crs,
-        HEATMAP_WORKING_CRS,
-        QgsProject.instance().transformContext(),
-    )
 
+    transform = None
+    if source_crs != HEATMAP_WORKING_CRS:
+        transform = QgsCoordinateTransform(
+            source_crs,
+            HEATMAP_WORKING_CRS,
+            QgsProject.instance().transformContext(),
+        )
 
-def _collect_heatmap_points(layer, cell_size):
-    transform = _resolve_heatmap_transform(layer)
-    points = []
-    buckets = {}
+    samples = []
     for feature in layer.getFeatures():
         geometry = feature.geometry()
         if geometry is None or geometry.isEmpty():
             continue
         point = geometry.asPoint()
+        metric_point = QgsPointXY(point.x(), point.y())
         if transform is not None:
-            point = transform.transform(point)
-        point_xy = (point.x(), point.y())
-        points.append(point_xy)
-        key = (floor(point_xy[0] / cell_size), floor(point_xy[1] / cell_size))
-        buckets.setdefault(key, []).append(point_xy)
-    return points, buckets
+            metric_point = transform.transform(metric_point)
+        samples.append(
+            StartPointSample(
+                x=metric_point.x(),
+                y=metric_point.y(),
+                source_activity_id=str(feature["source_activity_id"])
+                if "source_activity_id" in feature.fields().names()
+                else None,
+            )
+        )
+    return samples
 
 
-def _count_nearby_points(origin, buckets, cell_size, radius_squared):
-    x, y = origin
-    bucket_x = floor(x / cell_size)
-    bucket_y = floor(y / cell_size)
-    local_total = 0
-    for dx in (-1, 0, 1):
-        for dy in (-1, 0, 1):
-            for candidate_x, candidate_y in buckets.get((bucket_x + dx, bucket_y + dy), []):
-                if ((candidate_x - x) * (candidate_x - x)) + ((candidate_y - y) * (candidate_y - y)) <= radius_squared:
-                    local_total += 1
-    return local_total
-
-
-def _estimate_heatmap_maximum(layer, radius_map_units):
-    if layer is None:
-        return None
-
-    feature_count = layer.featureCount()
+def _heatmap_settings_from_frequent_starts(layer):
+    feature_count = 0 if layer is None else layer.featureCount()
     if feature_count <= 0:
-        return None
+        return HEATMAP_VISUALIZE_RADIUS_M, None
 
     try:
-        cell_size = max(radius_map_units, 1.0)
-        points, buckets = _collect_heatmap_points(layer, cell_size)
-        if not points:
-            return float(feature_count)
+        samples = _build_metric_start_samples(layer)
+        if not samples:
+            return HEATMAP_VISUALIZE_RADIUS_M, float(feature_count)
 
-        radius_squared = radius_map_units * radius_map_units
-        maximum = max(
-            _count_nearby_points(point, buckets, cell_size, radius_squared)
-            for point in points
-        )
-        return float(maximum)
+        clusters, radius_m = analyze_frequent_start_points(samples, max_clusters=len(samples))
+        maximum = max((cluster.activity_count for cluster in clusters), default=feature_count)
+        return max(40.0, float(radius_m or HEATMAP_VISUALIZE_RADIUS_M)), float(maximum)
     except Exception:
-        logger.debug("Failed to estimate heatmap maximum, falling back to feature count", exc_info=True)
-        return float(feature_count)
+        logger.debug("Failed to derive heatmap settings from frequent-start analysis", exc_info=True)
+        return HEATMAP_VISUALIZE_RADIUS_M, float(feature_count)
 
 
 def build_qfit_heatmap_renderer(*, maximum_value=None):
@@ -128,9 +118,9 @@ def build_qfit_heatmap_renderer(*, maximum_value=None):
     return renderer
 
 
-def build_qfit_visualize_heatmap_renderer(*, maximum_value=None):
+def build_qfit_visualize_heatmap_renderer(*, radius_map_units=HEATMAP_VISUALIZE_RADIUS_M, maximum_value=None):
     renderer = QgsHeatmapRenderer()
-    renderer.setRadius(HEATMAP_VISUALIZE_RADIUS_M)
+    renderer.setRadius(radius_map_units)
     renderer.setRadiusUnit(QgsUnitTypes.RenderMapUnits)
     renderer.setRenderQuality(2)
     heat_ramp = QgsGradientColorRamp(
@@ -160,22 +150,29 @@ class LayerStyleService:
     def apply_style(self, activities_layer, starts_layer, points_layer, atlas_layer, preset, background_preset_name=None):
         preset = preset or "Simple lines"
         basemap_preset_name = background_preset_name or self._infer_background_preset_name()
+        has_point_features = self._has_features(points_layer)
+        has_start_features = self._has_features(starts_layer)
 
         self._apply_activities_layer_style(
             activities_layer,
             preset,
             basemap_preset_name,
+            has_point_features=has_point_features,
         )
         self._apply_points_layer_style(
             points_layer,
             preset,
             basemap_preset_name,
+            has_point_features=has_point_features,
+            has_start_features=has_start_features,
         )
         self._apply_starts_layer_style(
             starts_layer,
             points_layer,
             preset,
             basemap_preset_name,
+            has_point_features=has_point_features,
+            has_start_features=has_start_features,
         )
 
         if atlas_layer is not None:
@@ -186,6 +183,8 @@ class LayerStyleService:
         activities_layer,
         preset,
         basemap_preset_name,
+        *,
+        has_point_features=False,
     ):
         if activities_layer is None:
             return
@@ -206,10 +205,16 @@ class LayerStyleService:
         points_layer,
         preset,
         basemap_preset_name,
+        *,
+        has_point_features=False,
+        has_start_features=False,
     ):
         if points_layer is None:
             return
         if preset == "Heatmap":
+            if has_point_features and not has_start_features:
+                self._apply_heatmap_style(points_layer)
+                return
             self._apply_track_point_style(points_layer, subtle=True)
             points_layer.setOpacity(0.0)
             return
@@ -227,6 +232,9 @@ class LayerStyleService:
         points_layer,
         preset,
         basemap_preset_name,
+        *,
+        has_point_features=False,
+        has_start_features=False,
     ):
         if starts_layer is None:
             return
@@ -237,6 +245,10 @@ class LayerStyleService:
             self._apply_start_point_style(starts_layer, subtle=False)
             return
         if preset == "Heatmap":
+            if not has_start_features and has_point_features:
+                self._apply_start_point_style(starts_layer, subtle=True)
+                starts_layer.setOpacity(0.0)
+                return
             self._apply_heatmap_style(starts_layer)
             return
         if preset == BY_ACTIVITY_TYPE_PRESET:
@@ -358,13 +370,18 @@ class LayerStyleService:
         layer.triggerRepaint()
 
     def _apply_heatmap_style(self, layer):
+        radius_map_units, maximum_value = _heatmap_settings_from_frequent_starts(layer)
         layer.setRenderer(
             build_qfit_visualize_heatmap_renderer(
-                maximum_value=_estimate_heatmap_maximum(layer, HEATMAP_VISUALIZE_RADIUS_M)
+                radius_map_units=radius_map_units,
+                maximum_value=maximum_value,
             )
         )
         layer.setOpacity(1.0)
         layer.triggerRepaint()
+
+    def _has_features(self, layer):
+        return layer is not None and layer.featureCount() > 0
 
     def _apply_clusterish_style(self, layer):
         symbol = QgsMarkerSymbol.createSimple(

--- a/visualization/infrastructure/project_layer_loader.py
+++ b/visualization/infrastructure/project_layer_loader.py
@@ -1,4 +1,4 @@
-from qgis.core import QgsProject, QgsVectorLayer
+from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsVectorLayer
 
 
 class ProjectLayerLoader:
@@ -44,6 +44,10 @@ class ProjectLayerLoader:
         layer = QgsVectorLayer(uri, display_name, "ogr")
         if not layer.isValid():
             raise RuntimeError(f"Could not load layer '{layer_name}' from {gpkg_path}")
+
+        layer_crs = layer.crs()
+        if layer_crs is None or not layer_crs.isValid():
+            layer.setCrs(QgsCoordinateReferenceSystem("EPSG:4326"))
 
         project = QgsProject.instance()
         for old_layer in project.mapLayersByName(display_name):

--- a/visualization/infrastructure/project_layer_loader.py
+++ b/visualization/infrastructure/project_layer_loader.py
@@ -4,6 +4,11 @@ from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsVectorLayer
 class ProjectLayerLoader:
     """Loads and replaces qfit output layers in the current QGIS project."""
 
+    DEFAULT_LAYER_CRS = "EPSG:4326"
+    LAYER_FALLBACK_CRS = {
+        "activity_atlas_pages": "EPSG:3857",
+    }
+
     ACTIVITIES_CANDIDATES = [
         ("activity_tracks", "qfit activities"),
         ("activities", "qfit activities"),
@@ -47,7 +52,8 @@ class ProjectLayerLoader:
 
         layer_crs = layer.crs()
         if layer_crs is None or not layer_crs.isValid():
-            layer.setCrs(QgsCoordinateReferenceSystem("EPSG:4326"))
+            fallback_authid = self.LAYER_FALLBACK_CRS.get(layer_name, self.DEFAULT_LAYER_CRS)
+            layer.setCrs(QgsCoordinateReferenceSystem(fallback_authid))
 
         project = QgsProject.instance()
         for old_layer in project.mapLayersByName(display_name):


### PR DESCRIPTION
## Summary
- render the Visualize heatmap from `activity_starts` instead of the full route-point layer so the density view stays readable and stable instead of flattening into route traces
- switch the heatmap renderer to map-unit radii and estimate a local maximum intensity from nearby start-point clusters for more consistent output across zoom levels
- default loaded geometry layers to EPSG:4326 when a layer comes back without a valid CRS so the heatmap normalization path has a reliable transform base

## Testing
- python3 -m pytest tests/test_layer_style_service.py -q
- python3 -m pytest tests/test_qgis_smoke.py -q -k 'heatmap_preset_assigns_heatmap_renderer_and_hides_other_layers or heatmap_preset_renders_visible_output or heatmap_preset_falls_back_to_starts_layer or heatmap_preset_uses_starts_when_points_layer_is_empty'
- python3 -m pytest tests/test_project_layer_loader.py -q
- python3 -m pytest tests/test_layer_gateway.py tests/test_load_workflow.py -q
- python3 -m pytest tests/ -x -q --tb=short
  - suite output completed cleanly (`968 passed, 152 skipped`) before the known local teardown segfault (`EXIT=139`)
