### PR TITLE
refactor: extract analysis request execution

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -4,9 +4,9 @@ from ...activities.application.activity_selection_state import ActivitySelection
 from .analysis_execution_dispatch import (
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
-    dispatch_analysis_request,
 )
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
+from .analysis_request_execution import execute_analysis_request
 
 
 class AnalysisController:
@@ -36,10 +36,11 @@ class AnalysisController:
         )
 
     def run(self, request: RunAnalysisRequest | None = None, **legacy_kwargs) -> RunAnalysisResult:
-        if request is None:
-            request = self.build_request(**legacy_kwargs)
-
-        return dispatch_analysis_request(request)
+        return execute_analysis_request(
+            build_request=self.build_request,
+            request=request,
+            legacy_kwargs=legacy_kwargs,
+        )
 
     def run_request(self, request: RunAnalysisRequest) -> RunAnalysisResult:
         return self.run(request=request)

--- a/analysis/application/analysis_request_execution.py
+++ b/analysis/application/analysis_request_execution.py
@@ -1,0 +1,8 @@
+from .analysis_execution_dispatch import dispatch_analysis_request
+
+
+def execute_analysis_request(*, build_request, request=None, legacy_kwargs=None):
+    if request is None:
+        request = build_request(**(legacy_kwargs or {}))
+
+    return dispatch_analysis_request(request)

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -65,13 +65,17 @@ class TestAnalysisController(unittest.TestCase):
         request = self.controller.build_request("None", object())
 
         with patch(
-            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
             return_value="result",
-        ) as dispatch_request:
+        ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        dispatch_request.assert_called_once_with(request)
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=request,
+            legacy_kwargs={},
+        )
 
     def test_run_request_returns_empty_result_without_starts_layer(self):
         request = self.controller.build_request(
@@ -80,13 +84,17 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
             return_value="result",
-        ) as dispatch_request:
+        ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        dispatch_request.assert_called_once_with(request)
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=request,
+            legacy_kwargs={},
+        )
 
     def test_run_request_reports_no_matches(self):
         request = self.controller.build_request(
@@ -95,13 +103,17 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
             return_value="result",
-        ) as dispatch_request:
+        ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        dispatch_request.assert_called_once_with(request)
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=request,
+            legacy_kwargs={},
+        )
 
     def test_run_request_returns_layer_for_matching_mode(self):
         request = self.controller.build_request(
@@ -111,13 +123,17 @@ class TestAnalysisController(unittest.TestCase):
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
             return_value=built_result,
-        ) as dispatch_request:
+        ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertIs(result, built_result)
-        dispatch_request.assert_called_once_with(request)
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=request,
+            legacy_kwargs={},
+        )
 
     def test_run_delegates_to_dispatch_helper(self):
         request = self.controller.build_request(
@@ -128,13 +144,41 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
             return_value="result",
-        ) as dispatch_request:
+        ) as execute_request:
             result = self.controller.run(request)
 
         self.assertEqual(result, "result")
-        dispatch_request.assert_called_once_with(request)
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=request,
+            legacy_kwargs={},
+        )
+
+    def test_run_builds_request_via_execution_use_case_when_request_missing(self):
+        with patch(
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            return_value="result",
+        ) as execute_request:
+            result = self.controller.run(
+                analysis_mode="Heatmap",
+                starts_layer="starts-layer",
+                activities_layer="activities-layer",
+                points_layer="points-layer",
+            )
+
+        self.assertEqual(result, "result")
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=None,
+            legacy_kwargs={
+                "analysis_mode": "Heatmap",
+                "starts_layer": "starts-layer",
+                "activities_layer": "activities-layer",
+                "points_layer": "points-layer",
+            },
+        )
 
     def test_run_request_returns_empty_result_without_heatmap_layers(self):
         request = self.controller.build_request(
@@ -145,13 +189,17 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
             return_value="result",
-        ) as dispatch_request:
+        ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        dispatch_request.assert_called_once_with(request)
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=request,
+            legacy_kwargs={},
+        )
 
     def test_run_request_reports_no_heatmap_matches(self):
         request = self.controller.build_request(
@@ -162,13 +210,17 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
             return_value="result",
-        ) as dispatch_request:
+        ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
-        dispatch_request.assert_called_once_with(request)
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=request,
+            legacy_kwargs={},
+        )
 
     def test_run_request_returns_heatmap_layer(self):
         request = self.controller.build_request(
@@ -180,13 +232,17 @@ class TestAnalysisController(unittest.TestCase):
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller.dispatch_analysis_request",
+            "qfit.analysis.application.analysis_controller.execute_analysis_request",
             return_value=built_result,
-        ) as dispatch_request:
+        ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertIs(result, built_result)
-        dispatch_request.assert_called_once_with(request)
+        execute_request.assert_called_once_with(
+            build_request=self.controller.build_request,
+            request=request,
+            legacy_kwargs={},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis_request_execution.py
+++ b/tests/test_analysis_request_execution.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from tests import _path  # noqa: F401
+from qfit.analysis.application.analysis_request_execution import execute_analysis_request
+
+
+class TestAnalysisRequestExecution(unittest.TestCase):
+    def test_execute_analysis_request_dispatches_prebuilt_request(self):
+        build_request = Mock()
+        request = object()
+
+        with patch(
+            "qfit.analysis.application.analysis_request_execution.dispatch_analysis_request",
+            return_value="result",
+        ) as dispatch_request:
+            result = execute_analysis_request(
+                build_request=build_request,
+                request=request,
+            )
+
+        self.assertEqual(result, "result")
+        build_request.assert_not_called()
+        dispatch_request.assert_called_once_with(request)
+
+    def test_execute_analysis_request_builds_request_from_legacy_kwargs(self):
+        request = object()
+        build_request = Mock(return_value=request)
+
+        with patch(
+            "qfit.analysis.application.analysis_request_execution.dispatch_analysis_request",
+            return_value="result",
+        ) as dispatch_request:
+            result = execute_analysis_request(
+                build_request=build_request,
+                legacy_kwargs={
+                    "analysis_mode": "Heatmap",
+                    "starts_layer": "starts-layer",
+                    "activities_layer": "activities-layer",
+                    "points_layer": "points-layer",
+                },
+            )
+
+        self.assertEqual(result, "result")
+        build_request.assert_called_once_with(
+            analysis_mode="Heatmap",
+            starts_layer="starts-layer",
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+        dispatch_request.assert_called_once_with(request)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract analysis request execution from `AnalysisController` into a dedicated application use case
- keep the controller as a thin façade that delegates request construction and dispatch sequencing
- add focused coverage for the new execution helper and updated controller delegation path

## Testing
- `python3 -m pytest tests/test_analysis_request_execution.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_execution.py analysis/application/analysis_controller.py tests/test_analysis_request_execution.py tests/test_analysis_controller.py`

Closes #521
