### PR TITLE
ui: add range slider compatibility helper

### DIFF
--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -10,10 +10,40 @@ from qgis.PyQt.QtCore import Qt
 from qfit.ui.widgets.compat import make_range_slider
 
 
+class _FakeSignal:
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+        return slot
+
+    def emit(self, *args):
+        for slot in list(self._slots):
+            slot(*args)
+
+
+class _FakeSignalDescriptor:
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, instance, _owner):
+        if instance is None:
+            return self
+        return instance.base_signals[self.name]
+
+
 class _FakeIntegerRangeSlider:
+    rangeChanged = _FakeSignalDescriptor("rangeChanged")
+    rangeLimitsChanged = _FakeSignalDescriptor("rangeLimitsChanged")
+
     def __init__(self, orientation=Qt.Horizontal, parent=None):
         self.orientation = orientation
         self.parent = parent
+        self.base_signals = {
+            "rangeChanged": _FakeSignal(),
+            "rangeLimitsChanged": _FakeSignal(),
+        }
         self.limit_values = None
         self.selected_values = None
         self.lower_raw = None
@@ -23,6 +53,7 @@ class _FakeIntegerRangeSlider:
         self.limit_values = (minimum, maximum)
         self.minimum_raw = minimum
         self.maximum_raw = maximum
+        self.base_signals["rangeLimitsChanged"].emit(minimum, maximum)
 
     def setMinimum(self, value):  # noqa: N802
         self.minimum_raw = value
@@ -40,6 +71,7 @@ class _FakeIntegerRangeSlider:
         self.selected_values = (lower, upper)
         self.lower_raw = lower
         self.upper_raw = upper
+        self.base_signals["rangeChanged"].emit(lower, upper)
 
     def setLowerValue(self, value):  # noqa: N802
         self.lower_raw = value
@@ -155,6 +187,23 @@ class UiWidgetCompatTests(unittest.TestCase):
             second_slider = make_range_slider(minimum=2.0, maximum=5.0, decimals=2)
 
         self.assertIs(type(first_slider), type(second_slider))
