### PR TITLE
refactor: extract empty analysis result builder

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -4,6 +4,7 @@ from ...activities.application.activity_selection_state import ActivitySelection
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
 from .analysis_result_builder import (
     build_activity_heatmap_result,
+    build_empty_analysis_result,
     build_frequent_start_points_result,
 )
 
@@ -43,14 +44,14 @@ class AnalysisController:
 
         if request.analysis_mode == FREQUENT_STARTING_POINTS_MODE:
             if request.starts_layer is None:
-                return RunAnalysisResult()
+                return build_empty_analysis_result()
 
             layer, clusters = _build_frequent_start_points_layer(request.starts_layer)
             return build_frequent_start_points_result(layer, clusters)
 
         if request.analysis_mode == HEATMAP_MODE:
             if request.activities_layer is None and request.points_layer is None:
-                return RunAnalysisResult()
+                return build_empty_analysis_result()
 
             layer, sample_count = _build_activity_heatmap_layer(
                 request.activities_layer,
@@ -58,7 +59,7 @@ class AnalysisController:
             )
             return build_activity_heatmap_result(layer, sample_count)
 
-        return RunAnalysisResult()
+        return build_empty_analysis_result()
 
     def run_request(self, request: RunAnalysisRequest) -> RunAnalysisResult:
         return self.run(request=request)

--- a/analysis/application/analysis_result_builder.py
+++ b/analysis/application/analysis_result_builder.py
@@ -7,6 +7,10 @@ from .analysis_status_messages import (
 )
 
 
+def build_empty_analysis_result() -> RunAnalysisResult:
+    return RunAnalysisResult()
+
+
 def build_frequent_start_points_result(layer, clusters) -> RunAnalysisResult:
     if layer is None or not clusters:
         return RunAnalysisResult(status=build_frequent_start_points_empty_status())

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -64,10 +64,14 @@ class TestAnalysisController(unittest.TestCase):
     def test_run_request_returns_empty_result_for_non_matching_mode(self):
         request = self.controller.build_request("None", object())
 
-        result = self.controller.run_request(request)
+        with patch(
+            "qfit.analysis.application.analysis_controller.build_empty_analysis_result",
+            return_value="result",
+        ) as build_result:
+            result = self.controller.run_request(request)
 
-        self.assertEqual(result.status, "")
-        self.assertIsNone(result.layer)
+        self.assertEqual(result, "result")
+        build_result.assert_called_once_with()
 
     def test_run_request_returns_empty_result_without_starts_layer(self):
         request = self.controller.build_request(
@@ -75,10 +79,14 @@ class TestAnalysisController(unittest.TestCase):
             None,
         )
 
-        result = self.controller.run_request(request)
+        with patch(
+            "qfit.analysis.application.analysis_controller.build_empty_analysis_result",
+            return_value="result",
+        ) as build_result:
+            result = self.controller.run_request(request)
 
-        self.assertEqual(result.status, "")
-        self.assertIsNone(result.layer)
+        self.assertEqual(result, "result")
+        build_result.assert_called_once_with()
 
     def test_run_request_reports_no_matches(self):
         request = self.controller.build_request(
@@ -126,10 +134,14 @@ class TestAnalysisController(unittest.TestCase):
             points_layer=None,
         )
 
-        result = self.controller.run_request(request)
+        with patch(
+            "qfit.analysis.application.analysis_controller.build_empty_analysis_result",
+            return_value="result",
+        ) as build_result:
+            result = self.controller.run_request(request)
 
-        self.assertEqual(result.status, "")
-        self.assertIsNone(result.layer)
+        self.assertEqual(result, "result")
+        build_result.assert_called_once_with()
 
     def test_run_request_reports_no_heatmap_matches(self):
         request = self.controller.build_request(

--- a/tests/test_analysis_result_builder.py
+++ b/tests/test_analysis_result_builder.py
@@ -3,11 +3,18 @@ import unittest
 from tests import _path  # noqa: F401
 from qfit.analysis.application.analysis_result_builder import (
     build_activity_heatmap_result,
+    build_empty_analysis_result,
     build_frequent_start_points_result,
 )
 
 
 class TestAnalysisResultBuilder(unittest.TestCase):
+    def test_build_empty_analysis_result(self):
+        result = build_empty_analysis_result()
+
+        self.assertEqual(result.status, "")
+        self.assertIsNone(result.layer)
+
     def test_build_frequent_start_points_result_reports_empty(self):
         result = build_frequent_start_points_result(None, [])
 


### PR DESCRIPTION
## Summary
- extract the empty analysis result builder into `analysis/application/analysis_result_builder.py`
- stop constructing bare `RunAnalysisResult()` values inline in `AnalysisController.run()` for guard and unsupported paths
- add focused coverage for the new helper and controller delegation path

## Testing
- `python3 -m pytest tests/test_analysis_result_builder.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_result_builder.py analysis/application/analysis_controller.py tests/test_analysis_result_builder.py tests/test_analysis_controller.py`

Closes #513
