### PR TITLE
refactor: extract clear-database load-workflow error title

### DIFF
--- a/activities/application/clear_database_messages.py
+++ b/activities/application/clear_database_messages.py
@@ -9,6 +9,10 @@ def build_clear_database_delete_failure_status() -> str:
     return "Failed to delete the GeoPackage file"
 
 
+def build_clear_database_load_workflow_error_title() -> str:
+    return "No database path"
+
+
 def build_missing_output_path_error() -> tuple[str, str]:
     return (
         "No database path",

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -44,6 +44,7 @@ from .activities.application import (
 from .activities.application.clear_database_messages import (
     build_clear_database_delete_failure_error_title,
     build_clear_database_delete_failure_status,
+    build_clear_database_load_workflow_error_title,
     build_missing_output_path_error,
 )
 from .activities.application.layer_summary import (
@@ -716,7 +717,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
             result = self.load_workflow.clear_database_request(request)
         except LoadWorkflowError as exc:
-            self._show_error("No database path", str(exc))
+            self._show_error(build_clear_database_load_workflow_error_title(), str(exc))
             return
         except (RuntimeError, OSError) as exc:
             self._show_error(build_clear_database_delete_failure_error_title(), str(exc))

--- a/tests/test_clear_database_messages.py
+++ b/tests/test_clear_database_messages.py
@@ -5,6 +5,7 @@ from tests import _path  # noqa: F401
 from qfit.activities.application.clear_database_messages import (
     build_clear_database_delete_failure_error_title,
     build_clear_database_delete_failure_status,
+    build_clear_database_load_workflow_error_title,
     build_missing_output_path_error,
 )
 
@@ -20,6 +21,12 @@ class ClearDatabaseMessagesTests(unittest.TestCase):
         self.assertEqual(
             build_clear_database_delete_failure_status(),
             "Failed to delete the GeoPackage file",
+        )
+
+    def test_build_clear_database_load_workflow_error_title(self):
+        self.assertEqual(
+            build_clear_database_load_workflow_error_title(),
+            "No database path",
         )
 
     def test_build_missing_output_path_error(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -879,6 +879,30 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Set a GeoPackage output path first.",
         )
 
+    def test_on_clear_database_clicked_reports_load_workflow_error_title_via_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock.activities_layer = object()
+        dock.starts_layer = object()
+        dock.points_layer = object()
+        dock.atlas_layer = object()
+        dock._show_error = MagicMock()
+        dock.load_workflow = MagicMock()
+        dock.load_workflow.build_clear_database_request.return_value = "clear-request"
+        dock.load_workflow.clear_database_request.side_effect = self.module.LoadWorkflowError("missing file")
+        self.module.QMessageBox.Yes = 1
+        self.module.QMessageBox.No = 0
+
+        with patch.object(self.module.QMessageBox, "question", return_value=1, create=True), patch.object(
+            self.module,
+            "build_clear_database_load_workflow_error_title",
+            return_value="No database path",
+        ) as build_title:
+            self.module.QfitDockWidget.on_clear_database_clicked(dock)
+
+        build_title.assert_called_once_with()
+        dock._show_error.assert_called_once_with("No database path", "missing file")
+
     def test_on_clear_database_clicked_reports_delete_failure_status_via_helpers(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")


### PR DESCRIPTION
## Summary
- move the clear-database `LoadWorkflowError` title into `activities/application/clear_database_messages.py`
- keep `QfitDockWidget` responsible for exception handling and error display only
- add focused tests for the extracted helper and clear-database delegation path

## Testing
- python3 -m pytest tests/test_clear_database_messages.py tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k load_workflow_error_title
