### PR TITLE
refactor: extract heatmap result builder

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from ...activities.application.activity_selection_state import ActivitySelectionState
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
-from .analysis_result_builder import build_frequent_start_points_result
-from .analysis_status_messages import (
-    build_activity_heatmap_empty_status,
-    build_activity_heatmap_success_status,
+from .analysis_result_builder import (
+    build_activity_heatmap_result,
+    build_frequent_start_points_result,
 )
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
@@ -57,15 +56,7 @@ class AnalysisController:
                 request.activities_layer,
                 request.points_layer,
             )
-            if layer is None or sample_count <= 0:
-                return RunAnalysisResult(
-                    status=build_activity_heatmap_empty_status()
-                )
-
-            return RunAnalysisResult(
-                status=build_activity_heatmap_success_status(sample_count),
-                layer=layer,
-            )
+            return build_activity_heatmap_result(layer, sample_count)
 
         return RunAnalysisResult()
 

--- a/analysis/application/analysis_result_builder.py
+++ b/analysis/application/analysis_result_builder.py
@@ -1,5 +1,7 @@
 from .analysis_models import RunAnalysisResult
 from .analysis_status_messages import (
+    build_activity_heatmap_empty_status,
+    build_activity_heatmap_success_status,
     build_frequent_start_points_empty_status,
     build_frequent_start_points_success_status,
 )
@@ -11,5 +13,15 @@ def build_frequent_start_points_result(layer, clusters) -> RunAnalysisResult:
 
     return RunAnalysisResult(
         status=build_frequent_start_points_success_status(len(clusters)),
+        layer=layer,
+    )
+
+
+def build_activity_heatmap_result(layer, sample_count: int) -> RunAnalysisResult:
+    if layer is None or sample_count <= 0:
+        return RunAnalysisResult(status=build_activity_heatmap_empty_status())
+
+    return RunAnalysisResult(
+        status=build_activity_heatmap_success_status(sample_count),
         layer=layer,
     )

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -142,14 +142,14 @@ class TestAnalysisController(unittest.TestCase):
         with patch(
             "qfit.analysis.application.analysis_controller._build_activity_heatmap_layer",
             return_value=(None, 0),
-        ):
+        ), patch(
+            "qfit.analysis.application.analysis_controller.build_activity_heatmap_result",
+            return_value="result",
+        ) as build_result:
             result = self.controller.run_request(request)
 
-        self.assertEqual(
-            result.status,
-            "No activity heatmap data matched the current filters",
-        )
-        self.assertIsNone(result.layer)
+        self.assertEqual(result, "result")
+        build_result.assert_called_once_with(None, 0)
 
     def test_run_request_returns_heatmap_layer(self):
         request = self.controller.build_request(
@@ -159,18 +159,19 @@ class TestAnalysisController(unittest.TestCase):
             points_layer=object(),
         )
         layer = object()
+        built_result = object()
 
         with patch(
             "qfit.analysis.application.analysis_controller._build_activity_heatmap_layer",
             return_value=(layer, 42),
-        ):
+        ), patch(
+            "qfit.analysis.application.analysis_controller.build_activity_heatmap_result",
+            return_value=built_result,
+        ) as build_result:
             result = self.controller.run_request(request)
 
-        self.assertEqual(
-            result.status,
-            "Showing activity heatmap from 42 sampled route points",
-        )
-        self.assertIs(result.layer, layer)
+        self.assertIs(result, built_result)
+        build_result.assert_called_once_with(layer, 42)
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis_result_builder.py
+++ b/tests/test_analysis_result_builder.py
@@ -2,6 +2,7 @@ import unittest
 
 from tests import _path  # noqa: F401
 from qfit.analysis.application.analysis_result_builder import (
+    build_activity_heatmap_result,
     build_frequent_start_points_result,
 )
 
@@ -24,6 +25,26 @@ class TestAnalysisResultBuilder(unittest.TestCase):
         self.assertEqual(
             result.status,
             "Showing top 2 frequent starting-point clusters",
+        )
+        self.assertIs(result.layer, layer)
+
+    def test_build_activity_heatmap_result_reports_empty(self):
+        result = build_activity_heatmap_result(None, 0)
+
+        self.assertEqual(
+            result.status,
+            "No activity heatmap data matched the current filters",
+        )
+        self.assertIsNone(result.layer)
+
+    def test_build_activity_heatmap_result_reports_success(self):
+        layer = object()
+
+        result = build_activity_heatmap_result(layer, 42)
+
+        self.assertEqual(
+            result.status,
+            "Showing activity heatmap from 42 sampled route points",
         )
         self.assertIs(result.layer, layer)
 


### PR DESCRIPTION
## Summary
- extract heatmap result shaping from `AnalysisController.run()` into `analysis/application/analysis_result_builder.py`
- keep the infrastructure call in the controller, but stop constructing the heatmap branch result inline
- add focused coverage for the new helper and controller delegation path

## Testing
- `python3 -m pytest tests/test_analysis_result_builder.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_result_builder.py analysis/application/analysis_controller.py tests/test_analysis_result_builder.py tests/test_analysis_controller.py`

Closes #511
