### PR TITLE
refactor: extract clear-database confirmation title

### DIFF
--- a/activities/application/clear_database_messages.py
+++ b/activities/application/clear_database_messages.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 
+def build_clear_database_confirmation_title() -> str:
+    return "Clear database"
+
+
 def build_clear_database_delete_failure_error_title() -> str:
     return "Could not delete database"
 

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -42,6 +42,7 @@ from .activities.application import (
     build_activity_type_options_from_records,
 )
 from .activities.application.clear_database_messages import (
+    build_clear_database_confirmation_title,
     build_clear_database_delete_failure_error_title,
     build_clear_database_delete_failure_status,
     build_clear_database_load_workflow_error_title,
@@ -693,7 +694,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         reply = QMessageBox.question(
             self,
-            "Clear database",
+            build_clear_database_confirmation_title(),
             (
                 "This will delete the GeoPackage file and remove all qfit layers from QGIS:\n\n"
                 f"  {output_path}\n\n"

--- a/tests/test_clear_database_messages.py
+++ b/tests/test_clear_database_messages.py
@@ -3,6 +3,7 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.activities.application.clear_database_messages import (
+    build_clear_database_confirmation_title,
     build_clear_database_delete_failure_error_title,
     build_clear_database_delete_failure_status,
     build_clear_database_load_workflow_error_title,
@@ -11,6 +12,12 @@ from qfit.activities.application.clear_database_messages import (
 
 
 class ClearDatabaseMessagesTests(unittest.TestCase):
+    def test_build_clear_database_confirmation_title(self):
+        self.assertEqual(
+            build_clear_database_confirmation_title(),
+            "Clear database",
+        )
+
     def test_build_clear_database_delete_failure_error_title(self):
         self.assertEqual(
             build_clear_database_delete_failure_error_title(),

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -879,6 +879,42 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Set a GeoPackage output path first.",
         )
 
+    def test_on_clear_database_clicked_uses_confirmation_title_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock.activities_layer = object()
+        dock.starts_layer = object()
+        dock.points_layer = object()
+        dock.atlas_layer = object()
+        dock.load_workflow = MagicMock()
+        dock.load_workflow.build_clear_database_request.return_value = "clear-request"
+        dock.load_workflow.clear_database_request.return_value = SimpleNamespace(status="Database cleared")
+        dock._clear_analysis_layer = MagicMock()
+        dock._update_cleared_activities_summary = MagicMock()
+        dock._set_status = MagicMock()
+        dock._show_error = MagicMock()
+        dock.activities = []
+        dock.output_path = "/tmp/qfit.gpkg"
+        dock.last_fetch_context = {}
+        self.module.QMessageBox.Yes = 1
+        self.module.QMessageBox.No = 0
+
+        with patch.object(
+            self.module,
+            "build_clear_database_confirmation_title",
+            return_value="Clear database",
+        ) as build_title, patch.object(
+            self.module.QMessageBox,
+            "question",
+            return_value=1,
+            create=True,
+        ) as question:
+            self.module.QfitDockWidget.on_clear_database_clicked(dock)
+
+        build_title.assert_called_once_with()
+        question.assert_called_once()
+        self.assertEqual(question.call_args.args[1], "Clear database")
+
     def test_on_clear_database_clicked_reports_load_workflow_error_title_via_helper(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")


### PR DESCRIPTION
## Summary
- move the clear-database confirmation dialog title into `activities/application/clear_database_messages.py`
- keep `QfitDockWidget` responsible for dialog invocation and workflow control only
- add focused tests for the extracted helper and dialog delegation path

## Testing
- python3 -m pytest tests/test_clear_database_messages.py tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k confirmation_title
