### PR TITLE
refactor: extract frequent start points result builder

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from ...activities.application.activity_selection_state import ActivitySelectionState
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
+from .analysis_result_builder import build_frequent_start_points_result
 from .analysis_status_messages import (
     build_activity_heatmap_empty_status,
     build_activity_heatmap_success_status,
-    build_frequent_start_points_empty_status,
-    build_frequent_start_points_success_status,
 )
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
@@ -48,15 +47,7 @@ class AnalysisController:
                 return RunAnalysisResult()
 
             layer, clusters = _build_frequent_start_points_layer(request.starts_layer)
-            if layer is None or not clusters:
-                return RunAnalysisResult(
-                    status=build_frequent_start_points_empty_status()
-                )
-
-            return RunAnalysisResult(
-                status=build_frequent_start_points_success_status(len(clusters)),
-                layer=layer,
-            )
+            return build_frequent_start_points_result(layer, clusters)
 
         if request.analysis_mode == HEATMAP_MODE:
             if request.activities_layer is None and request.points_layer is None:

--- a/analysis/application/analysis_result_builder.py
+++ b/analysis/application/analysis_result_builder.py
@@ -1,0 +1,15 @@
+from .analysis_models import RunAnalysisResult
+from .analysis_status_messages import (
+    build_frequent_start_points_empty_status,
+    build_frequent_start_points_success_status,
+)
+
+
+def build_frequent_start_points_result(layer, clusters) -> RunAnalysisResult:
+    if layer is None or not clusters:
+        return RunAnalysisResult(status=build_frequent_start_points_empty_status())
+
+    return RunAnalysisResult(
+        status=build_frequent_start_points_success_status(len(clusters)),
+        layer=layer,
+    )

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -89,14 +89,14 @@ class TestAnalysisController(unittest.TestCase):
         with patch(
             "qfit.analysis.application.analysis_controller._build_frequent_start_points_layer",
             return_value=(None, []),
-        ):
+        ), patch(
+            "qfit.analysis.application.analysis_controller.build_frequent_start_points_result",
+            return_value="result",
+        ) as build_result:
             result = self.controller.run_request(request)
 
-        self.assertEqual(
-            result.status,
-            "No frequent starting points matched the current filters",
-        )
-        self.assertIsNone(result.layer)
+        self.assertEqual(result, "result")
+        build_result.assert_called_once_with(None, [])
 
     def test_run_request_returns_layer_for_matching_mode(self):
         request = self.controller.build_request(
@@ -104,18 +104,19 @@ class TestAnalysisController(unittest.TestCase):
             object(),
         )
         layer = object()
+        built_result = object()
 
         with patch(
             "qfit.analysis.application.analysis_controller._build_frequent_start_points_layer",
             return_value=(layer, [object(), object()]),
-        ):
+        ), patch(
+            "qfit.analysis.application.analysis_controller.build_frequent_start_points_result",
+            return_value=built_result,
+        ) as build_result:
             result = self.controller.run_request(request)
 
-        self.assertEqual(
-            result.status,
-            "Showing top 2 frequent starting-point clusters",
-        )
-        self.assertIs(result.layer, layer)
+        self.assertIs(result, built_result)
+        build_result.assert_called_once()
 
     def test_run_request_returns_empty_result_without_heatmap_layers(self):
         request = self.controller.build_request(

--- a/tests/test_analysis_result_builder.py
+++ b/tests/test_analysis_result_builder.py
@@ -1,0 +1,32 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.analysis.application.analysis_result_builder import (
+    build_frequent_start_points_result,
+)
+
+
+class TestAnalysisResultBuilder(unittest.TestCase):
+    def test_build_frequent_start_points_result_reports_empty(self):
+        result = build_frequent_start_points_result(None, [])
+
+        self.assertEqual(
+            result.status,
+            "No frequent starting points matched the current filters",
+        )
+        self.assertIsNone(result.layer)
+
+    def test_build_frequent_start_points_result_reports_success(self):
+        layer = object()
+
+        result = build_frequent_start_points_result(layer, [object(), object()])
+
+        self.assertEqual(
+            result.status,
+            "Showing top 2 frequent starting-point clusters",
+        )
+        self.assertIs(result.layer, layer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract frequent-start-points result shaping from `AnalysisController.run()` into `analysis/application/analysis_result_builder.py`
- keep infrastructure calls in the controller, but stop constructing that branch result inline
- add focused coverage for the new helper and controller delegation path

## Testing
- `python3 -m pytest tests/test_analysis_result_builder.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_result_builder.py analysis/application/analysis_controller.py tests/test_analysis_result_builder.py tests/test_analysis_controller.py`

Closes #509
