### PR TITLE
refactor: extract analysis request models

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 from ...activities.application.activity_selection_state import ActivitySelectionState
+from .analysis_models import RunAnalysisRequest, RunAnalysisResult
 from .analysis_status_messages import (
     build_activity_heatmap_empty_status,
     build_activity_heatmap_success_status,
@@ -12,21 +11,6 @@ from .analysis_status_messages import (
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
 HEATMAP_MODE = "Heatmap"
-
-
-@dataclass(frozen=True)
-class RunAnalysisRequest:
-    analysis_mode: str = ""
-    activities_layer: object = None
-    starts_layer: object = None
-    points_layer: object = None
-    selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
-
-
-@dataclass(frozen=True)
-class RunAnalysisResult:
-    status: str = ""
-    layer: object = None
 
 
 class AnalysisController:

--- a/analysis/application/analysis_models.py
+++ b/analysis/application/analysis_models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ...activities.application.activity_selection_state import ActivitySelectionState
+
+
+@dataclass(frozen=True)
+class RunAnalysisRequest:
+    analysis_mode: str = ""
+    activities_layer: object = None
+    starts_layer: object = None
+    points_layer: object = None
+    selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
+
+
+@dataclass(frozen=True)
+class RunAnalysisResult:
+    status: str = ""
+    layer: object = None

--- a/analysis/application/analysis_request_builder.py
+++ b/analysis/application/analysis_request_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from ...activities.application.activity_selection_state import ActivitySelectionState
-from .analysis_controller import RunAnalysisRequest
+from .analysis_models import RunAnalysisRequest
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- extract `RunAnalysisRequest` and `RunAnalysisResult` into `analysis/application/analysis_models.py`
- stop making `analysis_request_builder.py` depend on controller-owned dataclasses
- keep controller behavior unchanged while sharing the models from a dedicated analysis application module

## Testing
- `python3 -m pytest tests/test_analysis_controller.py tests/test_analysis_request_builder.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_models.py analysis/application/analysis_controller.py analysis/application/analysis_request_builder.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py`

Closes #507
