### PR TITLE
architecture: extract dock atlas export command building

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -71,6 +71,8 @@ from .atlas.profile_style import build_native_profile_plot_style_from_settings
 from .ui.application import (
     ApplyVisualizationAction,
     DockActionDispatcher,
+    DockAtlasExportRequest,
+    DockAtlasWorkflowCoordinator,
     DockFetchCompletionRequest,
     DockFetchRequest,
     DockRuntimeStore,
@@ -444,6 +446,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.visual_apply = dependencies.visual_apply
         self.atlas_export_service = dependencies.atlas_export_service
         self.activity_workflow = dependencies.activity_workflow
+        self.atlas_workflow = getattr(dependencies, "atlas_workflow", None)
         self.cache = dependencies.cache
 
     def _store_activities_workflow(self):
@@ -454,6 +457,15 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _clear_database_workflow_service(self):
         return getattr(self, "clear_database_workflow", None) or self.load_workflow
+
+    def _atlas_workflow_service(self):
+        atlas_workflow = getattr(self, "atlas_workflow", None)
+        if atlas_workflow is None:
+            atlas_workflow = DockAtlasWorkflowCoordinator(
+                atlas_export_use_case=self.atlas_export_use_case,
+            )
+            self.atlas_workflow = atlas_workflow
+        return atlas_workflow
 
     @staticmethod
     def _set_combo_value(combo_box, value, default_text) -> None:
@@ -1136,22 +1148,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._runtime_store().clear_atlas_export()
             return
 
-        export_command = self.atlas_export_use_case.build_command(
-            atlas_layer=self.atlas_layer,
-            selection_state=build_activity_preview_selection_state(
-                self._current_activity_preview_request()
-            ),
-            output_path=self.atlasPdfPathLineEdit.text().strip(),
-            atlas_title=self.atlasTitleLineEdit.text().strip(),
-            atlas_subtitle=self.atlasSubtitleLineEdit.text().strip(),
-            on_finished=self._on_atlas_export_finished,
-            pre_export_tile_mode=self.tileModeComboBox.currentText(),
-            preset_name=self.backgroundPresetComboBox.currentText(),
-            access_token=self._mapbox_access_token(),
-            style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
-            style_id=self.mapboxStyleIdLineEdit.text().strip(),
-            background_enabled=self.backgroundMapCheckBox.isChecked(),
-            profile_plot_style=build_native_profile_plot_style_from_settings(self.settings),
+        export_command = self._atlas_workflow_service().build_export_command(
+            self._current_atlas_export_request(),
         )
         prepared_export = self.atlas_export_use_case.prepare_export(export_command)
         if prepared_export.path_changed:
@@ -1178,6 +1176,25 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._set_status("Generating atlas PDF…")
 
         QgsApplication.taskManager().addTask(atlas_export_task)
+
+    def _current_atlas_export_request(self):
+        return DockAtlasExportRequest(
+            atlas_layer=self.atlas_layer,
+            selection_state=build_activity_preview_selection_state(
+                self._current_activity_preview_request()
+            ),
+            output_path=self.atlasPdfPathLineEdit.text().strip(),
+            atlas_title=self.atlasTitleLineEdit.text().strip(),
+            atlas_subtitle=self.atlasSubtitleLineEdit.text().strip(),
+            on_finished=self._on_atlas_export_finished,
+            pre_export_tile_mode=self.tileModeComboBox.currentText(),
+            preset_name=self.backgroundPresetComboBox.currentText(),
+            access_token=self._mapbox_access_token(),
+            style_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
+            style_id=self.mapboxStyleIdLineEdit.text().strip(),
+            background_enabled=self.backgroundMapCheckBox.isChecked(),
+            profile_plot_style=build_native_profile_plot_style_from_settings(self.settings),
+        )
 
     def _set_atlas_export_running(self, running: bool) -> None:
         self.generateAtlasPdfButton.setText(

--- a/tests/test_dock_atlas_workflow.py
+++ b/tests/test_dock_atlas_workflow.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+from qfit.activities.application.activity_selection_state import ActivitySelectionState
+from qfit.activities.domain.activity_query import ActivityQuery
+from qfit.ui.application import DockAtlasExportRequest, DockAtlasWorkflowCoordinator
+
+
+class DockAtlasWorkflowCoordinatorTests(unittest.TestCase):
+    def test_build_export_command_delegates_to_use_case(self):
+        atlas_export_use_case = MagicMock()
+        atlas_export_use_case.build_command.return_value = "command"
+        coordinator = DockAtlasWorkflowCoordinator(
+            atlas_export_use_case=atlas_export_use_case,
+        )
+        request = DockAtlasExportRequest(
+            atlas_layer="atlas-layer",
+            selection_state=ActivitySelectionState(
+                query=ActivityQuery(),
+                filtered_count=5,
+            ),
+            output_path="/tmp/out.pdf",
+            atlas_title="Spring Atlas",
+            atlas_subtitle="Road and trail",
+            on_finished="finished-callback",
+            pre_export_tile_mode="Raster",
+            preset_name="Outdoors",
+            access_token="token",
+            style_owner="mapbox",
+            style_id="outdoors-v12",
+            background_enabled=True,
+            profile_plot_style="profile-style",
+        )
+
+        command = coordinator.build_export_command(request)
+
+        self.assertEqual(command, "command")
+        atlas_export_use_case.build_command.assert_called_once_with(
+            atlas_layer="atlas-layer",
+            selection_state=request.selection_state,
+            output_path="/tmp/out.pdf",
+            atlas_title="Spring Atlas",
+            atlas_subtitle="Road and trail",
+            on_finished="finished-callback",
+            pre_export_tile_mode="Raster",
+            preset_name="Outdoors",
+            access_token="token",
+            style_owner="mapbox",
+            style_id="outdoors-v12",
+            background_enabled=True,
+            profile_plot_style="profile-style",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -103,6 +103,10 @@ class DockWidgetDependenciesTests(unittest.TestCase):
                 "qfit.ui.dockwidget_dependencies.DockActivityWorkflowCoordinator",
                 return_value=sentinel.activity_workflow,
             ) as activity_workflow,
+            patch(
+                "qfit.ui.dockwidget_dependencies.DockAtlasWorkflowCoordinator",
+                return_value=sentinel.atlas_workflow,
+            ) as atlas_workflow,
             patch("qfit.ui.dockwidget_dependencies._build_cache", return_value=sentinel.cache),
         ):
             dependencies = build_dockwidget_dependencies(iface)
@@ -122,6 +126,7 @@ class DockWidgetDependenciesTests(unittest.TestCase):
         self.assertIs(dependencies.visual_apply, sentinel.visual_apply)
         self.assertIs(dependencies.atlas_export_service, sentinel.atlas_export_service)
         self.assertIs(dependencies.activity_workflow, sentinel.activity_workflow)
+        self.assertIs(dependencies.atlas_workflow, sentinel.atlas_workflow)
         self.assertIs(dependencies.cache, sentinel.cache)
 
         background_controller.assert_called_once_with(layer_gateway)
@@ -146,6 +151,9 @@ class DockWidgetDependenciesTests(unittest.TestCase):
             sync_controller=sentinel.sync_controller,
             fetch_result_service=sentinel.fetch_result_service,
             activity_preview_service=sentinel.activity_preview_service,
+        )
+        atlas_workflow.assert_called_once_with(
+            atlas_export_use_case=sentinel.atlas_export_use_case,
         )
 
     def test_build_cache_prefers_legacy_cache_path_when_current_path_is_missing(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1123,6 +1123,104 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF export cancelled.")
         dock._set_atlas_export_running.assert_called_once_with(False)
 
+    def test_current_atlas_export_request_uses_current_ui_state(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.atlas_layer = "atlas-layer"
+        dock._current_activity_preview_request = MagicMock(return_value="preview-request")
+        dock.atlasPdfPathLineEdit = _FakeLineEdit(" /tmp/qfit-atlas.pdf ")
+        dock.atlasTitleLineEdit = _FakeLineEdit(" Spring Atlas ")
+        dock.atlasSubtitleLineEdit = _FakeLineEdit(" Road and trail ")
+        dock.tileModeComboBox = _FakeComboBox(current_text="Raster")
+        dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
+        dock.backgroundMapCheckBox = _FakeCheckBox(True)
+        dock.mapboxStyleOwnerLineEdit = _FakeLineEdit(" mapbox ")
+        dock.mapboxStyleIdLineEdit = _FakeLineEdit(" outdoors-v12 ")
+        dock.settings = _FakeSettings()
+        dock._on_atlas_export_finished = MagicMock()
+        dock._mapbox_access_token = MagicMock(return_value="token")
+
+        with patch.object(
+            self.module,
+            "build_activity_preview_selection_state",
+            return_value="selection",
+        ) as build_selection, patch.object(
+            self.module,
+            "build_native_profile_plot_style_from_settings",
+            return_value="profile-style",
+        ) as build_profile_style:
+            request = self.module.QfitDockWidget._current_atlas_export_request(dock)
+
+        self.assertEqual(request.atlas_layer, "atlas-layer")
+        self.assertEqual(request.selection_state, "selection")
+        self.assertEqual(request.output_path, "/tmp/qfit-atlas.pdf")
+        self.assertEqual(request.atlas_title, "Spring Atlas")
+        self.assertEqual(request.atlas_subtitle, "Road and trail")
+        self.assertIs(request.on_finished, dock._on_atlas_export_finished)
+        self.assertEqual(request.pre_export_tile_mode, "Raster")
+        self.assertEqual(request.preset_name, "Outdoors")
+        self.assertEqual(request.access_token, "token")
+        self.assertEqual(request.style_owner, "mapbox")
+        self.assertEqual(request.style_id, "outdoors-v12")
+        self.assertTrue(request.background_enabled)
+        self.assertEqual(request.profile_plot_style, "profile-style")
+        build_selection.assert_called_once_with("preview-request")
+        build_profile_style.assert_called_once_with(dock.settings)
+
+    def test_on_generate_atlas_pdf_clicked_builds_command_via_atlas_workflow(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        atlas_layer = MagicMock()
+        atlas_layer.featureCount.return_value = 3
+        dock.atlas_export_use_case = MagicMock()
+        dock.atlas_export_use_case.prepare_export.return_value = SimpleNamespace(
+            path_changed=False,
+            is_ready=True,
+            output_path="/tmp/qfit-atlas.pdf",
+        )
+        dock.atlas_export_use_case.start_export.return_value = "atlas-task"
+        dock._save_settings = MagicMock()
+        runtime_store = MagicMock()
+        runtime_store.state = SimpleNamespace(
+            tasks=SimpleNamespace(atlas_export=None),
+            layers=SimpleNamespace(atlas=atlas_layer),
+        )
+        dock._runtime_state_store = runtime_store
+        dock._set_atlas_export_running = MagicMock()
+        dock._set_atlas_pdf_status = MagicMock()
+        dock._set_status = MagicMock()
+        atlas_workflow = MagicMock()
+        atlas_workflow.build_export_command.return_value = "command"
+        task_manager = MagicMock()
+
+        with patch.object(
+            self.module.QfitDockWidget,
+            "_current_atlas_export_request",
+            return_value="request",
+        ) as current_request, patch.object(
+            self.module.QfitDockWidget,
+            "_atlas_workflow_service",
+            return_value=atlas_workflow,
+        ) as atlas_workflow_service, patch.object(
+            self.module.QgsApplication,
+            "taskManager",
+            return_value=task_manager,
+        ):
+            self.module.QfitDockWidget.on_generate_atlas_pdf_clicked(dock)
+
+        atlas_workflow_service.assert_called_once_with()
+        current_request.assert_called_once_with()
+        atlas_workflow.build_export_command.assert_called_once_with("request")
+        dock.atlas_export_use_case.prepare_export.assert_called_once_with("command")
+        dock._save_settings.assert_called_once_with()
+        dock.atlas_export_use_case.start_export.assert_called_once_with(
+            dock.atlas_export_use_case.prepare_export.return_value,
+            "command",
+        )
+        runtime_store.begin_atlas_export.assert_called_once_with("atlas-task")
+        dock._set_atlas_export_running.assert_called_once_with(True)
+        dock._set_atlas_pdf_status.assert_called_once_with("Exporting atlas (3 pages)…")
+        dock._set_status.assert_called_once_with("Generating atlas PDF…")
+        task_manager.addTask.assert_called_once_with("atlas-task")
+
     def test_on_atlas_export_finished_clears_task_and_updates_status(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._atlas_export_task = object()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -488,6 +488,8 @@ class QgisSmokeTests(unittest.TestCase):
             dock.atlas_layer = MagicMock()
             dock.atlas_layer.featureCount.return_value = 3
             dock.atlasPdfPathLineEdit.setText("/tmp/qfit-atlas.pdf")
+            dock.atlasTitleLineEdit.setText("Custom Atlas")
+            dock.atlasSubtitleLineEdit.setText("April 2026")
 
             prepared_export = MagicMock(name="prepared_export")
             prepared_export.is_ready = True

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -12,6 +12,10 @@ from .dock_activity_workflow import (
     DockFetchCompletionResult,
     DockFetchRequest,
 )
+from .dock_atlas_workflow import (
+    DockAtlasExportRequest,
+    DockAtlasWorkflowCoordinator,
+)
 from .dock_visual_workflow import (
     DockVisualWorkflowCoordinator,
     DockVisualWorkflowRequest,
@@ -37,6 +41,8 @@ __all__ = [
     "DockActionDispatcher",
     "DockActionResult",
     "DockActivityWorkflowCoordinator",
+    "DockAtlasExportRequest",
+    "DockAtlasWorkflowCoordinator",
     "DockFetchCompletionRequest",
     "DockFetchCompletionResult",
     "DockFetchRequest",

--- a/ui/application/dock_atlas_workflow.py
+++ b/ui/application/dock_atlas_workflow.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from ...activities.application.activity_selection_state import ActivitySelectionState
+from ...atlas.export_use_case import AtlasExportUseCase, GenerateAtlasPdfCommand
+
+
+@dataclass(frozen=True)
+class DockAtlasExportRequest:
+    atlas_layer: object = None
+    selection_state: ActivitySelectionState = field(default_factory=ActivitySelectionState)
+    output_path: str = ""
+    atlas_title: str = ""
+    atlas_subtitle: str = ""
+    on_finished: Callable | None = None
+    pre_export_tile_mode: str = ""
+    preset_name: str = ""
+    access_token: str = ""
+    style_owner: str = ""
+    style_id: str = ""
+    background_enabled: bool = False
+    profile_plot_style: object | None = None
+
+
+class DockAtlasWorkflowCoordinator:
+    """Build dock atlas export commands from a dock-edge request snapshot."""
+
+    def __init__(self, *, atlas_export_use_case: AtlasExportUseCase) -> None:
+        self.atlas_export_use_case = atlas_export_use_case
+
+    def build_export_command(self, request: DockAtlasExportRequest) -> GenerateAtlasPdfCommand:
+        return self.atlas_export_use_case.build_command(
+            atlas_layer=request.atlas_layer,
+            selection_state=request.selection_state,
+            output_path=request.output_path,
+            atlas_title=request.atlas_title,
+            atlas_subtitle=request.atlas_subtitle,
+            on_finished=request.on_finished,
+            pre_export_tile_mode=request.pre_export_tile_mode,
+            preset_name=request.preset_name,
+            access_token=request.access_token,
+            style_owner=request.style_owner,
+            style_id=request.style_id,
+            background_enabled=request.background_enabled,
+            profile_plot_style=request.profile_plot_style,
+        )
+
+
+__all__ = [
+    "DockAtlasExportRequest",
+    "DockAtlasWorkflowCoordinator",
+]

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -17,7 +17,7 @@ from ..activities.application.load_workflow import (
 from ..qfit_cache import QfitCache
 from ..configuration.application.settings_service import SettingsService
 from ..activities.application.sync_controller import SyncController
-from ..ui.application import DockActivityWorkflowCoordinator
+from ..ui.application import DockActivityWorkflowCoordinator, DockAtlasWorkflowCoordinator
 from ..visualization.application import (
     BackgroundMapController,
     LayerGateway,
@@ -50,6 +50,7 @@ class DockWidgetDependencies:
     visual_apply: VisualApplyService
     atlas_export_service: AtlasExportService
     activity_workflow: DockActivityWorkflowCoordinator
+    atlas_workflow: DockAtlasWorkflowCoordinator
     cache: QfitCache
 
 
@@ -62,6 +63,7 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
     layer_gateway = _build_layer_gateway(iface)
     cache = _build_cache()
     atlas_export_service = AtlasExportService(layer_gateway)
+    atlas_export_use_case = AtlasExportUseCase(atlas_export_controller, atlas_export_service)
     fetch_result_service = FetchResultService(sync_controller)
     activity_preview_service = ActivityPreviewService()
     store_workflow = StoreActivitiesWorkflow()
@@ -72,7 +74,7 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
         sync_controller=sync_controller,
         analysis_workflow=build_analysis_workflow(),
         atlas_export_controller=atlas_export_controller,
-        atlas_export_use_case=AtlasExportUseCase(atlas_export_controller, atlas_export_service),
+        atlas_export_use_case=atlas_export_use_case,
         layer_gateway=layer_gateway,
         background_controller=BackgroundMapController(layer_gateway),
         project_hygiene_service=_build_project_hygiene_service(),
@@ -91,6 +93,9 @@ def build_dockwidget_dependencies(iface) -> DockWidgetDependencies:
             sync_controller=sync_controller,
             fetch_result_service=fetch_result_service,
             activity_preview_service=activity_preview_service,
+        ),
+        atlas_workflow=DockAtlasWorkflowCoordinator(
+            atlas_export_use_case=atlas_export_use_case,
         ),
         cache=cache,
     )

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -113,12 +113,10 @@ def _build_project_hygiene_service() -> ProjectHygienePort:
     return ProjectHygieneService()
 
 
-
 def _writable_app_data_location() -> str:
     from qgis.PyQt.QtCore import QStandardPaths
 
     return QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)
-
 
 
 def _build_cache() -> QfitCache:


### PR DESCRIPTION
## Summary
- extract dock atlas export command building into `ui/application`
- move atlas export startup command assembly behind a focused dock atlas workflow coordinator
- add focused pure coverage plus targeted QGIS smoke checks for the new seam

## Testing
- python3 -m pytest tests/test_dock_atlas_workflow.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_dockwidget_dependencies.py tests/test_qgis_smoke.py::QgisSmokeTests::test_generate_atlas_pdf_shows_clear_error_when_pypdf_is_missing tests/test_qgis_smoke.py::QgisSmokeTests::test_generate_atlas_pdf_passes_profile_plot_style_from_settings -q --tb=short

Closes #600
