### PR TITLE
refactor: retire layer style service root shim

### DIFF
--- a/layer_style_service.py
+++ b/layer_style_service.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the visualization layer-style service.
-
-Prefer importing from ``qfit.visualization.infrastructure.layer_style_service``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .visualization.infrastructure.layer_style_service import LayerStyleService
-
-__all__ = ["LayerStyleService"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -312,7 +312,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "gpkg_writer.py",
         "layer_filter_service.py",
         "layer_manager.py",
-        "layer_style_service.py",
         "load_workflow.py",
         "map_canvas_service.py",
         "map_style.py",

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -215,7 +215,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
             "qfit.background_map_service",
             "qfit.layer_manager",
             "qfit.layer_filter_service",
-            "qfit.layer_style_service",
             "qfit.map_canvas_service",
             "qfit.project_layer_loader",
             "qfit.visualization.infrastructure",
@@ -319,11 +318,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
                 "qfit.visualization.infrastructure.layer_filter_service",
                 "LayerFilterService",
                 filter_service,
-            ),
-            "qfit.layer_style_service": class_module(
-                "qfit.layer_style_service",
-                "LayerStyleService",
-                style_service,
             ),
             "qfit.visualization.infrastructure.layer_style_service": class_module(
                 "qfit.visualization.infrastructure.layer_style_service",


### PR DESCRIPTION
## Summary
- retire the dead root `layer_style_service.py` compatibility shim
- keep layer-style ownership under `visualization/infrastructure/layer_style_service.py`
- update legacy test scaffolding and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_layer_gateway.py tests/test_architecture_boundaries.py tests/test_layer_style_service.py -q --tb=short`

Closes #431
