### PR TITLE
refactor: extract analysis mode dispatch

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from ...activities.application.activity_selection_state import ActivitySelectionState
+from .analysis_execution_dispatch import (
+    FREQUENT_STARTING_POINTS_MODE,
+    HEATMAP_MODE,
+    dispatch_analysis_request,
+)
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
-from .analysis_result_builder import build_empty_analysis_result
-
-FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
-HEATMAP_MODE = "Heatmap"
 
 
 class AnalysisController:
@@ -38,31 +39,7 @@ class AnalysisController:
         if request is None:
             request = self.build_request(**legacy_kwargs)
 
-        if request.analysis_mode == FREQUENT_STARTING_POINTS_MODE:
-            return _run_frequent_start_points_analysis(request.starts_layer)
-
-        if request.analysis_mode == HEATMAP_MODE:
-            return _run_activity_heatmap_analysis(
-                activities_layer=request.activities_layer,
-                points_layer=request.points_layer,
-            )
-
-        return build_empty_analysis_result()
+        return dispatch_analysis_request(request)
 
     def run_request(self, request: RunAnalysisRequest) -> RunAnalysisResult:
         return self.run(request=request)
-
-
-def _run_frequent_start_points_analysis(starts_layer):
-    from .frequent_start_points_analysis import run_frequent_start_points_analysis
-
-    return run_frequent_start_points_analysis(starts_layer)
-
-
-def _run_activity_heatmap_analysis(activities_layer=None, points_layer=None):
-    from .activity_heatmap_analysis import run_activity_heatmap_analysis
-
-    return run_activity_heatmap_analysis(
-        activities_layer=activities_layer,
-        points_layer=points_layer,
-    )

--- a/analysis/application/analysis_execution_dispatch.py
+++ b/analysis/application/analysis_execution_dispatch.py
@@ -1,0 +1,19 @@
+from .activity_heatmap_analysis import run_activity_heatmap_analysis
+from .analysis_result_builder import build_empty_analysis_result
+from .frequent_start_points_analysis import run_frequent_start_points_analysis
+
+FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
+HEATMAP_MODE = "Heatmap"
+
+
+def dispatch_analysis_request(request):
+    if request.analysis_mode == FREQUENT_STARTING_POINTS_MODE:
+        return run_frequent_start_points_analysis(request.starts_layer)
+
+    if request.analysis_mode == HEATMAP_MODE:
+        return run_activity_heatmap_analysis(
+            activities_layer=request.activities_layer,
+            points_layer=request.points_layer,
+        )
+
+    return build_empty_analysis_result()

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -8,8 +8,6 @@ from qfit.analysis.application.analysis_controller import (
     AnalysisController,
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
-    _run_activity_heatmap_analysis,
-    _run_frequent_start_points_analysis,
 )
 
 
@@ -67,13 +65,13 @@ class TestAnalysisController(unittest.TestCase):
         request = self.controller.build_request("None", object())
 
         with patch(
-            "qfit.analysis.application.analysis_controller.build_empty_analysis_result",
+            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
             return_value="result",
-        ) as build_result:
+        ) as dispatch_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        build_result.assert_called_once_with()
+        dispatch_request.assert_called_once_with(request)
 
     def test_run_request_returns_empty_result_without_starts_layer(self):
         request = self.controller.build_request(
@@ -82,13 +80,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller._run_frequent_start_points_analysis",
+            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
             return_value="result",
-        ) as run_analysis:
+        ) as dispatch_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        run_analysis.assert_called_once_with(None)
+        dispatch_request.assert_called_once_with(request)
 
     def test_run_request_reports_no_matches(self):
         request = self.controller.build_request(
@@ -97,13 +95,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller._run_frequent_start_points_analysis",
+            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
             return_value="result",
-        ) as run_analysis:
+        ) as dispatch_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        run_analysis.assert_called_once_with(request.starts_layer)
+        dispatch_request.assert_called_once_with(request)
 
     def test_run_request_returns_layer_for_matching_mode(self):
         request = self.controller.build_request(
@@ -113,23 +111,30 @@ class TestAnalysisController(unittest.TestCase):
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller._run_frequent_start_points_analysis",
+            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
             return_value=built_result,
-        ) as run_analysis:
+        ) as dispatch_request:
             result = self.controller.run_request(request)
 
         self.assertIs(result, built_result)
-        run_analysis.assert_called_once_with(request.starts_layer)
+        dispatch_request.assert_called_once_with(request)
 
-    def test_run_frequent_start_points_analysis_delegates_to_application_helper(self):
+    def test_run_delegates_to_dispatch_helper(self):
+        request = self.controller.build_request(
+            FREQUENT_STARTING_POINTS_MODE,
+            "starts-layer",
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+
         with patch(
-            "qfit.analysis.application.frequent_start_points_analysis.run_frequent_start_points_analysis",
+            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
             return_value="result",
-        ) as run_analysis:
-            result = _run_frequent_start_points_analysis("starts-layer")
+        ) as dispatch_request:
+            result = self.controller.run(request)
 
         self.assertEqual(result, "result")
