### PR TITLE
refactor: retire settings port root shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See `docs/architecture.md` for the contributor-facing boundary rules and placeme
 - `activities/application/fetch_task.py` — QgsTask wrapper for background Strava fetching
 - `activities/application/load_workflow.py` / `visualization/application/visual_apply.py` / `atlas/export_service.py` — workflow services with explicit request/result dataclasses to keep dock-widget calls structured during the architecture migration
 - `visual_apply.py` — compatibility import shim for the migrated visualization workflow module
-- `settings_port.py` — small application-facing settings access contract
+- `configuration/application/settings_port.py` — small application-facing settings access contract
 - `configuration/application/settings_service.py` — QGIS-backed settings adapter implementing that contract
 - `activities/application/sync_controller.py` — fetch/sync orchestration bridging the dock widget and Strava client
 - `scripts/install_plugin.py` — install qfit into a local QGIS profile for testing

--- a/configuration/application/settings_service.py
+++ b/configuration/application/settings_service.py
@@ -15,7 +15,7 @@ LEGACY_SETTINGS_PREFIX = "QFIT"
 
 
 class QgisSettingsAdapter(SettingsPort):
-    """QGIS-backed implementation of the :class:`~qfit.settings_port.SettingsPort`.
+    """QGIS-backed implementation of the :class:`~qfit.configuration.application.settings_port.SettingsPort`.
 
     Sensitive keys (see :data:`~qfit.configuration.infrastructure.credential_store.SENSITIVE_KEYS`) are
     routed through a :class:`~qfit.configuration.infrastructure.credential_store.CredentialStore` so they

--- a/settings_port.py
+++ b/settings_port.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for qfit configuration settings protocol.
-
-Prefer importing from ``qfit.configuration.application.settings_port``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .configuration.application.settings_port import SettingsPort
-
-__all__ = ["SettingsPort"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -186,7 +186,7 @@ class WorkflowBoundaryTests(unittest.TestCase):
 class PortBoundaryTests(unittest.TestCase):
     PORT_MODULES = [
         "atlas/export_runtime.py",
-        "settings_port.py",
+        "configuration/application/settings_port.py",
         "visualization/application/layer_gateway.py",
     ]
 
@@ -312,7 +312,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "qfit_config_dialog.py",
         "qfit_dockwidget.py",
         "qfit_plugin.py",
-        "settings_port.py",
         "sync_repository.py",
         "time_utils.py",
         "ui_settings_binding.py",

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
 from qfit.configuration.infrastructure.credential_store import InMemoryCredentialStore, NullCredentialStore
-from qfit.settings_port import SettingsPort
+from qfit.configuration.application.settings_port import SettingsPort
 from qfit.configuration.application.settings_service import QgisSettingsAdapter, SettingsService
 
 


### PR DESCRIPTION
## Summary
- retire the dead root `settings_port.py` compatibility shim
- keep settings-port ownership under `configuration/application/settings_port.py`
- update tests, architecture guardrails, README references, and the settings-service docstring that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_settings_service.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #459
