### PR TITLE
refactor: use explicit dock dependency ports

### DIFF
--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 from types import ModuleType
+from typing import get_type_hints
 from unittest.mock import MagicMock, call, patch, sentinel
 
 from tests import _path  # noqa: F401
@@ -9,10 +10,13 @@ from tests import _path  # noqa: F401
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from qfit.ui.dockwidget_dependencies import (
+    DockWidgetDependencies,
     build_dockwidget_dependencies,
     _build_cache,
     _build_project_hygiene_service,
 )
+from qfit.visualization.application.layer_gateway import LayerGateway
+from qfit.visualization.application.project_hygiene_port import ProjectHygienePort
 from qfit.ui.dock_startup_coordinator import DockStartupCoordinator, DockStartupResult
 
 
@@ -25,8 +29,16 @@ class _FakeIface:
 
 
 class DockWidgetDependenciesTests(unittest.TestCase):
+    def test_dependency_annotations_use_explicit_ports(self):
+        hints = get_type_hints(DockWidgetDependencies)
+
+        self.assertIs(hints["layer_gateway"], LayerGateway)
+        self.assertIs(hints["project_hygiene_service"], ProjectHygienePort)
+
     def test_build_dockwidget_dependencies_wires_shared_gateway_and_sync_controller(self):
         iface = _FakeIface()
