### PR TITLE
fix: default the Date to filter to today

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -513,10 +513,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
 
     def _set_default_dates(self):
-        if not self.dateFromEdit.date().isValid():
-            self.dateFromEdit.setDate(QDate.currentDate().addYears(-1))
-        if not self.dateToEdit.date().isValid():
-            self.dateToEdit.setDate(QDate.currentDate())
+        today = QDate.currentDate()
+        self.dateFromEdit.setDate(today.addYears(-1))
+        self.dateToEdit.setDate(today)
 
     def on_background_preset_changed(self, preset_name):
         self._sync_background_style_fields(preset_name, force=True)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -333,6 +333,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
 
+    def test_set_default_dates_uses_current_date_window(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.dateFromEdit = MagicMock()
+        dock.dateToEdit = MagicMock()
+        today = MagicMock()
+        last_year = object()
+        today.addYears.return_value = last_year
+
+        with patch.object(self.module.QDate, "currentDate", return_value=today):
+            self.module.QfitDockWidget._set_default_dates(dock)
+
+        dock.dateFromEdit.setDate.assert_called_once_with(last_year)
+        dock.dateToEdit.setDate.assert_called_once_with(today)
+        today.addYears.assert_called_once_with(-1)
+
     def test_remove_stale_qfit_layers_delegates_to_project_hygiene_service(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.project_hygiene_service = MagicMock()


### PR DESCRIPTION
## Summary
- default the dock's date filter window to today and one year back on startup
- stop relying on the static UI designer date for the Date to field
- add focused regression coverage for the default-date initialization helper

## Testing
- python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short

Fixes #588
