### PR TITLE
refactor: extract activity type option building

### DIFF
--- a/activities/application/__init__.py
+++ b/activities/application/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "ActivityPreviewRequest",
     "ActivityPreviewResult",
     "ActivitySelectionState",
+    "ActivityTypeOptionsResult",
     "BuildStravaProviderRequest",
     "FetchActivitiesRequest",
     "FetchResult",
@@ -28,12 +29,18 @@ __all__ = [
     "build_activity_preview",
     "build_activity_query",
     "build_activity_selection_state",
+    "build_activity_type_options",
+    "build_activity_type_options_from_activities",
+    "build_activity_type_options_from_records",
 ]
+
+_ACTIVITY_TYPE_OPTIONS_MODULE = ".activity_type_options"
 
 _EXPORTS = {
     "ActivityPreviewRequest": (_ACTIVITY_PREVIEW_MODULE, "ActivityPreviewRequest"),
     "ActivityPreviewResult": (_ACTIVITY_PREVIEW_MODULE, "ActivityPreviewResult"),
     "ActivitySelectionState": (".activity_selection_state", "ActivitySelectionState"),
+    "ActivityTypeOptionsResult": (_ACTIVITY_TYPE_OPTIONS_MODULE, "ActivityTypeOptionsResult"),
     "BuildStravaProviderRequest": (".sync_controller", "BuildStravaProviderRequest"),
     "FetchActivitiesRequest": (".fetch_result_service", "FetchActivitiesRequest"),
     "FetchResult": (".fetch_result_service", "FetchResult"),
@@ -50,6 +57,9 @@ _EXPORTS = {
     "build_activity_preview": (_ACTIVITY_PREVIEW_MODULE, "build_activity_preview"),
     "build_activity_query": (_ACTIVITY_PREVIEW_MODULE, "build_activity_query"),
     "build_activity_selection_state": (_ACTIVITY_PREVIEW_MODULE, "build_activity_selection_state"),
+    "build_activity_type_options": (_ACTIVITY_TYPE_OPTIONS_MODULE, "build_activity_type_options"),
+    "build_activity_type_options_from_activities": (_ACTIVITY_TYPE_OPTIONS_MODULE, "build_activity_type_options_from_activities"),
+    "build_activity_type_options_from_records": (_ACTIVITY_TYPE_OPTIONS_MODULE, "build_activity_type_options_from_records"),
 }
 
 

--- a/activities/application/activity_type_options.py
+++ b/activities/application/activity_type_options.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from ..domain.activity_classification import ordered_canonical_activity_labels, preferred_activity_field
+
+
+@dataclass(frozen=True)
+class ActivityTypeOptionsResult:
+    options: list[str]
+    selected_value: str
+
+
+def build_activity_type_options(
+    label_pairs: Iterable[tuple[str | None, str | None]],
+    *,
+    current_value: str | None = "All",
+) -> ActivityTypeOptionsResult:
+    values = sorted(ordered_canonical_activity_labels(label_pairs))
+    options = ["All", *values]
+    normalized_current = current_value or "All"
+    selected_value = normalized_current if normalized_current in options else "All"
+    return ActivityTypeOptionsResult(options=options, selected_value=selected_value)
+
+
+def build_activity_type_options_from_activities(
+    activities: Sequence[object],
+    *,
+    current_value: str | None = "All",
+) -> ActivityTypeOptionsResult:
+    return build_activity_type_options(
+        (
+            (getattr(activity, "activity_type", None), getattr(activity, "sport_type", None))
+            for activity in activities
+        ),
+        current_value=current_value,
+    )
+
+
+def build_activity_type_options_from_records(
+    records: Iterable[object],
+    field_names: Iterable[str],
+    *,
+    current_value: str | None = "All",
+) -> ActivityTypeOptionsResult | None:
+    available_fields = {str(name) for name in field_names}
+    if preferred_activity_field(available_fields) is None:
+        return None
+
+    return build_activity_type_options(
+        (
+            (
+                record["activity_type"] if "activity_type" in available_fields else None,
+                record["sport_type"] if "sport_type" in available_fields else None,
+            )
+            for record in records
+        ),
+        current_value=current_value,
+    )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -24,7 +24,6 @@ from qgis.PyQt.QtWidgets import (
     QWidget,
 )
 
-from .activities.domain.activity_classification import ordered_canonical_activity_labels
 from .activities.domain.activity_query import (
     DEFAULT_SORT_LABEL,
     DETAILED_ROUTE_FILTER_ANY,
@@ -36,8 +35,11 @@ from .activities.domain.activity_query import (
 from .activities.application import (
     ActivityPreviewRequest,
     ActivitySelectionState,
+    ActivityTypeOptionsResult,
     build_activity_preview,
     build_activity_selection_state,
+    build_activity_type_options_from_activities,
+    build_activity_type_options_from_records,
 )
 from .activities.application.load_workflow import LoadWorkflowError
 from .activities.application.store_task import build_store_task
@@ -887,20 +889,20 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _qdate_to_date(self, value):
         return date(value.year(), value.month(), value.day())
 
+    def _apply_activity_type_options(self, result: ActivityTypeOptionsResult) -> None:
+        self.activityTypeComboBox.clear()
+        for value in result.options:
+            self.activityTypeComboBox.addItem(value)
+        index = self.activityTypeComboBox.findText(result.selected_value)
+        self.activityTypeComboBox.setCurrentIndex(max(index, 0))
+
     def _populate_activity_types(self):
-        current_value = self.activityTypeComboBox.currentText() or "All"
-        values = sorted(
-            ordered_canonical_activity_labels(
-                (getattr(activity, "activity_type", None), getattr(activity, "sport_type", None))
-                for activity in self.activities
+        self._apply_activity_type_options(
+            build_activity_type_options_from_activities(
+                self.activities,
+                current_value=self.activityTypeComboBox.currentText() or "All",
             )
         )
-        self.activityTypeComboBox.clear()
-        self.activityTypeComboBox.addItem("All")
-        for value in values:
-            self.activityTypeComboBox.addItem(value)
-        index = self.activityTypeComboBox.findText(current_value)
-        self.activityTypeComboBox.setCurrentIndex(max(index, 0))
 
     def _populate_activity_types_from_layer(self):
         """Populate the activity type filter from the loaded activities layer.
@@ -913,26 +915,17 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         current_value = self.activityTypeComboBox.currentText() or "All"
         try:
             field_names = [self.activities_layer.fields().at(i).name() for i in range(self.activities_layer.fields().count())]
-            if not any(name in field_names for name in ("activity_type", "sport_type")):
-                return
-            values = sorted(
-                ordered_canonical_activity_labels(
-                    (
-                        feature["activity_type"] if "activity_type" in field_names else None,
-                        feature["sport_type"] if "sport_type" in field_names else None,
-                    )
-                    for feature in self.activities_layer.getFeatures()
-                )
+            result = build_activity_type_options_from_records(
+                self.activities_layer.getFeatures(),
+                field_names,
+                current_value=current_value,
             )
         except (RuntimeError, KeyError):
             logger.debug("Failed to populate activity types from layer", exc_info=True)
             return
-        self.activityTypeComboBox.clear()
-        self.activityTypeComboBox.addItem("All")
-        for value in values:
-            self.activityTypeComboBox.addItem(value)
-        index = self.activityTypeComboBox.findText(current_value)
-        self.activityTypeComboBox.setCurrentIndex(max(index, 0))
+        if result is None:
+            return
+        self._apply_activity_type_options(result)
 
 
     def _update_connection_status(self):

--- a/tests/test_activity_type_options.py
+++ b/tests/test_activity_type_options.py
@@ -1,0 +1,74 @@
+import unittest
+from types import SimpleNamespace
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.application.activity_type_options import (
+    ActivityTypeOptionsResult,
+    build_activity_type_options,
+    build_activity_type_options_from_activities,
+    build_activity_type_options_from_records,
+)
+
+
+class ActivityTypeOptionsTests(unittest.TestCase):
+    def test_build_activity_type_options_sorts_and_preserves_all_option(self):
+        result = build_activity_type_options(
+            [
+                ("Ride", "GravelRide"),
+                ("Run", "Trail Run"),
+                ("Ride", None),
+            ],
+            current_value="Trail Run",
+        )
+
+        self.assertEqual(
+            result,
+            ActivityTypeOptionsResult(
+                options=["All", "GravelRide", "Ride", "Trail Run"],
+                selected_value="Trail Run",
+            ),
+        )
+
+    def test_build_activity_type_options_falls_back_to_all_when_current_missing(self):
+        result = build_activity_type_options([(None, "Run")], current_value="Swim")
+
+        self.assertEqual(result.options, ["All", "Run"])
+        self.assertEqual(result.selected_value, "All")
+
+    def test_build_activity_type_options_from_activities_reads_activity_and_sport_type(self):
+        activities = [
+            SimpleNamespace(activity_type="Ride", sport_type="GravelRide"),
+            SimpleNamespace(activity_type="Run", sport_type=None),
+        ]
+
+        result = build_activity_type_options_from_activities(activities, current_value="Ride")
+
+        self.assertEqual(result.options, ["All", "GravelRide", "Run"])
+        self.assertEqual(result.selected_value, "All")
+
+    def test_build_activity_type_options_from_records_returns_none_without_label_fields(self):
+        records = [{"name": "Morning Ride"}]
+
+        result = build_activity_type_options_from_records(records, ["name"], current_value="All")
+
+        self.assertIsNone(result)
+
+    def test_build_activity_type_options_from_records_uses_available_fields(self):
+        records = [
+            {"activity_type": "Ride", "sport_type": "GravelRide"},
+            {"activity_type": "Run", "sport_type": "TrailRun"},
+        ]
+
+        result = build_activity_type_options_from_records(
+            records,
+            ["sport_type", "activity_type"],
+            current_value="TrailRun",
+        )
+
+        self.assertEqual(result.options, ["All", "GravelRide", "TrailRun"])
+        self.assertEqual(result.selected_value, "TrailRun")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -77,17 +77,38 @@ class _FakeComboBox(_FakeWidget):
         super().__init__(parent)
         self.items = []
         self._current_text = current_text
+        self._current_index = 0
 
     def addItem(self, text):
         self.items.append(text)
         if self._current_text is None:
             self._current_text = text
+            self._current_index = len(self.items) - 1
+
+    def clear(self):
+        self.items = []
+        self._current_text = None
+        self._current_index = 0
+
+    def findText(self, text):
+        try:
+            return self.items.index(text)
+        except ValueError:
+            return -1
 
     def currentText(self):
         return self._current_text
 
     def setCurrentText(self, text):
         self._current_text = text
+        index = self.findText(text)
+        if index >= 0:
+            self._current_index = index
+
+    def setCurrentIndex(self, index):
+        self._current_index = index
+        if 0 <= index < len(self.items):
+            self._current_text = self.items[index]
 
 
 class _FakeButton(_FakeWidget):
@@ -513,6 +534,35 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.background_layer, "background-layer")
         dock._show_error.assert_not_called()
 
+    def test_apply_activity_type_options_updates_combo_items_and_selection(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.activityTypeComboBox = _FakeComboBox(current_text="Swim")
+        dock.activityTypeComboBox.items = ["Swim"]
+
+        self.module.QfitDockWidget._apply_activity_type_options(
+            dock,
+            self.module.ActivityTypeOptionsResult(
+                options=["All", "Ride", "Trail Run"],
+                selected_value="Trail Run",
+            ),
+        )
+
+        self.assertEqual(dock.activityTypeComboBox.items, ["All", "Ride", "Trail Run"])
+        self.assertEqual(dock.activityTypeComboBox.currentText(), "Trail Run")
+
+    def test_populate_activity_types_delegates_to_activity_type_options_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.activities = ["a1", "a2"]
+        dock.activityTypeComboBox = _FakeComboBox(current_text="Run")
+        dock._apply_activity_type_options = MagicMock()
+        result = self.module.ActivityTypeOptionsResult(options=["All", "Run"], selected_value="Run")
+
+        with patch.object(self.module, "build_activity_type_options_from_activities", return_value=result) as build_options:
+            self.module.QfitDockWidget._populate_activity_types(dock)
+
+        build_options.assert_called_once_with(["a1", "a2"], current_value="Run")
+        dock._apply_activity_type_options.assert_called_once_with(result)
+
     def test_current_activity_preview_request_reads_current_ui_filters(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.activities = ["a1", "a2"]
@@ -566,6 +616,40 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         build_preview.assert_called_once_with("preview-request")
         dock.querySummaryLabel.setText.assert_called_once_with("2 activities")
         dock.activityPreviewPlainTextEdit.setPlainText.assert_called_once_with("first\nsecond")
+
+    def test_populate_activity_types_from_layer_delegates_and_applies_result(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.activityTypeComboBox = _FakeComboBox(current_text="Ride")
+        dock._apply_activity_type_options = MagicMock()
+        fields = SimpleNamespace(
+            count=lambda: 2,
+            at=lambda i: SimpleNamespace(name=lambda: ["sport_type", "activity_type"][i]),
+        )
+        dock.activities_layer = SimpleNamespace(
+            isValid=lambda: True,
+            fields=lambda: fields,
+            getFeatures=lambda: [SimpleNamespace(__getitem__=lambda self, key: {"sport_type": "TrailRun", "activity_type": "Run"}[key])],
+        )
+        result = self.module.ActivityTypeOptionsResult(options=["All", "TrailRun"], selected_value="TrailRun")
+
+        class _Feature:
+            def __getitem__(self, key):
+                return {"sport_type": "TrailRun", "activity_type": "Run"}[key]
+
+        dock.activities_layer = SimpleNamespace(
+            isValid=lambda: True,
+            fields=lambda: fields,
+            getFeatures=lambda: [_Feature()],
+        )
+
+        with patch.object(self.module, "build_activity_type_options_from_records", return_value=result) as build_options:
+            self.module.QfitDockWidget._populate_activity_types_from_layer(dock)
+
+        build_options.assert_called_once()
+        args, kwargs = build_options.call_args
+        self.assertEqual(list(args[1]), ["sport_type", "activity_type"])
+        self.assertEqual(kwargs["current_value"], "Ride")
+        dock._apply_activity_type_options.assert_called_once_with(result)
 
     def test_apply_analysis_configuration_delegates_current_mode_and_layer(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary
- move activity-type filter option derivation into `activities/application/activity_type_options.py`
- keep `QfitDockWidget` responsible for combo-box mutation while delegating option-building policy
- add focused tests for the extracted helper and dock delegation paths

## Testing
- python3 -m pytest tests/test_activity_type_options.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_activity_classification.py tests/test_qgis_smoke.py -q --tb=short -k activity_type