+
+    def test_fallback_signals_emit_logical_float_values(self):
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui()}):
+            slider = make_range_slider(minimum=1.0, maximum=2.5, decimals=2)
+
+        range_changes = []
+        range_limit_changes = []
+        slider.rangeChanged.connect(lambda lower, upper: range_changes.append((lower, upper)))
+        slider.rangeLimitsChanged.connect(
+            lambda minimum, maximum: range_limit_changes.append((minimum, maximum)),
+        )
+
+        slider.setRange(6.75, 20.5)
+        slider.setRangeLimits(1.25, 40.75)
+
+        self.assertEqual(range_changes, [(6.75, 20.5)])
+        self.assertEqual(range_limit_changes, [(1.25, 40.75)])
 
     def test_configures_parent_only_native_slider_api(self):
         parent = object()

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -1,0 +1,116 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+from qgis.PyQt.QtCore import Qt
+
+from qfit.ui.widgets.compat import make_range_slider
+
+
+class _FakeIntegerRangeSlider:
+    def __init__(self, orientation=Qt.Horizontal, parent=None):
+        self.orientation = orientation
+        self.parent = parent
+        self.limit_values = None
+        self.selected_values = None
+        self.lower_raw = None
+        self.upper_raw = None
+
+    def setRangeLimits(self, minimum, maximum):  # noqa: N802
+        self.limit_values = (minimum, maximum)
+        self.minimum_raw = minimum
+        self.maximum_raw = maximum
+
+    def setMinimum(self, value):  # noqa: N802
+        self.minimum_raw = value
+
+    def setMaximum(self, value):  # noqa: N802
+        self.maximum_raw = value
+
+    def minimum(self):
+        return self.minimum_raw
+
+    def maximum(self):
+        return self.maximum_raw
+
+    def setRange(self, lower, upper):  # noqa: N802
+        self.selected_values = (lower, upper)
+        self.lower_raw = lower
+        self.upper_raw = upper
+
+    def setLowerValue(self, value):  # noqa: N802
+        self.lower_raw = value
+
+    def setUpperValue(self, value):  # noqa: N802
+        self.upper_raw = value
+
+    def lowerValue(self):  # noqa: N802
+        return self.lower_raw
+
+    def upperValue(self):  # noqa: N802
+        return self.upper_raw
+
+
+class _FakeDoubleRangeSlider(_FakeIntegerRangeSlider):
+    pass
+
+
+def _fake_qgis_gui(*, double_range_slider=None):
+    module = types.ModuleType("qgis.gui")
+    module.QgsRangeSlider = _FakeIntegerRangeSlider
+    if double_range_slider is not None:
+        module.QgsDoubleRangeSlider = double_range_slider
+    return module
+
+
+class UiWidgetCompatTests(unittest.TestCase):
+    def test_uses_native_double_range_slider_when_qgis_provides_it(self):
+        with patch.dict(
+            sys.modules,
+            {"qgis.gui": _fake_qgis_gui(double_range_slider=_FakeDoubleRangeSlider)},
+        ):
+            slider = make_range_slider(minimum=0.5, maximum=42.5, lower=5.5, upper=21.25)
+
+        self.assertIsInstance(slider, _FakeDoubleRangeSlider)
+        self.assertEqual(slider.limit_values, (0.5, 42.5))
+        self.assertEqual(slider.selected_values, (5.5, 21.25))
+
+    def test_scales_float_values_when_falling_back_to_integer_qgs_range_slider(self):
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui()}):
+            slider = make_range_slider(
+                minimum=0.0,
+                maximum=42.5,
+                lower=5.5,
+                upper=21.25,
+                decimals=2,
+            )
+
+        self.assertEqual(slider.limit_values, (0, 4250))
+        self.assertEqual(slider.selected_values, (550, 2125))
+        self.assertEqual(slider.minimum(), 0.0)
+        self.assertEqual(slider.maximum(), 42.5)
+        self.assertEqual(slider.lowerValue(), 5.5)
+        self.assertEqual(slider.upperValue(), 21.25)
+
+        slider.setLowerValue(6.75)
+        slider.setUpperValue(20.5)
+
+        self.assertEqual(slider.lower_raw, 675)
+        self.assertEqual(slider.upper_raw, 2050)
+        self.assertEqual(slider.lowerValue(), 6.75)
+        self.assertEqual(slider.upperValue(), 20.5)
+
+    def test_defaults_selected_range_to_limits(self):
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui()}):
+            slider = make_range_slider(minimum=1.0, maximum=2.5, decimals=1)
+
+        self.assertEqual(slider.selected_values, (10, 25))
+        self.assertEqual(slider.lowerValue(), 1.0)
+        self.assertEqual(slider.upperValue(), 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -149,6 +149,13 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertEqual(slider.lowerValue(), 1.0)
         self.assertEqual(slider.upperValue(), 2.5)
 
+    def test_reuses_fallback_class_for_consistent_slider_types(self):
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui()}):
+            first_slider = make_range_slider(minimum=1.0, maximum=2.5, decimals=1)
+            second_slider = make_range_slider(minimum=2.0, maximum=5.0, decimals=2)
+
+        self.assertIs(type(first_slider), type(second_slider))
+
     def test_configures_parent_only_native_slider_api(self):
         parent = object()
         with patch.dict(

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -58,9 +58,43 @@ class _FakeDoubleRangeSlider(_FakeIntegerRangeSlider):
     pass
 
 
-def _fake_qgis_gui(*, double_range_slider=None):
+class _FakeParentOnlyDoubleRangeSlider:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.orientation = None
+        self.minimum_value = None
+        self.maximum_value = None
+        self.lower_value = None
+        self.upper_value = None
+
+    def setOrientation(self, orientation):  # noqa: N802
+        self.orientation = orientation
+
+    def setMinimum(self, value):  # noqa: N802
+        self.minimum_value = value
+
+    def setMaximum(self, value):  # noqa: N802
+        self.maximum_value = value
+
+    def setLowerValue(self, value):  # noqa: N802
+        self.lower_value = value
+
+    def setUpperValue(self, value):  # noqa: N802
+        self.upper_value = value
+
+
+class _FakeParentOnlyIntegerRangeSlider(_FakeIntegerRangeSlider):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.orientation_set_later = None
+
+    def setOrientation(self, orientation):  # noqa: N802
+        self.orientation_set_later = orientation
+
+
+def _fake_qgis_gui(*, double_range_slider=None, range_slider=_FakeIntegerRangeSlider):
     module = types.ModuleType("qgis.gui")
-    module.QgsRangeSlider = _FakeIntegerRangeSlider
+    module.QgsRangeSlider = range_slider
     if double_range_slider is not None:
         module.QgsDoubleRangeSlider = double_range_slider
     return module
@@ -95,9 +129,13 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertEqual(slider.lowerValue(), 5.5)
         self.assertEqual(slider.upperValue(), 21.25)
 
+        slider.setMinimum(1.25)
+        slider.setMaximum(40.75)
         slider.setLowerValue(6.75)
         slider.setUpperValue(20.5)
 
+        self.assertEqual(slider.minimum_raw, 125)
+        self.assertEqual(slider.maximum_raw, 4075)
         self.assertEqual(slider.lower_raw, 675)
         self.assertEqual(slider.upper_raw, 2050)
         self.assertEqual(slider.lowerValue(), 6.75)
@@ -110,6 +148,49 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertEqual(slider.selected_values, (10, 25))
         self.assertEqual(slider.lowerValue(), 1.0)
         self.assertEqual(slider.upperValue(), 2.5)
+
+    def test_configures_parent_only_native_slider_api(self):
+        parent = object()
+        with patch.dict(
+            sys.modules,
+            {"qgis.gui": _fake_qgis_gui(double_range_slider=_FakeParentOnlyDoubleRangeSlider)},
+        ):
+            slider = make_range_slider(
+                minimum=1.5,
+                maximum=9.5,
+                lower=2.5,
+                upper=8.5,
+                orientation=Qt.Vertical,
+                parent=parent,
+            )
+
+        self.assertIs(slider.parent, parent)
+        self.assertEqual(slider.orientation, Qt.Vertical)
+        self.assertEqual(slider.minimum_value, 1.5)
+        self.assertEqual(slider.maximum_value, 9.5)
+        self.assertEqual(slider.lower_value, 2.5)
+        self.assertEqual(slider.upper_value, 8.5)
+
+    def test_configures_parent_only_fallback_slider_api(self):
+        parent = object()
+        with patch.dict(
+            sys.modules,
+            {"qgis.gui": _fake_qgis_gui(range_slider=_FakeParentOnlyIntegerRangeSlider)},
+        ):
+            slider = make_range_slider(
+                minimum=1.5,
+                maximum=9.5,
+                lower=2.5,
+                upper=8.5,
+                decimals=1,
+                orientation=Qt.Vertical,
+                parent=parent,
+            )
+
+        self.assertIs(slider.parent, parent)
+        self.assertEqual(slider.orientation_set_later, Qt.Vertical)
+        self.assertEqual(slider.limit_values, (15, 95))
+        self.assertEqual(slider.selected_values, (25, 85))
 
 
 if __name__ == "__main__":

--- a/ui/widgets/__init__.py
+++ b/ui/widgets/__init__.py
@@ -1,0 +1,3 @@
+from .compat import make_range_slider
+
+__all__ = ["make_range_slider"]

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -6,6 +6,25 @@ from importlib import import_module
 from qgis.PyQt.QtCore import Qt
 
 
+class _ScaledSignal:
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+        return slot
+
+    def disconnect(self, slot=None):
+        if slot is None:
+            self._slots.clear()
+            return
+        self._slots.remove(slot)
+
+    def emit(self, *args) -> None:
+        for slot in list(self._slots):
+            slot(*args)
+
+
 def make_range_slider(
     *,
     minimum: float,
@@ -70,6 +89,17 @@ def _configure_slider(slider, minimum, maximum, lower, upper) -> None:
         slider.setUpperValue(upper_value)
 
 
+def _bind_base_signal(signal_owner, signal_name: str, instance):
+    signal = getattr(signal_owner, signal_name, None)
+    if signal is None:
+        return None
+    if hasattr(signal, "__get__"):
+        signal = signal.__get__(instance, type(instance))
+    if not hasattr(signal, "connect"):
+        return None
+    return signal
+
+
 @lru_cache(maxsize=None)
 def _build_scaled_range_slider(range_slider_class):
     class ScaledRangeSlider(range_slider_class):
@@ -81,6 +111,37 @@ def _build_scaled_range_slider(range_slider_class):
                 super().__init__(parent)
                 if hasattr(self, "setOrientation"):
                     self.setOrientation(orientation)
+            self._wire_scaled_signals(range_slider_class)
+
+        def _wire_scaled_signals(self, range_slider_base_class) -> None:
+            base_range_changed = _bind_base_signal(
+                range_slider_base_class,
+                "rangeChanged",
+                self,
+            )
+            base_range_limits_changed = _bind_base_signal(
+                range_slider_base_class,
+                "rangeLimitsChanged",
+                self,
+            )
+            self.rangeChanged = _ScaledSignal()
+            self.rangeLimitsChanged = _ScaledSignal()
+            if base_range_changed is not None:
+                base_range_changed.connect(self._emit_scaled_range_changed)
+            if base_range_limits_changed is not None:
+                base_range_limits_changed.connect(self._emit_scaled_range_limits_changed)
+
+        def _emit_scaled_range_changed(self, lower: int, upper: int) -> None:
+            self.rangeChanged.emit(
+                self._from_slider_value(lower),
+                self._from_slider_value(upper),
+            )
+
+        def _emit_scaled_range_limits_changed(self, minimum: int, maximum: int) -> None:
+            self.rangeLimitsChanged.emit(
+                self._from_slider_value(minimum),
+                self._from_slider_value(maximum),
+            )
 
         def setRangeLimits(self, minimum: float, maximum: float) -> None:  # noqa: N802
             super().setRangeLimits(self._to_slider_value(minimum), self._to_slider_value(maximum))

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+from qgis.PyQt.QtCore import Qt
+
+
+def make_range_slider(
+    *,
+    minimum: float,
+    maximum: float,
+    lower: float | None = None,
+    upper: float | None = None,
+    decimals: int = 1,
+    orientation: Qt.Orientation = Qt.Horizontal,
+    parent=None,
+):
+    """Create a double range slider with a QGIS-version-safe fallback.
+
+    QGIS 3.38+ provides QgsDoubleRangeSlider. Earlier supported versions only
+    expose QgsRangeSlider, which stores integer values. The fallback scales
+    values internally while keeping a float-oriented API for wizard/page code.
+    """
+
+    gui = import_module("qgis.gui")
+
+    slider_class = getattr(gui, "QgsDoubleRangeSlider", None)
+    if slider_class is not None:
+        slider = _construct_slider(slider_class, orientation, parent)
+        _configure_slider(slider, minimum, maximum, lower, upper)
+        return slider
+
+    fallback_class = _build_scaled_range_slider(getattr(gui, "QgsRangeSlider"))
+    slider = fallback_class(orientation=orientation, parent=parent, decimals=decimals)
+    _configure_slider(slider, minimum, maximum, lower, upper)
+    return slider
+
+
+def _construct_slider(slider_class, orientation, parent):
+    try:
+        return slider_class(orientation, parent)
+    except TypeError:
+        slider = slider_class(parent)
+        if hasattr(slider, "setOrientation"):
+            slider.setOrientation(orientation)
+        return slider
+
+
+def _configure_slider(slider, minimum, maximum, lower, upper) -> None:
+    lower_value = minimum if lower is None else lower
+    upper_value = maximum if upper is None else upper
+
+    if hasattr(slider, "setRangeLimits"):
+        slider.setRangeLimits(minimum, maximum)
+    else:
+        slider.setMinimum(minimum)
+        slider.setMaximum(maximum)
+
+    if hasattr(slider, "setRange"):
+        slider.setRange(lower_value, upper_value)
+    else:
+        slider.setLowerValue(lower_value)
+        slider.setUpperValue(upper_value)
+
+
+def _build_scaled_range_slider(range_slider_class):
+    class ScaledRangeSlider(range_slider_class):
+        def __init__(self, orientation=Qt.Horizontal, parent=None, *, decimals: int = 1):
+            self._scale = 10 ** max(0, int(decimals))
+            try:
+                super().__init__(orientation, parent)
+            except TypeError:
+                super().__init__(parent)
+                if hasattr(self, "setOrientation"):
+                    self.setOrientation(orientation)
+
+        def setRangeLimits(self, minimum: float, maximum: float) -> None:  # noqa: N802
+            super().setRangeLimits(self._to_slider_value(minimum), self._to_slider_value(maximum))
+
+        def setMinimum(self, value: float) -> None:  # noqa: N802
+            super().setMinimum(self._to_slider_value(value))
+
+        def setMaximum(self, value: float) -> None:  # noqa: N802
+            super().setMaximum(self._to_slider_value(value))
+
+        def minimum(self) -> float:
+            return self._from_slider_value(super().minimum())
+
+        def maximum(self) -> float:
+            return self._from_slider_value(super().maximum())
+
+        def setRange(self, lower: float, upper: float) -> None:  # noqa: N802
+            super().setRange(self._to_slider_value(lower), self._to_slider_value(upper))
+
+        def setLowerValue(self, value: float) -> None:  # noqa: N802
+            super().setLowerValue(self._to_slider_value(value))
+
+        def setUpperValue(self, value: float) -> None:  # noqa: N802
+            super().setUpperValue(self._to_slider_value(value))
+
+        def lowerValue(self) -> float:  # noqa: N802
+            return self._from_slider_value(super().lowerValue())
+
+        def upperValue(self) -> float:  # noqa: N802
+            return self._from_slider_value(super().upperValue())
+
+        def _to_slider_value(self, value: float) -> int:
+            return int(round(float(value) * self._scale))
+
+        def _from_slider_value(self, value: int) -> float:
+            return float(value) / self._scale
+
+    return ScaledRangeSlider

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from importlib import import_module
 
 from qgis.PyQt.QtCore import Qt
@@ -19,10 +20,12 @@ def make_range_slider(
 
     QGIS 3.38+ provides QgsDoubleRangeSlider. Earlier supported versions only
     expose QgsRangeSlider, which stores integer values. The fallback scales
-    values internally while keeping a float-oriented API for wizard/page code.
+    values internally using ``decimals`` while keeping a float-oriented API for
+    wizard/page code.
     """
 
     gui = import_module("qgis.gui")
+    precision = _normalise_decimals(decimals)
 
     slider_class = getattr(gui, "QgsDoubleRangeSlider", None)
     if slider_class is not None:
@@ -31,9 +34,13 @@ def make_range_slider(
         return slider
 
     fallback_class = _build_scaled_range_slider(getattr(gui, "QgsRangeSlider"))
-    slider = fallback_class(orientation=orientation, parent=parent, decimals=decimals)
+    slider = fallback_class(orientation=orientation, parent=parent, decimals=precision)
     _configure_slider(slider, minimum, maximum, lower, upper)
     return slider
+
+
+def _normalise_decimals(decimals: int) -> int:
+    return max(0, int(decimals))
 
 
 def _construct_slider(slider_class, orientation, parent):
@@ -63,10 +70,11 @@ def _configure_slider(slider, minimum, maximum, lower, upper) -> None:
         slider.setUpperValue(upper_value)
 
 
+@lru_cache(maxsize=None)
 def _build_scaled_range_slider(range_slider_class):
     class ScaledRangeSlider(range_slider_class):
         def __init__(self, orientation=Qt.Horizontal, parent=None, *, decimals: int = 1):
-            self._scale = 10 ** max(0, int(decimals))
+            self._scale = 10 ** decimals
             try:
                 super().__init__(orientation, parent)
             except TypeError:

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -21,7 +21,7 @@ class _ScaledSignal:
         self._slots.remove(slot)
 
     def emit(self, *args) -> None:
-        for slot in list(self._slots):
+        for slot in self._slots:
             slot(*args)
 
 


### PR DESCRIPTION
## Summary

Add a wizard-neutral range-slider compatibility helper for qfit UI pages. The factory uses `QgsDoubleRangeSlider` when QGIS provides it and falls back to scaled `QgsRangeSlider` values on older supported QGIS versions.

## Changes

- Add `qfit.ui.widgets.make_range_slider` as the shared widget factory.
- Preserve a float-oriented lower/upper value API when falling back to integer-backed `QgsRangeSlider`.
- Cover native and fallback selection paths with unit tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
Refs #608.
