### PR TITLE
ci: add plugin security scan and PR build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -29,9 +31,21 @@ jobs:
           python scripts/package_plugin.py
           echo "zip=$(ls dist/*.zip)" >> "$GITHUB_OUTPUT"
 
+      - name: Build artifact metadata
+        id: artifact
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "name=qfit-plugin-pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" = "main" ]; then
+            echo "name=qfit-plugin-main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=qfit-plugin-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload plugin ZIP
         uses: actions/upload-artifact@v4
         with:
-          name: qfit-plugin
+          name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.package.outputs.zip }}
           if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,14 @@ jobs:
 
       - name: Build artifact metadata
         id: artifact
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "name=qfit-plugin-pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.ref_name }}" = "main" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "name=qfit-plugin-pr-${PR_NUMBER}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          elif [ "$REF_NAME" = "main" ]; then
             echo "name=qfit-plugin-main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           else
             echo "name=qfit-plugin-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/plugin-security-scan.yml
+++ b/.github/workflows/plugin-security-scan.yml
@@ -1,0 +1,28 @@
+name: plugin-security-scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install scan dependencies
+        run: python -m pip install --upgrade pypdf bandit detect-secrets flake8
+
+      - name: Build packaged plugin and run local-style scans
+        run: python scripts/run_plugin_security_scan.py --allow-findings

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ coverage.xml
 
 symbology-style.db
 
-# Debug / test material — drop files here freely, never committed
+# Debug / test / local scan material, never committed
 debug/

