### PR TITLE
Improve dock field unit copy

### DIFF
--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -309,6 +309,15 @@ class _FakeLabel(_FakeWidget):
         self.text = text
 
 
+class _FakeSpinBox(_FakeWidget):
+    def __init__(self):
+        super().__init__()
+        self.suffix = None
+
+    def setSuffix(self, suffix):
+        self.suffix = suffix
+
+
 
 
 class _FakeGroupBox:
@@ -365,6 +374,14 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         dock.outputIntroLabel.text = "Pick where qfit should store the synced GeoPackage."
         dock.atlasPdfHelpLabel = _FakeLabel()
         dock.atlasPdfHelpLabel.text = "Export a per-activity PDF atlas using loaded activity_atlas_pages."
+        dock.perPageLabel = _FakeLabel()
+        dock.perPageSpinBox = _FakeSpinBox()
+        dock.maxPagesLabel = _FakeLabel()
+        dock.maxPagesSpinBox = _FakeSpinBox()
+        dock.maxDetailedActivitiesLabel = _FakeLabel()
+        dock.maxDetailedActivitiesSpinBox = _FakeSpinBox()
+        dock.pointSamplingStrideLabel = _FakeLabel()
+        dock.pointSamplingStrideSpinBox = _FakeSpinBox()
         dock.atlasPdfGroupBox = _FakeGroupBox()
         dock.generateAtlasPdfButton = _FakeWidget()
         dock.mapboxAccessTokenLabel = _FakeWidget()
@@ -504,6 +521,14 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertFalse(dock.atlasPdfHelpLabel.visible)
         self.assertEqual(dock.atlasPdfGroupBox.tooltip, dock.atlasPdfHelpLabel.text)
         self.assertEqual(dock.generateAtlasPdfButton.tooltip, dock.atlasPdfHelpLabel.text)
+        self.assertEqual(dock.perPageLabel.text, "Page size")
+        self.assertEqual(dock.perPageSpinBox.suffix, " activities")
+        self.assertEqual(dock.maxPagesLabel.text, "Pages to fetch")
+        self.assertEqual(dock.maxPagesSpinBox.suffix, " pages")
+        self.assertEqual(dock.maxDetailedActivitiesLabel.text, "Detailed route limit")
+        self.assertEqual(dock.maxDetailedActivitiesSpinBox.suffix, " routes")
+        self.assertEqual(dock.pointSamplingStrideLabel.text, "Point sampling stride")
+        self.assertEqual(dock.pointSamplingStrideSpinBox.suffix, " points")
         self.assertFalse(dock.mapboxAccessTokenLabel.visible)
         self.assertFalse(dock.mapboxAccessTokenLineEdit.visible)
 

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -318,8 +318,6 @@ class _FakeSpinBox(_FakeWidget):
         self.suffix = suffix
 
 
-
-
 class _FakeGroupBox:
     def __init__(self):
         self.parent_obj = None
@@ -521,6 +519,16 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertFalse(dock.atlasPdfHelpLabel.visible)
         self.assertEqual(dock.atlasPdfGroupBox.tooltip, dock.atlasPdfHelpLabel.text)
         self.assertEqual(dock.generateAtlasPdfButton.tooltip, dock.atlasPdfHelpLabel.text)
+        self.assertFalse(dock.mapboxAccessTokenLabel.visible)
+        self.assertFalse(dock.mapboxAccessTokenLineEdit.visible)
+
+    def test_configure_spinbox_unit_copy_moves_units_to_spinbox_suffixes(self):
+        import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
+
+        coordinator = workflow_section_coordinator.WorkflowSectionCoordinator(self._make_section_dock())
+        coordinator.configure_spinbox_unit_copy()
+        dock = coordinator.dock_widget
+
         self.assertEqual(dock.perPageLabel.text, "Page size")
         self.assertEqual(dock.perPageSpinBox.suffix, " activities")
         self.assertEqual(dock.maxPagesLabel.text, "Pages to fetch")
@@ -529,8 +537,6 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertEqual(dock.maxDetailedActivitiesSpinBox.suffix, " routes")
         self.assertEqual(dock.pointSamplingStrideLabel.text, "Point sampling stride")
         self.assertEqual(dock.pointSamplingStrideSpinBox.suffix, " points")
-        self.assertFalse(dock.mapboxAccessTokenLabel.visible)
-        self.assertFalse(dock.mapboxAccessTokenLineEdit.visible)
 
     def test_set_section_expanded_updates_toggle_arrow_and_content_visibility(self):
         import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
