### PR TITLE
refactor: extract analysis controller provider

### DIFF
--- a/analysis/application/analysis_controller_provider.py
+++ b/analysis/application/analysis_controller_provider.py
@@ -1,0 +1,4 @@
+def build_analysis_controller():
+    from .analysis_controller import AnalysisController
+
+    return AnalysisController()

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -32,7 +32,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
             patch("qfit.ui.dockwidget_dependencies.SettingsService", return_value=sentinel.settings),
             patch("qfit.ui.dockwidget_dependencies.SyncController", return_value=sentinel.sync_controller),
             patch(
-                "qfit.ui.dockwidget_dependencies.AnalysisController",
+                "qfit.ui.dockwidget_dependencies.build_analysis_controller",
                 return_value=sentinel.analysis_controller,
             ),
             patch(

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..analysis.application.analysis_controller import AnalysisController
+from ..analysis.application.analysis_controller_provider import build_analysis_controller
 from ..atlas.export_controller import AtlasExportController
 from ..atlas.export_service import AtlasExportService
 from ..atlas.export_use_case import AtlasExportUseCase
@@ -50,7 +51,7 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
     return DockWidgetDependencies(
         settings=settings,
         sync_controller=sync_controller,
-        analysis_controller=AnalysisController(),
+        analysis_controller=build_analysis_controller(),
         atlas_export_controller=atlas_export_controller,
         atlas_export_use_case=AtlasExportUseCase(atlas_export_controller, atlas_export_service),
         layer_gateway=layer_gateway,


### PR DESCRIPTION
## Summary
- extract a tiny analysis controller provider seam for dockwidget composition wiring
- stop instantiating `AnalysisController()` directly inside `build_dockwidget_dependencies()`
- update the wiring test to assert the new provider seam

## Testing
- `python3 -m pytest tests/test_dockwidget_dependencies.py tests/test_analysis_policy_facade.py tests/test_analysis_controller.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_controller_provider.py ui/dockwidget_dependencies.py tests/test_dockwidget_dependencies.py`

Closes #527
