### PR TITLE
ux: move distance units into spinbox suffixes

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -587,7 +587,7 @@
               <item row="4" column="0">
                <widget class="QLabel" name="distanceLabel">
                 <property name="text">
-                 <string>Min distance (km)</string>
+                 <string>Min distance</string>
                 </property>
                </widget>
               </item>
@@ -595,6 +595,9 @@
                <widget class="QDoubleSpinBox" name="minDistanceSpinBox">
                 <property name="decimals">
                  <number>1</number>
+                </property>
+                <property name="suffix">
+                 <string> km</string>
                 </property>
                 <property name="maximum">
                  <double>1000.000000000000000</double>
@@ -604,7 +607,7 @@
               <item row="5" column="0">
                <widget class="QLabel" name="maxDistanceLabel">
                 <property name="text">
-                 <string>Max distance (km)</string>
+                 <string>Max distance</string>
                 </property>
                </widget>
               </item>
@@ -612,6 +615,9 @@
                <widget class="QDoubleSpinBox" name="maxDistanceSpinBox">
                 <property name="decimals">
                  <number>1</number>
+                </property>
+                <property name="suffix">
+                 <string> km</string>
                 </property>
                 <property name="maximum">
                  <double>1000.000000000000000</double>

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -1,0 +1,47 @@
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from tests import _path  # noqa: F401
+
+
+UI_PATH = Path(__file__).resolve().parents[1] / "qfit_dockwidget_base.ui"
+
+
+def _widget(root: ET.Element, name: str) -> ET.Element:
+    for widget in root.iter("widget"):
+        if widget.get("name") == name:
+            return widget
+    raise AssertionError(f"widget {name!r} not found")
+
+
+def _property_text(widget: ET.Element, property_name: str) -> str:
+    for prop in widget.findall("property"):
+        if prop.get("name") == property_name:
+            string = prop.find("string")
+            return string.text if string is not None and string.text is not None else ""
+    raise AssertionError(f"property {property_name!r} not found on {widget.get('name')!r}")
+
+
+class DockUiDistanceUnitTests(unittest.TestCase):
+    def setUp(self):
+        self.root = ET.parse(UI_PATH).getroot()
+
+    def test_distance_labels_keep_units_in_spinbox_suffixes(self):
+        self.assertEqual(_property_text(_widget(self.root, "distanceLabel"), "text"), "Min distance")
+        self.assertEqual(
+            _property_text(_widget(self.root, "maxDistanceLabel"), "text"),
+            "Max distance",
+        )
+        self.assertEqual(
+            _property_text(_widget(self.root, "minDistanceSpinBox"), "suffix"),
+            " km",
+        )
+        self.assertEqual(
+            _property_text(_widget(self.root, "maxDistanceSpinBox"), "suffix"),
+            " km",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #608.\n\n## Summary\n- remove the distance unit from min/max distance labels\n- show the unit in the distance spin boxes via Qt suffixes\n- add a UI XML regression test for the label/suffix contract\n\n## Tests\n- python3 -m pytest tests/test_dock_ui_distance_units.py -q --tb=short\n- python3 -m pytest tests/ -x -q --tb=short\n- python3 scripts/package_plugin.py