### PR TITLE
refactor: extract background map cleared status

### DIFF
--- a/tests/test_background_map_controller.py
+++ b/tests/test_background_map_controller.py
@@ -92,13 +92,20 @@ class LoadBackgroundTests(unittest.TestCase):
         lm = MagicMock()
         lm.ensure_background_layer.return_value = None
         ctrl = BackgroundMapController(lm)
-        result = ctrl.load_background(
-            enabled=False,
-            preset_name="Mapbox Dark",
-            access_token="",
-            style_owner="",
-            style_id="",
-            tile_mode="raster",
-        )
+
+        with patch(
+            "qfit.visualization.application.background_map_controller.build_background_map_cleared_status",
+            return_value="Background map cleared",
+        ) as build_status:
+            result = ctrl.load_background(
+                enabled=False,
+                preset_name="Mapbox Dark",
+                access_token="",
+                style_owner="",
+                style_id="",
+                tile_mode="raster",
+            )
+
         self.assertIsNone(result.layer)
         self.assertEqual(result.status, "Background map cleared")
+        build_status.assert_called_once_with()

--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -3,6 +3,7 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.visualization.application.background_map_messages import (
+    build_background_map_cleared_status,
     build_background_map_failure_status,
     build_background_map_failure_title,
     build_background_map_loaded_status,
@@ -10,6 +11,12 @@ from qfit.visualization.application.background_map_messages import (
 
 
 class BackgroundMapMessagesTests(unittest.TestCase):
+    def test_build_background_map_cleared_status(self):
+        self.assertEqual(
+            build_background_map_cleared_status(),
+            "Background map cleared",
+        )
+
     def test_build_background_map_failure_status(self):
         self.assertEqual(
             build_background_map_failure_status(),

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -6,6 +6,7 @@ from .background_map_controller import (
     LoadBackgroundResult,
 )
 from .background_map_messages import (
+    build_background_map_cleared_status,
     build_background_map_failure_status,
     build_background_map_failure_title,
     build_background_map_loaded_status,
@@ -55,6 +56,7 @@ __all__ = [
     "ApplyVisualizationRequest",
     "BackgroundConfig",
     "BackgroundMapController",
+    "build_background_map_cleared_status",
     "build_background_map_failure_status",
     "build_background_map_failure_title",
     "build_background_map_loaded_status",

--- a/visualization/application/background_map_controller.py
+++ b/visualization/application/background_map_controller.py
@@ -2,7 +2,10 @@ import logging
 from dataclasses import dataclass
 
 from ...mapbox_config import preset_defaults, preset_requires_custom_style
-from .background_map_messages import build_background_map_loaded_status
+from .background_map_messages import (
+    build_background_map_cleared_status,
+    build_background_map_loaded_status,
+)
 from .layer_gateway import LayerGateway
 
 logger = logging.getLogger(__name__)
@@ -83,7 +86,7 @@ class BackgroundMapController:
         status = (
             build_background_map_loaded_status()
             if request.enabled and layer is not None
-            else "Background map cleared"
+            else build_background_map_cleared_status()
         )
         return LoadBackgroundResult(layer=layer, status=status)
 

--- a/visualization/application/background_map_messages.py
+++ b/visualization/application/background_map_messages.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 
+def build_background_map_cleared_status() -> str:
+    return "Background map cleared"
+
+
 def build_background_map_failure_status() -> str:
     return "Background map could not be updated"
 


### PR DESCRIPTION
## Summary
- move the background-map cleared status text into `visualization/application/background_map_messages.py`
- keep `BackgroundMapController` responsible for control flow while delegating status wording to application-owned helpers
- add focused tests for the extracted helper and the controller path that uses it

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_background_map_controller.py tests/test_qgis_smoke.py -q --tb=short -k background_map_cleared_status
