### PR TITLE
refactor: extract connection status messaging

### DIFF
--- a/configuration/application/connection_status.py
+++ b/configuration/application/connection_status.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+def build_strava_connection_status(
+    *,
+    client_id: str | None,
+    client_secret: str | None,
+    refresh_token: str | None,
+) -> str:
+    has_client = bool((client_id or "").strip() and (client_secret or "").strip())
+    has_refresh = bool((refresh_token or "").strip())
+    if has_client and has_refresh:
+        return "Strava connection: ready to fetch activities"
+    if has_client:
+        return "Strava connection: app credentials saved; add a refresh token in Configuration to fetch activities"
+    return "Strava connection: open qfit → Configuration to add your Strava credentials"

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -78,6 +78,7 @@ from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mod
 from .ui.dockwidget_dependencies import DockWidgetDependencies, build_dockwidget_dependencies
 from .ui.dock_startup_coordinator import DockStartupCoordinator
 from .ui.workflow_section_coordinator import WorkflowSectionCoordinator
+from .configuration.application.connection_status import build_strava_connection_status
 from .configuration.application.dock_settings_bindings import build_dock_settings_bindings
 from .configuration.application.ui_settings_binding import load_bindings, save_bindings
 
@@ -929,15 +930,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
 
     def _update_connection_status(self):
-        has_client = bool(self.clientIdLineEdit.text().strip() and self.clientSecretLineEdit.text().strip())
-        has_refresh = bool(self.refreshTokenLineEdit.text().strip())
-        if has_client and has_refresh:
-            message = "Strava connection: ready to fetch activities"
-        elif has_client:
-            message = "Strava connection: app credentials saved; add a refresh token in Configuration to fetch activities"
-        else:
-            message = "Strava connection: open qfit → Configuration to add your Strava credentials"
-        self.connectionStatusLabel.setText(message)
+        self.connectionStatusLabel.setText(
+            build_strava_connection_status(
+                client_id=self.clientIdLineEdit.text(),
+                client_secret=self.clientSecretLineEdit.text(),
+                refresh_token=self.refreshTokenLineEdit.text(),
+            )
+        )
 
     def on_atlas_pdf_browse_clicked(self):
         path, _selected = QFileDialog.getSaveFileName(

--- a/tests/test_connection_status.py
+++ b/tests/test_connection_status.py
@@ -1,0 +1,51 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.configuration.application.connection_status import build_strava_connection_status
+
+
+class ConnectionStatusTests(unittest.TestCase):
+    def test_ready_when_client_credentials_and_refresh_token_exist(self):
+        self.assertEqual(
+            build_strava_connection_status(
+                client_id="client-id",
+                client_secret="client-secret",
+                refresh_token="refresh-token",
+            ),
+            "Strava connection: ready to fetch activities",
+        )
+
+    def test_requests_refresh_token_when_only_client_credentials_exist(self):
+        self.assertEqual(
+            build_strava_connection_status(
+                client_id="client-id",
+                client_secret="client-secret",
+                refresh_token="",
+            ),
+            "Strava connection: app credentials saved; add a refresh token in Configuration to fetch activities",
+        )
+
+    def test_requests_configuration_when_credentials_missing(self):
+        self.assertEqual(
+            build_strava_connection_status(
+                client_id="",
+                client_secret="client-secret",
+                refresh_token="refresh-token",
+            ),
+            "Strava connection: open qfit → Configuration to add your Strava credentials",
+        )
+
+    def test_ignores_whitespace_only_values(self):
+        self.assertEqual(
+            build_strava_connection_status(
+                client_id="  ",
+                client_secret=" client-secret ",
+                refresh_token="  refresh-token  ",
+            ),
+            "Strava connection: open qfit → Configuration to add your Strava credentials",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -625,11 +625,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             count=lambda: 2,
             at=lambda i: SimpleNamespace(name=lambda: ["sport_type", "activity_type"][i]),
         )
-        dock.activities_layer = SimpleNamespace(
-            isValid=lambda: True,
-            fields=lambda: fields,
-            getFeatures=lambda: [SimpleNamespace(__getitem__=lambda self, key: {"sport_type": "TrailRun", "activity_type": "Run"}[key])],
-        )
         result = self.module.ActivityTypeOptionsResult(options=["All", "TrailRun"], selected_value="TrailRun")
 
         class _Feature:
@@ -650,6 +645,29 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(list(args[1]), ["sport_type", "activity_type"])
         self.assertEqual(kwargs["current_value"], "Ride")
         dock._apply_activity_type_options.assert_called_once_with(result)
+
+    def test_update_connection_status_delegates_to_connection_status_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock.connectionStatusLabel = SimpleNamespace(setText=MagicMock())
+
+        with patch.object(
+            self.module,
+            "build_strava_connection_status",
+            return_value="Strava connection: ready to fetch activities",
+        ) as build_status:
+            self.module.QfitDockWidget._update_connection_status(dock)
+
+        build_status.assert_called_once_with(
+            client_id="client-id",
+            client_secret="client-secret",
+            refresh_token="refresh-token",
+        )
+        dock.connectionStatusLabel.setText.assert_called_once_with(
+            "Strava connection: ready to fetch activities"
+        )
 
     def test_apply_analysis_configuration_delegates_current_mode_and_layer(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary
- move Strava connection-status message policy into `configuration/application/connection_status.py`
- keep `QfitDockWidget` responsible for reading field values and updating the label only
- add focused tests for the extracted helper and dock delegation

## Testing
- python3 -m pytest tests/test_connection_status.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dockwidget_dependencies.py -q --tb=short -k connection_status
