### PR TITLE
refactor: retire project layer loader root shim

### DIFF
--- a/project_layer_loader.py
+++ b/project_layer_loader.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the visualization project-layer loader.
-
-Prefer importing from ``qfit.visualization.infrastructure.project_layer_loader``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .visualization.infrastructure.project_layer_loader import ProjectLayerLoader
-
-__all__ = ["ProjectLayerLoader"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -314,7 +314,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "mapbox_config.py",
         "models.py",
         "polyline_utils.py",
-        "project_layer_loader.py",
         "qfit_cache.py",
         "qfit_config_dialog.py",
         "qfit_dockwidget.py",

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -199,7 +199,6 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
     def _reset_qgis_gateway_imports():
         for name in [
             "qfit.layer_manager",
-            "qfit.project_layer_loader",
             "qfit.visualization.infrastructure",
             "qfit.visualization.infrastructure.background_map_service",
             "qfit.visualization.infrastructure.layer_filter_service",

--- a/tests/test_project_layer_loader.py
+++ b/tests/test_project_layer_loader.py
@@ -17,13 +17,11 @@ except ValueError:
     )
 
 try:
-    from qfit.project_layer_loader import ProjectLayerLoader as LegacyProjectLayerLoader
     from qfit.visualization.infrastructure.project_layer_loader import ProjectLayerLoader
 
     QGIS_AVAILABLE = True
     QGIS_IMPORT_ERROR = None
 except Exception as exc:  # pragma: no cover
-    LegacyProjectLayerLoader = None
     ProjectLayerLoader = None
     QGIS_AVAILABLE = False
     QGIS_IMPORT_ERROR = exc
@@ -76,9 +74,6 @@ SKIP_MOCK_LOAD = (
 
 @unittest.skipUnless(QGIS_AVAILABLE, SKIP_REAL)
 class ProjectLayerLoaderRealTests(unittest.TestCase):
-    def test_root_shim_exports_visualization_project_layer_loader(self):
-        self.assertIs(LegacyProjectLayerLoader, ProjectLayerLoader)
-
     def test_load_output_layers_uses_current_and_legacy_activity_names(self):
         loader = ProjectLayerLoader()
 


### PR DESCRIPTION
## Summary
- retire the dead root `project_layer_loader.py` compatibility shim
- keep project-layer loading ownership under `visualization/infrastructure/project_layer_loader.py`
- update tests and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_project_layer_loader.py tests/test_layer_gateway.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #441
