### PR TITLE
ux: clarify point sampling label

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -369,7 +369,7 @@
              <item row="1" column="0">
               <widget class="QLabel" name="pointSamplingStrideLabel">
                <property name="text">
-                <string>Point sampling stride</string>
+                <string>Keep every Nth point</string>
                </property>
               </widget>
              </item>

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -70,6 +70,12 @@ class DockUiFieldGrammarTests(unittest.TestCase):
             "Generate sampled activity points for analysis",
         )
 
+    def test_point_sampling_label_describes_user_visible_effect(self):
+        self.assertEqual(
+            _property_text(_widget(self.root, "pointSamplingStrideLabel"), "text"),
+            "Keep every Nth point",
+        )
+
     def test_atlas_pdf_labels_use_sentence_case(self):
         self.assertEqual(_property_text(_widget(self.root, "atlasPdfGroupBox"), "title"), "Generate atlas PDF")
         self.assertEqual(


### PR DESCRIPTION
Refs #608.

## Summary
- replace the technical point sampling stride label with the user-facing effect
- keep the runtime label and UI source aligned
- extend the UI XML regression test for the point sampling label

## Tests
- `python3 -m pytest tests/test_dock_ui_distance_units.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
