### PR TITLE
refactor: retire unused activity preview wrappers

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -34,8 +34,6 @@ from .activities.domain.activity_query import (
 from .activities.application import (
     ActivitySelectionState,
     ActivityTypeOptionsResult,
-    build_activity_preview_filtered_activities,
-    build_activity_preview_query,
     build_activity_preview_request,
     build_activity_preview_selection_state,
     build_activity_type_options_from_activities,
@@ -888,9 +886,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _current_activity_selection_state(self):
         return build_activity_preview_selection_state(self._current_activity_preview_request())
 
-    def _current_activity_query(self):
-        return build_activity_preview_query(self._current_activity_preview_request())
-
     def _refresh_activity_preview(self):
         preview = self.activity_preview_service.build_result_request(
             self._current_activity_preview_request()
@@ -924,12 +919,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 last_sync_date=self.settings.get("last_sync_date", date.today().isoformat()),
             )
         )
-
-    def _filtered_activities(self):
-        return build_activity_preview_filtered_activities(
-            self._current_activity_preview_request()
-        )
-
 
     def _redirect_uri(self):
         return self.redirectUriLineEdit.text().strip() or StravaProvider.DEFAULT_REDIRECT_URI

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -692,35 +692,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIs(result, selection_state)
         build_state.assert_called_once_with("preview-request")
 
-    def test_current_activity_query_delegates_to_activity_preview_query_helper(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._current_activity_preview_request = MagicMock(return_value="preview-request")
-        query = object()
-
-        with patch.object(
-            self.module,
-            "build_activity_preview_query",
-            return_value=query,
-        ) as build_query:
-            result = self.module.QfitDockWidget._current_activity_query(dock)
-
-        self.assertIs(result, query)
-        build_query.assert_called_once_with("preview-request")
-
-    def test_filtered_activities_delegates_to_filtered_preview_helper(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._current_activity_preview_request = MagicMock(return_value="preview-request")
-
-        with patch.object(
-            self.module,
-            "build_activity_preview_filtered_activities",
-            return_value=["a2"],
-        ) as build_filtered:
-            result = self.module.QfitDockWidget._filtered_activities(dock)
-
-        self.assertEqual(result, ["a2"])
-        build_filtered.assert_called_once_with("preview-request")
-
     def test_refresh_activity_preview_delegates_and_updates_widgets(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._current_activity_preview_request = MagicMock(return_value="preview-request")


### PR DESCRIPTION
## Summary
- remove the now-unused activity preview query/filter wrapper methods from `QfitDockWidget`
- drop the corresponding now-unused imports
- update focused dock tests to match the thinner dock surface

## Testing
- `python3 -m pytest tests/test_activity_preview.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_activity_preview_service.py tests/test_dockwidget_dependencies.py -q --tb=short`
- `python3 -m py_compile qfit_dockwidget.py tests/test_qfit_dockwidget_analysis_pure.py`

Closes #563