-        run_analysis.assert_called_once_with("starts-layer")
+        dispatch_request.assert_called_once_with(request)
 
     def test_run_request_returns_empty_result_without_heatmap_layers(self):
         request = self.controller.build_request(
@@ -140,16 +145,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller._run_activity_heatmap_analysis",
+            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
             return_value="result",
-        ) as run_analysis:
+        ) as dispatch_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        run_analysis.assert_called_once_with(
-            activities_layer=None,
-            points_layer=None,
-        )
+        dispatch_request.assert_called_once_with(request)
 
     def test_run_request_reports_no_heatmap_matches(self):
         request = self.controller.build_request(
@@ -160,16 +162,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller._run_activity_heatmap_analysis",
+            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
             return_value="result",
-        ) as run_analysis:
+        ) as dispatch_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        run_analysis.assert_called_once_with(
-            activities_layer=request.activities_layer,
-            points_layer=request.points_layer,
-        )
+        dispatch_request.assert_called_once_with(request)
 
     def test_run_request_returns_heatmap_layer(self):
         request = self.controller.build_request(
@@ -181,32 +180,13 @@ class TestAnalysisController(unittest.TestCase):
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller._run_activity_heatmap_analysis",
+            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
             return_value=built_result,
-        ) as run_analysis:
+        ) as dispatch_request:
             result = self.controller.run_request(request)
 
         self.assertIs(result, built_result)
-        run_analysis.assert_called_once_with(
-            activities_layer=request.activities_layer,
-            points_layer=request.points_layer,
-        )
-
-    def test_run_activity_heatmap_analysis_delegates_to_application_helper(self):
-        with patch(
-            "qfit.analysis.application.activity_heatmap_analysis.run_activity_heatmap_analysis",
-            return_value="result",
-        ) as run_analysis:
-            result = _run_activity_heatmap_analysis(
-                activities_layer="activities-layer",
-                points_layer="points-layer",
-            )
-
-        self.assertEqual(result, "result")
-        run_analysis.assert_called_once_with(
-            activities_layer="activities-layer",
-            points_layer="points-layer",
-        )
+        dispatch_request.assert_called_once_with(request)
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis_execution_dispatch.py
+++ b/tests/test_analysis_execution_dispatch.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from qfit.analysis.application.analysis_controller import (
+    FREQUENT_STARTING_POINTS_MODE,
+    HEATMAP_MODE,
+)
+from qfit.analysis.application.analysis_models import RunAnalysisRequest
+from qfit.analysis.application.analysis_execution_dispatch import dispatch_analysis_request
+
+
+class TestAnalysisExecutionDispatch(unittest.TestCase):
+    def test_dispatch_analysis_request_routes_frequent_start_points_mode(self):
+        request = RunAnalysisRequest(
+            analysis_mode=FREQUENT_STARTING_POINTS_MODE,
+            starts_layer="starts-layer",
+        )
+
+        with patch(
+            "qfit.analysis.application.analysis_execution_dispatch.run_frequent_start_points_analysis",
+            return_value="result",
+        ) as run_analysis:
+            result = dispatch_analysis_request(request)
+
+        self.assertEqual(result, "result")
+        run_analysis.assert_called_once_with("starts-layer")
+
+    def test_dispatch_analysis_request_routes_heatmap_mode(self):
+        request = RunAnalysisRequest(
+            analysis_mode=HEATMAP_MODE,
+            starts_layer=None,
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+
+        with patch(
+            "qfit.analysis.application.analysis_execution_dispatch.run_activity_heatmap_analysis",
+            return_value="result",
+        ) as run_analysis:
+            result = dispatch_analysis_request(request)
+
+        self.assertEqual(result, "result")
+        run_analysis.assert_called_once_with(
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+
+    def test_dispatch_analysis_request_returns_empty_result_for_unknown_mode(self):
+        request = RunAnalysisRequest(
+            analysis_mode="Unknown",
+            starts_layer=None,
+        )
+
+        with patch(
+            "qfit.analysis.application.analysis_execution_dispatch.build_empty_analysis_result",
+            return_value="result",
+        ) as build_empty:
+            result = dispatch_analysis_request(request)
+
+        self.assertEqual(result, "result")
+        build_empty.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract analysis mode dispatch from `AnalysisController.run()` into a dedicated application helper
- keep the controller responsible for request construction and delegation only
- add focused coverage for the new dispatch helper and updated controller delegation path

## Testing
- `python3 -m pytest tests/test_analysis_execution_dispatch.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_execution_dispatch.py analysis/application/analysis_controller.py tests/test_analysis_execution_dispatch.py tests/test_analysis_controller.py`

Closes #519
