### PR TITLE
refactor: extract visual apply temporal note formatting

### DIFF
--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -15,6 +15,9 @@ from qfit.visualization.application.visual_apply import (
     VisualApplyResult,
     VisualApplyService,
 )
+from qfit.visualization.application.visual_apply_messages import (
+    append_visual_apply_temporal_note,
+)
 
 
 def _make_query(**overrides):
@@ -525,32 +528,42 @@ class TemporalNoteTests(unittest.TestCase):
         self.layers = LayerRefs(activities=MagicMock())
 
     def test_temporal_note_appended_to_status(self):
-        result = self.service.apply(
-            layers=self.layers,
-            query=_make_query(),
-            style_preset="By activity type",
-            temporal_mode="Monthly",
-            background_config=_make_bg_config(),
-            apply_subset_filters=False,
-            filtered_count=0,
-        )
+        with patch(
+            "qfit.visualization.application.visual_apply.append_visual_apply_temporal_note",
+            wraps=append_visual_apply_temporal_note,
+        ) as append_note:
+            result = self.service.apply(
+                layers=self.layers,
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Monthly",
+                background_config=_make_bg_config(),
+                apply_subset_filters=False,
+                filtered_count=0,
+            )
 
         self.assertIn("Temporal mode: Monthly", result.status)
+        append_note.assert_called()
 
     def test_temporal_note_appended_to_failure_status(self):
         self.layer_manager.ensure_background_layer.side_effect = RuntimeError("fail")
-        result = self.service.apply(
-            layers=self.layers,
-            query=_make_query(),
-            style_preset="By activity type",
-            temporal_mode="Monthly",
-            background_config=_make_bg_config(enabled=True),
-            apply_subset_filters=False,
-            filtered_count=0,
-        )
+        with patch(
+            "qfit.visualization.application.visual_apply.append_visual_apply_temporal_note",
+            wraps=append_visual_apply_temporal_note,
+        ) as append_note:
+            result = self.service.apply(
+                layers=self.layers,
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Monthly",
+                background_config=_make_bg_config(enabled=True),
+                apply_subset_filters=False,
+                filtered_count=0,
+            )
 
         self.assertIn("Temporal mode: Monthly", result.status)
         self.assertIn("could not be updated", result.status.lower())
+        append_note.assert_called()
 
 
 class BackgroundPresetPassthroughTests(unittest.TestCase):

--- a/tests/test_visual_apply_messages.py
+++ b/tests/test_visual_apply_messages.py
@@ -3,6 +3,7 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.visualization.application.visual_apply_messages import (
+    append_visual_apply_temporal_note,
     build_filtered_visual_apply_status,
 )
 
@@ -12,6 +13,24 @@ class VisualApplyMessagesTests(unittest.TestCase):
         self.assertEqual(
             build_filtered_visual_apply_status(42),
             "Applied filters and styling (42 matching activities)",
+        )
+
+    def test_append_visual_apply_temporal_note(self):
+        self.assertEqual(
+            append_visual_apply_temporal_note(
+                "Applied styling to the loaded qfit layers",
+                "Temporal mode: Monthly",
+            ),
+            "Applied styling to the loaded qfit layers. Temporal mode: Monthly.",
+        )
+
+    def test_append_visual_apply_temporal_note_returns_status_when_empty(self):
+        self.assertEqual(
+            append_visual_apply_temporal_note(
+                "Applied styling to the loaded qfit layers",
+                "",
+            ),
+            "Applied styling to the loaded qfit layers",
         )
 
 

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -46,7 +46,10 @@ from .temporal_config import (
     is_temporal_mode_enabled,
     temporal_mode_labels,
 )
-from .visual_apply_messages import build_filtered_visual_apply_status
+from .visual_apply_messages import (
+    append_visual_apply_temporal_note,
+    build_filtered_visual_apply_status,
+)
 from .visual_apply import (
     ApplyVisualizationRequest,
     BackgroundConfig,
@@ -64,6 +67,7 @@ __all__ = [
     "build_background_map_failure_status",
     "build_background_map_failure_title",
     "build_background_map_loaded_status",
+    "append_visual_apply_temporal_note",
     "build_filtered_visual_apply_status",
     "build_styled_background_map_failure_status",
     "build_styled_background_map_loaded_status",

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -14,7 +14,10 @@ from .background_map_messages import (
 )
 from .layer_gateway import LayerGateway
 from .render_plan import build_render_plan
-from .visual_apply_messages import build_filtered_visual_apply_status
+from .visual_apply_messages import (
+    append_visual_apply_temporal_note,
+    build_filtered_visual_apply_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -234,11 +237,7 @@ class VisualApplyService:
             status = build_background_map_failure_status()
         else:
             status = build_styled_background_map_failure_status()
-        if temporal_note:
-            status = "{status}. {temporal_note}.".format(
-                status=status, temporal_note=temporal_note
-            )
-        return status
+        return append_visual_apply_temporal_note(status, temporal_note)
 
     @staticmethod
     def _build_status(
@@ -260,8 +259,4 @@ class VisualApplyService:
         else:
             status = build_background_map_cleared_status()
 
-        if temporal_note:
-            status = "{status}. {temporal_note}.".format(
-                status=status, temporal_note=temporal_note
-            )
-        return status
+        return append_visual_apply_temporal_note(status, temporal_note)

--- a/visualization/application/visual_apply_messages.py
+++ b/visualization/application/visual_apply_messages.py
@@ -5,3 +5,11 @@ def build_filtered_visual_apply_status(filtered_count: int) -> str:
     return "Applied filters and styling ({count} matching activities)".format(
         count=filtered_count
     )
+
+
+def append_visual_apply_temporal_note(status: str, temporal_note: str) -> str:
+    if not temporal_note:
+        return status
+    return "{status}. {temporal_note}.".format(
+        status=status, temporal_note=temporal_note
+    )


### PR DESCRIPTION
## Summary
- move visual-apply temporal-note status formatting into visualization application-owned message helpers
- reuse that helper for both success and failure status paths in `VisualApplyService`
- add focused helper and service-path coverage for the extracted behavior

## Testing
- python3 -m pytest tests/test_visual_apply_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k append_visual_apply_temporal_note
