### PR TITLE
refactor: extract activity preview workflow

### DIFF
--- a/activities/application/__init__.py
+++ b/activities/application/__init__.py
@@ -6,6 +6,8 @@ import lightweight application models without pulling in QGIS task modules.
 
 from importlib import import_module
 
+_ACTIVITY_PREVIEW_MODULE = ".activity_preview"
+
 __all__ = [
     "ActivityPreviewRequest",
     "ActivityPreviewResult",
@@ -29,8 +31,8 @@ __all__ = [
 ]
 
 _EXPORTS = {
-    "ActivityPreviewRequest": (".activity_preview", "ActivityPreviewRequest"),
-    "ActivityPreviewResult": (".activity_preview", "ActivityPreviewResult"),
+    "ActivityPreviewRequest": (_ACTIVITY_PREVIEW_MODULE, "ActivityPreviewRequest"),
+    "ActivityPreviewResult": (_ACTIVITY_PREVIEW_MODULE, "ActivityPreviewResult"),
     "ActivitySelectionState": (".activity_selection_state", "ActivitySelectionState"),
     "BuildStravaProviderRequest": (".sync_controller", "BuildStravaProviderRequest"),
     "FetchActivitiesRequest": (".fetch_result_service", "FetchActivitiesRequest"),
@@ -45,9 +47,9 @@ _EXPORTS = {
     "LoadWorkflowService": (".load_workflow", "LoadWorkflowService"),
     "StoreActivitiesRequest": (".load_workflow", "StoreActivitiesRequest"),
     "SyncController": (".sync_controller", "SyncController"),
-    "build_activity_preview": (".activity_preview", "build_activity_preview"),
-    "build_activity_query": (".activity_preview", "build_activity_query"),
-    "build_activity_selection_state": (".activity_preview", "build_activity_selection_state"),
+    "build_activity_preview": (_ACTIVITY_PREVIEW_MODULE, "build_activity_preview"),
+    "build_activity_query": (_ACTIVITY_PREVIEW_MODULE, "build_activity_query"),
+    "build_activity_selection_state": (_ACTIVITY_PREVIEW_MODULE, "build_activity_selection_state"),
 }
 
 

--- a/activities/application/__init__.py
+++ b/activities/application/__init__.py
@@ -7,6 +7,8 @@ import lightweight application models without pulling in QGIS task modules.
 from importlib import import_module
 
 __all__ = [
+    "ActivityPreviewRequest",
+    "ActivityPreviewResult",
     "ActivitySelectionState",
     "BuildStravaProviderRequest",
     "FetchActivitiesRequest",
@@ -21,9 +23,14 @@ __all__ = [
     "LoadWorkflowService",
     "StoreActivitiesRequest",
     "SyncController",
+    "build_activity_preview",
+    "build_activity_query",
+    "build_activity_selection_state",
 ]
 
 _EXPORTS = {
+    "ActivityPreviewRequest": (".activity_preview", "ActivityPreviewRequest"),
+    "ActivityPreviewResult": (".activity_preview", "ActivityPreviewResult"),
     "ActivitySelectionState": (".activity_selection_state", "ActivitySelectionState"),
     "BuildStravaProviderRequest": (".sync_controller", "BuildStravaProviderRequest"),
     "FetchActivitiesRequest": (".fetch_result_service", "FetchActivitiesRequest"),
@@ -38,6 +45,9 @@ _EXPORTS = {
     "LoadWorkflowService": (".load_workflow", "LoadWorkflowService"),
     "StoreActivitiesRequest": (".load_workflow", "StoreActivitiesRequest"),
     "SyncController": (".sync_controller", "SyncController"),
+    "build_activity_preview": (".activity_preview", "build_activity_preview"),
+    "build_activity_query": (".activity_preview", "build_activity_query"),
+    "build_activity_selection_state": (".activity_preview", "build_activity_selection_state"),
 }
 
 

--- a/activities/application/activity_preview.py
+++ b/activities/application/activity_preview.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from ..domain.activity_query import (
+    DEFAULT_SORT_LABEL,
+    ActivityQuery,
+    build_preview_lines,
+    format_summary_text,
+    sort_activities,
+    summarize_activities,
+)
+from .activity_selection_state import ActivitySelectionState
+
+
+_FETCH_PREVIEW_EMPTY_TEXT = "Fetch activities to preview your latest synced activities."
+
+
+@dataclass(frozen=True)
+class ActivityPreviewRequest:
+    activities: Sequence[object]
+    activity_type: str | None = "All"
+    date_from: str | None = None
+    date_to: str | None = None
+    min_distance_km: float | int | None = None
+    max_distance_km: float | int | None = None
+    search_text: str | None = None
+    detailed_route_filter: str | None = None
+    sort_label: str | None = DEFAULT_SORT_LABEL
+    preview_limit: int = 10
+
+
+@dataclass(frozen=True)
+class ActivityPreviewResult:
+    selection_state: ActivitySelectionState
+    fetched_activities: list[object]
+    query_summary_text: str
+    preview_text: str
+
+
+def build_activity_query(request: ActivityPreviewRequest) -> ActivityQuery:
+    return ActivityQuery(
+        activity_type=request.activity_type or "All",
+        date_from=request.date_from,
+        date_to=request.date_to,
+        min_distance_km=request.min_distance_km,
+        max_distance_km=request.max_distance_km,
+        search_text=request.search_text,
+        detailed_route_filter=request.detailed_route_filter,
+        sort_label=request.sort_label or DEFAULT_SORT_LABEL,
+    )
+
+
+def build_activity_selection_state(request: ActivityPreviewRequest) -> ActivitySelectionState:
+    return ActivitySelectionState.from_activities(
+        request.activities,
+        build_activity_query(request),
+    )
+
+
+def build_activity_preview(request: ActivityPreviewRequest) -> ActivityPreviewResult:
+    selection_state = build_activity_selection_state(request)
+
+    if not request.activities:
+        return ActivityPreviewResult(
+            selection_state=selection_state,
+            fetched_activities=[],
+            query_summary_text=_FETCH_PREVIEW_EMPTY_TEXT,
+            preview_text="",
+        )
+
+    fetched_activities = sort_activities(request.activities, DEFAULT_SORT_LABEL)
+    summary = summarize_activities(fetched_activities)
+    query_summary_text = format_summary_text(summary)
+    if selection_state.filtered_count != len(request.activities):
+        query_summary_text = (
+            f"{query_summary_text}\n"
+            f"Visualize filters currently match {selection_state.filtered_count} activities."
+        )
+
+    preview_lines = build_preview_lines(fetched_activities, limit=request.preview_limit)
+    if len(fetched_activities) > len(preview_lines):
+        preview_lines.append(
+            "… and {count} more".format(count=len(fetched_activities) - len(preview_lines))
+        )
+
+    return ActivityPreviewResult(
+        selection_state=selection_state,
+        fetched_activities=fetched_activities,
+        query_summary_text=query_summary_text,
+        preview_text="\n".join(preview_lines),
+    )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -31,14 +31,14 @@ from .activities.domain.activity_query import (
     DETAILED_ROUTE_FILTER_MISSING,
     DETAILED_ROUTE_FILTER_PRESENT,
     SORT_OPTIONS,
-    ActivityQuery,
-    build_preview_lines,
     filter_activities,
-    format_summary_text,
-    sort_activities,
-    summarize_activities,
 )
-from .activities.application.activity_selection_state import ActivitySelectionState
+from .activities.application import (
+    ActivityPreviewRequest,
+    ActivitySelectionState,
+    build_activity_preview,
+    build_activity_selection_state,
+)
 from .activities.application.load_workflow import LoadWorkflowError
 from .activities.application.store_task import build_store_task
 from .analysis.infrastructure.activity_heatmap_layer import (
@@ -849,8 +849,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             except RuntimeError:
                 logger.debug("Failed to remove stale analysis layer", exc_info=True)
 
-    def _current_activity_selection_state(self):
-        query = ActivityQuery(
+    def _current_activity_preview_request(self):
+        return ActivityPreviewRequest(
+            activities=self.activities,
             activity_type=self.activityTypeComboBox.currentText() or "All",
             date_from=self.dateFromEdit.date().toString("yyyy-MM-dd") if self.dateFromEdit.date().isValid() else None,
             date_to=self.dateToEdit.date().toString("yyyy-MM-dd") if self.dateToEdit.date().isValid() else None,
@@ -860,34 +861,18 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             detailed_route_filter=self.detailedRouteStatusComboBox.currentData(),
             sort_label=self.previewSortComboBox.currentText() or DEFAULT_SORT_LABEL,
         )
-        return ActivitySelectionState.from_activities(self.activities, query)
+
+    def _current_activity_selection_state(self):
+        return build_activity_selection_state(self._current_activity_preview_request())
 
     def _current_activity_query(self):
         return self._current_activity_selection_state().query
 
     def _refresh_activity_preview(self):
-        if not self.activities:
-            self.querySummaryLabel.setText("Fetch activities to preview your latest synced activities.")
-            self.activityPreviewPlainTextEdit.setPlainText("")
-            return []
-
-        fetched_activities = sort_activities(self.activities, DEFAULT_SORT_LABEL)
-        summary = summarize_activities(fetched_activities)
-        selection_state = self._current_activity_selection_state()
-
-        query_summary = format_summary_text(summary)
-        if selection_state.filtered_count != len(self.activities):
-            query_summary = (
-                f"{query_summary}\n"
-                f"Visualize filters currently match {selection_state.filtered_count} activities."
-            )
-        self.querySummaryLabel.setText(query_summary)
-
-        preview_lines = build_preview_lines(fetched_activities, limit=10)
-        if len(fetched_activities) > len(preview_lines):
-            preview_lines.append("… and {count} more".format(count=len(fetched_activities) - len(preview_lines)))
-        self.activityPreviewPlainTextEdit.setPlainText("\n".join(preview_lines))
-        return fetched_activities
+        preview = build_activity_preview(self._current_activity_preview_request())
+        self.querySummaryLabel.setText(preview.query_summary_text)
+        self.activityPreviewPlainTextEdit.setPlainText(preview.preview_text)
+        return preview.fetched_activities
 
     def _filtered_activities(self):
         return filter_activities(self.activities, self._current_activity_selection_state().query)

--- a/tests/test_activity_preview.py
+++ b/tests/test_activity_preview.py
@@ -1,0 +1,125 @@
+import unittest
+from types import SimpleNamespace
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.application.activity_preview import (
+    ActivityPreviewRequest,
+    build_activity_preview,
+    build_activity_query,
+    build_activity_selection_state,
+)
+from qfit.activities.domain.activity_query import DEFAULT_SORT_LABEL, DETAILED_ROUTE_FILTER_MISSING
+
+
+class ActivityPreviewTests(unittest.TestCase):
+    def setUp(self):
+        self.activities = [
+            SimpleNamespace(
+                name="Morning Ride",
+                start_date="2026-04-10T08:00:00",
+                distance_m=25000,
+                moving_time_s=3600,
+                geometry_source="stream",
+                activity_type="Ride",
+                sport_type="Ride",
+            ),
+            SimpleNamespace(
+                name="Lunch Run",
+                start_date="2026-04-11T12:00:00",
+                distance_m=5000,
+                moving_time_s=1500,
+                geometry_source="summary",
+                activity_type="Run",
+                sport_type="Run",
+            ),
+        ]
+
+    def test_build_activity_query_preserves_filter_inputs(self):
+        request = ActivityPreviewRequest(
+            activities=self.activities,
+            activity_type="Run",
+            date_from="2026-04-01",
+            date_to="2026-04-30",
+            min_distance_km=2,
+            max_distance_km=8,
+            search_text="lunch",
+            detailed_route_filter=DETAILED_ROUTE_FILTER_MISSING,
+            sort_label="Name (A–Z)",
+        )
+
+        query = build_activity_query(request)
+
+        self.assertEqual(query.activity_type, "Run")
+        self.assertEqual(query.date_from, "2026-04-01")
+        self.assertEqual(query.date_to, "2026-04-30")
+        self.assertEqual(query.min_distance_km, 2.0)
+        self.assertEqual(query.max_distance_km, 8.0)
+        self.assertEqual(query.search_text, "lunch")
+        self.assertEqual(query.detailed_route_filter, DETAILED_ROUTE_FILTER_MISSING)
+        self.assertEqual(query.sort_label, "Name (A–Z)")
+
+    def test_build_activity_selection_state_filters_with_query(self):
+        request = ActivityPreviewRequest(
+            activities=self.activities,
+            activity_type="Run",
+            detailed_route_filter=DETAILED_ROUTE_FILTER_MISSING,
+        )
+
+        selection_state = build_activity_selection_state(request)
+
+        self.assertEqual(selection_state.filtered_count, 1)
+        self.assertEqual(selection_state.query.activity_type, "Run")
+        self.assertEqual(selection_state.query.detailed_route_filter, DETAILED_ROUTE_FILTER_MISSING)
+
+    def test_build_activity_preview_returns_empty_state_when_no_activities(self):
+        result = build_activity_preview(ActivityPreviewRequest(activities=[]))
+
+        self.assertEqual(result.selection_state.filtered_count, 0)
+        self.assertEqual(result.fetched_activities, [])
+        self.assertEqual(
+            result.query_summary_text,
+            "Fetch activities to preview your latest synced activities.",
+        )
+        self.assertEqual(result.preview_text, "")
+
+    def test_build_activity_preview_summarizes_and_formats_preview_lines(self):
+        result = build_activity_preview(ActivityPreviewRequest(activities=self.activities))
+
+        self.assertEqual(
+            [activity.name for activity in result.fetched_activities],
+            ["Lunch Run", "Morning Ride"],
+        )
+        self.assertIn("2 activities", result.query_summary_text)
+        self.assertNotIn("Visualize filters currently match", result.query_summary_text)
+        self.assertIn("Lunch Run", result.preview_text)
+        self.assertIn("Morning Ride", result.preview_text)
+
+    def test_build_activity_preview_reports_filtered_count_when_subset_is_active(self):
+        result = build_activity_preview(
+            ActivityPreviewRequest(
+                activities=self.activities,
+                activity_type="Run",
+            )
+        )
+
+        self.assertEqual(result.selection_state.filtered_count, 1)
+        self.assertIn("Visualize filters currently match 1 activities.", result.query_summary_text)
+
+    def test_build_activity_preview_uses_preview_limit_for_overflow_message(self):
+        result = build_activity_preview(
+            ActivityPreviewRequest(
+                activities=self.activities,
+                preview_limit=1,
+                sort_label="Name (A–Z)",
+            )
+        )
+
+        self.assertEqual(result.fetched_activities[0].name, "Lunch Run")
+        self.assertEqual(len(result.preview_text.splitlines()), 2)
+        self.assertIn("… and 1 more", result.preview_text)
+        self.assertEqual(result.selection_state.query.sort_label, "Name (A–Z)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -206,6 +206,25 @@ class _FakeSettings:
         return self._values.get(key, default)
 
 
+class _FakeQDate:
+    def __init__(self, value=None):
+        self._value = value
+
+    def isValid(self):
+        return self._value is not None
+
+    def toString(self, _format):
+        return self._value
+
+
+class _FakeDateEdit:
+    def __init__(self, value=None):
+        self._date = _FakeQDate(value)
+
+    def date(self):
+        return self._date
+
+
 class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -493,6 +512,60 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(status, "Applied styling")
         self.assertEqual(dock.background_layer, "background-layer")
         dock._show_error.assert_not_called()
+
+    def test_current_activity_preview_request_reads_current_ui_filters(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.activities = ["a1", "a2"]
+        dock.activityTypeComboBox = _FakeComboBox(current_text="Run")
+        dock.dateFromEdit = _FakeDateEdit("2026-04-01")
+        dock.dateToEdit = _FakeDateEdit("2026-04-30")
+        dock.minDistanceSpinBox = _FakeSpinBox(5)
+        dock.maxDistanceSpinBox = _FakeSpinBox(42)
+        dock.activitySearchLineEdit = _FakeLineEdit(" lunch ")
+        dock.detailedRouteStatusComboBox = SimpleNamespace(currentData=lambda: "missing")
+        dock.previewSortComboBox = _FakeComboBox(current_text="Name (A–Z)")
+
+        request = self.module.QfitDockWidget._current_activity_preview_request(dock)
+
+        self.assertEqual(request.activities, ["a1", "a2"])
+        self.assertEqual(request.activity_type, "Run")
+        self.assertEqual(request.date_from, "2026-04-01")
+        self.assertEqual(request.date_to, "2026-04-30")
+        self.assertEqual(request.min_distance_km, 5)
+        self.assertEqual(request.max_distance_km, 42)
+        self.assertEqual(request.search_text, "lunch")
+        self.assertEqual(request.detailed_route_filter, "missing")
+        self.assertEqual(request.sort_label, "Name (A–Z)")
+
+    def test_current_activity_selection_state_delegates_to_activity_preview_workflow(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._current_activity_preview_request = MagicMock(return_value="preview-request")
+        selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
+
+        with patch.object(self.module, "build_activity_selection_state", return_value=selection_state) as build_state:
+            result = self.module.QfitDockWidget._current_activity_selection_state(dock)
+
+        self.assertIs(result, selection_state)
+        build_state.assert_called_once_with("preview-request")
+
+    def test_refresh_activity_preview_delegates_and_updates_widgets(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._current_activity_preview_request = MagicMock(return_value="preview-request")
+        dock.querySummaryLabel = SimpleNamespace(setText=MagicMock())
+        dock.activityPreviewPlainTextEdit = SimpleNamespace(setPlainText=MagicMock())
+        preview_result = SimpleNamespace(
+            query_summary_text="2 activities",
+            preview_text="first\nsecond",
+            fetched_activities=["first", "second"],
+        )
+
+        with patch.object(self.module, "build_activity_preview", return_value=preview_result) as build_preview:
+            result = self.module.QfitDockWidget._refresh_activity_preview(dock)
+
+        self.assertEqual(result, ["first", "second"])
+        build_preview.assert_called_once_with("preview-request")
+        dock.querySummaryLabel.setText.assert_called_once_with("2 activities")
+        dock.activityPreviewPlainTextEdit.setPlainText.assert_called_once_with("first\nsecond")
 
     def test_apply_analysis_configuration_delegates_current_mode_and_layer(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary
- move activity preview and selection workflow logic into `activities/application/activity_preview.py`
- keep `QfitDockWidget` focused on reading current UI state and updating UI widgets
- add focused tests for the extracted preview workflow and the dock delegation points

## Testing
- python3 -m pytest tests/test_activity_preview.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_activity_query.py -q --tb=short
- python3 -m py_compile qfit_dockwidget.py activities/application/activity_preview.py activities/application/__init__.py

Closes #369.
