### PR TITLE
refactor: extract background map loaded status

### DIFF
--- a/tests/test_background_map_controller.py
+++ b/tests/test_background_map_controller.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 from qfit.visualization.application.background_map_controller import (
@@ -61,17 +61,24 @@ class LoadBackgroundTests(unittest.TestCase):
         sentinel = object()
         lm.ensure_background_layer.return_value = sentinel
         ctrl = BackgroundMapController(lm)
-        result = ctrl.load_background(
-            enabled=True,
-            preset_name="Mapbox Dark",
-            access_token="tok",
-            style_owner="mapbox",
-            style_id="dark-v11",
-            tile_mode="raster",
-        )
+
+        with patch(
+            "qfit.visualization.application.background_map_controller.build_background_map_loaded_status",
+            return_value="Background map loaded below the qfit activity layers",
+        ) as build_status:
+            result = ctrl.load_background(
+                enabled=True,
+                preset_name="Mapbox Dark",
+                access_token="tok",
+                style_owner="mapbox",
+                style_id="dark-v11",
+                tile_mode="raster",
+            )
+
         self.assertIsInstance(result, LoadBackgroundResult)
         self.assertIs(result.layer, sentinel)
         self.assertEqual(result.status, "Background map loaded below the qfit activity layers")
+        build_status.assert_called_once_with()
         lm.ensure_background_layer.assert_called_once_with(
             enabled=True,
             preset_name="Mapbox Dark",

--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -5,6 +5,7 @@ from tests import _path  # noqa: F401
 from qfit.visualization.application.background_map_messages import (
     build_background_map_failure_status,
     build_background_map_failure_title,
+    build_background_map_loaded_status,
 )
 
 
@@ -17,6 +18,12 @@ class BackgroundMapMessagesTests(unittest.TestCase):
 
     def test_build_background_map_failure_title(self):
         self.assertEqual(build_background_map_failure_title(), "Background map failed")
+
+    def test_build_background_map_loaded_status(self):
+        self.assertEqual(
+            build_background_map_loaded_status(),
+            "Background map loaded below the qfit activity layers",
+        )
 
 
 if __name__ == "__main__":

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -8,6 +8,7 @@ from .background_map_controller import (
 from .background_map_messages import (
     build_background_map_failure_status,
     build_background_map_failure_title,
+    build_background_map_loaded_status,
 )
 from .layer_gateway import LayerGateway
 from .render_plan import (
@@ -56,6 +57,7 @@ __all__ = [
     "BackgroundMapController",
     "build_background_map_failure_status",
     "build_background_map_failure_title",
+    "build_background_map_loaded_status",
     "BY_ACTIVITY_TYPE_PRESET",
     "CLUSTERED_STARTS_PRESET",
     "DEFAULT_RENDER_PRESET",

--- a/visualization/application/background_map_controller.py
+++ b/visualization/application/background_map_controller.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass
 
 from ...mapbox_config import preset_defaults, preset_requires_custom_style
+from .background_map_messages import build_background_map_loaded_status
 from .layer_gateway import LayerGateway
 
 logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ class BackgroundMapController:
             tile_mode=request.tile_mode,
         )
         status = (
-            "Background map loaded below the qfit activity layers"
+            build_background_map_loaded_status()
             if request.enabled and layer is not None
             else "Background map cleared"
         )

--- a/visualization/application/background_map_messages.py
+++ b/visualization/application/background_map_messages.py
@@ -7,3 +7,7 @@ def build_background_map_failure_status() -> str:
 
 def build_background_map_failure_title() -> str:
     return "Background map failed"
+
+
+def build_background_map_loaded_status() -> str:
+    return "Background map loaded below the qfit activity layers"


### PR DESCRIPTION
## Summary
- move the background-map loaded status text into `visualization/application/background_map_messages.py`
- keep `BackgroundMapController` responsible for control flow while delegating status wording to application-owned helpers
- add focused tests for the extracted helper and the controller path that uses it

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_background_map_controller.py tests/test_qgis_smoke.py -q --tb=short -k background_map_loaded_status