@@ -639,6 +645,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                     "configure_starting_sections",
                     "remove_stale_qfit_layers",
                     "apply_contextual_help",
+                    "configure_spinbox_unit_copy",
                     "configure_background_preset_options",
                     "configure_detailed_route_filter_options",
                     "configure_detailed_route_strategy_options",
@@ -678,6 +685,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
             workflow_section_coordinator.mock_calls,
             [
                 call.configure_starting_sections(),
+                call.configure_spinbox_unit_copy(),
                 call.configure_workflow_sections(),
             ],
         )

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -34,6 +34,9 @@ class DockStartupCoordinator:
         dock._apply_contextual_help()
         performed_steps.append("apply_contextual_help")
 
+        self.workflow_section_coordinator.configure_spinbox_unit_copy()
+        performed_steps.append("configure_spinbox_unit_copy")
+
         dock._configure_background_preset_options()
         performed_steps.append("configure_background_preset_options")
 

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -24,7 +24,6 @@ class WorkflowSectionCoordinator:
             "Fetch your activities from Strava using the credentials saved in qfit → Configuration. "
             "Store or clear the local GeoPackage here too. Filters are applied later in the Visualize step — no re-fetch needed."
         )
-        self._configure_spinbox_unit_copy()
         self._move_store_section_under_fetch()
         self._move_load_layers_to_visualize()
         self._move_temporal_controls_to_visualize()
@@ -104,7 +103,7 @@ class WorkflowSectionCoordinator:
             if label is not None and hasattr(label, "hide"):
                 label.hide()
 
-    def _configure_spinbox_unit_copy(self) -> None:
+    def configure_spinbox_unit_copy(self) -> None:
         """Keep units in spin boxes instead of repeating them in form labels."""
 
         for label_name, label_text, spinbox_name, suffix in (

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -24,6 +24,7 @@ class WorkflowSectionCoordinator:
             "Fetch your activities from Strava using the credentials saved in qfit → Configuration. "
             "Store or clear the local GeoPackage here too. Filters are applied later in the Visualize step — no re-fetch needed."
         )
+        self._configure_spinbox_unit_copy()
         self._move_store_section_under_fetch()
         self._move_load_layers_to_visualize()
         self._move_temporal_controls_to_visualize()
@@ -102,6 +103,38 @@ class WorkflowSectionCoordinator:
             label = getattr(self.dock_widget, name, None)
             if label is not None and hasattr(label, "hide"):
                 label.hide()
+
+    def _configure_spinbox_unit_copy(self) -> None:
+        """Keep units in spin boxes instead of repeating them in form labels."""
+
+        for label_name, label_text, spinbox_name, suffix in (
+            ("perPageLabel", "Page size", "perPageSpinBox", " activities"),
+            ("maxPagesLabel", "Pages to fetch", "maxPagesSpinBox", " pages"),
+            (
+                "maxDetailedActivitiesLabel",
+                "Detailed route limit",
+                "maxDetailedActivitiesSpinBox",
+                " routes",
+            ),
+            (
+                "pointSamplingStrideLabel",
+                "Point sampling stride",
+                "pointSamplingStrideSpinBox",
+                " points",
+            ),
+        ):
+            self._set_label_text(label_name, label_text)
+            self._set_spinbox_suffix(spinbox_name, suffix)
+
+    def _set_label_text(self, name: str, text: str) -> None:
+        label = getattr(self.dock_widget, name, None)
+        if label is not None and hasattr(label, "setText"):
+            label.setText(text)
+
+    def _set_spinbox_suffix(self, name: str, suffix: str) -> None:
+        spinbox = getattr(self.dock_widget, name, None)
+        if spinbox is not None and hasattr(spinbox, "setSuffix"):
+            spinbox.setSuffix(suffix)
 
     def _move_clear_database_to_actions_menu(self) -> None:
         dock = self.dock_widget


### PR DESCRIPTION
## Summary

- Standardize several dock field labels so units/details live in the spin boxes instead of repeated label text.
- Apply suffixes for page size, pages to fetch, detailed-route limit, and point sampling stride during workflow-section setup.
- Cover the startup coordinator behavior with focused unit tests.

## Issue #609 compatibility

This is intentionally a small #608 UX slice that does not deepen the current monolithic dock layout. The copy/suffix behavior is attached to the existing widget object names and can carry forward into the wizard-style dock direction from #609 or be moved cleanly into future wizard page setup.

## Tests

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608.
