### PR TITLE
feat: simplify atlas publish settings

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -3,6 +3,11 @@ import os
 from dataclasses import dataclass, field
 from datetime import date
 
+from ...atlas.publish_atlas import (
+    DEFAULT_ATLAS_MARGIN_PERCENT,
+    DEFAULT_ATLAS_TARGET_ASPECT_RATIO,
+    DEFAULT_MIN_EXTENT_DEGREES,
+)
 from ...sync_repository import SyncStats
 from ...visualization.application.layer_gateway import LayerGateway
 
@@ -17,9 +22,9 @@ class StoreActivitiesRequest:
     output_path: str = ""
     write_activity_points: bool = True
     point_stride: int = 5
-    atlas_margin_percent: float = 0.0
-    atlas_min_extent_degrees: float = 0.0
-    atlas_target_aspect_ratio: float = 0.0
+    atlas_margin_percent: float = DEFAULT_ATLAS_MARGIN_PERCENT
+    atlas_min_extent_degrees: float = DEFAULT_MIN_EXTENT_DEGREES
+    atlas_target_aspect_ratio: float = DEFAULT_ATLAS_TARGET_ASPECT_RATIO
     sync_metadata: dict | None = None
     last_sync_date: str | None = None
 
@@ -88,9 +93,9 @@ class LoadWorkflowService:
         output_path,
         write_activity_points=True,
         point_stride=5,
-        atlas_margin_percent=0.0,
-        atlas_min_extent_degrees=0.0,
-        atlas_target_aspect_ratio=0.0,
+        atlas_margin_percent=DEFAULT_ATLAS_MARGIN_PERCENT,
+        atlas_min_extent_degrees=DEFAULT_MIN_EXTENT_DEGREES,
+        atlas_target_aspect_ratio=DEFAULT_ATLAS_TARGET_ASPECT_RATIO,
         sync_metadata=None,
         last_sync_date=None,
     ) -> StoreActivitiesRequest:

--- a/atlas/export_service.py
+++ b/atlas/export_service.py
@@ -20,6 +20,8 @@ class AtlasExportPlan:
     """Structured atlas export plan independent of QGIS runtime execution."""
 
     output_path: str = ""
+    atlas_title: str = ""
+    atlas_subtitle: str = ""
     pre_export_tile_mode: str = ""
     preset_name: str = ""
     access_token: str = ""
@@ -35,6 +37,8 @@ class GenerateAtlasPdfRequest:
 
     atlas_layer: object = None
     output_path: str = ""
+    atlas_title: str = ""
+    atlas_subtitle: str = ""
     on_finished: Callable | None = None
     pre_export_tile_mode: str = ""
     preset_name: str = ""
