### PR TITLE
refactor: extract activities layer summary text

### DIFF
--- a/activities/application/layer_summary.py
+++ b/activities/application/layer_summary.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def build_loaded_activities_summary(*, total_activities: int, last_sync_date: str) -> str:
+    return "{total} activities loaded (last sync: {sync_date})".format(
+        total=total_activities,
+        sync_date=last_sync_date,
+    )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -41,6 +41,7 @@ from .activities.application import (
     build_activity_type_options_from_activities,
     build_activity_type_options_from_records,
 )
+from .activities.application.layer_summary import build_loaded_activities_summary
 from .activities.application.load_workflow import LoadWorkflowError
 from .activities.application.store_task import build_store_task
 from .analysis.infrastructure.activity_heatmap_layer import (
@@ -673,12 +674,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._populate_activity_types_from_layer()
         visual_status = self._apply_visual_configuration(apply_subset_filters=False)
 
-        last_sync = self.settings.get("last_sync_date", "unknown")
-        self.countLabel.setText(
-            "{total} activities loaded (last sync: {sync_date})".format(
-                total=result.total_stored, sync_date=last_sync,
-            )
-        )
+        self._update_loaded_activities_summary(result.total_stored)
         status = result.status
         if visual_status:
             status = "{status} {visual_status}".format(status=status, visual_status=visual_status)
@@ -876,6 +872,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.querySummaryLabel.setText(preview.query_summary_text)
         self.activityPreviewPlainTextEdit.setPlainText(preview.preview_text)
         return preview.fetched_activities
+
+    def _update_loaded_activities_summary(self, total_activities):
+        self.countLabel.setText(
+            build_loaded_activities_summary(
+                total_activities=total_activities,
+                last_sync_date=self.settings.get("last_sync_date", "unknown"),
+            )
+        )
 
     def _filtered_activities(self):
         return filter_activities(self.activities, self._current_activity_selection_state().query)

--- a/tests/test_layer_summary.py
+++ b/tests/test_layer_summary.py
@@ -1,0 +1,23 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.application.layer_summary import build_loaded_activities_summary
+
+
+class LoadedActivitiesSummaryTests(unittest.TestCase):
+    def test_builds_loaded_activities_summary_text(self):
+        self.assertEqual(
+            build_loaded_activities_summary(total_activities=12, last_sync_date="2026-04-12"),
+            "12 activities loaded (last sync: 2026-04-12)",
+        )
+
+    def test_preserves_unknown_last_sync_text(self):
+        self.assertEqual(
+            build_loaded_activities_summary(total_activities=0, last_sync_date="unknown"),
+            "0 activities loaded (last sync: unknown)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -669,6 +669,27 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Strava connection: ready to fetch activities"
         )
 
+    def test_update_loaded_activities_summary_delegates_to_layer_summary_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.settings = _FakeSettings({"last_sync_date": "2026-04-12"})
+        dock.countLabel = _FakeLabel("")
+
+        with patch.object(
+            self.module,
+            "build_loaded_activities_summary",
+            return_value="12 activities loaded (last sync: 2026-04-12)",
+        ) as build_summary:
+            self.module.QfitDockWidget._update_loaded_activities_summary(dock, 12)
+
+        build_summary.assert_called_once_with(
+            total_activities=12,
+            last_sync_date="2026-04-12",
+        )
+        self.assertEqual(
+            dock.countLabel.text(),
+            "12 activities loaded (last sync: 2026-04-12)",
+        )
+
     def test_apply_analysis_configuration_delegates_current_mode_and_layer(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")


### PR DESCRIPTION
## Summary
- move loaded-activities summary text construction into `activities/application/layer_summary.py`
- keep `QfitDockWidget` responsible for reading settings and updating the label only
- add focused tests for the extracted helper and dock delegation

## Testing
- python3 -m pytest tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k layer_summary
