### PR TITLE
refactor: extract visual apply result status shaping

### DIFF
--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -16,7 +16,8 @@ from qfit.visualization.application.visual_apply import (
     VisualApplyService,
 )
 from qfit.visualization.application.visual_apply_messages import (
-    append_visual_apply_temporal_note,
+    build_visual_apply_background_failure_result_status,
+    build_visual_apply_result_status,
 )
 
 
@@ -186,7 +187,7 @@ class ApplyWithSubsetFiltersTests(unittest.TestCase):
 
     def test_status_selection_uses_helper(self):
         with patch(
-            "qfit.visualization.application.visual_apply.build_visual_apply_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_result_status",
             return_value="Applied filters and styling (42 matching activities)",
         ) as build_status:
             result = self.service.apply(
@@ -206,6 +207,7 @@ class ApplyWithSubsetFiltersTests(unittest.TestCase):
             filtered_count=42,
             wants_background=False,
             background_loaded=False,
+            temporal_note="",
         )
 
     def test_does_not_update_background_on_filter_apply(self):
@@ -267,7 +269,7 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
         self.layer_manager.ensure_background_layer.return_value = None
 
         with patch(
-            "qfit.visualization.application.visual_apply.build_visual_apply_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_result_status",
             return_value="Background map cleared",
         ) as build_status:
             result = self.service.apply(
@@ -287,11 +289,12 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
             filtered_count=0,
             wants_background=False,
             background_loaded=False,
+            temporal_note="",
         )
 
     def test_returns_loaded_background_status_via_helper_when_only_background_is_loaded(self):
         with patch(
-            "qfit.visualization.application.visual_apply.build_visual_apply_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_result_status",
             return_value="Background map loaded below the qfit activity layers",
         ) as build_status:
             result = self.service.apply(
@@ -311,6 +314,7 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
             filtered_count=0,
             wants_background=True,
             background_loaded=True,
+            temporal_note="",
         )
 
     def test_applies_style_and_temporal(self):
@@ -370,7 +374,7 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
         bg = _make_bg_config(enabled=True)
 
         with patch(
-            "qfit.visualization.application.visual_apply.build_visual_apply_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_result_status",
             return_value="Applied styling and loaded the background map below the qfit activity layers",
         ) as build_status:
             result = self.service.apply(
@@ -393,6 +397,7 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
             filtered_count=0,
             wants_background=True,
             background_loaded=True,
+            temporal_note="",
         )
 
     def test_status_without_background(self):
@@ -436,7 +441,7 @@ class BackgroundFailureTests(unittest.TestCase):
         layers = LayerRefs(activities=MagicMock())
 
         with patch(
-            "qfit.visualization.application.visual_apply.build_styled_background_map_failure_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_background_failure_result_status",
             return_value="Loaded layers with styling, but the background map could not be updated",
         ) as build_status:
             result = self.service.apply(
@@ -450,13 +455,16 @@ class BackgroundFailureTests(unittest.TestCase):
             )
 
         self.assertIn("loaded layers", result.status.lower())
-        build_status.assert_called_once_with()
+        build_status.assert_called_once_with(
+            has_layers=True,
+            temporal_note="",
+        )
 
     def test_error_status_without_layers(self):
         layers = LayerRefs()
 
         with patch(
-            "qfit.visualization.application.visual_apply.build_background_map_failure_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_background_failure_result_status",
             return_value="Background map could not be updated",
         ) as build_status:
             result = self.service.apply(
@@ -471,7 +479,10 @@ class BackgroundFailureTests(unittest.TestCase):
 
         self.assertNotIn("loaded layers", result.status.lower())
         self.assertIn("could not be updated", result.status.lower())
-        build_status.assert_called_once_with()
+        build_status.assert_called_once_with(
+            has_layers=False,
+            temporal_note="",
+        )
 
     def test_unexpected_background_exception_propagates(self):
         self.layer_manager.ensure_background_layer.side_effect = TypeError("boom")
@@ -526,7 +537,7 @@ class NoLayersTests(unittest.TestCase):
         layers = LayerRefs(activities=MagicMock())
 
         with patch(
-            "qfit.visualization.application.visual_apply.build_visual_apply_status",
+            "qfit.visualization.application.visual_apply.build_visual_apply_result_status",
             return_value="Applied styling to the loaded qfit layers",
         ) as build_status:
             result = self.service.apply(
@@ -546,6 +557,7 @@ class NoLayersTests(unittest.TestCase):
             filtered_count=0,
             wants_background=False,
             background_loaded=False,
+            temporal_note="",
         )
 
 
@@ -559,9 +571,9 @@ class TemporalNoteTests(unittest.TestCase):
 
     def test_temporal_note_appended_to_status(self):
         with patch(
-            "qfit.visualization.application.visual_apply.append_visual_apply_temporal_note",
-            wraps=append_visual_apply_temporal_note,
-        ) as append_note:
+            "qfit.visualization.application.visual_apply.build_visual_apply_result_status",
+            wraps=build_visual_apply_result_status,
+        ) as build_status:
             result = self.service.apply(
                 layers=self.layers,
                 query=_make_query(),
@@ -573,14 +585,21 @@ class TemporalNoteTests(unittest.TestCase):
             )
 
         self.assertIn("Temporal mode: Monthly", result.status)
