### PR TITLE
fix: add derived layer attribute indexes

### DIFF
--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -15,6 +15,8 @@ It depends on :mod:`gpkg_io` (disk writes), :mod:`gpkg_layer_builders`
 but contains no schema definitions or repository logic.
 """
 
+import sqlite3
+
 from .gpkg_io import write_layer_to_gpkg
 from .gpkg_atlas_page_builder import build_atlas_layer
 from .gpkg_layer_builders import (
@@ -30,6 +32,43 @@ from .gpkg_atlas_table_builders import (
     build_toc_layer,
 )
 from ....atlas.publish_atlas import build_atlas_page_plans
+
+
+DERIVED_LAYER_ATTRIBUTE_INDEXES = {
+    "activity_tracks": (
+        "CREATE INDEX IF NOT EXISTS idx_activity_tracks_source_activity_id ON activity_tracks(source, source_activity_id)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_tracks_activity_type ON activity_tracks(activity_type)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_tracks_start_date ON activity_tracks(start_date)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_tracks_sport_type ON activity_tracks(sport_type)",
+    ),
+    "activity_starts": (
+        "CREATE INDEX IF NOT EXISTS idx_activity_starts_source_activity_id ON activity_starts(source, source_activity_id)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_starts_activity_type ON activity_starts(activity_type)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_starts_start_date ON activity_starts(start_date)",
+    ),
+    "activity_points": (
+        "CREATE INDEX IF NOT EXISTS idx_activity_points_source_activity_id ON activity_points(source, source_activity_id)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_points_activity_type ON activity_points(activity_type)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_points_start_date ON activity_points(start_date)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_points_point_timestamp_local ON activity_points(point_timestamp_local)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_points_point_timestamp_utc ON activity_points(point_timestamp_utc)",
+    ),
+    "activity_atlas_pages": (
+        "CREATE INDEX IF NOT EXISTS idx_activity_atlas_pages_page_number ON activity_atlas_pages(page_number)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_atlas_pages_page_sort_key ON activity_atlas_pages(page_sort_key)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_atlas_pages_source_activity_id ON activity_atlas_pages(source, source_activity_id)",
+    ),
+}
+
+
+def ensure_attribute_indexes(output_path):
+    """Create derived-layer attribute indexes inside *output_path* if missing."""
+    with sqlite3.connect(output_path) as connection:
+        cursor = connection.cursor()
+        for statements in DERIVED_LAYER_ATTRIBUTE_INDEXES.values():
+            for statement in statements:
+                cursor.execute(statement)
+        connection.commit()
 
 
 def bootstrap_empty_gpkg(output_path, atlas_page_settings):
@@ -78,5 +117,7 @@ def build_and_write_all_layers(
 
     for layer_name, layer in layers.items():
         write_layer_to_gpkg(layer, output_path, layer_name, overwrite_file=False)
+
+    ensure_attribute_indexes(output_path)
 
     return layers

--- a/gpkg_write_orchestration.py
+++ b/gpkg_write_orchestration.py
@@ -7,6 +7,7 @@ This module remains as a stable forwarding import during the package move.
 from .activities.infrastructure.geopackage.gpkg_write_orchestration import (
     bootstrap_empty_gpkg,
     build_and_write_all_layers,
+    ensure_attribute_indexes,
 )
 
-__all__ = ["bootstrap_empty_gpkg", "build_and_write_all_layers"]
+__all__ = ["bootstrap_empty_gpkg", "build_and_write_all_layers", "ensure_attribute_indexes"]

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -283,6 +283,7 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 legacy.build_and_write_all_layers,
                 moved.build_and_write_all_layers,
             )
+            self.assertIs(legacy.ensure_attribute_indexes, moved.ensure_attribute_indexes)
 
             moved.bootstrap_empty_gpkg("/tmp/bootstrap.gpkg", {"margin_percent": 8})
             self.assertEqual(write_layer_to_gpkg.call_count, 9)
@@ -296,23 +297,57 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
             )
 
             write_layer_to_gpkg.reset_mock()
-            layers = moved.build_and_write_all_layers(
-                [{"name": "Evening Run"}],
-                "/tmp/full.gpkg",
-                {"margin_percent": 10},
-                write_activity_points=True,
-                point_stride=3,
-            )
+            executed_sql = []
 
-            build_atlas_page_plans.assert_called_once_with(
-                [{"name": "Evening Run"}], settings={"margin_percent": 10}
-            )
-            self.assertEqual(write_layer_to_gpkg.call_count, 9)
-            self.assertEqual(
-                layers["activity_points"],
-                ("points", ({"name": "Evening Run"},), True, 3),
-            )
-            self.assertEqual(layers["atlas_toc_entries"], ("toc", ({"name": "Evening Run"},), {"margin_percent": 10}, [{"page": 1}]))
+            class _Cursor:
+                def execute(self, statement):
+                    executed_sql.append(statement)
+
+            class _Connection:
+                def cursor(self):
+                    return _Cursor()
+
+                def commit(self):
+                    executed_sql.append("COMMIT")
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+            with patch.object(moved.sqlite3, "connect", return_value=_Connection()) as sqlite_connect:
+                layers = moved.build_and_write_all_layers(
+                    [{"name": "Evening Run"}],
+                    "/tmp/full.gpkg",
+                    {"margin_percent": 10},
+                    write_activity_points=True,
+                    point_stride=3,
+                )
+
+                build_atlas_page_plans.assert_called_once_with(
+                    [{"name": "Evening Run"}], settings={"margin_percent": 10}
+                )
+                self.assertEqual(write_layer_to_gpkg.call_count, 9)
+                self.assertEqual(
+                    layers["activity_points"],
+                    ("points", ({"name": "Evening Run"},), True, 3),
+                )
+                self.assertEqual(layers["atlas_toc_entries"], ("toc", ({"name": "Evening Run"},), {"margin_percent": 10}, [{"page": 1}]))
+                self.assertEqual(sqlite_connect.call_args, call("/tmp/full.gpkg"))
+                self.assertIn(
+                    "CREATE INDEX IF NOT EXISTS idx_activity_tracks_source_activity_id ON activity_tracks(source, source_activity_id)",
+                    executed_sql,
+                )
+                self.assertIn(
+                    "CREATE INDEX IF NOT EXISTS idx_activity_points_point_timestamp_local ON activity_points(point_timestamp_local)",
+                    executed_sql,
+                )
+                self.assertIn(
+                    "CREATE INDEX IF NOT EXISTS idx_activity_atlas_pages_page_sort_key ON activity_atlas_pages(page_sort_key)",
+                    executed_sql,
+                )
+                self.assertEqual(executed_sql[-1], "COMMIT")
 
 
 if __name__ == "__main__":

--- a/tests/test_gpkg_write_orchestration.py
+++ b/tests/test_gpkg_write_orchestration.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 import tempfile
 import unittest
 
@@ -149,6 +150,46 @@ class BuildAndWriteAllLayersTests(unittest.TestCase):
                     mem_layer.featureCount(),
                     f"{layer_name!r} disk count should match memory count",
                 )
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_build_and_write_all_layers_creates_attribute_indexes_for_derived_layers(self):
+        path = self._temp_gpkg()
+        try:
+            bootstrap_empty_gpkg(path, self.settings)
+            build_and_write_all_layers(self.records, path, self.settings)
+
+            with sqlite3.connect(path) as connection:
+                expected_indexes = {
+                    "activity_tracks": {
+                        "idx_activity_tracks_source_activity_id",
+                        "idx_activity_tracks_activity_type",
+                        "idx_activity_tracks_start_date",
+                        "idx_activity_tracks_sport_type",
+                    },
+                    "activity_starts": {
+                        "idx_activity_starts_source_activity_id",
+                        "idx_activity_starts_activity_type",
+                        "idx_activity_starts_start_date",
+                    },
+                    "activity_points": {
+                        "idx_activity_points_source_activity_id",
+                        "idx_activity_points_activity_type",
+                        "idx_activity_points_start_date",
+                        "idx_activity_points_point_timestamp_local",
+                        "idx_activity_points_point_timestamp_utc",
+                    },
+                    "activity_atlas_pages": {
+                        "idx_activity_atlas_pages_page_number",
+                        "idx_activity_atlas_pages_page_sort_key",
+                        "idx_activity_atlas_pages_source_activity_id",
+                    },
+                }
+
+                for table_name, expected in expected_indexes.items():
+                    rows = connection.execute(f"PRAGMA index_list('{table_name}')").fetchall()
+                    self.assertTrue(expected.issubset({row[1] for row in rows}), table_name)
         finally:
             if os.path.exists(path):
                 os.unlink(path)


### PR DESCRIPTION
## Summary
- add explicit attribute indexes for the rebuilt derived GeoPackage layers (`activity_tracks`, `activity_starts`, `activity_points`, and `activity_atlas_pages`)
- recreate those indexes after each layer overwrite cycle via a single `ensure_attribute_indexes(...)` helper in the write orchestration path
- add pure orchestration coverage plus a real GeoPackage regression test that verifies the expected index names exist on disk after rebuild

## Testing
- python3 -m pytest tests/test_gpkg_geopackage_unit.py tests/test_gpkg_write_orchestration.py tests/test_sync_repository.py -q
- python3 -m pytest tests/test_gpkg_writer.py tests/test_qgis_smoke.py -q -k 'headless_qgis_smoke_covers_write_load_crs_temporal_and_background_order'
- python3 -m pytest tests/ -x -q --tb=short
  - suite output completed cleanly (`978 passed, 156 skipped`) before the known local teardown segfault (`EXIT=139`)
