### PR TITLE
refactor: extract analysis configuration defaulting

### DIFF
--- a/analysis/application/analysis_request_builder.py
+++ b/analysis/application/analysis_request_builder.py
@@ -7,12 +7,37 @@ from .analysis_controller import RunAnalysisRequest
 
 
 @dataclass(frozen=True)
+class ApplyAnalysisConfigurationInputs:
+    analysis_mode: str = ""
+    starts_layer: object = None
+    selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
+
+
+@dataclass(frozen=True)
 class RunAnalysisRequestInputs:
     analysis_mode: str = ""
     activities_layer: object = None
     starts_layer: object = None
     points_layer: object = None
     selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
+
+
+def build_apply_analysis_configuration_inputs(
+    *,
+    current_mode: str = "",
+    current_starts_layer=None,
+    current_selection_state: ActivitySelectionState | None = None,
+    analysis_mode: str | None = None,
+    starts_layer=None,
+    selection_state: ActivitySelectionState | None = None,
+) -> ApplyAnalysisConfigurationInputs:
+    """Build normalized analysis-configuration inputs from current dock state and overrides."""
+
+    return ApplyAnalysisConfigurationInputs(
+        analysis_mode=analysis_mode or current_mode or "",
+        starts_layer=starts_layer if starts_layer is not None else current_starts_layer,
+        selection_state=selection_state or current_selection_state or ActivitySelectionState(),
+    )
 
 
 def build_run_analysis_request(inputs: RunAnalysisRequestInputs) -> RunAnalysisRequest:

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -62,6 +62,7 @@ from .analysis.infrastructure.activity_heatmap_layer import (
 )
 from .analysis.application.analysis_request_builder import (
     RunAnalysisRequestInputs,
+    build_apply_analysis_configuration_inputs,
     build_run_analysis_request,
 )
 from .analysis.infrastructure.frequent_start_points_layer import (
@@ -839,14 +840,18 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     ):
         self._clear_analysis_layer()
 
-        current_mode = analysis_mode or self.analysisModeComboBox.currentText()
-        current_starts_layer = (
-            starts_layer if starts_layer is not None else getattr(self, "starts_layer", None)
+        inputs = build_apply_analysis_configuration_inputs(
+            current_mode=self.analysisModeComboBox.currentText(),
+            current_starts_layer=getattr(self, "starts_layer", None),
+            current_selection_state=self._current_activity_selection_state(),
+            analysis_mode=analysis_mode,
+            starts_layer=starts_layer,
+            selection_state=selection_state,
         )
         return self._run_selected_analysis(
-            current_mode,
-            current_starts_layer,
-            selection_state or self._current_activity_selection_state(),
+            inputs.analysis_mode,
+            inputs.starts_layer,
+            inputs.selection_state,
         )
 
     def _clear_analysis_layer(self):

--- a/tests/test_analysis_request_builder.py
+++ b/tests/test_analysis_request_builder.py
@@ -4,12 +4,52 @@ from tests import _path  # noqa: F401
 from qfit.activities.application.activity_selection_state import ActivitySelectionState
 from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.analysis.application.analysis_request_builder import (
+    ApplyAnalysisConfigurationInputs,
     RunAnalysisRequestInputs,
+    build_apply_analysis_configuration_inputs,
     build_run_analysis_request,
 )
 
 
 class TestAnalysisRequestBuilder(unittest.TestCase):
+    def test_build_apply_analysis_configuration_inputs_keeps_overrides(self):
+        current_selection_state = ActivitySelectionState(query=ActivityQuery(search_text="current"), filtered_count=1)
+        selection_state = ActivitySelectionState(query=ActivityQuery(search_text="override"), filtered_count=4)
+
+        inputs = build_apply_analysis_configuration_inputs(
+            current_mode="Most frequent starting points",
+            current_starts_layer="current-starts-layer",
+            current_selection_state=current_selection_state,
+            analysis_mode="Heatmap",
+            starts_layer="starts-layer",
+            selection_state=selection_state,
+        )
+
+        self.assertIsInstance(inputs, ApplyAnalysisConfigurationInputs)
+        self.assertEqual(inputs.analysis_mode, "Heatmap")
+        self.assertEqual(inputs.starts_layer, "starts-layer")
+        self.assertIs(inputs.selection_state, selection_state)
+
+    def test_build_apply_analysis_configuration_inputs_defaults_to_current_values(self):
+        current_selection_state = ActivitySelectionState(query=ActivityQuery(search_text="current"), filtered_count=2)
+
+        inputs = build_apply_analysis_configuration_inputs(
+            current_mode="Most frequent starting points",
+            current_starts_layer="current-starts-layer",
+            current_selection_state=current_selection_state,
+        )
+
+        self.assertEqual(inputs.analysis_mode, "Most frequent starting points")
+        self.assertEqual(inputs.starts_layer, "current-starts-layer")
+        self.assertIs(inputs.selection_state, current_selection_state)
+
+    def test_build_apply_analysis_configuration_inputs_defaults_empty_state(self):
+        inputs = build_apply_analysis_configuration_inputs()
+
+        self.assertEqual(inputs.analysis_mode, "")
+        self.assertIsNone(inputs.starts_layer)
+        self.assertEqual(inputs.selection_state.filtered_count, 0)
+
     def test_build_run_analysis_request_keeps_inputs(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -846,11 +846,29 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._run_selected_analysis = MagicMock(return_value="status")
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
         dock._current_activity_selection_state = MagicMock(return_value=selection_state)
+        inputs = SimpleNamespace(
+            analysis_mode="Most frequent starting points",
+            starts_layer="starts-layer",
+            selection_state=selection_state,
+        )
 
-        status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
+        with patch.object(
+            self.module,
+            "build_apply_analysis_configuration_inputs",
+            return_value=inputs,
+        ) as build_inputs:
+            status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
 
         self.assertEqual(status, "status")
         dock._clear_analysis_layer.assert_called_once_with()
+        build_inputs.assert_called_once_with(
+            current_mode="Most frequent starting points",
+            current_starts_layer="starts-layer",
+            current_selection_state=selection_state,
+            analysis_mode=None,
+            starts_layer=None,
+            selection_state=None,
+        )
         dock._run_selected_analysis.assert_called_once_with(
             "Most frequent starting points",
             "starts-layer",
@@ -864,8 +882,18 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._run_selected_analysis = MagicMock(return_value="")
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=0)
         dock._current_activity_selection_state = MagicMock(return_value=selection_state)
+        inputs = SimpleNamespace(
+            analysis_mode="Most frequent starting points",
+            starts_layer=None,
+            selection_state=selection_state,
+        )
 
-        status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
+        with patch.object(
+            self.module,
+            "build_apply_analysis_configuration_inputs",
+            return_value=inputs,
+        ):
+            status = self.module.QfitDockWidget._apply_analysis_configuration(dock)
 
         self.assertEqual(status, "")
         dock._run_selected_analysis.assert_called_once_with(


### PR DESCRIPTION
## Summary
- extract the analysis-configuration defaulting helper into `analysis/application/analysis_request_builder.py`
- keep raw widget reads in the dock, but stop computing fallback analysis mode, starts layer, and selection-state handoff inline in `_apply_analysis_configuration()`
- add focused coverage for the new helper and the dock delegation path

## Testing
- `python3 -m pytest tests/test_analysis_request_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_analysis_controller.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_builder.py qfit_dockwidget.py tests/test_analysis_request_builder.py tests/test_qfit_dockwidget_analysis_pure.py`

Closes #495
