### PR TITLE
refactor: rename analysis workflow provider

### DIFF
--- a/analysis/application/analysis_controller_provider.py
+++ b/analysis/application/analysis_controller_provider.py
@@ -1,7 +1,7 @@
 from .analysis_workflow_port import AnalysisWorkflowPort
 
 
-def build_analysis_controller() -> AnalysisWorkflowPort:
+def build_analysis_workflow() -> AnalysisWorkflowPort:
     from .analysis_controller import AnalysisController
 
     return AnalysisController()

--- a/tests/test_analysis_workflow_port.py
+++ b/tests/test_analysis_workflow_port.py
@@ -3,7 +3,7 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.analysis.application.analysis_controller import AnalysisController
-from qfit.analysis.application.analysis_controller_provider import build_analysis_controller
+from qfit.analysis.application.analysis_controller_provider import build_analysis_workflow
 from qfit.analysis.application.analysis_workflow_port import AnalysisWorkflowPort
 
 
@@ -12,7 +12,7 @@ class TestAnalysisWorkflowPort(unittest.TestCase):
         self.assertIsInstance(AnalysisController(), AnalysisWorkflowPort)
 
     def test_provider_returns_workflow_port(self):
-        self.assertIsInstance(build_analysis_controller(), AnalysisWorkflowPort)
+        self.assertIsInstance(build_analysis_workflow(), AnalysisWorkflowPort)
 
 
 if __name__ == "__main__":

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -32,7 +32,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
             patch("qfit.ui.dockwidget_dependencies.SettingsService", return_value=sentinel.settings),
             patch("qfit.ui.dockwidget_dependencies.SyncController", return_value=sentinel.sync_controller),
             patch(
-                "qfit.ui.dockwidget_dependencies.build_analysis_controller",
+                "qfit.ui.dockwidget_dependencies.build_analysis_workflow",
                 return_value=sentinel.analysis_workflow,
             ),
             patch(

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -2,7 +2,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from ..analysis.application.analysis_controller_provider import build_analysis_controller
+from ..analysis.application.analysis_controller_provider import build_analysis_workflow
 from ..analysis.application.analysis_workflow_port import AnalysisWorkflowPort
 from ..atlas.export_controller import AtlasExportController
 from ..atlas.export_service import AtlasExportService
@@ -51,7 +51,7 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
     return DockWidgetDependencies(
         settings=settings,
         sync_controller=sync_controller,
-        analysis_workflow=build_analysis_controller(),
+        analysis_workflow=build_analysis_workflow(),
         atlas_export_controller=atlas_export_controller,
         atlas_export_use_case=AtlasExportUseCase(atlas_export_controller, atlas_export_service),
         layer_gateway=layer_gateway,


### PR DESCRIPTION
## Summary
- rename the analysis workflow provider factory to `build_analysis_workflow()`
- update dock dependency wiring to use the renamed workflow factory
- refresh focused tests to match the workflow-oriented naming

## Testing
- `python3 -m pytest tests/test_analysis_workflow_port.py tests/test_dockwidget_dependencies.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_controller_provider.py ui/dockwidget_dependencies.py tests/test_analysis_workflow_port.py tests/test_dockwidget_dependencies.py`

Closes #533
