### PR TITLE
refactor: rename analysis workflow execution

### DIFF
--- a/analysis/application/analysis_policy_facade.py
+++ b/analysis/application/analysis_policy_facade.py
@@ -1,6 +1,6 @@
 from ...activities.application.activity_selection_state import ActivitySelectionState
 from .analysis_request_building import build_analysis_workflow
-from .analysis_request_execution import execute_analysis_request
+from .analysis_request_execution import run_analysis_workflow
 
 
 def build_analysis_workflow_request(
@@ -21,7 +21,7 @@ def build_analysis_workflow_request(
 
 
 def run_analysis_workflow_request(*, request=None, legacy_kwargs=None):
-    return execute_analysis_request(
+    return run_analysis_workflow(
         build_request=build_analysis_workflow_request,
         request=request,
         legacy_kwargs=legacy_kwargs,

--- a/analysis/application/analysis_request_execution.py
+++ b/analysis/application/analysis_request_execution.py
@@ -1,7 +1,7 @@
 from .analysis_execution_dispatch import dispatch_analysis_request
 
 
-def execute_analysis_request(*, build_request, request=None, legacy_kwargs=None):
+def run_analysis_workflow(*, build_request, request=None, legacy_kwargs=None):
     if request is None:
         request = build_request(**(legacy_kwargs or {}))
 

--- a/tests/test_analysis_policy_facade.py
+++ b/tests/test_analysis_policy_facade.py
@@ -39,7 +39,7 @@ class TestAnalysisPolicyFacade(unittest.TestCase):
         request = object()
 
         with patch(
-            "qfit.analysis.application.analysis_policy_facade.execute_analysis_request",
+            "qfit.analysis.application.analysis_policy_facade.run_analysis_workflow",
             return_value="result",
         ) as execute_request:
             result = run_analysis_workflow_request(

--- a/tests/test_analysis_request_execution.py
+++ b/tests/test_analysis_request_execution.py
@@ -2,11 +2,11 @@ import unittest
 from unittest.mock import Mock, patch
 
 from tests import _path  # noqa: F401
-from qfit.analysis.application.analysis_request_execution import execute_analysis_request
+from qfit.analysis.application.analysis_request_execution import run_analysis_workflow
 
 
 class TestAnalysisRequestExecution(unittest.TestCase):
-    def test_execute_analysis_request_dispatches_prebuilt_request(self):
+    def test_run_analysis_workflow_dispatches_prebuilt_request(self):
         build_request = Mock()
         request = object()
 
@@ -14,7 +14,7 @@ class TestAnalysisRequestExecution(unittest.TestCase):
             "qfit.analysis.application.analysis_request_execution.dispatch_analysis_request",
             return_value="result",
         ) as dispatch_request:
-            result = execute_analysis_request(
+            result = run_analysis_workflow(
                 build_request=build_request,
                 request=request,
             )
@@ -23,7 +23,7 @@ class TestAnalysisRequestExecution(unittest.TestCase):
         build_request.assert_not_called()
         dispatch_request.assert_called_once_with(request)
 
-    def test_execute_analysis_request_builds_request_from_legacy_kwargs(self):
+    def test_run_analysis_workflow_builds_request_from_legacy_kwargs(self):
         request = object()
         build_request = Mock(return_value=request)
 
@@ -31,7 +31,7 @@ class TestAnalysisRequestExecution(unittest.TestCase):
             "qfit.analysis.application.analysis_request_execution.dispatch_analysis_request",
             return_value="result",
         ) as dispatch_request:
-            result = execute_analysis_request(
+            result = run_analysis_workflow(
                 build_request=build_request,
                 legacy_kwargs={
                     "analysis_mode": "Heatmap",


### PR DESCRIPTION
## Summary
- rename the analysis request-execution use case entry point to `run_analysis_workflow(...)`
- update the policy facade to call the renamed workflow-oriented execution helper
- refresh focused execution and policy-facade tests to match the new entry point

## Testing
- `python3 -m pytest tests/test_analysis_request_execution.py tests/test_analysis_policy_facade.py tests/test_analysis_controller.py tests/test_analysis_request_building.py -q --tb=short`
- `python3 -m py_compile analysis/application/analysis_request_execution.py analysis/application/analysis_policy_facade.py tests/test_analysis_request_execution.py tests/test_analysis_policy_facade.py`

Closes #543
