### PR TITLE
refactor: extract visual workflow inputs builder

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -76,8 +76,9 @@ from .ui.application import (
     ApplyVisualizationAction,
     DockActionDispatcher,
     RunAnalysisAction,
-    VisualWorkflowActionInputs,
+    VisualWorkflowBackgroundInputs,
     build_visual_workflow_action,
+    build_visual_workflow_action_inputs,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import (
@@ -91,7 +92,6 @@ from .mapbox_config import (
     preset_requires_custom_style,
 )
 from .visualization.application import (
-    BackgroundConfig,
     LayerRefs,
     build_background_map_failure_status,
     build_background_map_failure_title,
@@ -770,7 +770,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _build_visual_workflow_action(self, action_type):
         return build_visual_workflow_action(
             action_type,
-            VisualWorkflowActionInputs(
+            build_visual_workflow_action_inputs(
                 layers=LayerRefs(
                     activities=self.activities_layer,
                     starts=self.starts_layer,
@@ -780,7 +780,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 selection_state=self._current_activity_selection_state(),
                 style_preset=self.stylePresetComboBox.currentText(),
                 temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
-                background_config=BackgroundConfig(
+                background=VisualWorkflowBackgroundInputs(
                     enabled=self.backgroundMapCheckBox.isChecked(),
                     preset_name=self.backgroundPresetComboBox.currentText(),
                     access_token=self._mapbox_access_token(),

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -473,6 +473,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         with patch.object(
             self.module,
+            "build_visual_workflow_action_inputs",
+            return_value="inputs",
+        ) as build_inputs, patch.object(
+            self.module,
             "build_visual_workflow_action",
             return_value="action",
         ) as build_action:
@@ -482,30 +486,28 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             )
 
         self.assertEqual(action, "action")
-        build_action.assert_called_once_with(
-            self.module.ApplyVisualizationAction,
-            self.module.VisualWorkflowActionInputs(
-                layers=self.module.LayerRefs(
-                    activities="activities",
-                    starts="starts",
-                    points="points",
-                    atlas="atlas",
-                ),
-                selection_state=selection_state,
-                style_preset="By activity type",
-                temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
-                background_config=self.module.BackgroundConfig(
-                    enabled=True,
-                    preset_name="Outdoors",
-                    access_token="token",
-                    style_owner="mapbox",
-                    style_id="style-id",
-                    tile_mode="Raster",
-                ),
-                analysis_mode="Most frequent starting points",
-                apply_subset_filters=True,
+        build_inputs.assert_called_once_with(
+            layers=self.module.LayerRefs(
+                activities="activities",
+                starts="starts",
+                points="points",
+                atlas="atlas",
             ),
+            selection_state=selection_state,
+            style_preset="By activity type",
+            temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
+            background=self.module.VisualWorkflowBackgroundInputs(
+                enabled=True,
+                preset_name="Outdoors",
+                access_token="token",
+                style_owner="mapbox",
+                style_id="style-id",
+                tile_mode="Raster",
+            ),
+            analysis_mode="Most frequent starting points",
+            apply_subset_filters=True,
         )
+        build_action.assert_called_once_with(self.module.ApplyVisualizationAction, "inputs")
 
     def test_run_selected_analysis_delegates_to_analysis_controller(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -579,7 +579,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             selection_state=self.module.ActivitySelectionState(query=object(), filtered_count=1),
             style_preset="By activity type",
             temporal_mode="By month",
-            background_config=self.module.BackgroundConfig(),
+            background_config=SimpleNamespace(),
             analysis_mode="None",
             apply_subset_filters=True,
         )

--- a/tests/test_visual_workflow_action_builder.py
+++ b/tests/test_visual_workflow_action_builder.py
@@ -6,13 +6,46 @@ from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.ui.application import (
     ApplyVisualizationAction,
     RunAnalysisAction,
+    VisualWorkflowBackgroundInputs,
     VisualWorkflowActionInputs,
     build_visual_workflow_action,
+    build_visual_workflow_action_inputs,
 )
 from qfit.visualization.application import BackgroundConfig, LayerRefs
 
 
 class TestVisualWorkflowActionBuilder(unittest.TestCase):
+    def test_build_visual_workflow_action_inputs_builds_background_config(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=3)
+
+        inputs = build_visual_workflow_action_inputs(
+            layers=LayerRefs(
+                activities="activities",
+                starts="starts",
+                points="points",
+                atlas="atlas",
+            ),
+            selection_state=selection_state,
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background=VisualWorkflowBackgroundInputs(
+                enabled=True,
+                preset_name="Outdoors",
+                access_token="token",
+                style_owner="mapbox",
+                style_id="style-id",
+                tile_mode="Raster",
+            ),
+            analysis_mode="Most frequent starting points",
+        )
+
+        self.assertIsInstance(inputs, VisualWorkflowActionInputs)
+        self.assertEqual(inputs.layers.activities, "activities")
+        self.assertIs(inputs.selection_state, selection_state)
+        self.assertTrue(inputs.background_config.enabled)
+        self.assertEqual(inputs.background_config.preset_name, "Outdoors")
+        self.assertEqual(inputs.background_config.access_token, "token")
+
     def test_builds_apply_visualization_action(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=3)
 

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -7,13 +7,17 @@ from .dock_action_dispatcher import (
     RunAnalysisAction,
 )
 from .visual_workflow_action_builder import build_visual_workflow_action
+from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import VisualWorkflowActionInputs
+from .visual_workflow_action_builder import VisualWorkflowBackgroundInputs
 
 __all__ = [
     "ApplyVisualizationAction",
     "DockActionDispatcher",
     "DockActionResult",
     "RunAnalysisAction",
+    "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",
     "build_visual_workflow_action",
+    "build_visual_workflow_action_inputs",
 ]

--- a/ui/application/visual_workflow_action_builder.py
+++ b/ui/application/visual_workflow_action_builder.py
@@ -15,6 +15,46 @@ class VisualWorkflowActionInputs:
     apply_subset_filters: bool = True
 
 
+@dataclass(frozen=True)
+class VisualWorkflowBackgroundInputs:
+    enabled: bool = False
+    preset_name: str = ""
+    access_token: str = ""
+    style_owner: str = ""
+    style_id: str = ""
+    tile_mode: str = ""
+
+
+def build_visual_workflow_action_inputs(
+    *,
+    layers: LayerRefs,
+    selection_state,
+    style_preset: str,
+    temporal_mode: str,
+    background: VisualWorkflowBackgroundInputs,
+    analysis_mode: str,
+    apply_subset_filters: bool = True,
+) -> VisualWorkflowActionInputs:
+    """Build normalized visual workflow inputs from dock-edge values."""
+
+    return VisualWorkflowActionInputs(
+        layers=layers,
+        selection_state=selection_state,
+        style_preset=style_preset,
+        temporal_mode=temporal_mode,
+        background_config=BackgroundConfig(
+            enabled=background.enabled,
+            preset_name=background.preset_name,
+            access_token=background.access_token,
+            style_owner=background.style_owner,
+            style_id=background.style_id,
+            tile_mode=background.tile_mode,
+        ),
+        analysis_mode=analysis_mode,
+        apply_subset_filters=apply_subset_filters,
+    )
+
+
 def build_visual_workflow_action(
     action_type,
     inputs: VisualWorkflowActionInputs,


### PR DESCRIPTION
## Summary
- extract `VisualWorkflowActionInputs` construction into a focused helper in `ui/application/visual_workflow_action_builder.py`
- keep raw widget reads in `QfitDockWidget`, but stop assembling `BackgroundConfig` and the structured input object inline there
- add focused coverage for the new helper and the dock delegation path

## Testing
- `python3 -m pytest tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dock_action_dispatcher.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py ui/application/__init__.py ui/application/visual_workflow_action_builder.py tests/test_visual_workflow_action_builder.py`

Closes #485
