### PR TITLE
refactor: retire layer filter service root shim

### DIFF
--- a/layer_filter_service.py
+++ b/layer_filter_service.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the visualization layer-filter service.
-
-Prefer importing from ``qfit.visualization.infrastructure.layer_filter_service``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .visualization.infrastructure.layer_filter_service import LayerFilterService
-
-__all__ = ["LayerFilterService"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -309,7 +309,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "gpkg_schema.py",
         "gpkg_write_orchestration.py",
         "gpkg_writer.py",
-        "layer_filter_service.py",
         "layer_manager.py",
         "load_workflow.py",
         "map_canvas_service.py",

--- a/tests/test_layer_filter_service.py
+++ b/tests/test_layer_filter_service.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 from tests import _path  # noqa: F401
 
 from qfit.activities.domain.activity_query import ActivityQuery, build_subset_string
-from qfit.layer_filter_service import LayerFilterService as LegacyLayerFilterService
 from qfit.visualization.infrastructure.layer_filter_service import LayerFilterService
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -36,9 +35,6 @@ SKIP_REAL = f"QGIS not available: {QGIS_IMPORT_ERROR}" if not QGIS_AVAILABLE els
 class LayerFilterServiceTests(unittest.TestCase):
     def setUp(self):
         self.service = LayerFilterService()
-
-    def test_root_shim_exports_visualization_layer_filter_service(self):
-        self.assertIs(LegacyLayerFilterService, LayerFilterService)
 
     def test_apply_filters_sets_subset_string_and_repaints(self):
         layer = MagicMock()

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -199,7 +199,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
     def _reset_qgis_gateway_imports():
         for name in [
             "qfit.layer_manager",
-            "qfit.layer_filter_service",
             "qfit.map_canvas_service",
             "qfit.project_layer_loader",
             "qfit.visualization.infrastructure",
@@ -293,11 +292,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
                 "qfit.visualization.infrastructure.background_map_service",
                 "BackgroundMapService",
                 background_service,
-            ),
-            "qfit.layer_filter_service": class_module(
-                "qfit.layer_filter_service",
-                "LayerFilterService",
-                filter_service,
             ),
             "qfit.visualization.infrastructure.layer_filter_service": class_module(
                 "qfit.visualization.infrastructure.layer_filter_service",


### PR DESCRIPTION
## Summary
- retire the dead root `layer_filter_service.py` compatibility shim
- keep layer-filter ownership under `visualization/infrastructure/layer_filter_service.py`
- update legacy tests and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_layer_filter_service.py tests/test_layer_gateway.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #435
