### PR TITLE
refactor: retire gpkg atlas page builder root shim

### DIFF
--- a/gpkg_atlas_page_builder.py
+++ b/gpkg_atlas_page_builder.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for qfit GeoPackage atlas page builders.
-
-Prefer importing from ``qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .activities.infrastructure.geopackage.gpkg_atlas_page_builder import build_atlas_layer
-
-__all__ = ["build_atlas_layer"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -296,7 +296,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "activity_query.py",
         "activity_storage.py",
         "detailed_route_strategy.py",
-        "gpkg_atlas_page_builder.py",
         "gpkg_atlas_table_builders.py",
         "gpkg_layer_builders.py",
         "gpkg_write_orchestration.py",

--- a/tests/test_gpkg_atlas_page_builder.py
+++ b/tests/test_gpkg_atlas_page_builder.py
@@ -23,7 +23,6 @@ if QgsApplication is not None:
     from qfit.atlas.export_task import _build_cover_summary_from_current_atlas_features
     from qfit.atlas.publish_atlas import normalize_atlas_page_settings
     from qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder import build_atlas_layer
-    from qfit.gpkg_atlas_page_builder import build_atlas_layer as legacy_build_atlas_layer
 else:  # pragma: no cover
     _build_cover_summary_from_current_atlas_features = None
     normalize_atlas_page_settings = None
@@ -52,20 +51,6 @@ def _ensure_qgis_app():
         _QGIS_APP = QgsApplication([], False)
         _QGIS_APP.initQgis()
     return _QGIS_APP
-
-
-@unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
-class AtlasPageLayerBuilderShimTests(unittest.TestCase):
-    def test_legacy_gpkg_atlas_page_builder_shim_exports_same_function(self):
-        global legacy_build_atlas_layer
-
-        _ensure_qgis_app()
-        if "legacy_build_atlas_layer" not in globals():
-            from qfit.gpkg_atlas_page_builder import (
-                build_atlas_layer as legacy_build_atlas_layer,
-            )
-
-        self.assertIs(legacy_build_atlas_layer, build_atlas_layer)
 
 
 @unittest.skipIf(not _REAL_QGIS_PRESENT, "QGIS Python bindings are not available")

--- a/tests/test_gpkg_atlas_page_builder_pure.py
+++ b/tests/test_gpkg_atlas_page_builder_pure.py
@@ -177,11 +177,12 @@ class BuildAtlasLayerPureTests(unittest.TestCase):
         }
 
         with patch.dict(sys.modules, module_overrides):
-            sys.modules.pop("qfit.gpkg_atlas_page_builder", None)
             sys.modules.pop("qfit.gpkg_layer_builders", None)
             sys.modules.pop("qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder", None)
             sys.modules.pop("qfit.activities.infrastructure.geopackage.gpkg_layer_builders", None)
-            atlas_page_builder = importlib.import_module("qfit.gpkg_atlas_page_builder")
+            atlas_page_builder = importlib.import_module(
+                "qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder"
+            )
             layer_builders = importlib.import_module("qfit.gpkg_layer_builders")
 
         return atlas_page_builder, layer_builders, publish_atlas_stub

--- a/tests/test_gpkg_builder_modules_pure.py
+++ b/tests/test_gpkg_builder_modules_pure.py
@@ -209,7 +209,6 @@ class GpkgBuilderModulesPureTests(unittest.TestCase):
             "qfit.activities.infrastructure.geopackage.gpkg_layer_builders": _fake_layer_builders_module(),
             "qfit.polyline_utils": _fake_polyline_utils_module(),
             "qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder": _fake_atlas_page_builder_module(),
-            "qfit.gpkg_atlas_page_builder": _fake_atlas_page_builder_module(),
         }
         with patch.dict(sys.modules, module_overrides):
             for name in [

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -236,10 +236,6 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 "qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder",
                 build_atlas_layer=build_atlas_layer,
             ),
-            "qfit.gpkg_atlas_page_builder": self._module(
-                "qfit.gpkg_atlas_page_builder",
-                build_atlas_layer=build_atlas_layer,
-            ),
             "qfit.activities.infrastructure.geopackage.gpkg_atlas_table_builders": self._module(
                 "qfit.activities.infrastructure.geopackage.gpkg_atlas_table_builders",
                 build_cover_highlight_layer=build_cover_highlight_layer,

--- a/tests/test_gpkg_writer.py
+++ b/tests/test_gpkg_writer.py
@@ -11,7 +11,7 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover - exercised only 
     QgsApplication = None
 
 if QgsApplication is not None:
-    from qfit.gpkg_atlas_page_builder import build_atlas_layer
+    from qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder import build_atlas_layer
     from qfit.gpkg_atlas_table_builders import (
         build_cover_highlight_layer,
         build_document_summary_layer,


### PR DESCRIPTION
## Summary
- retire the dead root `gpkg_atlas_page_builder.py` compatibility shim
- keep GeoPackage atlas-page builder ownership under `activities/infrastructure/geopackage/gpkg_atlas_page_builder.py`
- update tests and architecture guardrails that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_gpkg_atlas_page_builder.py tests/test_gpkg_atlas_page_builder_pure.py tests/test_gpkg_builder_modules_pure.py tests/test_gpkg_geopackage_unit.py tests/test_gpkg_writer.py tests/test_architecture_boundaries.py -q --tb=short -k "gpkg_atlas_page_builder or gpkg_builder_modules or gpkg_geopackage_unit or gpkg_writer or architecture_boundaries"`

Closes #471
