### PR TITLE
ux: use plain language in atlas help

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -830,7 +830,7 @@
               <item row="2" column="0" colspan="2">
                <widget class="QLabel" name="publishHelpLabel">
                 <property name="text">
-                 <string>Set the cover title and optional subtitle for the exported atlas PDF. qfit keeps the atlas page layout defaults internal when building activity_atlas_pages.</string>
+                 <string>Set the cover title and optional subtitle for the exported atlas PDF. qfit keeps the generated atlas page layout defaults internal.</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>
@@ -849,7 +849,7 @@
               <item>
                <widget class="QLabel" name="atlasPdfHelpLabel">
                 <property name="text">
-                 <string>Export a per-activity PDF atlas using the loaded activity_atlas_pages layer. Each page shows the activity title, date, stats, and a map centred on the activity extent. Store activities first, then load activity layers.</string>
+                 <string>Export a per-activity PDF atlas using the loaded atlas pages layer. Each page shows the activity title, date, stats, and a map centred on the activity extent. Store activities first, then load activity layers.</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -77,6 +77,13 @@ class DockUiFieldGrammarTests(unittest.TestCase):
             "Generate atlas PDF",
         )
 
+    def test_atlas_help_uses_plain_language_layer_name(self):
+        publish_help = _property_text(_widget(self.root, "publishHelpLabel"), "text")
+        atlas_help = _property_text(_widget(self.root, "atlasPdfHelpLabel"), "text")
+        self.assertNotIn("activity_atlas_pages", publish_help)
+        self.assertNotIn("activity_atlas_pages", atlas_help)
+        self.assertIn("atlas pages layer", atlas_help)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs #608.

## Summary
- replace technical `activity_atlas_pages` wording in atlas help with plain-language copy
- keep the visible/help text focused on the user-facing atlas pages layer
- extend the UI XML regression test for atlas help wording

## Tests
- `python3 -m pytest tests/test_dock_ui_distance_units.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
