### PR TITLE
refactor: rename analysis workflow facade functions

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -6,8 +6,8 @@ from .analysis_execution_dispatch import (
 )
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
 from .analysis_policy_facade import (
-    build_analysis_controller_request,
-    run_analysis_controller_request,
+    build_analysis_workflow_request,
+    run_analysis_workflow_request,
 )
 
 
@@ -22,7 +22,7 @@ class AnalysisController:
         activities_layer: object = None,
         points_layer: object = None,
     ) -> RunAnalysisRequest:
-        return build_analysis_controller_request(
+        return build_analysis_workflow_request(
             analysis_mode=analysis_mode,
             starts_layer=starts_layer,
             selection_state=selection_state,
@@ -31,7 +31,7 @@ class AnalysisController:
         )
 
     def run(self, request: RunAnalysisRequest | None = None, **legacy_kwargs) -> RunAnalysisResult:
-        return run_analysis_controller_request(
+        return run_analysis_workflow_request(
             request=request,
             legacy_kwargs=legacy_kwargs,
         )

--- a/analysis/application/analysis_policy_facade.py
+++ b/analysis/application/analysis_policy_facade.py
@@ -3,7 +3,7 @@ from .analysis_request_building import build_analysis_request
 from .analysis_request_execution import execute_analysis_request
 
 
-def build_analysis_controller_request(
+def build_analysis_workflow_request(
     *,
     analysis_mode: str,
     starts_layer,
@@ -20,9 +20,9 @@ def build_analysis_controller_request(
     )
 
 
-def run_analysis_controller_request(*, request=None, legacy_kwargs=None):
+def run_analysis_workflow_request(*, request=None, legacy_kwargs=None):
     return execute_analysis_request(
-        build_request=build_analysis_controller_request,
+        build_request=build_analysis_workflow_request,
         request=request,
         legacy_kwargs=legacy_kwargs,
     )

--- a/tests/test_analysis_controller.py
+++ b/tests/test_analysis_controller.py
@@ -30,7 +30,7 @@ class TestAnalysisController(unittest.TestCase):
 
     def test_build_request_delegates_to_request_builder_helper(self):
         with patch(
-            "qfit.analysis.application.analysis_controller.build_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.build_analysis_workflow_request",
             return_value="request",
         ) as build_request:
             request = self.controller.build_request(
@@ -61,7 +61,7 @@ class TestAnalysisController(unittest.TestCase):
         request = self.controller.build_request("None", object())
 
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
@@ -79,7 +79,7 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
@@ -97,7 +97,7 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
@@ -116,7 +116,7 @@ class TestAnalysisController(unittest.TestCase):
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value=built_result,
         ) as execute_request:
             result = self.controller.run_request(request)
@@ -136,7 +136,7 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run(request)
@@ -149,7 +149,7 @@ class TestAnalysisController(unittest.TestCase):
 
     def test_run_builds_request_via_execution_use_case_when_request_missing(self):
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run(
@@ -179,7 +179,7 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
@@ -199,7 +199,7 @@ class TestAnalysisController(unittest.TestCase):
         )
 
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value="result",
         ) as execute_request:
             result = self.controller.run_request(request)
@@ -220,7 +220,7 @@ class TestAnalysisController(unittest.TestCase):
         built_result = object()
 
         with patch(
-            "qfit.analysis.application.analysis_controller.run_analysis_controller_request",
+            "qfit.analysis.application.analysis_controller.run_analysis_workflow_request",
             return_value=built_result,
         ) as execute_request:
             result = self.controller.run_request(request)

--- a/tests/test_analysis_policy_facade.py
+++ b/tests/test_analysis_policy_facade.py
@@ -5,20 +5,20 @@ from tests import _path  # noqa: F401
 from qfit.activities.application.activity_selection_state import ActivitySelectionState
 from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.analysis.application.analysis_policy_facade import (
-    build_analysis_controller_request,
-    run_analysis_controller_request,
+    build_analysis_workflow_request,
+    run_analysis_workflow_request,
 )
 
 
 class TestAnalysisPolicyFacade(unittest.TestCase):
-    def test_build_analysis_controller_request_delegates_to_build_use_case(self):
+    def test_build_analysis_workflow_request_delegates_to_build_use_case(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
 
         with patch(
             "qfit.analysis.application.analysis_policy_facade.build_analysis_request",
             return_value="request",
         ) as build_request:
-            request = build_analysis_controller_request(
+            request = build_analysis_workflow_request(
                 analysis_mode="Heatmap",
                 starts_layer="starts-layer",
                 selection_state=selection_state,
@@ -35,21 +35,21 @@ class TestAnalysisPolicyFacade(unittest.TestCase):
             points_layer="points-layer",
         )
 
-    def test_run_analysis_controller_request_delegates_to_execution_use_case(self):
+    def test_run_analysis_workflow_request_delegates_to_execution_use_case(self):
         request = object()
 
         with patch(
             "qfit.analysis.application.analysis_policy_facade.execute_analysis_request",
             return_value="result",
         ) as execute_request:
-            result = run_analysis_controller_request(
+            result = run_analysis_workflow_request(
                 request=request,
                 legacy_kwargs={"analysis_mode": "Heatmap"},
             )
 
         self.assertEqual(result, "result")
         execute_request.assert_called_once_with(
-            build_request=build_analysis_controller_request,
+            build_request=build_analysis_workflow_request,
             request=request,
             legacy_kwargs={"analysis_mode": "Heatmap"},
         )


### PR DESCRIPTION
## Summary
- rename the analysis policy facade entry points to workflow-oriented names
- update `AnalysisController` to call the renamed workflow facade helpers
- refresh the focused policy-facade and controller tests to match the new names

## Testing
- `python3 -m pytest tests/test_analysis_policy_facade.py tests/test_analysis_controller.py tests/test_analysis_workflow_port.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_policy_facade.py analysis/application/analysis_controller.py tests/test_analysis_policy_facade.py tests/test_analysis_controller.py`

Closes #537
