### PR TITLE
refactor: extract visual apply background failure status

### DIFF
--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -7,6 +7,7 @@ from qfit.visualization.application.background_map_messages import (
     build_background_map_failure_status,
     build_background_map_failure_title,
     build_background_map_loaded_status,
+    build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
 )
 
@@ -31,6 +32,12 @@ class BackgroundMapMessagesTests(unittest.TestCase):
         self.assertEqual(
             build_background_map_loaded_status(),
             "Background map loaded below the qfit activity layers",
+        )
+
+    def test_build_styled_background_map_failure_status(self):
+        self.assertEqual(
+            build_styled_background_map_failure_status(),
+            "Loaded layers with styling, but the background map could not be updated",
         )
 
     def test_build_styled_background_map_loaded_status(self):

--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -389,17 +389,23 @@ class BackgroundFailureTests(unittest.TestCase):
 
     def test_error_status_with_layers(self):
         layers = LayerRefs(activities=MagicMock())
-        result = self.service.apply(
-            layers=layers,
-            query=_make_query(),
-            style_preset="By activity type",
-            temporal_mode="Off",
-            background_config=_make_bg_config(enabled=True),
-            apply_subset_filters=False,
-            filtered_count=0,
-        )
+
+        with patch(
+            "qfit.visualization.application.visual_apply.build_styled_background_map_failure_status",
+            return_value="Loaded layers with styling, but the background map could not be updated",
+        ) as build_status:
+            result = self.service.apply(
+                layers=layers,
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=_make_bg_config(enabled=True),
+                apply_subset_filters=False,
+                filtered_count=0,
+            )
 
         self.assertIn("loaded layers", result.status.lower())
+        build_status.assert_called_once_with()
 
     def test_error_status_without_layers(self):
         layers = LayerRefs()

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -10,6 +10,7 @@ from .background_map_messages import (
     build_background_map_failure_status,
     build_background_map_failure_title,
     build_background_map_loaded_status,
+    build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
 )
 from .layer_gateway import LayerGateway
@@ -61,6 +62,7 @@ __all__ = [
     "build_background_map_failure_status",
     "build_background_map_failure_title",
     "build_background_map_loaded_status",
+    "build_styled_background_map_failure_status",
     "build_styled_background_map_loaded_status",
     "BY_ACTIVITY_TYPE_PRESET",
     "CLUSTERED_STARTS_PRESET",

--- a/visualization/application/background_map_messages.py
+++ b/visualization/application/background_map_messages.py
@@ -17,5 +17,9 @@ def build_background_map_loaded_status() -> str:
     return "Background map loaded below the qfit activity layers"
 
 
+def build_styled_background_map_failure_status() -> str:
+    return "Loaded layers with styling, but the background map could not be updated"
+
+
 def build_styled_background_map_loaded_status() -> str:
     return "Applied styling and loaded the background map below the qfit activity layers"

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -7,6 +7,7 @@ from ...mapbox_config import MapboxConfigError
 from .background_map_messages import (
     build_background_map_cleared_status,
     build_background_map_loaded_status,
+    build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
 )
 from .layer_gateway import LayerGateway
@@ -229,7 +230,7 @@ class VisualApplyService:
         if not has_layers:
             status = "Background map could not be updated"
         else:
-            status = "Loaded layers with styling, but the background map could not be updated"
+            status = build_styled_background_map_failure_status()
         if temporal_note:
             status = "{status}. {temporal_note}.".format(
                 status=status, temporal_note=temporal_note


### PR DESCRIPTION
## Summary
- move the styled background-failure status text used by `VisualApplyService` into the shared background-map helper module
- keep visualization apply control flow unchanged
- add focused helper/service coverage for the extracted path

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k styled_background_map_failure_status
