### PR TITLE
refactor: extract dock settings bindings

### DIFF
--- a/configuration/application/dock_settings_bindings.py
+++ b/configuration/application/dock_settings_bindings.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from .ui_settings_binding import UIFieldBinding
+from ...activities.domain.activity_query import DEFAULT_SORT_LABEL, DETAILED_ROUTE_FILTER_ANY
+from ...atlas.layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
+from ...detailed_route_strategy import DEFAULT_DETAILED_ROUTE_STRATEGY
+from ...mapbox_config import DEFAULT_BACKGROUND_PRESET, TILE_MODE_RASTER
+from ...providers.infrastructure.strava_provider import StravaProvider
+
+
+DEFAULT_STYLE_PRESET = "By activity type"
+
+
+def build_dock_settings_bindings(dock) -> list[UIFieldBinding]:
+    """Build the main dock widget settings binding table.
+
+    The dock remains responsible for its concrete UI widgets and coercion
+    helpers, while configuration-owned code owns the settings key mapping and
+    defaults.
+    """
+
+    return [
+        UIFieldBinding("client_id", "", lambda: dock.clientIdLineEdit.text().strip(), dock.clientIdLineEdit.setText),
+        UIFieldBinding("client_secret", "", lambda: dock.clientSecretLineEdit.text().strip(), dock.clientSecretLineEdit.setText),
+        UIFieldBinding(
+            "redirect_uri",
+            StravaProvider.DEFAULT_REDIRECT_URI,
+            lambda: dock.redirectUriLineEdit.text().strip(),
+            dock.redirectUriLineEdit.setText,
+        ),
+        UIFieldBinding("refresh_token", "", lambda: dock.refreshTokenLineEdit.text().strip(), dock.refreshTokenLineEdit.setText),
+        UIFieldBinding("output_path", dock._default_output_path(), lambda: dock.outputPathLineEdit.text().strip(), dock.outputPathLineEdit.setText),
+        UIFieldBinding("per_page", 200, lambda: dock.perPageSpinBox.value(), lambda value: dock._set_int_value(dock.perPageSpinBox, value, 200)),
+        UIFieldBinding("max_pages", 0, lambda: dock.maxPagesSpinBox.value(), lambda value: dock._set_int_value(dock.maxPagesSpinBox, value, 0)),
+        UIFieldBinding(
+            "use_detailed_streams",
+            False,
+            lambda: dock.detailedStreamsCheckBox.isChecked(),
+            lambda value: dock._set_bool_value(dock.detailedStreamsCheckBox, value, False),
+        ),
+        UIFieldBinding(
+            "max_detailed_activities",
+            25,
+            lambda: dock.maxDetailedActivitiesSpinBox.value(),
+            lambda value: dock._set_int_value(dock.maxDetailedActivitiesSpinBox, value, 25),
+        ),
+        UIFieldBinding(
+            "detailed_route_strategy",
+            DEFAULT_DETAILED_ROUTE_STRATEGY,
+            lambda: dock.detailedRouteStrategyComboBox.currentText(),
+            lambda value: dock._set_combo_value(
+                dock.detailedRouteStrategyComboBox,
+                value,
+                DEFAULT_DETAILED_ROUTE_STRATEGY,
+            ),
+        ),
+        UIFieldBinding(
+            "write_activity_points",
+            True,
+            lambda: dock.writeActivityPointsCheckBox.isChecked(),
+            lambda value: dock._set_bool_value(dock.writeActivityPointsCheckBox, value, True),
+        ),
+        UIFieldBinding(
+            "point_sampling_stride",
+            5,
+            lambda: dock.pointSamplingStrideSpinBox.value(),
+            lambda value: dock._set_int_value(dock.pointSamplingStrideSpinBox, value, 5),
+        ),
+        UIFieldBinding(
+            "activity_search_text",
+            "",
+            lambda: dock.activitySearchLineEdit.text().strip(),
+            dock.activitySearchLineEdit.setText,
+        ),
+        UIFieldBinding(
+            "max_distance_km",
+            0.0,
+            lambda: dock.maxDistanceSpinBox.value(),
+            lambda value: dock._set_float_value(dock.maxDistanceSpinBox, value, 0.0),
+        ),
+        UIFieldBinding(
+            "detailed_route_filter",
+            DETAILED_ROUTE_FILTER_ANY,
+            lambda: dock.detailedRouteStatusComboBox.currentData(),
+            lambda value: dock._set_combo_data_value(
+                dock.detailedRouteStatusComboBox,
+                value,
+                DETAILED_ROUTE_FILTER_ANY,
+            ),
+        ),
+        UIFieldBinding(
+            "use_background_map",
+            False,
+            lambda: dock.backgroundMapCheckBox.isChecked(),
+            lambda value: dock._set_bool_value(dock.backgroundMapCheckBox, value, False),
+        ),
+        UIFieldBinding(
+            "mapbox_style_owner",
+            "mapbox",
+            lambda: dock.mapboxStyleOwnerLineEdit.text().strip(),
+            dock.mapboxStyleOwnerLineEdit.setText,
+        ),
+        UIFieldBinding(
+            "mapbox_style_id",
+            "",
+            lambda: dock.mapboxStyleIdLineEdit.text().strip(),
+            dock.mapboxStyleIdLineEdit.setText,
+        ),
+        UIFieldBinding(
+            "atlas_margin_percent",
+            8.0,
+            lambda: dock.atlasMarginPercentSpinBox.value(),
+            lambda value: dock._set_float_value(dock.atlasMarginPercentSpinBox, value, 8.0),
+        ),
+        UIFieldBinding(
+            "atlas_min_extent_degrees",
+            0.01,
+            lambda: dock.atlasMinExtentSpinBox.value(),
+            lambda value: dock._set_float_value(dock.atlasMinExtentSpinBox, value, 0.01),
+        ),
+        UIFieldBinding(
+            "atlas_target_aspect_ratio",
+            BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO,
+            lambda: dock.atlasTargetAspectRatioSpinBox.value(),
+            dock._set_atlas_target_aspect_ratio_value,
+        ),
+        UIFieldBinding(
+            "atlas_pdf_path",
+            dock._default_atlas_pdf_path(),
+            lambda: dock.atlasPdfPathLineEdit.text().strip(),
+            dock.atlasPdfPathLineEdit.setText,
+        ),
+        UIFieldBinding(
+            "analysis_mode",
+            "None",
+            lambda: dock.analysisModeComboBox.currentText(),
+            lambda value: dock._set_combo_value(dock.analysisModeComboBox, value, "None"),
+        ),
+        UIFieldBinding(
+            "background_preset",
+            DEFAULT_BACKGROUND_PRESET,
+            lambda: dock.backgroundPresetComboBox.currentText(),
+            lambda value: dock._set_combo_value(dock.backgroundPresetComboBox, value, DEFAULT_BACKGROUND_PRESET),
+        ),
+        UIFieldBinding(
+            "tile_mode",
+            TILE_MODE_RASTER,
+            lambda: dock.tileModeComboBox.currentText(),
+            lambda value: dock._set_combo_value(dock.tileModeComboBox, value, TILE_MODE_RASTER),
+        ),
+        UIFieldBinding(
+            "preview_sort",
+            DEFAULT_SORT_LABEL,
+            lambda: dock.previewSortComboBox.currentText(),
+            lambda value: dock._set_combo_value(dock.previewSortComboBox, value, DEFAULT_SORT_LABEL),
+        ),
+        UIFieldBinding(
+            "style_preset",
+            DEFAULT_STYLE_PRESET,
+            lambda: dock.stylePresetComboBox.currentText(),
+            lambda value: dock._set_combo_value(dock.stylePresetComboBox, value, DEFAULT_STYLE_PRESET),
+        ),
+    ]

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -59,13 +59,10 @@ from .ui.application import (
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import (
-    DEFAULT_DETAILED_ROUTE_STRATEGY,
     DETAILED_ROUTE_STRATEGY_MISSING,
     detailed_route_strategy_labels,
 )
 from .mapbox_config import (
-    DEFAULT_BACKGROUND_PRESET,
-    TILE_MODE_RASTER,
     TILE_MODES,
     MapboxConfigError,
     background_preset_names,
@@ -79,7 +76,8 @@ from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mod
 from .ui.dockwidget_dependencies import DockWidgetDependencies, build_dockwidget_dependencies
 from .ui.dock_startup_coordinator import DockStartupCoordinator
 from .ui.workflow_section_coordinator import WorkflowSectionCoordinator
-from .configuration.application.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
+from .configuration.application.dock_settings_bindings import build_dock_settings_bindings
+from .configuration.application.ui_settings_binding import load_bindings, save_bindings
 
 FORM_CLASS, _ = uic.loadUiType(
     __import__("os").path.join(__import__("os").path.dirname(__file__), "qfit_dockwidget_base.ui")
@@ -346,153 +344,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _default_atlas_pdf_path(self) -> str:
         return os.path.join(os.path.expanduser("~"), "qfit_atlas.pdf")
 
-    def _settings_bindings(self) -> list[UIFieldBinding]:
-        default_style_preset = "By activity type"
-        return [
-            UIFieldBinding("client_id", "", lambda: self.clientIdLineEdit.text().strip(), self.clientIdLineEdit.setText),
-            UIFieldBinding("client_secret", "", lambda: self.clientSecretLineEdit.text().strip(), self.clientSecretLineEdit.setText),
-            UIFieldBinding(
-                "redirect_uri",
-                StravaProvider.DEFAULT_REDIRECT_URI,
-                lambda: self.redirectUriLineEdit.text().strip(),
-                self.redirectUriLineEdit.setText,
-            ),
-            UIFieldBinding("refresh_token", "", lambda: self.refreshTokenLineEdit.text().strip(), self.refreshTokenLineEdit.setText),
-            UIFieldBinding("output_path", self._default_output_path(), lambda: self.outputPathLineEdit.text().strip(), self.outputPathLineEdit.setText),
-            UIFieldBinding("per_page", 200, lambda: self.perPageSpinBox.value(), lambda value: self._set_int_value(self.perPageSpinBox, value, 200)),
-            UIFieldBinding("max_pages", 0, lambda: self.maxPagesSpinBox.value(), lambda value: self._set_int_value(self.maxPagesSpinBox, value, 0)),
-            UIFieldBinding(
-                "use_detailed_streams",
-                False,
-                lambda: self.detailedStreamsCheckBox.isChecked(),
-                lambda value: self._set_bool_value(self.detailedStreamsCheckBox, value, False),
-            ),
-            UIFieldBinding(
-                "max_detailed_activities",
-                25,
-                lambda: self.maxDetailedActivitiesSpinBox.value(),
-                lambda value: self._set_int_value(self.maxDetailedActivitiesSpinBox, value, 25),
-            ),
-            UIFieldBinding(
-                "detailed_route_strategy",
-                DEFAULT_DETAILED_ROUTE_STRATEGY,
-                lambda: self.detailedRouteStrategyComboBox.currentText(),
-                lambda value: self._set_combo_value(
-                    self.detailedRouteStrategyComboBox,
-                    value,
-                    DEFAULT_DETAILED_ROUTE_STRATEGY,
-                ),
-            ),
-            UIFieldBinding(
-                "write_activity_points",
-                True,
-                lambda: self.writeActivityPointsCheckBox.isChecked(),
-                lambda value: self._set_bool_value(self.writeActivityPointsCheckBox, value, True),
-            ),
-            UIFieldBinding(
-                "point_sampling_stride",
-                5,
-                lambda: self.pointSamplingStrideSpinBox.value(),
-                lambda value: self._set_int_value(self.pointSamplingStrideSpinBox, value, 5),
-            ),
-            UIFieldBinding(
-                "activity_search_text",
-                "",
-                lambda: self.activitySearchLineEdit.text().strip(),
-                self.activitySearchLineEdit.setText,
-            ),
-            UIFieldBinding(
-                "max_distance_km",
-                0.0,
-                lambda: self.maxDistanceSpinBox.value(),
-                lambda value: self._set_float_value(self.maxDistanceSpinBox, value, 0.0),
-            ),
-            UIFieldBinding(
-                "detailed_route_filter",
-                DETAILED_ROUTE_FILTER_ANY,
-                lambda: self.detailedRouteStatusComboBox.currentData(),
-                lambda value: self._set_combo_data_value(
-                    self.detailedRouteStatusComboBox,
-                    value,
-                    DETAILED_ROUTE_FILTER_ANY,
-                ),
-            ),
-            UIFieldBinding(
-                "use_background_map",
-                False,
-                lambda: self.backgroundMapCheckBox.isChecked(),
-                lambda value: self._set_bool_value(self.backgroundMapCheckBox, value, False),
-            ),
-            UIFieldBinding(
-                "mapbox_style_owner",
-                "mapbox",
-                lambda: self.mapboxStyleOwnerLineEdit.text().strip(),
-                self.mapboxStyleOwnerLineEdit.setText,
-            ),
-            UIFieldBinding(
-                "mapbox_style_id",
-                "",
-                lambda: self.mapboxStyleIdLineEdit.text().strip(),
-                self.mapboxStyleIdLineEdit.setText,
-            ),
-            UIFieldBinding(
-                "atlas_margin_percent",
-                8.0,
-                lambda: self.atlasMarginPercentSpinBox.value(),
-                lambda value: self._set_float_value(self.atlasMarginPercentSpinBox, value, 8.0),
-            ),
-            UIFieldBinding(
-                "atlas_min_extent_degrees",
-                0.01,
-                lambda: self.atlasMinExtentSpinBox.value(),
-                lambda value: self._set_float_value(self.atlasMinExtentSpinBox, value, 0.01),
-            ),
-            UIFieldBinding(
-                "atlas_target_aspect_ratio",
-                BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO,
-                lambda: self.atlasTargetAspectRatioSpinBox.value(),
-                self._set_atlas_target_aspect_ratio_value,
-            ),
-            UIFieldBinding(
-                "atlas_pdf_path",
-                self._default_atlas_pdf_path(),
-                lambda: self.atlasPdfPathLineEdit.text().strip(),
-                self.atlasPdfPathLineEdit.setText,
-            ),
-            UIFieldBinding(
-                "analysis_mode",
-                "None",
-                lambda: self.analysisModeComboBox.currentText(),
-                lambda value: self._set_combo_value(self.analysisModeComboBox, value, "None"),
-            ),
-            UIFieldBinding(
-                "background_preset",
-                DEFAULT_BACKGROUND_PRESET,
-                lambda: self.backgroundPresetComboBox.currentText(),
-                lambda value: self._set_combo_value(self.backgroundPresetComboBox, value, DEFAULT_BACKGROUND_PRESET),
-            ),
-            UIFieldBinding(
-                "tile_mode",
-                TILE_MODE_RASTER,
-                lambda: self.tileModeComboBox.currentText(),
-                lambda value: self._set_combo_value(self.tileModeComboBox, value, TILE_MODE_RASTER),
-            ),
-            UIFieldBinding(
-                "preview_sort",
-                DEFAULT_SORT_LABEL,
-                lambda: self.previewSortComboBox.currentText(),
-                lambda value: self._set_combo_value(self.previewSortComboBox, value, DEFAULT_SORT_LABEL),
-            ),
-            UIFieldBinding(
-                "style_preset",
-                default_style_preset,
-                lambda: self.stylePresetComboBox.currentText(),
-                lambda value: self._set_combo_value(self.stylePresetComboBox, value, default_style_preset),
-            ),
-        ]
-
     def _load_settings(self):
-        load_bindings(self._settings_bindings(), self.settings)
+        load_bindings(build_dock_settings_bindings(self), self.settings)
         self.authCodeLineEdit.setText("")
         self._sync_background_style_fields(self.backgroundPresetComboBox.currentText(), force=False)
 
@@ -501,7 +354,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self.countLabel.setText(f"Last sync: {last_sync}")
 
     def _save_settings(self):
-        save_bindings(self._settings_bindings(), self.settings)
+        save_bindings(build_dock_settings_bindings(self), self.settings)
 
 
     def _set_default_dates(self):

--- a/tests/test_dock_settings_bindings.py
+++ b/tests/test_dock_settings_bindings.py
@@ -1,0 +1,301 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.credential_store import InMemoryCredentialStore
+from qfit.settings_service import SettingsService
+from qfit.activities.domain.activity_query import DEFAULT_SORT_LABEL, DETAILED_ROUTE_FILTER_ANY
+from qfit.atlas.layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
+from qfit.configuration.application.dock_settings_bindings import build_dock_settings_bindings
+from qfit.configuration.application.ui_settings_binding import load_bindings, save_bindings
+from qfit.detailed_route_strategy import DEFAULT_DETAILED_ROUTE_STRATEGY
+from qfit.mapbox_config import DEFAULT_BACKGROUND_PRESET, TILE_MODE_RASTER
+from qfit.providers.infrastructure.strava_provider import StravaProvider
+
+
+class FakeQSettings:
+    def __init__(self, data=None):
+        self._data = data or {}
+
+    def value(self, key, default=None):
+        return self._data.get(key, default)
+
+    def setValue(self, key, value):
+        self._data[key] = value
+
+    def remove(self, key):
+        self._data.pop(key, None)
+
+
+class TextWidget:
+    def __init__(self, value=""):
+        self._value = value
+
+    def text(self):
+        return self._value
+
+    def setText(self, value):
+        self._value = value
+
+
+class SpinWidget:
+    def __init__(self, value=0):
+        self._value = value
+
+    def value(self):
+        return self._value
+
+    def setValue(self, value):
+        self._value = value
+
+
+class CheckWidget:
+    def __init__(self, checked=False):
+        self._checked = checked
+
+    def isChecked(self):
+        return self._checked
+
+    def setChecked(self, checked):
+        self._checked = checked
+
+
+class ComboWidget:
+    def __init__(self, items, current_index=0, data=None):
+        self._items = list(items)
+        self._data = list(data) if data is not None else list(items)
+        self._current_index = current_index
+
+    def currentText(self):
+        return self._items[self._current_index]
+
+    def currentData(self):
+        return self._data[self._current_index]
+
+    def findText(self, text):
+        try:
+            return self._items.index(text)
+        except ValueError:
+            return -1
+
+    def findData(self, value):
+        try:
+            return self._data.index(value)
+        except ValueError:
+            return -1
+
+    def setCurrentIndex(self, index):
+        self._current_index = index
+
+
+def _settings(data=None):
+    return SettingsService(
+        qsettings=FakeQSettings(data or {}),
+        credential_store=InMemoryCredentialStore(),
+    )
+
+
+class FakeDock:
+    def __init__(self):
+        self.clientIdLineEdit = TextWidget()
+        self.clientSecretLineEdit = TextWidget()
+        self.redirectUriLineEdit = TextWidget()
+        self.refreshTokenLineEdit = TextWidget()
+        self.outputPathLineEdit = TextWidget()
+        self.perPageSpinBox = SpinWidget(200)
+        self.maxPagesSpinBox = SpinWidget(0)
+        self.detailedStreamsCheckBox = CheckWidget(False)
+        self.maxDetailedActivitiesSpinBox = SpinWidget(25)
+        self.detailedRouteStrategyComboBox = ComboWidget(
+            [DEFAULT_DETAILED_ROUTE_STRATEGY, "Only missing detailed routes"],
+        )
+        self.writeActivityPointsCheckBox = CheckWidget(True)
+        self.pointSamplingStrideSpinBox = SpinWidget(5)
+        self.activitySearchLineEdit = TextWidget()
+        self.maxDistanceSpinBox = SpinWidget(0.0)
+        self.detailedRouteStatusComboBox = ComboWidget(
+            ["Any routes", "Detailed routes only", "Missing detailed routes"],
+            data=[DETAILED_ROUTE_FILTER_ANY, "present", "missing"],
+        )
+        self.backgroundMapCheckBox = CheckWidget(False)
+        self.mapboxStyleOwnerLineEdit = TextWidget()
+        self.mapboxStyleIdLineEdit = TextWidget()
+        self.atlasMarginPercentSpinBox = SpinWidget(8.0)
+        self.atlasMinExtentSpinBox = SpinWidget(0.01)
+        self.atlasTargetAspectRatioSpinBox = SpinWidget(BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO)
+        self.atlasPdfPathLineEdit = TextWidget()
+        self.analysisModeComboBox = ComboWidget(["None", "Most frequent starting points"])
+        self.backgroundPresetComboBox = ComboWidget([DEFAULT_BACKGROUND_PRESET, "Custom"])
+        self.tileModeComboBox = ComboWidget([TILE_MODE_RASTER, "Vector"])
+        self.previewSortComboBox = ComboWidget([DEFAULT_SORT_LABEL, "Newest first"])
+        self.stylePresetComboBox = ComboWidget(["By activity type", "Heatmap"])
+
+    def _default_output_path(self):
+        return "/tmp/qfit_activities.gpkg"
+
+    def _default_atlas_pdf_path(self):
+        return "/tmp/qfit_atlas.pdf"
+
+    @staticmethod
+    def _set_combo_value(combo_box, value, default_text):
+        selected = default_text if value in (None, "") else str(value)
+        index = combo_box.findText(selected)
+        if index < 0:
+            index = combo_box.findText(default_text)
+        combo_box.setCurrentIndex(max(index, 0))
+
+    @staticmethod
+    def _set_bool_value(check_box, value, default):
+        if isinstance(value, str):
+            check_box.setChecked(value.lower() in ("1", "true", "yes", "on"))
+            return
+        if value is None:
+            check_box.setChecked(default)
+            return
+        check_box.setChecked(bool(value))
+
+    @staticmethod
+    def _set_int_value(spin_box, value, default):
+        try:
+            spin_box.setValue(int(value))
+        except (TypeError, ValueError):
+            spin_box.setValue(int(default))
+
+    @staticmethod
+    def _set_combo_data_value(combo_box, value, default):
+        target = value if value not in (None, "") else default
+        index = combo_box.findData(target)
+        if index < 0:
+            index = combo_box.findData(default)
+        if index < 0:
+            index = 0
+        combo_box.setCurrentIndex(index)
+
+    @staticmethod
+    def _set_float_value(spin_box, value, default):
+        try:
+            spin_box.setValue(float(value))
+        except (TypeError, ValueError):
+            spin_box.setValue(float(default))
+
+    def _set_atlas_target_aspect_ratio_value(self, value):
+        try:
+            aspect_ratio = float(value)
+        except (TypeError, ValueError):
+            aspect_ratio = BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
+        if aspect_ratio <= 0:
+            aspect_ratio = BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
+        self.atlasTargetAspectRatioSpinBox.setValue(aspect_ratio)
+
+
+class DockSettingsBindingsTests(unittest.TestCase):
+    EXPECTED_KEYS = {
+        "client_id",
+        "client_secret",
+        "redirect_uri",
+        "refresh_token",
+        "output_path",
+        "per_page",
+        "max_pages",
+        "use_detailed_streams",
+        "max_detailed_activities",
+        "detailed_route_strategy",
+        "write_activity_points",
+        "point_sampling_stride",
+        "activity_search_text",
+        "max_distance_km",
+        "detailed_route_filter",
+        "use_background_map",
+        "mapbox_style_owner",
+        "mapbox_style_id",
+        "atlas_margin_percent",
+        "atlas_min_extent_degrees",
+        "atlas_target_aspect_ratio",
+        "atlas_pdf_path",
+        "analysis_mode",
+        "background_preset",
+        "tile_mode",
+        "preview_sort",
+        "style_preset",
+    }
+
+    def test_binding_table_covers_expected_keys(self):
+        bindings = build_dock_settings_bindings(FakeDock())
+        self.assertEqual({binding.key for binding in bindings}, self.EXPECTED_KEYS)
+
+    def test_load_applies_stored_values_and_defaults(self):
+        dock = FakeDock()
+        settings = _settings(
+            {
+                "qfit/client_id": "client-123",
+                "qfit/redirect_uri": "http://example.test/callback",
+                "qfit/per_page": "75",
+                "qfit/use_detailed_streams": "true",
+                "qfit/detailed_route_filter": "missing",
+                "qfit/use_background_map": True,
+                "qfit/atlas_target_aspect_ratio": "2.5",
+                "qfit/preview_sort": "Newest first",
+                "qfit/style_preset": "Heatmap",
+            }
+        )
+
+        load_bindings(build_dock_settings_bindings(dock), settings)
+
+        self.assertEqual(dock.clientIdLineEdit.text(), "client-123")
+        self.assertEqual(dock.redirectUriLineEdit.text(), "http://example.test/callback")
+        self.assertEqual(dock.outputPathLineEdit.text(), dock._default_output_path())
+        self.assertEqual(dock.perPageSpinBox.value(), 75)
+        self.assertTrue(dock.detailedStreamsCheckBox.isChecked())
+        self.assertEqual(dock.detailedRouteStatusComboBox.currentData(), "missing")
+        self.assertTrue(dock.backgroundMapCheckBox.isChecked())
+        self.assertEqual(dock.atlasTargetAspectRatioSpinBox.value(), 2.5)
+        self.assertEqual(dock.previewSortComboBox.currentText(), "Newest first")
+        self.assertEqual(dock.stylePresetComboBox.currentText(), "Heatmap")
+        self.assertEqual(dock.analysisModeComboBox.currentText(), "None")
+
+    def test_save_roundtrip_preserves_values(self):
+        dock = FakeDock()
+        dock.clientIdLineEdit.setText("  abc  ")
+        dock.clientSecretLineEdit.setText("secret")
+        dock.redirectUriLineEdit.setText(StravaProvider.DEFAULT_REDIRECT_URI)
+        dock.outputPathLineEdit.setText("/tmp/out.gpkg")
+        dock.perPageSpinBox.setValue(123)
+        dock.detailedStreamsCheckBox.setChecked(True)
+        dock.maxDetailedActivitiesSpinBox.setValue(11)
+        dock.detailedRouteStrategyComboBox.setCurrentIndex(1)
+        dock.writeActivityPointsCheckBox.setChecked(False)
+        dock.pointSamplingStrideSpinBox.setValue(9)
+        dock.activitySearchLineEdit.setText(" commute ")
+        dock.maxDistanceSpinBox.setValue(42.5)
+        dock.detailedRouteStatusComboBox.setCurrentIndex(2)
+        dock.backgroundMapCheckBox.setChecked(True)
+        dock.mapboxStyleOwnerLineEdit.setText("custom-owner")
+        dock.mapboxStyleIdLineEdit.setText("style-id")
+        dock.atlasMarginPercentSpinBox.setValue(12.0)
+        dock.atlasMinExtentSpinBox.setValue(0.25)
+        dock.atlasTargetAspectRatioSpinBox.setValue(1.75)
+        dock.atlasPdfPathLineEdit.setText("/tmp/atlas.pdf")
+        dock.analysisModeComboBox.setCurrentIndex(1)
+        dock.backgroundPresetComboBox.setCurrentIndex(1)
+        dock.tileModeComboBox.setCurrentIndex(1)
+        dock.previewSortComboBox.setCurrentIndex(1)
+        dock.stylePresetComboBox.setCurrentIndex(1)
+
+        settings = _settings()
+        save_bindings(build_dock_settings_bindings(dock), settings)
+
+        self.assertEqual(settings.get("client_id"), "abc")
+        self.assertEqual(settings.get("activity_search_text"), "commute")
+        self.assertEqual(settings.get("per_page"), 123)
+        self.assertTrue(settings.get_bool("use_detailed_streams"))
+        self.assertEqual(settings.get("detailed_route_strategy"), "Only missing detailed routes")
+        self.assertFalse(settings.get_bool("write_activity_points", True))
+        self.assertEqual(settings.get("detailed_route_filter"), "missing")
+        self.assertEqual(settings.get("mapbox_style_owner"), "custom-owner")
+        self.assertEqual(settings.get("atlas_target_aspect_ratio"), 1.75)
+        self.assertEqual(settings.get("analysis_mode"), "Most frequent starting points")
+        self.assertEqual(settings.get("style_preset"), "Heatmap")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move the main dock settings binding table into configuration-owned code
- keep `QfitDockWidget` focused on calling load/save instead of owning the mapping table
- add focused tests for the extracted dock settings bindings helper

## Testing
- python3 -m pytest tests/test_dock_settings_bindings.py tests/test_ui_settings_binding.py tests/test_settings_port_usage.py -q --tb=short
- python3 -m pytest tests/test_dockwidget_dependencies.py -q --tb=short
- python3 -m py_compile qfit_dockwidget.py configuration/application/dock_settings_bindings.py

Closes #367.
