### PR TITLE
refactor: add analysis workflow port

### DIFF
--- a/analysis/application/analysis_controller_provider.py
+++ b/analysis/application/analysis_controller_provider.py
@@ -1,4 +1,7 @@
-def build_analysis_controller():
+from .analysis_workflow_port import AnalysisWorkflowPort
+
+
+def build_analysis_controller() -> AnalysisWorkflowPort:
     from .analysis_controller import AnalysisController
 
     return AnalysisController()

--- a/analysis/application/analysis_workflow_port.py
+++ b/analysis/application/analysis_workflow_port.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .analysis_models import RunAnalysisRequest, RunAnalysisResult
+
+
+@runtime_checkable
+class AnalysisWorkflowPort(Protocol):
+    def build_request(
+        self,
+        analysis_mode: str,
+        starts_layer: object,
+        selection_state=None,
+        activities_layer: object = None,
+        points_layer: object = None,
+    ) -> RunAnalysisRequest: ...
+
+    def run_request(self, request: RunAnalysisRequest) -> RunAnalysisResult: ...

--- a/tests/test_analysis_workflow_port.py
+++ b/tests/test_analysis_workflow_port.py
@@ -1,0 +1,19 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.analysis.application.analysis_controller import AnalysisController
+from qfit.analysis.application.analysis_controller_provider import build_analysis_controller
+from qfit.analysis.application.analysis_workflow_port import AnalysisWorkflowPort
+
+
+class TestAnalysisWorkflowPort(unittest.TestCase):
+    def test_analysis_controller_implements_workflow_port(self):
+        self.assertIsInstance(AnalysisController(), AnalysisWorkflowPort)
+
+    def test_provider_returns_workflow_port(self):
+        self.assertIsInstance(build_analysis_controller(), AnalysisWorkflowPort)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -2,8 +2,8 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from ..analysis.application.analysis_controller import AnalysisController
 from ..analysis.application.analysis_controller_provider import build_analysis_controller
+from ..analysis.application.analysis_workflow_port import AnalysisWorkflowPort
 from ..atlas.export_controller import AtlasExportController
 from ..atlas.export_service import AtlasExportService
 from ..atlas.export_use_case import AtlasExportUseCase
@@ -26,7 +26,7 @@ class DockWidgetDependencies:
 
     settings: SettingsService
     sync_controller: SyncController
-    analysis_controller: AnalysisController
+    analysis_controller: AnalysisWorkflowPort
     atlas_export_controller: AtlasExportController
     atlas_export_use_case: AtlasExportUseCase
     layer_gateway: Any


### PR DESCRIPTION
## Summary
- add a narrow analysis workflow port for the dock-facing analysis methods
- type the analysis controller provider and dock dependency wiring against that port
- cover the seam with focused runtime-conformance tests

## Testing
- `python3 -m pytest tests/test_analysis_workflow_port.py tests/test_dockwidget_dependencies.py tests/test_analysis_controller.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_workflow_port.py analysis/application/analysis_controller_provider.py ui/dockwidget_dependencies.py tests/test_analysis_workflow_port.py`

Closes #529
