### PR TITLE
refactor: extract visual workflow action builder

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -72,6 +72,7 @@ from .ui.application import (
     ApplyVisualizationAction,
     DockActionDispatcher,
     RunAnalysisAction,
+    build_visual_workflow_action,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import (
@@ -762,29 +763,23 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(result.status)
 
     def _build_visual_workflow_action(self, action_type):
-        selection_state = self._current_activity_selection_state()
-
-        return action_type(
-            layers=LayerRefs(
-                activities=self.activities_layer,
-                starts=self.starts_layer,
-                points=self.points_layer,
-                atlas=self.atlas_layer,
-            ),
-            selection_state=selection_state,
+        return build_visual_workflow_action(
+            action_type,
+            activities_layer=self.activities_layer,
+            starts_layer=self.starts_layer,
+            points_layer=self.points_layer,
+            atlas_layer=self.atlas_layer,
+            selection_state=self._current_activity_selection_state(),
             style_preset=self.stylePresetComboBox.currentText(),
             temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
-            background_config=BackgroundConfig(
-                enabled=self.backgroundMapCheckBox.isChecked(),
-                preset_name=self.backgroundPresetComboBox.currentText(),
-                access_token=self._mapbox_access_token(),
-                style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
-                style_id=self.mapboxStyleIdLineEdit.text().strip(),
-                tile_mode=self.tileModeComboBox.currentText(),
-            ),
-            apply_subset_filters=True,
+            background_enabled=self.backgroundMapCheckBox.isChecked(),
+            background_preset_name=self.backgroundPresetComboBox.currentText(),
+            access_token=self._mapbox_access_token(),
+            style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+            style_id=self.mapboxStyleIdLineEdit.text().strip(),
+            tile_mode=self.tileModeComboBox.currentText(),
             analysis_mode=self.analysisModeComboBox.currentText(),
-            starts_layer=self.starts_layer,
+            apply_subset_filters=True,
         )
 
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -72,6 +72,7 @@ from .ui.application import (
     ApplyVisualizationAction,
     DockActionDispatcher,
     RunAnalysisAction,
+    VisualWorkflowActionInputs,
     build_visual_workflow_action,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
@@ -765,21 +766,27 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _build_visual_workflow_action(self, action_type):
         return build_visual_workflow_action(
             action_type,
-            activities_layer=self.activities_layer,
-            starts_layer=self.starts_layer,
-            points_layer=self.points_layer,
-            atlas_layer=self.atlas_layer,
-            selection_state=self._current_activity_selection_state(),
-            style_preset=self.stylePresetComboBox.currentText(),
-            temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
-            background_enabled=self.backgroundMapCheckBox.isChecked(),
-            background_preset_name=self.backgroundPresetComboBox.currentText(),
-            access_token=self._mapbox_access_token(),
-            style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
-            style_id=self.mapboxStyleIdLineEdit.text().strip(),
-            tile_mode=self.tileModeComboBox.currentText(),
-            analysis_mode=self.analysisModeComboBox.currentText(),
-            apply_subset_filters=True,
+            VisualWorkflowActionInputs(
+                layers=LayerRefs(
+                    activities=self.activities_layer,
+                    starts=self.starts_layer,
+                    points=self.points_layer,
+                    atlas=self.atlas_layer,
+                ),
+                selection_state=self._current_activity_selection_state(),
+                style_preset=self.stylePresetComboBox.currentText(),
+                temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
+                background_config=BackgroundConfig(
+                    enabled=self.backgroundMapCheckBox.isChecked(),
+                    preset_name=self.backgroundPresetComboBox.currentText(),
+                    access_token=self._mapbox_access_token(),
+                    style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+                    style_id=self.mapboxStyleIdLineEdit.text().strip(),
+                    tile_mode=self.tileModeComboBox.currentText(),
+                ),
+                analysis_mode=self.analysisModeComboBox.currentText(),
+                apply_subset_filters=True,
+            ),
         )
 
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -471,21 +471,35 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.tileModeComboBox = _FakeComboBox(current_text="Raster")
         dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")
 
-        action = self.module.QfitDockWidget._build_visual_workflow_action(
-            dock,
-            self.module.ApplyVisualizationAction,
-        )
+        with patch.object(
+            self.module,
+            "build_visual_workflow_action",
+            return_value="action",
+        ) as build_action:
+            action = self.module.QfitDockWidget._build_visual_workflow_action(
+                dock,
+                self.module.ApplyVisualizationAction,
+            )
 
-        self.assertIsInstance(action, self.module.ApplyVisualizationAction)
-        self.assertEqual(action.layers.activities, "activities")
-        self.assertEqual(action.layers.starts, "starts")
-        self.assertIs(action.selection_state, selection_state)
-        self.assertIs(action.query, selection_state.query)
-        self.assertEqual(action.filtered_count, 3)
-        self.assertEqual(action.analysis_mode, "Most frequent starting points")
-        self.assertEqual(action.temporal_mode, self.module.DEFAULT_TEMPORAL_MODE_LABEL)
-        self.assertEqual(action.background_config.access_token, "token")
-        self.assertEqual(action.background_config.tile_mode, "Raster")
+        self.assertEqual(action, "action")
+        build_action.assert_called_once_with(
+            self.module.ApplyVisualizationAction,
+            activities_layer="activities",
+            starts_layer="starts",
+            points_layer="points",
+            atlas_layer="atlas",
+            selection_state=selection_state,
+            style_preset="By activity type",
+            temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
+            background_enabled=True,
+            background_preset_name="Outdoors",
+            access_token="token",
+            style_owner="mapbox",
+            style_id="style-id",
+            tile_mode="Raster",
+            analysis_mode="Most frequent starting points",
+            apply_subset_filters=True,
+        )
 
     def test_run_selected_analysis_delegates_to_analysis_controller(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -484,21 +484,27 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(action, "action")
         build_action.assert_called_once_with(
             self.module.ApplyVisualizationAction,
-            activities_layer="activities",
-            starts_layer="starts",
-            points_layer="points",
-            atlas_layer="atlas",
-            selection_state=selection_state,
-            style_preset="By activity type",
-            temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
-            background_enabled=True,
-            background_preset_name="Outdoors",
-            access_token="token",
-            style_owner="mapbox",
-            style_id="style-id",
-            tile_mode="Raster",
-            analysis_mode="Most frequent starting points",
-            apply_subset_filters=True,
+            self.module.VisualWorkflowActionInputs(
+                layers=self.module.LayerRefs(
+                    activities="activities",
+                    starts="starts",
+                    points="points",
+                    atlas="atlas",
+                ),
+                selection_state=selection_state,
+                style_preset="By activity type",
+                temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
+                background_config=self.module.BackgroundConfig(
+                    enabled=True,
+                    preset_name="Outdoors",
+                    access_token="token",
+                    style_owner="mapbox",
+                    style_id="style-id",
+                    tile_mode="Raster",
+                ),
+                analysis_mode="Most frequent starting points",
+                apply_subset_filters=True,
+            ),
         )
 
     def test_run_selected_analysis_delegates_to_analysis_controller(self):

--- a/tests/test_visual_workflow_action_builder.py
+++ b/tests/test_visual_workflow_action_builder.py
@@ -6,8 +6,10 @@ from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.ui.application import (
     ApplyVisualizationAction,
     RunAnalysisAction,
+    VisualWorkflowActionInputs,
     build_visual_workflow_action,
 )
+from qfit.visualization.application import BackgroundConfig, LayerRefs
 
 
 class TestVisualWorkflowActionBuilder(unittest.TestCase):
@@ -16,20 +18,26 @@ class TestVisualWorkflowActionBuilder(unittest.TestCase):
 
         action = build_visual_workflow_action(
             ApplyVisualizationAction,
-            activities_layer="activities",
-            starts_layer="starts",
-            points_layer="points",
-            atlas_layer="atlas",
-            selection_state=selection_state,
-            style_preset="By activity type",
-            temporal_mode="Off",
-            background_enabled=True,
-            background_preset_name="Outdoors",
-            access_token="token",
-            style_owner="mapbox",
-            style_id="style-id",
-            tile_mode="Raster",
-            analysis_mode="Most frequent starting points",
+            VisualWorkflowActionInputs(
+                layers=LayerRefs(
+                    activities="activities",
+                    starts="starts",
+                    points="points",
+                    atlas="atlas",
+                ),
+                selection_state=selection_state,
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_config=BackgroundConfig(
+                    enabled=True,
+                    preset_name="Outdoors",
+                    access_token="token",
+                    style_owner="mapbox",
+                    style_id="style-id",
+                    tile_mode="Raster",
+                ),
+                analysis_mode="Most frequent starting points",
+            ),
         )
 
         self.assertIsInstance(action, ApplyVisualizationAction)
@@ -50,21 +58,15 @@ class TestVisualWorkflowActionBuilder(unittest.TestCase):
 
         action = build_visual_workflow_action(
             RunAnalysisAction,
-            activities_layer=None,
-            starts_layer="starts",
-            points_layer=None,
-            atlas_layer=None,
-            selection_state=selection_state,
-            style_preset="Heatmap",
-            temporal_mode="By month",
-            background_enabled=False,
-            background_preset_name="",
-            access_token="",
-            style_owner="",
-            style_id="",
-            tile_mode="Raster",
-            analysis_mode="Heatmap",
-            apply_subset_filters=False,
+            VisualWorkflowActionInputs(
+                layers=LayerRefs(starts="starts"),
+                selection_state=selection_state,
+                style_preset="Heatmap",
+                temporal_mode="By month",
+                background_config=BackgroundConfig(tile_mode="Raster"),
+                analysis_mode="Heatmap",
+                apply_subset_filters=False,
+            ),
         )
 
         self.assertIsInstance(action, RunAnalysisAction)
@@ -76,23 +78,17 @@ class TestVisualWorkflowActionBuilder(unittest.TestCase):
         with self.assertRaises(TypeError):
             build_visual_workflow_action(
                 object,
-                activities_layer=None,
-                starts_layer=None,
-                points_layer=None,
-                atlas_layer=None,
-                selection_state=ActivitySelectionState(
-                    query=ActivityQuery(),
-                    filtered_count=0,
+                VisualWorkflowActionInputs(
+                    layers=LayerRefs(),
+                    selection_state=ActivitySelectionState(
+                        query=ActivityQuery(),
+                        filtered_count=0,
+                    ),
+                    style_preset="By activity type",
+                    temporal_mode="Off",
+                    background_config=BackgroundConfig(tile_mode="Raster"),
+                    analysis_mode="None",
                 ),
-                style_preset="By activity type",
-                temporal_mode="Off",
-                background_enabled=False,
-                background_preset_name="",
-                access_token="",
-                style_owner="",
-                style_id="",
-                tile_mode="Raster",
-                analysis_mode="None",
             )
 
 

--- a/tests/test_visual_workflow_action_builder.py
+++ b/tests/test_visual_workflow_action_builder.py
@@ -1,0 +1,100 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
+from qfit.ui.application import (
+    ApplyVisualizationAction,
+    RunAnalysisAction,
+    build_visual_workflow_action,
+)
+
+
+class TestVisualWorkflowActionBuilder(unittest.TestCase):
+    def test_builds_apply_visualization_action(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=3)
+
+        action = build_visual_workflow_action(
+            ApplyVisualizationAction,
+            activities_layer="activities",
+            starts_layer="starts",
+            points_layer="points",
+            atlas_layer="atlas",
+            selection_state=selection_state,
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_enabled=True,
+            background_preset_name="Outdoors",
+            access_token="token",
+            style_owner="mapbox",
+            style_id="style-id",
+            tile_mode="Raster",
+            analysis_mode="Most frequent starting points",
+        )
+
+        self.assertIsInstance(action, ApplyVisualizationAction)
+        self.assertEqual(action.layers.activities, "activities")
+        self.assertEqual(action.layers.starts, "starts")
+        self.assertEqual(action.layers.points, "points")
+        self.assertEqual(action.layers.atlas, "atlas")
+        self.assertIs(action.selection_state, selection_state)
+        self.assertEqual(action.style_preset, "By activity type")
+        self.assertEqual(action.temporal_mode, "Off")
+        self.assertTrue(action.background_config.enabled)
+        self.assertEqual(action.background_config.access_token, "token")
+        self.assertEqual(action.analysis_mode, "Most frequent starting points")
+        self.assertEqual(action.filtered_count, 3)
+
+    def test_builds_run_analysis_action(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=1)
+
+        action = build_visual_workflow_action(
+            RunAnalysisAction,
+            activities_layer=None,
+            starts_layer="starts",
+            points_layer=None,
+            atlas_layer=None,
+            selection_state=selection_state,
+            style_preset="Heatmap",
+            temporal_mode="By month",
+            background_enabled=False,
+            background_preset_name="",
+            access_token="",
+            style_owner="",
+            style_id="",
+            tile_mode="Raster",
+            analysis_mode="Heatmap",
+            apply_subset_filters=False,
+        )
+
+        self.assertIsInstance(action, RunAnalysisAction)
+        self.assertFalse(action.apply_subset_filters)
+        self.assertEqual(action.starts_layer, "starts")
+        self.assertFalse(action.background_config.enabled)
+
+    def test_rejects_unsupported_action_types(self):
+        with self.assertRaises(TypeError):
+            build_visual_workflow_action(
+                object,
+                activities_layer=None,
+                starts_layer=None,
+                points_layer=None,
+                atlas_layer=None,
+                selection_state=ActivitySelectionState(
+                    query=ActivityQuery(),
+                    filtered_count=0,
+                ),
+                style_preset="By activity type",
+                temporal_mode="Off",
+                background_enabled=False,
+                background_preset_name="",
+                access_token="",
+                style_owner="",
+                style_id="",
+                tile_mode="Raster",
+                analysis_mode="None",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -7,11 +7,13 @@ from .dock_action_dispatcher import (
     RunAnalysisAction,
 )
 from .visual_workflow_action_builder import build_visual_workflow_action
+from .visual_workflow_action_builder import VisualWorkflowActionInputs
 
 __all__ = [
     "ApplyVisualizationAction",
     "DockActionDispatcher",
     "DockActionResult",
     "RunAnalysisAction",
+    "VisualWorkflowActionInputs",
     "build_visual_workflow_action",
 ]

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -6,10 +6,12 @@ from .dock_action_dispatcher import (
     DockActionResult,
     RunAnalysisAction,
 )
+from .visual_workflow_action_builder import build_visual_workflow_action
 
 __all__ = [
     "ApplyVisualizationAction",
     "DockActionDispatcher",
     "DockActionResult",
     "RunAnalysisAction",
+    "build_visual_workflow_action",
 ]

--- a/ui/application/visual_workflow_action_builder.py
+++ b/ui/application/visual_workflow_action_builder.py
@@ -1,0 +1,50 @@
+from .dock_action_dispatcher import ApplyVisualizationAction, RunAnalysisAction
+from ...visualization.application import BackgroundConfig, LayerRefs
+
+
+def build_visual_workflow_action(
+    action_type,
+    *,
+    activities_layer,
+    starts_layer,
+    points_layer,
+    atlas_layer,
+    selection_state,
+    style_preset,
+    temporal_mode,
+    background_enabled,
+    background_preset_name,
+    access_token,
+    style_owner,
+    style_id,
+    tile_mode,
+    analysis_mode,
+    apply_subset_filters=True,
+):
+    """Build a normalized visual workflow action from dock-edge inputs."""
+
+    if action_type not in (ApplyVisualizationAction, RunAnalysisAction):
+        raise TypeError(f"Unsupported visual workflow action type: {action_type!r}")
+
+    return action_type(
+        layers=LayerRefs(
+            activities=activities_layer,
+            starts=starts_layer,
+            points=points_layer,
+            atlas=atlas_layer,
+        ),
+        selection_state=selection_state,
+        style_preset=style_preset,
+        temporal_mode=temporal_mode,
+        background_config=BackgroundConfig(
+            enabled=background_enabled,
+            preset_name=background_preset_name,
+            access_token=access_token,
+            style_owner=style_owner,
+            style_id=style_id,
+            tile_mode=tile_mode,
+        ),
+        analysis_mode=analysis_mode,
+        starts_layer=starts_layer,
+        apply_subset_filters=apply_subset_filters,
+    )

--- a/ui/application/visual_workflow_action_builder.py
+++ b/ui/application/visual_workflow_action_builder.py
@@ -1,25 +1,23 @@
+from dataclasses import dataclass
+
 from .dock_action_dispatcher import ApplyVisualizationAction, RunAnalysisAction
 from ...visualization.application import BackgroundConfig, LayerRefs
 
 
+@dataclass(frozen=True)
+class VisualWorkflowActionInputs:
+    layers: LayerRefs
+    selection_state: object
+    style_preset: str
+    temporal_mode: str
+    background_config: BackgroundConfig
+    analysis_mode: str
+    apply_subset_filters: bool = True
+
+
 def build_visual_workflow_action(
     action_type,
-    *,
-    activities_layer,
-    starts_layer,
-    points_layer,
-    atlas_layer,
-    selection_state,
-    style_preset,
-    temporal_mode,
-    background_enabled,
-    background_preset_name,
-    access_token,
-    style_owner,
-    style_id,
-    tile_mode,
-    analysis_mode,
-    apply_subset_filters=True,
+    inputs: VisualWorkflowActionInputs,
 ):
     """Build a normalized visual workflow action from dock-edge inputs."""
 
@@ -27,24 +25,12 @@ def build_visual_workflow_action(
         raise TypeError(f"Unsupported visual workflow action type: {action_type!r}")
 
     return action_type(
-        layers=LayerRefs(
-            activities=activities_layer,
-            starts=starts_layer,
-            points=points_layer,
-            atlas=atlas_layer,
-        ),
-        selection_state=selection_state,
-        style_preset=style_preset,
-        temporal_mode=temporal_mode,
-        background_config=BackgroundConfig(
-            enabled=background_enabled,
-            preset_name=background_preset_name,
-            access_token=access_token,
-            style_owner=style_owner,
-            style_id=style_id,
-            tile_mode=tile_mode,
-        ),
-        analysis_mode=analysis_mode,
-        starts_layer=starts_layer,
-        apply_subset_filters=apply_subset_filters,
+        layers=inputs.layers,
+        selection_state=inputs.selection_state,
+        style_preset=inputs.style_preset,
+        temporal_mode=inputs.temporal_mode,
+        background_config=inputs.background_config,
+        analysis_mode=inputs.analysis_mode,
+        starts_layer=inputs.layers.starts,
+        apply_subset_filters=inputs.apply_subset_filters,
     )


### PR DESCRIPTION
## Summary
- extract normalized visual workflow action building into `ui/application/visual_workflow_action_builder.py`
- keep `QfitDockWidget` as the UI edge, but stop constructing the action inline
- add focused coverage for the new builder seam and the dock wrapper delegation

## Testing
- `python3 -m pytest tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dock_action_dispatcher.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py ui/application/__init__.py ui/application/visual_workflow_action_builder.py tests/test_visual_workflow_action_builder.py`

Closes #481
