### PR TITLE
refactor: extract clear-database confirmation body

### DIFF
--- a/activities/application/clear_database_messages.py
+++ b/activities/application/clear_database_messages.py
@@ -5,6 +5,14 @@ def build_clear_database_confirmation_title() -> str:
     return "Clear database"
 
 
+def build_clear_database_confirmation_body(output_path: str) -> str:
+    return (
+        "This will delete the GeoPackage file and remove all qfit layers from QGIS:\n\n"
+        f"  {output_path}\n\n"
+        "The file cannot be recovered. Continue?"
+    )
+
+
 def build_clear_database_delete_failure_error_title() -> str:
     return "Could not delete database"
 

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -42,6 +42,7 @@ from .activities.application import (
     build_activity_type_options_from_records,
 )
 from .activities.application.clear_database_messages import (
+    build_clear_database_confirmation_body,
     build_clear_database_confirmation_title,
     build_clear_database_delete_failure_error_title,
     build_clear_database_delete_failure_status,
@@ -695,11 +696,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         reply = QMessageBox.question(
             self,
             build_clear_database_confirmation_title(),
-            (
-                "This will delete the GeoPackage file and remove all qfit layers from QGIS:\n\n"
-                f"  {output_path}\n\n"
-                "The file cannot be recovered. Continue?"
-            ),
+            build_clear_database_confirmation_body(output_path),
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )

--- a/tests/test_clear_database_messages.py
+++ b/tests/test_clear_database_messages.py
@@ -3,6 +3,7 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.activities.application.clear_database_messages import (
+    build_clear_database_confirmation_body,
     build_clear_database_confirmation_title,
     build_clear_database_delete_failure_error_title,
     build_clear_database_delete_failure_status,
@@ -16,6 +17,14 @@ class ClearDatabaseMessagesTests(unittest.TestCase):
         self.assertEqual(
             build_clear_database_confirmation_title(),
             "Clear database",
+        )
+
+    def test_build_clear_database_confirmation_body(self):
+        self.assertEqual(
+            build_clear_database_confirmation_body("/tmp/qfit.gpkg"),
+            "This will delete the GeoPackage file and remove all qfit layers from QGIS:\n\n"
+            "  /tmp/qfit.gpkg\n\n"
+            "The file cannot be recovered. Continue?",
         )
 
     def test_build_clear_database_delete_failure_error_title(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -879,7 +879,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Set a GeoPackage output path first.",
         )
 
-    def test_on_clear_database_clicked_uses_confirmation_title_helper(self):
+    def test_on_clear_database_clicked_uses_confirmation_helpers(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
         dock.activities_layer = object()
@@ -904,6 +904,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "build_clear_database_confirmation_title",
             return_value="Clear database",
         ) as build_title, patch.object(
+            self.module,
+            "build_clear_database_confirmation_body",
+            return_value="Body text",
+        ) as build_body, patch.object(
             self.module.QMessageBox,
             "question",
             return_value=1,
@@ -912,8 +916,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             self.module.QfitDockWidget.on_clear_database_clicked(dock)
 
         build_title.assert_called_once_with()
+        build_body.assert_called_once_with("/tmp/qfit.gpkg")
         question.assert_called_once()
         self.assertEqual(question.call_args.args[1], "Clear database")
+        self.assertEqual(question.call_args.args[2], "Body text")
 
     def test_on_clear_database_clicked_reports_load_workflow_error_title_via_helper(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary
- move the clear-database confirmation dialog body into `activities/application/clear_database_messages.py`
- keep `QfitDockWidget` responsible for dialog invocation and workflow control only
- add focused tests for the extracted helper and dialog delegation path

## Testing
- python3 -m pytest tests/test_clear_database_messages.py tests/test_layer_summary.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short -k confirmation_body
