### PR TITLE
refactor: extract last sync summary text

### DIFF
--- a/activities/application/layer_summary.py
+++ b/activities/application/layer_summary.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 
+def build_last_sync_summary(*, last_sync_date: str | None) -> str | None:
+    if not last_sync_date:
+        return None
+    return f"Last sync: {last_sync_date}"
+
+
 def build_loaded_activities_summary(*, total_activities: int, last_sync_date: str) -> str:
     return "{total} activities loaded (last sync: {sync_date})".format(
         total=total_activities,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -42,6 +42,7 @@ from .activities.application import (
     build_activity_type_options_from_records,
 )
 from .activities.application.layer_summary import (
+    build_last_sync_summary,
     build_loaded_activities_summary,
     build_stored_activities_summary,
 )
@@ -356,9 +357,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.authCodeLineEdit.setText("")
         self._sync_background_style_fields(self.backgroundPresetComboBox.currentText(), force=False)
 
-        last_sync = self.settings.get("last_sync_date", None)
-        if last_sync:
-            self.countLabel.setText(f"Last sync: {last_sync}")
+        self._update_last_sync_summary()
 
     def _save_settings(self):
         save_bindings(build_dock_settings_bindings(self), self.settings)
@@ -870,6 +869,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.querySummaryLabel.setText(preview.query_summary_text)
         self.activityPreviewPlainTextEdit.setPlainText(preview.preview_text)
         return preview.fetched_activities
+
+    def _update_last_sync_summary(self):
+        summary = build_last_sync_summary(
+            last_sync_date=self.settings.get("last_sync_date", None),
+        )
+        if summary:
+            self.countLabel.setText(summary)
 
     def _update_loaded_activities_summary(self, total_activities):
         self.countLabel.setText(

--- a/tests/test_layer_summary.py
+++ b/tests/test_layer_summary.py
@@ -3,9 +3,22 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.activities.application.layer_summary import (
+    build_last_sync_summary,
     build_loaded_activities_summary,
     build_stored_activities_summary,
 )
+
+
+class LastSyncSummaryTests(unittest.TestCase):
+    def test_builds_last_sync_summary_text(self):
+        self.assertEqual(
+            build_last_sync_summary(last_sync_date="2026-04-12"),
+            "Last sync: 2026-04-12",
+        )
+
+    def test_returns_none_when_last_sync_missing(self):
+        self.assertIsNone(build_last_sync_summary(last_sync_date=None))
+        self.assertIsNone(build_last_sync_summary(last_sync_date=""))
 
 
 class LoadedActivitiesSummaryTests(unittest.TestCase):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -669,6 +669,31 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Strava connection: ready to fetch activities"
         )
 
+    def test_update_last_sync_summary_delegates_to_layer_summary_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.settings = _FakeSettings({"last_sync_date": "2026-04-12"})
+        dock.countLabel = _FakeLabel("")
+
+        with patch.object(
+            self.module,
+            "build_last_sync_summary",
+            return_value="Last sync: 2026-04-12",
+        ) as build_summary:
+            self.module.QfitDockWidget._update_last_sync_summary(dock)
+
+        build_summary.assert_called_once_with(last_sync_date="2026-04-12")
+        self.assertEqual(dock.countLabel.text(), "Last sync: 2026-04-12")
+
+    def test_update_last_sync_summary_skips_empty_summary(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.settings = _FakeSettings({})
+        dock.countLabel = _FakeLabel("unchanged")
+
+        with patch.object(self.module, "build_last_sync_summary", return_value=None):
+            self.module.QfitDockWidget._update_last_sync_summary(dock)
+
+        self.assertEqual(dock.countLabel.text(), "unchanged")
+
     def test_update_loaded_activities_summary_delegates_to_layer_summary_helper(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.settings = _FakeSettings({"last_sync_date": "2026-04-12"})


### PR DESCRIPTION
## Summary
- move initial last-sync summary text construction into `activities/application/layer_summary.py`
- keep `QfitDockWidget` responsible for settings reads and label updates only
- add focused tests for the extracted helper and dock delegation

## Testing
- python3 -m pytest tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k last_sync_summary
