### PR TITLE
refactor: extract frequent start points analysis execution

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -5,7 +5,6 @@ from .analysis_models import RunAnalysisRequest, RunAnalysisResult
 from .analysis_result_builder import (
     build_activity_heatmap_result,
     build_empty_analysis_result,
-    build_frequent_start_points_result,
 )
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
@@ -43,11 +42,7 @@ class AnalysisController:
             request = self.build_request(**legacy_kwargs)
 
         if request.analysis_mode == FREQUENT_STARTING_POINTS_MODE:
-            if request.starts_layer is None:
-                return build_empty_analysis_result()
-
-            layer, clusters = _build_frequent_start_points_layer(request.starts_layer)
-            return build_frequent_start_points_result(layer, clusters)
+            return _run_frequent_start_points_analysis(request.starts_layer)
 
         if request.analysis_mode == HEATMAP_MODE:
             if request.activities_layer is None and request.points_layer is None:
@@ -65,12 +60,10 @@ class AnalysisController:
         return self.run(request=request)
 
 
-def _build_frequent_start_points_layer(starts_layer):
-    from ..infrastructure.frequent_start_points_layer import (
-        build_frequent_start_points_layer,
-    )
+def _run_frequent_start_points_analysis(starts_layer):
+    from .frequent_start_points_analysis import run_frequent_start_points_analysis
 
-    return build_frequent_start_points_layer(starts_layer)
+    return run_frequent_start_points_analysis(starts_layer)
 
 
 def _build_activity_heatmap_layer(activities_layer, points_layer):

--- a/analysis/application/frequent_start_points_analysis.py
+++ b/analysis/application/frequent_start_points_analysis.py
@@ -1,0 +1,16 @@
+from .analysis_result_builder import (
+    build_empty_analysis_result,
+    build_frequent_start_points_result,
+)
+
+
+def run_frequent_start_points_analysis(starts_layer):
+    if starts_layer is None:
+        return build_empty_analysis_result()
+
+    from ..infrastructure.frequent_start_points_layer import (
+        build_frequent_start_points_layer,
+    )
+
+    layer, clusters = build_frequent_start_points_layer(starts_layer)
+    return build_frequent_start_points_result(layer, clusters)

--- a/analysis/application/frequent_start_points_analysis.py
+++ b/analysis/application/frequent_start_points_analysis.py
@@ -8,9 +8,13 @@ def run_frequent_start_points_analysis(starts_layer):
     if starts_layer is None:
         return build_empty_analysis_result()
 
+    layer, clusters = _build_frequent_start_points_layer(starts_layer)
+    return build_frequent_start_points_result(layer, clusters)
+
+
+def _build_frequent_start_points_layer(starts_layer):
     from ..infrastructure.frequent_start_points_layer import (
         build_frequent_start_points_layer,
     )
 
-    layer, clusters = build_frequent_start_points_layer(starts_layer)
-    return build_frequent_start_points_result(layer, clusters)
+    return build_frequent_start_points_layer(starts_layer)

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -8,6 +8,7 @@ from qfit.analysis.application.analysis_controller import (
     AnalysisController,
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
+    _run_frequent_start_points_analysis,
 )
 
 
@@ -118,6 +119,16 @@ class TestAnalysisController(unittest.TestCase):
 
         self.assertIs(result, built_result)
         run_analysis.assert_called_once_with(request.starts_layer)
+
+    def test_run_frequent_start_points_analysis_delegates_to_application_helper(self):
+        with patch(
+            "qfit.analysis.application.frequent_start_points_analysis.run_frequent_start_points_analysis",
+            return_value="result",
+        ) as run_analysis:
+            result = _run_frequent_start_points_analysis("starts-layer")
+
+        self.assertEqual(result, "result")
+        run_analysis.assert_called_once_with("starts-layer")
 
     def test_run_request_returns_empty_result_without_heatmap_layers(self):
         request = self.controller.build_request(

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -80,13 +80,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.build_empty_analysis_result",
+            "qfit.analysis.application.analysis_controller._run_frequent_start_points_analysis",
             return_value="result",
-        ) as build_result:
+        ) as run_analysis:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        build_result.assert_called_once_with()
+        run_analysis.assert_called_once_with(None)
 
     def test_run_request_reports_no_matches(self):
         request = self.controller.build_request(
@@ -95,36 +95,29 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller._build_frequent_start_points_layer",
-            return_value=(None, []),
-        ), patch(
-            "qfit.analysis.application.analysis_controller.build_frequent_start_points_result",
+            "qfit.analysis.application.analysis_controller._run_frequent_start_points_analysis",
             return_value="result",
-        ) as build_result:
+        ) as run_analysis:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        build_result.assert_called_once_with(None, [])
+        run_analysis.assert_called_once_with(request.starts_layer)
 
     def test_run_request_returns_layer_for_matching_mode(self):
         request = self.controller.build_request(
             FREQUENT_STARTING_POINTS_MODE,
             object(),
         )
