### PR TITLE
refactor: finish the root-level compatibility shim migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ Keep these rules lightweight and practical:
 - Do not add new top-level Python modules for feature-specific code; prefer the owning feature package (`activities/`, `atlas/`, `providers/`, `visualization/`, `ui/`, `validation/`).
 - Treat existing root-level modules as grandfathered transitional modules unless the code is truly shared across features.
 - If you touch a transitional root module that now only forwards imports, prefer moving the real implementation in the owned package and keep the root file as a thin compatibility shim instead of re-expanding it.
+- Deprecated compatibility shims currently include `activity_classification.py`, `activity_query.py`, `models.py`, `activity_storage.py`, and `layer_manager.py`; new in-repo imports should target their package-owned replacements instead.
 - If a new top-level shared module is genuinely needed, document the reason and update `tests/test_architecture_boundaries.py` in the same PR.
 - Keep `QfitDockWidget` and other UI classes focused on widget wiring, input mapping, and result rendering.
 - Put workflow orchestration into controllers/services/use cases instead of the dock widget where practical.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The top-level Python module layer is now mostly limited to:
 
 - plugin/bootstrap entrypoints
 - a few small shared helpers such as `polyline_utils.py`, `time_utils.py`, `mapbox_config.py`, and `qfit_cache.py`
-- transitional compatibility shims such as `activity_query.py`, `activity_classification.py`, `models.py`, and other grandfathered modules that still exist only to cushion package migration
+- transitional compatibility shims such as `activity_query.py`, `activity_classification.py`, `models.py`, `activity_storage.py`, and `layer_manager.py` that still exist only to cushion package migration
 
 Rule of thumb:
 

