### PR TITLE
ux: clarify clear database action

### DIFF
--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -267,6 +267,7 @@ class ContextualHelpTests(unittest.TestCase):
             "atlasSubtitleLineEdit",
             "refreshButton",
             "loadButton",
+            "clearDatabaseButton",
             "applyFiltersButton",
             "buttonLayout",
         ]:
@@ -287,6 +288,8 @@ class ContextualHelpTests(unittest.TestCase):
         self.assertEqual(entries["atlasTitleLineEdit"].label_text, "Atlas title")
         self.assertEqual(entries["atlasSubtitleLineEdit"].label_text, "Atlas subtitle")
         self.assertEqual(entries["refreshButton"].target_text, "Fetch activities")
+        self.assertEqual(entries["clearDatabaseButton"].target_text, "Clear database…")
+        self.assertIn("after confirmation", entries["clearDatabaseButton"].tooltip)
         self.assertIn("Store activities", entries["buttonLayout"].helper_text)
 
     def test_contextual_help_binder_is_importable_without_instantiating_qgis_widgets(self):

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -198,6 +198,14 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
         ),
     ),
     HelpEntry(
+        anchor_name="clearDatabaseButton",
+        target_text="Clear database…",
+        tooltip=(
+            "Deletes qfit's stored activities and derived layers from the selected GeoPackage after confirmation. "
+            "Use this only when you want to rebuild the local qfit database from scratch."
+        ),
+    ),
+    HelpEntry(
         anchor_name="loadLayersButton",
         target_text="Load activity layers",
         tooltip=(


### PR DESCRIPTION
Refs #608.\n\n## Summary\n- route the clear-database button through contextual help\n- add an ellipsis to signal the confirmation step before destructive work\n- add a tooltip that explains the destructive scope\n\n## Tests\n- python3 -m pytest tests/test_contextual_help.py -q --tb=short\n- python3 -m pytest tests/ -x -q --tb=short\n- python3 scripts/package_plugin.py