### PR TITLE
refactor: extract visual apply status selection

### DIFF
--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -208,24 +208,6 @@ class ApplyWithSubsetFiltersTests(unittest.TestCase):
             background_loaded=False,
         )
 
-    def test_filtered_status_uses_helper(self):
-        with patch(
-            "qfit.visualization.application.visual_apply.build_filtered_visual_apply_status",
-            return_value="Applied filters and styling (42 matching activities)",
-        ) as build_status:
-            result = self.service.apply(
-                layers=self.layers,
-                query=_make_query(),
-                style_preset="By activity type",
-                temporal_mode="Off",
-                background_config=_make_bg_config(),
-                apply_subset_filters=True,
-                filtered_count=42,
-            )
-
-        self.assertIn("42", result.status)
-        build_status.assert_called_once_with(42)
-
     def test_does_not_update_background_on_filter_apply(self):
         self.service.apply(
             layers=self.layers,
@@ -285,7 +267,7 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
         self.layer_manager.ensure_background_layer.return_value = None
 
         with patch(
-            "qfit.visualization.application.visual_apply.build_background_map_cleared_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_status",
             return_value="Background map cleared",
         ) as build_status:
             result = self.service.apply(
@@ -299,11 +281,17 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
             )
 
         self.assertEqual(result.status, "Background map cleared")
-        build_status.assert_called_once_with()
+        build_status.assert_called_once_with(
+            has_layers=False,
+            apply_subset_filters=False,
+            filtered_count=0,
+            wants_background=False,
+            background_loaded=False,
+        )
 
     def test_returns_loaded_background_status_via_helper_when_only_background_is_loaded(self):
         with patch(
-            "qfit.visualization.application.visual_apply.build_background_map_loaded_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_status",
             return_value="Background map loaded below the qfit activity layers",
         ) as build_status:
             result = self.service.apply(
@@ -317,7 +305,13 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
             )
 
         self.assertEqual(result.status, "Background map loaded below the qfit activity layers")
-        build_status.assert_called_once_with()
+        build_status.assert_called_once_with(
+            has_layers=False,
+            apply_subset_filters=False,
+            filtered_count=0,
+            wants_background=True,
+            background_loaded=True,
+        )
 
     def test_applies_style_and_temporal(self):
         self.service.apply(
@@ -376,7 +370,7 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
         bg = _make_bg_config(enabled=True)
 
         with patch(
-            "qfit.visualization.application.visual_apply.build_styled_background_map_loaded_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_status",
             return_value="Applied styling and loaded the background map below the qfit activity layers",
         ) as build_status:
             result = self.service.apply(
@@ -393,7 +387,13 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
             result.status,
             "Applied styling and loaded the background map below the qfit activity layers",
         )
-        build_status.assert_called_once_with()
+        build_status.assert_called_once_with(
+            has_layers=True,
+            apply_subset_filters=False,
+            filtered_count=0,
+            wants_background=True,
+            background_loaded=True,
+        )
 
     def test_status_without_background(self):
         result = self.service.apply(
@@ -526,7 +526,7 @@ class NoLayersTests(unittest.TestCase):
         layers = LayerRefs(activities=MagicMock())
 
         with patch(
-            "qfit.visualization.application.visual_apply.build_styled_visual_apply_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_status",
             return_value="Applied styling to the loaded qfit layers",
         ) as build_status:
             result = self.service.apply(
@@ -540,7 +540,13 @@ class NoLayersTests(unittest.TestCase):
             )
 
         self.assertIn("applied styling", result.status.lower())
-        build_status.assert_called_once_with()
+        build_status.assert_called_once_with(
+            has_layers=True,
+            apply_subset_filters=False,
+            filtered_count=0,
+            wants_background=False,
+            background_loaded=False,
+        )
 
 
 class TemporalNoteTests(unittest.TestCase):

--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -184,6 +184,30 @@ class ApplyWithSubsetFiltersTests(unittest.TestCase):
         self.assertIn("42", result.status)
         self.assertIn("filters", result.status.lower())
 
+    def test_status_selection_uses_helper(self):
+        with patch(
+            "qfit.visualization.application.visual_apply.build_visual_apply_status",
+            return_value="Applied filters and styling (42 matching activities)",
+        ) as build_status:
+            result = self.service.apply(
+                layers=self.layers,
+                query=_make_query(),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=_make_bg_config(),
+                apply_subset_filters=True,
+                filtered_count=42,
+            )
+
+        self.assertIn("42", result.status)
+        build_status.assert_called_once_with(
+            has_layers=True,
+            apply_subset_filters=True,
+            filtered_count=42,
+            wants_background=False,
+            background_loaded=False,
+        )
+
     def test_filtered_status_uses_helper(self):
         with patch(
             "qfit.visualization.application.visual_apply.build_filtered_visual_apply_status",

--- a/tests/test_visual_apply_messages.py
+++ b/tests/test_visual_apply_messages.py
@@ -5,6 +5,7 @@ from tests import _path  # noqa: F401
 from qfit.visualization.application.visual_apply_messages import (
     append_visual_apply_temporal_note,
     build_filtered_visual_apply_status,
+    build_visual_apply_status,
 )
 
 
@@ -31,6 +32,36 @@ class VisualApplyMessagesTests(unittest.TestCase):
                 "",
             ),
             "Applied styling to the loaded qfit layers",
+        )
+
+    def test_build_visual_apply_status_for_filtered_apply(self):
+        self.assertEqual(
+            build_visual_apply_status(True, True, 42, False, False),
+            "Applied filters and styling (42 matching activities)",
+        )
+
+    def test_build_visual_apply_status_for_styled_background_loaded(self):
+        self.assertEqual(
+            build_visual_apply_status(True, False, 0, True, True),
+            "Applied styling and loaded the background map below the qfit activity layers",
+        )
+
+    def test_build_visual_apply_status_for_styled_only(self):
+        self.assertEqual(
+            build_visual_apply_status(True, False, 0, False, False),
+            "Applied styling to the loaded qfit layers",
+        )
+
+    def test_build_visual_apply_status_for_background_only(self):
+        self.assertEqual(
+            build_visual_apply_status(False, False, 0, True, True),
+            "Background map loaded below the qfit activity layers",
+        )
+
+    def test_build_visual_apply_status_for_background_cleared(self):
+        self.assertEqual(
+            build_visual_apply_status(False, False, 0, False, False),
+            "Background map cleared",
         )
 
 

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -49,6 +49,7 @@ from .temporal_config import (
 from .visual_apply_messages import (
     append_visual_apply_temporal_note,
     build_filtered_visual_apply_status,
+    build_visual_apply_status,
 )
 from .visual_apply import (
     ApplyVisualizationRequest,
@@ -69,6 +70,7 @@ __all__ = [
     "build_background_map_loaded_status",
     "append_visual_apply_temporal_note",
     "build_filtered_visual_apply_status",
+    "build_visual_apply_status",
     "build_styled_background_map_failure_status",
     "build_styled_background_map_loaded_status",
     "build_styled_visual_apply_status",

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -5,18 +5,15 @@ from ...activities.application.activity_selection_state import ActivitySelection
 from ...activities.domain.activity_query import ActivityQuery
 from ...mapbox_config import MapboxConfigError
 from .background_map_messages import (
-    build_background_map_cleared_status,
     build_background_map_failure_status,
-    build_background_map_loaded_status,
     build_styled_background_map_failure_status,
-    build_styled_background_map_loaded_status,
-    build_styled_visual_apply_status,
 )
 from .layer_gateway import LayerGateway
 from .render_plan import build_render_plan
 from .visual_apply_messages import (
     append_visual_apply_temporal_note,
     build_filtered_visual_apply_status,
+    build_visual_apply_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -248,15 +245,12 @@ class VisualApplyService:
         background_layer,
         temporal_note,
     ):
-        if apply_subset_filters and has_layers:
-            status = build_filtered_visual_apply_status(filtered_count)
-        elif has_layers and wants_background and background_layer is not None:
-            status = build_styled_background_map_loaded_status()
-        elif has_layers:
-            status = build_styled_visual_apply_status()
-        elif wants_background and background_layer is not None:
-            status = build_background_map_loaded_status()
-        else:
-            status = build_background_map_cleared_status()
+        status = build_visual_apply_status(
+            has_layers=has_layers,
+            apply_subset_filters=apply_subset_filters,
+            filtered_count=filtered_count,
+            wants_background=wants_background,
+            background_loaded=background_layer is not None,
+        )
 
         return append_visual_apply_temporal_note(status, temporal_note)

--- a/visualization/application/visual_apply_messages.py
+++ b/visualization/application/visual_apply_messages.py
@@ -1,10 +1,35 @@
 from __future__ import annotations
 
+from .background_map_messages import (
+    build_background_map_cleared_status,
+    build_background_map_loaded_status,
+    build_styled_background_map_loaded_status,
+    build_styled_visual_apply_status,
+)
+
 
 def build_filtered_visual_apply_status(filtered_count: int) -> str:
     return "Applied filters and styling ({count} matching activities)".format(
         count=filtered_count
     )
+
+
+def build_visual_apply_status(
+    has_layers: bool,
+    apply_subset_filters: bool,
+    filtered_count: int,
+    wants_background: bool,
+    background_loaded: bool,
+) -> str:
+    if apply_subset_filters and has_layers:
+        return build_filtered_visual_apply_status(filtered_count)
+    if has_layers and wants_background and background_loaded:
+        return build_styled_background_map_loaded_status()
+    if has_layers:
+        return build_styled_visual_apply_status()
+    if wants_background and background_loaded:
+        return build_background_map_loaded_status()
+    return build_background_map_cleared_status()
 
 
 def append_visual_apply_temporal_note(status: str, temporal_note: str) -> str:


### PR DESCRIPTION
## Summary
- move `VisualApplyService` success-status selection policy into visualization application-owned helpers
- keep visual apply orchestration unchanged while preserving current visible behavior
- add focused helper and service-path coverage for the extracted policy

## Testing
- python3 -m pytest tests/test_visual_apply_messages.py tests/test_visual_apply.py tests/test_qgis_smoke.py -q --tb=short -k build_visual_apply_status
