### PR TITLE
refactor: extract analysis status messages

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from ...activities.application.activity_selection_state import ActivitySelectionState
+from .analysis_status_messages import (
+    build_activity_heatmap_empty_status,
+    build_activity_heatmap_success_status,
+    build_frequent_start_points_empty_status,
+    build_frequent_start_points_success_status,
+)
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
 HEATMAP_MODE = "Heatmap"
@@ -60,13 +66,11 @@ class AnalysisController:
             layer, clusters = _build_frequent_start_points_layer(request.starts_layer)
             if layer is None or not clusters:
                 return RunAnalysisResult(
-                    status="No frequent starting points matched the current filters"
+                    status=build_frequent_start_points_empty_status()
                 )
 
             return RunAnalysisResult(
-                status="Showing top {count} frequent starting-point clusters".format(
-                    count=len(clusters)
-                ),
+                status=build_frequent_start_points_success_status(len(clusters)),
                 layer=layer,
             )
 
@@ -80,13 +84,11 @@ class AnalysisController:
             )
             if layer is None or sample_count <= 0:
                 return RunAnalysisResult(
-                    status="No activity heatmap data matched the current filters"
+                    status=build_activity_heatmap_empty_status()
                 )
 
             return RunAnalysisResult(
-                status="Showing activity heatmap from {count} sampled route points".format(
-                    count=sample_count
-                ),
+                status=build_activity_heatmap_success_status(sample_count),
                 layer=layer,
             )
 

--- a/analysis/application/analysis_status_messages.py
+++ b/analysis/application/analysis_status_messages.py
@@ -1,0 +1,18 @@
+def build_frequent_start_points_empty_status() -> str:
+    return "No frequent starting points matched the current filters"
+
+
+def build_frequent_start_points_success_status(cluster_count: int) -> str:
+    return "Showing top {count} frequent starting-point clusters".format(
+        count=cluster_count
+    )
+
+
+def build_activity_heatmap_empty_status() -> str:
+    return "No activity heatmap data matched the current filters"
+
+
+def build_activity_heatmap_success_status(sample_count: int) -> str:
+    return "Showing activity heatmap from {count} sampled route points".format(
+        count=sample_count
+    )

--- a/tests/test_analysis_status_messages.py
+++ b/tests/test_analysis_status_messages.py
@@ -1,0 +1,39 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.analysis.application.analysis_status_messages import (
+    build_activity_heatmap_empty_status,
+    build_activity_heatmap_success_status,
+    build_frequent_start_points_empty_status,
+    build_frequent_start_points_success_status,
+)
+
+
+class TestAnalysisStatusMessages(unittest.TestCase):
+    def test_build_frequent_start_points_empty_status(self):
+        self.assertEqual(
+            build_frequent_start_points_empty_status(),
+            "No frequent starting points matched the current filters",
+        )
+
+    def test_build_frequent_start_points_success_status(self):
+        self.assertEqual(
+            build_frequent_start_points_success_status(2),
+            "Showing top 2 frequent starting-point clusters",
+        )
+
+    def test_build_activity_heatmap_empty_status(self):
+        self.assertEqual(
+            build_activity_heatmap_empty_status(),
+            "No activity heatmap data matched the current filters",
+        )
+
+    def test_build_activity_heatmap_success_status(self):
+        self.assertEqual(
+            build_activity_heatmap_success_status(42),
+            "Showing activity heatmap from 42 sampled route points",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract analysis status message policy from `AnalysisController.run()` into `analysis/application/analysis_status_messages.py`
- keep analysis execution flow unchanged while moving user-facing success and empty-result text into an analysis-owned helper
- add focused coverage for the new helper and controller behavior

## Testing
- `python3 -m pytest tests/test_analysis_status_messages.py tests/test_analysis_controller.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_status_messages.py analysis/application/analysis_controller.py tests/test_analysis_status_messages.py`

Closes #505
