### PR TITLE
ui: add checkable list helper for wizard controls

### DIFF
--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -7,7 +7,7 @@ from tests import _path  # noqa: F401
 
 from qgis.PyQt.QtCore import Qt
 
-from qfit.ui.widgets.compat import make_range_slider
+from qfit.ui.widgets.compat import checked_list_values, make_checkable_list, make_range_slider
 
 
 class _FakeSignal:
@@ -124,6 +124,47 @@ class _FakeParentOnlyIntegerRangeSlider(_FakeIntegerRangeSlider):
         self.orientation_set_later = orientation
 
 
+class _FakeListWidget:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.items = []
+
+    def addItem(self, item):  # noqa: N802
+        self.items.append(item)
+
+    def count(self):
+        return len(self.items)
+
+    def item(self, index):
+        return self.items[index]
+
+
+class _FakeListWidgetItem:
+    def __init__(self, text):
+        self.text = text
+        self._flags = 0
+        self._check_state = None
+        self._data = {}
+
+    def flags(self):
+        return self._flags
+
+    def setFlags(self, flags):  # noqa: N802
+        self._flags = flags
+
+    def setCheckState(self, check_state):  # noqa: N802
+        self._check_state = check_state
+
+    def checkState(self):  # noqa: N802
+        return self._check_state
+
+    def setData(self, role, value):  # noqa: N802
+        self._data[role] = value
+
+    def data(self, role):
+        return self._data[role]
+
+
 def _fake_qgis_gui(*, double_range_slider=None, range_slider=_FakeIntegerRangeSlider):
     module = types.ModuleType("qgis.gui")
     module.QgsRangeSlider = range_slider
