### PR TITLE
refactor: centralize dock runtime state

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -74,6 +74,7 @@ from .ui.application import (
     DockActionDispatcher,
     DockFetchCompletionRequest,
     DockFetchRequest,
+    DockRuntimeStore,
     RunAnalysisAction,
     build_visual_layer_refs,
     build_visual_workflow_action,
@@ -128,18 +129,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             parent = iface.mainWindow()
         super().__init__(parent)
         self.iface = iface
-        self.activities = []
-        self.output_path = None
-        self.activities_layer = None
-        self.starts_layer = None
-        self.points_layer = None
-        self.atlas_layer = None
-        self.background_layer = None
-        self.analysis_layer = None
-        self.last_fetch_context = {}
-        self._fetch_task = None
-        self._store_task = None
-        self._atlas_export_task = None
+        self._runtime_state_store = DockRuntimeStore()
         self._dependencies = dependencies or build_dockwidget_dependencies(iface)
         self._bind_dependencies(self._dependencies)
         self.setupUi(self)
@@ -154,6 +144,133 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             save_settings=self._save_settings,
             run_analysis=self._apply_analysis_configuration,
         )
+
+    def _runtime_store(self) -> DockRuntimeStore:
+        store = getattr(self, "_runtime_state_store", None)
+        if store is None:
+            store = DockRuntimeStore()
+            self._runtime_state_store = store
+        return store
+
+    @property
+    def runtime_state(self):
+        return self._runtime_store().state
+
+    @property
+    def activities(self):
+        return list(self.runtime_state.activities)
+
+    @activities.setter
+    def activities(self, value):
+        self._runtime_store().set_activities(value)
+
+    @property
+    def output_path(self):
+        return self.runtime_state.output_path
+
+    @output_path.setter
+    def output_path(self, value):
+        self._runtime_store().set_output_path(value)
+
+    @property
+    def activities_layer(self):
+        return self.runtime_state.layers.activities
+
+    @activities_layer.setter
+    def activities_layer(self, value):
+        self._runtime_store().set_dataset_layers(
+            activities_layer=value,
+            starts_layer=self.starts_layer,
+            points_layer=self.points_layer,
+            atlas_layer=self.atlas_layer,
+        )
+
+    @property
+    def starts_layer(self):
+        return self.runtime_state.layers.starts
+
+    @starts_layer.setter
+    def starts_layer(self, value):
+        self._runtime_store().set_dataset_layers(
+            activities_layer=self.activities_layer,
+            starts_layer=value,
+            points_layer=self.points_layer,
+            atlas_layer=self.atlas_layer,
+        )
+
+    @property
+    def points_layer(self):
+        return self.runtime_state.layers.points
+
+    @points_layer.setter
+    def points_layer(self, value):
+        self._runtime_store().set_dataset_layers(
+            activities_layer=self.activities_layer,
+            starts_layer=self.starts_layer,
+            points_layer=value,
+            atlas_layer=self.atlas_layer,
+        )
+
+    @property
+    def atlas_layer(self):
+        return self.runtime_state.layers.atlas
+
+    @atlas_layer.setter
+    def atlas_layer(self, value):
+        self._runtime_store().set_dataset_layers(
+            activities_layer=self.activities_layer,
+            starts_layer=self.starts_layer,
+            points_layer=self.points_layer,
+            atlas_layer=value,
+        )
+
+    @property
+    def background_layer(self):
+        return self.runtime_state.layers.background
+
+    @background_layer.setter
+    def background_layer(self, value):
+        self._runtime_store().set_background_layer(value)
+
+    @property
+    def analysis_layer(self):
+        return self.runtime_state.layers.analysis
+
+    @analysis_layer.setter
+    def analysis_layer(self, value):
+        self._runtime_store().set_analysis_layer(value)
+
+    @property
+    def last_fetch_context(self):
+        return dict(self.runtime_state.last_fetch_context)
+
+    @last_fetch_context.setter
+    def last_fetch_context(self, value):
+        self._runtime_store().set_last_fetch_context(value)
+
+    @property
+    def _fetch_task(self):
+        return self.runtime_state.tasks.fetch
+
+    @_fetch_task.setter
+    def _fetch_task(self, value):
+        self._runtime_store().set_fetch_task(value)
+
+    @property
+    def _store_task(self):
+        return self.runtime_state.tasks.store
+
+    @_store_task.setter
+    def _store_task(self, value):
+        self._runtime_store().set_store_task(value)
+
+    @property
+    def _atlas_export_task(self):
+        return self.runtime_state.tasks.atlas_export
+
+    @_atlas_export_task.setter
+    def _atlas_export_task(self, value):
+        self._runtime_store().set_atlas_export_task(value)
 
     def _remove_stale_qfit_layers(self):
         """Remove stale qfit project layers before startup signals begin firing."""
