### PR TITLE
ux: use sentence case for atlas labels

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -802,7 +802,7 @@
               <item row="0" column="0">
                <widget class="QLabel" name="atlasTitleLabel">
                 <property name="text">
-                 <string>Atlas Title</string>
+                 <string>Atlas title</string>
                 </property>
                </widget>
               </item>
@@ -816,7 +816,7 @@
               <item row="1" column="0">
                <widget class="QLabel" name="atlasSubtitleLabel">
                 <property name="text">
-                 <string>Atlas Subtitle</string>
+                 <string>Atlas subtitle</string>
                 </property>
                </widget>
               </item>

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -57,6 +57,13 @@ class DockUiFieldGrammarTests(unittest.TestCase):
         )
         self.assertIn("recommended full-sync defaults", _property_text(group_box, "toolTip"))
 
+    def test_atlas_labels_use_sentence_case(self):
+        self.assertEqual(_property_text(_widget(self.root, "atlasTitleLabel"), "text"), "Atlas title")
+        self.assertEqual(
+            _property_text(_widget(self.root, "atlasSubtitleLabel"), "text"),
+            "Atlas subtitle",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs #608.

## Summary
- change atlas title/subtitle labels to sentence case in the UI source
- extend the UI XML regression test for atlas label grammar

## Tests
- `python3 -m pytest tests/test_dock_ui_distance_units.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
