### PR TITLE
refactor: extract dock activity workflow coordination

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -72,6 +72,8 @@ from .atlas.profile_style import build_native_profile_plot_style_from_settings
 from .ui.application import (
     ApplyVisualizationAction,
     DockActionDispatcher,
+    DockFetchCompletionRequest,
+    DockFetchRequest,
     RunAnalysisAction,
     build_visual_layer_refs,
     build_visual_workflow_action,
@@ -311,8 +313,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.load_workflow = dependencies.load_workflow
         self.visual_apply = dependencies.visual_apply
         self.atlas_export_service = dependencies.atlas_export_service
-        self.fetch_result_service = dependencies.fetch_result_service
-        self.activity_preview_service = dependencies.activity_preview_service
+        self.activity_workflow = dependencies.activity_workflow
         self.cache = dependencies.cache
 
     @staticmethod
@@ -524,30 +525,23 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _start_fetch(self, detailed_route_strategy, status_text, use_detailed_streams=None):
         self._save_settings()
-        advanced_fetch_enabled = self.advancedFetchGroupBox.isChecked()
-        if use_detailed_streams is None:
-            use_detailed_streams = self.detailedStreamsCheckBox.isChecked() if advanced_fetch_enabled else False
-        per_page = self.perPageSpinBox.value() if advanced_fetch_enabled else 200
-        max_pages = self.maxPagesSpinBox.value() if advanced_fetch_enabled else 0
-        max_detailed_activities = (
-            self.maxDetailedActivitiesSpinBox.value()
-            if advanced_fetch_enabled or use_detailed_streams
-            else 25
-        )
         try:
-            fetch_request = self.sync_controller.build_fetch_task_request(
-                client_id=self.clientIdLineEdit.text().strip(),
-                client_secret=self.clientSecretLineEdit.text().strip(),
-                refresh_token=self.refreshTokenLineEdit.text().strip(),
-                cache=self.cache,
-                per_page=per_page,
-                max_pages=max_pages,
-                use_detailed_streams=use_detailed_streams,
-                max_detailed_activities=max_detailed_activities,
-                detailed_route_strategy=detailed_route_strategy,
-                on_finished=self._on_fetch_finished,
+            self._fetch_task = self.activity_workflow.build_fetch_task(
+                DockFetchRequest(
+                    client_id=self.clientIdLineEdit.text().strip(),
+                    client_secret=self.clientSecretLineEdit.text().strip(),
+                    refresh_token=self.refreshTokenLineEdit.text().strip(),
+                    cache=self.cache,
+                    detailed_route_strategy=detailed_route_strategy,
+                    on_finished=self._on_fetch_finished,
+                    advanced_fetch_enabled=self.advancedFetchGroupBox.isChecked(),
+                    detailed_streams_checked=self.detailedStreamsCheckBox.isChecked(),
+                    per_page_value=self.perPageSpinBox.value(),
+                    max_pages_value=self.maxPagesSpinBox.value(),
+                    max_detailed_activities_value=self.maxDetailedActivitiesSpinBox.value(),
+                    use_detailed_streams_override=use_detailed_streams,
+                )
             )
-            self._fetch_task = self.sync_controller.build_fetch_task(fetch_request)
         except ProviderError as exc:
             self._show_error("Strava import failed", str(exc))
             self._set_status("Strava fetch failed")
@@ -569,31 +563,36 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._fetch_task = None
         self._set_fetch_running(False)
 
-        fetch_request = self.fetch_result_service.build_request(
-            activities=activities,
-            error=error,
-            cancelled=cancelled,
-            provider=provider,
+        result = self.activity_workflow.build_fetch_completion_result(
+            DockFetchCompletionRequest(
+                activities=[] if activities is None else list(activities),
+                error=error,
+                cancelled=cancelled,
+                provider=provider,
+                current_activity_type=self.activityTypeComboBox.currentText() or "All",
+                preview_request=self._current_activity_preview_request(),
+            )
         )
-        result = self.fetch_result_service.build_result_request(fetch_request)
 
-        if cancelled:
+        if result.cancelled:
             self._set_status(result.status_text)
             return
 
-        if error is not None:
-            self._show_error("Strava import failed", error)
+        if result.error_message is not None:
+            self._show_error(result.error_title or "Strava import failed", result.error_message)
             self._set_status(result.status_text)
             return
 
         self.activities = result.activities
         self.last_fetch_context = result.metadata
-        # Persist last sync date
         self.settings.set("last_sync_date", result.today_str)
 
-        self._populate_activity_types()
+        if result.activity_type_options is not None:
+            self._apply_activity_type_options(result.activity_type_options)
         self.countLabel.setText(result.count_label_text)
-        self._refresh_activity_preview()
+        if result.preview_result is not None:
+            self.querySummaryLabel.setText(result.preview_result.query_summary_text)
+            self.activityPreviewPlainTextEdit.setPlainText(result.preview_result.preview_text)
         self._set_status(result.status_text)
 
     def on_load_clicked(self):
@@ -875,7 +874,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
 
     def _refresh_activity_preview(self):
-        preview = self.activity_preview_service.build_result_request(
+        preview = self.activity_workflow.build_preview_result(
             self._current_activity_preview_request()
         )
         self.querySummaryLabel.setText(preview.query_summary_text)

--- a/tests/test_dock_activity_workflow.py
+++ b/tests/test_dock_activity_workflow.py
@@ -1,0 +1,166 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.application import build_activity_preview_request
+from qfit.ui.application import (
+    DockActivityWorkflowCoordinator,
+    DockFetchCompletionRequest,
+    DockFetchRequest,
+)
+
+
+class DockActivityWorkflowCoordinatorTests(unittest.TestCase):
+    def setUp(self):
+        self.sync_controller = MagicMock()
+        self.fetch_result_service = MagicMock()
+        self.activity_preview_service = MagicMock()
+        self.coordinator = DockActivityWorkflowCoordinator(
+            sync_controller=self.sync_controller,
+            fetch_result_service=self.fetch_result_service,
+            activity_preview_service=self.activity_preview_service,
+        )
+
+    def test_build_fetch_task_uses_defaults_when_advanced_fetch_is_disabled(self):
+        self.sync_controller.build_fetch_task_request.return_value = "fetch-request"
+        self.sync_controller.build_fetch_task.return_value = "fetch-task"
+
+        result = self.coordinator.build_fetch_task(
+            DockFetchRequest(
+                client_id="cid",
+                client_secret="secret",
+                refresh_token="token",
+                cache=object(),
+                detailed_route_strategy="missing",
+                on_finished=object(),
+                advanced_fetch_enabled=False,
+                detailed_streams_checked=True,
+                per_page_value=50,
+                max_pages_value=7,
+                max_detailed_activities_value=12,
+            )
+        )
+
+        self.assertEqual(result, "fetch-task")
+        self.sync_controller.build_fetch_task_request.assert_called_once()
+        _, kwargs = self.sync_controller.build_fetch_task_request.call_args
+        self.assertEqual(kwargs["per_page"], 200)
+        self.assertEqual(kwargs["max_pages"], 0)
+        self.assertFalse(kwargs["use_detailed_streams"])
+        self.assertEqual(kwargs["max_detailed_activities"], 25)
+        self.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
+
+    def test_build_fetch_task_respects_advanced_fetch_values(self):
+        self.sync_controller.build_fetch_task_request.return_value = "fetch-request"
+        self.sync_controller.build_fetch_task.return_value = "fetch-task"
+
+        self.coordinator.build_fetch_task(
+            DockFetchRequest(
+                client_id="cid",
+                client_secret="secret",
+                refresh_token="token",
+                cache=object(),
+                detailed_route_strategy="all",
+                on_finished=object(),
+                advanced_fetch_enabled=True,
+                detailed_streams_checked=True,
+                per_page_value=75,
+                max_pages_value=4,
+                max_detailed_activities_value=30,
+            )
+        )
+
+        _, kwargs = self.sync_controller.build_fetch_task_request.call_args
+        self.assertEqual(kwargs["per_page"], 75)
+        self.assertEqual(kwargs["max_pages"], 4)
+        self.assertTrue(kwargs["use_detailed_streams"])
+        self.assertEqual(kwargs["max_detailed_activities"], 30)
+
+    def test_build_fetch_completion_result_returns_cancelled_status_without_preview(self):
+        fetch_result = SimpleNamespace(cancelled=True, error=None, status_text="Fetch cancelled.")
+        self.fetch_result_service.build_request.return_value = "fetch-request"
+        self.fetch_result_service.build_result_request.return_value = fetch_result
+
+        result = self.coordinator.build_fetch_completion_result(
+            DockFetchCompletionRequest(cancelled=True)
+        )
+
+        self.assertTrue(result.cancelled)
+        self.assertEqual(result.status_text, "Fetch cancelled.")
+        self.activity_preview_service.build_result_request.assert_not_called()
+
+    def test_build_fetch_completion_result_returns_error_without_preview(self):
+        fetch_result = SimpleNamespace(cancelled=False, error="boom", status_text="Strava fetch failed")
+        self.fetch_result_service.build_request.return_value = "fetch-request"
+        self.fetch_result_service.build_result_request.return_value = fetch_result
+
+        result = self.coordinator.build_fetch_completion_result(
+            DockFetchCompletionRequest(error="boom")
+        )
+
+        self.assertEqual(result.error_title, "Strava import failed")
+        self.assertEqual(result.error_message, "boom")
+        self.assertEqual(result.status_text, "Strava fetch failed")
+        self.activity_preview_service.build_result_request.assert_not_called()
+
+    def test_build_fetch_completion_result_builds_activity_options_and_preview(self):
+        activities = ["a1", "a2"]
+        fetch_result = SimpleNamespace(
+            cancelled=False,
+            error=None,
+            activities=activities,
+            metadata={"today_str": "2026-04-16", "detailed_count": 1},
+            today_str="2026-04-16",
+            count_label_text="2 activities loaded",
+            status_text="Fetched 2 activities",
+        )
+        preview_request = build_activity_preview_request(
+            activities=["old"],
+            activity_type="Ride",
+        )
+        preview_result = SimpleNamespace(
+            query_summary_text="2 activities",
+            preview_text="first\nsecond",
+            fetched_activities=activities,
+        )
+        self.fetch_result_service.build_request.return_value = "fetch-request"
+        self.fetch_result_service.build_result_request.return_value = fetch_result
+        self.activity_preview_service.build_result_request.return_value = preview_result
+
+        result = self.coordinator.build_fetch_completion_result(
+            DockFetchCompletionRequest(
+                activities=activities,
+                provider=object(),
+                current_activity_type="Ride",
+                preview_request=preview_request,
+            )
+        )
+
+        self.assertEqual(result.activities, activities)
+        self.assertEqual(result.metadata, {"today_str": "2026-04-16", "detailed_count": 1})
+        self.assertEqual(result.today_str, "2026-04-16")
+        self.assertEqual(result.count_label_text, "2 activities loaded")
+        self.assertEqual(result.status_text, "Fetched 2 activities")
+        self.assertIsNotNone(result.activity_type_options)
+        self.assertEqual(result.activity_type_options.options, ["All"])
+        self.assertEqual(result.activity_type_options.selected_value, "All")
+        self.assertIs(result.preview_result, preview_result)
+        preview_call = self.activity_preview_service.build_result_request.call_args.args[0]
+        self.assertEqual(preview_call.activities, activities)
+        self.assertEqual(preview_call.activity_type, "All")
+
+    def test_build_preview_result_delegates_to_preview_service(self):
+        preview_request = object()
+        preview_result = object()
+        self.activity_preview_service.build_result_request.return_value = preview_result
+
+        result = self.coordinator.build_preview_result(preview_request)
+
+        self.assertIs(result, preview_result)
+        self.activity_preview_service.build_result_request.assert_called_once_with(preview_request)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -75,6 +75,10 @@ class DockWidgetDependenciesTests(unittest.TestCase):
                 "qfit.ui.dockwidget_dependencies.ActivityPreviewService",
                 return_value=sentinel.activity_preview_service,
             ) as activity_preview_service,
+            patch(
+                "qfit.ui.dockwidget_dependencies.DockActivityWorkflowCoordinator",
+                return_value=sentinel.activity_workflow,
+            ) as activity_workflow,
             patch("qfit.ui.dockwidget_dependencies._build_cache", return_value=sentinel.cache),
         ):
             dependencies = build_dockwidget_dependencies(iface)
@@ -90,8 +94,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
         self.assertIs(dependencies.load_workflow, sentinel.load_workflow)
         self.assertIs(dependencies.visual_apply, sentinel.visual_apply)
         self.assertIs(dependencies.atlas_export_service, sentinel.atlas_export_service)
-        self.assertIs(dependencies.fetch_result_service, sentinel.fetch_result_service)
-        self.assertIs(dependencies.activity_preview_service, sentinel.activity_preview_service)
+        self.assertIs(dependencies.activity_workflow, sentinel.activity_workflow)
         self.assertIs(dependencies.cache, sentinel.cache)
 
         background_controller.assert_called_once_with(sentinel.layer_gateway)
@@ -104,6 +107,11 @@ class DockWidgetDependenciesTests(unittest.TestCase):
         )
         fetch_result_service.assert_called_once_with(sentinel.sync_controller)
         activity_preview_service.assert_called_once_with()
+        activity_workflow.assert_called_once_with(
+            sync_controller=sentinel.sync_controller,
+            fetch_result_service=sentinel.fetch_result_service,
+            activity_preview_service=sentinel.activity_preview_service,
+        )
 
     def test_build_cache_prefers_legacy_cache_path_when_current_path_is_missing(self):
         with (

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -685,7 +685,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
     def test_refresh_activity_preview_delegates_and_updates_widgets(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._current_activity_preview_request = MagicMock(return_value="preview-request")
-        dock.activity_preview_service = SimpleNamespace(build_result_request=MagicMock())
+        dock.activity_workflow = SimpleNamespace(build_preview_result=MagicMock())
         dock.querySummaryLabel = SimpleNamespace(setText=MagicMock())
         dock.activityPreviewPlainTextEdit = SimpleNamespace(setPlainText=MagicMock())
         preview_result = SimpleNamespace(
@@ -693,12 +693,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             preview_text="first\nsecond",
             fetched_activities=["first", "second"],
         )
-        dock.activity_preview_service.build_result_request.return_value = preview_result
+        dock.activity_workflow.build_preview_result.return_value = preview_result
 
         result = self.module.QfitDockWidget._refresh_activity_preview(dock)
 
         self.assertEqual(result, ["first", "second"])
-        dock.activity_preview_service.build_result_request.assert_called_once_with("preview-request")
+        dock.activity_workflow.build_preview_result.assert_called_once_with("preview-request")
         dock.querySummaryLabel.setText.assert_called_once_with("2 activities")
         dock.activityPreviewPlainTextEdit.setPlainText.assert_called_once_with("first\nsecond")
 

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -201,7 +201,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertIs(dock.load_workflow, dependencies.load_workflow)
             self.assertIs(dock.visual_apply, dependencies.visual_apply)
             self.assertIs(dock.atlas_export_service, dependencies.atlas_export_service)
-            self.assertIs(dock.fetch_result_service, dependencies.fetch_result_service)
+            self.assertIs(dock.activity_workflow, dependencies.activity_workflow)
             self.assertIs(dock.cache, dependencies.cache)
         finally:
             dock.close()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -6,6 +6,12 @@ from .dock_action_dispatcher import (
     DockActionResult,
     RunAnalysisAction,
 )
+from .dock_activity_workflow import (
+    DockActivityWorkflowCoordinator,
+    DockFetchCompletionRequest,
+    DockFetchCompletionResult,
+    DockFetchRequest,
+)
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -20,6 +26,10 @@ __all__ = [
     "ApplyVisualizationAction",
     "DockActionDispatcher",
     "DockActionResult",
+    "DockActivityWorkflowCoordinator",
+    "DockFetchCompletionRequest",
+    "DockFetchCompletionResult",
+    "DockFetchRequest",
     "RunAnalysisAction",
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",

--- a/ui/application/dock_activity_workflow.py
+++ b/ui/application/dock_activity_workflow.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from ...activities.application import (
+    ActivityPreviewRequest,
+    ActivityPreviewResult,
+    ActivityTypeOptionsResult,
+    build_activity_type_options_from_activities,
+)
+
+
+_DEFAULT_PER_PAGE = 200
+_DEFAULT_MAX_PAGES = 0
+_DEFAULT_MAX_DETAILED_ACTIVITIES = 25
+
+
+@dataclass(frozen=True)
+class DockFetchRequest:
+    client_id: str
+    client_secret: str
+    refresh_token: str
+    cache: object
+    detailed_route_strategy: str
+    on_finished: object
+    advanced_fetch_enabled: bool
+    detailed_streams_checked: bool
+    per_page_value: int
+    max_pages_value: int
+    max_detailed_activities_value: int
+    use_detailed_streams_override: bool | None = None
+
+
+@dataclass(frozen=True)
+class DockFetchCompletionRequest:
+    activities: list[object] = field(default_factory=list)
+    error: str | None = None
+    cancelled: bool = False
+    provider: object = None
+    current_activity_type: str = "All"
+    preview_request: ActivityPreviewRequest | None = None
+
+
+@dataclass(frozen=True)
+class DockFetchCompletionResult:
+    activities: list[object] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    today_str: str = ""
+    count_label_text: str = ""
+    status_text: str = ""
+    cancelled: bool = False
+    error_title: str | None = None
+    error_message: str | None = None
+    activity_type_options: ActivityTypeOptionsResult | None = None
+    preview_result: ActivityPreviewResult | None = None
+
+
+class DockActivityWorkflowCoordinator:
+    """Coordinate the dock's fetch and preview workflow family.
+
+    This keeps fetch-task request building, completion handling, and preview
+    refresh orchestration out of ``QfitDockWidget`` so the widget can focus on
+    rendering and signal wiring.
+    """
+
+    def __init__(
+        self,
+        *,
+        sync_controller,
+        fetch_result_service,
+        activity_preview_service,
+    ) -> None:
+        self.sync_controller = sync_controller
+        self.fetch_result_service = fetch_result_service
+        self.activity_preview_service = activity_preview_service
+
+    def build_fetch_task(self, request: DockFetchRequest):
+        use_detailed_streams = self._resolve_use_detailed_streams(request)
+        fetch_request = self.sync_controller.build_fetch_task_request(
+            client_id=request.client_id,
+            client_secret=request.client_secret,
+            refresh_token=request.refresh_token,
+            cache=request.cache,
+            per_page=self._resolve_per_page(request),
+            max_pages=self._resolve_max_pages(request),
+            use_detailed_streams=use_detailed_streams,
+            max_detailed_activities=self._resolve_max_detailed_activities(
+                request,
+                use_detailed_streams=use_detailed_streams,
+            ),
+            detailed_route_strategy=request.detailed_route_strategy,
+            on_finished=request.on_finished,
+        )
+        return self.sync_controller.build_fetch_task(fetch_request)
+
+    def build_fetch_completion_result(
+        self,
+        request: DockFetchCompletionRequest,
+    ) -> DockFetchCompletionResult:
+        fetch_request = self.fetch_result_service.build_request(
+            activities=request.activities,
+            error=request.error,
+            cancelled=request.cancelled,
+            provider=request.provider,
+        )
+        fetch_result = self.fetch_result_service.build_result_request(fetch_request)
+
+        if fetch_result.cancelled:
+            return DockFetchCompletionResult(
+                cancelled=True,
+                status_text=fetch_result.status_text,
+            )
+
+        if fetch_result.error is not None:
+            return DockFetchCompletionResult(
+                error_title="Strava import failed",
+                error_message=fetch_result.error,
+                status_text=fetch_result.status_text,
+            )
+
+        activity_type_options = build_activity_type_options_from_activities(
+            fetch_result.activities,
+            current_value=request.current_activity_type or "All",
+        )
+        preview_result = None
+        if request.preview_request is not None:
+            preview_request = replace(
+                request.preview_request,
+                activities=fetch_result.activities,
+                activity_type=activity_type_options.selected_value,
+            )
+            preview_result = self.build_preview_result(preview_request)
+
+        return DockFetchCompletionResult(
+            activities=fetch_result.activities,
+            metadata=fetch_result.metadata,
+            today_str=fetch_result.today_str,
+            count_label_text=fetch_result.count_label_text,
+            status_text=fetch_result.status_text,
+            activity_type_options=activity_type_options,
+            preview_result=preview_result,
+        )
+
+    def build_preview_result(self, request: ActivityPreviewRequest) -> ActivityPreviewResult:
+        return self.activity_preview_service.build_result_request(request)
+
+    @staticmethod
+    def _resolve_use_detailed_streams(request: DockFetchRequest) -> bool:
+        if request.use_detailed_streams_override is not None:
+            return request.use_detailed_streams_override
+        if request.advanced_fetch_enabled:
+            return request.detailed_streams_checked
+        return False
+
+    @staticmethod
+    def _resolve_per_page(request: DockFetchRequest) -> int:
+        if request.advanced_fetch_enabled:
+            return request.per_page_value
+        return _DEFAULT_PER_PAGE
+
+    @staticmethod
+    def _resolve_max_pages(request: DockFetchRequest) -> int:
+        if request.advanced_fetch_enabled:
+            return request.max_pages_value
+        return _DEFAULT_MAX_PAGES
+
+    @staticmethod
+    def _resolve_max_detailed_activities(
+        request: DockFetchRequest,
+        *,
+        use_detailed_streams: bool,
+    ) -> int:
+        if request.advanced_fetch_enabled or use_detailed_streams:
+            return request.max_detailed_activities_value
+        return _DEFAULT_MAX_DETAILED_ACTIVITIES
+
+
+__all__ = [
+    "DockActivityWorkflowCoordinator",
+    "DockFetchCompletionRequest",
+    "DockFetchCompletionResult",
+    "DockFetchRequest",
+]

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -13,6 +13,7 @@ from ..activities.application.load_workflow import LoadWorkflowService
 from ..qfit_cache import QfitCache
 from ..configuration.application.settings_service import SettingsService
 from ..activities.application.sync_controller import SyncController
+from ..ui.application import DockActivityWorkflowCoordinator
 from ..visualization.application import BackgroundMapController, VisualApplyService
 
 
@@ -36,8 +37,7 @@ class DockWidgetDependencies:
     load_workflow: LoadWorkflowService
     visual_apply: VisualApplyService
     atlas_export_service: AtlasExportService
-    fetch_result_service: FetchResultService
-    activity_preview_service: ActivityPreviewService
+    activity_workflow: DockActivityWorkflowCoordinator
     cache: QfitCache
 
 
@@ -50,6 +50,8 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
     layer_gateway = _build_layer_gateway(iface)
     cache = _build_cache()
     atlas_export_service = AtlasExportService(layer_gateway)
+    fetch_result_service = FetchResultService(sync_controller)
+    activity_preview_service = ActivityPreviewService()
     return DockWidgetDependencies(
         settings=settings,
         sync_controller=sync_controller,
@@ -62,8 +64,11 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
         load_workflow=LoadWorkflowService(layer_gateway),
         visual_apply=VisualApplyService(layer_gateway),
         atlas_export_service=atlas_export_service,
-        fetch_result_service=FetchResultService(sync_controller),
-        activity_preview_service=ActivityPreviewService(),
+        activity_workflow=DockActivityWorkflowCoordinator(
+            sync_controller=sync_controller,
+            fetch_result_service=fetch_result_service,
+            activity_preview_service=activity_preview_service,
+        ),
         cache=cache,
     )
 


### PR DESCRIPTION
## Summary
- extract the dock fetch and preview workflow into a dedicated UI/application coordinator
- move fetch-task request building and fetch-completion orchestration out of `QfitDockWidget`
- keep the dock focused on rendering fetch results instead of coordinating the workflow itself

## Changes
- add `DockActivityWorkflowCoordinator` plus explicit request/result models for dock fetch and preview flow
- wire the new coordinator through `DockWidgetDependencies`
- update `QfitDockWidget` to delegate fetch start, fetch completion, and preview refresh to the coordinator
- add focused unit coverage for the new coordinator and update dock dependency/widget tests

## Testing
- `python3 -m unittest tests.test_dock_activity_workflow tests.test_dockwidget_dependencies tests.test_qfit_dockwidget_analysis_pure tests.test_qgis_smoke.QgisSmokeTests.test_dock_widget_uses_injected_dependencies_without_rebuilding_defaults tests.test_qgis_smoke.QgisSmokeTests.test_dock_widget_delegates_startup_to_coordinator`
- `python3 -m unittest tests.test_fetch_result_service tests.test_activity_preview_service tests.test_dock_activity_workflow`
- `python3 -m unittest tests.test_architecture_boundaries tests.test_dock_activity_workflow tests.test_dockwidget_dependencies tests.test_qfit_dockwidget_analysis_pure`
- `python3 -m unittest tests.test_qgis_smoke.QgisSmokeTests.test_dock_widget_contextual_help_smoke`

Fixes #574