@@ -417,7 +534,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 tile_mode=self.tileModeComboBox.currentText(),
             )
             result = self.background_controller.load_background_request(request)
-            self.background_layer = result.layer
+            self._runtime_store().set_background_layer(result.layer)
         except (MapboxConfigError, RuntimeError) as exc:
             self._show_error(build_background_map_failure_title(), str(exc))
             self._set_status(build_background_map_failure_status())
@@ -523,9 +640,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         # If a fetch is already running, cancel it.
         if self._fetch_task is not None:
             self._fetch_task.cancel()
+            self._runtime_store().clear_fetch()
             self._set_fetch_running(False)
             self._set_status("Fetch cancelled.")
-            self._fetch_task = None
             return
 
         self._start_fetch(
@@ -546,7 +663,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _start_fetch(self, detailed_route_strategy, status_text, use_detailed_streams=None):
         self._save_settings()
         try:
-            self._fetch_task = self.activity_workflow.build_fetch_task(
+            fetch_task = self.activity_workflow.build_fetch_task(
                 DockFetchRequest(
                     client_id=self.clientIdLineEdit.text().strip(),
                     client_secret=self.clientSecretLineEdit.text().strip(),
@@ -567,9 +684,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status("Strava fetch failed")
             return
 
+        self._runtime_store().begin_fetch(fetch_task)
         self._set_fetch_running(True)
         self._set_status(status_text)
-        QgsApplication.taskManager().addTask(self._fetch_task)
+        QgsApplication.taskManager().addTask(fetch_task)
 
     def _set_fetch_running(self, running):
         """Toggle UI state while a background fetch is in progress."""
@@ -580,7 +698,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _on_fetch_finished(self, activities, error, cancelled, provider):
         """Called on the main thread when the background fetch completes."""
-        self._fetch_task = None
+        self._runtime_store().clear_fetch()
         self._set_fetch_running(False)
 
         result = self.activity_workflow.build_fetch_completion_result(
@@ -603,8 +721,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(result.status_text)
             return
 
-        self.activities = result.activities
-        self.last_fetch_context = result.metadata
+        self._runtime_store().finish_fetch(
+            activities=result.activities,
+            metadata=result.metadata,
+        )
         self.settings.set("last_sync_date", result.today_str)
 
         if result.activity_type_options is not None:
@@ -641,18 +761,19 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(_msg)
             return
 
-        self._store_task = build_store_task(
+        store_task = build_store_task(
             workflow,
             request,
             on_finished=self._handle_store_task_finished,
         )
+        self._runtime_store().begin_store(store_task)
         self.loadButton.setEnabled(False)
         self.loadButton.setText("Store in progress...")
         self._set_status("Store started...")
-        QgsApplication.taskManager().addTask(self._store_task)
+        QgsApplication.taskManager().addTask(store_task)
 
     def _handle_store_task_finished(self, result, error_message, cancelled):
-        self._store_task = None
+        self._runtime_store().clear_store()
         self.loadButton.setEnabled(True)
         self.loadButton.setText("Store activities")
 
@@ -668,7 +789,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status("GeoPackage export failed")
             return
 
-        self.output_path = result.output_path
+        self._runtime_store().finish_store(output_path=result.output_path)
         self._update_stored_activities_summary(result.total_stored)
         self._set_status(result.status)
 
@@ -691,11 +812,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(_msg)
             return
 
-        self.output_path = result.output_path
-        self.activities_layer = result.activities_layer
-        self.starts_layer = result.starts_layer
-        self.points_layer = result.points_layer
-        self.atlas_layer = result.atlas_layer
+        self._runtime_store().load_dataset(
+            output_path=result.output_path,
+            activities_layer=result.activities_layer,
+            starts_layer=result.starts_layer,
+            points_layer=result.points_layer,
+            atlas_layer=result.atlas_layer,
+        )
 
         self._populate_activity_types_from_layer()
         visual_status = self._apply_visual_configuration(apply_subset_filters=False)
@@ -743,14 +866,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status(build_clear_database_delete_failure_status())
             return
 
-        self.activities_layer = None
-        self.starts_layer = None
-        self.points_layer = None
-        self.atlas_layer = None
+        self._runtime_store().reset_loaded_dataset()
         self._clear_analysis_layer()
-        self.activities = []
-        self.output_path = None
-        self.last_fetch_context = {}
 
         self._update_cleared_activities_summary()
         self._set_status(result.status)
@@ -773,7 +890,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if result.background_error:
             self._show_error(build_background_map_failure_title(), result.background_error)
         if result.background_layer is not None:
-            self.background_layer = result.background_layer
+            self._runtime_store().set_background_layer(result.background_layer)
         if result.status:
             self._set_status(result.status)
 
@@ -823,7 +940,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         QgsProject.instance().addMapLayer(result.layer, False)
         QgsProject.instance().layerTreeRoot().insertLayer(0, result.layer)
-        self.analysis_layer = result.layer
+        self._runtime_store().set_analysis_layer(result.layer)
         return result.status
 
     def _apply_visual_configuration(self, apply_subset_filters):
@@ -835,7 +952,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if result.background_error:
             self._show_error(build_background_map_failure_title(), result.background_error)
         if result.background_layer is not None:
-            self.background_layer = result.background_layer
+            self._runtime_store().set_background_layer(result.background_layer)
         return result.status
 
     def _apply_analysis_configuration(
@@ -869,7 +986,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 project.removeMapLayer(self.analysis_layer.id())
             except RuntimeError:
                 logger.debug("Failed to remove analysis layer", exc_info=True)
-            self.analysis_layer = None
+            self._runtime_store().clear_analysis_layer()
 
         analysis_layer_names = {
             FREQUENT_STARTING_POINTS_LAYER_NAME,
@@ -1005,7 +1122,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._atlas_export_task.cancel()
             self._set_atlas_pdf_status("Atlas PDF export cancelled.")
             self._set_atlas_export_running(False)
-            self._atlas_export_task = None
+            self._runtime_store().clear_atlas_export()
             return
 
         export_command = self.atlas_export_use_case.build_command(
@@ -1037,10 +1154,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self._save_settings()
-        self._atlas_export_task = self.atlas_export_use_case.start_export(
+        atlas_export_task = self.atlas_export_use_case.start_export(
             prepared_export,
             export_command,
         )
+        self._runtime_store().begin_atlas_export(atlas_export_task)
 
         self._set_atlas_export_running(True)
         self._set_atlas_pdf_status(
@@ -1048,7 +1166,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self._set_status("Generating atlas PDF…")
 
-        QgsApplication.taskManager().addTask(self._atlas_export_task)
+        QgsApplication.taskManager().addTask(atlas_export_task)
 
     def _set_atlas_export_running(self, running: bool) -> None:
         self.generateAtlasPdfButton.setText(
@@ -1066,7 +1184,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         page_count,
     ) -> None:
         """Called on the main thread when the atlas export task completes."""
-        self._atlas_export_task = None
+        self._runtime_store().clear_atlas_export()
         self._set_atlas_export_running(False)
 
         result = self.atlas_export_use_case.finish_export(output_path, error, cancelled, page_count)

--- a/tests/test_dock_runtime_state.py
+++ b/tests/test_dock_runtime_state.py
@@ -1,0 +1,102 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.dock_runtime_state import DockRuntimeStore
+
+
+class TestDockRuntimeStore(unittest.TestCase):
+    def test_fetch_lifecycle_tracks_task_activities_and_metadata(self):
+        store = DockRuntimeStore()
+        task = object()
+
+        store.begin_fetch(task)
+        self.assertIs(store.state.fetch_task, task)
+
+        activities = ["run", "ride"]
+        metadata = {"provider": "strava"}
+        store.finish_fetch(activities=activities, metadata=metadata)
+
+        self.assertIsNone(store.state.fetch_task)
+        self.assertEqual(store.state.activities, tuple(activities))
+        self.assertEqual(store.state.last_fetch_context, metadata)
+
+    def test_store_and_load_lifecycle_updates_output_and_layers(self):
+        store = DockRuntimeStore()
+        task = object()
+        activities_layer = object()
+        starts_layer = object()
+        points_layer = object()
+        atlas_layer = object()
+
+        store.begin_store(task)
+        self.assertIs(store.state.store_task, task)
+
+        store.finish_store(output_path="/tmp/qfit.gpkg")
+        self.assertIsNone(store.state.store_task)
+        self.assertEqual(store.state.output_path, "/tmp/qfit.gpkg")
+
+        store.load_dataset(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer=activities_layer,
+            starts_layer=starts_layer,
+            points_layer=points_layer,
+            atlas_layer=atlas_layer,
+        )
+        self.assertIs(store.state.activities_layer, activities_layer)
+        self.assertIs(store.state.starts_layer, starts_layer)
+        self.assertIs(store.state.points_layer, points_layer)
+        self.assertIs(store.state.atlas_layer, atlas_layer)
+
+    def test_reset_loaded_dataset_clears_loaded_runtime_fields(self):
+        store = DockRuntimeStore()
+        background_layer = object()
+        analysis_layer = object()
+
+        store.finish_fetch(activities=["run"], metadata={"provider": "strava"})
+        store.finish_store(output_path="/tmp/qfit.gpkg")
+        store.load_dataset(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer=object(),
+            starts_layer=object(),
+            points_layer=object(),
+            atlas_layer=object(),
+        )
+        store.set_background_layer(background_layer)
+        store.set_analysis_layer(analysis_layer)
+
+        store.reset_loaded_dataset()
+
+        self.assertEqual(store.state.activities, ())
+        self.assertIsNone(store.state.output_path)
+        self.assertIsNone(store.state.activities_layer)
+        self.assertIsNone(store.state.starts_layer)
+        self.assertIsNone(store.state.points_layer)
+        self.assertIsNone(store.state.atlas_layer)
+        self.assertEqual(store.state.last_fetch_context, {})
+        self.assertIs(store.state.background_layer, background_layer)
+        self.assertIs(store.state.analysis_layer, analysis_layer)
+
+    def test_analysis_background_and_export_helpers_update_runtime(self):
+        store = DockRuntimeStore()
+        background_layer = object()
+        analysis_layer = object()
+        export_task = object()
+
+        store.set_background_layer(background_layer)
+        store.set_analysis_layer(analysis_layer)
+        store.begin_atlas_export(export_task)
+
+        self.assertIs(store.state.background_layer, background_layer)
+        self.assertIs(store.state.analysis_layer, analysis_layer)
+        self.assertIs(store.state.atlas_export_task, export_task)
+
+        store.clear_analysis_layer()
+        store.clear_atlas_export()
+
+        self.assertIsNone(store.state.analysis_layer)
+        self.assertIsNone(store.state.atlas_export_task)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -17,16 +17,11 @@ except Exception as exc:
     QGIS_IMPORT_ERROR = exc
 
 
-class FakeMainWindow:
-    """Minimal stand-in for iface.mainWindow()."""
-    pass
-
-
 class FakeIface:
     """Minimal iface stub that records plugin menu and toolbar registrations."""
 
     def __init__(self):
-        self._main_window = FakeMainWindow()
+        self._main_window = None
         self.menu_actions: list[tuple[str, object]] = []
         self.toolbar_actions: list[object] = []
         self.removed_menu_actions: list[tuple[str, object]] = []

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -226,6 +226,9 @@ class _FakeSettings:
     def get(self, key, default=None):
         return self._values.get(key, default)
 
+    def set(self, key, value):
+        self._values[key] = value
+
 
 class _FakeQDate:
     def __init__(self, value=None):
@@ -986,6 +989,139 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.output_path, "/tmp/qfit.gpkg")
         dock._update_stored_activities_summary.assert_called_once_with(12)
         dock._set_status.assert_called_once_with("Stored 12 activities")
+
+    def test_on_refresh_clicked_cancels_existing_fetch_task(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        running_task = MagicMock()
+        dock._fetch_task = running_task
+        dock._set_fetch_running = MagicMock()
+        dock._set_status = MagicMock()
+
+        self.module.QfitDockWidget.on_refresh_clicked(dock)
+
+        running_task.cancel.assert_called_once_with()
+        self.assertIsNone(dock._fetch_task)
+        dock._set_fetch_running.assert_called_once_with(False)
+        dock._set_status.assert_called_once_with("Fetch cancelled.")
+
+    def test_on_fetch_finished_updates_runtime_state_on_success(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._fetch_task = object()
+        dock._set_fetch_running = MagicMock()
+        dock.activityTypeComboBox = _FakeComboBox(current_text="All")
+        dock._current_activity_preview_request = MagicMock(return_value="preview-request")
+        dock.activity_workflow = MagicMock()
+        dock.settings = _FakeSettings()
+        dock._apply_activity_type_options = MagicMock()
+        dock.countLabel = _FakeLabel("")
+        dock.querySummaryLabel = SimpleNamespace(setText=MagicMock())
+        dock.activityPreviewPlainTextEdit = SimpleNamespace(setPlainText=MagicMock())
+        dock._set_status = MagicMock()
+        result = SimpleNamespace(
+            cancelled=False,
+            error_message=None,
+            activities=[{"id": 1}],
+            metadata={"provider": "strava"},
+            today_str="2026-04-16",
+            activity_type_options=SimpleNamespace(options=["All"], selected_value="All"),
+            count_label_text="Activities fetched: 1",
+            preview_result=SimpleNamespace(
+                query_summary_text="1 activity",
+                preview_text="Morning Run",
+            ),
+            status_text="Fetched 1 activity",
+        )
+        dock.activity_workflow.build_fetch_completion_result.return_value = result
+
+        self.module.QfitDockWidget._on_fetch_finished(dock, [{"id": 1}], None, False, object())
+
+        self.assertIsNone(dock._fetch_task)
+        self.assertEqual(dock.activities, [{"id": 1}])
+        self.assertEqual(dock.last_fetch_context, {"provider": "strava"})
+        self.assertEqual(dock.settings.get("last_sync_date"), "2026-04-16")
+        dock._set_fetch_running.assert_called_once_with(False)
+        dock._apply_activity_type_options.assert_called_once_with(result.activity_type_options)
+        self.assertEqual(dock.countLabel.text(), "Activities fetched: 1")
+        dock.querySummaryLabel.setText.assert_called_once_with("1 activity")
+        dock.activityPreviewPlainTextEdit.setPlainText.assert_called_once_with("Morning Run")
+        dock._set_status.assert_called_once_with("Fetched 1 activity")
+
+    def test_on_load_layers_clicked_updates_runtime_state_from_result(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._save_settings = MagicMock()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock._populate_activity_types_from_layer = MagicMock()
+        dock._apply_visual_configuration = MagicMock(return_value="Styled layers")
+        dock._update_loaded_activities_summary = MagicMock()
+        dock._set_status = MagicMock()
+        workflow = MagicMock()
+        workflow.build_load_existing_request.return_value = "load-request"
+        result = SimpleNamespace(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer="activities-layer",
+            starts_layer="starts-layer",
+            points_layer="points-layer",
+            atlas_layer="atlas-layer",
+            total_stored=12,
+            status="Loaded 12 activities",
+        )
+        workflow.load_existing_request.return_value = result
+        dock.dataset_load_workflow = workflow
+
+        self.module.QfitDockWidget.on_load_layers_clicked(dock)
+
+        self.assertEqual(dock.output_path, "/tmp/qfit.gpkg")
+        self.assertEqual(dock.activities_layer, "activities-layer")
+        self.assertEqual(dock.starts_layer, "starts-layer")
+        self.assertEqual(dock.points_layer, "points-layer")
+        self.assertEqual(dock.atlas_layer, "atlas-layer")
+        dock._populate_activity_types_from_layer.assert_called_once_with()
+        dock._apply_visual_configuration.assert_called_once_with(apply_subset_filters=False)
+        dock._update_loaded_activities_summary.assert_called_once_with(12)
+        dock._set_status.assert_called_once_with("Loaded 12 activities Styled layers")
+
+    def test_on_generate_atlas_pdf_clicked_cancels_existing_export_task(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        running_task = MagicMock()
+        dock._atlas_export_task = running_task
+        dock._set_atlas_pdf_status = MagicMock()
+        dock._set_atlas_export_running = MagicMock()
+
+        self.module.QfitDockWidget.on_generate_atlas_pdf_clicked(dock)
+
+        running_task.cancel.assert_called_once_with()
+        self.assertIsNone(dock._atlas_export_task)
+        dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF export cancelled.")
+        dock._set_atlas_export_running.assert_called_once_with(False)
+
+    def test_on_atlas_export_finished_clears_task_and_updates_status(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._atlas_export_task = object()
+        dock._set_atlas_export_running = MagicMock()
+        dock._set_atlas_pdf_status = MagicMock()
+        dock._set_status = MagicMock()
+        dock._show_error = MagicMock()
+        dock.atlas_export_use_case = MagicMock()
+        dock.atlas_export_use_case.finish_export.return_value = SimpleNamespace(
+            pdf_status="Atlas PDF ready",
+            main_status="Atlas created",
+            error=None,
+            cancelled=False,
+        )
+
+        self.module.QfitDockWidget._on_atlas_export_finished(
+            dock,
+            "/tmp/qfit-atlas.pdf",
+            None,
+            False,
+            3,
+        )
+
+        self.assertIsNone(dock._atlas_export_task)
+        dock._set_atlas_export_running.assert_called_once_with(False)
+        dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF ready")
+        dock._set_status.assert_called_once_with("Atlas created")
+        dock._show_error.assert_not_called()
 
     def test_on_clear_database_clicked_reports_missing_output_path_via_helper(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -12,6 +12,12 @@ from .dock_activity_workflow import (
     DockFetchCompletionResult,
     DockFetchRequest,
 )
+from .dock_runtime_state import (
+    DockRuntimeLayers,
+    DockRuntimeState,
+    DockRuntimeStore,
+    DockRuntimeTasks,
+)
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -30,6 +36,10 @@ __all__ = [
     "DockFetchCompletionRequest",
     "DockFetchCompletionResult",
     "DockFetchRequest",
+    "DockRuntimeLayers",
+    "DockRuntimeState",
+    "DockRuntimeStore",
+    "DockRuntimeTasks",
     "RunAnalysisAction",
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",

--- a/ui/application/dock_runtime_state.py
+++ b/ui/application/dock_runtime_state.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Iterable
+
+from ...visualization.application import LayerRefs
+
+
+@dataclass(frozen=True)
+class DockRuntimeLayers:
+    activities: object = None
+    starts: object = None
+    points: object = None
+    atlas: object = None
+    background: object = None
+    analysis: object = None
+
+    def with_dataset(
+        self,
+        *,
+        activities_layer=None,
+        starts_layer=None,
+        points_layer=None,
+        atlas_layer=None,
+    ) -> "DockRuntimeLayers":
+        return replace(
+            self,
+            activities=activities_layer,
+            starts=starts_layer,
+            points=points_layer,
+            atlas=atlas_layer,
+        )
+
+    def clear_dataset(self) -> "DockRuntimeLayers":
+        return self.with_dataset()
+
+    def with_background(self, layer) -> "DockRuntimeLayers":
+        return replace(self, background=layer)
+
+    def with_analysis(self, layer) -> "DockRuntimeLayers":
+        return replace(self, analysis=layer)
+
+    def clear_analysis(self) -> "DockRuntimeLayers":
+        return self.with_analysis(None)
+
+    def visual_refs(self) -> LayerRefs:
+        return LayerRefs(
+            activities=self.activities,
+            starts=self.starts,
+            points=self.points,
+            atlas=self.atlas,
+        )
+
+
+@dataclass(frozen=True)
+class DockRuntimeTasks:
+    fetch: object = None
+    store: object = None
+    atlas_export: object = None
+
+    def with_fetch(self, task) -> "DockRuntimeTasks":
+        return replace(self, fetch=task)
+
+    def with_store(self, task) -> "DockRuntimeTasks":
+        return replace(self, store=task)
+
+    def with_atlas_export(self, task) -> "DockRuntimeTasks":
+        return replace(self, atlas_export=task)
+
+    def clear_fetch(self) -> "DockRuntimeTasks":
+        return self.with_fetch(None)
+
+    def clear_store(self) -> "DockRuntimeTasks":
+        return self.with_store(None)
+
+    def clear_atlas_export(self) -> "DockRuntimeTasks":
+        return self.with_atlas_export(None)
+
+
+@dataclass(frozen=True)
+class DockRuntimeState:
+    activities: tuple[object, ...] = field(default_factory=tuple)
+    output_path: str | None = None
+    last_fetch_context: dict[str, Any] = field(default_factory=dict)
+    layers: DockRuntimeLayers = field(default_factory=DockRuntimeLayers)
+    tasks: DockRuntimeTasks = field(default_factory=DockRuntimeTasks)
+
+    @property
+    def activities_layer(self):
+        return self.layers.activities
+
+    @property
+    def starts_layer(self):
+        return self.layers.starts
+
+    @property
+    def points_layer(self):
+        return self.layers.points
+
+    @property
+    def atlas_layer(self):
+        return self.layers.atlas
+
+    @property
+    def background_layer(self):
+        return self.layers.background
+
+    @property
+    def analysis_layer(self):
+        return self.layers.analysis
+
+    @property
+    def fetch_task(self):
+        return self.tasks.fetch
+
+    @property
+    def store_task(self):
+        return self.tasks.store
+
+    @property
+    def atlas_export_task(self):
+        return self.tasks.atlas_export
+
+    def visual_layer_refs(self) -> LayerRefs:
+        return self.layers.visual_refs()
+
+
+class DockRuntimeStore:
+    """Own the dock runtime snapshot and expose explicit workflow transitions."""
+
+    def __init__(self, state: DockRuntimeState | None = None) -> None:
+        self._state = state or DockRuntimeState()
+
+    @property
+    def state(self) -> DockRuntimeState:
+        return self._state
+
+    def _replace_state(self, **changes) -> DockRuntimeState:
+        self._state = replace(self._state, **changes)
+        return self._state
+
+    def set_activities(self, activities: Iterable[object] | None) -> DockRuntimeState:
+        return self._replace_state(activities=tuple(activities or ()))
+
+    def set_output_path(self, output_path: str | None) -> DockRuntimeState:
+        return self._replace_state(output_path=output_path)
+
+    def set_last_fetch_context(self, last_fetch_context: dict[str, Any] | None) -> DockRuntimeState:
+        return self._replace_state(last_fetch_context=dict(last_fetch_context or {}))
+
+    def set_dataset_layers(
+        self,
+        *,
+        activities_layer=None,
+        starts_layer=None,
+        points_layer=None,
+        atlas_layer=None,
+    ) -> DockRuntimeState:
+        return self._replace_state(
+            layers=self._state.layers.with_dataset(
+                activities_layer=activities_layer,
+                starts_layer=starts_layer,
+                points_layer=points_layer,
+                atlas_layer=atlas_layer,
+            )
+        )
+
+    def set_background_layer(self, layer) -> DockRuntimeState:
+        return self._replace_state(layers=self._state.layers.with_background(layer))
+
+    def set_analysis_layer(self, layer) -> DockRuntimeState:
+        return self._replace_state(layers=self._state.layers.with_analysis(layer))
+
+    def clear_analysis_layer(self) -> DockRuntimeState:
+        return self._replace_state(layers=self._state.layers.clear_analysis())
+
+    def set_fetch_task(self, task) -> DockRuntimeState:
+        return self._replace_state(tasks=self._state.tasks.with_fetch(task))
+
+    def clear_fetch(self) -> DockRuntimeState:
+        return self._replace_state(tasks=self._state.tasks.clear_fetch())
+
+    def set_store_task(self, task) -> DockRuntimeState:
+        return self._replace_state(tasks=self._state.tasks.with_store(task))
+
+    def clear_store(self) -> DockRuntimeState:
+        return self._replace_state(tasks=self._state.tasks.clear_store())
+
+    def set_atlas_export_task(self, task) -> DockRuntimeState:
+        return self._replace_state(tasks=self._state.tasks.with_atlas_export(task))
+
+    def clear_atlas_export(self) -> DockRuntimeState:
+        return self._replace_state(tasks=self._state.tasks.clear_atlas_export())
+
+    def begin_fetch(self, task) -> DockRuntimeState:
+        return self.set_fetch_task(task)
+
+    def finish_fetch(
+        self,
+        *,
+        activities: Iterable[object] | None = None,
+        metadata: dict[str, Any] | None = None,
+        last_fetch_context: dict[str, Any] | None = None,
+    ) -> DockRuntimeState:
+        context = metadata if last_fetch_context is None else last_fetch_context
+        next_state = replace(self._state, tasks=self._state.tasks.clear_fetch())
+        if activities is not None:
+            next_state = replace(next_state, activities=tuple(activities))
+        if context is not None:
+            next_state = replace(next_state, last_fetch_context=dict(context))
+        self._state = next_state
+        return self._state
+
+    def begin_store(self, task) -> DockRuntimeState:
+        return self.set_store_task(task)
+
+    def finish_store(self, *, output_path: str | None = None) -> DockRuntimeState:
+        next_state = replace(self._state, tasks=self._state.tasks.clear_store())
+        if output_path is not None:
+            next_state = replace(next_state, output_path=output_path)
+        self._state = next_state
+        return self._state
+
+    def load_dataset(
+        self,
+        *,
+        output_path: str | None,
+        activities_layer=None,
+        starts_layer=None,
+        points_layer=None,
+        atlas_layer=None,
+    ) -> DockRuntimeState:
+        return self._replace_state(
+            output_path=output_path,
+            layers=self._state.layers.with_dataset(
+                activities_layer=activities_layer,
+                starts_layer=starts_layer,
+                points_layer=points_layer,
+                atlas_layer=atlas_layer,
+            ),
+        )
+
+    def apply_loaded_dataset(
+        self,
+        *,
+        output_path: str | None,
+        activities_layer=None,
+        starts_layer=None,
+        points_layer=None,
+        atlas_layer=None,
+    ) -> DockRuntimeState:
+        return self.load_dataset(
+            output_path=output_path,
+            activities_layer=activities_layer,
+            starts_layer=starts_layer,
+            points_layer=points_layer,
+            atlas_layer=atlas_layer,
+        )
+
+    def reset_loaded_dataset(self) -> DockRuntimeState:
+        return self._replace_state(
+            activities=(),
+            output_path=None,
+            last_fetch_context={},
+            layers=self._state.layers.clear_dataset(),
+        )
+
+    def clear_loaded_dataset(self) -> DockRuntimeState:
+        return self.reset_loaded_dataset()
+
+    def begin_atlas_export(self, task) -> DockRuntimeState:
+        return self.set_atlas_export_task(task)
+
+    def finish_atlas_export(self) -> DockRuntimeState:
+        return self.clear_atlas_export()
+
+
+__all__ = [
+    "DockRuntimeLayers",
+    "DockRuntimeState",
+    "DockRuntimeStore",
+    "DockRuntimeTasks",
+]


### PR DESCRIPTION
## Summary
- add a dedicated `DockRuntimeStore` with explicit fetch, store, load, analysis, and atlas-export transitions
- route `QfitDockWidget` runtime fields through the centralized store instead of scattering mutable widget state
- cover the new state transitions with focused runtime-store and dock-widget tests

## Testing
- `PYTHONPATH=.. python3 -m unittest tests.test_dock_runtime_state tests.test_qfit_dockwidget_analysis_pure tests.test_plugin tests.test_visual_workflow_action_builder -v`
- `PYTHONPATH=.. python3 -m py_compile qfit_dockwidget.py ui/application/__init__.py ui/application/dock_runtime_state.py tests/test_plugin.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dock_runtime_state.py`

Fixes #578