### PR TITLE
refactor: extract background map failure title

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -84,7 +84,11 @@ from .mapbox_config import (
     background_preset_names,
     preset_requires_custom_style,
 )
-from .visualization.application import BackgroundConfig, LayerRefs
+from .visualization.application import (
+    BackgroundConfig,
+    LayerRefs,
+    build_background_map_failure_title,
+)
 from .atlas.layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_provider import StravaProvider
@@ -396,7 +400,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             result = self.background_controller.load_background_request(request)
             self.background_layer = result.layer
         except (MapboxConfigError, RuntimeError) as exc:
-            self._show_error("Background map failed", str(exc))
+            self._show_error(build_background_map_failure_title(), str(exc))
             self._set_status("Background map could not be updated")
             return
 
@@ -750,7 +754,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(result.unsupported_reason)
             return
         if result.background_error:
-            self._show_error("Background map failed", result.background_error)
+            self._show_error(build_background_map_failure_title(), result.background_error)
         if result.background_layer is not None:
             self.background_layer = result.background_layer
         if result.status:
@@ -806,7 +810,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         result = self._dock_action_dispatcher.dispatch(action)
         if result.background_error:
-            self._show_error("Background map failed", result.background_error)
+            self._show_error(build_background_map_failure_title(), result.background_error)
         if result.background_layer is not None:
             self.background_layer = result.background_layer
         return result.status

--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -1,0 +1,16 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.visualization.application.background_map_messages import (
+    build_background_map_failure_title,
+)
+
+
+class BackgroundMapMessagesTests(unittest.TestCase):
+    def test_build_background_map_failure_title(self):
+        self.assertEqual(build_background_map_failure_title(), "Background map failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -386,12 +386,18 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._show_error = MagicMock()
         dock._set_status = MagicMock()
 
-        self.module.QfitDockWidget._dispatch_dock_action(
-            dock,
-            self.module.RunAnalysisAction,
-        )
+        with patch.object(
+            self.module,
+            "build_background_map_failure_title",
+            return_value="Background map failed",
+        ) as build_title:
+            self.module.QfitDockWidget._dispatch_dock_action(
+                dock,
+                self.module.RunAnalysisAction,
+            )
 
         dock._dock_action_dispatcher.dispatch.assert_called_once_with(action)
+        build_title.assert_called_once_with()
         dock._show_error.assert_called_once_with("Background map failed", "boom")
         self.assertEqual(dock.background_layer, "background-layer")
         dock._set_status.assert_called_once_with("Applied current filters")
@@ -415,6 +421,32 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
 
         dock._set_status.assert_called_once_with("Unsupported dock action: object")
+
+    def test_on_load_background_clicked_uses_failure_title_helper(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._save_settings = MagicMock()
+        dock.background_controller = MagicMock()
+        dock.background_controller.build_load_request.return_value = "background-request"
+        dock.background_controller.load_background_request.side_effect = RuntimeError("boom")
+        dock.backgroundMapCheckBox = _FakeCheckBox(True)
+        dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
+        dock._mapbox_access_token = MagicMock(return_value="token")
+        dock.mapboxStyleOwnerLineEdit = _FakeLineEdit("mapbox")
+        dock.mapboxStyleIdLineEdit = _FakeLineEdit("outdoors-v12")
+        dock.tileModeComboBox = _FakeComboBox(current_text="raster")
+        dock._show_error = MagicMock()
+        dock._set_status = MagicMock()
+
+        with patch.object(
+            self.module,
+            "build_background_map_failure_title",
+            return_value="Background map failed",
+        ) as build_title:
+            self.module.QfitDockWidget.on_load_background_clicked(dock)
+
+        build_title.assert_called_once_with()
+        dock._show_error.assert_called_once_with("Background map failed", "boom")
+        dock._set_status.assert_called_once_with("Background map could not be updated")
 
     def test_build_visual_workflow_action_uses_current_ui_state(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -5,6 +5,7 @@ from .background_map_controller import (
     LoadBackgroundRequest,
     LoadBackgroundResult,
 )
+from .background_map_messages import build_background_map_failure_title
 from .layer_gateway import LayerGateway
 from .render_plan import (
     BY_ACTIVITY_TYPE_PRESET,
@@ -50,6 +51,7 @@ __all__ = [
     "ApplyVisualizationRequest",
     "BackgroundConfig",
     "BackgroundMapController",
+    "build_background_map_failure_title",
     "BY_ACTIVITY_TYPE_PRESET",
     "CLUSTERED_STARTS_PRESET",
     "DEFAULT_RENDER_PRESET",

--- a/visualization/application/background_map_messages.py
+++ b/visualization/application/background_map_messages.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def build_background_map_failure_title() -> str:
+    return "Background map failed"


### PR DESCRIPTION
## Summary
- move the repeated background map failure title into `visualization/application/background_map_messages.py`
- keep the dock responsible for dialog invocation and background-map workflow control
- add focused tests for the extracted helper and the dock failure paths that use it

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dockwidget_dependencies.py -q --tb=short -k background_map_failure_title
