### PR TITLE
feat: add atlas export estimates

### DIFF
--- a/atlas/application/__init__.py
+++ b/atlas/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application helpers for atlas workflows."""

--- a/atlas/application/atlas_config.py
+++ b/atlas/application/atlas_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 PAGES_PER_MINUTE = 150
 KB_PER_PAGE = 28
 
@@ -7,14 +9,21 @@ KB_PER_PAGE = 28
 def estimate_time_min(page_count: int) -> int:
     """Return the estimated atlas export duration in whole minutes."""
 
-    return max(1, round(_normalise_page_count(page_count) / PAGES_PER_MINUTE))
+    return max(1, _round_half_up(_normalise_page_count(page_count) / PAGES_PER_MINUTE))
 
 
 def estimate_size_mb(page_count: int) -> float:
     """Return the estimated atlas PDF size in megabytes."""
 
-    return round(_normalise_page_count(page_count) * KB_PER_PAGE / 1024, 1)
+    page_count = _normalise_page_count(page_count)
+    if page_count == 0:
+        return 0.0
+    return max(0.1, round(page_count * KB_PER_PAGE / 1024, 1))
 
 
 def _normalise_page_count(page_count: int) -> int:
     return max(0, int(page_count))
+
+
+def _round_half_up(value: float) -> int:
+    return math.floor(value + 0.5)

--- a/atlas/application/atlas_config.py
+++ b/atlas/application/atlas_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+PAGES_PER_MINUTE = 150
+KB_PER_PAGE = 28
+
+
+def estimate_time_min(page_count: int) -> int:
+    """Return the estimated atlas export duration in whole minutes."""
+
+    return max(1, round(_normalise_page_count(page_count) / PAGES_PER_MINUTE))
+
+
+def estimate_size_mb(page_count: int) -> float:
+    """Return the estimated atlas PDF size in megabytes."""
+
+    return round(_normalise_page_count(page_count) * KB_PER_PAGE / 1024, 1)
+
+
+def _normalise_page_count(page_count: int) -> int:
+    return max(0, int(page_count))

--- a/tests/test_atlas_config.py
+++ b/tests/test_atlas_config.py
@@ -5,13 +5,16 @@ from qfit.atlas.application.atlas_config import estimate_size_mb, estimate_time_
 
 
 class AtlasConfigTests(unittest.TestCase):
-    def test_estimates_single_page_with_minimum_duration(self):
+    def test_estimates_single_page_with_minimum_display_values(self):
         self.assertEqual(estimate_time_min(1), 1)
-        self.assertEqual(estimate_size_mb(1), 0.0)
+        self.assertEqual(estimate_size_mb(1), 0.1)
 
     def test_estimates_larger_exports_from_spec_baselines(self):
         self.assertEqual(estimate_time_min(300), 2)
         self.assertEqual(estimate_size_mb(300), 8.2)
+
+    def test_rounds_half_minute_estimates_up(self):
+        self.assertEqual(estimate_time_min(375), 3)
 
     def test_treats_negative_page_counts_as_empty_exports(self):
         self.assertEqual(estimate_time_min(-10), 1)

--- a/tests/test_atlas_config.py
+++ b/tests/test_atlas_config.py
@@ -1,0 +1,22 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.atlas.application.atlas_config import estimate_size_mb, estimate_time_min
+
+
+class AtlasConfigTests(unittest.TestCase):
+    def test_estimates_single_page_with_minimum_duration(self):
+        self.assertEqual(estimate_time_min(1), 1)
+        self.assertEqual(estimate_size_mb(1), 0.0)
+
+    def test_estimates_larger_exports_from_spec_baselines(self):
+        self.assertEqual(estimate_time_min(300), 2)
+        self.assertEqual(estimate_size_mb(300), 8.2)
+
+    def test_treats_negative_page_counts_as_empty_exports(self):
+        self.assertEqual(estimate_time_min(-10), 1)
+        self.assertEqual(estimate_size_mb(-10), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add the wizard-neutral atlas export estimate helper requested by the Option B dock spec, so the future Atlas PDF page can share tested duration and size estimates instead of hardcoding them in UI code.

## Changes

- Add `qfit.atlas.application.atlas_config` with configurable baseline constants.
- Add `estimate_time_min()` and `estimate_size_mb()` helpers from issue #609 §6.4 / §13.3.
- Cover minimum-duration, baseline, and negative-count handling with unit tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`

Refs #609
