### PR TITLE
ux: add contextual help for fetch paging controls

### DIFF
--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -258,6 +258,8 @@ class ContextualHelpTests(unittest.TestCase):
         for anchor_name in [
             "detailedRouteStrategyComboBox",
             "maxDetailedActivitiesSpinBox",
+            "perPageSpinBox",
+            "maxPagesSpinBox",
             "writeActivityPointsCheckBox",
             "pointSamplingStrideSpinBox",
             "backgroundPresetComboBox",
@@ -275,6 +277,11 @@ class ContextualHelpTests(unittest.TestCase):
         self.assertEqual(entries["maxDetailedActivitiesSpinBox"].label_text, "Max new detailed routes this run")
         self.assertTrue(entries["maxDetailedActivitiesSpinBox"].help_button)
         self.assertIn("downloads up to 25 new detailed routes", entries["maxDetailedActivitiesSpinBox"].helper_text)
+        self.assertEqual(entries["perPageSpinBox"].label_text, "Activities per page")
+        self.assertIn("fewer API requests", entries["perPageSpinBox"].tooltip)
+        self.assertEqual(entries["maxPagesSpinBox"].label_text, "Max pages")
+        self.assertTrue(entries["maxPagesSpinBox"].help_button)
+        self.assertIn("All is recommended", entries["maxPagesSpinBox"].helper_text)
         self.assertEqual(entries["pointSamplingStrideSpinBox"].label_text, "Keep every Nth point")
         self.assertEqual(entries["backgroundPresetComboBox"].label_text, "Basemap preset")
         self.assertEqual(entries["atlasTitleLineEdit"].label_text, "Atlas title")

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -58,6 +58,29 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
         help_button=True,
     ),
     HelpEntry(
+        anchor_name="perPageSpinBox",
+        label_name="perPageLabel",
+        label_text="Activities per page",
+        tooltip=(
+            "Number of activities qfit asks Strava for in each API page. Higher values usually finish large "
+            "syncs with fewer API requests."
+        ),
+    ),
+    HelpEntry(
+        anchor_name="maxPagesSpinBox",
+        label_name="maxPagesLabel",
+        label_text="Max pages",
+        tooltip=(
+            "Limits how many Strava result pages qfit fetches in this run. Use All for a full sync, or a small "
+            "number when testing credentials and paging behavior."
+        ),
+        helper_text=(
+            "All is recommended for normal syncs. Smaller limits are useful for quick checks because they stop "
+            "after that many Strava pages even when more activities exist."
+        ),
+        help_button=True,
+    ),
+    HelpEntry(
         anchor_name="backgroundMapCheckBox",
         target_text="Load a Mapbox basemap in QGIS",
         tooltip=(


### PR DESCRIPTION
Refs #608.\n\n## Summary\n- add tooltips for the advanced fetch paging controls\n- add helper copy and an inline help button for the max-pages control\n- extend contextual-help tests for the paging entries\n\n## Tests\n- python3 -m pytest tests/test_contextual_help.py -q --tb=short\n- python3 -m pytest tests/ -x -q --tb=short\n- python3 scripts/package_plugin.py