### PR TITLE
ux: show status only in dock footer

### DIFF
--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -368,6 +368,8 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         dock.mapboxAccessTokenLineEdit = _FakeWidget()
         dock.loadLayersButton = _FakeWidget()
         dock.summaryStatusLabel = _FakeWidget()
+        dock.countLabel = _FakeWidget()
+        dock.statusLabel = _FakeWidget()
         return dock
 
     def test_configure_starting_sections_moves_widgets_and_installs_collapsibles(self):
@@ -442,6 +444,8 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertIn(dock.summaryStatusLabel, dock.verticalLayout.removed_widgets)
         self.assertIn(dock.summaryStatusLabel, dock.outerLayout.added_widgets)
         self.assertTrue(dock._summary_status_footer_pinned)
+        self.assertFalse(dock.countLabel.visible)
+        self.assertFalse(dock.statusLabel.visible)
         self.assertEqual(dock.outputGroupBox.visible, None)
         self.assertTrue(hasattr(dock, "activitiesSectionToggleButton"))
         self.assertTrue(hasattr(dock, "activitiesSectionContentWidget"))

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -31,6 +31,7 @@ class WorkflowSectionCoordinator:
         dock.publishGroupBox.setCheckable(False)
         dock.publishSettingsWidget.setVisible(True)
         self._pin_summary_status_footer()
+        self._hide_redundant_status_labels()
         self.install_collapsible_section(
             dock.activitiesGroupBox,
             "activitiesGroupLayout",
@@ -94,6 +95,12 @@ class WorkflowSectionCoordinator:
 
         outer_layout.addWidget(label)
         dock._summary_status_footer_pinned = True
+
+    def _hide_redundant_status_labels(self) -> None:
+        for name in ("countLabel", "statusLabel"):
+            label = getattr(self.dock_widget, name, None)
+            if label is not None and hasattr(label, "hide"):
+                label.hide()
 
     def install_collapsible_section(self, group_box, layout_attr: str, title: str, key: str) -> None:
         dock = self.dock_widget


### PR DESCRIPTION
## Summary

Keeps the consolidated footer as the single visible status surface by hiding the older scroll-area count and workflow status labels during dock startup.

## Changes

- Hide `countLabel` and `statusLabel` once the persistent footer is configured.
- Keep existing status updates intact so `summaryStatusLabel` continues to combine connection, count, query, and workflow status text.
- Cover the visibility rule in workflow section coordinator tests.

## Testing

- `python3 -m pytest tests/test_dockwidget_dependencies.py::WorkflowSectionCoordinatorTests -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs ebelo/qfit#608
