### PR TITLE
refactor: rename dock analysis workflow seam

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -305,7 +305,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _bind_dependencies(self, dependencies: DockWidgetDependencies) -> None:
         self.settings = dependencies.settings
         self.sync_controller = dependencies.sync_controller
-        self.analysis_controller = dependencies.analysis_controller
+        self.analysis_workflow = dependencies.analysis_workflow
         self.atlas_export_controller = dependencies.atlas_export_controller
         self.atlas_export_use_case = dependencies.atlas_export_use_case
         self.layer_gateway = dependencies.layer_gateway
@@ -800,14 +800,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
 
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
-        request = self.analysis_controller.build_request(
+        request = self.analysis_workflow.build_request(
             analysis_mode=analysis_mode,
             starts_layer=starts_layer,
             selection_state=selection_state,
             activities_layer=getattr(self, "activities_layer", None),
             points_layer=getattr(self, "points_layer", None),
         )
-        result = self.analysis_controller.run_request(request)
+        result = self.analysis_workflow.run_request(request)
         if result.layer is None:
             return result.status
 

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -33,7 +33,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
             patch("qfit.ui.dockwidget_dependencies.SyncController", return_value=sentinel.sync_controller),
             patch(
                 "qfit.ui.dockwidget_dependencies.build_analysis_controller",
-                return_value=sentinel.analysis_controller,
+                return_value=sentinel.analysis_workflow,
             ),
             patch(
                 "qfit.ui.dockwidget_dependencies.AtlasExportController",
@@ -77,7 +77,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
 
         self.assertIs(dependencies.settings, sentinel.settings)
         self.assertIs(dependencies.sync_controller, sentinel.sync_controller)
-        self.assertIs(dependencies.analysis_controller, sentinel.analysis_controller)
+        self.assertIs(dependencies.analysis_workflow, sentinel.analysis_workflow)
         self.assertIs(dependencies.atlas_export_controller, sentinel.atlas_export_controller)
         self.assertIs(dependencies.atlas_export_use_case, sentinel.atlas_export_use_case)
         self.assertIs(dependencies.layer_gateway, sentinel.layer_gateway)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -531,11 +531,11 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         build_action.assert_called_once_with(self.module.ApplyVisualizationAction, "inputs")
 
-    def test_run_selected_analysis_delegates_to_analysis_controller(self):
+    def test_run_selected_analysis_delegates_to_analysis_workflow(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock.analysis_controller = MagicMock()
-        dock.analysis_controller.build_request.return_value = "analysis-request"
-        dock.analysis_controller.run_request.return_value = SimpleNamespace(
+        dock.analysis_workflow = MagicMock()
+        dock.analysis_workflow.build_request.return_value = "analysis-request"
+        dock.analysis_workflow.run_request.return_value = SimpleNamespace(
             status="Showing top 2 frequent starting-point clusters",
             layer=None,
         )
@@ -551,21 +551,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
 
         self.assertEqual(result, "Showing top 2 frequent starting-point clusters")
-        dock.analysis_controller.build_request.assert_called_once_with(
+        dock.analysis_workflow.build_request.assert_called_once_with(
             analysis_mode="Most frequent starting points",
             starts_layer="starts-layer",
             selection_state=selection_state,
             activities_layer="activities-layer",
             points_layer="points-layer",
         )
-        dock.analysis_controller.run_request.assert_called_once_with("analysis-request")
+        dock.analysis_workflow.run_request.assert_called_once_with("analysis-request")
 
     def test_run_selected_analysis_adds_returned_layer_to_project(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock.analysis_controller = MagicMock()
-        dock.analysis_controller.build_request.return_value = "analysis-request"
+        dock.analysis_workflow = MagicMock()
+        dock.analysis_workflow.build_request.return_value = "analysis-request"
         analysis_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
-        dock.analysis_controller.run_request.return_value = SimpleNamespace(
+        dock.analysis_workflow.run_request.return_value = SimpleNamespace(
             status="Showing top 2 frequent starting-point clusters",
             layer=analysis_layer,
         )

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -26,7 +26,7 @@ class DockWidgetDependencies:
 
     settings: SettingsService
     sync_controller: SyncController
-    analysis_controller: AnalysisWorkflowPort
+    analysis_workflow: AnalysisWorkflowPort
     atlas_export_controller: AtlasExportController
     atlas_export_use_case: AtlasExportUseCase
     layer_gateway: Any
@@ -51,7 +51,7 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
     return DockWidgetDependencies(
         settings=settings,
         sync_controller=sync_controller,
-        analysis_controller=build_analysis_controller(),
+        analysis_workflow=build_analysis_controller(),
         atlas_export_controller=atlas_export_controller,
         atlas_export_use_case=AtlasExportUseCase(atlas_export_controller, atlas_export_service),
         layer_gateway=layer_gateway,


### PR DESCRIPTION
## Summary
- rename the dock-facing analysis dependency from `analysis_controller` to `analysis_workflow`
- update dock wiring and analysis execution calls to use the workflow seam name
- refresh focused tests to match the renamed dependency without changing behavior

## Testing
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_dockwidget_dependencies.py tests/test_analysis_workflow_port.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py ui/dockwidget_dependencies.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dockwidget_dependencies.py`

Closes #531
