### PR TITLE
refactor: rename analysis workflow request inputs

### DIFF
--- a/analysis/application/analysis_request_builder.py
+++ b/analysis/application/analysis_request_builder.py
@@ -78,7 +78,7 @@ def build_run_analysis_request_inputs(
     )
 
 
-def build_analysis_controller_request_inputs(
+def build_analysis_workflow_request_inputs(
     *,
     analysis_mode: str,
     starts_layer,
@@ -86,7 +86,7 @@ def build_analysis_controller_request_inputs(
     activities_layer: object = None,
     points_layer: object = None,
 ) -> RunAnalysisRequestInputs:
-    """Build normalized request inputs for AnalysisController.build_request()."""
+    """Build normalized request inputs for the analysis workflow seam."""
 
     return build_run_analysis_request_inputs(
         current=build_run_analysis_current_inputs(

--- a/analysis/application/analysis_request_building.py
+++ b/analysis/application/analysis_request_building.py
@@ -10,12 +10,12 @@ def build_analysis_request(
     points_layer=None,
 ):
     from .analysis_request_builder import (
-        build_analysis_controller_request_inputs,
+        build_analysis_workflow_request_inputs,
         build_run_analysis_request,
     )
 
     return build_run_analysis_request(
-        build_analysis_controller_request_inputs(
+        build_analysis_workflow_request_inputs(
             analysis_mode=analysis_mode,
             starts_layer=starts_layer,
             selection_state=selection_state,

--- a/tests/test_analysis_request_builder.py
+++ b/tests/test_analysis_request_builder.py
@@ -7,7 +7,7 @@ from qfit.analysis.application.analysis_request_builder import (
     ApplyAnalysisConfigurationInputs,
     RunAnalysisCurrentInputs,
     RunAnalysisRequestInputs,
-    build_analysis_controller_request_inputs,
+    build_analysis_workflow_request_inputs,
     build_apply_analysis_configuration_inputs,
     build_run_analysis_current_inputs,
     build_run_analysis_request,
@@ -93,10 +93,10 @@ class TestAnalysisRequestBuilder(unittest.TestCase):
         self.assertIsNone(inputs.points_layer)
         self.assertEqual(inputs.selection_state.filtered_count, 0)
 
-    def test_build_analysis_controller_request_inputs_keeps_inputs(self):
+    def test_build_analysis_workflow_request_inputs_keeps_inputs(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
 
-        inputs = build_analysis_controller_request_inputs(
+        inputs = build_analysis_workflow_request_inputs(
             analysis_mode="Heatmap",
             starts_layer="starts-layer",
             selection_state=selection_state,

--- a/tests/test_analysis_request_building.py
+++ b/tests/test_analysis_request_building.py
@@ -12,7 +12,7 @@ class TestAnalysisRequestBuilding(unittest.TestCase):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
 
         with patch(
-            "qfit.analysis.application.analysis_request_builder.build_analysis_controller_request_inputs",
+            "qfit.analysis.application.analysis_request_builder.build_analysis_workflow_request_inputs",
             return_value="request-inputs",
         ) as build_inputs, patch(
             "qfit.analysis.application.analysis_request_builder.build_run_analysis_request",


### PR DESCRIPTION
## Summary
- rename the analysis request-builder helper to `build_analysis_workflow_request_inputs(...)`
- update the request-building use case to call the renamed workflow-oriented helper
- refresh focused request-builder and request-building tests to match the new helper name

## Testing
- `python3 -m pytest tests/test_analysis_request_builder.py tests/test_analysis_request_building.py tests/test_analysis_policy_facade.py tests/test_analysis_controller.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_builder.py analysis/application/analysis_request_building.py tests/test_analysis_request_builder.py tests/test_analysis_request_building.py`

Closes #539
