### PR TITLE
fix: hide atlas pages from layer tree

### DIFF
--- a/tests/test_project_layer_loader.py
+++ b/tests/test_project_layer_loader.py
@@ -131,7 +131,7 @@ class ProjectLayerLoaderRealTests(unittest.TestCase):
 
         self.assertIs(loaded, new_layer)
         project.removeMapLayer.assert_called_once_with("old-id")
-        project.addMapLayer.assert_called_once_with(new_layer)
+        project.addMapLayer.assert_called_once_with(new_layer, True)
 
     def test_load_layer_defaults_geometry_layers_to_wgs84_when_crs_is_missing(self):
         loader = ProjectLayerLoader()
@@ -174,6 +174,7 @@ class ProjectLayerLoaderRealTests(unittest.TestCase):
             loader._load_layer("/tmp/out.gpkg", "activity_atlas_pages", "qfit atlas pages")
 
         new_layer.setCrs.assert_called_once_with("EPSG:3857")
+        project.addMapLayer.assert_called_once_with(new_layer, False)
 
 
 @unittest.skipIf(QGIS_AVAILABLE, SKIP_MOCK)
@@ -260,3 +261,4 @@ class ProjectLayerLoaderMockTests(unittest.TestCase):
             self.loader._load_layer("/tmp/out.gpkg", "activity_atlas_pages", "qfit atlas pages")
 
         new_layer.setCrs.assert_called_once_with("EPSG:3857")
+        project.addMapLayer.assert_called_once_with(new_layer, False)

--- a/visualization/infrastructure/project_layer_loader.py
+++ b/visualization/infrastructure/project_layer_loader.py
@@ -8,6 +8,7 @@ class ProjectLayerLoader:
     LAYER_FALLBACK_CRS = {
         "activity_atlas_pages": "EPSG:3857",
     }
+    HIDDEN_LAYER_NAMES = {"activity_atlas_pages"}
 
     ACTIVITIES_CANDIDATES = [
         ("activity_tracks", "qfit activities"),
@@ -58,5 +59,5 @@ class ProjectLayerLoader:
         project = QgsProject.instance()
         for old_layer in project.mapLayersByName(display_name):
             project.removeMapLayer(old_layer.id())
-        project.addMapLayer(layer)
+        project.addMapLayer(layer, layer_name not in self.HIDDEN_LAYER_NAMES)
         return layer


### PR DESCRIPTION
## Summary
- keep activity_atlas_pages loaded in the QGIS project without adding it to the user-visible layer tree
- preserve atlas pages CRS fallback behavior
- update loader tests to cover the hidden technical-layer behavior

## Testing
- python3 -m pytest tests/test_project_layer_loader.py -q --tb=short
