### PR TITLE
refactor: extract combined visual apply background status

### DIFF
--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -7,6 +7,7 @@ from qfit.visualization.application.background_map_messages import (
     build_background_map_failure_status,
     build_background_map_failure_title,
     build_background_map_loaded_status,
+    build_styled_background_map_loaded_status,
 )
 
 
@@ -30,6 +31,12 @@ class BackgroundMapMessagesTests(unittest.TestCase):
         self.assertEqual(
             build_background_map_loaded_status(),
             "Background map loaded below the qfit activity layers",
+        )
+
+    def test_build_styled_background_map_loaded_status(self):
+        self.assertEqual(
+            build_styled_background_map_loaded_status(),
+            "Applied styling and loaded the background map below the qfit activity layers",
         )
 
 

--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -327,6 +327,29 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
         self.assertIn("styling", result.status.lower())
         self.assertIn("background", result.status.lower())
 
+    def test_returns_styled_background_loaded_status_via_helper(self):
+        bg = _make_bg_config(enabled=True)
+
+        with patch(
+            "qfit.visualization.application.visual_apply.build_styled_background_map_loaded_status",
+            return_value="Applied styling and loaded the background map below the qfit activity layers",
+        ) as build_status:
+            result = self.service.apply(
+                layers=self.layers,
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=bg,
+                apply_subset_filters=False,
+                filtered_count=0,
+            )
+
+        self.assertEqual(
+            result.status,
+            "Applied styling and loaded the background map below the qfit activity layers",
+        )
+        build_status.assert_called_once_with()
+
     def test_status_without_background(self):
         result = self.service.apply(
             layers=self.layers,

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -10,6 +10,7 @@ from .background_map_messages import (
     build_background_map_failure_status,
     build_background_map_failure_title,
     build_background_map_loaded_status,
+    build_styled_background_map_loaded_status,
 )
 from .layer_gateway import LayerGateway
 from .render_plan import (
@@ -60,6 +61,7 @@ __all__ = [
     "build_background_map_failure_status",
     "build_background_map_failure_title",
     "build_background_map_loaded_status",
+    "build_styled_background_map_loaded_status",
     "BY_ACTIVITY_TYPE_PRESET",
     "CLUSTERED_STARTS_PRESET",
     "DEFAULT_RENDER_PRESET",

--- a/visualization/application/background_map_messages.py
+++ b/visualization/application/background_map_messages.py
@@ -15,3 +15,7 @@ def build_background_map_failure_title() -> str:
 
 def build_background_map_loaded_status() -> str:
     return "Background map loaded below the qfit activity layers"
+
+
+def build_styled_background_map_loaded_status() -> str:
+    return "Applied styling and loaded the background map below the qfit activity layers"

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -7,6 +7,7 @@ from ...mapbox_config import MapboxConfigError
 from .background_map_messages import (
     build_background_map_cleared_status,
     build_background_map_loaded_status,
+    build_styled_background_map_loaded_status,
 )
 from .layer_gateway import LayerGateway
 from .render_plan import build_render_plan
@@ -249,7 +250,7 @@ class VisualApplyService:
                 count=filtered_count
             )
         elif has_layers and wants_background and background_layer is not None:
-            status = "Applied styling and loaded the background map below the qfit activity layers"
+            status = build_styled_background_map_loaded_status()
         elif has_layers:
             status = "Applied styling to the loaded qfit layers"
         elif wants_background and background_layer is not None:


### PR DESCRIPTION
## Summary
- move the combined styling+background-loaded status text used by `VisualApplyService` into the shared background-map helper module
- keep visualization apply control flow unchanged
- add focused helper/service coverage for the extracted path

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k styled_background_map_loaded_status
