### PR TITLE
refactor: extract heatmap analysis execution

### DIFF
--- a/analysis/application/activity_heatmap_analysis.py
+++ b/analysis/application/activity_heatmap_analysis.py
@@ -1,0 +1,24 @@
+from .analysis_result_builder import (
+    build_activity_heatmap_result,
+    build_empty_analysis_result,
+)
+
+
+def run_activity_heatmap_analysis(activities_layer=None, points_layer=None):
+    if activities_layer is None and points_layer is None:
+        return build_empty_analysis_result()
+
+    layer, sample_count = _build_activity_heatmap_layer(
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+    )
+    return build_activity_heatmap_result(layer, sample_count)
+
+
+def _build_activity_heatmap_layer(activities_layer=None, points_layer=None):
+    from ..infrastructure.activity_heatmap_layer import build_activity_heatmap_layer
+
+    return build_activity_heatmap_layer(
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+    )

--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from ...activities.application.activity_selection_state import ActivitySelectionState
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
-from .analysis_result_builder import (
-    build_activity_heatmap_result,
-    build_empty_analysis_result,
-)
+from .analysis_result_builder import build_empty_analysis_result
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
 HEATMAP_MODE = "Heatmap"
@@ -45,14 +42,10 @@ class AnalysisController:
             return _run_frequent_start_points_analysis(request.starts_layer)
 
         if request.analysis_mode == HEATMAP_MODE:
