### PR TITLE
refactor: extract styled visual apply status

### DIFF
--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -9,6 +9,7 @@ from qfit.visualization.application.background_map_messages import (
     build_background_map_loaded_status,
     build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
+    build_styled_visual_apply_status,
 )
 
 
@@ -44,6 +45,12 @@ class BackgroundMapMessagesTests(unittest.TestCase):
         self.assertEqual(
             build_styled_background_map_loaded_status(),
             "Applied styling and loaded the background map below the qfit activity layers",
+        )
+
+    def test_build_styled_visual_apply_status(self):
+        self.assertEqual(
+            build_styled_visual_apply_status(),
+            "Applied styling to the loaded qfit layers",
         )
 
 

--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -477,6 +477,26 @@ class NoLayersTests(unittest.TestCase):
 
         self.assertIn("cleared", result.status.lower())
 
+    def test_styled_only_status_uses_helper(self):
+        layers = LayerRefs(activities=MagicMock())
+
+        with patch(
+            "qfit.visualization.application.visual_apply.build_styled_visual_apply_status",
+            return_value="Applied styling to the loaded qfit layers",
+        ) as build_status:
+            result = self.service.apply(
+                layers=layers,
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=_make_bg_config(enabled=False),
+                apply_subset_filters=False,
+                filtered_count=0,
+            )
+
+        self.assertIn("applied styling", result.status.lower())
+        build_status.assert_called_once_with()
+
 
 class TemporalNoteTests(unittest.TestCase):
     def setUp(self):

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -12,6 +12,7 @@ from .background_map_messages import (
     build_background_map_loaded_status,
     build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
+    build_styled_visual_apply_status,
 )
 from .layer_gateway import LayerGateway
 from .render_plan import (
@@ -64,6 +65,7 @@ __all__ = [
     "build_background_map_loaded_status",
     "build_styled_background_map_failure_status",
     "build_styled_background_map_loaded_status",
+    "build_styled_visual_apply_status",
     "BY_ACTIVITY_TYPE_PRESET",
     "CLUSTERED_STARTS_PRESET",
     "DEFAULT_RENDER_PRESET",

--- a/visualization/application/background_map_messages.py
+++ b/visualization/application/background_map_messages.py
@@ -23,3 +23,7 @@ def build_styled_background_map_failure_status() -> str:
 
 def build_styled_background_map_loaded_status() -> str:
     return "Applied styling and loaded the background map below the qfit activity layers"
+
+
+def build_styled_visual_apply_status() -> str:
+    return "Applied styling to the loaded qfit layers"

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -10,6 +10,7 @@ from .background_map_messages import (
     build_background_map_loaded_status,
     build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
+    build_styled_visual_apply_status,
 )
 from .layer_gateway import LayerGateway
 from .render_plan import build_render_plan
@@ -254,7 +255,7 @@ class VisualApplyService:
         elif has_layers and wants_background and background_layer is not None:
             status = build_styled_background_map_loaded_status()
         elif has_layers:
-            status = "Applied styling to the loaded qfit layers"
+            status = build_styled_visual_apply_status()
         elif wants_background and background_layer is not None:
             status = build_background_map_loaded_status()
         else:


### PR DESCRIPTION
## Summary
- move the styled-only `VisualApplyService` success status into visualization application message helpers
- keep visual apply control flow unchanged
- add focused helper and service coverage for the extracted path

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k styled_visual_apply_status
