### PR TITLE
refactor: extract analysis workflow request builder

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -34,12 +34,19 @@ class AnalysisController:
         activities_layer: object = None,
         points_layer: object = None,
     ) -> RunAnalysisRequest:
-        return RunAnalysisRequest(
-            analysis_mode=analysis_mode or "",
-            activities_layer=activities_layer,
-            starts_layer=starts_layer,
-            points_layer=points_layer,
-            selection_state=selection_state or ActivitySelectionState(),
+        from .analysis_request_builder import (
+            RunAnalysisRequestInputs,
+            build_run_analysis_request,
+        )
+
+        return build_run_analysis_request(
+            RunAnalysisRequestInputs(
+                analysis_mode=analysis_mode,
+                activities_layer=activities_layer,
+                starts_layer=starts_layer,
+                points_layer=points_layer,
+                selection_state=selection_state or ActivitySelectionState(),
+            )
         )
 
     def run(self, request: RunAnalysisRequest | None = None, **legacy_kwargs) -> RunAnalysisResult:

--- a/analysis/application/analysis_request_builder.py
+++ b/analysis/application/analysis_request_builder.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ...activities.application.activity_selection_state import ActivitySelectionState
+from .analysis_controller import RunAnalysisRequest
+
+
+@dataclass(frozen=True)
+class RunAnalysisRequestInputs:
+    analysis_mode: str = ""
+    activities_layer: object = None
+    starts_layer: object = None
+    points_layer: object = None
+    selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
+
+
+def build_run_analysis_request(inputs: RunAnalysisRequestInputs) -> RunAnalysisRequest:
+    """Build a normalized analysis request from dock-edge inputs."""
+
+    return RunAnalysisRequest(
+        analysis_mode=inputs.analysis_mode or "",
+        activities_layer=inputs.activities_layer,
+        starts_layer=inputs.starts_layer,
+        points_layer=inputs.points_layer,
+        selection_state=inputs.selection_state or ActivitySelectionState(),
+    )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -60,6 +60,10 @@ from .activities.application.store_task import build_store_task
 from .analysis.infrastructure.activity_heatmap_layer import (
     ACTIVITY_HEATMAP_LAYER_NAME,
 )
+from .analysis.application.analysis_request_builder import (
+    RunAnalysisRequestInputs,
+    build_run_analysis_request,
+)
 from .analysis.infrastructure.frequent_start_points_layer import (
     FREQUENT_STARTING_POINTS_LAYER_NAME,
 )
@@ -790,12 +794,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
 
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
-        request = self.analysis_controller.build_request(
-            analysis_mode=analysis_mode,
-            activities_layer=getattr(self, "activities_layer", None),
-            starts_layer=starts_layer,
-            points_layer=getattr(self, "points_layer", None),
-            selection_state=selection_state,
+        request = build_run_analysis_request(
+            RunAnalysisRequestInputs(
+                analysis_mode=analysis_mode,
+                activities_layer=getattr(self, "activities_layer", None),
+                starts_layer=starts_layer,
+                points_layer=getattr(self, "points_layer", None),
+                selection_state=selection_state,
+            )
         )
         result = self.analysis_controller.run_request(request)
         if result.layer is None:

--- a/tests/test_analysis_request_builder.py
+++ b/tests/test_analysis_request_builder.py
@@ -1,0 +1,43 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
+from qfit.analysis.application.analysis_request_builder import (
+    RunAnalysisRequestInputs,
+    build_run_analysis_request,
+)
+
+
+class TestAnalysisRequestBuilder(unittest.TestCase):
+    def test_build_run_analysis_request_keeps_inputs(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
+
+        request = build_run_analysis_request(
+            RunAnalysisRequestInputs(
+                analysis_mode="Heatmap",
+                activities_layer="activities-layer",
+                starts_layer="starts-layer",
+                points_layer="points-layer",
+                selection_state=selection_state,
+            )
+        )
+
+        self.assertEqual(request.analysis_mode, "Heatmap")
+        self.assertEqual(request.activities_layer, "activities-layer")
+        self.assertEqual(request.starts_layer, "starts-layer")
+        self.assertEqual(request.points_layer, "points-layer")
+        self.assertIs(request.selection_state, selection_state)
+
+    def test_build_run_analysis_request_defaults_empty_values(self):
+        request = build_run_analysis_request(RunAnalysisRequestInputs())
+
+        self.assertEqual(request.analysis_mode, "")
+        self.assertIsNone(request.activities_layer)
+        self.assertIsNone(request.starts_layer)
+        self.assertIsNone(request.points_layer)
+        self.assertEqual(request.selection_state.filtered_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -510,7 +510,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
     def test_run_selected_analysis_delegates_to_analysis_controller(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysis_controller = MagicMock()
-        dock.analysis_controller.build_request.return_value = "analysis-request"
         dock.analysis_controller.run_request.return_value = SimpleNamespace(
             status="Showing top 2 frequent starting-point clusters",
             layer=None,
@@ -519,27 +518,33 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.points_layer = "points-layer"
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
-        result = self.module.QfitDockWidget._run_selected_analysis(
-            dock,
-            "Most frequent starting points",
-            "starts-layer",
-            selection_state,
-        )
+        with patch.object(
+            self.module,
+            "build_run_analysis_request",
+            return_value="analysis-request",
+        ) as build_request:
+            result = self.module.QfitDockWidget._run_selected_analysis(
+                dock,
+                "Most frequent starting points",
+                "starts-layer",
+                selection_state,
+            )
 
         self.assertEqual(result, "Showing top 2 frequent starting-point clusters")
-        dock.analysis_controller.build_request.assert_called_once_with(
-            analysis_mode="Most frequent starting points",
-            activities_layer="activities-layer",
-            starts_layer="starts-layer",
-            points_layer="points-layer",
-            selection_state=selection_state,
+        build_request.assert_called_once_with(
+            self.module.RunAnalysisRequestInputs(
+                analysis_mode="Most frequent starting points",
+                activities_layer="activities-layer",
+                starts_layer="starts-layer",
+                points_layer="points-layer",
+                selection_state=selection_state,
+            )
         )
         dock.analysis_controller.run_request.assert_called_once_with("analysis-request")
 
     def test_run_selected_analysis_adds_returned_layer_to_project(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysis_controller = MagicMock()
-        dock.analysis_controller.build_request.return_value = "analysis-request"
         analysis_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
         dock.analysis_controller.run_request.return_value = SimpleNamespace(
             status="Showing top 2 frequent starting-point clusters",
@@ -550,7 +555,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         project = _FakeProject()
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
-        with patch.object(self.module.QgsProject, "instance", return_value=project):
+        with patch.object(self.module, "build_run_analysis_request", return_value="analysis-request"), patch.object(
+            self.module.QgsProject, "instance", return_value=project
+        ):
             status = self.module.QfitDockWidget._run_selected_analysis(
                 dock,
                 "Most frequent starting points",


### PR DESCRIPTION
## Summary
- extract normalized analysis request building into `analysis/application/analysis_request_builder.py`
- point both `QfitDockWidget` and `AnalysisController.build_request()` at the shared builder seam
- add focused coverage for the new builder and the dock delegation path

## Testing
- `python3 -m pytest tests/test_analysis_request_builder.py tests/test_analysis_controller.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_builder.py analysis/application/analysis_controller.py qfit_dockwidget.py tests/test_analysis_request_builder.py`

Closes #483
