### PR TITLE
ui: share dock workflow section metadata

### DIFF
--- a/tests/test_dock_workflow_sections.py
+++ b/tests/test_dock_workflow_sections.py
@@ -1,0 +1,41 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.dock_workflow_sections import (
+    CURRENT_DOCK_SECTIONS,
+    WIZARD_WORKFLOW_STEPS,
+    build_current_dock_workflow_label,
+    get_workflow_section,
+)
+
+
+class DockWorkflowSectionsTests(unittest.TestCase):
+    def test_wizard_steps_keep_stable_order_and_labels(self):
+        self.assertEqual(
+            [section.key for section in WIZARD_WORKFLOW_STEPS],
+            ["connection", "sync", "map", "analysis", "atlas"],
+        )
+        self.assertEqual(
+            [section.title for section in WIZARD_WORKFLOW_STEPS],
+            ["Connection", "Synchronization", "Map & filters", "Spatial analysis", "Atlas PDF"],
+        )
+
+    def test_current_dock_sections_reuse_wizard_steps_without_connection_page(self):
+        self.assertEqual(
+            [section.key for section in CURRENT_DOCK_SECTIONS],
+            ["sync", "map", "analysis", "atlas"],
+        )
+        self.assertEqual(
+            build_current_dock_workflow_label(),
+            "Sections: Fetch & store · Visualize · Analyze · Publish",
+        )
+        self.assertEqual(get_workflow_section("sync").current_dock_title, "Fetch and store")
+
+    def test_get_workflow_section_rejects_unknown_keys(self):
+        with self.assertRaises(KeyError):
+            get_workflow_section("unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -27,6 +27,13 @@ from .dock_runtime_state import (
     DockRuntimeTasks,
 )
 from .dock_summary_status import build_dock_summary_status
+from .dock_workflow_sections import (
+    CURRENT_DOCK_SECTIONS,
+    WIZARD_WORKFLOW_STEPS,
+    DockWorkflowSection,
+    build_current_dock_workflow_label,
+    get_workflow_section,
+)
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -53,10 +60,14 @@ __all__ = [
     "DockRuntimeTasks",
     "DockVisualWorkflowCoordinator",
     "DockVisualWorkflowRequest",
+    "DockWorkflowSection",
+    "CURRENT_DOCK_SECTIONS",
+    "WIZARD_WORKFLOW_STEPS",
     "RunAnalysisAction",
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",
     "VisualWorkflowSettingsSnapshot",
+    "build_current_dock_workflow_label",
     "build_dock_summary_status",
     "build_visual_layer_refs",
     "build_visual_workflow_action",
@@ -64,4 +75,5 @@ __all__ = [
     "build_visual_workflow_background_inputs",
     "build_visual_workflow_selection_state_handoff",
     "build_visual_workflow_settings_snapshot",
+    "get_workflow_section",
 ]

--- a/ui/application/dock_workflow_sections.py
+++ b/ui/application/dock_workflow_sections.py
@@ -47,7 +47,7 @@ WIZARD_WORKFLOW_STEPS: tuple[DockWorkflowSection, ...] = (
     ),
 )
 
-CURRENT_DOCK_SECTION_KEYS: tuple[str, ...] = ("sync", "map", "analysis", "atlas")
+CURRENT_DOCK_SECTION_KEYS: frozenset[str] = frozenset({"sync", "map", "analysis", "atlas"})
 CURRENT_DOCK_SECTIONS: tuple[DockWorkflowSection, ...] = tuple(
     section for section in WIZARD_WORKFLOW_STEPS if section.key in CURRENT_DOCK_SECTION_KEYS
 )

