### PR TITLE
refactor: extract stored activities summary text

### DIFF
--- a/activities/application/layer_summary.py
+++ b/activities/application/layer_summary.py
@@ -6,3 +6,10 @@ def build_loaded_activities_summary(*, total_activities: int, last_sync_date: st
         total=total_activities,
         sync_date=last_sync_date,
     )
+
+
+def build_stored_activities_summary(*, total_activities: int, last_sync_date: str) -> str:
+    return "{total} activities stored in database (last sync: {sync_date})".format(
+        total=total_activities,
+        sync_date=last_sync_date,
+    )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -41,7 +41,10 @@ from .activities.application import (
     build_activity_type_options_from_activities,
     build_activity_type_options_from_records,
 )
-from .activities.application.layer_summary import build_loaded_activities_summary
+from .activities.application.layer_summary import (
+    build_loaded_activities_summary,
+    build_stored_activities_summary,
+)
 from .activities.application.load_workflow import LoadWorkflowError
 from .activities.application.store_task import build_store_task
 from .analysis.infrastructure.activity_heatmap_layer import (
@@ -639,12 +642,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self.output_path = result.output_path
-        last_sync = self.settings.get("last_sync_date", date.today().isoformat())
-        self.countLabel.setText(
-            "{total} activities stored in database (last sync: {sync_date})".format(
-                total=result.total_stored, sync_date=last_sync,
-            )
-        )
+        self._update_stored_activities_summary(result.total_stored)
         self._set_status(result.status)
 
     def on_load_layers_clicked(self):
@@ -878,6 +876,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             build_loaded_activities_summary(
                 total_activities=total_activities,
                 last_sync_date=self.settings.get("last_sync_date", "unknown"),
+            )
+        )
+
+    def _update_stored_activities_summary(self, total_activities):
+        self.countLabel.setText(
+            build_stored_activities_summary(
+                total_activities=total_activities,
+                last_sync_date=self.settings.get("last_sync_date", date.today().isoformat()),
             )
         )
 

--- a/tests/test_layer_summary.py
+++ b/tests/test_layer_summary.py
@@ -2,7 +2,10 @@ import unittest
 
 from tests import _path  # noqa: F401
 
-from qfit.activities.application.layer_summary import build_loaded_activities_summary
+from qfit.activities.application.layer_summary import (
+    build_loaded_activities_summary,
+    build_stored_activities_summary,
+)
 
 
 class LoadedActivitiesSummaryTests(unittest.TestCase):
@@ -16,6 +19,20 @@ class LoadedActivitiesSummaryTests(unittest.TestCase):
         self.assertEqual(
             build_loaded_activities_summary(total_activities=0, last_sync_date="unknown"),
             "0 activities loaded (last sync: unknown)",
+        )
+
+
+class StoredActivitiesSummaryTests(unittest.TestCase):
+    def test_builds_stored_activities_summary_text(self):
+        self.assertEqual(
+            build_stored_activities_summary(total_activities=12, last_sync_date="2026-04-12"),
+            "12 activities stored in database (last sync: 2026-04-12)",
+        )
+
+    def test_preserves_unknown_last_sync_text(self):
+        self.assertEqual(
+            build_stored_activities_summary(total_activities=0, last_sync_date="unknown"),
+            "0 activities stored in database (last sync: unknown)",
         )
 
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -690,6 +690,27 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "12 activities loaded (last sync: 2026-04-12)",
         )
 
+    def test_update_stored_activities_summary_delegates_to_layer_summary_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.settings = _FakeSettings({"last_sync_date": "2026-04-12"})
+        dock.countLabel = _FakeLabel("")
+
+        with patch.object(
+            self.module,
+            "build_stored_activities_summary",
+            return_value="12 activities stored in database (last sync: 2026-04-12)",
+        ) as build_summary:
+            self.module.QfitDockWidget._update_stored_activities_summary(dock, 12)
+
+        build_summary.assert_called_once_with(
+            total_activities=12,
+            last_sync_date="2026-04-12",
+        )
+        self.assertEqual(
+            dock.countLabel.text(),
+            "12 activities stored in database (last sync: 2026-04-12)",
+        )
+
     def test_apply_analysis_configuration_delegates_current_mode_and_layer(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")
@@ -788,6 +809,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.outputPathLineEdit = _FakeLineEdit()
         dock.settings = _FakeSettings({"last_sync_date": "2026-04-07"})
         dock.countLabel = _FakeLabel("")
+        dock._update_stored_activities_summary = MagicMock()
         dock._set_status = MagicMock()
         result = SimpleNamespace(output_path="/tmp/qfit.gpkg", total_stored=12, status="Stored 12 activities")
 
@@ -797,7 +819,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(dock.loadButton.isEnabled())
         self.assertEqual(dock.loadButton.text(), "Store activities")
         self.assertEqual(dock.output_path, "/tmp/qfit.gpkg")
-        self.assertIn("12 activities stored in database", dock.countLabel.text())
+        dock._update_stored_activities_summary.assert_called_once_with(12)
         dock._set_status.assert_called_once_with("Stored 12 activities")
 
 


### PR DESCRIPTION
## Summary
- move stored-activities summary text construction into `activities/application/layer_summary.py`
- keep `QfitDockWidget` responsible for settings reads and label updates only
- add focused tests for the extracted helper and store-finish delegation path

## Testing
- python3 -m pytest tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k stored_activities_summary
