### PR TITLE
ux: shorten basemap checkbox label

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -446,7 +446,7 @@
               <item row="0" column="0" colspan="2">
                <widget class="QCheckBox" name="backgroundMapCheckBox">
                 <property name="text">
-                 <string>Load a Mapbox basemap in QGIS</string>
+                 <string>Enable Mapbox basemap</string>
                 </property>
                </widget>
               </item>

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -278,6 +278,7 @@ class ContextualHelpTests(unittest.TestCase):
         self.assertEqual(entries["maxDetailedActivitiesSpinBox"].label_text, "Max new detailed routes this run")
         self.assertTrue(entries["maxDetailedActivitiesSpinBox"].help_button)
         self.assertIn("downloads up to 25 new detailed routes", entries["maxDetailedActivitiesSpinBox"].helper_text)
+        self.assertEqual(entries["backgroundMapCheckBox"].target_text, "Enable Mapbox basemap")
         self.assertEqual(entries["perPageSpinBox"].label_text, "Activities per page")
         self.assertIn("fewer API requests", entries["perPageSpinBox"].tooltip)
         self.assertEqual(entries["maxPagesSpinBox"].label_text, "Max pages")

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -79,6 +79,9 @@ class DockUiFieldGrammarTests(unittest.TestCase):
     def test_apply_filters_button_uses_short_primary_action_label(self):
         self.assertEqual(_property_text(_widget(self.root, "applyFiltersButton"), "text"), "Apply filters")
 
+    def test_basemap_checkbox_uses_short_action_label(self):
+        self.assertEqual(_property_text(_widget(self.root, "backgroundMapCheckBox"), "text"), "Enable Mapbox basemap")
+
     def test_atlas_pdf_labels_use_sentence_case(self):
         self.assertEqual(_property_text(_widget(self.root, "atlasPdfGroupBox"), "title"), "Generate atlas PDF")
         self.assertEqual(

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -82,7 +82,7 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
     ),
     HelpEntry(
         anchor_name="backgroundMapCheckBox",
-        target_text="Load a Mapbox basemap in QGIS",
+        target_text="Enable Mapbox basemap",
         tooltip=(
             "Adds a background basemap underneath qfit layers. Use the separate load button when you want to add "
             "or refresh it explicitly."


### PR DESCRIPTION
Refs #608.

## Summary
- shorten the basemap checkbox label to `Enable Mapbox basemap`
- keep the detailed Mapbox/QGIS behavior in contextual help
- extend UI/contextual-help tests for the label contract

## Tests
- `python3 -m pytest tests/test_dock_ui_distance_units.py tests/test_contextual_help.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