-        layer = object()
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller._build_frequent_start_points_layer",
-            return_value=(layer, [object(), object()]),
-        ), patch(
-            "qfit.analysis.application.analysis_controller.build_frequent_start_points_result",
+            "qfit.analysis.application.analysis_controller._run_frequent_start_points_analysis",
             return_value=built_result,
-        ) as build_result:
+        ) as run_analysis:
             result = self.controller.run_request(request)
 
         self.assertIs(result, built_result)
-        build_result.assert_called_once()
+        run_analysis.assert_called_once_with(request.starts_layer)
 
     def test_run_request_returns_empty_result_without_heatmap_layers(self):
         request = self.controller.build_request(

--- a/tests/test_frequent_start_points_analysis.py
+++ b/tests/test_frequent_start_points_analysis.py
@@ -1,8 +1,11 @@
+import sys
+import types
 import unittest
 from unittest.mock import patch
 
 from tests import _path  # noqa: F401
 from qfit.analysis.application.frequent_start_points_analysis import (
+    _build_frequent_start_points_layer,
     run_frequent_start_points_analysis,
 )
 
@@ -33,6 +36,16 @@ class TestFrequentStartPointsAnalysis(unittest.TestCase):
         self.assertEqual(result, "result")
         build_layer.assert_called_once_with("starts-layer")
         build_result.assert_called_once_with("layer", clusters)
+
+    def test_build_frequent_start_points_layer_delegates_to_infrastructure_builder(self):
+        fake_module = types.ModuleType("qfit.analysis.infrastructure.frequent_start_points_layer")
+        fake_module.build_frequent_start_points_layer = lambda layer: ("built-layer", [layer])
+
+        with patch.dict(sys.modules, {fake_module.__name__: fake_module}):
+            layer, clusters = _build_frequent_start_points_layer("starts-layer")
+
+        self.assertEqual(layer, "built-layer")
+        self.assertEqual(clusters, ["starts-layer"])
 
 
 if __name__ == "__main__":

--- a/tests/test_frequent_start_points_analysis.py
+++ b/tests/test_frequent_start_points_analysis.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from qfit.analysis.application.frequent_start_points_analysis import (
+    run_frequent_start_points_analysis,
+)
+
+
+class TestFrequentStartPointsAnalysis(unittest.TestCase):
+    def test_run_frequent_start_points_analysis_returns_empty_result_without_layer(self):
+        with patch(
+            "qfit.analysis.application.frequent_start_points_analysis.build_empty_analysis_result",
+            return_value="result",
+        ) as build_empty:
+            result = run_frequent_start_points_analysis(None)
+
+        self.assertEqual(result, "result")
+        build_empty.assert_called_once_with()
+
+    def test_run_frequent_start_points_analysis_builds_result_from_layer_output(self):
+        clusters = [object(), object()]
+
+        with patch(
+            "qfit.analysis.infrastructure.frequent_start_points_layer.build_frequent_start_points_layer",
+            return_value=("layer", clusters),
+        ) as build_layer, patch(
+            "qfit.analysis.application.frequent_start_points_analysis.build_frequent_start_points_result",
+            return_value="result",
+        ) as build_result:
+            result = run_frequent_start_points_analysis("starts-layer")
+
+        self.assertEqual(result, "result")
+        build_layer.assert_called_once_with("starts-layer")
+        build_result.assert_called_once_with("layer", clusters)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frequent_start_points_analysis.py
+++ b/tests/test_frequent_start_points_analysis.py
@@ -22,7 +22,7 @@ class TestFrequentStartPointsAnalysis(unittest.TestCase):
         clusters = [object(), object()]
 
         with patch(
-            "qfit.analysis.infrastructure.frequent_start_points_layer.build_frequent_start_points_layer",
+            "qfit.analysis.application.frequent_start_points_analysis._build_frequent_start_points_layer",
             return_value=("layer", clusters),
         ) as build_layer, patch(
             "qfit.analysis.application.frequent_start_points_analysis.build_frequent_start_points_result",


### PR DESCRIPTION
## Summary
- extract the frequent-start-points analysis execution flow from `AnalysisController.run()` into a dedicated application helper
- keep the controller responsible for mode dispatch while the helper owns guard handling, infrastructure delegation, and result shaping for this branch
- add focused coverage for the new helper and updated controller delegation path

## Testing
- `python3 -m pytest tests/test_frequent_start_points_analysis.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/frequent_start_points_analysis.py analysis/application/analysis_controller.py tests/test_frequent_start_points_analysis.py tests/test_analysis_controller.py`

Closes #515