-            if request.activities_layer is None and request.points_layer is None:
-                return build_empty_analysis_result()
-
-            layer, sample_count = _build_activity_heatmap_layer(
-                request.activities_layer,
-                request.points_layer,
+            return _run_activity_heatmap_analysis(
+                activities_layer=request.activities_layer,
+                points_layer=request.points_layer,
             )
-            return build_activity_heatmap_result(layer, sample_count)
 
         return build_empty_analysis_result()
 
@@ -66,10 +59,10 @@ def _run_frequent_start_points_analysis(starts_layer):
     return run_frequent_start_points_analysis(starts_layer)
 
 
-def _build_activity_heatmap_layer(activities_layer, points_layer):
-    from ..infrastructure.activity_heatmap_layer import build_activity_heatmap_layer
+def _run_activity_heatmap_analysis(activities_layer=None, points_layer=None):
+    from .activity_heatmap_analysis import run_activity_heatmap_analysis
 
-    return build_activity_heatmap_layer(
+    return run_activity_heatmap_analysis(
         activities_layer=activities_layer,
         points_layer=points_layer,
     )

--- a/tests/test_activity_heatmap_analysis.py
+++ b/tests/test_activity_heatmap_analysis.py
@@ -1,0 +1,62 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from qfit.analysis.application.activity_heatmap_analysis import (
+    _build_activity_heatmap_layer,
+    run_activity_heatmap_analysis,
+)
+
+
+class TestActivityHeatmapAnalysis(unittest.TestCase):
+    def test_run_activity_heatmap_analysis_returns_empty_result_without_layers(self):
+        with patch(
+            "qfit.analysis.application.activity_heatmap_analysis.build_empty_analysis_result",
+            return_value="result",
+        ) as build_empty:
+            result = run_activity_heatmap_analysis()
+
+        self.assertEqual(result, "result")
+        build_empty.assert_called_once_with()
+
+    def test_run_activity_heatmap_analysis_builds_result_from_layer_output(self):
+        with patch(
+            "qfit.analysis.application.activity_heatmap_analysis._build_activity_heatmap_layer",
+            return_value=("layer", 42),
+        ) as build_layer, patch(
+            "qfit.analysis.application.activity_heatmap_analysis.build_activity_heatmap_result",
+            return_value="result",
+        ) as build_result:
+            result = run_activity_heatmap_analysis(
+                activities_layer="activities-layer",
+                points_layer="points-layer",
+            )
+
+        self.assertEqual(result, "result")
+        build_layer.assert_called_once_with(
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+        build_result.assert_called_once_with("layer", 42)
+
+    def test_build_activity_heatmap_layer_delegates_to_infrastructure_builder(self):
+        fake_module = types.ModuleType("qfit.analysis.infrastructure.activity_heatmap_layer")
+        fake_module.build_activity_heatmap_layer = lambda activities_layer=None, points_layer=None: (
+            "built-layer",
+            7,
+        )
+
+        with patch.dict(sys.modules, {fake_module.__name__: fake_module}):
+            layer, sample_count = _build_activity_heatmap_layer(
+                activities_layer="activities-layer",
+                points_layer="points-layer",
+            )
+
+        self.assertEqual(layer, "built-layer")
+        self.assertEqual(sample_count, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -8,6 +8,7 @@ from qfit.analysis.application.analysis_controller import (
     AnalysisController,
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
+    _run_activity_heatmap_analysis,
     _run_frequent_start_points_analysis,
 )
 
@@ -139,13 +140,16 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.build_empty_analysis_result",
+            "qfit.analysis.application.analysis_controller._run_activity_heatmap_analysis",
             return_value="result",
-        ) as build_result:
+        ) as run_analysis:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        build_result.assert_called_once_with()
+        run_analysis.assert_called_once_with(
+            activities_layer=None,
+            points_layer=None,
+        )
 
     def test_run_request_reports_no_heatmap_matches(self):
         request = self.controller.build_request(
@@ -156,16 +160,16 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller._build_activity_heatmap_layer",
-            return_value=(None, 0),
-        ), patch(
-            "qfit.analysis.application.analysis_controller.build_activity_heatmap_result",
+            "qfit.analysis.application.analysis_controller._run_activity_heatmap_analysis",
             return_value="result",
-        ) as build_result:
+        ) as run_analysis:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        build_result.assert_called_once_with(None, 0)
+        run_analysis.assert_called_once_with(
+            activities_layer=request.activities_layer,
+            points_layer=request.points_layer,
+        )
 
     def test_run_request_returns_heatmap_layer(self):
         request = self.controller.build_request(
@@ -174,20 +178,35 @@ class TestAnalysisController(unittest.TestCase):
             activities_layer=object(),
             points_layer=object(),
         )
-        layer = object()
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller._build_activity_heatmap_layer",
-            return_value=(layer, 42),
-        ), patch(
-            "qfit.analysis.application.analysis_controller.build_activity_heatmap_result",
+            "qfit.analysis.application.analysis_controller._run_activity_heatmap_analysis",
             return_value=built_result,
-        ) as build_result:
+        ) as run_analysis:
             result = self.controller.run_request(request)
 
         self.assertIs(result, built_result)
-        build_result.assert_called_once_with(layer, 42)
+        run_analysis.assert_called_once_with(
+            activities_layer=request.activities_layer,
+            points_layer=request.points_layer,
+        )
+
+    def test_run_activity_heatmap_analysis_delegates_to_application_helper(self):
+        with patch(
+            "qfit.analysis.application.activity_heatmap_analysis.run_activity_heatmap_analysis",
+            return_value="result",
+        ) as run_analysis:
+            result = _run_activity_heatmap_analysis(
+                activities_layer="activities-layer",
+                points_layer="points-layer",
+            )
+
+        self.assertEqual(result, "result")
+        run_analysis.assert_called_once_with(
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extract the heatmap analysis execution flow from `AnalysisController.run()` into a dedicated application helper
- keep the controller responsible for mode dispatch while the helper owns guard handling, infrastructure delegation, and result shaping for the heatmap branch
- add focused coverage for the new helper and updated controller delegation path

## Testing
- `python3 -m pytest tests/test_activity_heatmap_analysis.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/activity_heatmap_analysis.py analysis/application/analysis_controller.py tests/test_activity_heatmap_analysis.py tests/test_analysis_controller.py`

Closes #517
