### PR TITLE
fix: extend activity registry indexes

### DIFF
--- a/sync_repository.py
+++ b/sync_repository.py
@@ -154,12 +154,16 @@ class SyncRepository:
                 )
                 """
             )
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS idx_activity_registry_start_date ON activity_registry(start_date)"
-            )
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS idx_activity_registry_type ON activity_registry(activity_type)"
-            )
+            for statement in (
+                "CREATE INDEX IF NOT EXISTS idx_activity_registry_start_date ON activity_registry(start_date)",
+                "CREATE INDEX IF NOT EXISTS idx_activity_registry_type ON activity_registry(activity_type)",
+                "CREATE INDEX IF NOT EXISTS idx_activity_registry_source_start_date ON activity_registry(source, start_date)",
+                "CREATE INDEX IF NOT EXISTS idx_activity_registry_start_date_local ON activity_registry(start_date_local)",
+                "CREATE INDEX IF NOT EXISTS idx_activity_registry_sport_type ON activity_registry(sport_type)",
+                "CREATE INDEX IF NOT EXISTS idx_activity_registry_distance_m ON activity_registry(distance_m)",
+                "CREATE INDEX IF NOT EXISTS idx_activity_registry_last_synced_at ON activity_registry(last_synced_at)",
+            ):
+                cursor.execute(statement)
             connection.commit()
 
     def upsert_activities(self, activities, sync_metadata=None):

--- a/tests/test_sync_repository.py
+++ b/tests/test_sync_repository.py
@@ -88,6 +88,26 @@ class SyncRepositoryTests(unittest.TestCase):
             self.assertEqual(len(rows), 1)
             self.assertEqual(rows[0][0], "strava")
 
+    def test_ensure_schema_creates_activity_registry_indexes_idempotently(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = SyncRepository(str(Path(tmpdir) / "qfit.sqlite"))
+
+            repo.ensure_schema()
+            repo.ensure_schema()
+
+            index_rows = repo._connect().execute("PRAGMA index_list('activity_registry')").fetchall()
+            index_names = {row[1] for row in index_rows}
+
+            self.assertTrue({
+                "idx_activity_registry_start_date",
+                "idx_activity_registry_type",
+                "idx_activity_registry_source_start_date",
+                "idx_activity_registry_start_date_local",
+                "idx_activity_registry_sport_type",
+                "idx_activity_registry_distance_m",
+                "idx_activity_registry_last_synced_at",
+            }.issubset(index_names))
+
 
 class SyncUnchangedBehaviorTests(unittest.TestCase):
     """Verify that re-syncing identical activities does not rewrite rows."""


### PR DESCRIPTION
## Summary
- add the missing `activity_registry` indexes for provider-scoped chronology, local-time queries, sport filters, distance filters, and sync diagnostics
- keep schema setup idempotent by applying the full registry index set through `CREATE INDEX IF NOT EXISTS`
- add a regression test that verifies all expected registry indexes exist after repeated `ensure_schema()` runs

## Testing
- python3 -m pytest tests/test_sync_repository.py -q
- python3 -m pytest tests/test_gpkg_builder_modules_pure.py tests/test_sync_controller.py tests/test_load_workflow.py -q
- python3 -m pytest tests/ -x -q --tb=short
  - suite output completed cleanly (`978 passed, 155 skipped`) before the known local teardown segfault (`EXIT=139`)