-        append_note.assert_called()
+        build_status.assert_called_once_with(
+            has_layers=True,
+            apply_subset_filters=False,
+            filtered_count=0,
+            wants_background=False,
+            background_loaded=False,
+            temporal_note="Temporal mode: Monthly",
+        )
 
     def test_temporal_note_appended_to_failure_status(self):
         self.layer_manager.ensure_background_layer.side_effect = RuntimeError("fail")
         with patch(
-            "qfit.visualization.application.visual_apply.append_visual_apply_temporal_note",
-            wraps=append_visual_apply_temporal_note,
-        ) as append_note:
+            "qfit.visualization.application.visual_apply.build_visual_apply_background_failure_result_status",
+            wraps=build_visual_apply_background_failure_result_status,
+        ) as build_status:
             result = self.service.apply(
                 layers=self.layers,
                 query=_make_query(),
@@ -593,7 +612,10 @@ class TemporalNoteTests(unittest.TestCase):
 
         self.assertIn("Temporal mode: Monthly", result.status)
         self.assertIn("could not be updated", result.status.lower())
-        append_note.assert_called()
+        build_status.assert_called_once_with(
+            has_layers=True,
+            temporal_note="Temporal mode: Monthly",
+        )
 
 
 class BackgroundPresetPassthroughTests(unittest.TestCase):

--- a/tests/test_visual_apply_messages.py
+++ b/tests/test_visual_apply_messages.py
@@ -5,6 +5,8 @@ from tests import _path  # noqa: F401
 from qfit.visualization.application.visual_apply_messages import (
     append_visual_apply_temporal_note,
     build_filtered_visual_apply_status,
+    build_visual_apply_background_failure_result_status,
+    build_visual_apply_result_status,
     build_visual_apply_status,
 )
 
@@ -62,6 +64,37 @@ class VisualApplyMessagesTests(unittest.TestCase):
         self.assertEqual(
             build_visual_apply_status(False, False, 0, False, False),
             "Background map cleared",
+        )
+
+    def test_build_visual_apply_result_status_appends_temporal_note(self):
+        self.assertEqual(
+            build_visual_apply_result_status(
+                has_layers=True,
+                apply_subset_filters=False,
+                filtered_count=0,
+                wants_background=False,
+                background_loaded=False,
+                temporal_note="Temporal mode: Monthly",
+            ),
+            "Applied styling to the loaded qfit layers. Temporal mode: Monthly.",
+        )
+
+    def test_build_visual_apply_background_failure_result_status_for_layers(self):
+        self.assertEqual(
+            build_visual_apply_background_failure_result_status(
+                has_layers=True,
+                temporal_note="Temporal mode: Monthly",
+            ),
+            "Loaded layers with styling, but the background map could not be updated. Temporal mode: Monthly.",
+        )
+
+    def test_build_visual_apply_background_failure_result_status_without_layers(self):
+        self.assertEqual(
+            build_visual_apply_background_failure_result_status(
+                has_layers=False,
+                temporal_note="",
+            ),
+            "Background map could not be updated",
         )
 
 

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -4,16 +4,11 @@ from dataclasses import dataclass, field
 from ...activities.application.activity_selection_state import ActivitySelectionState
 from ...activities.domain.activity_query import ActivityQuery
 from ...mapbox_config import MapboxConfigError
-from .background_map_messages import (
-    build_background_map_failure_status,
-    build_styled_background_map_failure_status,
-)
 from .layer_gateway import LayerGateway
 from .render_plan import build_render_plan
 from .visual_apply_messages import (
-    append_visual_apply_temporal_note,
-    build_filtered_visual_apply_status,
-    build_visual_apply_status,
+    build_visual_apply_background_failure_result_status,
+    build_visual_apply_result_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -164,8 +159,9 @@ class VisualApplyService:
         if self.should_update_background(request.apply_subset_filters):
             background_layer, bg_error = self._ensure_background(request.background_config)
             if bg_error is not None:
-                failure_status = self._background_failure_status(
-                    has_layers, temporal_note, bg_error
+                failure_status = build_visual_apply_background_failure_result_status(
+                    has_layers=has_layers,
+                    temporal_note=temporal_note,
                 )
                 return VisualApplyResult(
                     status=failure_status,
@@ -173,12 +169,12 @@ class VisualApplyService:
                     background_error=bg_error,
                 )
 
-        status = self._build_status(
+        status = build_visual_apply_result_status(
             has_layers=has_layers,
             apply_subset_filters=request.apply_subset_filters,
             filtered_count=request.filtered_count,
             wants_background=request.background_config.enabled,
-            background_layer=background_layer,
+            background_loaded=background_layer is not None,
             temporal_note=temporal_note,
         )
         return VisualApplyResult(status=status, background_layer=background_layer)
@@ -228,29 +224,3 @@ class VisualApplyService:
         except (AttributeError, TypeError):
             return False
 
-    @staticmethod
-    def _background_failure_status(has_layers, temporal_note, error):
-        if not has_layers:
-            status = build_background_map_failure_status()
-        else:
-            status = build_styled_background_map_failure_status()
-        return append_visual_apply_temporal_note(status, temporal_note)
-
-    @staticmethod
-    def _build_status(
-        has_layers,
-        apply_subset_filters,
-        filtered_count,
-        wants_background,
-        background_layer,
-        temporal_note,
-    ):
-        status = build_visual_apply_status(
-            has_layers=has_layers,
-            apply_subset_filters=apply_subset_filters,
-            filtered_count=filtered_count,
-            wants_background=wants_background,
-            background_loaded=background_layer is not None,
-        )
-
-        return append_visual_apply_temporal_note(status, temporal_note)

--- a/visualization/application/visual_apply_messages.py
+++ b/visualization/application/visual_apply_messages.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from .background_map_messages import (
     build_background_map_cleared_status,
+    build_background_map_failure_status,
     build_background_map_loaded_status,
+    build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
     build_styled_visual_apply_status,
 )
@@ -30,6 +32,35 @@ def build_visual_apply_status(
     if wants_background and background_loaded:
         return build_background_map_loaded_status()
     return build_background_map_cleared_status()
+
+
+def build_visual_apply_result_status(
+    has_layers: bool,
+    apply_subset_filters: bool,
+    filtered_count: int,
+    wants_background: bool,
+    background_loaded: bool,
+    temporal_note: str,
+) -> str:
+    status = build_visual_apply_status(
+        has_layers=has_layers,
+        apply_subset_filters=apply_subset_filters,
+        filtered_count=filtered_count,
+        wants_background=wants_background,
+        background_loaded=background_loaded,
+    )
+    return append_visual_apply_temporal_note(status, temporal_note)
+
+
+def build_visual_apply_background_failure_result_status(
+    has_layers: bool,
+    temporal_note: str,
+) -> str:
+    if not has_layers:
+        status = build_background_map_failure_status()
+    else:
+        status = build_styled_background_map_failure_status()
+    return append_visual_apply_temporal_note(status, temporal_note)
 
 
 def append_visual_apply_temporal_note(status: str, temporal_note: str) -> str:


### PR DESCRIPTION
## Summary
- move visual-apply success and background-failure result-status shaping into pure helpers
- keep `VisualApplyService` focused on execution and delegate status policy to `visual_apply_messages`
- extend focused tests for helper behavior and service delegation

## Testing
- python3 -m pytest tests/test_visual_apply_messages.py tests/test_visual_apply.py -q --tb=short

Closes #602
