### PR TITLE
refactor: extract analysis controller request inputs

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -35,17 +35,17 @@ class AnalysisController:
         points_layer: object = None,
     ) -> RunAnalysisRequest:
         from .analysis_request_builder import (
-            RunAnalysisRequestInputs,
+            build_analysis_controller_request_inputs,
             build_run_analysis_request,
         )
 
         return build_run_analysis_request(
-            RunAnalysisRequestInputs(
+            build_analysis_controller_request_inputs(
                 analysis_mode=analysis_mode,
-                activities_layer=activities_layer,
                 starts_layer=starts_layer,
+                selection_state=selection_state,
+                activities_layer=activities_layer,
                 points_layer=points_layer,
-                selection_state=selection_state or ActivitySelectionState(),
             )
         )
 

--- a/analysis/application/analysis_request_builder.py
+++ b/analysis/application/analysis_request_builder.py
@@ -78,6 +78,27 @@ def build_run_analysis_request_inputs(
     )
 
 
+def build_analysis_controller_request_inputs(
+    *,
+    analysis_mode: str,
+    starts_layer,
+    selection_state: ActivitySelectionState | None = None,
+    activities_layer: object = None,
+    points_layer: object = None,
+) -> RunAnalysisRequestInputs:
+    """Build normalized request inputs for AnalysisController.build_request()."""
+
+    return build_run_analysis_request_inputs(
+        current=build_run_analysis_current_inputs(
+            activities_layer=activities_layer,
+            points_layer=points_layer,
+        ),
+        analysis_mode=analysis_mode,
+        starts_layer=starts_layer,
+        selection_state=selection_state,
+    )
+
+
 def build_run_analysis_request(inputs: RunAnalysisRequestInputs) -> RunAnalysisRequest:
     """Build a normalized analysis request from dock-edge inputs."""
 

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -28,6 +28,32 @@ class TestAnalysisController(unittest.TestCase):
         self.assertEqual(request.starts_layer, "starts-layer")
         self.assertEqual(request.points_layer, "points-layer")
 
+    def test_build_request_delegates_to_request_builder_helper(self):
+        with patch(
+            "qfit.analysis.application.analysis_request_builder.build_run_analysis_request",
+            return_value="request",
+        ) as build_request, patch(
+            "qfit.analysis.application.analysis_request_builder.build_analysis_controller_request_inputs",
+            return_value="request-inputs",
+        ) as build_inputs:
+            request = self.controller.build_request(
+                "Heatmap",
+                "starts-layer",
+                selection_state="selection-state",
+                activities_layer="activities-layer",
+                points_layer="points-layer",
+            )
+
+        self.assertEqual(request, "request")
+        build_inputs.assert_called_once_with(
+            analysis_mode="Heatmap",
+            starts_layer="starts-layer",
+            selection_state="selection-state",
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+        build_request.assert_called_once_with("request-inputs")
+
     def test_build_request_keeps_selection_state(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
 

--- a/tests/test_analysis_request_builder.py
+++ b/tests/test_analysis_request_builder.py
@@ -7,6 +7,7 @@ from qfit.analysis.application.analysis_request_builder import (
     ApplyAnalysisConfigurationInputs,
     RunAnalysisCurrentInputs,
     RunAnalysisRequestInputs,
+    build_analysis_controller_request_inputs,
     build_apply_analysis_configuration_inputs,
     build_run_analysis_current_inputs,
     build_run_analysis_request,
@@ -91,6 +92,24 @@ class TestAnalysisRequestBuilder(unittest.TestCase):
         self.assertIsNone(inputs.starts_layer)
         self.assertIsNone(inputs.points_layer)
         self.assertEqual(inputs.selection_state.filtered_count, 0)
+
+    def test_build_analysis_controller_request_inputs_keeps_inputs(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
+
+        inputs = build_analysis_controller_request_inputs(
+            analysis_mode="Heatmap",
+            starts_layer="starts-layer",
+            selection_state=selection_state,
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+
+        self.assertIsInstance(inputs, RunAnalysisRequestInputs)
+        self.assertEqual(inputs.analysis_mode, "Heatmap")
+        self.assertEqual(inputs.activities_layer, "activities-layer")
+        self.assertEqual(inputs.starts_layer, "starts-layer")
+        self.assertEqual(inputs.points_layer, "points-layer")
+        self.assertIs(inputs.selection_state, selection_state)
 
     def test_build_run_analysis_request_keeps_inputs(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)


### PR DESCRIPTION
## Summary
- extract `AnalysisController.build_request()` request-input assembly into `analysis_request_builder.py`
- keep `AnalysisController` as the seam the dock uses, but move the last inline `RunAnalysisRequestInputs(...)` construction into the builder module
- add focused coverage for the new helper and controller delegation path

## Testing
- `python3 -m pytest tests/test_analysis_controller.py tests/test_analysis_request_builder.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_controller.py analysis/application/analysis_request_builder.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py`

Closes #503
