### PR TITLE
refactor: extract visual workflow selection handoff

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -80,6 +80,7 @@ from .ui.application import (
     build_visual_layer_refs,
     build_visual_workflow_action,
     build_visual_workflow_action_inputs,
+    build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
@@ -779,7 +780,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     points_layer=self.points_layer,
                     atlas_layer=self.atlas_layer,
                 ),
-                selection_state=self._current_activity_selection_state(),
+                selection_state=build_visual_workflow_selection_state_handoff(
+                    self._current_activity_selection_state()
+                ),
                 settings=build_visual_workflow_settings_snapshot(
                     style_preset=self.stylePresetComboBox.currentText(),
                     temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -477,6 +477,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             return_value="layers",
         ) as build_layers, patch.object(
             self.module,
+            "build_visual_workflow_selection_state_handoff",
+            return_value="selection",
+        ) as build_selection, patch.object(
+            self.module,
             "build_visual_workflow_settings_snapshot",
             return_value="settings",
         ) as build_settings, patch.object(
@@ -500,9 +504,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             points_layer="points",
             atlas_layer="atlas",
         )
+        build_selection.assert_called_once_with(selection_state)
         build_inputs.assert_called_once_with(
             layers="layers",
-            selection_state=selection_state,
+            selection_state="selection",
             settings="settings",
             background=self.module.VisualWorkflowBackgroundInputs(
                 enabled=True,

--- a/tests/test_visual_workflow_action_builder.py
+++ b/tests/test_visual_workflow_action_builder.py
@@ -12,12 +12,26 @@ from qfit.ui.application import (
     build_visual_layer_refs,
     build_visual_workflow_action,
     build_visual_workflow_action_inputs,
+    build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
 )
 from qfit.visualization.application import BackgroundConfig, LayerRefs
 
 
 class TestVisualWorkflowActionBuilder(unittest.TestCase):
+    def test_build_visual_workflow_selection_state_handoff_keeps_selection_state(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=3)
+
+        handoff = build_visual_workflow_selection_state_handoff(selection_state)
+
+        self.assertIs(handoff, selection_state)
+
+    def test_build_visual_workflow_selection_state_handoff_defaults_empty_state(self):
+        handoff = build_visual_workflow_selection_state_handoff()
+
+        self.assertIsInstance(handoff, ActivitySelectionState)
+        self.assertEqual(handoff.filtered_count, 0)
+
     def test_build_visual_workflow_settings_snapshot_keeps_values(self):
         settings = build_visual_workflow_settings_snapshot(
             style_preset="By activity type",

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -8,6 +8,7 @@ from .dock_action_dispatcher import (
 )
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
+from .visual_workflow_action_builder import build_visual_workflow_selection_state_handoff
 from .visual_workflow_action_builder import build_visual_layer_refs
 from .visual_workflow_action_builder import VisualWorkflowActionInputs
 from .visual_workflow_action_builder import VisualWorkflowBackgroundInputs
@@ -25,5 +26,6 @@ __all__ = [
     "build_visual_layer_refs",
     "build_visual_workflow_action",
     "build_visual_workflow_action_inputs",
+    "build_visual_workflow_selection_state_handoff",
     "build_visual_workflow_settings_snapshot",
 ]

--- a/ui/application/visual_workflow_action_builder.py
+++ b/ui/application/visual_workflow_action_builder.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from .dock_action_dispatcher import ApplyVisualizationAction, RunAnalysisAction
+from ...activities.application.activity_selection_state import ActivitySelectionState
 from ...visualization.application import BackgroundConfig, LayerRefs
 
 
@@ -64,6 +65,14 @@ def build_visual_workflow_settings_snapshot(
     )
 
 
+def build_visual_workflow_selection_state_handoff(
+    selection_state=None,
+) -> ActivitySelectionState:
+    """Normalize the current visual workflow selection-state handoff."""
+
+    return selection_state or ActivitySelectionState()
+
+
 def build_visual_workflow_action_inputs(
     *,
     layers: LayerRefs,
@@ -76,7 +85,7 @@ def build_visual_workflow_action_inputs(
 
     return VisualWorkflowActionInputs(
         layers=layers,
-        selection_state=selection_state,
+        selection_state=build_visual_workflow_selection_state_handoff(selection_state),
         style_preset=settings.style_preset,
         temporal_mode=settings.temporal_mode,
         background_config=BackgroundConfig(


### PR DESCRIPTION
## Summary
- extract the visual workflow selection-state handoff into a focused helper in `ui/application/visual_workflow_action_builder.py`
- keep selection-state computation where it is, but stop passing that handoff inline through the dock visual workflow builder chain
- add focused coverage for the new helper and the dock delegation path

## Testing
- `python3 -m pytest tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dock_action_dispatcher.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py ui/application/__init__.py ui/application/visual_workflow_action_builder.py tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py`

Closes #491
