### PR TITLE
ux: shorten detailed route action labels

### DIFF
--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -184,7 +184,7 @@
            <item>
             <widget class="QPushButton" name="backfillMissingDetailedRoutesButton">
              <property name="text">
-              <string>Backfill missing detailed routes</string>
+              <string>Backfill routes</string>
              </property>
             </widget>
            </item>
@@ -255,7 +255,7 @@
                  <item row="2" column="0" colspan="2">
                  <widget class="QCheckBox" name="detailedStreamsCheckBox">
                   <property name="text">
-                    <string>Fetch detailed routes when available</string>
+                    <string>Fetch detailed routes</string>
                   </property>
                  </widget>
                  </item>

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -258,6 +258,7 @@ class ContextualHelpTests(unittest.TestCase):
         for anchor_name in [
             "detailedRouteStrategyComboBox",
             "maxDetailedActivitiesSpinBox",
+            "backfillMissingDetailedRoutesButton",
             "perPageSpinBox",
             "maxPagesSpinBox",
             "writeActivityPointsCheckBox",
@@ -273,6 +274,9 @@ class ContextualHelpTests(unittest.TestCase):
         ]:
             self.assertIn(anchor_name, entries)
 
+        self.assertEqual(entries["detailedStreamsCheckBox"].target_text, "Fetch detailed routes")
+        self.assertEqual(entries["backfillMissingDetailedRoutesButton"].target_text, "Backfill routes")
+        self.assertIn("still missing", entries["backfillMissingDetailedRoutesButton"].tooltip)
         self.assertEqual(entries["detailedRouteStrategyComboBox"].label_text, "Detailed route strategy")
         self.assertIn("Missing routes only", entries["detailedRouteStrategyComboBox"].helper_text)
         self.assertEqual(entries["maxDetailedActivitiesSpinBox"].label_text, "Max new detailed routes this run")

--- a/tests/test_dock_ui_distance_units.py
+++ b/tests/test_dock_ui_distance_units.py
@@ -82,6 +82,10 @@ class DockUiFieldGrammarTests(unittest.TestCase):
     def test_basemap_checkbox_uses_short_action_label(self):
         self.assertEqual(_property_text(_widget(self.root, "backgroundMapCheckBox"), "text"), "Enable Mapbox basemap")
 
+    def test_detailed_route_actions_use_short_labels(self):
+        self.assertEqual(_property_text(_widget(self.root, "detailedStreamsCheckBox"), "text"), "Fetch detailed routes")
+        self.assertEqual(_property_text(_widget(self.root, "backfillMissingDetailedRoutesButton"), "text"), "Backfill routes")
+
     def test_atlas_pdf_labels_use_sentence_case(self):
         self.assertEqual(_property_text(_widget(self.root, "atlasPdfGroupBox"), "title"), "Generate atlas PDF")
         self.assertEqual(

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -778,7 +778,7 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
-    def test_detailed_route_controls_use_missing_route_wording(self):
+    def test_detailed_route_controls_use_short_route_wording(self):
         dock = QfitDockWidget(self.iface)
         try:
             self.assertEqual(

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -783,11 +783,11 @@ class QgisSmokeTests(unittest.TestCase):
         try:
             self.assertEqual(
                 dock.detailedStreamsCheckBox.text(),
-                "Fetch detailed routes when available",
+                "Fetch detailed routes",
             )
             self.assertEqual(
                 dock.backfillMissingDetailedRoutesButton.text(),
-                "Backfill missing detailed routes",
+                "Backfill routes",
             )
             self.assertEqual(dock.detailedRouteStrategyLabel.text(), "Detailed route strategy")
             self.assertEqual(

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -18,7 +18,7 @@ class HelpEntry:
 DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
     HelpEntry(
         anchor_name="detailedStreamsCheckBox",
-        target_text="Fetch detailed routes when available",
+        target_text="Fetch detailed routes",
         tooltip=(
             "Downloads higher-fidelity Strava route data for some activities so qfit can write richer "
             "geometry, timestamps, sampled points, and publish/profile metadata."
@@ -26,6 +26,14 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
         helper_text=(
             "Turn this on when you want more than start/end points. qfit caches downloaded routes locally, "
             "and already detailed or cached routes do not consume the per-run download budget."
+        ),
+    ),
+    HelpEntry(
+        anchor_name="backfillMissingDetailedRoutesButton",
+        target_text="Backfill routes",
+        tooltip=(
+            "Downloads detailed Strava routes for stored activities that are still missing them, then rewrites the "
+            "GeoPackage with the enriched geometry and sampled points."
         ),
     ),
     HelpEntry(


### PR DESCRIPTION
Refs #608.

## Summary
- shorten detailed-route action labels to reduce dock text density
- keep the detailed behavior in contextual help and tooltips
- cover the UI, contextual-help, and QGIS smoke label contracts

## Tests
- `python3 -m pytest tests/test_dock_ui_distance_units.py tests/test_contextual_help.py tests/test_qgis_smoke.py::QgisSmokeTests::test_detailed_route_controls_use_missing_route_wording -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
