### PR TITLE
refactor: retire config status root shim

### DIFF
--- a/config_status.py
+++ b/config_status.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for qfit configuration status helpers.
-
-Prefer importing from ``qfit.configuration.application.config_status``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .configuration.application.config_status import mapbox_status_text, strava_status_text
-
-__all__ = ["mapbox_status_text", "strava_status_text"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -295,7 +295,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "activity_classification.py",
         "activity_query.py",
         "activity_storage.py",
-        "config_status.py",
         "credential_store.py",
         "detailed_route_strategy.py",
         "fetch_task.py",

--- a/tests/test_config_dialog.py
+++ b/tests/test_config_dialog.py
@@ -2,7 +2,7 @@ import unittest
 
 from tests import _path  # noqa: F401
 
-from qfit.config_status import mapbox_status_text, strava_status_text
+from qfit.configuration.application.config_status import mapbox_status_text, strava_status_text
 from qfit.settings_service import SettingsService
 
 

--- a/tests/test_settings_port_usage.py
+++ b/tests/test_settings_port_usage.py
@@ -2,7 +2,7 @@ import unittest
 
 from tests import _path  # noqa: F401
 
-from qfit.config_status import mapbox_status_text, strava_status_text
+from qfit.configuration.application.config_status import mapbox_status_text, strava_status_text
 from qfit.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
 
 


### PR DESCRIPTION
## Summary
- retire the dead root `config_status.py` compatibility shim
- keep config-status helper ownership under `configuration/application/config_status.py`
- update tests and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_config_dialog.py tests/test_settings_port_usage.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #447
