### PR TITLE
ui: add datetime range edit helper

### DIFF
--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -9,8 +9,10 @@ from qgis.PyQt.QtCore import Qt
 
 from qfit.ui.widgets.compat import (
     checked_list_values,
+    datetime_range_values,
     file_widget_path,
     make_checkable_list,
+    make_datetime_range_edits,
     make_file_widget,
     make_password_line_edit,
     make_range_slider,
@@ -171,6 +173,26 @@ class _FakeFileWidget:
         self.storage_mode = storage_mode
 
 
+class _FakeDateTimeEdit:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.date_time = None
+        self.display_format = ""
+        self.calendar_popup = None
+
+    def setDateTime(self, value):  # noqa: N802
+        self.date_time = value
+
+    def dateTime(self):  # noqa: N802
+        return self.date_time
+
+    def setDisplayFormat(self, value):  # noqa: N802
+        self.display_format = value
+
+    def setCalendarPopup(self, value):  # noqa: N802
+        self.calendar_popup = value
+
+
 class _FakeLineEdit(_FakePasswordLineEdit):
     Password = 2
 
@@ -225,6 +247,7 @@ class _FakeListWidgetItem:
 
 def _fake_qgis_gui(
     *,
+    datetime_edit=None,
     double_range_slider=None,
     file_widget=None,
     password_line_edit=None,
@@ -232,6 +255,8 @@ def _fake_qgis_gui(
 ):
     module = types.ModuleType("qgis.gui")
     module.QgsRangeSlider = range_slider
+    if datetime_edit is not None:
+        module.QgsDateTimeEdit = datetime_edit
     if double_range_slider is not None:
         module.QgsDoubleRangeSlider = double_range_slider
     if file_widget is not None:
@@ -243,6 +268,7 @@ def _fake_qgis_gui(
 
 def _fake_qt_widgets():
     module = types.ModuleType("qgis.PyQt.QtWidgets")
+    module.QDateTimeEdit = _FakeDateTimeEdit
     module.QLineEdit = _FakeLineEdit
     module.QListWidget = _FakeListWidget
     module.QListWidgetItem = _FakeListWidgetItem
@@ -368,6 +394,46 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertIs(widget.parent, parent)
         self.assertEqual(widget.echo_mode, _FakeLineEdit.Password)
         self.assertEqual(widget.placeholder_text, "Client secret")
+
+    def test_uses_native_datetime_edits_for_range_filters(self):
+        parent = object()
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui(datetime_edit=_FakeDateTimeEdit)}):
+            edits = make_datetime_range_edits(
+                start_datetime="2026-04-01T08:00:00",
+                end_datetime="2026-04-30T18:30:00",
+                display_format="dd.MM.yyyy HH:mm",
+                calendar_popup=False,
+                parent=parent,
+            )
+
+        self.assertIsInstance(edits.start, _FakeDateTimeEdit)
+        self.assertIsInstance(edits.end, _FakeDateTimeEdit)
+        self.assertIs(edits.start.parent, parent)
+        self.assertEqual(edits.start.date_time, "2026-04-01T08:00:00")
+        self.assertEqual(edits.end.date_time, "2026-04-30T18:30:00")
+        self.assertEqual(edits.start.display_format, "dd.MM.yyyy HH:mm")
+        self.assertFalse(edits.start.calendar_popup)
+        self.assertEqual(
+            datetime_range_values(edits),
+            ("2026-04-01T08:00:00", "2026-04-30T18:30:00"),
+        )
+
+    def test_datetime_range_edits_fall_back_to_qt_widgets(self):
+        def import_module_side_effect(name):
+            if name == "qgis.gui":
+                raise ModuleNotFoundError(name=name)
+            if name == "qgis.PyQt.QtWidgets":
+                return _fake_qt_widgets()
+            raise AssertionError(name)
+
+        with patch("qfit.ui.widgets.compat.import_module", side_effect=import_module_side_effect):
+            edits = make_datetime_range_edits(start_datetime="start", end_datetime="end")
+
+        self.assertIsInstance(edits.start, _FakeDateTimeEdit)
+        self.assertEqual(edits.start.date_time, "start")
+        self.assertEqual(edits.end.date_time, "end")
+        self.assertEqual(edits.start.display_format, "yyyy-MM-dd HH:mm")
+        self.assertTrue(edits.start.calendar_popup)
 
     def test_uses_native_double_range_slider_when_qgis_provides_it(self):
         with patch.dict(

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -176,7 +176,7 @@ class _FakeFileWidget:
 class _FakeDateTimeEdit:
     def __init__(self, parent=None):
         self.parent = parent
-        self.date_time = None
+        self.date_time = "constructor-default"
         self.display_format = ""
         self.calendar_popup = None
 
@@ -409,10 +409,15 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertIsInstance(edits.start, _FakeDateTimeEdit)
         self.assertIsInstance(edits.end, _FakeDateTimeEdit)
         self.assertIs(edits.start.parent, parent)
+        self.assertIs(edits.end.parent, parent)
+        self.assertTrue(edits.start_enabled)
+        self.assertTrue(edits.end_enabled)
         self.assertEqual(edits.start.date_time, "2026-04-01T08:00:00")
         self.assertEqual(edits.end.date_time, "2026-04-30T18:30:00")
         self.assertEqual(edits.start.display_format, "dd.MM.yyyy HH:mm")
+        self.assertEqual(edits.end.display_format, "dd.MM.yyyy HH:mm")
         self.assertFalse(edits.start.calendar_popup)
+        self.assertFalse(edits.end.calendar_popup)
         self.assertEqual(
             datetime_range_values(edits),
             ("2026-04-01T08:00:00", "2026-04-30T18:30:00"),
@@ -434,6 +439,32 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertEqual(edits.end.date_time, "end")
         self.assertEqual(edits.start.display_format, "yyyy-MM-dd HH:mm")
         self.assertTrue(edits.start.calendar_popup)
+
+    def test_datetime_range_values_preserve_unset_bounds(self):
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui(datetime_edit=_FakeDateTimeEdit)}):
+            edits = make_datetime_range_edits(end_datetime="2026-04-30T18:30:00")
+
+        self.assertFalse(edits.start_enabled)
+        self.assertTrue(edits.end_enabled)
+        self.assertEqual(edits.start.date_time, "constructor-default")
+        self.assertEqual(
+            datetime_range_values(edits),
+            (None, "2026-04-30T18:30:00"),
+        )
+
+    def test_datetime_range_enabled_flags_override_initial_values(self):
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui(datetime_edit=_FakeDateTimeEdit)}):
+            edits = make_datetime_range_edits(
+                start_datetime="2026-04-01T08:00:00",
+                end_datetime="2026-04-30T18:30:00",
+                start_enabled=False,
+                end_enabled=True,
+            )
+
+        self.assertEqual(
+            datetime_range_values(edits),
+            (None, "2026-04-30T18:30:00"),
+        )
 
     def test_uses_native_double_range_slider_when_qgis_provides_it(self):
         with patch.dict(

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -179,9 +179,11 @@ class _FakeDateTimeEdit:
         self.date_time = "constructor-default"
         self.display_format = ""
         self.calendar_popup = None
+        self.dateTimeChanged = _FakeSignal()
 
     def setDateTime(self, value):  # noqa: N802
         self.date_time = value
+        self.dateTimeChanged.emit(value)
 
     def dateTime(self):  # noqa: N802
         return self.date_time
@@ -464,6 +466,27 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertEqual(
             datetime_range_values(edits),
             (None, "2026-04-30T18:30:00"),
+        )
+
+    def test_datetime_range_values_accept_read_time_enabled_flags(self):
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui(datetime_edit=_FakeDateTimeEdit)}):
+            edits = make_datetime_range_edits(start_datetime="2026-04-01T08:00:00")
+
+        self.assertEqual(
+            datetime_range_values(edits, start_enabled=False, end_enabled=True),
+            (None, "constructor-default"),
+        )
+
+    def test_datetime_range_edits_enable_bound_after_user_change(self):
+        with patch.dict(sys.modules, {"qgis.gui": _fake_qgis_gui(datetime_edit=_FakeDateTimeEdit)}):
+            edits = make_datetime_range_edits()
+
+        edits.start.setDateTime("2026-04-01T08:00:00")
+
+        self.assertTrue(edits.start_enabled)
+        self.assertEqual(
+            datetime_range_values(edits),
+            ("2026-04-01T08:00:00", None),
         )
 
     def test_uses_native_double_range_slider_when_qgis_provides_it(self):