--- a/ui/application/dock_workflow_sections.py
+++ b/ui/application/dock_workflow_sections.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DockWorkflowSection:
+    """UI-neutral workflow section metadata shared by dock layouts."""
+
+    key: str
+    title: str
+    current_dock_title: str
+    current_dock_overview_title: str | None = None
+
+    @property
+    def overview_title(self) -> str:
+        return self.current_dock_overview_title or self.current_dock_title
+
+
+WIZARD_WORKFLOW_STEPS: tuple[DockWorkflowSection, ...] = (
+    DockWorkflowSection(
+        key="connection",
+        title="Connection",
+        current_dock_title="Strava connection",
+    ),
+    DockWorkflowSection(
+        key="sync",
+        title="Synchronization",
+        current_dock_title="Fetch and store",
+        current_dock_overview_title="Fetch & store",
+    ),
+    DockWorkflowSection(
+        key="map",
+        title="Map & filters",
+        current_dock_title="Visualize",
+    ),
+    DockWorkflowSection(
+        key="analysis",
+        title="Spatial analysis",
+        current_dock_title="Analyze",
+    ),
+    DockWorkflowSection(
+        key="atlas",
+        title="Atlas PDF",
+        current_dock_title="Publish / atlas",
+        current_dock_overview_title="Publish",
+    ),
+)
+
+CURRENT_DOCK_SECTION_KEYS: tuple[str, ...] = ("sync", "map", "analysis", "atlas")
+CURRENT_DOCK_SECTIONS: tuple[DockWorkflowSection, ...] = tuple(
+    section for section in WIZARD_WORKFLOW_STEPS if section.key in CURRENT_DOCK_SECTION_KEYS
+)
+
+
+def build_current_dock_workflow_label() -> str:
+    """Return the compact workflow overview label for the current dock shell."""
+
+    titles = " · ".join(section.overview_title for section in CURRENT_DOCK_SECTIONS)
+    return f"Sections: {titles}"
+
+
+def get_workflow_section(key: str) -> DockWorkflowSection:
+    """Return a workflow section by stable key."""
+
+    for section in WIZARD_WORKFLOW_STEPS:
+        if section.key == key:
+            return section
+    raise KeyError(key)

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from qgis.PyQt.QtCore import Qt
 
 from ..mapbox_config import preset_requires_custom_style
+from .application.dock_workflow_sections import (
+    CURRENT_DOCK_SECTIONS,
+    build_current_dock_workflow_label,
+)
 
 
 class WorkflowSectionCoordinator:
@@ -17,7 +21,7 @@ class WorkflowSectionCoordinator:
 
     def configure_starting_sections(self) -> None:
         dock = self.dock_widget
-        dock.workflowLabel.setText("Sections: Fetch & store · Visualize · Analyze · Publish")
+        dock.workflowLabel.setText(build_current_dock_workflow_label())
         dock.credentialsGroupBox.hide()
         dock.activitiesGroupBox.setTitle("")
         dock.activitiesIntroLabel.setText(
@@ -33,25 +37,20 @@ class WorkflowSectionCoordinator:
         dock.publishSettingsWidget.setVisible(True)
         self._pin_summary_status_footer()
         self._hide_redundant_status_labels()
-        self.install_collapsible_section(
-            dock.activitiesGroupBox,
-            "activitiesGroupLayout",
-            "Fetch and store",
-            "activities",
-        )
-        self.install_collapsible_section(dock.styleGroupBox, "styleGroupLayout", "Visualize", "style")
-        self.install_collapsible_section(
-            dock.analysisWorkflowGroupBox,
-            "analysisWorkflowLayout",
-            "Analyze",
-            "analysis",
-        )
-        self.install_collapsible_section(
-            dock.publishGroupBox,
-            "publishGroupLayout",
-            "Publish / atlas",
-            "publish",
-        )
+        section_widgets = {
+            "sync": (dock.activitiesGroupBox, "activitiesGroupLayout", "activities"),
+            "map": (dock.styleGroupBox, "styleGroupLayout", "style"),
+            "analysis": (dock.analysisWorkflowGroupBox, "analysisWorkflowLayout", "analysis"),
+            "atlas": (dock.publishGroupBox, "publishGroupLayout", "publish"),
+        }
+        for section in CURRENT_DOCK_SECTIONS:
+            group_box, layout_attr, toggle_key = section_widgets[section.key]
+            self.install_collapsible_section(
+                group_box,
+                layout_attr,
+                section.current_dock_title,
+                toggle_key,
+            )
         self._move_help_label_to_tooltip(
             dock.activitiesIntroLabel,
             getattr(dock, "activitiesSectionToggleButton", None),

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -43,6 +43,10 @@ class WorkflowSectionCoordinator:
             "analysis": (dock.analysisWorkflowGroupBox, "analysisWorkflowLayout", "analysis"),
             "atlas": (dock.publishGroupBox, "publishGroupLayout", "publish"),
         }
+        section_keys = {section.key for section in CURRENT_DOCK_SECTIONS}
+        if set(section_widgets) != section_keys:
+            raise RuntimeError("Current dock workflow bindings must match shared section metadata")
+
         for section in CURRENT_DOCK_SECTIONS:
             group_box, layout_attr, toggle_key = section_widgets[section.key]
             self.install_collapsible_section(


### PR DESCRIPTION
## Summary

Introduce shared dock workflow-section metadata that keeps the current dock labels aligned with the upcoming wizard-style flow from #609 without changing the dock shell yet.

## Changes

- Added `DockWorkflowSection` metadata for the five wizard steps: connection, sync, map, analysis, and atlas.
- Reused the shared metadata when configuring the current collapsible dock sections and workflow overview label.
- Exported the metadata helpers from `qfit.ui.application` for future wizard pages.
- Added unit coverage for wizard-step order, current-dock section projection, and unknown-key handling.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Related to #608 and #609.
