### PR TITLE
refactor: retire gpkg io root shim

### DIFF
--- a/gpkg_io.py
+++ b/gpkg_io.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for qfit GeoPackage I/O helpers.
-
-Prefer importing from ``qfit.activities.infrastructure.geopackage.gpkg_io``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .activities.infrastructure.geopackage.gpkg_io import write_layer_to_gpkg
-
-__all__ = ["write_layer_to_gpkg"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -298,7 +298,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "detailed_route_strategy.py",
         "gpkg_atlas_page_builder.py",
         "gpkg_atlas_table_builders.py",
-        "gpkg_io.py",
         "gpkg_layer_builders.py",
         "gpkg_point_layer_builder.py",
         "gpkg_schema.py",

--- a/tests/test_gpkg_geopackage_pure.py
+++ b/tests/test_gpkg_geopackage_pure.py
@@ -107,10 +107,7 @@ class GpkgGeopackagePureTests(unittest.TestCase):
             self.assertIs(legacy_module.make_qgs_fields, schema_module.make_qgs_fields)
 
     def test_gpkg_io_module_handles_success_and_error_paths(self):
-        module_names = [
-            "qfit.activities.infrastructure.geopackage.gpkg_io",
-            "qfit.gpkg_io",
-        ]
+        module_names = ["qfit.activities.infrastructure.geopackage.gpkg_io"]
         qgis_stubs = self._install_qgis_stubs()
         qgis_core = qgis_stubs["qgis.core"]
         project_instance = SimpleNamespace(transformContext=lambda: "project-context")
@@ -125,8 +122,6 @@ class GpkgGeopackagePureTests(unittest.TestCase):
                 sys.modules.pop(name, None)
 
             module = importlib.import_module("qfit.activities.infrastructure.geopackage.gpkg_io")
-            legacy_module = importlib.import_module("qfit.gpkg_io")
-
             _StubVectorFileWriter.write_result = (_StubVectorFileWriter.NoError, "", "")
             module.write_layer_to_gpkg("layer", "/tmp/out.gpkg", "activity_tracks", True)
             self.assertEqual(
@@ -134,7 +129,6 @@ class GpkgGeopackagePureTests(unittest.TestCase):
                 _StubVectorFileWriter.CreateOrOverwriteFile,
             )
             self.assertEqual(_StubVectorFileWriter.last_call["transform_context"], "project-context")
-            self.assertIs(legacy_module.write_layer_to_gpkg, module.write_layer_to_gpkg)
 
             module.QgsProject = type(
                 "QgsProject",

--- a/tests/test_gpkg_io.py
+++ b/tests/test_gpkg_io.py
@@ -13,7 +13,6 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover
 
 if QgsApplication is not None:
     from qfit.activities.infrastructure.geopackage.gpkg_io import write_layer_to_gpkg
-    from qfit.gpkg_io import write_layer_to_gpkg as legacy_write_layer_to_gpkg
     from qfit.activities.infrastructure.geopackage.gpkg_layer_builders import (
         build_start_layer,
         build_track_layer,
@@ -37,9 +36,6 @@ def _ensure_qgis_app():
 
 @unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
 class WriteLayerToGpkgTests(unittest.TestCase):
-    def test_legacy_gpkg_io_shim_exports_same_writer(self):
-        self.assertIs(legacy_write_layer_to_gpkg, write_layer_to_gpkg)
-
     @classmethod
     def setUpClass(cls):
         _ensure_qgis_app()


### PR DESCRIPTION
## Summary
- retire the dead root `gpkg_io.py` compatibility shim
- keep GeoPackage I/O ownership under `activities/infrastructure/geopackage/gpkg_io.py`
- update tests and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_gpkg_io.py tests/test_gpkg_geopackage_pure.py tests/test_architecture_boundaries.py -q --tb=short -k "gpkg_io or architecture_boundaries"`

Closes #465
