### PR TITLE
refactor: extract visual workflow settings snapshot

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -80,6 +80,7 @@ from .ui.application import (
     build_visual_layer_refs,
     build_visual_workflow_action,
     build_visual_workflow_action_inputs,
+    build_visual_workflow_settings_snapshot,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import (
@@ -779,8 +780,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     atlas_layer=self.atlas_layer,
                 ),
                 selection_state=self._current_activity_selection_state(),
-                style_preset=self.stylePresetComboBox.currentText(),
-                temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
+                settings=build_visual_workflow_settings_snapshot(
+                    style_preset=self.stylePresetComboBox.currentText(),
+                    temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
+                    analysis_mode=self.analysisModeComboBox.currentText(),
+                ),
                 background=VisualWorkflowBackgroundInputs(
                     enabled=self.backgroundMapCheckBox.isChecked(),
                     preset_name=self.backgroundPresetComboBox.currentText(),
@@ -789,7 +793,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     style_id=self.mapboxStyleIdLineEdit.text().strip(),
                     tile_mode=self.tileModeComboBox.currentText(),
                 ),
-                analysis_mode=self.analysisModeComboBox.currentText(),
                 apply_subset_filters=True,
             ),
         )

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -477,6 +477,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             return_value="layers",
         ) as build_layers, patch.object(
             self.module,
+            "build_visual_workflow_settings_snapshot",
+            return_value="settings",
+        ) as build_settings, patch.object(
+            self.module,
             "build_visual_workflow_action_inputs",
             return_value="inputs",
         ) as build_inputs, patch.object(
@@ -499,8 +503,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         build_inputs.assert_called_once_with(
             layers="layers",
             selection_state=selection_state,
-            style_preset="By activity type",
-            temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
+            settings="settings",
             background=self.module.VisualWorkflowBackgroundInputs(
                 enabled=True,
                 preset_name="Outdoors",
@@ -509,8 +512,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 style_id="style-id",
                 tile_mode="Raster",
             ),
-            analysis_mode="Most frequent starting points",
             apply_subset_filters=True,
+        )
+        build_settings.assert_called_once_with(
+            style_preset="By activity type",
+            temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
+            analysis_mode="Most frequent starting points",
         )
         build_action.assert_called_once_with(self.module.ApplyVisualizationAction, "inputs")
 

--- a/tests/test_visual_workflow_action_builder.py
+++ b/tests/test_visual_workflow_action_builder.py
@@ -8,14 +8,28 @@ from qfit.ui.application import (
     RunAnalysisAction,
     VisualWorkflowBackgroundInputs,
     VisualWorkflowActionInputs,
+    VisualWorkflowSettingsSnapshot,
     build_visual_layer_refs,
     build_visual_workflow_action,
     build_visual_workflow_action_inputs,
+    build_visual_workflow_settings_snapshot,
 )
 from qfit.visualization.application import BackgroundConfig, LayerRefs
 
 
 class TestVisualWorkflowActionBuilder(unittest.TestCase):
+    def test_build_visual_workflow_settings_snapshot_keeps_values(self):
+        settings = build_visual_workflow_settings_snapshot(
+            style_preset="By activity type",
+            temporal_mode="Off",
+            analysis_mode="Most frequent starting points",
+        )
+
+        self.assertIsInstance(settings, VisualWorkflowSettingsSnapshot)
+        self.assertEqual(settings.style_preset, "By activity type")
+        self.assertEqual(settings.temporal_mode, "Off")
+        self.assertEqual(settings.analysis_mode, "Most frequent starting points")
+
     def test_build_visual_layer_refs_snapshots_all_layers(self):
         layers = build_visual_layer_refs(
             activities_layer="activities",
@@ -41,8 +55,11 @@ class TestVisualWorkflowActionBuilder(unittest.TestCase):
                 atlas="atlas",
             ),
             selection_state=selection_state,
-            style_preset="By activity type",
-            temporal_mode="Off",
+            settings=VisualWorkflowSettingsSnapshot(
+                style_preset="By activity type",
+                temporal_mode="Off",
+                analysis_mode="Most frequent starting points",
+            ),
             background=VisualWorkflowBackgroundInputs(
                 enabled=True,
                 preset_name="Outdoors",
@@ -51,7 +68,6 @@ class TestVisualWorkflowActionBuilder(unittest.TestCase):
                 style_id="style-id",
                 tile_mode="Raster",
             ),
-            analysis_mode="Most frequent starting points",
         )
 
         self.assertIsInstance(inputs, VisualWorkflowActionInputs)
