### PR TITLE
refactor: retire ui settings binding root shim

### DIFF
--- a/configuration/application/ui_settings_binding.py
+++ b/configuration/application/ui_settings_binding.py
@@ -7,7 +7,7 @@ widget → key pairs independently.
 
 Usage example::
 
-    from qfit.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
+    from qfit.configuration.application.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
 
     bindings = [
         UIFieldBinding(

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -314,7 +314,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "qfit_plugin.py",
         "sync_repository.py",
         "time_utils.py",
-        "ui_settings_binding.py",
         "visual_apply.py",
     }
 

--- a/tests/test_settings_port_usage.py
+++ b/tests/test_settings_port_usage.py
@@ -3,7 +3,7 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.configuration.application.config_status import mapbox_status_text, strava_status_text
-from qfit.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
+from qfit.configuration.application.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
 
 
 class FakeSettingsPort:

--- a/tests/test_ui_settings_binding.py
+++ b/tests/test_ui_settings_binding.py
@@ -4,7 +4,7 @@ from tests import _path  # noqa: F401
 
 from qfit.configuration.infrastructure.credential_store import InMemoryCredentialStore
 from qfit.configuration.application.settings_service import SettingsService
-from qfit.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
+from qfit.configuration.application.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
 
 
 class FakeQSettings:

--- a/ui_settings_binding.py
+++ b/ui_settings_binding.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for qfit UI/settings binding helpers.
-
-Prefer importing from ``qfit.configuration.application.ui_settings_binding``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .configuration.application.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
-
-__all__ = ["UIFieldBinding", "load_bindings", "save_bindings"]


### PR DESCRIPTION
## Summary
- retire the dead root `ui_settings_binding.py` compatibility shim
- keep ui-settings binding ownership under `configuration/application/ui_settings_binding.py`
- update tests, architecture guardrails, and the application module doc example that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_ui_settings_binding.py tests/test_settings_port_usage.py tests/test_architecture_boundaries.py -q --tb=short`

Closes #461
