### PR TITLE
refactor: retire gpkg writer root shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See `docs/architecture.md` for the contributor-facing boundary rules and placeme
 - `time_utils.py` — ISO timestamp parsing / offset helpers
 - `activity_storage.py` — small activity storage port plus the GeoPackage-backed adapter
 - `sync_repository.py` — GeoPackage registry persistence and sync metadata upserts
-- `gpkg_writer.py` — derived GeoPackage layer rebuilds via QGIS APIs, depending on the storage port/adapter seam
+- `activities/infrastructure/geopackage/gpkg_writer.py` — derived GeoPackage layer rebuilds via QGIS APIs, depending on the storage port/adapter seam
 - `layer_manager.py` — layer loading, filtering, styling, and background-map wiring
 - `visualization/map_style.py` — semantic activity-color mapping and basemap-aware line-style rules
 - `mapbox_config.py` — background-map preset resolution and Mapbox XYZ URL helpers

--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -2,7 +2,7 @@
 GeoPackage bootstrap and layer-write sequencing for qfit.
 
 This module owns the two write-orchestration steps that were previously
-inlined in :class:`~qfit.gpkg_writer.GeoPackageWriter`:
+inlined in :class:`~qfit.activities.infrastructure.geopackage.gpkg_writer.GeoPackageWriter`:
 
 - :func:`bootstrap_empty_gpkg` — create a fresh GeoPackage with empty layers
   in the canonical order.

--- a/gpkg_writer.py
+++ b/gpkg_writer.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for qfit GeoPackage writer helpers.
-
-Prefer importing from ``qfit.activities.infrastructure.geopackage.gpkg_writer``.
-This module remains as a stable forwarding import during the package move.
-"""
-
-from .activities.infrastructure.geopackage.gpkg_writer import GeoPackageWriter
-
-__all__ = ["GeoPackageWriter"]

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -296,7 +296,6 @@ class PackageOwnershipBoundaryTests(unittest.TestCase):
         "activity_query.py",
         "activity_storage.py",
         "detailed_route_strategy.py",
-        "gpkg_writer.py",
         "layer_manager.py",
         "mapbox_config.py",
         "models.py",

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -40,14 +40,10 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
 
         with patch.dict(sys.modules, module_overrides):
             sys.modules.pop("qfit.activities.infrastructure.geopackage.gpkg_writer", None)
-            sys.modules.pop("qfit.gpkg_writer", None)
 
             moved = importlib.import_module(
                 "qfit.activities.infrastructure.geopackage.gpkg_writer"
             )
-            legacy = importlib.import_module("qfit.gpkg_writer")
-
-            self.assertIs(legacy.GeoPackageWriter, moved.GeoPackageWriter)
 
             activity_store = MagicMock()
             activity_store.upsert_activities.return_value = {"added": 1}

--- a/tests/test_gpkg_writer.py
+++ b/tests/test_gpkg_writer.py
@@ -20,7 +20,6 @@ if QgsApplication is not None:
         build_toc_layer,
     )
     from qfit.activities.infrastructure.geopackage.gpkg_writer import GeoPackageWriter
-    from qfit.gpkg_writer import GeoPackageWriter as LegacyGeoPackageWriter
 else:  # pragma: no cover - exercised only on non-QGIS runners
     build_atlas_layer = None
     build_cover_highlight_layer = None
@@ -44,9 +43,6 @@ def _ensure_qgis_app():
 
 @unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
 class GeoPackageWriterAtlasTests(unittest.TestCase):
-    def test_legacy_gpkg_writer_shim_exports_same_writer(self):
-        self.assertIs(LegacyGeoPackageWriter, GeoPackageWriter)
-
     @classmethod
     def setUpClass(cls):
         _ensure_qgis_app()

--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -38,7 +38,7 @@ try:
         QgsSingleSymbolRenderer,
     )
 
-    from qfit.gpkg_writer import GeoPackageWriter
+    from qfit.activities.infrastructure.geopackage.gpkg_writer import GeoPackageWriter
     from qfit.layer_manager import LayerManager
     from qfit.visualization.infrastructure.layer_style_service import LayerStyleService
 

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -48,7 +48,7 @@ try:
     )
     from qfit.atlas.profile_item import build_profile_item_adapter
     from qfit.configuration.infrastructure.credential_store import InMemoryCredentialStore
-    from qfit.gpkg_writer import GeoPackageWriter
+    from qfit.activities.infrastructure.geopackage.gpkg_writer import GeoPackageWriter
     from qfit.layer_manager import LayerManager
     from qfit.mapbox_config import TILE_MODE_RASTER
     from qfit.activities.domain.models import Activity
@@ -1648,7 +1648,7 @@ class QgisSmokeTests(unittest.TestCase):
                 build_atlas_layout,
             )
             from qfit.atlas.profile_item import build_profile_item_adapter
-            from qfit.gpkg_writer import GeoPackageWriter
+            from qfit.activities.infrastructure.geopackage.gpkg_writer import GeoPackageWriter
             from qfit.layer_manager import LayerManager
 
             class _FakeCanvas:


### PR DESCRIPTION
## Summary
- retire the dead root `gpkg_writer.py` compatibility shim
- keep GeoPackage writer ownership under `activities/infrastructure/geopackage/gpkg_writer.py`
- update tests, architecture guardrails, and doc references that still mentioned the root path

## Testing
- `python3 -m pytest tests/test_gpkg_writer.py tests/test_layer_style_service.py tests/test_gpkg_geopackage_unit.py tests/test_architecture_boundaries.py -q --tb=short -k "gpkg_writer or layer_style_service or gpkg_geopackage_unit or architecture_boundaries"`
- `python3 -m py_compile tests/test_qgis_smoke.py activities/infrastructure/geopackage/gpkg_write_orchestration.py tests/test_gpkg_writer.py tests/test_layer_style_service.py tests/test_gpkg_geopackage_unit.py tests/test_architecture_boundaries.py`

## Notes
- a broader `tests/test_qgis_smoke.py` slice hit the known host-side QGIS segfault path during class setup, so I validated the updated smoke file by compile-check and relied on the stable focused test set above.

Closes #479