@@ -60,6 +76,7 @@ class TestVisualWorkflowActionBuilder(unittest.TestCase):
         self.assertTrue(inputs.background_config.enabled)
         self.assertEqual(inputs.background_config.preset_name, "Outdoors")
         self.assertEqual(inputs.background_config.access_token, "token")
+        self.assertEqual(inputs.analysis_mode, "Most frequent starting points")
 
     def test_builds_apply_visualization_action(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=3)

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -11,6 +11,8 @@ from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_layer_refs
 from .visual_workflow_action_builder import VisualWorkflowActionInputs
 from .visual_workflow_action_builder import VisualWorkflowBackgroundInputs
+from .visual_workflow_action_builder import VisualWorkflowSettingsSnapshot
+from .visual_workflow_action_builder import build_visual_workflow_settings_snapshot
 
 __all__ = [
     "ApplyVisualizationAction",
@@ -19,7 +21,9 @@ __all__ = [
     "RunAnalysisAction",
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",
+    "VisualWorkflowSettingsSnapshot",
     "build_visual_layer_refs",
     "build_visual_workflow_action",
     "build_visual_workflow_action_inputs",
+    "build_visual_workflow_settings_snapshot",
 ]

--- a/ui/application/visual_workflow_action_builder.py
+++ b/ui/application/visual_workflow_action_builder.py
@@ -25,6 +25,13 @@ class VisualWorkflowBackgroundInputs:
     tile_mode: str = ""
 
 
+@dataclass(frozen=True)
+class VisualWorkflowSettingsSnapshot:
+    style_preset: str = ""
+    temporal_mode: str = ""
+    analysis_mode: str = ""
+
+
 def build_visual_layer_refs(
     *,
     activities_layer=None,
@@ -42,14 +49,27 @@ def build_visual_layer_refs(
     )
 
 
+def build_visual_workflow_settings_snapshot(
+    *,
+    style_preset: str,
+    temporal_mode: str,
+    analysis_mode: str,
+) -> VisualWorkflowSettingsSnapshot:
+    """Build a normalized snapshot of the current visual workflow settings."""
+
+    return VisualWorkflowSettingsSnapshot(
+        style_preset=style_preset,
+        temporal_mode=temporal_mode,
+        analysis_mode=analysis_mode,
+    )
+
+
 def build_visual_workflow_action_inputs(
     *,
     layers: LayerRefs,
     selection_state,
-    style_preset: str,
-    temporal_mode: str,
+    settings: VisualWorkflowSettingsSnapshot,
     background: VisualWorkflowBackgroundInputs,
-    analysis_mode: str,
     apply_subset_filters: bool = True,
 ) -> VisualWorkflowActionInputs:
     """Build normalized visual workflow inputs from dock-edge values."""
@@ -57,8 +77,8 @@ def build_visual_workflow_action_inputs(
     return VisualWorkflowActionInputs(
         layers=layers,
         selection_state=selection_state,
-        style_preset=style_preset,
-        temporal_mode=temporal_mode,
+        style_preset=settings.style_preset,
+        temporal_mode=settings.temporal_mode,
         background_config=BackgroundConfig(
             enabled=background.enabled,
             preset_name=background.preset_name,
@@ -67,7 +87,7 @@ def build_visual_workflow_action_inputs(
             style_id=background.style_id,
             tile_mode=background.tile_mode,
         ),
-        analysis_mode=analysis_mode,
+        analysis_mode=settings.analysis_mode,
         apply_subset_filters=apply_subset_filters,
     )
 


### PR DESCRIPTION
## Summary
- extract the current style/temporal/analysis snapshot into a focused helper in `ui/application/visual_workflow_action_builder.py`
- keep `QfitDockWidget` at the UI edge, but stop assembling that settings snapshot inline in `_build_visual_workflow_action()`
- add focused coverage for the new helper and the dock delegation path

## Testing
- `python3 -m pytest tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dock_action_dispatcher.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py ui/application/__init__.py ui/application/visual_workflow_action_builder.py tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py`

Closes #489
