### PR TITLE
ux: signal advanced fetch settings are optional

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -191,7 +191,10 @@
            <item>
             <widget class="QGroupBox" name="advancedFetchGroupBox">
              <property name="title">
-              <string>Advanced fetch settings</string>
+              <string>Advanced fetch settings (optional)</string>
+             </property>
+             <property name="toolTip">
+              <string>Optional limits for Strava paging and detailed-route downloads. Leave collapsed for the recommended full-sync defaults.</string>
              </property>
              <property name="checkable">
               <bool>true</bool>

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -49,6 +49,14 @@ class DockUiFieldGrammarTests(unittest.TestCase):
             "All",
         )
 
+    def test_advanced_fetch_group_signals_optional_defaults(self):
+        group_box = _widget(self.root, "advancedFetchGroupBox")
+        self.assertEqual(
+            _property_text(group_box, "title"),
+            "Advanced fetch settings (optional)",
+        )
+        self.assertIn("recommended full-sync defaults", _property_text(group_box, "toolTip"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs #608.

## Summary
- label the advanced fetch section as optional
- add a tooltip explaining the recommended collapsed/default path
- extend the UI XML regression test for the optional-section cue

## Tests
- `python3 -m pytest tests/test_dock_ui_distance_units.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
