### PR TITLE
fix: ensure geopackage spatial indexes

### DIFF
--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -17,6 +17,12 @@ but contains no schema definitions or repository logic.
 
 import sqlite3
 
+from qgis.core import (
+    QgsFeatureSource,
+    QgsVectorDataProvider,
+    QgsVectorLayer,
+)
+
 from .gpkg_io import write_layer_to_gpkg
 from .gpkg_atlas_page_builder import build_atlas_layer
 from .gpkg_layer_builders import (
@@ -71,6 +77,24 @@ def ensure_attribute_indexes(output_path):
         connection.commit()
 
 
+def ensure_spatial_indexes(output_path):
+    """Create derived-layer spatial indexes inside *output_path* if missing."""
+    for layer_name in DERIVED_LAYER_ATTRIBUTE_INDEXES:
+        layer = QgsVectorLayer(f"{output_path}|layername={layer_name}", layer_name, "ogr")
+        if not layer.isValid():
+            raise RuntimeError(f"Failed to load GeoPackage layer {layer_name!r} from {output_path}")
+
+        provider = layer.dataProvider()
+        if not provider.capabilities() & QgsVectorDataProvider.CreateSpatialIndex:
+            raise RuntimeError(f"Layer {layer_name!r} does not support spatial index creation")
+
+        if provider.hasSpatialIndex() == QgsFeatureSource.SpatialIndexPresent:
+            continue
+
+        if not provider.createSpatialIndex():
+            raise RuntimeError(f"Failed to create spatial index for layer {layer_name!r}")
+
+
 def bootstrap_empty_gpkg(output_path, atlas_page_settings):
     """Create a new GeoPackage with empty layers in the canonical order.
 
@@ -119,5 +143,6 @@ def build_and_write_all_layers(
         write_layer_to_gpkg(layer, output_path, layer_name, overwrite_file=False)
 
     ensure_attribute_indexes(output_path)
+    ensure_spatial_indexes(output_path)
 
     return layers

--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -17,11 +17,21 @@ but contains no schema definitions or repository logic.
 
 import sqlite3
 
-from qgis.core import (
-    QgsFeatureSource,
-    QgsVectorDataProvider,
-    QgsVectorLayer,
-)
+try:
+    from qgis.core import (
+        QgsFeatureSource,
+        QgsVectorDataProvider,
+        QgsVectorLayer,
+    )
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    class QgsFeatureSource:  # type: ignore[no-redef]
+        SpatialIndexNotPresent = 1
+        SpatialIndexPresent = 2
+
+    class QgsVectorDataProvider:  # type: ignore[no-redef]
+        CreateSpatialIndex = 1
+
+    QgsVectorLayer = None
 
 from .gpkg_io import write_layer_to_gpkg
 from .gpkg_atlas_page_builder import build_atlas_layer
@@ -79,6 +89,9 @@ def ensure_attribute_indexes(output_path):
 
 def ensure_spatial_indexes(output_path):
     """Create derived-layer spatial indexes inside *output_path* if missing."""
+    if QgsVectorLayer is None:
+        raise RuntimeError("QGIS Python bindings are required to create GeoPackage spatial indexes")
+
     for layer_name in DERIVED_LAYER_ATTRIBUTE_INDEXES:
         layer = QgsVectorLayer(f"{output_path}|layername={layer_name}", layer_name, "ogr")
         if not layer.isValid():

--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -17,22 +17,6 @@ but contains no schema definitions or repository logic.
 
 import sqlite3
 
-try:
-    from qgis.core import (
-        QgsFeatureSource,
-        QgsVectorDataProvider,
-        QgsVectorLayer,
-    )
-except (ImportError, ModuleNotFoundError):  # pragma: no cover
-    class QgsFeatureSource:  # type: ignore[no-redef]
-        SpatialIndexNotPresent = 1
-        SpatialIndexPresent = 2
-
-    class QgsVectorDataProvider:  # type: ignore[no-redef]
-        CreateSpatialIndex = 1
-
-    QgsVectorLayer = None
-
 from .gpkg_io import write_layer_to_gpkg
 from .gpkg_atlas_page_builder import build_atlas_layer
 from .gpkg_layer_builders import (
@@ -87,21 +71,29 @@ def ensure_attribute_indexes(output_path):
         connection.commit()
 
 
+def _import_qgis_spatial_index_api():
+    try:
+        from qgis.core import QgsFeatureSource, QgsVectorDataProvider, QgsVectorLayer
+    except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover
+        raise RuntimeError("QGIS Python bindings are required to create GeoPackage spatial indexes") from exc
+
+    return QgsFeatureSource, QgsVectorDataProvider, QgsVectorLayer
+
+
 def ensure_spatial_indexes(output_path):
     """Create derived-layer spatial indexes inside *output_path* if missing."""
-    if QgsVectorLayer is None:
-        raise RuntimeError("QGIS Python bindings are required to create GeoPackage spatial indexes")
+    qgs_feature_source, qgs_vector_data_provider, qgs_vector_layer = _import_qgis_spatial_index_api()
 
     for layer_name in DERIVED_LAYER_ATTRIBUTE_INDEXES:
-        layer = QgsVectorLayer(f"{output_path}|layername={layer_name}", layer_name, "ogr")
+        layer = qgs_vector_layer(f"{output_path}|layername={layer_name}", layer_name, "ogr")
         if not layer.isValid():
             raise RuntimeError(f"Failed to load GeoPackage layer {layer_name!r} from {output_path}")
 
         provider = layer.dataProvider()
-        if not provider.capabilities() & QgsVectorDataProvider.CreateSpatialIndex:
+        if not provider.capabilities() & qgs_vector_data_provider.CreateSpatialIndex:
             raise RuntimeError(f"Layer {layer_name!r} does not support spatial index creation")
 
-        if provider.hasSpatialIndex() == QgsFeatureSource.SpatialIndexPresent:
+        if provider.hasSpatialIndex() == qgs_feature_source.SpatialIndexPresent:
             continue
 
         if not provider.createSpatialIndex():

--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -74,7 +74,7 @@ def ensure_attribute_indexes(output_path):
 def _import_qgis_spatial_index_api():
     try:
         from qgis.core import QgsFeatureSource, QgsVectorDataProvider, QgsVectorLayer
-    except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover
+    except ImportError as exc:  # pragma: no cover
         raise RuntimeError("QGIS Python bindings are required to create GeoPackage spatial indexes") from exc
 
     return QgsFeatureSource, QgsVectorDataProvider, QgsVectorLayer

--- a/gpkg_write_orchestration.py
+++ b/gpkg_write_orchestration.py
@@ -8,6 +8,12 @@ from .activities.infrastructure.geopackage.gpkg_write_orchestration import (
     bootstrap_empty_gpkg,
     build_and_write_all_layers,
     ensure_attribute_indexes,
+    ensure_spatial_indexes,
 )
 
-__all__ = ["bootstrap_empty_gpkg", "build_and_write_all_layers", "ensure_attribute_indexes"]
+__all__ = [
+    "bootstrap_empty_gpkg",
+    "build_and_write_all_layers",
+    "ensure_attribute_indexes",
+    "ensure_spatial_indexes",
+]

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -450,6 +450,65 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
             self.assertEqual(providers["activity_points"].create_calls, 1)
             self.assertEqual(providers["activity_atlas_pages"].create_calls, 0)
 
+            class _InvalidLayer:
+                def isValid(self):
+                    return False
+
+            with patch.object(
+                moved,
+                "_import_qgis_spatial_index_api",
+                return_value=(_FeatureSource, _VectorDataProvider, lambda uri, layer_name, provider_key: _InvalidLayer()),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "Failed to load GeoPackage layer 'activity_tracks'"):
+                    moved.ensure_spatial_indexes("/tmp/full.gpkg")
+
+            class _NoCapabilityProvider:
+                def capabilities(self):
+                    return 0
+
+                def hasSpatialIndex(self):
+                    return missing
+
+            class _NoCapabilityLayer:
+                def isValid(self):
+                    return True
+
+                def dataProvider(self):
+                    return _NoCapabilityProvider()
+
+            with patch.object(
+                moved,
+                "_import_qgis_spatial_index_api",
+                return_value=(_FeatureSource, _VectorDataProvider, lambda uri, layer_name, provider_key: _NoCapabilityLayer()),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "does not support spatial index creation"):
+                    moved.ensure_spatial_indexes("/tmp/full.gpkg")
+
+            class _CreateFailureProvider:
+                def capabilities(self):
+                    return _VectorDataProvider.CreateSpatialIndex
+
+                def hasSpatialIndex(self):
+                    return missing
+
+                def createSpatialIndex(self):
+                    return False
+
+            class _CreateFailureLayer:
+                def isValid(self):
+                    return True
+
+                def dataProvider(self):
+                    return _CreateFailureProvider()
+
+            with patch.object(
+                moved,
+                "_import_qgis_spatial_index_api",
+                return_value=(_FeatureSource, _VectorDataProvider, lambda uri, layer_name, provider_key: _CreateFailureLayer()),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "Failed to create spatial index for layer 'activity_tracks'"):
+                    moved.ensure_spatial_indexes("/tmp/full.gpkg")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -319,15 +319,22 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
 
             spatial_index_calls = []
 
+            class _FeatureSource:
+                SpatialIndexNotPresent = 1
+                SpatialIndexPresent = 2
+
+            class _VectorDataProvider:
+                CreateSpatialIndex = 1
+
             class _Provider:
                 def __init__(self, layer_name):
                     self.layer_name = layer_name
 
                 def capabilities(self):
-                    return moved.QgsVectorDataProvider.CreateSpatialIndex
+                    return _VectorDataProvider.CreateSpatialIndex
 
                 def hasSpatialIndex(self):
-                    return moved.QgsFeatureSource.SpatialIndexPresent
+                    return _FeatureSource.SpatialIndexPresent
 
                 def createSpatialIndex(self):
                     spatial_index_calls.append(self.layer_name)
@@ -346,7 +353,11 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                     return _Provider(self.layer_name)
 
             with patch.object(moved.sqlite3, "connect", return_value=_Connection()) as sqlite_connect, \
-                    patch.object(moved, "QgsVectorLayer", side_effect=lambda uri, layer_name, provider_key: _Layer(uri, layer_name, provider_key)):
+                    patch.object(
+                        moved,
+                        "_import_qgis_spatial_index_api",
+                        return_value=(_FeatureSource, _VectorDataProvider, lambda uri, layer_name, provider_key: _Layer(uri, layer_name, provider_key)),
+                    ):
                 layers = moved.build_and_write_all_layers(
                     [{"name": "Evening Run"}],
                     "/tmp/full.gpkg",
@@ -380,8 +391,8 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 self.assertEqual(executed_sql[-1], "COMMIT")
                 self.assertEqual(spatial_index_calls, [])
 
-            present = moved.QgsFeatureSource.SpatialIndexPresent
-            missing = moved.QgsFeatureSource.SpatialIndexNotPresent
+            present = _FeatureSource.SpatialIndexPresent
+            missing = _FeatureSource.SpatialIndexNotPresent
             loaded_layers = []
 
             class _SpatialProvider:
@@ -390,7 +401,7 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                     self.create_calls = 0
 
                 def capabilities(self):
-                    return moved.QgsVectorDataProvider.CreateSpatialIndex
+                    return _VectorDataProvider.CreateSpatialIndex
 
                 def hasSpatialIndex(self):
                     return self.state
@@ -418,7 +429,11 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 def dataProvider(self):
                     return providers[self.layer_name]
 
-            with patch.object(moved, "QgsVectorLayer", side_effect=lambda uri, layer_name, provider_key: _SpatialLayer(uri, layer_name, provider_key)):
+            with patch.object(
+                moved,
+                "_import_qgis_spatial_index_api",
+                return_value=(_FeatureSource, _VectorDataProvider, lambda uri, layer_name, provider_key: _SpatialLayer(uri, layer_name, provider_key)),
+            ):
                 moved.ensure_spatial_indexes("/tmp/full.gpkg")
 
             self.assertEqual(

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -284,6 +284,7 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 moved.build_and_write_all_layers,
             )
             self.assertIs(legacy.ensure_attribute_indexes, moved.ensure_attribute_indexes)
+            self.assertIs(legacy.ensure_spatial_indexes, moved.ensure_spatial_indexes)
 
             moved.bootstrap_empty_gpkg("/tmp/bootstrap.gpkg", {"margin_percent": 8})
             self.assertEqual(write_layer_to_gpkg.call_count, 9)
@@ -316,7 +317,36 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 def __exit__(self, exc_type, exc, tb):
                     return False
 
-            with patch.object(moved.sqlite3, "connect", return_value=_Connection()) as sqlite_connect:
+            spatial_index_calls = []
+
+            class _Provider:
+                def __init__(self, layer_name):
+                    self.layer_name = layer_name
+
+                def capabilities(self):
+                    return moved.QgsVectorDataProvider.CreateSpatialIndex
+
+                def hasSpatialIndex(self):
+                    return moved.QgsFeatureSource.SpatialIndexPresent
+
+                def createSpatialIndex(self):
+                    spatial_index_calls.append(self.layer_name)
+                    return True
+
+            class _Layer:
+                def __init__(self, uri, layer_name, provider_key):
+                    self.uri = uri
+                    self.layer_name = layer_name
+                    self.provider_key = provider_key
+
+                def isValid(self):
+                    return True
+
+                def dataProvider(self):
+                    return _Provider(self.layer_name)
+
+            with patch.object(moved.sqlite3, "connect", return_value=_Connection()) as sqlite_connect, \
+                    patch.object(moved, "QgsVectorLayer", side_effect=lambda uri, layer_name, provider_key: _Layer(uri, layer_name, provider_key)):
                 layers = moved.build_and_write_all_layers(
                     [{"name": "Evening Run"}],
                     "/tmp/full.gpkg",
@@ -348,6 +378,62 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                     executed_sql,
                 )
                 self.assertEqual(executed_sql[-1], "COMMIT")
+                self.assertEqual(spatial_index_calls, [])
+
+            present = moved.QgsFeatureSource.SpatialIndexPresent
+            missing = moved.QgsFeatureSource.SpatialIndexNotPresent
+            loaded_layers = []
+
+            class _SpatialProvider:
+                def __init__(self, state):
+                    self.state = state
+                    self.create_calls = 0
+
+                def capabilities(self):
+                    return moved.QgsVectorDataProvider.CreateSpatialIndex
+
+                def hasSpatialIndex(self):
+                    return self.state
+
+                def createSpatialIndex(self):
+                    self.create_calls += 1
+                    self.state = present
+                    return True
+
+            providers = {
+                "activity_tracks": _SpatialProvider(missing),
+                "activity_starts": _SpatialProvider(present),
+                "activity_points": _SpatialProvider(missing),
+                "activity_atlas_pages": _SpatialProvider(present),
+            }
+
+            class _SpatialLayer:
+                def __init__(self, uri, layer_name, provider_key):
+                    loaded_layers.append((uri, layer_name, provider_key))
+                    self.layer_name = layer_name
+
+                def isValid(self):
+                    return True
+
+                def dataProvider(self):
+                    return providers[self.layer_name]
+
+            with patch.object(moved, "QgsVectorLayer", side_effect=lambda uri, layer_name, provider_key: _SpatialLayer(uri, layer_name, provider_key)):
+                moved.ensure_spatial_indexes("/tmp/full.gpkg")
+
+            self.assertEqual(
+                loaded_layers,
+                [
+                    ("/tmp/full.gpkg|layername=activity_tracks", "activity_tracks", "ogr"),
+                    ("/tmp/full.gpkg|layername=activity_starts", "activity_starts", "ogr"),
+                    ("/tmp/full.gpkg|layername=activity_points", "activity_points", "ogr"),
+                    ("/tmp/full.gpkg|layername=activity_atlas_pages", "activity_atlas_pages", "ogr"),
+                ],
+            )
+            self.assertEqual(providers["activity_tracks"].create_calls, 1)
+            self.assertEqual(providers["activity_starts"].create_calls, 0)
+            self.assertEqual(providers["activity_points"].create_calls, 1)
+            self.assertEqual(providers["activity_atlas_pages"].create_calls, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_gpkg_write_orchestration.py
+++ b/tests/test_gpkg_write_orchestration.py
@@ -17,15 +17,18 @@ if QgsApplication is not None:
     from qfit.activities.infrastructure.geopackage.gpkg_write_orchestration import (
         bootstrap_empty_gpkg,
         build_and_write_all_layers,
+        ensure_spatial_indexes,
     )
     from qfit.gpkg_write_orchestration import (
         bootstrap_empty_gpkg as legacy_bootstrap_empty_gpkg,
         build_and_write_all_layers as legacy_build_and_write_all_layers,
+        ensure_spatial_indexes as legacy_ensure_spatial_indexes,
     )
     from qfit.atlas.publish_atlas import normalize_atlas_page_settings
 else:  # pragma: no cover
     bootstrap_empty_gpkg = None
     build_and_write_all_layers = None
+    ensure_spatial_indexes = None
     normalize_atlas_page_settings = None
 
 
@@ -58,6 +61,7 @@ class BootstrapEmptyGpkgTests(unittest.TestCase):
     def test_legacy_gpkg_write_orchestration_shim_exports_same_functions(self):
         self.assertIs(legacy_bootstrap_empty_gpkg, bootstrap_empty_gpkg)
         self.assertIs(legacy_build_and_write_all_layers, build_and_write_all_layers)
+        self.assertIs(legacy_ensure_spatial_indexes, ensure_spatial_indexes)
 
     @classmethod
     def setUpClass(cls):
@@ -190,6 +194,70 @@ class BuildAndWriteAllLayersTests(unittest.TestCase):
                 for table_name, expected in expected_indexes.items():
                     rows = connection.execute(f"PRAGMA index_list('{table_name}')").fetchall()
                     self.assertTrue(expected.issubset({row[1] for row in rows}), table_name)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_ensure_spatial_indexes_recreates_missing_rtree_metadata(self):
+        path = self._temp_gpkg()
+        try:
+            bootstrap_empty_gpkg(path, self.settings)
+            build_and_write_all_layers(self.records, path, self.settings)
+
+            with sqlite3.connect(path) as connection:
+                connection.execute(
+                    "DELETE FROM gpkg_extensions WHERE table_name='activity_points' AND extension_name='gpkg_rtree_index'"
+                )
+                for table_name in (
+                    "rtree_activity_points_geom",
+                    "rtree_activity_points_geom_rowid",
+                    "rtree_activity_points_geom_node",
+                    "rtree_activity_points_geom_parent",
+                ):
+                    connection.execute(f"DROP TABLE IF EXISTS {table_name}")
+                for trigger_name in (
+                    "rtree_activity_points_geom_insert",
+                    "rtree_activity_points_geom_update1",
+                    "rtree_activity_points_geom_update2",
+                    "rtree_activity_points_geom_update3",
+                    "rtree_activity_points_geom_update4",
+                    "rtree_activity_points_geom_delete",
+                ):
+                    connection.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+                connection.commit()
+
+            layer = QgsVectorLayer(f"{path}|layername=activity_points", "activity_points", "ogr")
+            self.assertTrue(layer.isValid())
+            self.assertEqual(layer.dataProvider().hasSpatialIndex(), layer.dataProvider().SpatialIndexNotPresent)
+
+            ensure_spatial_indexes(path)
+            ensure_spatial_indexes(path)
+
+            reloaded_layer = QgsVectorLayer(f"{path}|layername=activity_points", "activity_points", "ogr")
+            self.assertTrue(reloaded_layer.isValid())
+            self.assertEqual(reloaded_layer.dataProvider().hasSpatialIndex(), reloaded_layer.dataProvider().SpatialIndexPresent)
+
+            with sqlite3.connect(path) as connection:
+                extension_rows = connection.execute(
+                    "SELECT table_name, column_name, extension_name FROM gpkg_extensions WHERE table_name='activity_points'"
+                ).fetchall()
+                self.assertIn(("activity_points", "geom", "gpkg_rtree_index"), extension_rows)
+
+                rtree_tables = {
+                    row[0]
+                    for row in connection.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'rtree_activity_points_geom%'"
+                    ).fetchall()
+                }
+                self.assertEqual(
+                    rtree_tables,
+                    {
+                        "rtree_activity_points_geom",
+                        "rtree_activity_points_geom_rowid",
+                        "rtree_activity_points_geom_node",
+                        "rtree_activity_points_geom_parent",
+                    },
+                )
         finally:
             if os.path.exists(path):
                 os.unlink(path)


### PR DESCRIPTION
## Summary
- explicitly ensure GeoPackage spatial indexes exist for `activity_tracks`, `activity_starts`, `activity_points`, and `activity_atlas_pages`
- use the QGIS provider `hasSpatialIndex()` / `createSpatialIndex()` seam instead of hand-rolled GeoPackage RTree SQL
- add pure orchestration coverage plus a real GeoPackage regression that deletes an index and verifies qfit recreates it idempotently

## Testing
- python3 -m pytest tests/test_gpkg_geopackage_unit.py -q
- python3 -m pytest tests/test_gpkg_write_orchestration.py -q
- python3 -m pytest tests/test_gpkg_writer.py -q
- python3 -m pytest tests/test_qgis_smoke.py -q -k 'headless_qgis_smoke_covers_write_load_crs_temporal_and_background_order'
- python3 -m pytest tests/ -x -q --tb=short
  - suite output completed cleanly (`978 passed, 157 skipped`) before the known local teardown segfault (`EXIT=139`)
