### PR TITLE
refactor: extract no-layers visual apply background failure status

### DIFF
--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -409,18 +409,24 @@ class BackgroundFailureTests(unittest.TestCase):
 
     def test_error_status_without_layers(self):
         layers = LayerRefs()
-        result = self.service.apply(
-            layers=layers,
-            query=_make_query(),
-            style_preset="By activity type",
-            temporal_mode="Off",
-            background_config=_make_bg_config(enabled=True),
-            apply_subset_filters=False,
-            filtered_count=0,
-        )
+
+        with patch(
+            "qfit.visualization.application.visual_apply.build_background_map_failure_status",
+            return_value="Background map could not be updated",
+        ) as build_status:
+            result = self.service.apply(
+                layers=layers,
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=_make_bg_config(enabled=True),
+                apply_subset_filters=False,
+                filtered_count=0,
+            )
 
         self.assertNotIn("loaded layers", result.status.lower())
         self.assertIn("could not be updated", result.status.lower())
+        build_status.assert_called_once_with()
 
     def test_unexpected_background_exception_propagates(self):
         self.layer_manager.ensure_background_layer.side_effect = TypeError("boom")

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -6,6 +6,7 @@ from ...activities.domain.activity_query import ActivityQuery
 from ...mapbox_config import MapboxConfigError
 from .background_map_messages import (
     build_background_map_cleared_status,
+    build_background_map_failure_status,
     build_background_map_loaded_status,
     build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
@@ -228,7 +229,7 @@ class VisualApplyService:
     @staticmethod
     def _background_failure_status(has_layers, temporal_note, error):
         if not has_layers:
-            status = "Background map could not be updated"
+            status = build_background_map_failure_status()
         else:
             status = build_styled_background_map_failure_status()
         if temporal_note:


### PR DESCRIPTION
## Summary
- move the no-layers background-failure status used by `VisualApplyService` to the shared background-map helper module
- keep visualization apply control flow unchanged
- add focused service coverage for the extracted path

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k background_map_failure_status
