### PR TITLE
ux: use sentence case for atlas PDF labels

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1205,7 +1205,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _set_atlas_export_running(self, running: bool) -> None:
         self.generateAtlasPdfButton.setText(
-            "Cancel export" if running else "Generate Atlas PDF"
+            "Cancel export" if running else "Generate atlas PDF"
         )
         self.loadButton.setEnabled(not running)
         self.loadLayersButton.setEnabled(not running)

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -843,7 +843,7 @@
            <item>
             <widget class="QGroupBox" name="atlasPdfGroupBox">
              <property name="title">
-              <string>Generate Atlas PDF</string>
+              <string>Generate atlas PDF</string>
              </property>
              <layout class="QVBoxLayout" name="atlasPdfGroupLayout">
               <item>
@@ -877,7 +877,7 @@
               <item>
                <widget class="QPushButton" name="generateAtlasPdfButton">
                 <property name="text">
-                 <string>Generate Atlas PDF</string>
+                 <string>Generate atlas PDF</string>
                 </property>
                </widget>
               </item>

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -70,6 +70,13 @@ class DockUiFieldGrammarTests(unittest.TestCase):
             "Generate sampled activity points for analysis",
         )
 
+    def test_atlas_pdf_labels_use_sentence_case(self):
+        self.assertEqual(_property_text(_widget(self.root, "atlasPdfGroupBox"), "title"), "Generate atlas PDF")
+        self.assertEqual(
+            _property_text(_widget(self.root, "generateAtlasPdfButton"), "text"),
+            "Generate atlas PDF",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1221,6 +1221,27 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._set_status.assert_called_once_with("Generating atlas PDF…")
         task_manager.addTask.assert_called_once_with("atlas-task")
 
+    def test_set_atlas_export_running_restores_sentence_case_button_label(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.generateAtlasPdfButton = _FakeButton("Generate atlas PDF")
+        dock.loadButton = _FakeButton("Store activities")
+        dock.loadLayersButton = _FakeButton("Load activity layers")
+        dock.refreshButton = _FakeButton("Fetch activities")
+
+        self.module.QfitDockWidget._set_atlas_export_running(dock, True)
+
+        self.assertEqual(dock.generateAtlasPdfButton.text(), "Cancel export")
+        self.assertFalse(dock.loadButton.isEnabled())
+        self.assertFalse(dock.loadLayersButton.isEnabled())
+        self.assertFalse(dock.refreshButton.isEnabled())
+
+        self.module.QfitDockWidget._set_atlas_export_running(dock, False)
+
+        self.assertEqual(dock.generateAtlasPdfButton.text(), "Generate atlas PDF")
+        self.assertTrue(dock.loadButton.isEnabled())
+        self.assertTrue(dock.loadLayersButton.isEnabled())
+        self.assertTrue(dock.refreshButton.isEnabled())
+
     def test_on_atlas_export_finished_clears_task_and_updates_status(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._atlas_export_task = object()


### PR DESCRIPTION
Refs #608.

## Summary
- change the atlas PDF group and button labels to sentence case
- extend the UI XML regression test for the atlas PDF label contract

## Tests
- `python3 -m pytest tests/test_dock_ui_distance_units.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
