### PR TITLE
refactor: retire fetch task root shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See `docs/architecture.md` for the contributor-facing boundary rules and placeme
 - `atlas_export_controller.py` — atlas export orchestration extracted from the dock widget
 - `visualization/application/background_map_controller.py` — background map wiring and basemap orchestration
 - `ui/contextual_help.py` — reusable contextual help entries for dock widget controls
-- `fetch_task.py` — QgsTask wrapper for background Strava fetching
+- `activities/application/fetch_task.py` — QgsTask wrapper for background Strava fetching
 - `activities/application/load_workflow.py` / `visualization/application/visual_apply.py` / `atlas/export_service.py` — workflow services with explicit request/result dataclasses to keep dock-widget calls structured during the architecture migration
 - `load_workflow.py` / `visual_apply.py` — compatibility import shims for migrated workflow modules
 - `settings_port.py` — small application-facing settings access contract

--- a/fetch_task.py
+++ b/fetch_task.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the background fetch task.
-
-Prefer importing from ``qfit.activities.application.fetch_task``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .activities.application.fetch_task import FetchTask
-
-__all__ = ["FetchTask"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -296,7 +296,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "activity_query.py",
         "activity_storage.py",
         "detailed_route_strategy.py",
-        "fetch_task.py",
         "gpkg_atlas_page_builder.py",
         "gpkg_atlas_table_builders.py",
         "gpkg_io.py",


### PR DESCRIPTION
## Summary
- retire the dead root `fetch_task.py` compatibility shim
- keep fetch-task ownership under `activities/application/fetch_task.py`
- update architecture guardrails and README path references that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_fetch_task.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #451
