### PR TITLE
refactor: extract visual workflow background inputs

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -76,10 +76,10 @@ from .ui.application import (
     ApplyVisualizationAction,
     DockActionDispatcher,
     RunAnalysisAction,
-    VisualWorkflowBackgroundInputs,
     build_visual_layer_refs,
     build_visual_workflow_action,
     build_visual_workflow_action_inputs,
+    build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
 )
@@ -788,7 +788,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
                     analysis_mode=self.analysisModeComboBox.currentText(),
                 ),
-                background=VisualWorkflowBackgroundInputs(
+                background=build_visual_workflow_background_inputs(
                     enabled=self.backgroundMapCheckBox.isChecked(),
                     preset_name=self.backgroundPresetComboBox.currentText(),
                     access_token=self._mapbox_access_token(),

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -485,6 +485,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             return_value="settings",
         ) as build_settings, patch.object(
             self.module,
+            "build_visual_workflow_background_inputs",
+            return_value="background",
+        ) as build_background, patch.object(
+            self.module,
             "build_visual_workflow_action_inputs",
             return_value="inputs",
         ) as build_inputs, patch.object(
@@ -509,20 +513,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             layers="layers",
             selection_state="selection",
             settings="settings",
-            background=self.module.VisualWorkflowBackgroundInputs(
-                enabled=True,
-                preset_name="Outdoors",
-                access_token="token",
-                style_owner="mapbox",
-                style_id="style-id",
-                tile_mode="Raster",
-            ),
+            background="background",
             apply_subset_filters=True,
         )
         build_settings.assert_called_once_with(
             style_preset="By activity type",
             temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
             analysis_mode="Most frequent starting points",
+        )
+        build_background.assert_called_once_with(
+            enabled=True,
+            preset_name="Outdoors",
+            access_token="token",
+            style_owner="mapbox",
+            style_id="style-id",
+            tile_mode="Raster",
         )
         build_action.assert_called_once_with(self.module.ApplyVisualizationAction, "inputs")
 

--- a/tests/test_visual_workflow_action_builder.py
+++ b/tests/test_visual_workflow_action_builder.py
@@ -12,6 +12,7 @@ from qfit.ui.application import (
     build_visual_layer_refs,
     build_visual_workflow_action,
     build_visual_workflow_action_inputs,
+    build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
 )
@@ -43,6 +44,24 @@ class TestVisualWorkflowActionBuilder(unittest.TestCase):
         self.assertEqual(settings.style_preset, "By activity type")
         self.assertEqual(settings.temporal_mode, "Off")
         self.assertEqual(settings.analysis_mode, "Most frequent starting points")
+
+    def test_build_visual_workflow_background_inputs_keeps_values(self):
+        background = build_visual_workflow_background_inputs(
+            enabled=True,
+            preset_name="Outdoors",
+            access_token="token",
+            style_owner="mapbox",
+            style_id="style-id",
+            tile_mode="Raster",
+        )
+
+        self.assertIsInstance(background, VisualWorkflowBackgroundInputs)
+        self.assertTrue(background.enabled)
+        self.assertEqual(background.preset_name, "Outdoors")
+        self.assertEqual(background.access_token, "token")
+        self.assertEqual(background.style_owner, "mapbox")
+        self.assertEqual(background.style_id, "style-id")
+        self.assertEqual(background.tile_mode, "Raster")
 
     def test_build_visual_layer_refs_snapshots_all_layers(self):
         layers = build_visual_layer_refs(

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -8,6 +8,7 @@ from .dock_action_dispatcher import (
 )
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
+from .visual_workflow_action_builder import build_visual_workflow_background_inputs
 from .visual_workflow_action_builder import build_visual_workflow_selection_state_handoff
 from .visual_workflow_action_builder import build_visual_layer_refs
 from .visual_workflow_action_builder import VisualWorkflowActionInputs
@@ -26,6 +27,7 @@ __all__ = [
     "build_visual_layer_refs",
     "build_visual_workflow_action",
     "build_visual_workflow_action_inputs",
+    "build_visual_workflow_background_inputs",
     "build_visual_workflow_selection_state_handoff",
     "build_visual_workflow_settings_snapshot",
 ]

--- a/ui/application/visual_workflow_action_builder.py
+++ b/ui/application/visual_workflow_action_builder.py
@@ -65,6 +65,27 @@ def build_visual_workflow_settings_snapshot(
     )
 
 
+def build_visual_workflow_background_inputs(
+    *,
+    enabled: bool,
+    preset_name: str,
+    access_token: str,
+    style_owner: str,
+    style_id: str,
+    tile_mode: str,
+) -> VisualWorkflowBackgroundInputs:
+    """Build a normalized snapshot of the current visual workflow background inputs."""
+
+    return VisualWorkflowBackgroundInputs(
+        enabled=enabled,
+        preset_name=preset_name,
+        access_token=access_token,
+        style_owner=style_owner,
+        style_id=style_id,
+        tile_mode=tile_mode,
+    )
+
+
 def build_visual_workflow_selection_state_handoff(
     selection_state=None,
 ) -> ActivitySelectionState:


### PR DESCRIPTION
## Summary
- extract the visual workflow background-inputs handoff into a focused helper in `ui/application/visual_workflow_action_builder.py`
- keep raw widget reads at the dock edge, but stop assembling `VisualWorkflowBackgroundInputs(...)` inline in `_build_visual_workflow_action()`
- add focused coverage for the new helper and the dock delegation path

## Testing
- `python3 -m pytest tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dock_action_dispatcher.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py ui/application/__init__.py ui/application/visual_workflow_action_builder.py tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py`

Closes #493
