### PR TITLE
refactor: route analysis request through controller

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -62,9 +62,6 @@ from .analysis.infrastructure.activity_heatmap_layer import (
 )
 from .analysis.application.analysis_request_builder import (
     build_apply_analysis_configuration_inputs,
-    build_run_analysis_current_inputs,
-    build_run_analysis_request,
-    build_run_analysis_request_inputs,
 )
 from .analysis.infrastructure.frequent_start_points_layer import (
     FREQUENT_STARTING_POINTS_LAYER_NAME,
@@ -803,16 +800,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
 
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
-        request = build_run_analysis_request(
-            build_run_analysis_request_inputs(
-                current=build_run_analysis_current_inputs(
-                    activities_layer=getattr(self, "activities_layer", None),
-                    points_layer=getattr(self, "points_layer", None),
-                ),
-                analysis_mode=analysis_mode,
-                starts_layer=starts_layer,
-                selection_state=selection_state,
-            )
+        request = self.analysis_controller.build_request(
+            analysis_mode=analysis_mode,
+            starts_layer=starts_layer,
+            selection_state=selection_state,
+            activities_layer=getattr(self, "activities_layer", None),
+            points_layer=getattr(self, "points_layer", None),
         )
         result = self.analysis_controller.run_request(request)
         if result.layer is None:

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -534,6 +534,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
     def test_run_selected_analysis_delegates_to_analysis_controller(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysis_controller = MagicMock()
+        dock.analysis_controller.build_request.return_value = "analysis-request"
         dock.analysis_controller.run_request.return_value = SimpleNamespace(
             status="Showing top 2 frequent starting-point clusters",
             layer=None,
@@ -542,43 +543,27 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.points_layer = "points-layer"
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
-        with patch.object(
-            self.module,
-            "build_run_analysis_current_inputs",
-            return_value="current-inputs",
-        ) as build_current_inputs, patch.object(
-            self.module,
-            "build_run_analysis_request_inputs",
-            return_value="request-inputs",
-        ) as build_request_inputs, patch.object(
-            self.module,
-            "build_run_analysis_request",
-            return_value="analysis-request",
-        ) as build_request:
-            result = self.module.QfitDockWidget._run_selected_analysis(
-                dock,
-                "Most frequent starting points",
-                "starts-layer",
-                selection_state,
-            )
+        result = self.module.QfitDockWidget._run_selected_analysis(
+            dock,
+            "Most frequent starting points",
+            "starts-layer",
+            selection_state,
+        )
 
         self.assertEqual(result, "Showing top 2 frequent starting-point clusters")
-        build_current_inputs.assert_called_once_with(
-            activities_layer="activities-layer",
-            points_layer="points-layer",
-        )
-        build_request_inputs.assert_called_once_with(
-            current="current-inputs",
+        dock.analysis_controller.build_request.assert_called_once_with(
             analysis_mode="Most frequent starting points",
             starts_layer="starts-layer",
             selection_state=selection_state,
+            activities_layer="activities-layer",
+            points_layer="points-layer",
         )
-        build_request.assert_called_once_with("request-inputs")
         dock.analysis_controller.run_request.assert_called_once_with("analysis-request")
 
     def test_run_selected_analysis_adds_returned_layer_to_project(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysis_controller = MagicMock()
+        dock.analysis_controller.build_request.return_value = "analysis-request"
         analysis_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
         dock.analysis_controller.run_request.return_value = SimpleNamespace(
             status="Showing top 2 frequent starting-point clusters",
@@ -589,19 +574,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         project = _FakeProject()
         selection_state = self.module.ActivitySelectionState(query=object(), filtered_count=2)
 
-        with patch.object(
-            self.module,
-            "build_run_analysis_current_inputs",
-            return_value="current-inputs",
-        ), patch.object(
-            self.module,
-            "build_run_analysis_request_inputs",
-            return_value="request-inputs",
-        ), patch.object(
-            self.module, "build_run_analysis_request", return_value="analysis-request"
-        ), patch.object(
-            self.module.QgsProject, "instance", return_value=project
-        ):
+        with patch.object(self.module.QgsProject, "instance", return_value=project):
             status = self.module.QfitDockWidget._run_selected_analysis(
                 dock,
                 "Most frequent starting points",


### PR DESCRIPTION
## Summary
- route dock-side analysis request building through `AnalysisController.build_request()`
- remove the direct low-level analysis request-builder dependency from `qfit_dockwidget.py`
- add focused coverage for the updated dock delegation path

## Testing
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py tests/test_qfit_dockwidget_analysis_pure.py analysis/application/analysis_controller.py analysis/application/analysis_request_builder.py`

Closes #501
