### PR TITLE
architecture: extract dock visual workflow coordination

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -880,7 +880,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._dispatch_dock_action(RunAnalysisAction)
 
     def _dispatch_dock_action(self, action_type):
-        result = self._visual_workflow_coordinator().dispatch_action(
+        result = self._dock_visual_workflow.dispatch_action(
             action_type,
             self._current_visual_workflow_request(),
             require_layers=True,
@@ -898,14 +898,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if result.status:
             self._set_status(result.status)
 
-    def _visual_workflow_coordinator(self):
-        coordinator = getattr(self, "_dock_visual_workflow", None)
-        if coordinator is None:
-            coordinator = DockVisualWorkflowCoordinator(
-                dispatcher=self._dock_action_dispatcher,
-            )
-            self._dock_visual_workflow = coordinator
-        return coordinator
+    def _build_visual_workflow_action(self, action_type):
+        """Compatibility wrapper while older smoke tests migrate to coordinator entry points."""
+
+        return self._dock_visual_workflow.build_action(
+            action_type,
+            self._current_visual_workflow_request(),
+        )
 
     def _current_visual_workflow_request(self, *, apply_subset_filters=True):
         return DockVisualWorkflowRequest(
@@ -954,7 +953,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return result.status
 
     def _apply_visual_configuration(self, apply_subset_filters):
-        result = self._visual_workflow_coordinator().dispatch_action(
+        result = self._dock_visual_workflow.dispatch_action(
             ApplyVisualizationAction,
             self._current_visual_workflow_request(
                 apply_subset_filters=apply_subset_filters,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from dataclasses import replace
 from datetime import date
 
 logger = logging.getLogger(__name__)
@@ -75,10 +74,10 @@ from .ui.application import (
     DockFetchCompletionRequest,
     DockFetchRequest,
     DockRuntimeStore,
+    DockVisualWorkflowCoordinator,
+    DockVisualWorkflowRequest,
     RunAnalysisAction,
     build_visual_layer_refs,
-    build_visual_workflow_action,
-    build_visual_workflow_action_inputs,
     build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
@@ -143,6 +142,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             visual_apply=self.visual_apply,
             save_settings=self._save_settings,
             run_analysis=self._apply_analysis_configuration,
+        )
+        self._dock_visual_workflow = DockVisualWorkflowCoordinator(
+            dispatcher=self._dock_action_dispatcher,
         )
 
     def _runtime_store(self) -> DockRuntimeStore:
@@ -878,11 +880,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._dispatch_dock_action(RunAnalysisAction)
 
     def _dispatch_dock_action(self, action_type):
-        action = self._build_visual_workflow_action(action_type)
-        if not action.layers.has_any():
+        result = self._visual_workflow_coordinator().dispatch_action(
+            action_type,
+            self._current_visual_workflow_request(),
+            require_layers=True,
+        )
+        if result is None:
             return
 
-        result = self._dock_action_dispatcher.dispatch(action)
         if result.unsupported_reason:
             self._set_status(result.unsupported_reason)
             return
@@ -893,36 +898,42 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if result.status:
             self._set_status(result.status)
 
-    def _build_visual_workflow_action(self, action_type):
-        return build_visual_workflow_action(
-            action_type,
-            build_visual_workflow_action_inputs(
-                layers=build_visual_layer_refs(
-                    activities_layer=self.activities_layer,
-                    starts_layer=self.starts_layer,
-                    points_layer=self.points_layer,
-                    atlas_layer=self.atlas_layer,
-                ),
-                selection_state=build_visual_workflow_selection_state_handoff(
-                    build_activity_preview_selection_state(
-                        self._current_activity_preview_request()
-                    )
-                ),
-                settings=build_visual_workflow_settings_snapshot(
-                    style_preset=self.stylePresetComboBox.currentText(),
-                    temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
-                    analysis_mode=self.analysisModeComboBox.currentText(),
-                ),
-                background=build_visual_workflow_background_inputs(
-                    enabled=self.backgroundMapCheckBox.isChecked(),
-                    preset_name=self.backgroundPresetComboBox.currentText(),
-                    access_token=self._mapbox_access_token(),
-                    style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
-                    style_id=self.mapboxStyleIdLineEdit.text().strip(),
-                    tile_mode=self.tileModeComboBox.currentText(),
-                ),
-                apply_subset_filters=True,
+    def _visual_workflow_coordinator(self):
+        coordinator = getattr(self, "_dock_visual_workflow", None)
+        if coordinator is None:
+            coordinator = DockVisualWorkflowCoordinator(
+                dispatcher=self._dock_action_dispatcher,
+            )
+            self._dock_visual_workflow = coordinator
+        return coordinator
+
+    def _current_visual_workflow_request(self, *, apply_subset_filters=True):
+        return DockVisualWorkflowRequest(
+            layers=build_visual_layer_refs(
+                activities_layer=self.activities_layer,
+                starts_layer=self.starts_layer,
+                points_layer=self.points_layer,
+                atlas_layer=self.atlas_layer,
             ),
+            selection_state=build_visual_workflow_selection_state_handoff(
+                build_activity_preview_selection_state(
+                    self._current_activity_preview_request()
+                )
+            ),
+            settings=build_visual_workflow_settings_snapshot(
+                style_preset=self.stylePresetComboBox.currentText(),
+                temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
+                analysis_mode=self.analysisModeComboBox.currentText(),
+            ),
+            background=build_visual_workflow_background_inputs(
+                enabled=self.backgroundMapCheckBox.isChecked(),
+                preset_name=self.backgroundPresetComboBox.currentText(),
+                access_token=self._mapbox_access_token(),
+                style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+                style_id=self.mapboxStyleIdLineEdit.text().strip(),
+                tile_mode=self.tileModeComboBox.currentText(),
+            ),
+            apply_subset_filters=apply_subset_filters,
         )
 
     def _run_selected_analysis(self, analysis_mode, starts_layer, selection_state=None):
@@ -943,11 +954,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return result.status
 
     def _apply_visual_configuration(self, apply_subset_filters):
-        action = replace(
-            self._build_visual_workflow_action(ApplyVisualizationAction),
-            apply_subset_filters=apply_subset_filters,
+        result = self._visual_workflow_coordinator().dispatch_action(
+            ApplyVisualizationAction,
+            self._current_visual_workflow_request(
+                apply_subset_filters=apply_subset_filters,
+            ),
+            require_layers=False,
         )
-        result = self._dock_action_dispatcher.dispatch(action)
         if result.background_error:
             self._show_error(build_background_map_failure_title(), result.background_error)
         if result.background_layer is not None:

--- a/tests/test_dock_visual_workflow.py
+++ b/tests/test_dock_visual_workflow.py
@@ -1,0 +1,78 @@
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
+from qfit.ui.application import (
+    ApplyVisualizationAction,
+    DockVisualWorkflowCoordinator,
+    DockVisualWorkflowRequest,
+    RunAnalysisAction,
+    VisualWorkflowBackgroundInputs,
+    build_visual_layer_refs,
+    build_visual_workflow_settings_snapshot,
+)
+
+
+class DockVisualWorkflowCoordinatorTests(unittest.TestCase):
+    def setUp(self):
+        self.dispatcher = MagicMock()
+        self.dispatcher.dispatch.return_value = "dispatch-result"
+        self.coordinator = DockVisualWorkflowCoordinator(dispatcher=self.dispatcher)
+        self.request = DockVisualWorkflowRequest(
+            layers=build_visual_layer_refs(activities_layer=object(), starts_layer=object()),
+            selection_state=ActivitySelectionState(query=ActivityQuery(), filtered_count=3),
+            settings=build_visual_workflow_settings_snapshot(
+                style_preset="By activity type",
+                temporal_mode="By month",
+                analysis_mode="Most frequent starting points",
+            ),
+            background=VisualWorkflowBackgroundInputs(
+                enabled=True,
+                preset_name="Outdoors",
+                access_token="tok",
+                style_owner="mapbox",
+                style_id="outdoors-v12",
+                tile_mode="raster",
+            ),
+        )
+
+    def test_build_action_returns_normalized_apply_action(self):
+        action = self.coordinator.build_action(ApplyVisualizationAction, self.request)
+
+        self.assertIsInstance(action, ApplyVisualizationAction)
+        self.assertEqual(action.style_preset, "By activity type")
+        self.assertEqual(action.temporal_mode, "By month")
+        self.assertEqual(action.analysis_mode, "Most frequent starting points")
+        self.assertTrue(action.background_config.enabled)
+        self.assertIs(action.starts_layer, self.request.layers.starts)
+
+    def test_dispatch_action_delegates_to_dispatcher(self):
+        result = self.coordinator.dispatch_action(RunAnalysisAction, self.request)
+
+        self.assertEqual(result, "dispatch-result")
+        dispatched_action = self.dispatcher.dispatch.call_args.args[0]
+        self.assertIsInstance(dispatched_action, RunAnalysisAction)
+        self.assertEqual(dispatched_action.filtered_count, 3)
+
+    def test_dispatch_action_can_skip_empty_layers(self):
+        request = DockVisualWorkflowRequest(
+            layers=build_visual_layer_refs(),
+            selection_state=ActivitySelectionState(query=ActivityQuery(), filtered_count=0),
+            settings=self.request.settings,
+            background=self.request.background,
+        )
+
+        result = self.coordinator.dispatch_action(
+            ApplyVisualizationAction,
+            request,
+            require_layers=True,
+        )
+
+        self.assertIsNone(result)
+        self.dispatcher.dispatch.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -378,24 +378,26 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
     def test_dispatch_dock_action_returns_early_without_layers(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock._build_visual_workflow_action = MagicMock(
-            return_value=SimpleNamespace(layers=SimpleNamespace(has_any=lambda: False))
-        )
-        dock._dock_action_dispatcher = MagicMock()
+        dock._dock_visual_workflow = MagicMock()
+        dock._dock_visual_workflow.dispatch_action.return_value = None
+        dock._current_visual_workflow_request = MagicMock(return_value="request")
 
         self.module.QfitDockWidget._dispatch_dock_action(
             dock,
             self.module.ApplyVisualizationAction,
         )
 
-        dock._dock_action_dispatcher.dispatch.assert_not_called()
+        dock._dock_visual_workflow.dispatch_action.assert_called_once_with(
+            self.module.ApplyVisualizationAction,
+            "request",
+            require_layers=True,
+        )
 
     def test_dispatch_dock_action_handles_structured_dispatch_result(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        action = SimpleNamespace(layers=SimpleNamespace(has_any=lambda: True))
-        dock._build_visual_workflow_action = MagicMock(return_value=action)
-        dock._dock_action_dispatcher = MagicMock()
-        dock._dock_action_dispatcher.dispatch.return_value = SimpleNamespace(
+        dock._dock_visual_workflow = MagicMock()
+        dock._current_visual_workflow_request = MagicMock(return_value="request")
+        dock._dock_visual_workflow.dispatch_action.return_value = SimpleNamespace(
             unsupported_reason="",
             background_error="boom",
             background_layer="background-layer",
@@ -414,7 +416,11 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 self.module.RunAnalysisAction,
             )
 
-        dock._dock_action_dispatcher.dispatch.assert_called_once_with(action)
+        dock._dock_visual_workflow.dispatch_action.assert_called_once_with(
+            self.module.RunAnalysisAction,
+            "request",
+            require_layers=True,
+        )
         build_title.assert_called_once_with()
         dock._show_error.assert_called_once_with("Background map failed", "boom")
         self.assertEqual(dock.background_layer, "background-layer")
@@ -422,10 +428,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
     def test_dispatch_dock_action_reports_unsupported_reason(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        action = SimpleNamespace(layers=SimpleNamespace(has_any=lambda: True))
-        dock._build_visual_workflow_action = MagicMock(return_value=action)
-        dock._dock_action_dispatcher = MagicMock()
-        dock._dock_action_dispatcher.dispatch.return_value = SimpleNamespace(
+        dock._dock_visual_workflow = MagicMock()
+        dock._current_visual_workflow_request = MagicMock(return_value="request")
+        dock._dock_visual_workflow.dispatch_action.return_value = SimpleNamespace(
             unsupported_reason="Unsupported dock action: object",
             background_error="",
             background_layer=None,
@@ -509,21 +514,17 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             self.module,
             "build_visual_workflow_background_inputs",
             return_value="background",
-        ) as build_background, patch.object(
-            self.module,
-            "build_visual_workflow_action_inputs",
-            return_value="inputs",
-        ) as build_inputs, patch.object(
-            self.module,
-            "build_visual_workflow_action",
-            return_value="action",
-        ) as build_action:
-            action = self.module.QfitDockWidget._build_visual_workflow_action(
+        ) as build_background:
+            request = self.module.QfitDockWidget._current_visual_workflow_request(
                 dock,
-                self.module.ApplyVisualizationAction,
+                apply_subset_filters=False,
             )
 
-        self.assertEqual(action, "action")
+        self.assertEqual(request.layers, "layers")
+        self.assertEqual(request.selection_state, "selection")
+        self.assertEqual(request.settings, "settings")
+        self.assertEqual(request.background, "background")
+        self.assertFalse(request.apply_subset_filters)
         build_layers.assert_called_once_with(
             activities_layer="activities",
             starts_layer="starts",
@@ -532,13 +533,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         build_selection.assert_called_once_with("preview-request")
         build_selection_handoff.assert_called_once_with(selection_state)
-        build_inputs.assert_called_once_with(
-            layers="layers",
-            selection_state="selection",
-            settings="settings",
-            background="background",
-            apply_subset_filters=True,
-        )
         build_settings.assert_called_once_with(
             style_preset="By activity type",
             temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
@@ -552,7 +546,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             style_id="style-id",
             tile_mode="Raster",
         )
-        build_action.assert_called_once_with(self.module.ApplyVisualizationAction, "inputs")
 
     def test_run_selected_analysis_delegates_to_analysis_workflow(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -612,18 +605,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
     def test_apply_visual_configuration_dispatches_apply_action(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        action = self.module.ApplyVisualizationAction(
-            layers=self.module.LayerRefs(activities="activities"),
-            selection_state=self.module.ActivitySelectionState(query=object(), filtered_count=1),
-            style_preset="By activity type",
-            temporal_mode="By month",
-            background_config=SimpleNamespace(),
-            analysis_mode="None",
-            apply_subset_filters=True,
-        )
-        dock._build_visual_workflow_action = MagicMock(return_value=action)
-        dock._dock_action_dispatcher = MagicMock()
-        dock._dock_action_dispatcher.dispatch.return_value = SimpleNamespace(
+        dock._dock_visual_workflow = MagicMock()
+        dock._current_visual_workflow_request = MagicMock(return_value="request")
+        dock._dock_visual_workflow.dispatch_action.return_value = SimpleNamespace(
             status="Applied styling",
             background_error="",
             background_layer="background-layer",
@@ -632,8 +616,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         status = self.module.QfitDockWidget._apply_visual_configuration(dock, False)
 
-        dispatched_action = dock._dock_action_dispatcher.dispatch.call_args.args[0]
-        self.assertFalse(dispatched_action.apply_subset_filters)
+        dock._current_visual_workflow_request.assert_called_once_with(
+            apply_subset_filters=False
+        )
+        dock._dock_visual_workflow.dispatch_action.assert_called_once_with(
+            self.module.ApplyVisualizationAction,
+            "request",
+            require_layers=False,
+        )
         self.assertEqual(status, "Applied styling")
         self.assertEqual(dock.background_layer, "background-layer")
         dock._show_error.assert_not_called()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -547,6 +547,24 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             tile_mode="Raster",
         )
 
+    def test_build_visual_workflow_action_delegates_to_visual_workflow_coordinator(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._dock_visual_workflow = MagicMock()
+        dock._dock_visual_workflow.build_action.return_value = "action"
+        dock._current_visual_workflow_request = MagicMock(return_value="request")
+
+        action = self.module.QfitDockWidget._build_visual_workflow_action(
+            dock,
+            self.module.ApplyVisualizationAction,
+        )
+
+        self.assertEqual(action, "action")
+        dock._current_visual_workflow_request.assert_called_once_with()
+        dock._dock_visual_workflow.build_action.assert_called_once_with(
+            self.module.ApplyVisualizationAction,
+            "request",
+        )
+
     def test_run_selected_analysis_delegates_to_analysis_workflow(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysis_workflow = MagicMock()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -12,6 +12,10 @@ from .dock_activity_workflow import (
     DockFetchCompletionResult,
     DockFetchRequest,
 )
+from .dock_visual_workflow import (
+    DockVisualWorkflowCoordinator,
+    DockVisualWorkflowRequest,
+)
 from .dock_runtime_state import (
     DockRuntimeLayers,
     DockRuntimeState,
@@ -40,6 +44,8 @@ __all__ = [
     "DockRuntimeState",
     "DockRuntimeStore",
     "DockRuntimeTasks",
+    "DockVisualWorkflowCoordinator",
+    "DockVisualWorkflowRequest",
     "RunAnalysisAction",
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",

--- a/ui/application/dock_visual_workflow.py
+++ b/ui/application/dock_visual_workflow.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .visual_workflow_action_builder import (
+    VisualWorkflowBackgroundInputs,
+    VisualWorkflowSettingsSnapshot,
+    build_visual_workflow_action,
+    build_visual_workflow_action_inputs,
+)
+
+
+@dataclass(frozen=True)
+class DockVisualWorkflowRequest:
+    layers: object
+    selection_state: object
+    settings: VisualWorkflowSettingsSnapshot
+    background: VisualWorkflowBackgroundInputs
+    apply_subset_filters: bool = True
+
+
+class DockVisualWorkflowCoordinator:
+    """Build and dispatch dock visual-workflow actions from dock-edge snapshots."""
+
+    def __init__(self, *, dispatcher) -> None:
+        self.dispatcher = dispatcher
+
+    def build_action(self, action_type, request: DockVisualWorkflowRequest):
+        return build_visual_workflow_action(
+            action_type,
+            build_visual_workflow_action_inputs(
+                layers=request.layers,
+                selection_state=request.selection_state,
+                settings=request.settings,
+                background=request.background,
+                apply_subset_filters=request.apply_subset_filters,
+            ),
+        )
+
+    def dispatch_action(
+        self,
+        action_type,
+        request: DockVisualWorkflowRequest,
+        *,
+        require_layers: bool = True,
+    ):
+        action = self.build_action(action_type, request)
+        if require_layers and not action.layers.has_any():
+            return None
+        return self.dispatcher.dispatch(action)
+
+
+__all__ = [
+    "DockVisualWorkflowCoordinator",
+    "DockVisualWorkflowRequest",
+]

--- a/ui/application/dock_visual_workflow.py
+++ b/ui/application/dock_visual_workflow.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ...activities.application.activity_selection_state import ActivitySelectionState
+from ...visualization.application import LayerRefs
 from .visual_workflow_action_builder import (
     VisualWorkflowBackgroundInputs,
     VisualWorkflowSettingsSnapshot,
@@ -12,8 +14,8 @@ from .visual_workflow_action_builder import (
 
 @dataclass(frozen=True)
 class DockVisualWorkflowRequest:
-    layers: object
-    selection_state: object
+    layers: LayerRefs
+    selection_state: ActivitySelectionState
     settings: VisualWorkflowSettingsSnapshot
     background: VisualWorkflowBackgroundInputs
     apply_subset_filters: bool = True


### PR DESCRIPTION
## Summary
- extract a dock visual-workflow coordinator under `ui/application/`
- move visual-workflow action assembly/dispatch orchestration out of `QfitDockWidget`
- add focused coordinator coverage and update dockwidget pure tests for the new delegation path

## Testing
- python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_dock_visual_workflow.py tests/test_dock_action_dispatcher.py tests/test_dock_activity_workflow.py -q --tb=short

Closes #598
