### PR TITLE
refactor: extract clear-database delete-failure error title

### DIFF
--- a/activities/application/clear_database_messages.py
+++ b/activities/application/clear_database_messages.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 
+def build_clear_database_delete_failure_error_title() -> str:
+    return "Could not delete database"
+
+
 def build_clear_database_delete_failure_status() -> str:
     return "Failed to delete the GeoPackage file"
 

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -42,6 +42,7 @@ from .activities.application import (
     build_activity_type_options_from_records,
 )
 from .activities.application.clear_database_messages import (
+    build_clear_database_delete_failure_error_title,
     build_clear_database_delete_failure_status,
     build_missing_output_path_error,
 )
@@ -718,7 +719,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._show_error("No database path", str(exc))
             return
         except (RuntimeError, OSError) as exc:
-            self._show_error("Could not delete database", str(exc))
+            self._show_error(build_clear_database_delete_failure_error_title(), str(exc))
             self._set_status(build_clear_database_delete_failure_status())
             return
 

--- a/tests/test_clear_database_messages.py
+++ b/tests/test_clear_database_messages.py
@@ -3,12 +3,19 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.activities.application.clear_database_messages import (
+    build_clear_database_delete_failure_error_title,
     build_clear_database_delete_failure_status,
     build_missing_output_path_error,
 )
 
 
 class ClearDatabaseMessagesTests(unittest.TestCase):
+    def test_build_clear_database_delete_failure_error_title(self):
+        self.assertEqual(
+            build_clear_database_delete_failure_error_title(),
+            "Could not delete database",
+        )
+
     def test_build_clear_database_delete_failure_status(self):
         self.assertEqual(
             build_clear_database_delete_failure_status(),

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -879,7 +879,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Set a GeoPackage output path first.",
         )
 
-    def test_on_clear_database_clicked_reports_delete_failure_status_via_helper(self):
+    def test_on_clear_database_clicked_reports_delete_failure_status_via_helpers(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
         dock.activities_layer = object()
@@ -896,11 +896,16 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         with patch.object(self.module.QMessageBox, "question", return_value=1, create=True), patch.object(
             self.module,
+            "build_clear_database_delete_failure_error_title",
+            return_value="Could not delete database",
+        ) as build_title, patch.object(
+            self.module,
             "build_clear_database_delete_failure_status",
             return_value="Failed to delete the GeoPackage file",
         ) as build_status:
             self.module.QfitDockWidget.on_clear_database_clicked(dock)
 
+        build_title.assert_called_once_with()
         dock._show_error.assert_called_once_with("Could not delete database", "permission denied")
         build_status.assert_called_once_with()
         dock._set_status.assert_called_once_with("Failed to delete the GeoPackage file")


### PR DESCRIPTION
## Summary
- move the clear-database delete-failure error title into `activities/application/clear_database_messages.py`
- keep `QfitDockWidget` responsible for exception handling and error display only
- add focused tests for the extracted helper and clear-database delegation path

## Testing
- python3 -m pytest tests/test_clear_database_messages.py tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k delete_failure_error_title
