### PR TITLE
ux: add consolidated dock summary status

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -79,6 +79,7 @@ from .ui.application import (
     DockVisualWorkflowCoordinator,
     DockVisualWorkflowRequest,
     RunAnalysisAction,
+    build_dock_summary_status,
     build_visual_layer_refs,
     build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
@@ -746,6 +747,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if result.preview_result is not None:
             self.querySummaryLabel.setText(result.preview_result.query_summary_text)
             self.activityPreviewPlainTextEdit.setPlainText(result.preview_result.preview_text)
+            self._refresh_summary_status()
         self._set_status(result.status_text)
 
     def on_load_clicked(self):
@@ -1042,10 +1044,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self.querySummaryLabel.setText(preview.query_summary_text)
         self.activityPreviewPlainTextEdit.setPlainText(preview.preview_text)
+        self._refresh_summary_status()
         return preview.fetched_activities
 
     def _update_cleared_activities_summary(self):
         self.countLabel.setText(build_cleared_activities_summary())
+        self._refresh_summary_status()
 
     def _update_last_sync_summary(self):
         summary = build_last_sync_summary(
@@ -1053,6 +1057,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         if summary:
             self.countLabel.setText(summary)
+            self._refresh_summary_status()
 
     def _update_loaded_activities_summary(self, total_activities):
         self.countLabel.setText(
@@ -1061,6 +1066,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 last_sync_date=self.settings.get("last_sync_date", "unknown"),
             )
         )
+        self._refresh_summary_status()
 
     def _update_stored_activities_summary(self, total_activities):
         self.countLabel.setText(
@@ -1069,6 +1075,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 last_sync_date=self.settings.get("last_sync_date", date.today().isoformat()),
             )
         )
+        self._refresh_summary_status()
 
     def _redirect_uri(self):
         return self.redirectUriLineEdit.text().strip() or StravaProvider.DEFAULT_REDIRECT_URI
@@ -1126,6 +1133,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 refresh_token=self.refreshTokenLineEdit.text(),
             )
         )
+        self._refresh_summary_status()
 
     def on_atlas_pdf_browse_clicked(self):
         path, _selected = QFileDialog.getSaveFileName(
@@ -1228,6 +1236,30 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _set_status(self, text):
         self.statusLabel.setText(text)
+        self._refresh_summary_status()
+
+    def _refresh_summary_status(self) -> None:
+        label = getattr(self, "summaryStatusLabel", None)
+        if label is None:
+            return
+
+        label.setText(
+            build_dock_summary_status(
+                connection_status=self._label_text("connectionStatusLabel"),
+                activity_summary=self._label_text("countLabel"),
+                query_summary=self._label_text("querySummaryLabel"),
+                workflow_status=self._label_text("statusLabel"),
+            )
+        )
+
+    def _label_text(self, name: str) -> str:
+        label = getattr(self, name, None)
+        if label is None:
+            return ""
+        text = getattr(label, "text", "")
+        if callable(text):
+            return text()
+        return text or ""
 
     def _show_info(self, title, message):
         QMessageBox.information(self, title, message)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -747,7 +747,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if result.preview_result is not None:
             self.querySummaryLabel.setText(result.preview_result.query_summary_text)
             self.activityPreviewPlainTextEdit.setPlainText(result.preview_result.preview_text)
-            self._refresh_summary_status()
         self._set_status(result.status_text)
 
     def on_load_clicked(self):

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -908,7 +908,7 @@
            <string>Consolidated qfit status summary.</string>
           </property>
           <property name="text">
-           <string>Strava connection: not connected yet · Activities fetched: 0 · Ready</string>
+           <string>Ready</string>
           </property>
           <property name="wordWrap">
            <bool>true</bool>

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -903,6 +903,19 @@
          </widget>
         </item>
         <item>
+         <widget class="QLabel" name="summaryStatusLabel">
+          <property name="toolTip">
+           <string>Consolidated qfit status summary.</string>
+          </property>
+          <property name="text">
+           <string>Strava connection: not connected yet · Activities fetched: 0 · Ready</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/tests/test_dock_summary_status.py
+++ b/tests/test_dock_summary_status.py
@@ -1,0 +1,44 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.ui.application.dock_summary_status import build_dock_summary_status
+
+
+class DockSummaryStatusTests(unittest.TestCase):
+    def test_builds_compact_summary_from_existing_status_labels(self):
+        self.assertEqual(
+            build_dock_summary_status(
+                connection_status="Strava connection: connected",
+                activity_summary="12 activities stored in database",
+                query_summary="Visualize filters currently match 3 activities.",
+                workflow_status="Ready",
+            ),
+            "Strava connection: connected · 12 activities stored in database · "
+            "Visualize filters currently match 3 activities. · Ready",
+        )
+
+    def test_omits_empty_and_duplicate_parts(self):
+        self.assertEqual(
+            build_dock_summary_status(
+                connection_status="",
+                activity_summary="Ready",
+                query_summary=None,
+                workflow_status="Ready",
+            ),
+            "Ready",
+        )
+
+    def test_falls_back_to_ready_when_all_parts_are_empty(self):
+        self.assertEqual(
+            build_dock_summary_status(
+                connection_status="",
+                activity_summary="",
+                query_summary=None,
+                workflow_status="",
+            ),
+            "Ready",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -26,6 +26,7 @@ from .dock_runtime_state import (
     DockRuntimeStore,
     DockRuntimeTasks,
 )
+from .dock_summary_status import build_dock_summary_status
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -56,6 +57,7 @@ __all__ = [
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",
     "VisualWorkflowSettingsSnapshot",
+    "build_dock_summary_status",
     "build_visual_layer_refs",
     "build_visual_workflow_action",
     "build_visual_workflow_action_inputs",

--- a/ui/application/dock_summary_status.py
+++ b/ui/application/dock_summary_status.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def build_dock_summary_status(
+    *,
+    connection_status: str | None,
+    activity_summary: str | None,
+    query_summary: str | None,
+    workflow_status: str | None,
+) -> str:
+    """Build the compact dock-wide status summary shown near the footer."""
+
+    parts = []
+    seen = set()
+    for value in (connection_status, activity_summary, query_summary, workflow_status):
+        part = (value or "").strip()
+        if not part or part in seen:
+            continue
+        parts.append(part)
+        seen.add(part)
+
+    if not parts:
+        return "Ready"
+    return " · ".join(parts)


### PR DESCRIPTION
Closes #612.

## Summary
- add a consolidated footer summary label to the dock
- derive the summary from existing connection, activity, query, and workflow status labels
- add focused tests for summary text shaping

## Tests
- `python3 -m pytest tests/test_dock_summary_status.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