--- a/scripts/package_plugin.py
+++ b/scripts/package_plugin.py
@@ -20,6 +20,7 @@ EXCLUDED_DIRS = {
     ".pytest_cache",
     ".venv",
     "__pycache__",
+    "debug",
     "dist",
     "docs",
     "scripts",

--- a/scripts/package_plugin.py
+++ b/scripts/package_plugin.py
@@ -18,6 +18,7 @@ EXCLUDED_DIRS = {
     ".git",
     ".github",
     ".pytest_cache",
+    ".venv",
     "__pycache__",
     "dist",
     "docs",

--- a/scripts/run_plugin_security_scan.py
+++ b/scripts/run_plugin_security_scan.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Build the packaged plugin and run local security/quality scans on it."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import package_plugin
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REPORTS_DIR = ROOT / "debug" / "plugin-security-scan"
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    name: str
+    command: tuple[str, ...]
+    report_path: Path
+    stderr_path: Path
+    exit_code: int
+    has_findings: bool
+
+    @property
+    def status(self) -> str:
+        if self.has_findings:
+            return "findings"
+        if self.exit_code == 0:
+            return "clean"
+        return f"error ({self.exit_code})"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build qfit's plugin ZIP, extract it, and run Bandit, detect-secrets, "
+            "and Flake8 against the packaged contents."
+        )
+    )
+    parser.add_argument(
+        "--reports-dir",
+        type=Path,
+        default=DEFAULT_REPORTS_DIR,
+        help=f"Directory where local scan reports are written (default: {DEFAULT_REPORTS_DIR})",
+    )
+    parser.add_argument(
+        "--allow-findings",
+        action="store_true",
+        help="Return success even when scanners report findings, while still failing on execution errors.",
+    )
+    return parser.parse_args(argv)
+
+
+def prepare_scan_tree(reports_dir: Path) -> tuple[Path, Path]:
+    archive_path = package_plugin.build_zip()
+    if reports_dir.exists():
+        shutil.rmtree(reports_dir)
+    extracted_dir = reports_dir / "extracted"
+    extracted_dir.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        archive.extractall(extracted_dir)
+
+    plugin_root = find_extracted_plugin_root(extracted_dir)
+    return archive_path, plugin_root
+
+
+def find_extracted_plugin_root(extracted_dir: Path) -> Path:
+    roots = sorted(path for path in extracted_dir.iterdir() if path.is_dir())
+    if len(roots) != 1:
+        raise RuntimeError(
+            f"Expected exactly one plugin directory in {extracted_dir}, found {len(roots)}"
+        )
+    return roots[0]
+
+
+def run_scan(name: str, command: list[str], report_path: Path, *, findings_checker=None) -> ScanResult:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    stderr_path = report_path.with_suffix(report_path.suffix + ".stderr.txt")
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        report_path.write_text("", encoding="utf-8")
+        stderr_path.write_text(str(exc), encoding="utf-8")
+        return ScanResult(
+            name=name,
+            command=tuple(command),
+            report_path=report_path,
+            stderr_path=stderr_path,
+            exit_code=127,
+            has_findings=False,
+        )
+
+    report_path.write_text(completed.stdout, encoding="utf-8")
+    stderr_path.write_text(completed.stderr, encoding="utf-8")
+
+    has_findings = False
+    if findings_checker is not None:
+        has_findings = findings_checker(completed.returncode, completed.stdout)
+    elif completed.returncode != 0:
+        has_findings = True
+
+    return ScanResult(
+        name=name,
+        command=tuple(command),
+        report_path=report_path,
+        stderr_path=stderr_path,
+        exit_code=completed.returncode,
+        has_findings=has_findings,
+    )
+
+
+def exit_code_one_is_findings(exit_code: int, _stdout: str) -> bool:
+    return exit_code == 1
+
+
+def detect_secrets_has_findings(exit_code: int, stdout: str) -> bool:
+    if exit_code != 0:
+        return False
+    payload = json.loads(stdout or "{}")
+    results = payload.get("results", {})
+    return any(entries for entries in results.values())
+
+
+def evaluate_results(results: list[ScanResult], *, allow_findings: bool) -> int:
+    execution_errors = [result for result in results if result.exit_code != 0 and not result.has_findings]
+    if execution_errors:
+        return 2
+    if any(result.has_findings for result in results) and not allow_findings:
+        return 1
+    return 0
+
+
+def write_summary(
+    summary_path: Path,
+    *,
+    archive_path: Path,
+    plugin_root: Path,
+    results: list[ScanResult],
+) -> None:
+    lines = [
+        f"Archive: {archive_path}",
+        f"Packaged plugin root: {plugin_root}",
+        "",
+    ]
+    for result in results:
+        lines.extend(
+            [
+                f"[{result.name}] {result.status}",
+                f"  command: {' '.join(result.command)}",
+                f"  report: {result.report_path}",
+                f"  stderr: {result.stderr_path}",
+                "",
+            ]
+        )
+    summary_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def build_scan_commands(plugin_root: Path, reports_dir: Path) -> list[tuple[str, list[str], Path, object | None]]:
+    return [
+        (
+            "bandit",
+            [sys.executable, "-m", "bandit", "-r", str(plugin_root), "-f", "json", "-q"],
+            reports_dir / "bandit.json",
+            exit_code_one_is_findings,
+        ),
+        (
+            "detect-secrets",
+            [
+                sys.executable,
+                "-m",
+                "detect_secrets.main",
+                "scan",
+                "--all-files",
+                str(plugin_root),
+            ],
+            reports_dir / "detect-secrets.json",
+            detect_secrets_has_findings,
+        ),
+        (
+            "flake8",
+            [sys.executable, "-m", "flake8", str(plugin_root)],
+            reports_dir / "flake8.txt",
+            exit_code_one_is_findings,
+        ),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    archive_path, plugin_root = prepare_scan_tree(args.reports_dir)
+
+    results = [
+        run_scan(name, command, report_path, findings_checker=findings_checker)
+        for name, command, report_path, findings_checker in build_scan_commands(
+            plugin_root, args.reports_dir
+        )
+    ]
+
+    summary_path = args.reports_dir / "summary.txt"
+    write_summary(summary_path, archive_path=archive_path, plugin_root=plugin_root, results=results)
+
+    print(summary_path.read_text(encoding="utf-8"), end="")
+    exit_code = evaluate_results(results, allow_findings=args.allow_findings)
+    if exit_code == 1:
+        print("Scan findings detected. See local reports above.", file=sys.stderr)
+    elif exit_code == 2:
+        print("One or more scan commands failed to run cleanly.", file=sys.stderr)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_plugin_security_scan.py
+++ b/scripts/run_plugin_security_scan.py
@@ -58,9 +58,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def prepare_scan_tree(reports_dir: Path) -> tuple[Path, Path]:
-    archive_path = package_plugin.build_zip()
     if reports_dir.exists():
         shutil.rmtree(reports_dir)
+    archive_path = package_plugin.build_zip()
     extracted_dir = reports_dir / "extracted"
     extracted_dir.mkdir(parents=True, exist_ok=True)
 
@@ -185,7 +185,13 @@ def build_scan_commands(plugin_root: Path, reports_dir: Path) -> list[tuple[str,
         ),
         (
             "flake8",
-            [sys.executable, "-m", "flake8", str(plugin_root)],
+            [
+                sys.executable,
+                "-m",
+                "flake8",
+                "--extend-exclude=vendor/",
+                str(plugin_root),
+            ],
             reports_dir / "flake8.txt",
             exit_code_one_is_findings,
         ),

--- a/tests/test_package_plugin.py
+++ b/tests/test_package_plugin.py
@@ -29,6 +29,7 @@ class PackagePluginTests(unittest.TestCase):
                 root / "tests" / "test_example.py",
                 root / ".pytest_cache" / "v" / "cache" / "nodeids",
                 root / ".venv" / "lib" / "python3.12" / "site-packages" / "sample.py",
+                root / "debug" / "plugin-security-scan" / "summary.txt",
                 root / "validation" / "sample.txt",
                 root / "validation_artifacts" / "artifact.txt",
             ]
@@ -57,6 +58,8 @@ class PackagePluginTests(unittest.TestCase):
             (root / ".pytest_cache" / "README.md").write_text("cache\n", encoding="utf-8")
             (root / ".venv" / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
             (root / ".venv" / "lib" / "python3.12" / "site-packages" / "sample.py").write_text("# venv\n", encoding="utf-8")
+            (root / "debug" / "plugin-security-scan").mkdir(parents=True)
+            (root / "debug" / "plugin-security-scan" / "summary.txt").write_text("summary\n", encoding="utf-8")
             (root / "validation").mkdir()
             (root / "validation" / "sample.txt").write_text("validation\n", encoding="utf-8")
             (root / "validation_artifacts").mkdir()
@@ -79,6 +82,7 @@ class PackagePluginTests(unittest.TestCase):
             self.assertFalse(any(name.startswith("qfit/tests/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.pytest_cache/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.venv/") for name in names))
+            self.assertFalse(any(name.startswith("qfit/debug/") for name in names))
             self.assertFalse(any(name.startswith("qfit/validation/") for name in names))
             self.assertFalse(any(name.startswith("qfit/validation_artifacts/") for name in names))
 

--- a/tests/test_package_plugin.py
+++ b/tests/test_package_plugin.py
@@ -28,6 +28,7 @@ class PackagePluginTests(unittest.TestCase):
             ignored = [
                 root / "tests" / "test_example.py",
                 root / ".pytest_cache" / "v" / "cache" / "nodeids",
+                root / ".venv" / "lib" / "python3.12" / "site-packages" / "sample.py",
                 root / "validation" / "sample.txt",
                 root / "validation_artifacts" / "artifact.txt",
             ]
@@ -54,6 +55,8 @@ class PackagePluginTests(unittest.TestCase):
             (root / "tests" / "test_core.py").write_text("# test\n", encoding="utf-8")
             (root / ".pytest_cache").mkdir()
             (root / ".pytest_cache" / "README.md").write_text("cache\n", encoding="utf-8")
+            (root / ".venv" / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
+            (root / ".venv" / "lib" / "python3.12" / "site-packages" / "sample.py").write_text("# venv\n", encoding="utf-8")
             (root / "validation").mkdir()
             (root / "validation" / "sample.txt").write_text("validation\n", encoding="utf-8")
             (root / "validation_artifacts").mkdir()
@@ -75,6 +78,7 @@ class PackagePluginTests(unittest.TestCase):
             self.assertIn("qfit/core.py", names)
             self.assertFalse(any(name.startswith("qfit/tests/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.pytest_cache/") for name in names))
+            self.assertFalse(any(name.startswith("qfit/.venv/") for name in names))
             self.assertFalse(any(name.startswith("qfit/validation/") for name in names))
             self.assertFalse(any(name.startswith("qfit/validation_artifacts/") for name in names))
 

--- a/tests/test_plugin_security_scan.py
+++ b/tests/test_plugin_security_scan.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 
 _SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
@@ -96,6 +97,40 @@ class PrepareScanTreeTests(unittest.TestCase):
             self.assertEqual(built_archive, archive_path)
             self.assertEqual(plugin_root, reports_dir / "extracted" / "qfit")
             self.assertTrue((plugin_root / "metadata.txt").exists())
+
+    def test_prepare_scan_tree_removes_stale_reports_before_packaging(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            archive_path = temp_path / "qfit-1.2.3.zip"
+            reports_dir = temp_path / "debug" / "plugin-security-scan"
+            reports_dir.mkdir(parents=True)
+            stale_report = reports_dir / "summary.txt"
+            stale_report.write_text("old\n", encoding="utf-8")
+
+            def fake_build_zip():
+                self.assertFalse(stale_report.exists())
+                with zipfile.ZipFile(archive_path, "w") as archive:
+                    archive.writestr("qfit/__init__.py", "# plugin\n")
+                    archive.writestr("qfit/metadata.txt", "[general]\nname=qfit\n")
+                return archive_path
+
+            with patch.object(plugin_security_scan.package_plugin, "build_zip", side_effect=fake_build_zip):
+                built_archive, plugin_root = plugin_security_scan.prepare_scan_tree(reports_dir)
+
+            self.assertEqual(built_archive, archive_path)
+            self.assertEqual(plugin_root, reports_dir / "extracted" / "qfit")
+            self.assertFalse(stale_report.exists())
+
+
+class BuildScanCommandsTests(unittest.TestCase):
+    def test_flake8_command_excludes_vendor_tree(self):
+        commands = plugin_security_scan.build_scan_commands(
+            Path("/tmp/plugin-root"),
+            Path("/tmp/reports"),
+        )
+
+        flake8_entry = next(command for command in commands if command[0] == "flake8")
+        self.assertIn("--extend-exclude=vendor/", flake8_entry[1])
 
 
 if __name__ == "__main__":

--- a/tests/test_plugin_security_scan.py
+++ b/tests/test_plugin_security_scan.py
@@ -1,0 +1,102 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "qfit_plugin_security_scan", _SCRIPTS_DIR / "run_plugin_security_scan.py"
+)
+if _SPEC is None:
+    raise RuntimeError(f"Could not locate run_plugin_security_scan.py at {_SCRIPTS_DIR}")
+plugin_security_scan = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = plugin_security_scan
+if _SPEC.loader is None:
+    raise RuntimeError("run_plugin_security_scan.py spec has no loader")
+_SPEC.loader.exec_module(plugin_security_scan)
+
+
+class DetectSecretsHelperTests(unittest.TestCase):
+    def test_detect_secrets_has_findings_when_results_present(self):
+        payload = '{"results": {"plugin.py": [{"type": "Secret Keyword"}]}}'
+        self.assertTrue(plugin_security_scan.detect_secrets_has_findings(0, payload))
+
+    def test_detect_secrets_has_findings_is_false_when_results_empty(self):
+        payload = '{"results": {}}'
+        self.assertFalse(plugin_security_scan.detect_secrets_has_findings(0, payload))
+
+
+class EvaluateResultsTests(unittest.TestCase):
+    def test_evaluate_results_fails_when_findings_not_allowed(self):
+        result = plugin_security_scan.ScanResult(
+            name="bandit",
+            command=("bandit",),
+            report_path=Path("bandit.json"),
+            stderr_path=Path("bandit.stderr.txt"),
+            exit_code=1,
+            has_findings=True,
+        )
+        self.assertEqual(
+            plugin_security_scan.evaluate_results([result], allow_findings=False),
+            1,
+        )
+
+    def test_evaluate_results_allows_findings_when_requested(self):
+        result = plugin_security_scan.ScanResult(
+            name="bandit",
+            command=("bandit",),
+            report_path=Path("bandit.json"),
+            stderr_path=Path("bandit.stderr.txt"),
+            exit_code=1,
+            has_findings=True,
+        )
+        self.assertEqual(
+            plugin_security_scan.evaluate_results([result], allow_findings=True),
+            0,
+        )
+
+    def test_evaluate_results_detects_execution_errors(self):
+        result = plugin_security_scan.ScanResult(
+            name="flake8",
+            command=("flake8",),
+            report_path=Path("flake8.txt"),
+            stderr_path=Path("flake8.stderr.txt"),
+            exit_code=127,
+            has_findings=False,
+        )
+        self.assertEqual(
+            plugin_security_scan.evaluate_results([result], allow_findings=True),
+            2,
+        )
+
+
+class PrepareScanTreeTests(unittest.TestCase):
+    def test_prepare_scan_tree_extracts_single_plugin_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            archive_path = temp_path / "qfit-1.2.3.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr("qfit/__init__.py", "# plugin\n")
+                archive.writestr("qfit/metadata.txt", "[general]\nname=qfit\n")
+
+            reports_dir = temp_path / "debug" / "plugin-security-scan"
+            original_build_zip = plugin_security_scan.package_plugin.build_zip
+            plugin_security_scan.package_plugin.build_zip = lambda: archive_path
+            try:
+                built_archive, plugin_root = plugin_security_scan.prepare_scan_tree(reports_dir)
+            finally:
+                plugin_security_scan.package_plugin.build_zip = original_build_zip
+
+            self.assertEqual(built_archive, archive_path)
+            self.assertEqual(plugin_root, reports_dir / "extracted" / "qfit")
+            self.assertTrue((plugin_root / "metadata.txt").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a local plugin security scan runner that builds the packaged ZIP and scans the extracted packaged contents
- add a GitHub Actions workflow to run the scan on pushes and pull requests without uploading reports
- publish downloadable plugin ZIP artifacts for pull requests and main builds, and exclude repo-local `.venv` contents from packaged plugin zips

## Testing
- python3 -m unittest tests.test_package_plugin tests.test_plugin_security_scan -v
- .venv/bin/python scripts/run_plugin_security_scan.py --allow-findings
