### PR TITLE
chore: mark plugin as stable and bump version to 0.42.2

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.42.1
+version=0.42.2
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.
@@ -12,6 +12,6 @@ tracker=https://github.com/ebelo/qfit/issues
 repository=https://github.com/ebelo/qfit
 homepage=https://github.com/ebelo/qfit
 icon=icon.png
-experimental=True
+experimental=False
 deprecated=False
 tags=strava,fitness,gis,qgis,gpx,fit,geopackage,activities


### PR DESCRIPTION
## Summary\n- mark the QGIS plugin as non-experimental in metadata\n- bump plugin version to 0.42.2\n- rebuild the distributable ZIP for validation\n\n## Notes\n- metadata-only change\n- CI will validate the PR normally\n