### PR TITLE
refactor: rename analysis workflow builder

### DIFF
--- a/analysis/application/analysis_policy_facade.py
+++ b/analysis/application/analysis_policy_facade.py
@@ -1,5 +1,5 @@
 from ...activities.application.activity_selection_state import ActivitySelectionState
-from .analysis_request_building import build_analysis_request
+from .analysis_request_building import build_analysis_workflow
 from .analysis_request_execution import execute_analysis_request
 
 
@@ -11,7 +11,7 @@ def build_analysis_workflow_request(
     activities_layer: object = None,
     points_layer: object = None,
 ):
-    return build_analysis_request(
+    return build_analysis_workflow(
         analysis_mode=analysis_mode,
         starts_layer=starts_layer,
         selection_state=selection_state,

--- a/analysis/application/analysis_request_building.py
+++ b/analysis/application/analysis_request_building.py
@@ -1,7 +1,7 @@
 from ...activities.application.activity_selection_state import ActivitySelectionState
 
 
-def build_analysis_request(
+def build_analysis_workflow(
     *,
     analysis_mode: str,
     starts_layer,

--- a/tests/test_analysis_policy_facade.py
+++ b/tests/test_analysis_policy_facade.py
@@ -15,7 +15,7 @@ class TestAnalysisPolicyFacade(unittest.TestCase):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
 
         with patch(
-            "qfit.analysis.application.analysis_policy_facade.build_analysis_request",
+            "qfit.analysis.application.analysis_policy_facade.build_analysis_workflow",
             return_value="request",
         ) as build_request:
             request = build_analysis_workflow_request(

--- a/tests/test_analysis_request_building.py
+++ b/tests/test_analysis_request_building.py
@@ -4,11 +4,11 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from qfit.activities.application.activity_selection_state import ActivitySelectionState
 from qfit.activities.domain.activity_query import ActivityQuery
-from qfit.analysis.application.analysis_request_building import build_analysis_request
+from qfit.analysis.application.analysis_request_building import build_analysis_workflow
 
 
 class TestAnalysisRequestBuilding(unittest.TestCase):
-    def test_build_analysis_request_delegates_to_request_builder_helpers(self):
+    def test_build_analysis_workflow_delegates_to_request_builder_helpers(self):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="gravel"), filtered_count=4)
 
         with patch(
@@ -18,7 +18,7 @@ class TestAnalysisRequestBuilding(unittest.TestCase):
             "qfit.analysis.application.analysis_request_builder.build_run_analysis_request",
             return_value="request",
         ) as build_request:
-            request = build_analysis_request(
+            request = build_analysis_workflow(
                 analysis_mode="Heatmap",
                 starts_layer="starts-layer",
                 selection_state=selection_state,


### PR DESCRIPTION
## Summary
- rename the analysis request-building use case entry point to `build_analysis_workflow(...)`
- update the policy facade to call the renamed workflow-oriented builder
- refresh focused request-building and policy-facade tests to match the new entry point

## Testing
- `python3 -m pytest tests/test_analysis_request_building.py tests/test_analysis_policy_facade.py tests/test_analysis_controller.py tests/test_analysis_request_builder.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_building.py analysis/application/analysis_policy_facade.py tests/test_analysis_request_building.py tests/test_analysis_policy_facade.py`

Closes #541
