### PR TITLE
refactor: extract background map result status shaping

### DIFF
--- a/tests/test_background_map_controller.py
+++ b/tests/test_background_map_controller.py
@@ -63,7 +63,7 @@ class LoadBackgroundTests(unittest.TestCase):
         ctrl = BackgroundMapController(lm)
 
         with patch(
-            "qfit.visualization.application.background_map_controller.build_background_map_loaded_status",
+            "qfit.visualization.application.background_map_controller.build_background_map_result_status",
             return_value="Background map loaded below the qfit activity layers",
         ) as build_status:
             result = ctrl.load_background(
@@ -78,7 +78,7 @@ class LoadBackgroundTests(unittest.TestCase):
         self.assertIsInstance(result, LoadBackgroundResult)
         self.assertIs(result.layer, sentinel)
         self.assertEqual(result.status, "Background map loaded below the qfit activity layers")
-        build_status.assert_called_once_with()
+        build_status.assert_called_once_with(enabled=True, background_loaded=True)
         lm.ensure_background_layer.assert_called_once_with(
             enabled=True,
             preset_name="Mapbox Dark",
@@ -94,7 +94,7 @@ class LoadBackgroundTests(unittest.TestCase):
         ctrl = BackgroundMapController(lm)
 
         with patch(
-            "qfit.visualization.application.background_map_controller.build_background_map_cleared_status",
+            "qfit.visualization.application.background_map_controller.build_background_map_result_status",
             return_value="Background map cleared",
         ) as build_status:
             result = ctrl.load_background(
@@ -108,4 +108,4 @@ class LoadBackgroundTests(unittest.TestCase):
 
         self.assertIsNone(result.layer)
         self.assertEqual(result.status, "Background map cleared")
-        build_status.assert_called_once_with()
+        build_status.assert_called_once_with(enabled=False, background_loaded=False)

--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -7,6 +7,7 @@ from qfit.visualization.application.background_map_messages import (
     build_background_map_failure_status,
     build_background_map_failure_title,
     build_background_map_loaded_status,
+    build_background_map_result_status,
     build_styled_background_map_failure_status,
     build_styled_background_map_loaded_status,
     build_styled_visual_apply_status,
@@ -33,6 +34,18 @@ class BackgroundMapMessagesTests(unittest.TestCase):
         self.assertEqual(
             build_background_map_loaded_status(),
             "Background map loaded below the qfit activity layers",
+        )
+
+    def test_build_background_map_result_status_for_loaded_background(self):
+        self.assertEqual(
+            build_background_map_result_status(enabled=True, background_loaded=True),
+            "Background map loaded below the qfit activity layers",
+        )
+
+    def test_build_background_map_result_status_for_cleared_background(self):
+        self.assertEqual(
+            build_background_map_result_status(enabled=False, background_loaded=False),
+            "Background map cleared",
         )
 
     def test_build_styled_background_map_failure_status(self):

--- a/tests/test_background_map_messages.py
+++ b/tests/test_background_map_messages.py
@@ -48,6 +48,12 @@ class BackgroundMapMessagesTests(unittest.TestCase):
             "Background map cleared",
         )
 
+    def test_build_background_map_result_status_when_enabled_but_not_loaded(self):
+        self.assertEqual(
+            build_background_map_result_status(enabled=True, background_loaded=False),
+            "Background map cleared",
+        )
+
     def test_build_styled_background_map_failure_status(self):
         self.assertEqual(
             build_styled_background_map_failure_status(),

--- a/visualization/application/background_map_controller.py
+++ b/visualization/application/background_map_controller.py
@@ -3,8 +3,7 @@ from dataclasses import dataclass
 
 from ...mapbox_config import preset_defaults, preset_requires_custom_style
 from .background_map_messages import (
-    build_background_map_cleared_status,
-    build_background_map_loaded_status,
+    build_background_map_result_status,
 )
 from .layer_gateway import LayerGateway
 
@@ -83,10 +82,9 @@ class BackgroundMapController:
             style_id=request.style_id,
             tile_mode=request.tile_mode,
         )
-        status = (
-            build_background_map_loaded_status()
-            if request.enabled and layer is not None
-            else build_background_map_cleared_status()
+        status = build_background_map_result_status(
+            enabled=request.enabled,
+            background_loaded=layer is not None,
         )
         return LoadBackgroundResult(layer=layer, status=status)
 

--- a/visualization/application/background_map_messages.py
+++ b/visualization/application/background_map_messages.py
@@ -17,6 +17,12 @@ def build_background_map_loaded_status() -> str:
     return "Background map loaded below the qfit activity layers"
 
 
+def build_background_map_result_status(enabled: bool, background_loaded: bool) -> str:
+    if enabled and background_loaded:
+        return build_background_map_loaded_status()
+    return build_background_map_cleared_status()
+
+
 def build_styled_background_map_failure_status() -> str:
     return "Loaded layers with styling, but the background map could not be updated"
 


### PR DESCRIPTION
## Summary
- move background-map load result-status shaping into a pure helper
- keep `BackgroundMapController` focused on orchestration rather than inline status selection
- extend focused message/controller tests for the new helper delegation

## Testing
- python3 -m pytest tests/test_background_map_messages.py tests/test_background_map_controller.py -q --tb=short

Closes #606
