### PR TITLE
ux: move clear database into actions menu

### DIFF
--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -287,6 +287,9 @@ class _FakeWidget:
     def hide(self):
         self.visible = False
 
+    def click(self):
+        pass
+
     def setTitle(self, title):
         self.title = title
 
@@ -367,6 +370,7 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         dock.mapboxAccessTokenLabel = _FakeWidget()
         dock.mapboxAccessTokenLineEdit = _FakeWidget()
         dock.loadLayersButton = _FakeWidget()
+        dock.clearDatabaseButton = _FakeWidget()
         dock.summaryStatusLabel = _FakeWidget()
         dock.countLabel = _FakeWidget()
         dock.statusLabel = _FakeWidget()
@@ -376,8 +380,30 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
 
         class _FakeSignal:
-            def connect(self, _callback):
-                pass
+            def __init__(self):
+                self.callback = None
+
+            def connect(self, callback):
+                self.callback = callback
+
+        class _FakeAction:
+            def __init__(self, text):
+                self.text = text
+                self.tooltip = None
+                self.triggered = _FakeSignal()
+
+            def setToolTip(self, text):
+                self.tooltip = text
+
+        class _FakeMenu(_FakeWidget):
+            def __init__(self, parent=None):
+                super().__init__(parent)
+                self.actions = []
+
+            def addAction(self, text):
+                action = _FakeAction(text)
+                self.actions.append(action)
+                return action
 
         class _FakeToolButton(_FakeWidget):
             def __init__(self, _parent=None):
@@ -387,6 +413,8 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
                 self.checked = None
                 self.object_name = None
                 self.text = None
+                self.menu = None
+                self.popup_mode = None
 
             def setObjectName(self, name):
                 self.object_name = name
@@ -402,6 +430,12 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
 
             def setChecked(self, checked):
                 self.checked = checked
+
+            def setPopupMode(self, mode):
+                self.popup_mode = mode
+
+            def setMenu(self, menu):
+                self.menu = menu
 
             def setStyleSheet(self, _style):
                 pass
@@ -426,7 +460,10 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
             def addItem(self, item):
                 self.items.append(("item", item))
 
+        _FakeToolButton.InstantPopup = "instant-popup"
+
         qtwidgets = ModuleType("qgis.PyQt.QtWidgets")
+        qtwidgets.QMenu = _FakeMenu
         qtwidgets.QToolButton = _FakeToolButton
         qtwidgets.QVBoxLayout = _FakeVBoxLayout
         qtwidgets.QWidget = _FakeWidget
@@ -440,6 +477,15 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertFalse(dock.credentialsGroupBox.visible)
         self.assertEqual(dock.outputGroupBox.parent(), dock.activitiesGroupBox)
         self.assertEqual(dock.loadLayersButton.parent(), dock.styleGroupBox)
+        self.assertFalse(dock.clearDatabaseButton.visible)
+        self.assertIn(dock.clearDatabaseButton, dock.outputGroupLayout.removed_widgets)
+        self.assertIn(dock.databaseActionsButton, dock.outputGroupLayout.added_widgets)
+        self.assertEqual(dock.databaseActionsButton.text, "Database actions")
+        self.assertEqual(dock.databaseActionsMenu.actions[0].text, "Clear database…")
+        self.assertIs(
+            dock.databaseActionsMenu.actions[0].triggered.callback.__self__,
+            dock.clearDatabaseButton,
+        )
         self.assertEqual(dock.summaryStatusLabel.parent(), dock.dockWidgetContents)
         self.assertIn(dock.summaryStatusLabel, dock.verticalLayout.removed_widgets)
         self.assertIn(dock.summaryStatusLabel, dock.outerLayout.added_widgets)

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -27,6 +27,7 @@ class WorkflowSectionCoordinator:
         self._move_store_section_under_fetch()
         self._move_load_layers_to_visualize()
         self._move_temporal_controls_to_visualize()
+        self._move_clear_database_to_actions_menu()
         dock.outputGroupBox.setTitle("Store / database")
         dock.publishGroupBox.setCheckable(False)
         dock.publishSettingsWidget.setVisible(True)
@@ -101,6 +102,45 @@ class WorkflowSectionCoordinator:
             label = getattr(self.dock_widget, name, None)
             if label is not None and hasattr(label, "hide"):
                 label.hide()
+
+    def _move_clear_database_to_actions_menu(self) -> None:
+        dock = self.dock_widget
+        if hasattr(dock, "databaseActionsButton"):
+            return
+
+        clear_button = getattr(dock, "clearDatabaseButton", None)
+        output_layout = getattr(dock, "outputGroupLayout", None)
+        if clear_button is None or output_layout is None:
+            return
+
+        from qgis.PyQt.QtWidgets import QMenu, QToolButton
+
+        menu = QMenu(getattr(dock, "outputGroupBox", None))
+        if hasattr(menu, "setObjectName"):
+            menu.setObjectName("databaseActionsMenu")
+        clear_action = menu.addAction("Clear database…")
+        clear_action.setToolTip(
+            "Delete qfit's stored activities and derived layers after confirmation."
+        )
+        clear_action.triggered.connect(clear_button.click)
+
+        menu_button = QToolButton(getattr(dock, "outputGroupBox", None))
+        menu_button.setObjectName("databaseActionsButton")
+        menu_button.setText("Database actions")
+        menu_button.setToolTip(
+            "Less common database operations; destructive actions ask for confirmation."
+        )
+        menu_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        menu_button.setPopupMode(QToolButton.InstantPopup)
+        menu_button.setMenu(menu)
+
+        output_layout.removeWidget(clear_button)
+        clear_button.hide()
+        output_layout.addWidget(menu_button)
+
+        dock.databaseActionsMenu = menu
+        dock.databaseActionsButton = menu_button
+        dock.clearDatabaseAction = clear_action
 
     def install_collapsible_section(self, group_box, layout_attr: str, title: str, key: str) -> None:
         dock = self.dock_widget


### PR DESCRIPTION
## Summary

Moves the destructive Clear database action out of the main Store section flow and into a secondary Database actions menu.

## Changes

- Add a `Database actions` tool button menu during dock startup.
- Move the existing `clearDatabaseButton` behavior behind a `Clear database…` menu action, preserving the existing confirmation workflow.
- Cover the menu move in workflow section coordinator tests.

## Testing

- `python3 -m pytest tests/test_dockwidget_dependencies.py::WorkflowSectionCoordinatorTests -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs ebelo/qfit#608
