### PR TITLE
refactor: retire fetch result service root shim

### DIFF
--- a/fetch_result_service.py
+++ b/fetch_result_service.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for fetch result workflow objects.
-
-Prefer importing from ``qfit.activities.application.fetch_result_service``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .activities.application.fetch_result_service import FetchActivitiesRequest, FetchResult, FetchResultService
-
-__all__ = ["FetchActivitiesRequest", "FetchResult", "FetchResultService"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -299,7 +299,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "config_status.py",
         "credential_store.py",
         "detailed_route_strategy.py",
-        "fetch_result_service.py",
         "fetch_task.py",
         "gpkg_atlas_page_builder.py",
         "gpkg_atlas_table_builders.py",

--- a/tests/test_fetch_result_service.py
+++ b/tests/test_fetch_result_service.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
 
-from qfit.fetch_result_service import FetchActivitiesRequest, FetchResult, FetchResultService
+from qfit.activities.application.fetch_result_service import (
+    FetchActivitiesRequest,
+    FetchResult,
+    FetchResultService,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -6,7 +6,7 @@ from ..analysis.application.analysis_controller import AnalysisController
 from ..atlas.export_controller import AtlasExportController
 from ..atlas.export_service import AtlasExportService
 from ..atlas.export_use_case import AtlasExportUseCase
-from ..fetch_result_service import FetchResultService
+from ..activities.application.fetch_result_service import FetchResultService
 from ..load_workflow import LoadWorkflowService
 from ..qfit_cache import QfitCache
 from ..configuration.application.settings_service import SettingsService


### PR DESCRIPTION
## Summary
- retire the dead root `fetch_result_service.py` compatibility shim
- keep fetch-result ownership under `activities/application/fetch_result_service.py`
- update tests and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_fetch_result_service.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #439
