### PR TITLE
ux: pin dock status summary footer

### DIFF
--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -346,7 +346,9 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         dock.analysisWorkflowLayout = _FakeLayoutContainer([_FakeItem(widget=object())])
         dock.publishGroupLayout = _FakeLayoutContainer([_FakeItem(widget=object())])
         dock.verticalLayout = _FakeLayoutContainer()
+        dock.outerLayout = _FakeLayoutContainer()
         dock.outputGroupLayout = _FakeLayoutContainer()
+        dock.dockWidgetContents = _FakeWidget()
         dock.activitiesGroupBox = _FakeGroupBox()
         dock.styleGroupBox = _FakeGroupBox()
         dock.analysisWorkflowGroupBox = _FakeGroupBox()
@@ -365,6 +367,7 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         dock.mapboxAccessTokenLabel = _FakeWidget()
         dock.mapboxAccessTokenLineEdit = _FakeWidget()
         dock.loadLayersButton = _FakeWidget()
+        dock.summaryStatusLabel = _FakeWidget()
         return dock
 
     def test_configure_starting_sections_moves_widgets_and_installs_collapsibles(self):
@@ -435,6 +438,10 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertFalse(dock.credentialsGroupBox.visible)
         self.assertEqual(dock.outputGroupBox.parent(), dock.activitiesGroupBox)
         self.assertEqual(dock.loadLayersButton.parent(), dock.styleGroupBox)
+        self.assertEqual(dock.summaryStatusLabel.parent(), dock.dockWidgetContents)
+        self.assertIn(dock.summaryStatusLabel, dock.verticalLayout.removed_widgets)
+        self.assertIn(dock.summaryStatusLabel, dock.outerLayout.added_widgets)
+        self.assertTrue(dock._summary_status_footer_pinned)
         self.assertEqual(dock.outputGroupBox.visible, None)
         self.assertTrue(hasattr(dock, "activitiesSectionToggleButton"))
         self.assertTrue(hasattr(dock, "activitiesSectionContentWidget"))

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -30,6 +30,7 @@ class WorkflowSectionCoordinator:
         dock.outputGroupBox.setTitle("Store / database")
         dock.publishGroupBox.setCheckable(False)
         dock.publishSettingsWidget.setVisible(True)
+        self._pin_summary_status_footer()
         self.install_collapsible_section(
             dock.activitiesGroupBox,
             "activitiesGroupLayout",
@@ -62,6 +63,37 @@ class WorkflowSectionCoordinator:
         )
         dock.mapboxAccessTokenLabel.hide()
         dock.mapboxAccessTokenLineEdit.hide()
+
+    def _pin_summary_status_footer(self) -> None:
+        dock = self.dock_widget
+        if getattr(dock, "_summary_status_footer_pinned", False):
+            return
+
+        label = getattr(dock, "summaryStatusLabel", None)
+        outer_layout = getattr(dock, "outerLayout", None)
+        if label is None or outer_layout is None:
+            return
+
+        scroll_layout = getattr(dock, "verticalLayout", None)
+        if scroll_layout is not None and hasattr(scroll_layout, "removeWidget"):
+            scroll_layout.removeWidget(label)
+
+        parent = getattr(dock, "dockWidgetContents", None)
+        if parent is not None and hasattr(label, "setParent"):
+            label.setParent(parent)
+
+        if hasattr(label, "setMinimumHeight"):
+            label.setMinimumHeight(28)
+        if hasattr(label, "setStyleSheet"):
+            label.setStyleSheet(
+                "QLabel#summaryStatusLabel { "
+                "border-top: 1px solid palette(mid); "
+                "padding: 4px 8px; "
+                "}"
+            )
+
+        outer_layout.addWidget(label)
+        dock._summary_status_footer_pinned = True
 
     def install_collapsible_section(self, group_box, layout_attr: str, title: str, key: str) -> None:
         dock = self.dock_widget


### PR DESCRIPTION
## Summary

Pins the consolidated qfit status summary outside the scroll area so it behaves like a persistent dock footer while users move through the workflow sections.

## Changes

- Move `summaryStatusLabel` from the scroll content into the dock `outerLayout` during startup.
- Give the summary label a small footer height and top border for visual separation.
- Cover the runtime layout move in the workflow section coordinator tests.

## Testing

- `python3 -m pytest tests/test_dockwidget_dependencies.py::WorkflowSectionCoordinatorTests -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs ebelo/qfit#608
