### PR TITLE
refactor: move visual-apply feature probing behind gateway

### DIFF
--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -107,10 +107,13 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
             populated_layer.featureCount.return_value = 3
             empty_layer = MagicMock(name="empty_layer")
             empty_layer.featureCount.return_value = 0
+            zombie_layer = MagicMock(name="zombie_layer")
+            zombie_layer.featureCount.side_effect = RuntimeError("wrapped C/C++ object has been deleted")
             opaque_layer = object()
 
         self.assertTrue(gateway.has_features(populated_layer))
         self.assertFalse(gateway.has_features(empty_layer))
+        self.assertFalse(gateway.has_features(zombie_layer))
         self.assertFalse(gateway.has_features(opaque_layer))
         self.assertFalse(gateway.has_features(None))
 

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -93,6 +93,27 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         modules["qgis.core"].QgsProject.instance.return_value.removeMapLayer.assert_any_call(layer_a)
         modules["qgis.core"].QgsProject.instance.return_value.removeMapLayer.assert_any_call(layer_b)
 
+    def test_qgis_gateway_has_features_handles_missing_feature_count(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            populated_layer = MagicMock(name="populated_layer")
+            populated_layer.featureCount.return_value = 3
+            empty_layer = MagicMock(name="empty_layer")
+            empty_layer.featureCount.return_value = 0
+            opaque_layer = object()
+
+        self.assertTrue(gateway.has_features(populated_layer))
+        self.assertFalse(gateway.has_features(empty_layer))
+        self.assertFalse(gateway.has_features(opaque_layer))
+        self.assertFalse(gateway.has_features(None))
+
     def test_qgis_gateway_lazy_services_delegate_cleanly(self):
         modules = self._qgis_gateway_modules()
 

--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -133,8 +133,7 @@ class ApplyWithSubsetFiltersTests(unittest.TestCase):
         self.assertEqual(args[0][4], "Speed gradient")
 
     def test_builds_and_passes_render_plan(self):
-        self.layers.starts.featureCount.return_value = 0
-        self.layers.points.featureCount.return_value = 4
+        self.layer_manager.has_features.side_effect = [False, True]
 
         self.service.apply(
             layers=self.layers,
@@ -151,10 +150,14 @@ class ApplyWithSubsetFiltersTests(unittest.TestCase):
         self.assertEqual(render_plan.selected_source_role, SOURCE_ROLE_POINTS)
         self.assertEqual(render_plan.points.renderer_family, RENDERER_HEATMAP)
         self.assertEqual(render_plan.background_preset_name, "Satellite")
+        self.layer_manager.has_features.assert_has_calls(
+            [call(self.layers.starts), call(self.layers.points)]
+        )
 
     def test_render_plan_tolerates_layers_without_feature_count(self):
         self.layers.starts = SimpleNamespace(name="starts")
         self.layers.points = SimpleNamespace(name="points")
+        self.layer_manager.has_features.side_effect = [False, False]
 
         self.service.apply(
             layers=self.layers,
@@ -170,6 +173,9 @@ class ApplyWithSubsetFiltersTests(unittest.TestCase):
         render_plan = kwargs["render_plan"]
         self.assertEqual(render_plan.selected_source_role, SOURCE_ROLE_STARTS)
         self.assertEqual(render_plan.starts.renderer_family, RENDERER_HEATMAP)
+        self.layer_manager.has_features.assert_has_calls(
+            [call(self.layers.starts), call(self.layers.points)]
+        )
 
     def test_status_includes_filtered_count(self):
         result = self.service.apply(

--- a/visualization/application/layer_gateway.py
+++ b/visualization/application/layer_gateway.py
@@ -13,6 +13,8 @@ class LayerGateway(Protocol):
 
     def remove_layers(self, layers): ...
 
+    def has_features(self, layer): ...
+
     def ensure_background_layer(
         self,
         enabled,

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -129,8 +129,8 @@ class VisualApplyService:
         if has_layers:
             render_plan = build_render_plan(
                 request.style_preset,
-                has_start_features=self._has_features(request.layers.starts),
-                has_point_features=self._has_features(request.layers.points),
+                has_start_features=self.layer_gateway.has_features(request.layers.starts),
+                has_point_features=self.layer_gateway.has_features(request.layers.points),
                 has_points_layer=request.layers.points is not None,
                 background_preset_name=(
                     request.background_config.preset_name
@@ -214,13 +214,3 @@ class VisualApplyService:
             return layer, None
         except (MapboxConfigError, RuntimeError) as exc:
             return None, str(exc)
-
-    @staticmethod
-    def _has_features(layer):
-        if layer is None:
-            return False
-        try:
-            return layer.featureCount() > 0
-        except (AttributeError, TypeError):
-            return False
-

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -110,6 +110,14 @@ class QgisLayerGateway:
             except RuntimeError:
                 logger.debug("Failed to remove layer from project", exc_info=True)
 
+    def has_features(self, layer):
+        if layer is None:
+            return False
+        try:
+            return layer.featureCount() > 0
+        except (AttributeError, TypeError):
+            return False
+
     def ensure_background_layer(self, enabled, preset_name, access_token, style_owner="", style_id="", tile_mode=TILE_MODE_RASTER):
         return self._get_background_service().ensure_background_layer(
             enabled=enabled,

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -115,7 +115,7 @@ class QgisLayerGateway:
             return False
         try:
             return layer.featureCount() > 0
-        except (AttributeError, TypeError):
+        except (AttributeError, RuntimeError, TypeError):
             return False
 
     def ensure_background_layer(self, enabled, preset_name, access_token, style_owner="", style_id="", tile_mode=TILE_MODE_RASTER):


### PR DESCRIPTION
## Summary
- move visual-apply layer feature probing behind the layer gateway boundary
- keep `VisualApplyService` focused on orchestration instead of direct `featureCount()` calls
- add focused coverage for the new gateway contract and render-plan delegation

## Testing
- python3 -m pytest tests/test_visual_apply.py tests/test_layer_gateway.py -q --tb=short

Closes #604
