### PR TITLE
refactor: retire background map service root shim

### DIFF
--- a/background_map_service.py
+++ b/background_map_service.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the visualization background-map service.
-
-Prefer importing from ``qfit.visualization.infrastructure.background_map_service``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .visualization.infrastructure.background_map_service import BackgroundMapService
-
-__all__ = ["BackgroundMapService"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -295,7 +295,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "activity_classification.py",
         "activity_query.py",
         "activity_storage.py",
-        "background_map_service.py",
         "config_connection_service.py",
         "config_status.py",
         "credential_store.py",

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -37,20 +37,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
 
         self.assertIs(layer_manager_module.LayerManager, adapter_module.QgisLayerGateway)
 
-    def test_background_map_service_legacy_import_shares_same_class(self):
-        modules = self._qgis_gateway_modules()
-
-        with patch.dict(sys.modules, modules, clear=False):
-            self._reset_qgis_gateway_imports()
-            sys.modules.pop("qfit.background_map_service", None)
-            sys.modules.pop("qfit.visualization.infrastructure.background_map_service", None)
-            adapter_module = importlib.import_module(
-                "qfit.visualization.infrastructure.background_map_service"
-            )
-            legacy_module = importlib.import_module("qfit.background_map_service")
-
-        self.assertIs(legacy_module.BackgroundMapService, adapter_module.BackgroundMapService)
-
     def test_qgis_gateway_satisfies_protocol_and_delegates_to_services(self):
         modules = self._qgis_gateway_modules()
 
@@ -212,7 +198,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
     @staticmethod
     def _reset_qgis_gateway_imports():
         for name in [
-            "qfit.background_map_service",
             "qfit.layer_manager",
             "qfit.layer_filter_service",
             "qfit.map_canvas_service",


### PR DESCRIPTION
## Summary
- retire the dead root `background_map_service.py` compatibility shim
- keep background-map service ownership under `visualization/infrastructure/background_map_service.py`
- update legacy test scaffolding and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_background_map_service.py tests/test_layer_gateway.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #433
