### PR TITLE
refactor: retire gpkg point layer builder root shim

### DIFF
--- a/gpkg_point_layer_builder.py
+++ b/gpkg_point_layer_builder.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for qfit GeoPackage point-layer builders.
-
-Prefer importing from ``qfit.activities.infrastructure.geopackage.gpkg_point_layer_builder``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .activities.infrastructure.geopackage.gpkg_point_layer_builder import build_point_layer
-
-__all__ = ["build_point_layer"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -299,7 +299,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "gpkg_atlas_page_builder.py",
         "gpkg_atlas_table_builders.py",
         "gpkg_layer_builders.py",
-        "gpkg_point_layer_builder.py",
         "gpkg_write_orchestration.py",
         "gpkg_writer.py",
         "layer_manager.py",

--- a/tests/test_gpkg_builder_modules_pure.py
+++ b/tests/test_gpkg_builder_modules_pure.py
@@ -217,7 +217,6 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
                 "qfit.activities.infrastructure.geopackage.gpkg_point_layer_builder",
                 "qfit.activities.infrastructure.geopackage.gpkg_layer_builders",
                 "qfit.gpkg_atlas_table_builders",
-                "qfit.gpkg_point_layer_builder",
                 "qfit.gpkg_layer_builders",
             ]:
                 sys.modules.pop(name, None)
@@ -231,19 +230,17 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
                 "qfit.activities.infrastructure.geopackage.gpkg_layer_builders"
             )
             legacy_atlas_tables = importlib.import_module("qfit.gpkg_atlas_table_builders")
-            legacy_point_builder = importlib.import_module("qfit.gpkg_point_layer_builder")
             legacy_layer_builders = importlib.import_module("qfit.gpkg_layer_builders")
         return (
             atlas_tables,
             point_builder,
             layer_builders,
             legacy_atlas_tables,
-            legacy_point_builder,
             legacy_layer_builders,
         )
 
     def test_moved_atlas_table_builders_work_without_real_qgis(self):
-        atlas_tables, _, _, legacy_atlas_tables, _, _ = self._import_with_stubs()
+        atlas_tables, _, _, legacy_atlas_tables, _ = self._import_with_stubs()
 
         summary_layer = atlas_tables.build_document_summary_layer(records=[{"id": 1}])
         highlight_layer = atlas_tables.build_cover_highlight_layer(records=[{"id": 1}])
@@ -262,7 +259,7 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
         )
 
     def test_moved_point_layer_builder_works_without_real_qgis(self):
-        _, point_builder, _, _, legacy_point_builder, _ = self._import_with_stubs()
+        _, point_builder, _, _, _ = self._import_with_stubs()
 
         layer = point_builder.build_point_layer(
             [
@@ -298,10 +295,9 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
         self.assertEqual(len(features), 1)
         self.assertEqual(features[0]["source_activity_id"], "42")
         self.assertEqual(features[0].geometry, ("point", 7.0, 46.0))
-        self.assertIs(legacy_point_builder.build_point_layer, point_builder.build_point_layer)
 
     def test_moved_point_layer_builder_falls_back_to_summary_polyline_without_real_qgis(self):
-        _, point_builder, _, _, _, _ = self._import_with_stubs()
+        _, point_builder, _, _, _ = self._import_with_stubs()
 
         layer = point_builder.build_point_layer(
             [
@@ -322,7 +318,7 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
         self.assertIsNone(features[0]["stream_time_s"])
 
     def test_moved_point_layer_builder_falls_back_to_start_end_without_real_qgis(self):
-        _, point_builder, _, _, _, _ = self._import_with_stubs()
+        _, point_builder, _, _, _ = self._import_with_stubs()
 
         layer = point_builder.build_point_layer(
             [
@@ -346,7 +342,7 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
         self.assertEqual(features[-1]["point_index"], 1)
 
     def test_moved_point_layer_builder_skips_records_without_geometry_without_real_qgis(self):
-        _, point_builder, _, _, _, _ = self._import_with_stubs()
+        _, point_builder, _, _, _ = self._import_with_stubs()
 
         layer = point_builder.build_point_layer(
             [
@@ -367,7 +363,7 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
         self.assertEqual(layer.featureCount(), 0)
 
     def test_moved_layer_builders_work_without_real_qgis(self):
-        _, _, layer_builders, _, _, legacy_layer_builders = self._import_with_stubs()
+        _, _, layer_builders, _, legacy_layer_builders = self._import_with_stubs()
 
         records = [
             {

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -232,10 +232,6 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 "qfit.activities.infrastructure.geopackage.gpkg_point_layer_builder",
                 build_point_layer=build_point_layer,
             ),
-            "qfit.gpkg_point_layer_builder": self._module(
-                "qfit.gpkg_point_layer_builder",
-                build_point_layer=build_point_layer,
-            ),
             "qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder": self._module(
                 "qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder",
                 build_atlas_layer=build_atlas_layer,

--- a/tests/test_gpkg_point_layer_builder.py
+++ b/tests/test_gpkg_point_layer_builder.py
@@ -28,7 +28,6 @@ if QgsApplication is not None and _REAL_QGIS_PRESENT:
         _stream_metrics,
         build_point_layer,
     )
-    from qfit.gpkg_point_layer_builder import build_point_layer as legacy_build_point_layer
 else:  # pragma: no cover
     _activity_point_sequence = None
     _metric_value = None
@@ -89,20 +88,6 @@ def _ensure_qgis_app():
         _QGIS_APP = QgsApplication([], False)
         _QGIS_APP.initQgis()
     return _QGIS_APP
-
-
-@unittest.skipIf(not _REAL_QGIS_PRESENT, "QGIS Python bindings are not available")
-class GpkgPointLayerBuilderShimTests(unittest.TestCase):
-    def test_legacy_gpkg_point_layer_builder_shim_exports_same_function(self):
-        global legacy_build_point_layer
-
-        _ensure_qgis_app()
-        if "legacy_build_point_layer" not in globals():
-            from qfit.gpkg_point_layer_builder import (
-                build_point_layer as legacy_build_point_layer,
-            )
-
-        self.assertIs(legacy_build_point_layer, build_point_layer)
 
 
 class SamplePointsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- retire the dead root `gpkg_point_layer_builder.py` compatibility shim
- keep GeoPackage point-layer builder ownership under `activities/infrastructure/geopackage/gpkg_point_layer_builder.py`
- update tests and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_gpkg_point_layer_builder.py tests/test_gpkg_builder_modules_pure.py tests/test_gpkg_geopackage_unit.py tests/test_architecture_boundaries.py -q --tb=short -k "gpkg_point_layer_builder or gpkg_builder_modules or gpkg_geopackage_unit or architecture_boundaries"`

Closes #469
