### PR TITLE
refactor: extract current analysis layer inputs

### DIFF
--- a/analysis/application/analysis_request_builder.py
+++ b/analysis/application/analysis_request_builder.py
@@ -46,6 +46,19 @@ def build_apply_analysis_configuration_inputs(
     )
 
 
+def build_run_analysis_current_inputs(
+    *,
+    activities_layer=None,
+    points_layer=None,
+) -> RunAnalysisCurrentInputs:
+    """Build normalized current layer inputs for analysis request shaping."""
+
+    return RunAnalysisCurrentInputs(
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+    )
+
+
 def build_run_analysis_request_inputs(
     *,
     current: RunAnalysisCurrentInputs | None = None,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -61,8 +61,8 @@ from .analysis.infrastructure.activity_heatmap_layer import (
     ACTIVITY_HEATMAP_LAYER_NAME,
 )
 from .analysis.application.analysis_request_builder import (
-    RunAnalysisCurrentInputs,
     build_apply_analysis_configuration_inputs,
+    build_run_analysis_current_inputs,
     build_run_analysis_request,
     build_run_analysis_request_inputs,
 )
@@ -805,7 +805,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
         request = build_run_analysis_request(
             build_run_analysis_request_inputs(
-                current=RunAnalysisCurrentInputs(
+                current=build_run_analysis_current_inputs(
                     activities_layer=getattr(self, "activities_layer", None),
                     points_layer=getattr(self, "points_layer", None),
                 ),

--- a/tests/test_analysis_request_builder.py
+++ b/tests/test_analysis_request_builder.py
@@ -8,6 +8,7 @@ from qfit.analysis.application.analysis_request_builder import (
     RunAnalysisCurrentInputs,
     RunAnalysisRequestInputs,
     build_apply_analysis_configuration_inputs,
+    build_run_analysis_current_inputs,
     build_run_analysis_request,
     build_run_analysis_request_inputs,
 )
@@ -51,6 +52,16 @@ class TestAnalysisRequestBuilder(unittest.TestCase):
         self.assertEqual(inputs.analysis_mode, "")
         self.assertIsNone(inputs.starts_layer)
         self.assertEqual(inputs.selection_state.filtered_count, 0)
+
+    def test_build_run_analysis_current_inputs_keeps_inputs(self):
+        current = build_run_analysis_current_inputs(
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+
+        self.assertIsInstance(current, RunAnalysisCurrentInputs)
+        self.assertEqual(current.activities_layer, "activities-layer")
+        self.assertEqual(current.points_layer, "points-layer")
 
     def test_build_run_analysis_request_inputs_keeps_inputs(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -544,6 +544,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         with patch.object(
             self.module,
+            "build_run_analysis_current_inputs",
+            return_value="current-inputs",
+        ) as build_current_inputs, patch.object(
+            self.module,
             "build_run_analysis_request_inputs",
             return_value="request-inputs",
         ) as build_request_inputs, patch.object(
@@ -559,11 +563,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             )
 
         self.assertEqual(result, "Showing top 2 frequent starting-point clusters")
+        build_current_inputs.assert_called_once_with(
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
         build_request_inputs.assert_called_once_with(
-            current=self.module.RunAnalysisCurrentInputs(
-                activities_layer="activities-layer",
-                points_layer="points-layer",
-            ),
+            current="current-inputs",
             analysis_mode="Most frequent starting points",
             starts_layer="starts-layer",
             selection_state=selection_state,
@@ -585,6 +590,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
         with patch.object(
+            self.module,
+            "build_run_analysis_current_inputs",
+            return_value="current-inputs",
+        ), patch.object(
             self.module,
             "build_run_analysis_request_inputs",
             return_value="request-inputs",


### PR DESCRIPTION
## Summary
- extract the current analysis layer-input snapshot helper into `analysis/application/analysis_request_builder.py`
- keep QGIS layer insertion in the dock, but stop assembling `RunAnalysisCurrentInputs(...)` inline in `_run_selected_analysis()`
- add focused coverage for the new helper and the dock delegation path

## Testing
- `python3 -m pytest tests/test_analysis_request_builder.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_analysis_controller.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_builder.py qfit_dockwidget.py tests/test_analysis_request_builder.py tests/test_qfit_dockwidget_analysis_pure.py`

Closes #499
