### PR TITLE
ux: reduce verbose dock help labels

### DIFF
--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -270,6 +270,7 @@ class _FakeWidget:
         self.title = None
         self.checkable = None
         self.object_name = None
+        self.tooltip = None
 
     def setParent(self, parent):
         self.parent_obj = parent
@@ -292,6 +293,9 @@ class _FakeWidget:
     def setCheckable(self, value):
         self.checkable = value
 
+    def setToolTip(self, text):
+        self.tooltip = text
+
 
 class _FakeLabel(_FakeWidget):
     def __init__(self):
@@ -310,6 +314,7 @@ class _FakeGroupBox:
         self.visible = None
         self.title = None
         self.checkable = None
+        self.tooltip = None
 
     def setParent(self, parent):
         self.parent_obj = parent
@@ -328,6 +333,9 @@ class _FakeGroupBox:
 
     def setCheckable(self, value):
         self.checkable = value
+
+    def setToolTip(self, text):
+        self.tooltip = text
 
 
 class WorkflowSectionCoordinatorTests(unittest.TestCase):
@@ -348,6 +356,12 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         dock.credentialsGroupBox = _FakeWidget()
         dock.workflowLabel = _FakeLabel()
         dock.activitiesIntroLabel = _FakeLabel()
+        dock.outputIntroLabel = _FakeLabel()
+        dock.outputIntroLabel.text = "Pick where qfit should store the synced GeoPackage."
+        dock.atlasPdfHelpLabel = _FakeLabel()
+        dock.atlasPdfHelpLabel.text = "Export a per-activity PDF atlas using loaded activity_atlas_pages."
+        dock.atlasPdfGroupBox = _FakeGroupBox()
+        dock.generateAtlasPdfButton = _FakeWidget()
         dock.mapboxAccessTokenLabel = _FakeWidget()
         dock.mapboxAccessTokenLineEdit = _FakeWidget()
         dock.loadLayersButton = _FakeWidget()
@@ -425,6 +439,14 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertTrue(hasattr(dock, "activitiesSectionToggleButton"))
         self.assertTrue(hasattr(dock, "activitiesSectionContentWidget"))
         self.assertTrue(hasattr(dock, "styleSectionToggleButton"))
+        self.assertFalse(dock.activitiesIntroLabel.visible)
+        self.assertIn("saved in qfit → Configuration", dock.activitiesSectionToggleButton.tooltip)
+        self.assertEqual(dock.activitiesGroupBox.tooltip, dock.activitiesSectionToggleButton.tooltip)
+        self.assertFalse(dock.outputIntroLabel.visible)
+        self.assertEqual(dock.outputGroupBox.tooltip, dock.outputIntroLabel.text)
+        self.assertFalse(dock.atlasPdfHelpLabel.visible)
+        self.assertEqual(dock.atlasPdfGroupBox.tooltip, dock.atlasPdfHelpLabel.text)
+        self.assertEqual(dock.generateAtlasPdfButton.tooltip, dock.atlasPdfHelpLabel.text)
         self.assertFalse(dock.mapboxAccessTokenLabel.visible)
         self.assertFalse(dock.mapboxAccessTokenLineEdit.visible)
 

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -248,6 +248,9 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertTrue(dock.activitiesSectionToggleButton.isChecked())
             self.assertEqual(dock.activitiesSectionToggleButton.arrowType(), Qt.DownArrow)
             self.assertFalse(dock.activitiesSectionContentWidget.isHidden())
+            self.assertTrue(dock.activitiesIntroLabel.isHidden())
+            self.assertIn("saved in qfit → Configuration", dock.activitiesSectionToggleButton.toolTip())
+            self.assertEqual(dock.activitiesGroupBox.toolTip(), dock.activitiesSectionToggleButton.toolTip())
             self.assertFalse(dock.mapboxAccessTokenLabel.isVisible())
             self.assertFalse(dock.mapboxAccessTokenLineEdit.isVisible())
             self.assertEqual(dock.refreshButton.text(), "Fetch activities")