--- a/activities/application/__init__.py
+++ b/activities/application/__init__.py
@@ -9,6 +9,7 @@ from importlib import import_module
 _ACTIVITY_PREVIEW_MODULE = ".activity_preview"
 
 __all__ = [
+    "ActivityStore",
     "ActivityPreviewRequest",
     "ActivityPreviewResult",
     "ActivityPreviewService",
@@ -43,6 +44,7 @@ __all__ = [
 _ACTIVITY_TYPE_OPTIONS_MODULE = ".activity_type_options"
 
 _EXPORTS = {
+    "ActivityStore": (".activity_storage", "ActivityStore"),
     "ActivityPreviewRequest": (_ACTIVITY_PREVIEW_MODULE, "ActivityPreviewRequest"),
     "ActivityPreviewResult": (_ACTIVITY_PREVIEW_MODULE, "ActivityPreviewResult"),
     "ActivityPreviewService": (".activity_preview_service", "ActivityPreviewService"),

--- a/activities/application/activity_storage.py
+++ b/activities/application/activity_storage.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ...sync_repository import SyncStats
+
+
+@runtime_checkable
+class ActivityStore(Protocol):
+    """Application-facing port for persisted qfit activity storage."""
+
+    def ensure_schema(self) -> None:
+        """Create or update storage metadata/schema as needed."""
+
+    def upsert_activities(self, activities, sync_metadata=None) -> SyncStats:
+        """Persist fetched activities and return sync counters."""
+
+    def load_all_activity_records(self) -> list[dict]:
+        """Return all stored activity records in canonical registry form."""
+
+    def load_all_activities(self):
+        """Return all stored activities as domain objects."""
+
+
+__all__ = ["ActivityStore"]

--- a/activities/infrastructure/geopackage/activity_storage.py
+++ b/activities/infrastructure/geopackage/activity_storage.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from ....sync_repository import SyncRepository
+
+
+class GeoPackageActivityStore(SyncRepository):
+    """GeoPackage-backed adapter implementing the ActivityStore port."""
+
+
+__all__ = ["GeoPackageActivityStore"]

--- a/activities/infrastructure/geopackage/gpkg_writer.py
+++ b/activities/infrastructure/geopackage/gpkg_writer.py
@@ -1,6 +1,6 @@
 import os
 
-from ....activity_storage import GeoPackageActivityStore
+from .activity_storage import GeoPackageActivityStore
 from .gpkg_schema import GPKG_LAYER_SCHEMA
 from .gpkg_write_orchestration import (
     bootstrap_empty_gpkg,

--- a/activity_classification.py
+++ b/activity_classification.py
@@ -1,7 +1,9 @@
-"""Compatibility wrapper for activity-domain classification helpers.
+"""Deprecated compatibility shim for activity-domain classification helpers.
 
 The canonical provider-neutral activity classification logic now lives in
 :mod:`qfit.activities.domain.activity_classification`.
+
+Do not add new in-repo imports here.
 """
 
 from .activities.domain.activity_classification import (

--- a/activity_query.py
+++ b/activity_query.py
@@ -1,7 +1,9 @@
-"""Compatibility wrapper for activity-domain query helpers.
+"""Deprecated compatibility shim for activity-domain query helpers.
 
 The canonical provider-neutral activity query/summary logic now lives in
 :mod:`qfit.activities.domain.activity_query`.
+
+Do not add new in-repo imports here.
 """
 
 from .activities.domain.activity_query import (

--- a/activity_storage.py
+++ b/activity_storage.py
@@ -1,26 +1,12 @@
-from __future__ import annotations
+"""Deprecated compatibility shim for qfit's activity storage helpers.
 
-from typing import Protocol, runtime_checkable
+Use :mod:`qfit.activities.application.activity_storage` for the
+application-facing port and
+:mod:`qfit.activities.infrastructure.geopackage.activity_storage` for the
+GeoPackage adapter. Do not add new in-repo imports here.
+"""
 
-from .sync_repository import SyncRepository, SyncStats
+from .activities.application.activity_storage import ActivityStore
+from .activities.infrastructure.geopackage.activity_storage import GeoPackageActivityStore
 
-
-@runtime_checkable
-class ActivityStore(Protocol):
-    """Application-facing port for persisted qfit activity storage."""
-
-    def ensure_schema(self) -> None:
-        """Create or update storage metadata/schema as needed."""
-
-    def upsert_activities(self, activities, sync_metadata=None) -> SyncStats:
-        """Persist fetched activities and return sync counters."""
-
-    def load_all_activity_records(self) -> list[dict]:
-        """Return all stored activity records in canonical registry form."""
-
-    def load_all_activities(self):
-        """Return all stored activities as domain objects."""
-
-
-class GeoPackageActivityStore(SyncRepository):
-    """GeoPackage-backed adapter implementing the ActivityStore port."""
+__all__ = ["ActivityStore", "GeoPackageActivityStore"]

--- a/atlas/cover_summary.py
+++ b/atlas/cover_summary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from ..activity_classification import ordered_canonical_activity_labels
+from ..activities.domain.activity_classification import ordered_canonical_activity_labels
 from .publish_atlas import (
     build_date_range_label,
     format_distance_label,

--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -59,7 +59,7 @@ from qgis.core import (
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QFont
 
-from ..activity_classification import ordered_canonical_activity_labels
+from ..activities.domain.activity_classification import ordered_canonical_activity_labels
 from .layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .profile_item import (
     NativeProfileItemConfig,

--- a/atlas/publish_atlas.py
+++ b/atlas/publish_atlas.py
@@ -5,8 +5,11 @@ from datetime import datetime
 from math import atan, exp, log, pi, tan
 from typing import Iterable
 
-from ..activity_classification import activity_prefers_pace, canonical_activity_label
-from ..activity_query import format_duration
+from ..activities.domain.activity_classification import (
+    activity_prefers_pace,
+    canonical_activity_label,
+)
+from ..activities.domain.activity_query import format_duration
 from ..polyline_utils import decode_polyline
 
 DEFAULT_ATLAS_MARGIN_PERCENT = 8.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,20 @@ The codebase now already reflects most of that shape:
 
 Some root-level modules still exist as **compatibility shims** so imports remain stable while the migration settles. Those files are transitional; new feature logic should not be added there.
 
+Current deprecated compatibility shims are:
+
+- `activity_classification.py` -> `activities/domain/activity_classification.py`
+- `activity_query.py` -> `activities/domain/activity_query.py`
+- `models.py` -> `activities/domain/models.py`
+- `activity_storage.py` -> `activities/application/activity_storage.py` plus `activities/infrastructure/geopackage/activity_storage.py`
+- `layer_manager.py` -> `visualization/infrastructure/qgis_layer_gateway.py`
+
+Migration policy for these shims:
+
+- new in-repo imports should use the canonical package-owned module, never the root shim
+- keep root shims as tiny forwarding modules only while external import stability still matters
+- once in-repo callers are gone and import stability is no longer needed, delete the shim instead of re-expanding it
+
 ## 2. Working layers
 
 Use these layers as a placement heuristic.

--- a/layer_manager.py
+++ b/layer_manager.py
@@ -1,4 +1,8 @@
-"""Backward-compatible import for qfit's QGIS layer gateway adapter."""
+"""Deprecated compatibility shim for qfit's QGIS layer gateway adapter.
+
+Use :mod:`qfit.visualization.infrastructure.qgis_layer_gateway` for new
+in-repo imports.
+"""
 
 from .visualization.infrastructure.qgis_layer_gateway import QgisLayerGateway
 

--- a/models.py
+++ b/models.py
@@ -1,8 +1,8 @@
-"""Compatibility wrapper for the activity domain model.
+"""Deprecated compatibility shim for the activity domain model.
 
 The canonical activity model now lives in :mod:`qfit.activities.domain.models`.
 Keep this module as a stable import surface while the package structure is
-refactored incrementally.
+refactored incrementally. Do not add new in-repo imports here.
 """
 
 from .activities.domain.models import Activity

--- a/tests/test_activity_storage.py
+++ b/tests/test_activity_storage.py
@@ -4,7 +4,16 @@ import unittest
 from pathlib import Path
 
 from tests import _path  # noqa: F401
-from qfit.activity_storage import ActivityStore, GeoPackageActivityStore
+from qfit.activities.application.activity_storage import ActivityStore
+from qfit.activities.infrastructure.geopackage.activity_storage import GeoPackageActivityStore
+from qfit.activity_storage import ActivityStore as LegacyActivityStore
+from qfit.activity_storage import GeoPackageActivityStore as LegacyGeoPackageActivityStore
+
+
+class ActivityStorageCompatibilityTests(unittest.TestCase):
+    def test_legacy_activity_storage_imports_remain_aliases(self):
+        self.assertIs(LegacyActivityStore, ActivityStore)
+        self.assertIs(LegacyGeoPackageActivityStore, GeoPackageActivityStore)
 
 
 class ActivityStoreAdapterTests(unittest.TestCase):

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -101,6 +101,35 @@ def _module_scope_import_targets(relative_path: str) -> set[str]:
     return _collect_module_scope_import_targets(tree)
 
 
+def _module_name_parts(relative_path: str) -> list[str]:
+    parts = list(pathlib.Path(relative_path).with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ["qfit", *parts]
+
+
+def _resolved_import_targets(relative_path: str) -> set[str]:
+    resolved: set[str] = set()
+    module_parts = _module_name_parts(relative_path)
+    package_parts = module_parts
+    if pathlib.Path(relative_path).stem != "__init__":
+        package_parts = module_parts[:-1]
+
+    for target in _import_targets(relative_path):
+        level = len(target) - len(target.lstrip("."))
+        if level == 0:
+            resolved.add(target)
+            continue
+
+        remainder = target[level:]
+        base_parts = package_parts[: len(package_parts) - (level - 1)]
+        pieces = list(base_parts)
+        if remainder:
+            pieces.extend(remainder.split("."))
+        resolved.add(".".join(pieces))
+    return resolved
+
+
 class CoreModuleBoundaryTests(unittest.TestCase):
     CORE_MODULES = [
         "activities/domain/activity_classification.py",
@@ -279,6 +308,66 @@ class ModuleScopeImportScannerTests(unittest.TestCase):
             "        import delta\n"
         )
         self.assertEqual({"alpha", "beta", "gamma", "delta"}, imports)
+
+
+class DeprecatedCompatibilityShimTests(unittest.TestCase):
+    DEPRECATED_ROOT_SHIMS = {
+        "activity_classification.py": "qfit.activities.domain.activity_classification",
+        "activity_query.py": "qfit.activities.domain.activity_query",
+        "models.py": "qfit.activities.domain.models",
+        "activity_storage.py": "qfit.activities.application.activity_storage",
+        "layer_manager.py": "qfit.visualization.infrastructure.qgis_layer_gateway",
+    }
+
+    FEATURE_ROOTS = (
+        "activities",
+        "analysis",
+        "atlas",
+        "configuration",
+        "providers",
+        "ui",
+        "validation",
+        "visualization",
+    )
+
+    def test_deprecated_root_shims_are_explicitly_marked(self):
+        for relative_path, canonical_module in self.DEPRECATED_ROOT_SHIMS.items():
+            source = (REPO_ROOT / relative_path).read_text()
+            self.assertIn(
+                "Deprecated compatibility shim",
+                source,
+                f"{relative_path} should clearly advertise its deprecated compatibility-shim status.",
+            )
+            self.assertIn(
+                canonical_module,
+                source,
+                f"{relative_path} should point contributors at its canonical module.",
+            )
+
+    def test_feature_owned_modules_do_not_import_deprecated_root_shims(self):
+        shim_prefixes = tuple(
+            f"qfit.{pathlib.Path(relative_path).stem}"
+            for relative_path in self.DEPRECATED_ROOT_SHIMS
+        )
+        offenders = {}
+
+        for feature_root in self.FEATURE_ROOTS:
+            for path in sorted((REPO_ROOT / feature_root).rglob("*.py")):
+                relative_path = path.relative_to(REPO_ROOT).as_posix()
+                forbidden = sorted(
+                    target
+                    for target in _resolved_import_targets(relative_path)
+                    if target.startswith(shim_prefixes)
+                )
+                if forbidden:
+                    offenders[relative_path] = forbidden
+
+        self.assertEqual(
+            {},
+            offenders,
+            "Feature-owned packages should import canonical package modules rather than deprecated root shims: "
+            f"{offenders}",
+        )
 
 
 class PackageOwnershipBoundaryTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- move the activity-storage port and GeoPackage adapter into feature-owned packages, leaving the root module as a deprecated forwarding shim
- migrate atlas and GeoPackage code away from deprecated root-level activity shims to their canonical package modules
- document the remaining compatibility shims and add architecture tests that block new feature-owned imports from using them

## Changes
- add canonical activity-storage modules under `activities/application` and `activities/infrastructure/geopackage`
- turn `activity_storage.py` into a thin compatibility shim and mark all remaining root shims as deprecated in code/docs
- update atlas imports, GeoPackage writer imports, README/contributing/architecture docs, and boundary tests

## Testing
- `python3 -m unittest tests.test_publish_atlas tests.test_cover_composer tests.test_activity_storage tests.test_activity_domain_compatibility tests.test_architecture_boundaries tests.test_load_workflow`
- `python3 - <<'PY'
import pathlib, sys
sys.path.insert(0, str(pathlib.Path('.').resolve().parent))
import qfit.atlas.export_task as export_task
import qfit.atlas.cover_summary as cover_summary
import qfit.atlas.publish_atlas as publish_atlas
print(export_task.ordered_canonical_activity_labels.__module__)
print(cover_summary.ordered_canonical_activity_labels.__module__)
print(publish_atlas.format_duration.__module__)
PY`

Fixes #575