### PR TITLE
refactor: retire temporal service root shim

### DIFF
--- a/temporal_service.py
+++ b/temporal_service.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the visualization temporal service.
-
-Prefer importing from ``qfit.visualization.infrastructure.temporal_service``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .visualization.infrastructure.temporal_service import TemporalService
-
-__all__ = ["TemporalService"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -328,7 +328,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "settings_service.py",
         "sync_controller.py",
         "sync_repository.py",
-        "temporal_service.py",
         "time_utils.py",
         "ui_settings_binding.py",
         "visual_apply.py",

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -218,7 +218,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
             "qfit.layer_style_service",
             "qfit.map_canvas_service",
             "qfit.project_layer_loader",
-            "qfit.temporal_service",
             "qfit.visualization.infrastructure",
             "qfit.visualization.infrastructure.background_map_service",
             "qfit.visualization.infrastructure.layer_filter_service",
@@ -341,11 +340,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
                 "qfit.visualization.infrastructure.project_layer_loader",
                 "ProjectLayerLoader",
                 project_layer_loader,
-            ),
-            "qfit.temporal_service": class_module(
-                "qfit.temporal_service",
-                "TemporalService",
-                temporal_service,
             ),
             "qfit.visualization.infrastructure.temporal_service": class_module(
                 "qfit.visualization.infrastructure.temporal_service",


### PR DESCRIPTION
## Summary
- retire the dead root `temporal_service.py` compatibility shim
- keep temporal service ownership under `visualization/infrastructure/temporal_service.py`
- update legacy test scaffolding and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_temporal_service.py tests/test_layer_gateway.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #429
