### PR TITLE
refactor: extract visual apply background cleared status

### DIFF
--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -1,6 +1,6 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 from tests import _path  # noqa: F401
 from qfit.visualization.application.render_plan import (
@@ -235,6 +235,26 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
         )
 
         self.layer_manager.apply_filters.assert_not_called()
+
+    def test_returns_cleared_status_via_helper_when_background_is_not_loaded(self):
+        self.layer_manager.ensure_background_layer.return_value = None
+
+        with patch(
+            "qfit.visualization.application.visual_apply.build_background_map_cleared_status",
+            return_value="Background map cleared",
+        ) as build_status:
+            result = self.service.apply(
+                layers=LayerRefs(),
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=_make_bg_config(enabled=False),
+                apply_subset_filters=False,
+                filtered_count=0,
+            )
+
+        self.assertEqual(result.status, "Background map cleared")
+        build_status.assert_called_once_with()
 
     def test_applies_style_and_temporal(self):
         self.service.apply(

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from ...activities.application.activity_selection_state import ActivitySelectionState
 from ...activities.domain.activity_query import ActivityQuery
 from ...mapbox_config import MapboxConfigError
+from .background_map_messages import build_background_map_cleared_status
 from .layer_gateway import LayerGateway
 from .render_plan import build_render_plan
 
@@ -251,7 +252,7 @@ class VisualApplyService:
         elif wants_background and background_layer is not None:
             status = "Background map loaded below the qfit activity layers"
         else:
-            status = "Background map cleared"
+            status = build_background_map_cleared_status()
 
         if temporal_note:
             status = "{status}. {temporal_note}.".format(


### PR DESCRIPTION
## Summary
- move the `VisualApplyService` background-cleared status text to the shared background-map message helper
- keep visualization apply control flow unchanged
- add focused service coverage for the extracted helper path

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k background_map_cleared_status
