### PR TITLE
refactor: extract activity preview refresh workflow

### DIFF
--- a/activities/application/__init__.py
+++ b/activities/application/__init__.py
@@ -11,6 +11,7 @@ _ACTIVITY_PREVIEW_MODULE = ".activity_preview"
 __all__ = [
     "ActivityPreviewRequest",
     "ActivityPreviewResult",
+    "ActivityPreviewService",
     "ActivitySelectionState",
     "ActivityTypeOptionsResult",
     "BuildStravaProviderRequest",
@@ -39,6 +40,7 @@ _ACTIVITY_TYPE_OPTIONS_MODULE = ".activity_type_options"
 _EXPORTS = {
     "ActivityPreviewRequest": (_ACTIVITY_PREVIEW_MODULE, "ActivityPreviewRequest"),
     "ActivityPreviewResult": (_ACTIVITY_PREVIEW_MODULE, "ActivityPreviewResult"),
+    "ActivityPreviewService": (".activity_preview_service", "ActivityPreviewService"),
     "ActivitySelectionState": (".activity_selection_state", "ActivitySelectionState"),
     "ActivityTypeOptionsResult": (_ACTIVITY_TYPE_OPTIONS_MODULE, "ActivityTypeOptionsResult"),
     "BuildStravaProviderRequest": (".sync_controller", "BuildStravaProviderRequest"),

--- a/activities/application/activity_preview_service.py
+++ b/activities/application/activity_preview_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from .activity_preview import ActivityPreviewRequest, ActivityPreviewResult, build_activity_preview
+
+
+class ActivityPreviewService:
+    """Structured seam for building dock activity-preview results.
+
+    Keeps the preview-refresh workflow behind a feature-owned application service,
+    matching the request/result service pattern already used by other dock-facing
+    workflows.
+    """
+
+    @staticmethod
+    def build_result(
+        request: ActivityPreviewRequest | None = None,
+        **legacy_kwargs,
+    ) -> ActivityPreviewResult:
+        if request is None:
+            request = ActivityPreviewRequest(**legacy_kwargs)
+        return build_activity_preview(request)
+
+    def build_result_request(self, request: ActivityPreviewRequest) -> ActivityPreviewResult:
+        return self.build_result(request=request)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -36,7 +36,6 @@ from .activities.application import (
     ActivityPreviewRequest,
     ActivitySelectionState,
     ActivityTypeOptionsResult,
-    build_activity_preview,
     build_activity_selection_state,
     build_activity_type_options_from_activities,
     build_activity_type_options_from_records,
@@ -315,6 +314,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.visual_apply = dependencies.visual_apply
         self.atlas_export_service = dependencies.atlas_export_service
         self.fetch_result_service = dependencies.fetch_result_service
+        self.activity_preview_service = dependencies.activity_preview_service
         self.cache = dependencies.cache
 
     @staticmethod
@@ -891,7 +891,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return self._current_activity_selection_state().query
 
     def _refresh_activity_preview(self):
-        preview = build_activity_preview(self._current_activity_preview_request())
+        preview = self.activity_preview_service.build_result_request(
+            self._current_activity_preview_request()
+        )
         self.querySummaryLabel.setText(preview.query_summary_text)
         self.activityPreviewPlainTextEdit.setPlainText(preview.preview_text)
         return preview.fetched_activities

--- a/tests/test_activity_preview_service.py
+++ b/tests/test_activity_preview_service.py
@@ -1,0 +1,46 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.application.activity_preview import ActivityPreviewRequest
+from qfit.activities.application.activity_preview_service import ActivityPreviewService
+
+
+class ActivityPreviewServiceTests(unittest.TestCase):
+    def test_build_result_request_delegates_to_preview_builder(self):
+        request = ActivityPreviewRequest(activities=[SimpleNamespace(name="Ride")])
+        service = ActivityPreviewService()
+
+        with patch(
+            "qfit.activities.application.activity_preview_service.build_activity_preview",
+            return_value="preview-result",
+        ) as build_preview:
+            result = service.build_result_request(request)
+
+        self.assertEqual(result, "preview-result")
+        build_preview.assert_called_once_with(request)
+
+    def test_build_result_builds_request_from_legacy_kwargs(self):
+        service = ActivityPreviewService()
+
+        with patch(
+            "qfit.activities.application.activity_preview_service.build_activity_preview",
+            return_value="preview-result",
+        ) as build_preview:
+            result = service.build_result(
+                activities=[],
+                activity_type="Run",
+                sort_label="Name (A–Z)",
+            )
+
+        self.assertEqual(result, "preview-result")
+        request = build_preview.call_args.args[0]
+        self.assertIsInstance(request, ActivityPreviewRequest)
+        self.assertEqual(request.activity_type, "Run")
+        self.assertEqual(request.sort_label, "Name (A–Z)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -71,6 +71,10 @@ class DockWidgetDependenciesTests(unittest.TestCase):
                 "qfit.ui.dockwidget_dependencies.FetchResultService",
                 return_value=sentinel.fetch_result_service,
             ) as fetch_result_service,
+            patch(
+                "qfit.ui.dockwidget_dependencies.ActivityPreviewService",
+                return_value=sentinel.activity_preview_service,
+            ) as activity_preview_service,
             patch("qfit.ui.dockwidget_dependencies._build_cache", return_value=sentinel.cache),
         ):
             dependencies = build_dockwidget_dependencies(iface)
@@ -87,6 +91,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
         self.assertIs(dependencies.visual_apply, sentinel.visual_apply)
         self.assertIs(dependencies.atlas_export_service, sentinel.atlas_export_service)
         self.assertIs(dependencies.fetch_result_service, sentinel.fetch_result_service)
+        self.assertIs(dependencies.activity_preview_service, sentinel.activity_preview_service)
         self.assertIs(dependencies.cache, sentinel.cache)
 
         background_controller.assert_called_once_with(sentinel.layer_gateway)
@@ -98,6 +103,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
             sentinel.atlas_export_service,
         )
         fetch_result_service.assert_called_once_with(sentinel.sync_controller)
+        activity_preview_service.assert_called_once_with()
 
     def test_build_cache_prefers_legacy_cache_path_when_current_path_is_missing(self):
         with (

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -682,6 +682,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
     def test_refresh_activity_preview_delegates_and_updates_widgets(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._current_activity_preview_request = MagicMock(return_value="preview-request")
+        dock.activity_preview_service = SimpleNamespace(build_result_request=MagicMock())
         dock.querySummaryLabel = SimpleNamespace(setText=MagicMock())
         dock.activityPreviewPlainTextEdit = SimpleNamespace(setPlainText=MagicMock())
         preview_result = SimpleNamespace(
@@ -689,12 +690,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             preview_text="first\nsecond",
             fetched_activities=["first", "second"],
         )
+        dock.activity_preview_service.build_result_request.return_value = preview_result
 
-        with patch.object(self.module, "build_activity_preview", return_value=preview_result) as build_preview:
-            result = self.module.QfitDockWidget._refresh_activity_preview(dock)
+        result = self.module.QfitDockWidget._refresh_activity_preview(dock)
 
         self.assertEqual(result, ["first", "second"])
-        build_preview.assert_called_once_with("preview-request")
+        dock.activity_preview_service.build_result_request.assert_called_once_with("preview-request")
         dock.querySummaryLabel.setText.assert_called_once_with("2 activities")
         dock.activityPreviewPlainTextEdit.setPlainText.assert_called_once_with("first\nsecond")
 

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -8,6 +8,7 @@ from ..atlas.export_controller import AtlasExportController
 from ..atlas.export_service import AtlasExportService
 from ..atlas.export_use_case import AtlasExportUseCase
 from ..activities.application.fetch_result_service import FetchResultService
+from ..activities.application.activity_preview_service import ActivityPreviewService
 from ..activities.application.load_workflow import LoadWorkflowService
 from ..qfit_cache import QfitCache
 from ..configuration.application.settings_service import SettingsService
@@ -36,6 +37,7 @@ class DockWidgetDependencies:
     visual_apply: VisualApplyService
     atlas_export_service: AtlasExportService
     fetch_result_service: FetchResultService
+    activity_preview_service: ActivityPreviewService
     cache: QfitCache
 
 
@@ -61,6 +63,7 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
         visual_apply=VisualApplyService(layer_gateway),
         atlas_export_service=atlas_export_service,
         fetch_result_service=FetchResultService(sync_controller),
+        activity_preview_service=ActivityPreviewService(),
         cache=cache,
     )
 


### PR DESCRIPTION
## Summary
- add an `ActivityPreviewService` seam under `activities/application`
- route dock preview refresh through injected dependencies instead of calling the preview builder directly
- cover the new service seam and updated dock/dependency wiring with focused tests

## Testing
- `python3 -m pytest tests/test_activity_preview.py tests/test_activity_preview_service.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dockwidget_dependencies.py -q --tb=short`
- `python3 -m py_compile activities/application/activity_preview_service.py activities/application/__init__.py ui/dockwidget_dependencies.py qfit_dockwidget.py tests/test_activity_preview_service.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dockwidget_dependencies.py`

Closes #551
