### PR TITLE
ux: use human-readable sampled points label

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -362,7 +362,7 @@
              <item row="0" column="0" colspan="2">
               <widget class="QCheckBox" name="writeActivityPointsCheckBox">
                <property name="text">
-                <string>Generate sampled activity_points for analysis</string>
+                <string>Generate sampled activity points for analysis</string>
                </property>
               </widget>
              </item>

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -283,6 +283,11 @@ class ContextualHelpTests(unittest.TestCase):
         self.assertEqual(entries["maxPagesSpinBox"].label_text, "Max pages")
         self.assertTrue(entries["maxPagesSpinBox"].help_button)
         self.assertIn("All is recommended", entries["maxPagesSpinBox"].helper_text)
+        self.assertEqual(
+            entries["writeActivityPointsCheckBox"].target_text,
+            "Write sampled activity points from detailed tracks",
+        )
+        self.assertIn("activity_points layer", entries["writeActivityPointsCheckBox"].helper_text)
         self.assertEqual(entries["pointSamplingStrideSpinBox"].label_text, "Keep every Nth point")
         self.assertEqual(entries["backgroundPresetComboBox"].label_text, "Basemap preset")
         self.assertEqual(entries["atlasTitleLineEdit"].label_text, "Atlas title")

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -64,6 +64,12 @@ class DockUiFieldGrammarTests(unittest.TestCase):
             "Atlas subtitle",
         )
 
+    def test_activity_points_checkbox_uses_human_readable_label(self):
+        self.assertEqual(
+            _property_text(_widget(self.root, "writeActivityPointsCheckBox"), "text"),
+            "Generate sampled activity points for analysis",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -130,14 +130,15 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
     ),
     HelpEntry(
         anchor_name="writeActivityPointsCheckBox",
-        target_text="Write sampled activity_points from detailed tracks",
+        target_text="Write sampled activity points from detailed tracks",
         tooltip=(
             "Creates an optional point layer along each detailed activity so you can style, analyze, or animate "
             "sampled stream data in QGIS."
         ),
         helper_text=(
-            "Best when detailed tracks are enabled. The point layer can include sampled distance, time, elevation, "
-            "speed, heart rate, cadence, power, temperature, and moving-state values when Strava provides them."
+            "Best when detailed tracks are enabled. qfit writes this data to the activity_points layer, which can "
+            "include sampled distance, time, elevation, speed, heart rate, cadence, power, temperature, and "
+            "moving-state values when Strava provides them."
         ),
     ),
     HelpEntry(


### PR DESCRIPTION
Refs #608.

## Summary
- replace the technical activity_points wording in the dock checkbox with a human-readable label
- keep the storage-layer name in contextual helper copy for users who need the detail
- extend UI/contextual-help tests for the label contract

## Tests
- `python3 -m pytest tests/test_dock_ui_distance_units.py tests/test_contextual_help.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
