### PR TITLE
refactor: extract filtered visual apply status

### DIFF
--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -181,6 +181,24 @@ class ApplyWithSubsetFiltersTests(unittest.TestCase):
         self.assertIn("42", result.status)
         self.assertIn("filters", result.status.lower())
 
+    def test_filtered_status_uses_helper(self):
+        with patch(
+            "qfit.visualization.application.visual_apply.build_filtered_visual_apply_status",
+            return_value="Applied filters and styling (42 matching activities)",
+        ) as build_status:
+            result = self.service.apply(
+                layers=self.layers,
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=_make_bg_config(),
+                apply_subset_filters=True,
+                filtered_count=42,
+            )
+
+        self.assertIn("42", result.status)
+        build_status.assert_called_once_with(42)
+
     def test_does_not_update_background_on_filter_apply(self):
         self.service.apply(
             layers=self.layers,

--- a/tests/test_visual_apply_messages.py
+++ b/tests/test_visual_apply_messages.py
@@ -1,0 +1,19 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.visualization.application.visual_apply_messages import (
+    build_filtered_visual_apply_status,
+)
+
+
+class VisualApplyMessagesTests(unittest.TestCase):
+    def test_build_filtered_visual_apply_status(self):
+        self.assertEqual(
+            build_filtered_visual_apply_status(42),
+            "Applied filters and styling (42 matching activities)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -46,6 +46,7 @@ from .temporal_config import (
     is_temporal_mode_enabled,
     temporal_mode_labels,
 )
+from .visual_apply_messages import build_filtered_visual_apply_status
 from .visual_apply import (
     ApplyVisualizationRequest,
     BackgroundConfig,
@@ -63,6 +64,7 @@ __all__ = [
     "build_background_map_failure_status",
     "build_background_map_failure_title",
     "build_background_map_loaded_status",
+    "build_filtered_visual_apply_status",
     "build_styled_background_map_failure_status",
     "build_styled_background_map_loaded_status",
     "build_styled_visual_apply_status",

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -14,6 +14,7 @@ from .background_map_messages import (
 )
 from .layer_gateway import LayerGateway
 from .render_plan import build_render_plan
+from .visual_apply_messages import build_filtered_visual_apply_status
 
 logger = logging.getLogger(__name__)
 
@@ -249,9 +250,7 @@ class VisualApplyService:
         temporal_note,
     ):
         if apply_subset_filters and has_layers:
-            status = "Applied filters and styling ({count} matching activities)".format(
-                count=filtered_count
-            )
+            status = build_filtered_visual_apply_status(filtered_count)
         elif has_layers and wants_background and background_layer is not None:
             status = build_styled_background_map_loaded_status()
         elif has_layers:

--- a/visualization/application/visual_apply_messages.py
+++ b/visualization/application/visual_apply_messages.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def build_filtered_visual_apply_status(filtered_count: int) -> str:
+    return "Applied filters and styling ({count} matching activities)".format(
+        count=filtered_count
+    )


### PR DESCRIPTION
## Summary
- move the filtered `VisualApplyService` status text into visualization application-owned message helpers
- keep visual apply control flow unchanged
- add focused helper and service-path coverage for the extracted path

## Testing
- python3 -m pytest tests/test_visual_apply_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k filtered_visual_apply_status
