### PR TITLE
refactor: extract clear-database summary text

### DIFF
--- a/activities/application/layer_summary.py
+++ b/activities/application/layer_summary.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 
+def build_cleared_activities_summary() -> str:
+    return "Activities fetched: 0"
+
+
 def build_last_sync_summary(*, last_sync_date: str | None) -> str | None:
     if not last_sync_date:
         return None

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -42,6 +42,7 @@ from .activities.application import (
     build_activity_type_options_from_records,
 )
 from .activities.application.layer_summary import (
+    build_cleared_activities_summary,
     build_last_sync_summary,
     build_loaded_activities_summary,
     build_stored_activities_summary,
@@ -726,7 +727,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.output_path = None
         self.last_fetch_context = {}
 
-        self.countLabel.setText("Activities fetched: 0")
+        self._update_cleared_activities_summary()
         self._set_status(result.status)
 
     def on_apply_filters_clicked(self):
@@ -869,6 +870,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.querySummaryLabel.setText(preview.query_summary_text)
         self.activityPreviewPlainTextEdit.setPlainText(preview.preview_text)
         return preview.fetched_activities
+
+    def _update_cleared_activities_summary(self):
+        self.countLabel.setText(build_cleared_activities_summary())
 
     def _update_last_sync_summary(self):
         summary = build_last_sync_summary(

--- a/tests/test_layer_summary.py
+++ b/tests/test_layer_summary.py
@@ -3,10 +3,16 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.activities.application.layer_summary import (
+    build_cleared_activities_summary,
     build_last_sync_summary,
     build_loaded_activities_summary,
     build_stored_activities_summary,
 )
+
+
+class ClearedActivitiesSummaryTests(unittest.TestCase):
+    def test_builds_cleared_activities_summary_text(self):
+        self.assertEqual(build_cleared_activities_summary(), "Activities fetched: 0")
 
 
 class LastSyncSummaryTests(unittest.TestCase):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -669,6 +669,20 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Strava connection: ready to fetch activities"
         )
 
+    def test_update_cleared_activities_summary_delegates_to_layer_summary_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.countLabel = _FakeLabel("")
+
+        with patch.object(
+            self.module,
+            "build_cleared_activities_summary",
+            return_value="Activities fetched: 0",
+        ) as build_summary:
+            self.module.QfitDockWidget._update_cleared_activities_summary(dock)
+
+        build_summary.assert_called_once_with()
+        self.assertEqual(dock.countLabel.text(), "Activities fetched: 0")
+
     def test_update_last_sync_summary_delegates_to_layer_summary_helper(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.settings = _FakeSettings({"last_sync_date": "2026-04-12"})
@@ -846,6 +860,38 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.output_path, "/tmp/qfit.gpkg")
         dock._update_stored_activities_summary.assert_called_once_with(12)
         dock._set_status.assert_called_once_with("Stored 12 activities")
+
+    def test_on_clear_database_clicked_delegates_reset_summary_update(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock.activities_layer = object()
+        dock.starts_layer = object()
+        dock.points_layer = object()
+        dock.atlas_layer = object()
+        dock._clear_analysis_layer = MagicMock()
+        dock.activities = [1]
+        dock.output_path = "/tmp/qfit.gpkg"
+        dock.last_fetch_context = {"provider": "strava"}
+        dock._update_cleared_activities_summary = MagicMock()
+        dock._set_status = MagicMock()
+        dock._show_error = MagicMock()
+        dock.load_workflow = MagicMock()
+        dock.load_workflow.build_clear_database_request.return_value = "clear-request"
+        dock.load_workflow.clear_database_request.return_value = SimpleNamespace(status="Database cleared")
+        self.module.QMessageBox.Yes = 1
+        self.module.QMessageBox.No = 0
+
+        with patch.object(self.module.QMessageBox, "question", return_value=1, create=True):
+            self.module.QfitDockWidget.on_clear_database_clicked(dock)
+
+        dock.load_workflow.build_clear_database_request.assert_called_once()
+        dock.load_workflow.clear_database_request.assert_called_once_with("clear-request")
+        dock._clear_analysis_layer.assert_called_once_with()
+        dock._update_cleared_activities_summary.assert_called_once_with()
+        dock._set_status.assert_called_once_with("Database cleared")
+        self.assertEqual(dock.activities, [])
+        self.assertIsNone(dock.activities_layer)
+        self.assertIsNone(dock.output_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- move clear-database summary text construction into `activities/application/layer_summary.py`
- keep `QfitDockWidget` responsible for reset state changes and label updates only
- add focused tests for the extracted helper and clear-database delegation path

## Testing
- python3 -m pytest tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k cleared_activities_summary
