### PR TITLE
refactor: retire map canvas service root shim

### DIFF
--- a/map_canvas_service.py
+++ b/map_canvas_service.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the visualization map-canvas service.
-
-Prefer importing from ``qfit.visualization.infrastructure.map_canvas_service``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .visualization.infrastructure.map_canvas_service import MapCanvasService, WORKING_CRS
-
-__all__ = ["MapCanvasService", "WORKING_CRS"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -311,7 +311,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "gpkg_writer.py",
         "layer_manager.py",
         "load_workflow.py",
-        "map_canvas_service.py",
         "map_style.py",
         "mapbox_config.py",
         "models.py",

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -199,7 +199,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
     def _reset_qgis_gateway_imports():
         for name in [
             "qfit.layer_manager",
-            "qfit.map_canvas_service",
             "qfit.project_layer_loader",
             "qfit.visualization.infrastructure",
             "qfit.visualization.infrastructure.background_map_service",

--- a/tests/test_map_canvas_service.py
+++ b/tests/test_map_canvas_service.py
@@ -17,7 +17,6 @@ except ValueError:
     )
 
 try:
-    from qfit.map_canvas_service import MapCanvasService as LegacyMapCanvasService
     from qfit.visualization.infrastructure.map_canvas_service import (
         MapCanvasService,
         WORKING_CRS,
@@ -26,7 +25,6 @@ try:
     QGIS_AVAILABLE = True
     QGIS_IMPORT_ERROR = None
 except Exception as exc:  # pragma: no cover
-    LegacyMapCanvasService = None
     MapCanvasService = None
     QGIS_AVAILABLE = False
     QGIS_IMPORT_ERROR = exc
@@ -119,9 +117,6 @@ def _make_layer(extent_vals=None, valid=True):
 @unittest.skipUnless(QGIS_AVAILABLE, SKIP_REAL)
 class MapCanvasServiceRealTests(unittest.TestCase):
     """Tests that run when real QGIS bindings are available."""
-
-    def test_root_shim_exports_visualization_map_canvas_service(self):
-        self.assertIs(LegacyMapCanvasService, MapCanvasService)
 
     def setUp(self):
         self._bg = MagicMock()


### PR DESCRIPTION
## Summary
- retire the dead root `map_canvas_service.py` compatibility shim
- keep map-canvas ownership under `visualization/infrastructure/map_canvas_service.py`
- update legacy tests and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_map_canvas_service.py tests/test_layer_gateway.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #437
