### PR TITLE
refactor: extract background map failure status

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -87,6 +87,7 @@ from .mapbox_config import (
 from .visualization.application import (
     BackgroundConfig,
     LayerRefs,
+    build_background_map_failure_status,
     build_background_map_failure_title,
 )
 from .atlas.layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
@@ -401,7 +402,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self.background_layer = result.layer
         except (MapboxConfigError, RuntimeError) as exc:
             self._show_error(build_background_map_failure_title(), str(exc))
-            self._set_status("Background map could not be updated")
+            self._set_status(build_background_map_failure_status())
             return
 
         self._set_status(result.status)

--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -3,11 +3,18 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.visualization.application.background_map_messages import (
+    build_background_map_failure_status,
     build_background_map_failure_title,
 )
 
 
 class BackgroundMapMessagesTests(unittest.TestCase):
+    def test_build_background_map_failure_status(self):
+        self.assertEqual(
+            build_background_map_failure_status(),
+            "Background map could not be updated",
+        )
+
     def test_build_background_map_failure_title(self):
         self.assertEqual(build_background_map_failure_title(), "Background map failed")
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -441,10 +441,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             self.module,
             "build_background_map_failure_title",
             return_value="Background map failed",
-        ) as build_title:
+        ) as build_title, patch.object(
+            self.module,
+            "build_background_map_failure_status",
+            return_value="Background map could not be updated",
+        ) as build_status:
             self.module.QfitDockWidget.on_load_background_clicked(dock)
 
         build_title.assert_called_once_with()
+        build_status.assert_called_once_with()
         dock._show_error.assert_called_once_with("Background map failed", "boom")
         dock._set_status.assert_called_once_with("Background map could not be updated")
 

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -5,7 +5,10 @@ from .background_map_controller import (
     LoadBackgroundRequest,
     LoadBackgroundResult,
 )
-from .background_map_messages import build_background_map_failure_title
+from .background_map_messages import (
+    build_background_map_failure_status,
+    build_background_map_failure_title,
+)
 from .layer_gateway import LayerGateway
 from .render_plan import (
     BY_ACTIVITY_TYPE_PRESET,
@@ -51,6 +54,7 @@ __all__ = [
     "ApplyVisualizationRequest",
     "BackgroundConfig",
     "BackgroundMapController",
+    "build_background_map_failure_status",
     "build_background_map_failure_title",
     "BY_ACTIVITY_TYPE_PRESET",
     "CLUSTERED_STARTS_PRESET",

--- a/visualization/application/background_map_messages.py
+++ b/visualization/application/background_map_messages.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
 
+def build_background_map_failure_status() -> str:
+    return "Background map could not be updated"
+
+
 def build_background_map_failure_title() -> str:
     return "Background map failed"


### PR DESCRIPTION
## Summary
- move the dock-owned background map update failure status text into `visualization/application/background_map_messages.py`
- keep the dock responsible for background-map workflow control and dialog invocation
- add focused tests for the extracted helper and the failure path that uses it

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dockwidget_dependencies.py -q --tb=short -k background_map_failure_status
