### PR TITLE
refactor: extract visual layer snapshot helper

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -77,6 +77,7 @@ from .ui.application import (
     DockActionDispatcher,
     RunAnalysisAction,
     VisualWorkflowBackgroundInputs,
+    build_visual_layer_refs,
     build_visual_workflow_action,
     build_visual_workflow_action_inputs,
 )
@@ -771,11 +772,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return build_visual_workflow_action(
             action_type,
             build_visual_workflow_action_inputs(
-                layers=LayerRefs(
-                    activities=self.activities_layer,
-                    starts=self.starts_layer,
-                    points=self.points_layer,
-                    atlas=self.atlas_layer,
+                layers=build_visual_layer_refs(
+                    activities_layer=self.activities_layer,
+                    starts_layer=self.starts_layer,
+                    points_layer=self.points_layer,
+                    atlas_layer=self.atlas_layer,
                 ),
                 selection_state=self._current_activity_selection_state(),
                 style_preset=self.stylePresetComboBox.currentText(),

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -473,6 +473,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         with patch.object(
             self.module,
+            "build_visual_layer_refs",
+            return_value="layers",
+        ) as build_layers, patch.object(
+            self.module,
             "build_visual_workflow_action_inputs",
             return_value="inputs",
         ) as build_inputs, patch.object(
@@ -486,13 +490,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             )
 
         self.assertEqual(action, "action")
+        build_layers.assert_called_once_with(
+            activities_layer="activities",
+            starts_layer="starts",
+            points_layer="points",
+            atlas_layer="atlas",
+        )
         build_inputs.assert_called_once_with(
-            layers=self.module.LayerRefs(
-                activities="activities",
-                starts="starts",
-                points="points",
-                atlas="atlas",
-            ),
+            layers="layers",
             selection_state=selection_state,
             style_preset="By activity type",
             temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,

--- a/tests/test_visual_workflow_action_builder.py
+++ b/tests/test_visual_workflow_action_builder.py
@@ -8,6 +8,7 @@ from qfit.ui.application import (
     RunAnalysisAction,
     VisualWorkflowBackgroundInputs,
     VisualWorkflowActionInputs,
+    build_visual_layer_refs,
     build_visual_workflow_action,
     build_visual_workflow_action_inputs,
 )
@@ -15,6 +16,20 @@ from qfit.visualization.application import BackgroundConfig, LayerRefs
 
 
 class TestVisualWorkflowActionBuilder(unittest.TestCase):
+    def test_build_visual_layer_refs_snapshots_all_layers(self):
+        layers = build_visual_layer_refs(
+            activities_layer="activities",
+            starts_layer="starts",
+            points_layer="points",
+            atlas_layer="atlas",
+        )
+
+        self.assertIsInstance(layers, LayerRefs)
+        self.assertEqual(layers.activities, "activities")
+        self.assertEqual(layers.starts, "starts")
+        self.assertEqual(layers.points, "points")
+        self.assertEqual(layers.atlas, "atlas")
+
     def test_build_visual_workflow_action_inputs_builds_background_config(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=3)
 

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -8,6 +8,7 @@ from .dock_action_dispatcher import (
 )
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
+from .visual_workflow_action_builder import build_visual_layer_refs
 from .visual_workflow_action_builder import VisualWorkflowActionInputs
 from .visual_workflow_action_builder import VisualWorkflowBackgroundInputs
 
@@ -18,6 +19,7 @@ __all__ = [
     "RunAnalysisAction",
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",
+    "build_visual_layer_refs",
     "build_visual_workflow_action",
     "build_visual_workflow_action_inputs",
 ]

--- a/ui/application/visual_workflow_action_builder.py
+++ b/ui/application/visual_workflow_action_builder.py
@@ -25,6 +25,23 @@ class VisualWorkflowBackgroundInputs:
     tile_mode: str = ""
 
 
+def build_visual_layer_refs(
+    *,
+    activities_layer=None,
+    starts_layer=None,
+    points_layer=None,
+    atlas_layer=None,
+) -> LayerRefs:
+    """Build a normalized snapshot of the current visual workflow layers."""
+
+    return LayerRefs(
+        activities=activities_layer,
+        starts=starts_layer,
+        points=points_layer,
+        atlas=atlas_layer,
+    )
+
+
 def build_visual_workflow_action_inputs(
     *,
     layers: LayerRefs,


### PR DESCRIPTION
## Summary
- extract `LayerRefs` snapshot building into a small helper in `ui/application/visual_workflow_action_builder.py`
- keep the dock as the UI edge, but stop assembling `LayerRefs(...)` inline in `_build_visual_workflow_action()`
- add focused coverage for the new helper and the dock delegation path

## Testing
- `python3 -m pytest tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dock_action_dispatcher.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py ui/application/__init__.py ui/application/visual_workflow_action_builder.py tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py`

Closes #487