--- a/ui/widgets/__init__.py
+++ b/ui/widgets/__init__.py
@@ -1,13 +1,23 @@
 from .compat import (
+    DateTimeRangeEdits,
     checked_list_values,
+    datetime_range_values,
+    file_widget_path,
     make_checkable_list,
+    make_datetime_range_edits,
+    make_file_widget,
     make_password_line_edit,
     make_range_slider,
 )
 
 __all__ = [
+    "DateTimeRangeEdits",
     "checked_list_values",
+    "datetime_range_values",
+    "file_widget_path",
     "make_checkable_list",
+    "make_datetime_range_edits",
+    "make_file_widget",
     "make_password_line_edit",
     "make_range_slider",
 ]

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -16,6 +16,8 @@ class DateTimeRangeEdits:
 
     start: object
     end: object
+    start_enabled: bool = False
+    end_enabled: bool = False
 
 
 class _ScaledSignal:
@@ -155,6 +157,8 @@ def make_datetime_range_edits(
     *,
     start_datetime=None,
     end_datetime=None,
+    start_enabled: bool | None = None,
+    end_enabled: bool | None = None,
     display_format: str = "yyyy-MM-dd HH:mm",
     calendar_popup: bool = True,
     parent=None,
@@ -186,13 +190,20 @@ def make_datetime_range_edits(
         display_format=display_format,
         calendar_popup=calendar_popup,
     )
-    return DateTimeRangeEdits(start=start, end=end)
+    return DateTimeRangeEdits(
+        start=start,
+        end=end,
+        start_enabled=_resolve_datetime_bound_enabled(start_datetime, start_enabled),
+        end_enabled=_resolve_datetime_bound_enabled(end_datetime, end_enabled),
+    )
 
 
 def datetime_range_values(range_edits: DateTimeRangeEdits) -> tuple[object | None, object | None]:
-    """Return the current start/end date-time values when supported."""
+    """Return active start/end date-time values, preserving unset bounds as ``None``."""
 
-    return (_datetime_edit_value(range_edits.start), _datetime_edit_value(range_edits.end))
+    start = _datetime_edit_value(range_edits.start) if range_edits.start_enabled else None
+    end = _datetime_edit_value(range_edits.end) if range_edits.end_enabled else None
+    return (start, end)
 
 
 def _import_optional_qgis_gui():
@@ -250,6 +261,12 @@ def _datetime_edit_value(widget):
     if hasattr(widget, "dateTime"):
         return widget.dateTime()
     return None
+
+
+def _resolve_datetime_bound_enabled(value, enabled: bool | None) -> bool:
+    if enabled is not None:
+        return enabled
+    return value is not None
 
 
 def make_range_slider(

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from functools import lru_cache
 from importlib import import_module
 
 from qgis.PyQt.QtCore import Qt
 
 CheckableListOption = str | tuple[str, str]
+
+
+@dataclass(frozen=True)
+class DateTimeRangeEdits:
+    """Pair of native date-time edits for start/end range selection."""
+
+    start: object
+    end: object
 
 
 class _ScaledSignal:
@@ -36,7 +45,7 @@ def make_checkable_list(
 ):
     """Create a native Qt checkable list for multi-select wizard controls.
 
-    QGIS does not provide ``QgsCheckableComboBox``. The wizard should use a
+    QGIS does not provide a native checkable combo box. The wizard should use a
     ``QListWidget`` with ``Qt.ItemIsUserCheckable`` items instead; this helper
     keeps that construction consistent and stores stable option values in
     ``Qt.UserRole`` for later request builders.
@@ -142,6 +151,50 @@ def make_password_line_edit(*, text: str = "", placeholder_text: str = "", paren
     return widget
 
 
+def make_datetime_range_edits(
+    *,
+    start_datetime=None,
+    end_datetime=None,
+    display_format: str = "yyyy-MM-dd HH:mm",
+    calendar_popup: bool = True,
+    parent=None,
+) -> DateTimeRangeEdits:
+    """Create paired date-time edits for wizard filter ranges.
+
+    The wizard spec uses two native QGIS date-time edits side by side. Minimal
+    test environments may not expose the QGIS widget, so fall back to Qt's
+    ``QDateTimeEdit`` while keeping one construction API for future pages.
+    """
+
+    gui = _import_optional_qgis_gui()
+    edit_class = getattr(gui, "QgsDateTimeEdit", None) if gui is not None else None
+    if edit_class is None:
+        widgets = import_module("qgis.PyQt.QtWidgets")
+        edit_class = widgets.QDateTimeEdit
+
+    start = edit_class(parent)
+    end = edit_class(parent)
+    _configure_datetime_edit(
+        start,
+        value=start_datetime,
+        display_format=display_format,
+        calendar_popup=calendar_popup,
+    )
+    _configure_datetime_edit(
+        end,
+        value=end_datetime,
+        display_format=display_format,
+        calendar_popup=calendar_popup,
+    )
+    return DateTimeRangeEdits(start=start, end=end)
+
+
+def datetime_range_values(range_edits: DateTimeRangeEdits) -> tuple[object | None, object | None]:
+    """Return the current start/end date-time values when supported."""
+
+    return (_datetime_edit_value(range_edits.start), _datetime_edit_value(range_edits.end))
+
+
 def _import_optional_qgis_gui():
     try:
         return import_module("qgis.gui")
@@ -176,6 +229,27 @@ def _normalise_checkable_list_option(option: CheckableListOption) -> tuple[str, 
             raise ValueError(msg)
         return option
     return option, option
+
+
+def _configure_datetime_edit(
+    widget,
+    *,
+    value,
+    display_format: str,
+    calendar_popup: bool,
+) -> None:
+    if value is not None and hasattr(widget, "setDateTime"):
+        widget.setDateTime(value)
+    if display_format and hasattr(widget, "setDisplayFormat"):
+        widget.setDisplayFormat(display_format)
+    if hasattr(widget, "setCalendarPopup"):
+        widget.setCalendarPopup(calendar_popup)
+
+
+def _datetime_edit_value(widget):
+    if hasattr(widget, "dateTime"):
+        return widget.dateTime()
+    return None
 
 
 def make_range_slider(

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -10,7 +10,7 @@ from qgis.PyQt.QtCore import Qt
 CheckableListOption = str | tuple[str, str]
 
 
-@dataclass(frozen=True)
+@dataclass
 class DateTimeRangeEdits:
     """Pair of native date-time edits for start/end range selection."""
 
@@ -190,19 +190,29 @@ def make_datetime_range_edits(
         display_format=display_format,
         calendar_popup=calendar_popup,
     )
-    return DateTimeRangeEdits(
+    range_edits = DateTimeRangeEdits(
         start=start,
         end=end,
         start_enabled=_resolve_datetime_bound_enabled(start_datetime, start_enabled),
         end_enabled=_resolve_datetime_bound_enabled(end_datetime, end_enabled),
     )
+    _bind_datetime_bound_activation(start, range_edits, "start_enabled")
+    _bind_datetime_bound_activation(end, range_edits, "end_enabled")
+    return range_edits
 
 
-def datetime_range_values(range_edits: DateTimeRangeEdits) -> tuple[object | None, object | None]:
+def datetime_range_values(
+    range_edits: DateTimeRangeEdits,
+    *,
+    start_enabled: bool | None = None,
+    end_enabled: bool | None = None,
+) -> tuple[object | None, object | None]:
     """Return active start/end date-time values, preserving unset bounds as ``None``."""
 
-    start = _datetime_edit_value(range_edits.start) if range_edits.start_enabled else None
-    end = _datetime_edit_value(range_edits.end) if range_edits.end_enabled else None
+    start_is_enabled = range_edits.start_enabled if start_enabled is None else start_enabled
+    end_is_enabled = range_edits.end_enabled if end_enabled is None else end_enabled
+    start = _datetime_edit_value(range_edits.start) if start_is_enabled else None
+    end = _datetime_edit_value(range_edits.end) if end_is_enabled else None
     return (start, end)
 
 
@@ -267,6 +277,13 @@ def _resolve_datetime_bound_enabled(value, enabled: bool | None) -> bool:
     if enabled is not None:
         return enabled
     return value is not None
+
+
+def _bind_datetime_bound_activation(widget, range_edits: DateTimeRangeEdits, field_name: str) -> None:
+    signal = getattr(widget, "dateTimeChanged", None)
+    if signal is None or not hasattr(signal, "connect"):
+        return
+    signal.connect(lambda *_args: setattr(range_edits, field_name, True))
 
 
 def make_range_slider(


### PR DESCRIPTION
## Summary

Adds a wizard-neutral date-time range edit compatibility helper so future wizard filter pages can use paired native QGIS date-time edits without depending on a non-portable range widget.

## Changes

- Added `DateTimeRangeEdits`, `make_datetime_range_edits`, and `datetime_range_values` to `qfit.ui.widgets.compat`.
- Prefer `QgsDateTimeEdit` when QGIS exposes it, with a `QDateTimeEdit` fallback for test/minimal environments.
- Exported the widget compatibility helpers through `qfit.ui.widgets`.
- Covered native and fallback construction paths in unit tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609 and #608.
