### PR TITLE
refactor: extract clear-database delete-failure status text

### DIFF
--- a/activities/application/clear_database_messages.py
+++ b/activities/application/clear_database_messages.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 
+def build_clear_database_delete_failure_status() -> str:
+    return "Failed to delete the GeoPackage file"
+
+
 def build_missing_output_path_error() -> tuple[str, str]:
     return (
         "No database path",

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -41,7 +41,10 @@ from .activities.application import (
     build_activity_type_options_from_activities,
     build_activity_type_options_from_records,
 )
-from .activities.application.clear_database_messages import build_missing_output_path_error
+from .activities.application.clear_database_messages import (
+    build_clear_database_delete_failure_status,
+    build_missing_output_path_error,
+)
 from .activities.application.layer_summary import (
     build_cleared_activities_summary,
     build_last_sync_summary,
@@ -716,7 +719,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
         except (RuntimeError, OSError) as exc:
             self._show_error("Could not delete database", str(exc))
-            self._set_status("Failed to delete the GeoPackage file")
+            self._set_status(build_clear_database_delete_failure_status())
             return
 
         self.activities_layer = None

--- a/tests/test_clear_database_messages.py
+++ b/tests/test_clear_database_messages.py
@@ -2,10 +2,19 @@ import unittest
 
 from tests import _path  # noqa: F401
 
-from qfit.activities.application.clear_database_messages import build_missing_output_path_error
+from qfit.activities.application.clear_database_messages import (
+    build_clear_database_delete_failure_status,
+    build_missing_output_path_error,
+)
 
 
 class ClearDatabaseMessagesTests(unittest.TestCase):
+    def test_build_clear_database_delete_failure_status(self):
+        self.assertEqual(
+            build_clear_database_delete_failure_status(),
+            "Failed to delete the GeoPackage file",
+        )
+
     def test_build_missing_output_path_error(self):
         self.assertEqual(
             build_missing_output_path_error(),

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -879,6 +879,32 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Set a GeoPackage output path first.",
         )
 
+    def test_on_clear_database_clicked_reports_delete_failure_status_via_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock.activities_layer = object()
+        dock.starts_layer = object()
+        dock.points_layer = object()
+        dock.atlas_layer = object()
+        dock._show_error = MagicMock()
+        dock._set_status = MagicMock()
+        dock.load_workflow = MagicMock()
+        dock.load_workflow.build_clear_database_request.return_value = "clear-request"
+        dock.load_workflow.clear_database_request.side_effect = OSError("permission denied")
+        self.module.QMessageBox.Yes = 1
+        self.module.QMessageBox.No = 0
+
+        with patch.object(self.module.QMessageBox, "question", return_value=1, create=True), patch.object(
+            self.module,
+            "build_clear_database_delete_failure_status",
+            return_value="Failed to delete the GeoPackage file",
+        ) as build_status:
+            self.module.QfitDockWidget.on_clear_database_clicked(dock)
+
+        dock._show_error.assert_called_once_with("Could not delete database", "permission denied")
+        build_status.assert_called_once_with()
+        dock._set_status.assert_called_once_with("Failed to delete the GeoPackage file")
+
     def test_on_clear_database_clicked_delegates_reset_summary_update(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")


### PR DESCRIPTION
## Summary
- move the clear-database delete-failure status text into `activities/application/clear_database_messages.py`
- keep `QfitDockWidget` responsible for exception handling and status display only
- add focused tests for the extracted helper and clear-database delegation path

## Testing
- python3 -m pytest tests/test_clear_database_messages.py tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k delete_failure_status
