### PR TITLE
refactor: extract current analysis request inputs

### DIFF
--- a/analysis/application/analysis_request_builder.py
+++ b/analysis/application/analysis_request_builder.py
@@ -14,6 +14,12 @@ class ApplyAnalysisConfigurationInputs:
 
 
 @dataclass(frozen=True)
+class RunAnalysisCurrentInputs:
+    activities_layer: object = None
+    points_layer: object = None
+
+
+@dataclass(frozen=True)
 class RunAnalysisRequestInputs:
     analysis_mode: str = ""
     activities_layer: object = None
@@ -37,6 +43,25 @@ def build_apply_analysis_configuration_inputs(
         analysis_mode=analysis_mode or current_mode or "",
         starts_layer=starts_layer if starts_layer is not None else current_starts_layer,
         selection_state=selection_state or current_selection_state or ActivitySelectionState(),
+    )
+
+
+def build_run_analysis_request_inputs(
+    *,
+    current: RunAnalysisCurrentInputs | None = None,
+    analysis_mode: str = "",
+    starts_layer=None,
+    selection_state: ActivitySelectionState | None = None,
+) -> RunAnalysisRequestInputs:
+    """Build normalized run-analysis request inputs from current dock state."""
+
+    current = current or RunAnalysisCurrentInputs()
+    return RunAnalysisRequestInputs(
+        analysis_mode=analysis_mode or "",
+        activities_layer=current.activities_layer,
+        starts_layer=starts_layer,
+        points_layer=current.points_layer,
+        selection_state=selection_state or ActivitySelectionState(),
     )
 
 

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -61,9 +61,10 @@ from .analysis.infrastructure.activity_heatmap_layer import (
     ACTIVITY_HEATMAP_LAYER_NAME,
 )
 from .analysis.application.analysis_request_builder import (
-    RunAnalysisRequestInputs,
+    RunAnalysisCurrentInputs,
     build_apply_analysis_configuration_inputs,
     build_run_analysis_request,
+    build_run_analysis_request_inputs,
 )
 from .analysis.infrastructure.frequent_start_points_layer import (
     FREQUENT_STARTING_POINTS_LAYER_NAME,
@@ -803,11 +804,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
         request = build_run_analysis_request(
-            RunAnalysisRequestInputs(
+            build_run_analysis_request_inputs(
+                current=RunAnalysisCurrentInputs(
+                    activities_layer=getattr(self, "activities_layer", None),
+                    points_layer=getattr(self, "points_layer", None),
+                ),
                 analysis_mode=analysis_mode,
-                activities_layer=getattr(self, "activities_layer", None),
                 starts_layer=starts_layer,
-                points_layer=getattr(self, "points_layer", None),
                 selection_state=selection_state,
             )
         )

--- a/tests/test_analysis_request_builder.py
+++ b/tests/test_analysis_request_builder.py
@@ -5,9 +5,11 @@ from qfit.activities.application.activity_selection_state import ActivitySelecti
 from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.analysis.application.analysis_request_builder import (
     ApplyAnalysisConfigurationInputs,
+    RunAnalysisCurrentInputs,
     RunAnalysisRequestInputs,
     build_apply_analysis_configuration_inputs,
     build_run_analysis_request,
+    build_run_analysis_request_inputs,
 )
 
 
@@ -48,6 +50,35 @@ class TestAnalysisRequestBuilder(unittest.TestCase):
 
         self.assertEqual(inputs.analysis_mode, "")
         self.assertIsNone(inputs.starts_layer)
+        self.assertEqual(inputs.selection_state.filtered_count, 0)
+
+    def test_build_run_analysis_request_inputs_keeps_inputs(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
+
+        inputs = build_run_analysis_request_inputs(
+            current=RunAnalysisCurrentInputs(
+                activities_layer="activities-layer",
+                points_layer="points-layer",
+            ),
+            analysis_mode="Heatmap",
+            starts_layer="starts-layer",
+            selection_state=selection_state,
+        )
+
+        self.assertIsInstance(inputs, RunAnalysisRequestInputs)
+        self.assertEqual(inputs.analysis_mode, "Heatmap")
+        self.assertEqual(inputs.activities_layer, "activities-layer")
+        self.assertEqual(inputs.starts_layer, "starts-layer")
+        self.assertEqual(inputs.points_layer, "points-layer")
+        self.assertIs(inputs.selection_state, selection_state)
+
+    def test_build_run_analysis_request_inputs_defaults_empty_values(self):
+        inputs = build_run_analysis_request_inputs()
+
+        self.assertEqual(inputs.analysis_mode, "")
+        self.assertIsNone(inputs.activities_layer)
+        self.assertIsNone(inputs.starts_layer)
+        self.assertIsNone(inputs.points_layer)
         self.assertEqual(inputs.selection_state.filtered_count, 0)
 
     def test_build_run_analysis_request_keeps_inputs(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -544,6 +544,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         with patch.object(
             self.module,
+            "build_run_analysis_request_inputs",
+            return_value="request-inputs",
+        ) as build_request_inputs, patch.object(
+            self.module,
             "build_run_analysis_request",
             return_value="analysis-request",
         ) as build_request:
@@ -555,15 +559,16 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             )
 
         self.assertEqual(result, "Showing top 2 frequent starting-point clusters")
-        build_request.assert_called_once_with(
-            self.module.RunAnalysisRequestInputs(
-                analysis_mode="Most frequent starting points",
+        build_request_inputs.assert_called_once_with(
+            current=self.module.RunAnalysisCurrentInputs(
                 activities_layer="activities-layer",
-                starts_layer="starts-layer",
                 points_layer="points-layer",
-                selection_state=selection_state,
-            )
+            ),
+            analysis_mode="Most frequent starting points",
+            starts_layer="starts-layer",
+            selection_state=selection_state,
         )
+        build_request.assert_called_once_with("request-inputs")
         dock.analysis_controller.run_request.assert_called_once_with("analysis-request")
 
     def test_run_selected_analysis_adds_returned_layer_to_project(self):
@@ -579,7 +584,13 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         project = _FakeProject()
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
-        with patch.object(self.module, "build_run_analysis_request", return_value="analysis-request"), patch.object(
+        with patch.object(
+            self.module,
+            "build_run_analysis_request_inputs",
+            return_value="request-inputs",
+        ), patch.object(
+            self.module, "build_run_analysis_request", return_value="analysis-request"
+        ), patch.object(
             self.module.QgsProject, "instance", return_value=project
         ):
             status = self.module.QfitDockWidget._run_selected_analysis(


### PR DESCRIPTION
## Summary
- extract the current analysis request-inputs helper into `analysis/application/analysis_request_builder.py`
- keep QGIS layer insertion in the dock, but stop assembling `RunAnalysisRequestInputs(...)` inline in `_run_selected_analysis()`
- add focused coverage for the new helper and the dock delegation path

## Testing
- `python3 -m pytest tests/test_analysis_request_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_analysis_controller.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_builder.py qfit_dockwidget.py tests/test_analysis_request_builder.py tests/test_qfit_dockwidget_analysis_pure.py`

Closes #497
