### PR TITLE
refactor: extract analysis request building

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ...activities.application.activity_selection_state import ActivitySelectionState
+from .analysis_request_building import build_analysis_request
 from .analysis_execution_dispatch import (
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
@@ -20,19 +21,12 @@ class AnalysisController:
         activities_layer: object = None,
         points_layer: object = None,
     ) -> RunAnalysisRequest:
-        from .analysis_request_builder import (
-            build_analysis_controller_request_inputs,
-            build_run_analysis_request,
-        )
-
-        return build_run_analysis_request(
-            build_analysis_controller_request_inputs(
-                analysis_mode=analysis_mode,
-                starts_layer=starts_layer,
-                selection_state=selection_state,
-                activities_layer=activities_layer,
-                points_layer=points_layer,
-            )
+        return build_analysis_request(
+            analysis_mode=analysis_mode,
+            starts_layer=starts_layer,
+            selection_state=selection_state,
+            activities_layer=activities_layer,
+            points_layer=points_layer,
         )
 
     def run(self, request: RunAnalysisRequest | None = None, **legacy_kwargs) -> RunAnalysisResult:

--- a/analysis/application/analysis_request_building.py
+++ b/analysis/application/analysis_request_building.py
@@ -1,0 +1,25 @@
+from ...activities.application.activity_selection_state import ActivitySelectionState
+
+
+def build_analysis_request(
+    *,
+    analysis_mode: str,
+    starts_layer,
+    selection_state: ActivitySelectionState | None = None,
+    activities_layer=None,
+    points_layer=None,
+):
+    from .analysis_request_builder import (
+        build_analysis_controller_request_inputs,
+        build_run_analysis_request,
+    )
+
+    return build_run_analysis_request(
+        build_analysis_controller_request_inputs(
+            analysis_mode=analysis_mode,
+            starts_layer=starts_layer,
+            selection_state=selection_state,
+            activities_layer=activities_layer,
+            points_layer=points_layer,
+        )
+    )

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -30,12 +30,9 @@ class TestAnalysisController(unittest.TestCase):
 
     def test_build_request_delegates_to_request_builder_helper(self):
         with patch(
-            "qfit.analysis.application.analysis_request_builder.build_run_analysis_request",
+            "qfit.analysis.application.analysis_controller.build_analysis_request",
             return_value="request",
-        ) as build_request, patch(
-            "qfit.analysis.application.analysis_request_builder.build_analysis_controller_request_inputs",
-            return_value="request-inputs",
-        ) as build_inputs:
+        ) as build_request:
             request = self.controller.build_request(
                 "Heatmap",
                 "starts-layer",
@@ -45,14 +42,13 @@ class TestAnalysisController(unittest.TestCase):
             )
 
         self.assertEqual(request, "request")
-        build_inputs.assert_called_once_with(
+        build_request.assert_called_once_with(
             analysis_mode="Heatmap",
             starts_layer="starts-layer",
             selection_state="selection-state",
             activities_layer="activities-layer",
             points_layer="points-layer",
         )
-        build_request.assert_called_once_with("request-inputs")
 
     def test_build_request_keeps_selection_state(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)

--- a/tests/test_analysis_request_building.py
+++ b/tests/test_analysis_request_building.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
+from qfit.analysis.application.analysis_request_building import build_analysis_request
+
+
+class TestAnalysisRequestBuilding(unittest.TestCase):
+    def test_build_analysis_request_delegates_to_request_builder_helpers(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
+
+        with patch(
+            "qfit.analysis.application.analysis_request_builder.build_analysis_controller_request_inputs",
+            return_value="request-inputs",
+        ) as build_inputs, patch(
+            "qfit.analysis.application.analysis_request_builder.build_run_analysis_request",
+            return_value="request",
+        ) as build_request:
+            request = build_analysis_request(
+                analysis_mode="Heatmap",
+                starts_layer="starts-layer",
+                selection_state=selection_state,
+                activities_layer="activities-layer",
+                points_layer="points-layer",
+            )
+
+        self.assertEqual(request, "request")
+        build_inputs.assert_called_once_with(
+            analysis_mode="Heatmap",
+            starts_layer="starts-layer",
+            selection_state=selection_state,
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+        build_request.assert_called_once_with("request-inputs")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract analysis request building from `AnalysisController` into a dedicated application use case
- keep the controller as a thin façade delegating request build and run use cases
- add focused coverage for the new build helper and updated controller delegation path

## Testing
- `python3 -m pytest tests/test_analysis_request_building.py tests/test_analysis_request_execution.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_building.py analysis/application/analysis_controller.py tests/test_analysis_request_building.py tests/test_analysis_controller.py`

Closes #523