+        layer_gateway = MagicMock(spec=LayerGateway)
+        project_hygiene_service = MagicMock(spec=ProjectHygienePort)
 
         with (
             patch("qfit.ui.dockwidget_dependencies.SettingsService", return_value=sentinel.settings),
@@ -45,7 +57,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
             ) as atlas_export_use_case,
             patch(
                 "qfit.ui.dockwidget_dependencies._build_layer_gateway",
-                return_value=sentinel.layer_gateway,
+                return_value=layer_gateway,
             ),
             patch(
                 "qfit.ui.dockwidget_dependencies.BackgroundMapController",
@@ -53,7 +65,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
             ) as background_controller,
             patch(
                 "qfit.ui.dockwidget_dependencies._build_project_hygiene_service",
-                return_value=sentinel.project_hygiene_service,
+                return_value=project_hygiene_service,
             ),
             patch(
                 "qfit.ui.dockwidget_dependencies.LoadWorkflowService",
@@ -88,19 +100,19 @@ class DockWidgetDependenciesTests(unittest.TestCase):
         self.assertIs(dependencies.analysis_workflow, sentinel.analysis_workflow)
         self.assertIs(dependencies.atlas_export_controller, sentinel.atlas_export_controller)
         self.assertIs(dependencies.atlas_export_use_case, sentinel.atlas_export_use_case)
-        self.assertIs(dependencies.layer_gateway, sentinel.layer_gateway)
+        self.assertIs(dependencies.layer_gateway, layer_gateway)
         self.assertIs(dependencies.background_controller, sentinel.background_controller)
-        self.assertIs(dependencies.project_hygiene_service, sentinel.project_hygiene_service)
+        self.assertIs(dependencies.project_hygiene_service, project_hygiene_service)
         self.assertIs(dependencies.load_workflow, sentinel.load_workflow)
         self.assertIs(dependencies.visual_apply, sentinel.visual_apply)
         self.assertIs(dependencies.atlas_export_service, sentinel.atlas_export_service)
         self.assertIs(dependencies.activity_workflow, sentinel.activity_workflow)
         self.assertIs(dependencies.cache, sentinel.cache)
 
-        background_controller.assert_called_once_with(sentinel.layer_gateway)
-        load_workflow.assert_called_once_with(sentinel.layer_gateway)
-        visual_apply.assert_called_once_with(sentinel.layer_gateway)
-        atlas_export_service.assert_called_once_with(sentinel.layer_gateway)
+        background_controller.assert_called_once_with(layer_gateway)
+        load_workflow.assert_called_once_with(layer_gateway)
+        visual_apply.assert_called_once_with(layer_gateway)
+        atlas_export_service.assert_called_once_with(layer_gateway)
         atlas_export_use_case.assert_called_once_with(
             sentinel.atlas_export_controller,
             sentinel.atlas_export_service,

--- a/tests/test_project_hygiene_service.py
+++ b/tests/test_project_hygiene_service.py
@@ -7,6 +7,7 @@ from tests import _path  # noqa: F401
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from qfit.visualization.infrastructure import project_hygiene_service as project_hygiene_service_module
+from qfit.visualization.application.project_hygiene_port import ProjectHygienePort
 from qfit.visualization.infrastructure.project_hygiene_service import ProjectHygieneService
 
 
@@ -39,6 +40,11 @@ class _FakeProject:
 
 
 class ProjectHygieneServiceTests(unittest.TestCase):
+    def test_service_satisfies_project_hygiene_port(self):
+        service = ProjectHygieneService(project=_FakeProject({}), path_exists=lambda _path: True)
+
+        self.assertIsInstance(service, ProjectHygienePort)
+
     def test_remove_stale_qfit_layers_removes_only_missing_known_file_backed_layers(self):
         project = _FakeProject(
             {

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -1,6 +1,5 @@
 import os
 from dataclasses import dataclass
-from typing import Any
 
 from ..analysis.application.analysis_workflow_provider import build_analysis_workflow
 from ..analysis.application.analysis_workflow_port import AnalysisWorkflowPort
@@ -14,7 +13,12 @@ from ..qfit_cache import QfitCache
 from ..configuration.application.settings_service import SettingsService
 from ..activities.application.sync_controller import SyncController
 from ..ui.application import DockActivityWorkflowCoordinator
-from ..visualization.application import BackgroundMapController, VisualApplyService
+from ..visualization.application import (
+    BackgroundMapController,
+    LayerGateway,
+    ProjectHygienePort,
+    VisualApplyService,
+)
 
 
 @dataclass(frozen=True)
@@ -31,9 +35,9 @@ class DockWidgetDependencies:
     analysis_workflow: AnalysisWorkflowPort
     atlas_export_controller: AtlasExportController
     atlas_export_use_case: AtlasExportUseCase
-    layer_gateway: Any
+    layer_gateway: LayerGateway
     background_controller: BackgroundMapController
-    project_hygiene_service: Any
+    project_hygiene_service: ProjectHygienePort
     load_workflow: LoadWorkflowService
     visual_apply: VisualApplyService
     atlas_export_service: AtlasExportService
@@ -73,13 +77,13 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
     )
 
 
-def _build_layer_gateway(iface):
+def _build_layer_gateway(iface) -> LayerGateway:
     from ..visualization.infrastructure.qgis_layer_gateway import QgisLayerGateway
 
     return QgisLayerGateway(iface)
 
 
-def _build_project_hygiene_service():
+def _build_project_hygiene_service() -> ProjectHygienePort:
     from ..visualization.infrastructure.project_hygiene_service import ProjectHygieneService
 
     return ProjectHygieneService()

--- a/visualization/application/__init__.py
+++ b/visualization/application/__init__.py
@@ -15,6 +15,7 @@ from .background_map_messages import (
     build_styled_visual_apply_status,
 )
 from .layer_gateway import LayerGateway
+from .project_hygiene_port import ProjectHygienePort
 from .render_plan import (
     BY_ACTIVITY_TYPE_PRESET,
     CLUSTERED_STARTS_PRESET,
@@ -93,6 +94,7 @@ __all__ = [
     "RENDERER_START_POINTS",
     "RENDERER_TRACK_POINTS",
     "RenderPlan",
+    "ProjectHygienePort",
     "SOURCE_ROLE_POINTS",
     "SOURCE_ROLE_STARTS",
     "START_POINTS_PRESET",

--- a/visualization/application/project_hygiene_port.py
+++ b/visualization/application/project_hygiene_port.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProjectHygienePort(Protocol):
+    """Application-facing boundary for qfit-owned project cleanup rules."""
+
+    def remove_stale_qfit_layers(self) -> None: ...
+
+
+__all__ = ["ProjectHygienePort"]


### PR DESCRIPTION
## Summary
- replace the dock dependency `Any` annotations with explicit layer-gateway and project-hygiene ports
- add a dedicated `ProjectHygienePort` protocol alongside the existing visualization-layer gateway port
- update dependency wiring tests to stub these collaborators through the protocol surface and verify the default QGIS hygiene service satisfies the port

## Changes
- type `DockWidgetDependencies.layer_gateway` as `LayerGateway` and `project_hygiene_service` as `ProjectHygienePort`
- export the new project-hygiene port from `visualization.application` and annotate the default builders accordingly
- strengthen tests around dependency annotations, protocol-shaped stubs, and the QGIS hygiene adapter boundary

## Testing
- `python3 -m unittest tests.test_dockwidget_dependencies tests.test_layer_gateway tests.test_project_hygiene_service tests.test_qfit_dockwidget_analysis_pure tests.test_architecture_boundaries`

Fixes #576