@@ -261,6 +264,11 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertFalse(dock.analysisHelpLabel.isVisible())
             self.assertFalse(dock.publishHelpLabel.isVisible())
             self.assertFalse(dock.temporalHelpLabel.isVisible())
+            self.assertTrue(dock.outputIntroLabel.isHidden())
+            self.assertEqual(
+                dock.outputGroupBox.toolTip(),
+                "Pick where qfit should store the synced GeoPackage. Tracks and start points are always written; sampled point analysis is optional.",
+            )
             self.assertEqual(dock.outputGroupBox.title(), "Store / database")
             self.assertEqual(dock.outputGroupBox.parent(), dock.activitiesSectionContentWidget)
             self.assertGreater(dock.activitiesSectionContentWidget.layout().indexOf(dock.outputGroupBox), dock.activitiesSectionContentWidget.layout().indexOf(dock.previewGroupBox))
@@ -290,6 +298,9 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.publishSectionToggleButton.text(), "4. Publish / atlas")
             self.assertFalse(dock.publishSectionContentWidget.isHidden())
             self.assertTrue(dock.publishSettingsWidget.parent() is dock.publishSectionContentWidget or dock.publishSettingsWidget.isVisible())
+            self.assertTrue(dock.atlasPdfHelpLabel.isHidden())
+            self.assertIn("per-activity PDF atlas", dock.atlasPdfGroupBox.toolTip())
+            self.assertEqual(dock.generateAtlasPdfButton.toolTip(), dock.atlasPdfGroupBox.toolTip())
             self.assertEqual(dock.tileModeComboBox.currentText(), TILE_MODE_RASTER)
             self.assertEqual(dock.atlasTitleLineEdit.text(), "qfit Activity Atlas")
             self.assertEqual(dock.atlasSubtitleLineEdit.text(), "")

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -49,6 +49,17 @@ class WorkflowSectionCoordinator:
             "4. Publish / atlas",
             "publish",
         )
+        self._move_help_label_to_tooltip(
+            dock.activitiesIntroLabel,
+            getattr(dock, "activitiesSectionToggleButton", None),
+            dock.activitiesGroupBox,
+        )
+        self._move_help_label_to_tooltip(dock.outputIntroLabel, dock.outputGroupBox)
+        self._move_help_label_to_tooltip(
+            dock.atlasPdfHelpLabel,
+            dock.atlasPdfGroupBox,
+            dock.generateAtlasPdfButton,
+        )
         dock.mapboxAccessTokenLabel.hide()
         dock.mapboxAccessTokenLineEdit.hide()
 
@@ -105,6 +116,23 @@ class WorkflowSectionCoordinator:
             toggle.setArrowType(Qt.DownArrow if expanded else Qt.RightArrow)
         if content is not None:
             content.setVisible(expanded)
+
+    def _move_help_label_to_tooltip(self, label, *widgets) -> None:
+        if label is None:
+            return
+
+        text = getattr(label, "text", None)
+        if callable(text):
+            text = text()
+        if not text:
+            return
+
+        for widget in widgets:
+            if widget is not None and hasattr(widget, "setToolTip"):
+                widget.setToolTip(text)
+
+        if hasattr(label, "hide"):
+            label.hide()
 
     def configure_workflow_sections(self) -> None:
         dock = self.dock_widget


### PR DESCRIPTION
## Summary
- move verbose dock intro/help copy for fetch/store/atlas into tooltips instead of inline labels
- keep the existing dock workflow and widgets unchanged while reducing scroll height and text noise
- cover the new tooltip surface in focused coordinator and QGIS smoke tests

## Testing
- python3 -m pytest tests/test_dockwidget_dependencies.py tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_contextual_help_smoke -q --tb=short

Closes #610.
