### PR TITLE
fix: restore Strava OAuth helper in configuration dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You need:
 - `client_secret`
 - `refresh_token`
 
-qfit includes a built-in OAuth helper for the refresh-token step.
+qfit includes a built-in OAuth helper in `qfit` → `Configuration` for the refresh-token step.
 
 See:
 - `docs/strava-setup.md`

--- a/docs/strava-setup.md
+++ b/docs/strava-setup.md
@@ -22,7 +22,7 @@ A practical default for local testing is:
 
 ## Generate the refresh token inside qfit
 
-1. Open the qfit dock in QGIS.
+1. Open `qfit` → `Configuration` in QGIS.
 2. Enter your `client_id` and `client_secret`.
 3. Enter the same redirect URI you configured in Strava.
 4. Click **Open Strava authorize page**.

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.42.0
+version=0.42.1
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -8,19 +8,24 @@ specific Mapbox styling options, which belong in the main map workflow.
 
 import logging
 
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import Qt, QUrl
+from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import (
+    QApplication,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
     QGroupBox,
+    QHBoxLayout,
     QLabel,
     QLineEdit,
+    QMessageBox,
     QPushButton,
     QVBoxLayout,
     QWidget,
 )
 
+from .activities.application.sync_controller import SyncController
 from .configuration.application.config_connection_service import (
     build_mapbox_connection_test_request,
     build_strava_connection_test_request,
@@ -30,25 +35,35 @@ from .configuration.application.config_connection_service import (
 from .configuration.application.config_status import mapbox_status_text, strava_status_text
 from .configuration.application.settings_port import SettingsPort
 from .configuration.application.settings_service import SettingsService
+from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_client import StravaClient
 from .configuration.application.ui_settings_binding import UIFieldBinding, load_bindings, save_bindings
 
 logger = logging.getLogger(__name__)
 
 _NOT_TESTED_LABEL = "Not tested"
+_OAUTH_NOT_STARTED_LABEL = "Not started"
 
 
 class QfitConfigDialog(QDialog):
     """Editable configuration dialog for qfit plugin connection settings.
 
     Allows the user to view and edit Strava credentials plus the Mapbox
-    access token, and to run provider-specific connection tests before
-    saving. Changes are persisted to QSettings on save.
+    access token, run the Strava OAuth helper flow, and test provider
+    connections before saving. Changes are persisted to QSettings on save.
     """
 
-    def __init__(self, settings_service: SettingsPort | None = None, parent: QWidget | None = None):
+    def __init__(
+        self,
+        settings_service: SettingsPort | None = None,
+        sync_controller: SyncController | None = None,
+        cache: object | None = None,
+        parent: QWidget | None = None,
+    ):
         super().__init__(parent)
         self._settings = settings_service or SettingsService()
+        self._sync_controller = sync_controller or SyncController()
+        self._cache = cache
         self.setWindowTitle("qfit — Configuration")
         self.setMinimumWidth(420)
         self._build_ui()
@@ -95,10 +110,50 @@ class QfitConfigDialog(QDialog):
         self._redirect_uri_edit.setObjectName("cfgRedirectUriEdit")
         form.addRow("Redirect URI:", self._redirect_uri_edit)
 
+        self._oauth_help_label = QLabel(
+            "Use qfit's OAuth helper below to generate the refresh token. Do not paste the token shown on the Strava API application page."
+        )
+        self._oauth_help_label.setObjectName("stravaOAuthHelpLabel")
+        self._oauth_help_label.setWordWrap(True)
+        self._oauth_help_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        form.addRow("", self._oauth_help_label)
+
+        self._authorization_code_edit = QLineEdit()
+        self._authorization_code_edit.setObjectName("cfgAuthorizationCodeEdit")
+        self._authorization_code_edit.setPlaceholderText(
+            "Paste the code returned by Strava after approval"
+        )
+        form.addRow("Authorization code:", self._authorization_code_edit)
+
+        oauth_button_row = QWidget(group)
+        oauth_button_layout = QHBoxLayout(oauth_button_row)
+        oauth_button_layout.setContentsMargins(0, 0, 0, 0)
+        oauth_button_layout.setSpacing(6)
+
+        self._open_authorize_button = QPushButton("Open Strava authorize page")
+        self._open_authorize_button.setObjectName("cfgOpenAuthorizeButton")
+        self._open_authorize_button.clicked.connect(self._open_strava_authorize_page)
+        oauth_button_layout.addWidget(self._open_authorize_button)
+
+        self._exchange_code_button = QPushButton("Exchange code")
+        self._exchange_code_button.setObjectName("cfgExchangeCodeButton")
+        self._exchange_code_button.clicked.connect(self._exchange_strava_code)
+        oauth_button_layout.addWidget(self._exchange_code_button)
+        oauth_button_layout.addStretch(1)
+        form.addRow("", oauth_button_row)
+
+        self._strava_oauth_status_label = QLabel(_OAUTH_NOT_STARTED_LABEL)
+        self._strava_oauth_status_label.setObjectName("stravaOAuthStatusLabel")
+        self._strava_oauth_status_label.setWordWrap(True)
+        self._strava_oauth_status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        form.addRow("OAuth helper:", self._strava_oauth_status_label)
+
         self._refresh_token_edit = QLineEdit()
         self._refresh_token_edit.setObjectName("cfgRefreshTokenEdit")
         self._refresh_token_edit.setEchoMode(QLineEdit.Password)
-        self._refresh_token_edit.setPlaceholderText("Obtained via OAuth flow in Activities")
+        self._refresh_token_edit.setPlaceholderText(
+            "Generated by qfit's OAuth flow, not the Strava app page"
+        )
         form.addRow("Refresh token:", self._refresh_token_edit)
 
         self._strava_test_status_label = QLabel(_NOT_TESTED_LABEL)
@@ -176,7 +231,9 @@ class QfitConfigDialog(QDialog):
     def _load(self) -> None:
         """Read current settings and populate all fields."""
         load_bindings(self._bindings, self._settings)
+        self._authorization_code_edit.clear()
         self._refresh_status_labels()
+        self._strava_oauth_status_label.setText(_OAUTH_NOT_STARTED_LABEL)
         self._strava_test_status_label.setText(_NOT_TESTED_LABEL)
         self._mapbox_test_status_label.setText(_NOT_TESTED_LABEL)
 
@@ -188,6 +245,92 @@ class QfitConfigDialog(QDialog):
     def _refresh_status_labels(self) -> None:
         self._strava_status_label.setText(strava_status_text(self._settings))
         self._mapbox_status_label.setText(mapbox_status_text(self._settings))
+
+    def _redirect_uri(self) -> str:
+        return self._redirect_uri_edit.text().strip() or StravaClient.DEFAULT_REDIRECT_URI
+
+    def _open_strava_authorize_page(self) -> None:
+        self._save()
+        try:
+            authorize_request = self._sync_controller.build_authorize_request(
+                client_id=self._client_id_edit.text().strip(),
+                client_secret=self._client_secret_edit.text().strip(),
+                refresh_token=self._refresh_token_edit.text().strip(),
+                cache=self._cache,
+                redirect_uri=self._redirect_uri(),
+            )
+            url = self._sync_controller.build_authorize_url(authorize_request)
+            if not QDesktopServices.openUrl(QUrl(url)):
+                clipboard = QApplication.clipboard()
+                if clipboard is not None:
+                    clipboard.setText(url)
+                self._show_info(
+                    "Open Strava authorize page manually",
+                    "qfit could not open the browser automatically. The authorization URL was copied to your clipboard.\n\nOpen this URL in a browser and continue the flow there:\n\n{url}".format(
+                        url=url
+                    ),
+                )
+                self._strava_oauth_status_label.setText(
+                    "Could not open browser automatically. Authorization URL copied to clipboard."
+                )
+                return
+            self._strava_oauth_status_label.setText(
+                "Strava authorization opened in your browser. Approve access, copy the returned code, then paste it here and click Exchange code."
+            )
+        except ProviderError as exc:
+            self._show_error("Strava authorization failed", str(exc))
+            self._strava_oauth_status_label.setText(
+                "Could not start the Strava authorization flow"
+            )
+
+    def _exchange_strava_code(self) -> None:
+        self._save()
+        authorization_code = self._authorization_code_edit.text().strip()
+        if not authorization_code:
+            self._show_error(
+                "Missing authorization code",
+                "Paste the code returned by Strava first.",
+            )
+            self._strava_oauth_status_label.setText(
+                "Paste the returned Strava code before exchanging it."
+            )
+            return
+
+        try:
+            exchange_request = self._sync_controller.build_exchange_code_request(
+                client_id=self._client_id_edit.text().strip(),
+                client_secret=self._client_secret_edit.text().strip(),
+                refresh_token=self._refresh_token_edit.text().strip(),
+                cache=self._cache,
+                authorization_code=authorization_code,
+                redirect_uri=self._redirect_uri(),
+            )
+            payload = self._sync_controller.exchange_code_for_tokens(exchange_request)
+            refresh_token = payload["refresh_token"]
+            self._refresh_token_edit.setText(refresh_token)
+            self._authorization_code_edit.clear()
+            self._save()
+
+            athlete = payload.get("athlete") or {}
+            athlete_name = " ".join(
+                part for part in [athlete.get("firstname"), athlete.get("lastname")] if part
+            ).strip()
+            if athlete_name:
+                self._strava_oauth_status_label.setText(
+                    "Strava connected for {name}. Refresh token saved locally in QGIS settings.".format(
+                        name=athlete_name
+                    )
+                )
+            else:
+                self._strava_oauth_status_label.setText(
+                    "Strava refresh token saved locally in QGIS settings."
+                )
+            self._strava_test_status_label.setText(_NOT_TESTED_LABEL)
+        except ProviderError as exc:
+            self._show_error("Token exchange failed", str(exc))
+            self._strava_oauth_status_label.setText(
+                "Could not exchange the Strava authorization code"
+            )
 
     def _test_strava(self) -> None:
         request = build_strava_connection_test_request(
@@ -202,6 +345,12 @@ class QfitConfigDialog(QDialog):
         request = build_mapbox_connection_test_request(self._mapbox_token_edit.text())
         result = validate_mapbox_connection_request(request)
         self._mapbox_test_status_label.setText(result.message)
+
+    def _show_info(self, title: str, message: str) -> None:
+        QMessageBox.information(self, title, message)
+
+    def _show_error(self, title: str, message: str) -> None:
+        QMessageBox.critical(self, title, message)
 
     # -- Visibility ----------------------------------------------------------
 

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -52,6 +52,7 @@ try:
     from qfit.layer_manager import LayerManager
     from qfit.mapbox_config import TILE_MODE_RASTER
     from qfit.activities.domain.models import Activity
+    from qfit.qfit_config_dialog import QfitConfigDialog
     from qfit.qfit_dockwidget import ApplyVisualizationAction, QfitDockWidget
     from qfit.configuration.application.settings_service import SettingsService
     from qfit.ui.dockwidget_dependencies import build_dockwidget_dependencies
@@ -78,6 +79,7 @@ except Exception as exc:  # pragma: no cover - exercised only when QGIS is unava
     LayerManager = None
     TILE_MODE_RASTER = None
     Activity = None
+    QfitConfigDialog = None
     QfitDockWidget = None
     build_dockwidget_dependencies = None
     QGIS_AVAILABLE = False
@@ -800,6 +802,75 @@ class QgisSmokeTests(unittest.TestCase):
         finally:
             dock.close()
             dock.deleteLater()
+
+    def test_config_dialog_exposes_strava_oauth_helper_controls(self):
+        dialog = QfitConfigDialog(
+            settings_service=SettingsService(
+                qsettings=_FakeQSettings(),
+                credential_store=InMemoryCredentialStore(),
+            )
+        )
+        try:
+            self.assertEqual(dialog._authorization_code_edit.objectName(), "cfgAuthorizationCodeEdit")
+            self.assertEqual(dialog._open_authorize_button.objectName(), "cfgOpenAuthorizeButton")
+            self.assertEqual(dialog._exchange_code_button.objectName(), "cfgExchangeCodeButton")
+            self.assertIn("Do not paste", dialog._oauth_help_label.text())
+            self.assertEqual(dialog._strava_oauth_status_label.text(), "Not started")
+        finally:
+            dialog.close()
+            dialog.deleteLater()
+
+    def test_config_dialog_open_authorize_clicked_builds_authorize_url_via_sync_controller(self):
+        dialog = QfitConfigDialog(
+            settings_service=SettingsService(
+                qsettings=_FakeQSettings(),
+                credential_store=InMemoryCredentialStore(),
+            )
+        )
+        try:
+            dialog._save = MagicMock()
+            dialog._sync_controller.build_authorize_request = MagicMock(return_value="authorize-request")
+            dialog._sync_controller.build_authorize_url = MagicMock(return_value="https://strava.test/auth")
+
+            with patch("qfit.qfit_config_dialog.QDesktopServices.openUrl", return_value=True) as open_url:
+                dialog._open_strava_authorize_page()
+
+            dialog._sync_controller.build_authorize_request.assert_called_once()
+            dialog._sync_controller.build_authorize_url.assert_called_once_with("authorize-request")
+            open_url.assert_called_once()
+            self.assertIn("Strava authorization opened", dialog._strava_oauth_status_label.text())
+        finally:
+            dialog.close()
+            dialog.deleteLater()
+
+    def test_config_dialog_exchange_code_clicked_uses_sync_controller_exchange_workflow(self):
+        dialog = QfitConfigDialog(
+            settings_service=SettingsService(
+                qsettings=_FakeQSettings(),
+                credential_store=InMemoryCredentialStore(),
+            )
+        )
+        try:
+            dialog._authorization_code_edit.setText("abc123")
+            dialog._save = MagicMock()
+            dialog._sync_controller.build_exchange_code_request = MagicMock(return_value="exchange-request")
+            dialog._sync_controller.exchange_code_for_tokens = MagicMock(
+                return_value={
+                    "refresh_token": "rtok",
+                    "athlete": {"firstname": "Ada", "lastname": "Lovelace"},
+                }
+            )
+
+            dialog._exchange_strava_code()
+
+            dialog._sync_controller.build_exchange_code_request.assert_called_once()
+            dialog._sync_controller.exchange_code_for_tokens.assert_called_once_with("exchange-request")
+            self.assertEqual(dialog._refresh_token_edit.text(), "rtok")
+            self.assertEqual(dialog._authorization_code_edit.text(), "")
+            self.assertIn("Ada Lovelace", dialog._strava_oauth_status_label.text())
+        finally:
+            dialog.close()
+            dialog.deleteLater()
 
     def test_exchange_code_clicked_uses_sync_controller_exchange_workflow(self):
         dock = QfitDockWidget(self.iface)


### PR DESCRIPTION
## Summary

Restore the built-in Strava OAuth helper flow in the Configuration dialog so users can open the authorize page, paste the returned authorization code, exchange it for a refresh token, and save that token without going back to the Activities dock.

## Changes

- add authorize-page and exchange-code controls to the Configuration dialog
- reuse the existing sync controller flow for Strava OAuth from the dialog
- improve token guidance so the dialog warns against pasting the token shown on the Strava app page
- update Strava setup docs and add regression smoke coverage for the new dialog flow

## Testing

- ran the focused unittest suite covering sync controller, config dialog bindings, and the dock/config dialog Strava OAuth smoke tests
- built a local plugin ZIP successfully with scripts/package_plugin.py after installing pypdf in a temporary virtual environment

Fixes #570