### PR TITLE
ux: show max pages all option in spin box

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -226,14 +226,17 @@
                  <item row="1" column="0">
                   <widget class="QLabel" name="maxPagesLabel">
                    <property name="text">
-                    <string>Max pages (0 = all)</string>
+                    <string>Max pages</string>
                    </property>
                   </widget>
                  </item>
                  <item row="1" column="1">
                   <widget class="QSpinBox" name="maxPagesSpinBox">
                    <property name="toolTip">
-                    <string>Maximum number of pages to fetch from Strava. Set to 0 to fetch all available activities (recommended).</string>
+                    <string>Maximum number of pages to fetch from Strava. Use All to fetch every available activity (recommended).</string>
+                   </property>
+                   <property name="specialValueText">
+                    <string>All</string>
                    </property>
                    <property name="minimum">
                     <number>0</number>

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -23,7 +23,7 @@ def _property_text(widget: ET.Element, property_name: str) -> str:
     raise AssertionError(f"property {property_name!r} not found on {widget.get('name')!r}")
 
 
-class DockUiDistanceUnitTests(unittest.TestCase):
+class DockUiFieldGrammarTests(unittest.TestCase):
     def setUp(self):
         self.root = ET.parse(UI_PATH).getroot()
 
@@ -40,6 +40,13 @@ class DockUiDistanceUnitTests(unittest.TestCase):
         self.assertEqual(
             _property_text(_widget(self.root, "maxDistanceSpinBox"), "suffix"),
             " km",
+        )
+
+    def test_max_pages_all_hint_lives_on_spinbox(self):
+        self.assertEqual(_property_text(_widget(self.root, "maxPagesLabel"), "text"), "Max pages")
+        self.assertEqual(
+            _property_text(_widget(self.root, "maxPagesSpinBox"), "specialValueText"),
+            "All",
         )
 
 


### PR DESCRIPTION
Refs #608.\n\n## Summary\n- simplify the max pages label\n- use the spin box special value text to show value 0 as All\n- extend the UI XML regression test for the field grammar contract\n\n## Tests\n- python3 -m pytest tests/test_dock_ui_distance_units.py -q --tb=short\n- python3 -m pytest tests/ -x -q --tb=short\n- python3 scripts/package_plugin.py