### PR TITLE
refactor: extract analysis execution policy facade

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from ...activities.application.activity_selection_state import ActivitySelectionState
-from .analysis_request_building import build_analysis_request
 from .analysis_execution_dispatch import (
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
 )
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
-from .analysis_request_execution import execute_analysis_request
+from .analysis_policy_facade import (
+    build_analysis_controller_request,
+    run_analysis_controller_request,
+)
 
 
 class AnalysisController:
@@ -17,11 +18,11 @@ class AnalysisController:
     def build_request(
         analysis_mode: str,
         starts_layer: object,
-        selection_state: ActivitySelectionState | None = None,
+        selection_state=None,
         activities_layer: object = None,
         points_layer: object = None,
     ) -> RunAnalysisRequest:
-        return build_analysis_request(
+        return build_analysis_controller_request(
             analysis_mode=analysis_mode,
             starts_layer=starts_layer,
             selection_state=selection_state,
@@ -30,8 +31,7 @@ class AnalysisController:
         )
 
     def run(self, request: RunAnalysisRequest | None = None, **legacy_kwargs) -> RunAnalysisResult:
-        return execute_analysis_request(
-            build_request=self.build_request,
+        return run_analysis_controller_request(
             request=request,
             legacy_kwargs=legacy_kwargs,
         )

--- a/analysis/application/analysis_policy_facade.py
+++ b/analysis/application/analysis_policy_facade.py
@@ -1,0 +1,28 @@
+from ...activities.application.activity_selection_state import ActivitySelectionState
+from .analysis_request_building import build_analysis_request
+from .analysis_request_execution import execute_analysis_request
+
+
+def build_analysis_controller_request(
+    *,
+    analysis_mode: str,
+    starts_layer,
+    selection_state: ActivitySelectionState | None = None,
+    activities_layer: object = None,
+    points_layer: object = None,
+):
+    return build_analysis_request(
+        analysis_mode=analysis_mode,
+        starts_layer=starts_layer,
+        selection_state=selection_state,
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+    )
+
+
+def run_analysis_controller_request(*, request=None, legacy_kwargs=None):
+    return execute_analysis_request(
+        build_request=build_analysis_controller_request,
+        request=request,
+        legacy_kwargs=legacy_kwargs,
+    )

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -30,7 +30,7 @@ class TestAnalysisController(unittest.TestCase):
 
     def test_build_request_delegates_to_request_builder_helper(self):
         with patch(
-            "qfit.analysis.application.analysis_controller.build_analysis_request",
+            "qfit.analysis.application.analysis_controller.build_analysis_controller_request",
             return_value="request",
         ) as build_request:
             request = self.controller.build_request(
@@ -61,14 +61,13 @@ class TestAnalysisController(unittest.TestCase):
         request = self.controller.build_request("None", object())
 
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=request,
             legacy_kwargs={},
         )
@@ -80,14 +79,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=request,
             legacy_kwargs={},
         )
@@ -99,14 +97,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=request,
             legacy_kwargs={},
         )
@@ -119,14 +116,13 @@ class TestAnalysisController(unittest.TestCase):
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value=built_result,
         ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertIs(result, built_result)
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=request,
             legacy_kwargs={},
         )
@@ -140,21 +136,20 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run(request)
 
         self.assertEqual(result, "result")
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=request,
             legacy_kwargs={},
         )
 
     def test_run_builds_request_via_execution_use_case_when_request_missing(self):
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run(
@@ -166,7 +161,6 @@ class TestAnalysisController(unittest.TestCase):
 
         self.assertEqual(result, "result")
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=None,
             legacy_kwargs={
                 "analysis_mode": "Heatmap",
@@ -185,14 +179,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=request,
             legacy_kwargs={},
         )
@@ -206,14 +199,13 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertEqual(result, "result")
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=request,
             legacy_kwargs={},
         )
@@ -228,14 +220,13 @@ class TestAnalysisController(unittest.TestCase):
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller.execute_analysis_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
             return_value=built_result,
         ) as execute_request:
             result = self.controller.run_request(request)
 
         self.assertIs(result, built_result)
         execute_request.assert_called_once_with(
-            build_request=self.controller.build_request,
             request=request,
             legacy_kwargs={},
         )

--- a/tests/test_analysis_policy_facade.py
+++ b/tests/test_analysis_policy_facade.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
+from qfit.analysis.application.analysis_policy_facade import (
+    build_analysis_controller_request,
+    run_analysis_controller_request,
+)
+
+
+class TestAnalysisPolicyFacade(unittest.TestCase):
+    def test_build_analysis_controller_request_delegates_to_build_use_case(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
+
+        with patch(
+            "qfit.analysis.application.analysis_policy_facade.build_analysis_request",
+            return_value="request",
+        ) as build_request:
+            request = build_analysis_controller_request(
+                analysis_mode="Heatmap",
+                starts_layer="starts-layer",
+                selection_state=selection_state,
+                activities_layer="activities-layer",
+                points_layer="points-layer",
+            )
+
+        self.assertEqual(request, "request")
+        build_request.assert_called_once_with(
+            analysis_mode="Heatmap",
+            starts_layer="starts-layer",
+            selection_state=selection_state,
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+
+    def test_run_analysis_controller_request_delegates_to_execution_use_case(self):
+        request = object()
+
+        with patch(
+            "qfit.analysis.application.analysis_policy_facade.execute_analysis_request",
+            return_value="result",
+        ) as execute_request:
+            result = run_analysis_controller_request(
+                request=request,
+                legacy_kwargs={"analysis_mode": "Heatmap"},
+            )
+
+        self.assertEqual(result, "result")
+        execute_request.assert_called_once_with(
+            build_request=build_analysis_controller_request,
+            request=request,
+            legacy_kwargs={"analysis_mode": "Heatmap"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract an analysis application policy façade for the controller-facing build and run operations
- keep `AnalysisController` as a minimal wrapper delegating through that façade
- add focused coverage for the new façade and updated controller delegation path

## Testing
- `python3 -m pytest tests/test_analysis_policy_facade.py tests/test_analysis_request_building.py tests/test_analysis_request_execution.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_policy_facade.py analysis/application/analysis_controller.py tests/test_analysis_policy_facade.py tests/test_analysis_controller.py`

Closes #525
