### PR TITLE
refactor: extract visual apply background loaded status

### DIFF
--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -256,6 +256,24 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
         self.assertEqual(result.status, "Background map cleared")
         build_status.assert_called_once_with()
 
+    def test_returns_loaded_background_status_via_helper_when_only_background_is_loaded(self):
+        with patch(
+            "qfit.visualization.application.visual_apply.build_background_map_loaded_status",
+            return_value="Background map loaded below the qfit activity layers",
+        ) as build_status:
+            result = self.service.apply(
+                layers=LayerRefs(),
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=_make_bg_config(enabled=True),
+                apply_subset_filters=False,
+                filtered_count=0,
+            )
+
+        self.assertEqual(result.status, "Background map loaded below the qfit activity layers")
+        build_status.assert_called_once_with()
+
     def test_applies_style_and_temporal(self):
         self.service.apply(
             layers=self.layers,

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass, field
 from ...activities.application.activity_selection_state import ActivitySelectionState
 from ...activities.domain.activity_query import ActivityQuery
 from ...mapbox_config import MapboxConfigError
-from .background_map_messages import build_background_map_cleared_status
+from .background_map_messages import (
+    build_background_map_cleared_status,
+    build_background_map_loaded_status,
+)
 from .layer_gateway import LayerGateway
 from .render_plan import build_render_plan
 
@@ -250,7 +253,7 @@ class VisualApplyService:
         elif has_layers:
             status = "Applied styling to the loaded qfit layers"
         elif wants_background and background_layer is not None:
-            status = "Background map loaded below the qfit activity layers"
+            status = build_background_map_loaded_status()
         else:
             status = build_background_map_cleared_status()
 


### PR DESCRIPTION
## Summary
- move the `VisualApplyService` loaded-background status text to the shared background-map message helper
- keep visualization apply control flow unchanged
- add focused service coverage for the extracted helper path

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k background_map_loaded_status
