### PR TITLE
refactor: extract clear-database missing-path error text

### DIFF
--- a/activities/application/clear_database_messages.py
+++ b/activities/application/clear_database_messages.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def build_missing_output_path_error() -> tuple[str, str]:
+    return (
+        "No database path",
+        "Set a GeoPackage output path first.",
+    )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -41,6 +41,7 @@ from .activities.application import (
     build_activity_type_options_from_activities,
     build_activity_type_options_from_records,
 )
+from .activities.application.clear_database_messages import build_missing_output_path_error
 from .activities.application.layer_summary import (
     build_cleared_activities_summary,
     build_last_sync_summary,
@@ -682,7 +683,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         """Delete the GeoPackage, clear loaded layers, and reset status."""
         output_path = self.outputPathLineEdit.text().strip()
         if not output_path:
-            self._show_error("No database path", "Set a GeoPackage output path first.")
+            self._show_error(*build_missing_output_path_error())
             return
 
         reply = QMessageBox.question(

--- a/tests/test_clear_database_messages.py
+++ b/tests/test_clear_database_messages.py
@@ -1,0 +1,17 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.application.clear_database_messages import build_missing_output_path_error
+
+
+class ClearDatabaseMessagesTests(unittest.TestCase):
+    def test_build_missing_output_path_error(self):
+        self.assertEqual(
+            build_missing_output_path_error(),
+            ("No database path", "Set a GeoPackage output path first."),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -861,6 +861,24 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._update_stored_activities_summary.assert_called_once_with(12)
         dock._set_status.assert_called_once_with("Stored 12 activities")
 
+    def test_on_clear_database_clicked_reports_missing_output_path_via_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.outputPathLineEdit = _FakeLineEdit("")
+        dock._show_error = MagicMock()
+
+        with patch.object(
+            self.module,
+            "build_missing_output_path_error",
+            return_value=("No database path", "Set a GeoPackage output path first."),
+        ) as build_error:
+            self.module.QfitDockWidget.on_clear_database_clicked(dock)
+
+        build_error.assert_called_once_with()
+        dock._show_error.assert_called_once_with(
+            "No database path",
+            "Set a GeoPackage output path first.",
+        )
+
     def test_on_clear_database_clicked_delegates_reset_summary_update(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")


### PR DESCRIPTION
## Summary
- move the clear-database missing-output-path error text into `activities/application/clear_database_messages.py`
- keep `QfitDockWidget` responsible for the dialog/workflow control and error display only
- add focused tests for the extracted helper and dock delegation path

## Testing
- python3 -m pytest tests/test_clear_database_messages.py tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k missing_output_path