@@ -132,7 +173,40 @@ def _fake_qgis_gui(*, double_range_slider=None, range_slider=_FakeIntegerRangeSl
     return module
 
 
+def _fake_qt_widgets():
+    module = types.ModuleType("qgis.PyQt.QtWidgets")
+    module.QListWidget = _FakeListWidget
+    module.QListWidgetItem = _FakeListWidgetItem
+    return module
+
+
 class UiWidgetCompatTests(unittest.TestCase):
+    def test_creates_native_checkable_list_with_stable_values(self):
+        parent = object()
+        with patch.dict(sys.modules, {"qgis.PyQt.QtWidgets": _fake_qt_widgets()}):
+            list_widget = make_checkable_list(
+                [("run", "Run"), ("ride", "Ride"), ("hike", "Hike")],
+                checked_values=["ride", "hike"],
+                parent=parent,
+            )
+
+        self.assertIs(list_widget.parent, parent)
+        self.assertEqual([item.text for item in list_widget.items], ["Run", "Ride", "Hike"])
+        self.assertTrue(list_widget.items[0].flags() & Qt.ItemIsUserCheckable)
+        self.assertEqual(list_widget.items[0].data(Qt.UserRole), "run")
+        self.assertEqual(list_widget.items[0].checkState(), Qt.Unchecked)
+        self.assertEqual(list_widget.items[1].checkState(), Qt.Checked)
+        self.assertEqual(checked_list_values(list_widget), ["ride", "hike"])
+
+    def test_checkable_list_uses_string_options_as_labels_and_values(self):
+        with patch.dict(sys.modules, {"qgis.PyQt.QtWidgets": _fake_qt_widgets()}):
+            list_widget = make_checkable_list(["Run", "Ride"])
+
+        self.assertEqual([item.text for item in list_widget.items], ["Run", "Ride"])
+        self.assertEqual([item.data(Qt.UserRole) for item in list_widget.items], ["Run", "Ride"])
+        self.assertEqual([item.checkState() for item in list_widget.items], [Qt.Unchecked, Qt.Unchecked])
+        self.assertEqual(checked_list_values(list_widget), [])
+
     def test_uses_native_double_range_slider_when_qgis_provides_it(self):
         with patch.dict(
             sys.modules,

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -207,6 +207,11 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertEqual([item.checkState() for item in list_widget.items], [Qt.Unchecked, Qt.Unchecked])
         self.assertEqual(checked_list_values(list_widget), [])
 
+    def test_checkable_list_rejects_malformed_tuple_options(self):
+        with patch.dict(sys.modules, {"qgis.PyQt.QtWidgets": _fake_qt_widgets()}):
+            with self.assertRaisesRegex(ValueError, "Expected a \\(value, label\\) pair"):
+                make_checkable_list([("run", "Run", "extra")])
+
     def test_uses_native_double_range_slider_when_qgis_provides_it(self):
         with patch.dict(
             sys.modules,

--- a/ui/widgets/__init__.py
+++ b/ui/widgets/__init__.py
@@ -1,3 +1,3 @@
-from .compat import make_range_slider
+from .compat import checked_list_values, make_checkable_list, make_range_slider
 
-__all__ = ["make_range_slider"]
+__all__ = ["checked_list_values", "make_checkable_list", "make_range_slider"]

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import lru_cache
 from importlib import import_module
 
 from qgis.PyQt.QtCore import Qt
+
+CheckableListOption = str | tuple[str, str]
 
 
 class _ScaledSignal:
@@ -23,6 +26,52 @@ class _ScaledSignal:
     def emit(self, *args) -> None:
         for slot in self._slots:
             slot(*args)
+
+
+def make_checkable_list(
+    options: Sequence[CheckableListOption],
+    *,
+    checked_values: Sequence[str] | None = None,
+    parent=None,
+):
+    """Create a native Qt checkable list for multi-select wizard controls.
+
+    QGIS does not provide ``QgsCheckableComboBox``. The wizard should use a
+    ``QListWidget`` with ``Qt.ItemIsUserCheckable`` items instead; this helper
+    keeps that construction consistent and stores stable option values in
+    ``Qt.UserRole`` for later request builders.
+    """
+
+    widgets = import_module("qgis.PyQt.QtWidgets")
+    checked = set(checked_values or ())
+    list_widget = widgets.QListWidget(parent)
+
+    for option in options:
+        value, label = _normalise_checkable_list_option(option)
+        item = widgets.QListWidgetItem(label)
+        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+        item.setData(Qt.UserRole, value)
+        item.setCheckState(Qt.Checked if value in checked else Qt.Unchecked)
+        list_widget.addItem(item)
+
+    return list_widget
+
+
+def checked_list_values(list_widget) -> list[str]:
+    """Return stable values for checked items in list order."""
+
+    values = []
+    for index in range(list_widget.count()):
+        item = list_widget.item(index)
+        if item.checkState() == Qt.Checked:
+            values.append(item.data(Qt.UserRole))
+    return values
+
+
+def _normalise_checkable_list_option(option: CheckableListOption) -> tuple[str, str]:
+    if isinstance(option, tuple):
+        return option
+    return option, option
 
 
 def make_range_slider(

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -70,6 +70,9 @@ def checked_list_values(list_widget) -> list[str]:
 
 def _normalise_checkable_list_option(option: CheckableListOption) -> tuple[str, str]:
     if isinstance(option, tuple):
+        if len(option) != 2:
+            msg = f"Expected a (value, label) pair, got {option!r}"
+            raise ValueError(msg)
         return option
     return option, option
 


### PR DESCRIPTION
## Summary

Adds a small wizard-neutral checkable-list helper for the corrected wizard spec's multi-select controls, using a native `QListWidget` with `Qt.ItemIsUserCheckable` items instead of relying on a non-existent QGIS checkable combo box.

## Changes

- Add `make_checkable_list()` to build checkable native Qt list widgets with stable values stored in `Qt.UserRole`.
- Add `checked_list_values()` to read checked values back in list order for future request/page builders.
- Cover the helper with focused tests using fake Qt widget classes.

## Testing

- `python3 -m pytest tests/test_ui_widget_compat.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609 and #608.
