### PR TITLE
ui: add file widget compatibility helper

### DIFF
--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -9,7 +9,9 @@ from qgis.PyQt.QtCore import Qt
 
 from qfit.ui.widgets.compat import (
     checked_list_values,
+    file_widget_path,
     make_checkable_list,
+    make_file_widget,
     make_password_line_edit,
     make_range_slider,
 )
@@ -138,8 +140,35 @@ class _FakePasswordLineEdit:
     def setText(self, text):  # noqa: N802
         self.text_value = text
 
+    def text(self):
+        return self.text_value
+
     def setPlaceholderText(self, text):  # noqa: N802
         self.placeholder_text = text
+
+
+class _FakeFileWidget:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.file_path = ""
+        self.dialog_title = ""
+        self.filter_text = ""
+        self.storage_mode = None
+
+    def setFilePath(self, file_path):  # noqa: N802
+        self.file_path = file_path
+
+    def filePath(self):  # noqa: N802
+        return self.file_path
+
+    def setDialogTitle(self, dialog_title):  # noqa: N802
+        self.dialog_title = dialog_title
+
+    def setFilter(self, filter_text):  # noqa: N802
+        self.filter_text = filter_text
+
+    def setStorageMode(self, storage_mode):  # noqa: N802
+        self.storage_mode = storage_mode
 
 
 class _FakeLineEdit(_FakePasswordLineEdit):
@@ -197,6 +226,7 @@ class _FakeListWidgetItem:
 def _fake_qgis_gui(
     *,
     double_range_slider=None,
+    file_widget=None,
     password_line_edit=None,
     range_slider=_FakeIntegerRangeSlider,
 ):
@@ -204,6 +234,8 @@ def _fake_qgis_gui(
     module.QgsRangeSlider = range_slider
     if double_range_slider is not None:
         module.QgsDoubleRangeSlider = double_range_slider
+    if file_widget is not None:
+        module.QgsFileWidget = file_widget
     if password_line_edit is not None:
         module.QgsPasswordLineEdit = password_line_edit
     return module
@@ -248,6 +280,61 @@ class UiWidgetCompatTests(unittest.TestCase):
         with patch.dict(sys.modules, {"qgis.PyQt.QtWidgets": _fake_qt_widgets()}):
             with self.assertRaisesRegex(ValueError, "Expected a \\(value, label\\) pair"):
                 make_checkable_list([("run", "Run", "extra")])
+
+    def test_uses_native_file_widget_when_qgis_provides_it(self):
+        parent = object()
+        storage_mode = object()
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui(file_widget=_FakeFileWidget)}):
+            widget = make_file_widget(
+                file_path="/tmp/activities.gpkg",
+                dialog_title="Select GeoPackage",
+                filter_text="GeoPackage (*.gpkg)",
+                storage_mode=storage_mode,
+                parent=parent,
+            )
+
+        self.assertIsInstance(widget, _FakeFileWidget)
+        self.assertIs(widget.parent, parent)
+        self.assertEqual(widget.file_path, "/tmp/activities.gpkg")
+        self.assertEqual(widget.dialog_title, "Select GeoPackage")
+        self.assertEqual(widget.filter_text, "GeoPackage (*.gpkg)")
+        self.assertIs(widget.storage_mode, storage_mode)
+        self.assertEqual(file_widget_path(widget), "/tmp/activities.gpkg")
+
+    def test_file_widget_falls_back_to_line_edit(self):
+        parent = object()
+        with patch.dict(
+            sys.modules,
+            {
+                "qgis.gui": _fake_qgis_gui(),
+                "qgis.PyQt.QtWidgets": _fake_qt_widgets(),
+            },
+        ):
+            widget = make_file_widget(
+                file_path="/tmp/export.pdf",
+                dialog_title="Export PDF",
+                parent=parent,
+            )
+
+        self.assertIsInstance(widget, _FakeLineEdit)
+        self.assertIs(widget.parent, parent)
+        self.assertEqual(widget.text_value, "/tmp/export.pdf")
+        self.assertEqual(widget.placeholder_text, "Export PDF")
+        self.assertEqual(file_widget_path(widget), "/tmp/export.pdf")
+
+    def test_file_widget_falls_back_when_qgis_gui_module_is_missing(self):
+        def import_module_side_effect(name):
+            if name == "qgis.gui":
+                raise ModuleNotFoundError(name=name)
+            if name == "qgis.PyQt.QtWidgets":
+                return _fake_qt_widgets()
+            raise AssertionError(name)
+
+        with patch("qfit.ui.widgets.compat.import_module", side_effect=import_module_side_effect):
+            widget = make_file_widget(file_path="/tmp/fallback.gpkg")
+
+        self.assertIsInstance(widget, _FakeLineEdit)
+        self.assertEqual(file_widget_path(widget), "/tmp/fallback.gpkg")
 
     def test_uses_native_password_line_edit_when_qgis_provides_it(self):
         parent = object()

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -68,6 +68,55 @@ def checked_list_values(list_widget) -> list[str]:
     return values
 
 