@@ -93,16 +97,20 @@ class AtlasExportService:
     @staticmethod
     def build_plan(
         output_path: str,
-        pre_export_tile_mode: str,
-        preset_name: str,
-        access_token: str,
-        style_owner: str,
-        style_id: str,
-        background_enabled: bool,
+        atlas_title: str = "",
+        atlas_subtitle: str = "",
+        pre_export_tile_mode: str = "",
+        preset_name: str = "",
+        access_token: str = "",
+        style_owner: str = "",
+        style_id: str = "",
+        background_enabled: bool = False,
         profile_plot_style: object | None = None,
     ) -> AtlasExportPlan:
         return AtlasExportPlan(
             output_path=output_path,
+            atlas_title=atlas_title,
+            atlas_subtitle=atlas_subtitle,
             pre_export_tile_mode=pre_export_tile_mode,
             preset_name=preset_name,
             access_token=access_token,
@@ -116,17 +124,21 @@ class AtlasExportService:
     def build_request(
         atlas_layer,
         output_path: str,
-        on_finished: Callable | None,
-        pre_export_tile_mode: str,
-        preset_name: str,
-        access_token: str,
-        style_owner: str,
-        style_id: str,
-        background_enabled: bool,
+        atlas_title: str = "",
+        atlas_subtitle: str = "",
+        on_finished: Callable | None = None,
+        pre_export_tile_mode: str = "",
+        preset_name: str = "",
+        access_token: str = "",
+        style_owner: str = "",
+        style_id: str = "",
+        background_enabled: bool = False,
         profile_plot_style: object | None = None,
     ) -> GenerateAtlasPdfRequest:
         plan = AtlasExportService.build_plan(
             output_path=output_path,
+            atlas_title=atlas_title,
+            atlas_subtitle=atlas_subtitle,
             pre_export_tile_mode=pre_export_tile_mode,
             preset_name=preset_name,
             access_token=access_token,
@@ -151,6 +163,8 @@ class AtlasExportService:
         return GenerateAtlasPdfRequest(
             atlas_layer=atlas_layer,
             output_path=plan.output_path,
+            atlas_title=plan.atlas_title,
+            atlas_subtitle=plan.atlas_subtitle,
             on_finished=on_finished,
             pre_export_tile_mode=plan.pre_export_tile_mode,
             preset_name=plan.preset_name,

--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -718,6 +718,25 @@ def _build_cover_summary_from_current_atlas_features(atlas_layer) -> dict:
     return build_cover_summary_from_rows(rows)
 
 
+def _build_cover_data_for_export(
+    atlas_layer,
+    *,
+    atlas_title: str = "",
+    atlas_subtitle: str = "",
+) -> dict:
+    cover_data = _build_cover_summary_from_current_atlas_features(atlas_layer)
+    if not cover_data:
+        return cover_data
+
+    title = atlas_title.strip()
+    subtitle = atlas_subtitle.strip()
+    if title:
+        cover_data["title"] = title
+    if subtitle:
+        cover_data["subtitle"] = subtitle
+    return cover_data
+
+
 def _apply_cover_heatmap_renderer(layer) -> None:
     """Apply a heatmap renderer to *layer* for the cover overview map.
 
@@ -767,6 +786,8 @@ def build_cover_layout(
     if not cover_data:
         return None
 
+    cover_title = str(cover_data.get("title") or "qfit Activity Atlas").strip()
+    cover_subtitle = str(cover_data.get("subtitle") or "").strip()
     cover_summary = cover_data.get("document_cover_summary", "")
     activity_count = cover_data.get("document_activity_count", "")
     date_range_label = cover_data.get("document_date_range_label", "")
@@ -805,7 +826,7 @@ def build_cover_layout(
         activity_noun = "activity" if str(activity_count) == "1" else "activities"
         activity_count_label = f"{activity_count} {activity_noun}"
 
-    subtitle_line = _join_cover_parts([
+    subtitle_line = cover_subtitle or _join_cover_parts([
         activity_count_label,
         date_range_label,
         activity_types_label,
@@ -828,7 +849,7 @@ def build_cover_layout(
     title_y = cover_top_margin_mm
     _add_label(
         layout,
-        "qfit Activity Atlas",
+        cover_title,
         x=content_x,
         y=title_y,
         w=content_width,
@@ -1110,7 +1131,9 @@ class AtlasExportTask(QgsTask):
         self,
         atlas_layer,
         output_path: str,
-        on_finished,
+        on_finished=None,
+        atlas_title: str = "",
+        atlas_subtitle: str = "",
         project=None,
         restore_tile_mode: str | None = None,
         layer_manager=None,
@@ -1124,6 +1147,8 @@ class AtlasExportTask(QgsTask):
         super().__init__("Export qfit atlas PDF", QgsTask.CanCancel)
         self._atlas_layer = atlas_layer
         self._output_path = output_path
+        self._atlas_title = atlas_title
+        self._atlas_subtitle = atlas_subtitle
         self._on_finished = on_finished
         self._project = project
         self._restore_tile_mode = restore_tile_mode
@@ -1163,7 +1188,13 @@ class AtlasExportTask(QgsTask):
             build_pdf_export_settings=self._build_pdf_export_settings,
             ensure_output_directory=self._ensure_output_directory,
             build_page_export_runner=self._build_page_export_runner,
-            export_cover_page=self._export_cover_page,
+            export_cover_page=lambda atlas_layer, output_path, project=None: self._export_cover_page(
+                atlas_layer,
+                output_path,
+                atlas_title=self._atlas_title,
+                atlas_subtitle=self._atlas_subtitle,
+                project=project,
+            ),
             export_toc_page=self._export_toc_page,
             assemble_output_pdf=self._assemble_output_pdf,
             logger=logger,
@@ -1224,6 +1255,8 @@ class AtlasExportTask(QgsTask):
     def _export_cover_page(
         atlas_layer,
         output_path: str,
+        atlas_title: str = "",
+        atlas_subtitle: str = "",
         project=None,
         cover_composer=_DEFAULT_COVER_COMPOSER,
     ) -> str | None:
@@ -1233,7 +1266,11 @@ class AtlasExportTask(QgsTask):
             output_path,
             project=project,
             get_project_instance=QgsProject.instance,
-            build_cover_data=_build_cover_summary_from_current_atlas_features,
+            build_cover_data=lambda layer: _build_cover_data_for_export(
+                layer,
+                atlas_title=atlas_title,
+                atlas_subtitle=atlas_subtitle,
+            ),
             apply_cover_heatmap_renderer=_apply_cover_heatmap_renderer,
             build_cover_layout_fn=cover_composer.build_layout,
             layout_exporter_cls=QgsLayoutExporter,

--- a/atlas/export_use_case.py
+++ b/atlas/export_use_case.py
@@ -20,6 +20,8 @@ class GenerateAtlasPdfCommand:
     atlas_layer: object = None
     selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
     output_path: str = ""
+    atlas_title: str = ""
+    atlas_subtitle: str = ""
     on_finished: Callable | None = None
     pre_export_tile_mode: str = ""
     preset_name: str = ""
@@ -93,6 +95,8 @@ class AtlasExportUseCase:
 
         plan = self.service.build_plan(
             output_path=output_path,
+            atlas_title=command.atlas_title,
+            atlas_subtitle=command.atlas_subtitle,
             pre_export_tile_mode=command.pre_export_tile_mode,
             preset_name=command.preset_name,
             access_token=command.access_token,

--- a/atlas/qgis_export_runtime.py
+++ b/atlas/qgis_export_runtime.py
@@ -23,6 +23,8 @@ class QgisAtlasExportRuntime(AtlasExportRuntime):
         return AtlasExportTask(
             atlas_layer=request.atlas_layer,
             output_path=request.output_path,
+            atlas_title=request.atlas_title,
+            atlas_subtitle=request.atlas_subtitle,
             on_finished=request.on_finished,
             restore_tile_mode=request.pre_export_tile_mode,
             layer_manager=layer_gateway,

--- a/configuration/application/dock_settings_bindings.py
+++ b/configuration/application/dock_settings_bindings.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from .ui_settings_binding import UIFieldBinding
 from ...activities.domain.activity_query import DEFAULT_SORT_LABEL, DETAILED_ROUTE_FILTER_ANY
-from ...atlas.layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from ...detailed_route_strategy import DEFAULT_DETAILED_ROUTE_STRATEGY
 from ...mapbox_config import DEFAULT_BACKGROUND_PRESET, TILE_MODE_RASTER
 from ...providers.infrastructure.strava_provider import StravaProvider
@@ -107,22 +106,16 @@ def build_dock_settings_bindings(dock) -> list[UIFieldBinding]:
             dock.mapboxStyleIdLineEdit.setText,
         ),
         UIFieldBinding(
-            "atlas_margin_percent",
-            8.0,
-            lambda: dock.atlasMarginPercentSpinBox.value(),
-            lambda value: dock._set_float_value(dock.atlasMarginPercentSpinBox, value, 8.0),
+            "atlas_title",
+            "qfit Activity Atlas",
+            lambda: dock.atlasTitleLineEdit.text().strip(),
+            dock.atlasTitleLineEdit.setText,
         ),
         UIFieldBinding(
-            "atlas_min_extent_degrees",
-            0.01,
-            lambda: dock.atlasMinExtentSpinBox.value(),
-            lambda value: dock._set_float_value(dock.atlasMinExtentSpinBox, value, 0.01),
-        ),
-        UIFieldBinding(
-            "atlas_target_aspect_ratio",
-            BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO,
-            lambda: dock.atlasTargetAspectRatioSpinBox.value(),
-            dock._set_atlas_target_aspect_ratio_value,
+            "atlas_subtitle",
+            "",
+            lambda: dock.atlasSubtitleLineEdit.text().strip(),
+            dock.atlasSubtitleLineEdit.setText,
         ),
         UIFieldBinding(
             "atlas_pdf_path",

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -96,7 +96,6 @@ from .visualization.application import (
     build_background_map_failure_status,
     build_background_map_failure_title,
 )
-from .atlas.layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_provider import StravaProvider
 from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
@@ -358,15 +357,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         except (TypeError, ValueError):
             spin_box.setValue(float(default))
 
-    def _set_atlas_target_aspect_ratio_value(self, value) -> None:
-        try:
-            aspect_ratio = float(value)
-        except (TypeError, ValueError):
-            aspect_ratio = BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
-        if aspect_ratio <= 0:
-            aspect_ratio = BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
-        self.atlasTargetAspectRatioSpinBox.setValue(aspect_ratio)
-
     def _default_output_path(self) -> str:
         return os.path.join(os.path.expanduser("~"), "qfit_activities.gpkg")
 
@@ -618,9 +608,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 output_path=self.outputPathLineEdit.text().strip(),
                 write_activity_points=self.writeActivityPointsCheckBox.isChecked(),
                 point_stride=self.pointSamplingStrideSpinBox.value(),
-                atlas_margin_percent=self.atlasMarginPercentSpinBox.value(),
-                atlas_min_extent_degrees=self.atlasMinExtentSpinBox.value(),
-                atlas_target_aspect_ratio=self.atlasTargetAspectRatioSpinBox.value(),
                 sync_metadata=self.last_fetch_context,
                 last_sync_date=self.settings.get("last_sync_date", None),
             )
@@ -1005,6 +992,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 self._current_activity_preview_request()
             ),
             output_path=self.atlasPdfPathLineEdit.text().strip(),
+            atlas_title=self.atlasTitleLineEdit.text().strip(),
+            atlas_subtitle=self.atlasSubtitleLineEdit.text().strip(),
             on_finished=self._on_atlas_export_finished,
             pre_export_tile_mode=self.tileModeComboBox.currentText(),
             preset_name=self.backgroundPresetComboBox.currentText(),

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -788,84 +788,37 @@
             <widget class="QWidget" name="publishSettingsWidget" native="true">
              <layout class="QFormLayout" name="publishLayout">
               <item row="0" column="0">
-               <widget class="QLabel" name="atlasMarginPercentLabel">
+               <widget class="QLabel" name="atlasTitleLabel">
                 <property name="text">
-                 <string>Page margin (%)</string>
+                 <string>Atlas Title</string>
                 </property>
                </widget>
               </item>
               <item row="0" column="1">
-               <widget class="QDoubleSpinBox" name="atlasMarginPercentSpinBox">
-                <property name="decimals">
-                 <number>1</number>
-                </property>
-                <property name="maximum">
-                 <double>1000.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>1.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>8.000000000000000</double>
+               <widget class="QLineEdit" name="atlasTitleLineEdit">
+                <property name="text">
+                 <string>qfit Activity Atlas</string>
                 </property>
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="atlasMinExtentLabel">
+               <widget class="QLabel" name="atlasSubtitleLabel">
                 <property name="text">
-                 <string>Minimum page extent (°)</string>
+                 <string>Atlas Subtitle</string>
                 </property>
                </widget>
               </item>
               <item row="1" column="1">
-               <widget class="QDoubleSpinBox" name="atlasMinExtentSpinBox">
-                <property name="decimals">
-                 <number>4</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000100000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>10.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.001000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.010000000000000</double>
+               <widget class="QLineEdit" name="atlasSubtitleLineEdit">
+                <property name="placeholderText">
+                 <string>Optional subtitle…</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="atlasTargetAspectRatioLabel">
-                <property name="text">
-                 <string>Target aspect ratio</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QDoubleSpinBox" name="atlasTargetAspectRatioSpinBox">
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="maximum">
-                 <double>10.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.050000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.000000000000000</double>
-                </property>
-                <property name="toolTip">
-                 <string>Width ÷ height in Web Mercator meters. Use 0 to keep each activity's natural aspect ratio.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0" colspan="2">
+              <item row="2" column="0" colspan="2">
                <widget class="QLabel" name="publishHelpLabel">
                 <property name="text">
-                 <string>These controls tune the generated activity_atlas_pages layer. Increase the margin when layouts need more surrounding context, raise the minimum extent so short activities still get readable atlas pages, or set a target aspect ratio (width ÷ height) when your print layout needs more consistent framing.</string>
+                 <string>Set the cover title and optional subtitle for the exported atlas PDF. qfit keeps the atlas page layout defaults internal when building activity_atlas_pages.</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>

--- a/tests/test_atlas_export_service.py
+++ b/tests/test_atlas_export_service.py
@@ -183,6 +183,8 @@ class BuildTaskTests(unittest.TestCase):
         request = GenerateAtlasPdfRequest(
             atlas_layer=MagicMock(),
             output_path="/out.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring rides",
             on_finished=MagicMock(),
             pre_export_tile_mode="Raster",
             preset_name="Dark",
@@ -200,6 +202,8 @@ class BuildTaskTests(unittest.TestCase):
         self.service.build_task(
             atlas_layer=MagicMock(),
             output_path="/out.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Subset",
             on_finished=MagicMock(),
             pre_export_tile_mode="Vector",
             preset_name="Light",
@@ -211,6 +215,8 @@ class BuildTaskTests(unittest.TestCase):
 
         request = self.runtime.build_task.call_args.args[0]
         self.assertIsInstance(request, GenerateAtlasPdfRequest)
+        self.assertEqual(request.atlas_title, "Atlas")
+        self.assertEqual(request.atlas_subtitle, "Subset")
         self.assertFalse(request.background_enabled)
         self.assertEqual(request.pre_export_tile_mode, "Vector")
 
@@ -220,6 +226,8 @@ class BuildTaskTests(unittest.TestCase):
         self.service.build_task(
             atlas_layer=MagicMock(),
             output_path="/out.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Subset",
             on_finished=MagicMock(),
             pre_export_tile_mode="Vector",
             preset_name="Light",
@@ -238,6 +246,8 @@ class AtlasExportRequestContractTests(unittest.TestCase):
     def test_build_plan_returns_dataclass(self):
         plan = AtlasExportService.build_plan(
             output_path="/tmp/atlas.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             pre_export_tile_mode="Raster",
             preset_name="Dark",
             access_token="tok",
@@ -248,12 +258,16 @@ class AtlasExportRequestContractTests(unittest.TestCase):
 
         self.assertIsInstance(plan, AtlasExportPlan)
         self.assertEqual(plan.output_path, "/tmp/atlas.pdf")
+        self.assertEqual(plan.atlas_title, "Atlas")
+        self.assertEqual(plan.atlas_subtitle, "Spring")
         self.assertTrue(plan.background_enabled)
 
     def test_build_request_returns_dataclass(self):
         request = AtlasExportService.build_request(
             atlas_layer=MagicMock(),
             output_path="/tmp/atlas.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             on_finished=MagicMock(),
             pre_export_tile_mode="Raster",
             preset_name="Dark",
@@ -265,6 +279,8 @@ class AtlasExportRequestContractTests(unittest.TestCase):
 
         self.assertIsInstance(request, GenerateAtlasPdfRequest)
         self.assertEqual(request.output_path, "/tmp/atlas.pdf")
+        self.assertEqual(request.atlas_title, "Atlas")
+        self.assertEqual(request.atlas_subtitle, "Spring")
         self.assertTrue(request.background_enabled)
 
     def test_build_request_preserves_profile_plot_style(self):
@@ -273,6 +289,8 @@ class AtlasExportRequestContractTests(unittest.TestCase):
         request = AtlasExportService.build_request(
             atlas_layer=MagicMock(),
             output_path="/tmp/atlas.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             on_finished=MagicMock(),
             pre_export_tile_mode="Raster",
             preset_name="Dark",
@@ -288,6 +306,8 @@ class AtlasExportRequestContractTests(unittest.TestCase):
     def test_build_request_from_plan_returns_dataclass(self):
         plan = AtlasExportService.build_plan(
             output_path="/tmp/atlas.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             pre_export_tile_mode="Raster",
             preset_name="Dark",
             access_token="tok",
@@ -304,4 +324,6 @@ class AtlasExportRequestContractTests(unittest.TestCase):
 
         self.assertIsInstance(request, GenerateAtlasPdfRequest)
         self.assertEqual(request.output_path, "/tmp/atlas.pdf")
+        self.assertEqual(request.atlas_title, "Atlas")
+        self.assertEqual(request.atlas_subtitle, "Spring")
         self.assertTrue(request.background_enabled)

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -3318,6 +3318,26 @@ class TestBuildCoverLayout(unittest.TestCase):
         label_texts = [label.setText.call_args[0][0] for label in labels]
         self.assertIn("legacy summary", label_texts)
 
+    def test_build_cover_layout_uses_custom_title_and_subtitle_when_provided(self):
+        layer = _make_cover_atlas_layer()
+        cover_data = {
+            "title": "Weekend Atlas",
+            "subtitle": "April highlights",
+            "document_cover_summary": "",
+            "document_activity_count": "2",
+            "document_date_range_label": "2026-04-01 → 2026-04-02",
+            "document_total_distance_label": "20.0 km",
+            "document_total_duration_label": "2h 00m",
+            "document_total_elevation_gain_label": "",
+            "document_activity_types_label": "Ride",
+        }
+        result, _layout, labels = self._capture_cover_labels(layer, cover_data=cover_data)
+        self.assertIsNotNone(result)
+        label_texts = [label.setText.call_args[0][0] for label in labels]
+        self.assertIn("Weekend Atlas", label_texts)
+        self.assertIn("April highlights", label_texts)
+        self.assertNotIn("2 activities · 2026-04-01 → 2026-04-02 · Ride", label_texts)
+
     def test_build_cover_layout_skips_zero_activity_count_row(self):
         """Activity count of '0' should not appear in the metrics band."""
         layer = _make_cover_atlas_layer()

--- a/tests/test_atlas_export_use_case.py
+++ b/tests/test_atlas_export_use_case.py
@@ -24,12 +24,16 @@ class AtlasExportUseCaseTests(unittest.TestCase):
         selection_state = ActivitySelectionState(query=ActivityQuery(search_text="ride"), filtered_count=7)
         command = self.use_case.build_command(
             output_path="/tmp/atlas.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             background_enabled=True,
             selection_state=selection_state,
         )
 
         self.assertIsInstance(command, GenerateAtlasPdfCommand)
         self.assertEqual(command.output_path, "/tmp/atlas.pdf")
+        self.assertEqual(command.atlas_title, "Atlas")
+        self.assertEqual(command.atlas_subtitle, "Spring")
         self.assertTrue(command.background_enabled)
         self.assertIs(command.selection_state, selection_state)
 
@@ -79,6 +83,8 @@ class AtlasExportUseCaseTests(unittest.TestCase):
         command = GenerateAtlasPdfCommand(
             atlas_layer=object(),
             output_path="/tmp/atlas",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             on_finished=MagicMock(),
             pre_export_tile_mode="Raster",
             preset_name="Outdoor",
@@ -96,6 +102,8 @@ class AtlasExportUseCaseTests(unittest.TestCase):
         self.assertTrue(result.path_changed)
         self.service.build_plan.assert_called_once_with(
             output_path="/tmp/atlas.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             pre_export_tile_mode="Raster",
             preset_name="Outdoor",
             access_token="tok",

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -261,7 +261,8 @@ class ContextualHelpTests(unittest.TestCase):
             "writeActivityPointsCheckBox",
             "pointSamplingStrideSpinBox",
             "backgroundPresetComboBox",
-            "atlasTargetAspectRatioSpinBox",
+            "atlasTitleLineEdit",
+            "atlasSubtitleLineEdit",
             "refreshButton",
             "loadButton",
             "applyFiltersButton",
@@ -276,7 +277,8 @@ class ContextualHelpTests(unittest.TestCase):
         self.assertIn("downloads up to 25 new detailed routes", entries["maxDetailedActivitiesSpinBox"].helper_text)
         self.assertEqual(entries["pointSamplingStrideSpinBox"].label_text, "Keep every Nth point")
         self.assertEqual(entries["backgroundPresetComboBox"].label_text, "Basemap preset")
-        self.assertEqual(entries["atlasTargetAspectRatioSpinBox"].label_text, "Target page aspect ratio")
+        self.assertEqual(entries["atlasTitleLineEdit"].label_text, "Atlas title")
+        self.assertEqual(entries["atlasSubtitleLineEdit"].label_text, "Atlas subtitle")
         self.assertEqual(entries["refreshButton"].target_text, "Fetch activities")
         self.assertIn("Store activities", entries["buttonLayout"].helper_text)
 

--- a/tests/test_dock_settings_bindings.py
+++ b/tests/test_dock_settings_bindings.py
@@ -5,7 +5,6 @@ from tests import _path  # noqa: F401
 from qfit.configuration.infrastructure.credential_store import InMemoryCredentialStore
 from qfit.configuration.application.settings_service import SettingsService
 from qfit.activities.domain.activity_query import DEFAULT_SORT_LABEL, DETAILED_ROUTE_FILTER_ANY
-from qfit.atlas.layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from qfit.configuration.application.dock_settings_bindings import build_dock_settings_bindings
 from qfit.configuration.application.ui_settings_binding import load_bindings, save_bindings
 from qfit.detailed_route_strategy import DEFAULT_DETAILED_ROUTE_STRATEGY
@@ -120,9 +119,8 @@ class FakeDock:
         self.backgroundMapCheckBox = CheckWidget(False)
         self.mapboxStyleOwnerLineEdit = TextWidget()
         self.mapboxStyleIdLineEdit = TextWidget()
-        self.atlasMarginPercentSpinBox = SpinWidget(8.0)
-        self.atlasMinExtentSpinBox = SpinWidget(0.01)
-        self.atlasTargetAspectRatioSpinBox = SpinWidget(BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO)
+        self.atlasTitleLineEdit = TextWidget("qfit Activity Atlas")
+        self.atlasSubtitleLineEdit = TextWidget()
         self.atlasPdfPathLineEdit = TextWidget()
         self.analysisModeComboBox = ComboWidget(["None", "Most frequent starting points"])
         self.backgroundPresetComboBox = ComboWidget([DEFAULT_BACKGROUND_PRESET, "Custom"])
@@ -178,16 +176,6 @@ class FakeDock:
         except (TypeError, ValueError):
             spin_box.setValue(float(default))
 
-    def _set_atlas_target_aspect_ratio_value(self, value):
-        try:
-            aspect_ratio = float(value)
-        except (TypeError, ValueError):
-            aspect_ratio = BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
-        if aspect_ratio <= 0:
-            aspect_ratio = BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
-        self.atlasTargetAspectRatioSpinBox.setValue(aspect_ratio)
-
-
 class DockSettingsBindingsTests(unittest.TestCase):
     EXPECTED_KEYS = {
         "client_id",
@@ -208,9 +196,8 @@ class DockSettingsBindingsTests(unittest.TestCase):
         "use_background_map",
         "mapbox_style_owner",
         "mapbox_style_id",
-        "atlas_margin_percent",
-        "atlas_min_extent_degrees",
-        "atlas_target_aspect_ratio",
+        "atlas_title",
+        "atlas_subtitle",
         "atlas_pdf_path",
         "analysis_mode",
         "background_preset",
@@ -233,7 +220,8 @@ class DockSettingsBindingsTests(unittest.TestCase):
                 "qfit/use_detailed_streams": "true",
                 "qfit/detailed_route_filter": "missing",
                 "qfit/use_background_map": True,
-                "qfit/atlas_target_aspect_ratio": "2.5",
+                "qfit/atlas_title": "Spring Atlas",
+                "qfit/atlas_subtitle": "Selected rides",
                 "qfit/preview_sort": "Newest first",
                 "qfit/style_preset": "Heatmap",
             }
@@ -248,7 +236,8 @@ class DockSettingsBindingsTests(unittest.TestCase):
         self.assertTrue(dock.detailedStreamsCheckBox.isChecked())
         self.assertEqual(dock.detailedRouteStatusComboBox.currentData(), "missing")
         self.assertTrue(dock.backgroundMapCheckBox.isChecked())
-        self.assertEqual(dock.atlasTargetAspectRatioSpinBox.value(), 2.5)
+        self.assertEqual(dock.atlasTitleLineEdit.text(), "Spring Atlas")
+        self.assertEqual(dock.atlasSubtitleLineEdit.text(), "Selected rides")
         self.assertEqual(dock.previewSortComboBox.currentText(), "Newest first")
         self.assertEqual(dock.stylePresetComboBox.currentText(), "Heatmap")
         self.assertEqual(dock.analysisModeComboBox.currentText(), "None")
@@ -271,9 +260,8 @@ class DockSettingsBindingsTests(unittest.TestCase):
         dock.backgroundMapCheckBox.setChecked(True)
         dock.mapboxStyleOwnerLineEdit.setText("custom-owner")
         dock.mapboxStyleIdLineEdit.setText("style-id")
-        dock.atlasMarginPercentSpinBox.setValue(12.0)
-        dock.atlasMinExtentSpinBox.setValue(0.25)
-        dock.atlasTargetAspectRatioSpinBox.setValue(1.75)
+        dock.atlasTitleLineEdit.setText(" Weekend Atlas ")
+        dock.atlasSubtitleLineEdit.setText("  Alpine routes  ")
         dock.atlasPdfPathLineEdit.setText("/tmp/atlas.pdf")
         dock.analysisModeComboBox.setCurrentIndex(1)
         dock.backgroundPresetComboBox.setCurrentIndex(1)
@@ -292,7 +280,8 @@ class DockSettingsBindingsTests(unittest.TestCase):
         self.assertFalse(settings.get_bool("write_activity_points", True))
         self.assertEqual(settings.get("detailed_route_filter"), "missing")
         self.assertEqual(settings.get("mapbox_style_owner"), "custom-owner")
-        self.assertEqual(settings.get("atlas_target_aspect_ratio"), 1.75)
+        self.assertEqual(settings.get("atlas_title"), "Weekend Atlas")
+        self.assertEqual(settings.get("atlas_subtitle"), "Alpine routes")
         self.assertEqual(settings.get("analysis_mode"), "Most frequent starting points")
         self.assertEqual(settings.get("style_preset"), "Heatmap")
 

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -13,6 +13,11 @@ from qfit.activities.application.load_workflow import (
     LoadWorkflowError,
     LoadWorkflowService,
 )
+from qfit.atlas.publish_atlas import (
+    DEFAULT_ATLAS_MARGIN_PERCENT,
+    DEFAULT_ATLAS_TARGET_ASPECT_RATIO,
+    DEFAULT_MIN_EXTENT_DEGREES,
+)
 from qfit.sync_repository import SyncStats
 
 # Ensure a stub ``qfit.activities.infrastructure.geopackage.gpkg_writer`` is
@@ -442,6 +447,16 @@ class LoadRequestContractTests(unittest.TestCase):
 
         self.assertTrue(request.write_activity_points)
         self.assertEqual(request.point_stride, 5)
+
+    def test_build_write_request_uses_internal_atlas_defaults_when_ui_omits_fields(self):
+        request = LoadWorkflowService.build_write_request(
+            activities=["a"],
+            output_path="/tmp/test.gpkg",
+        )
+
+        self.assertEqual(request.atlas_margin_percent, DEFAULT_ATLAS_MARGIN_PERCENT)
+        self.assertEqual(request.atlas_min_extent_degrees, DEFAULT_MIN_EXTENT_DEGREES)
+        self.assertEqual(request.atlas_target_aspect_ratio, DEFAULT_ATLAS_TARGET_ASPECT_RATIO)
 
     def test_build_load_existing_request_returns_dataclass(self):
         request = LoadWorkflowService.build_load_existing_request("/tmp/existing.gpkg")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -935,9 +935,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
         dock.writeActivityPointsCheckBox = _FakeCheckBox(True)
         dock.pointSamplingStrideSpinBox = _FakeSpinBox(2)
-        dock.atlasMarginPercentSpinBox = _FakeSpinBox(10)
-        dock.atlasMinExtentSpinBox = _FakeSpinBox(0.01)
-        dock.atlasTargetAspectRatioSpinBox = _FakeSpinBox(1.5)
         dock.last_fetch_context = {"provider": "strava"}
         dock.settings = _FakeSettings({"last_sync_date": "2026-04-07"})
         dock.loadButton = _FakeButton("Store activities")
@@ -955,7 +952,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             self.module.QfitDockWidget.on_load_clicked(dock)
 
         dock._save_settings.assert_called_once_with()
-        dock.load_workflow.build_write_request.assert_called_once()
+        dock.load_workflow.build_write_request.assert_called_once_with(
+            activities=dock.activities,
+            output_path="/tmp/qfit.gpkg",
+            write_activity_points=True,
+            point_stride=2,
+            sync_metadata={"provider": "strava"},
+            last_sync_date="2026-04-07",
+        )
         build_store_task.assert_called_once()
         self.assertIs(dock._store_task, fake_task)
         self.assertEqual(dock.loadButton.text(), "Store in progress...")

--- a/tests/test_qgis_atlas_export_runtime.py
+++ b/tests/test_qgis_atlas_export_runtime.py
@@ -40,6 +40,8 @@ class QgisAtlasExportRuntimeTests(unittest.TestCase):
         request = GenerateAtlasPdfRequest(
             atlas_layer=atlas_layer,
             output_path="/out.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             on_finished=on_finished,
             pre_export_tile_mode="Raster",
             preset_name="Dark",
@@ -56,6 +58,8 @@ class QgisAtlasExportRuntimeTests(unittest.TestCase):
         mock_task.assert_called_once_with(
             atlas_layer=atlas_layer,
             output_path="/out.pdf",
+            atlas_title="Atlas",
+            atlas_subtitle="Spring",
             on_finished=on_finished,
             restore_tile_mode="Raster",
             layer_manager=layer_gateway,

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -289,11 +289,8 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertFalse(dock.publishSectionContentWidget.isHidden())
             self.assertTrue(dock.publishSettingsWidget.parent() is dock.publishSectionContentWidget or dock.publishSettingsWidget.isVisible())
             self.assertEqual(dock.tileModeComboBox.currentText(), TILE_MODE_RASTER)
-            self.assertAlmostEqual(
-                dock.atlasTargetAspectRatioSpinBox.value(),
-                BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO,
-                places=3,
-            )
+            self.assertEqual(dock.atlasTitleLineEdit.text(), "qfit Activity Atlas")
+            self.assertEqual(dock.atlasSubtitleLineEdit.text(), "")
             self.assertEqual(dock.detailedRouteStrategyComboBox.currentText(), "Missing routes only")
             self.assertIsNotNone(dock.findChild(QLabel, "detailedRouteStrategyComboBoxContextHelpLabel"))
             self.assertIsNotNone(dock.findChild(QWidget, "detailedRouteStrategyComboBoxHelpField"))
@@ -382,7 +379,8 @@ class QgisSmokeTests(unittest.TestCase):
             dock.previewSortComboBox.setCurrentText(preview_sort_text)
             dock.stylePresetComboBox.setCurrentText(style_preset_text)
             dock.analysisModeComboBox.setCurrentText("Most frequent starting points")
-            dock.atlasTargetAspectRatioSpinBox.setValue(1.75)
+            dock.atlasTitleLineEdit.setText("Spring Atlas")
+            dock.atlasSubtitleLineEdit.setText("Road and trail")
             dock.atlasPdfPathLineEdit.setText("/tmp/roundtrip.pdf")
 
             dock._save_settings()
@@ -398,7 +396,8 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(settings.get("style_preset"), style_preset_text)
             self.assertIsNone(settings.get("temporal_mode"))
             self.assertEqual(settings.get("analysis_mode"), "Most frequent starting points")
-            self.assertAlmostEqual(float(settings.get("atlas_target_aspect_ratio")), 1.75, places=2)
+            self.assertEqual(settings.get("atlas_title"), "Spring Atlas")
+            self.assertEqual(settings.get("atlas_subtitle"), "Road and trail")
             self.assertEqual(settings.get("atlas_pdf_path"), "/tmp/roundtrip.pdf")
         finally:
             dock.close()
@@ -417,7 +416,8 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock_reloaded.stylePresetComboBox.currentText(), style_preset_text)
             self.assertEqual(dock_reloaded.temporalModeComboBox.currentText(), DEFAULT_TEMPORAL_MODE_LABEL)
             self.assertEqual(dock_reloaded.analysisModeComboBox.currentText(), "Most frequent starting points")
-            self.assertAlmostEqual(dock_reloaded.atlasTargetAspectRatioSpinBox.value(), 1.75, places=2)
+            self.assertEqual(dock_reloaded.atlasTitleLineEdit.text(), "Spring Atlas")
+            self.assertEqual(dock_reloaded.atlasSubtitleLineEdit.text(), "Road and trail")
             self.assertEqual(dock_reloaded.atlasPdfPathLineEdit.text(), "/tmp/roundtrip.pdf")
         finally:
             dock_reloaded.close()
@@ -448,6 +448,8 @@ class QgisSmokeTests(unittest.TestCase):
             dock.atlas_layer = MagicMock()
             dock.atlas_layer.featureCount.return_value = 3
             dock.atlasPdfPathLineEdit.setText("/tmp/qfit-atlas.pdf")
+            dock.atlasTitleLineEdit.setText("Custom Atlas")
+            dock.atlasSubtitleLineEdit.setText("April 2026")
 
             from qfit.atlas.export_use_case import PrepareAtlasPdfExportResult
 
@@ -502,6 +504,8 @@ class QgisSmokeTests(unittest.TestCase):
 
             build_style.assert_called_once_with(dock.settings)
             export_command = dock.atlas_export_use_case.prepare_export.call_args.args[0]
+            self.assertEqual(export_command.atlas_title, "Custom Atlas")
+            self.assertEqual(export_command.atlas_subtitle, "April 2026")
             self.assertEqual(export_command.profile_plot_style, "style-override")
             dock.atlas_export_use_case.start_export.assert_called_once_with(
                 prepared_export,

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -132,34 +132,22 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
         help_button=True,
     ),
     HelpEntry(
-        anchor_name="atlasMarginPercentSpinBox",
-        label_name="atlasMarginPercentLabel",
-        label_text="Atlas margin around route (%)",
+        anchor_name="atlasTitleLineEdit",
+        label_name="atlasTitleLabel",
+        label_text="Atlas title",
         tooltip=(
-            "Adds extra space around each activity when qfit builds the activity_atlas_pages layer."
+            "Sets the title shown on the exported atlas cover page."
         ),
     ),
     HelpEntry(
-        anchor_name="atlasMinExtentSpinBox",
-        label_name="atlasMinExtentLabel",
-        label_text="Minimum atlas extent (°)",
+        anchor_name="atlasSubtitleLineEdit",
+        label_name="atlasSubtitleLabel",
+        label_text="Atlas subtitle",
         tooltip=(
-            "Prevents very short or compact activities from collapsing into tiny atlas pages by enforcing a minimum "
-            "latitude/longitude extent before qfit expands to Web Mercator for layout work."
-        ),
-    ),
-    HelpEntry(
-        anchor_name="atlasTargetAspectRatioSpinBox",
-        label_name="atlasTargetAspectRatioLabel",
-        label_text="Target page aspect ratio",
-        tooltip=(
-            "Width divided by height for atlas framing in Web Mercator meters. Use 0 to keep each activity's natural "
-            "shape, 1 for square framing, or larger values for wider landscape layouts."
+            "Overrides the cover-page subtitle. Leave it blank to keep qfit's generated activity/date summary."
         ),
         helper_text=(
-            "These publish settings shape the generated activity_atlas_pages layer. Start with the defaults, then bump "
-            "margin for more surrounding context, minimum extent for short activities, or aspect ratio when your print "
-            "layout has a fixed frame shape."
+            "Atlas layout framing stays on qfit's internal defaults. These fields only affect the exported PDF cover text."
         ),
         help_button=True,
     ),


### PR DESCRIPTION
## Summary
- replace the publish-facing atlas layout tuning controls with atlas title and subtitle fields
- keep atlas framing defaults internal while passing title/subtitle through the export workflow
- update bindings, contextual help, cover rendering, and focused tests for the new publish behavior

## Testing
- python3 -m pytest tests/test_atlas_export_service.py tests/test_atlas_export_task.py tests/test_atlas_export_use_case.py tests/test_contextual_help.py tests/test_dock_settings_bindings.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_qgis_atlas_export_runtime.py tests/test_qgis_smoke.py -q --tb=short

Closes #568