+def make_file_widget(
+    *,
+    file_path: str = "",
+    dialog_title: str = "",
+    filter_text: str = "",
+    storage_mode: object | None = None,
+    parent=None,
+):
+    """Create a file path selector that prefers the native QGIS widget.
+
+    The wizard spec uses ``QgsFileWidget`` for GeoPackage/PDF paths. Minimal
+    test environments may not expose it, so fall back to a plain ``QLineEdit``
+    while preserving a tiny construction API that wizard pages can share.
+    Pass a real ``QgsFileWidget.StorageMode`` enum value as ``storage_mode``;
+    string names are not converted.
+    """
+
+    gui = _import_optional_qgis_gui()
+    file_widget_class = getattr(gui, "QgsFileWidget", None) if gui is not None else None
+    if file_widget_class is not None:
+        widget = file_widget_class(parent)
+        _configure_native_file_widget(
+            widget,
+            file_path=file_path,
+            dialog_title=dialog_title,
+            filter_text=filter_text,
+            storage_mode=storage_mode,
+        )
+        return widget
+
+    widgets = import_module("qgis.PyQt.QtWidgets")
+    widget = widgets.QLineEdit(parent)
+    if file_path:
+        widget.setText(file_path)
+    if dialog_title:
+        widget.setPlaceholderText(dialog_title)
+    return widget
+
+
+def file_widget_path(widget) -> str:
+    """Return the selected path from a native or fallback file widget."""
+
+    if hasattr(widget, "filePath"):
+        return str(widget.filePath())
+    if hasattr(widget, "text"):
+        return str(widget.text())
+    return ""
+
+
 def make_password_line_edit(*, text: str = "", placeholder_text: str = "", parent=None):
     """Create a password field that prefers the native QGIS widget.
 
@@ -91,6 +140,33 @@ def make_password_line_edit(*, text: str = "", placeholder_text: str = "", paren
     if placeholder_text:
         widget.setPlaceholderText(placeholder_text)
     return widget
+
+
+def _import_optional_qgis_gui():
+    try:
+        return import_module("qgis.gui")
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"qgis", "qgis.gui"}:
+            raise
+        return None
+
+
+def _configure_native_file_widget(
+    widget,
+    *,
+    file_path: str,
+    dialog_title: str,
+    filter_text: str,
+    storage_mode: object | None,
+) -> None:
+    if storage_mode is not None and hasattr(widget, "setStorageMode"):
+        widget.setStorageMode(storage_mode)
+    if filter_text and hasattr(widget, "setFilter"):
+        widget.setFilter(filter_text)
+    if dialog_title and hasattr(widget, "setDialogTitle"):
+        widget.setDialogTitle(dialog_title)
+    if file_path:
+        widget.setFilePath(file_path)
 
 
 def _normalise_checkable_list_option(option: CheckableListOption) -> tuple[str, str]:


### PR DESCRIPTION
## Summary

Adds a small wizard-neutral compatibility helper for native QGIS file path selectors. This gives future wizard pages a shared `QgsFileWidget` construction path, with a `QLineEdit` fallback for minimal test environments.

## Changes

- Add `make_file_widget()` for native `QgsFileWidget` creation with path, dialog title, filter, and storage mode configuration.
- Add `file_widget_path()` so request builders can read paths from native or fallback widgets consistently.
- Cover native and fallback behavior in the UI widget compatibility tests.

## Testing

- `python3 -m pytest tests/test_ui_widget_compat.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608.
Refs #609.
