### PR TITLE
ui: add collapsible group box compat helper

### DIFF
--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -9,9 +9,11 @@ from qgis.PyQt.QtCore import Qt
 
 from qfit.ui.widgets.compat import (
     checked_list_values,
+    collapsible_group_box_expanded,
     datetime_range_values,
     file_widget_path,
     make_checkable_list,
+    make_collapsible_group_box,
     make_datetime_range_edits,
     make_file_widget,
     make_password_line_edit,
@@ -173,6 +175,58 @@ class _FakeFileWidget:
         self.storage_mode = storage_mode
 
 
+class _FakeCollapsibleGroupBox:
+    def __init__(self, title="", parent=None):
+        self.title = title
+        self.parent = parent
+        self.checkable = None
+        self.collapsed = None
+        self.checked = None
+
+    def setTitle(self, title):  # noqa: N802
+        self.title = title
+
+    def setCheckable(self, value):  # noqa: N802
+        self.checkable = value
+
+    def setCollapsed(self, value):  # noqa: N802
+        self.collapsed = value
+
+    def isCollapsed(self):  # noqa: N802
+        return self.collapsed
+
+    def setChecked(self, value):  # noqa: N802
+        self.checked = value
+
+    def isChecked(self):  # noqa: N802
+        return self.checked
+
+
+class _FakeParentOnlyCollapsibleGroupBox(_FakeCollapsibleGroupBox):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+
+
+class _FakeGroupBox:
+    def __init__(self, title="", parent=None):
+        self.title = title
+        self.parent = parent
+        self.checkable = None
+        self.checked = None
+
+    def setTitle(self, title):  # noqa: N802
+        self.title = title
+
+    def setCheckable(self, value):  # noqa: N802
+        self.checkable = value
+
+    def setChecked(self, value):  # noqa: N802
+        self.checked = value
+
+    def isChecked(self):  # noqa: N802
+        return self.checked
+
+
 class _FakeDateTimeEdit:
     def __init__(self, parent=None):
         self.parent = parent
@@ -249,6 +303,7 @@ class _FakeListWidgetItem:
 
 def _fake_qgis_gui(
     *,
+    collapsible_group_box=None,
     datetime_edit=None,
     double_range_slider=None,
     file_widget=None,
@@ -257,6 +312,8 @@ def _fake_qgis_gui(
 ):
     module = types.ModuleType("qgis.gui")
     module.QgsRangeSlider = range_slider
+    if collapsible_group_box is not None:
+        module.QgsCollapsibleGroupBox = collapsible_group_box
     if datetime_edit is not None:
         module.QgsDateTimeEdit = datetime_edit
     if double_range_slider is not None:
@@ -271,6 +328,7 @@ def _fake_qgis_gui(
 def _fake_qt_widgets():
     module = types.ModuleType("qgis.PyQt.QtWidgets")
     module.QDateTimeEdit = _FakeDateTimeEdit
+    module.QGroupBox = _FakeGroupBox
     module.QLineEdit = _FakeLineEdit
     module.QListWidget = _FakeListWidget
     module.QListWidgetItem = _FakeListWidgetItem
@@ -278,6 +336,70 @@ def _fake_qt_widgets():
 
 
 class UiWidgetCompatTests(unittest.TestCase):
+    def test_uses_native_collapsible_group_box_when_qgis_provides_it(self):
+        parent = object()
+        with patch.dict(
+            sys.modules,
+            {"qgis.gui": _fake_qgis_gui(collapsible_group_box=_FakeCollapsibleGroupBox)},
+        ):
+            group_box = make_collapsible_group_box(
+                title="Map & filters",
+                collapsed=True,
+                parent=parent,
+            )
+
+        self.assertIsInstance(group_box, _FakeCollapsibleGroupBox)
+        self.assertIs(group_box.parent, parent)
+        self.assertEqual(group_box.title, "Map & filters")
+        self.assertTrue(group_box.checkable)
+        self.assertTrue(group_box.collapsed)
+        self.assertFalse(collapsible_group_box_expanded(group_box))
+
+    def test_collapsible_group_box_falls_back_to_checkable_qgroupbox(self):
+        parent = object()
+        with patch.dict(
+            sys.modules,
+            {
+                "qgis.gui": _fake_qgis_gui(),
+                "qgis.PyQt.QtWidgets": _fake_qt_widgets(),
+            },
+        ):
+            group_box = make_collapsible_group_box(
+                title="Atlas PDF",
+                collapsed=False,
+                parent=parent,
+            )
+
+        self.assertIsInstance(group_box, _FakeGroupBox)
+        self.assertIs(group_box.parent, parent)
+        self.assertEqual(group_box.title, "Atlas PDF")
+        self.assertTrue(group_box.checkable)
+        self.assertTrue(group_box.checked)
+        self.assertTrue(collapsible_group_box_expanded(group_box))
+
+    def test_configures_parent_only_native_collapsible_group_box_api(self):
+        parent = object()
+        with patch.dict(
+            sys.modules,
+            {
+                "qgis.gui": _fake_qgis_gui(
+                    collapsible_group_box=_FakeParentOnlyCollapsibleGroupBox,
+                )
+            },
+        ):
+            group_box = make_collapsible_group_box(
+                title="Spatial analysis",
+                collapsed=False,
+                checkable=False,
+                parent=parent,
+            )
+
+        self.assertIs(group_box.parent, parent)
+        self.assertEqual(group_box.title, "Spatial analysis")
+        self.assertFalse(group_box.checkable)
+        self.assertFalse(group_box.collapsed)
+        self.assertTrue(collapsible_group_box_expanded(group_box))
+
     def test_creates_native_checkable_list_with_stable_values(self):
         parent = object()
         with patch.dict(sys.modules, {"qgis.PyQt.QtWidgets": _fake_qt_widgets()}):

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -189,6 +189,9 @@ class _FakeCollapsibleGroupBox:
     def setCheckable(self, value):  # noqa: N802
         self.checkable = value
 
+    def isCheckable(self):  # noqa: N802
+        return self.checkable
+
     def setCollapsed(self, value):  # noqa: N802
         self.collapsed = value
 
@@ -220,8 +223,12 @@ class _FakeGroupBox:
     def setCheckable(self, value):  # noqa: N802
         self.checkable = value
 
+    def isCheckable(self):  # noqa: N802
+        return self.checkable
+
     def setChecked(self, value):  # noqa: N802
-        self.checked = value
+        if self.checkable:
+            self.checked = value
 
     def isChecked(self):  # noqa: N802
         return self.checked
@@ -376,6 +383,42 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertTrue(group_box.checkable)
         self.assertTrue(group_box.checked)
         self.assertTrue(collapsible_group_box_expanded(group_box))
+
+    def test_fallback_non_checkable_group_box_is_reported_expanded(self):
+        with patch.dict(
+            sys.modules,
+            {
+                "qgis.gui": _fake_qgis_gui(),
+                "qgis.PyQt.QtWidgets": _fake_qt_widgets(),
+            },
+        ):
+            group_box = make_collapsible_group_box(
+                title="Always visible",
+                collapsed=False,
+                checkable=False,
+            )
+
+        self.assertFalse(group_box.checkable)
+        self.assertIsNone(group_box.checked)
+        self.assertTrue(collapsible_group_box_expanded(group_box))
+
+    def test_fallback_enables_checkability_when_initially_collapsed(self):
+        with patch.dict(
+            sys.modules,
+            {
+                "qgis.gui": _fake_qgis_gui(),
+                "qgis.PyQt.QtWidgets": _fake_qt_widgets(),
+            },
+        ):
+            group_box = make_collapsible_group_box(
+                title="Initially collapsed",
+                collapsed=True,
+                checkable=False,
+            )
+
+        self.assertTrue(group_box.checkable)
+        self.assertFalse(group_box.checked)
+        self.assertFalse(collapsible_group_box_expanded(group_box))
 
     def test_configures_parent_only_native_collapsible_group_box_api(self):
         parent = object()

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -384,6 +384,21 @@ class UiWidgetCompatTests(unittest.TestCase):
         self.assertTrue(group_box.checked)
         self.assertTrue(collapsible_group_box_expanded(group_box))
 
+    def test_native_collapsible_group_box_respects_explicit_non_checkable_state(self):
+        with patch.dict(
+            sys.modules,
+            {"qgis.gui": _fake_qgis_gui(collapsible_group_box=_FakeCollapsibleGroupBox)},
+        ):
+            group_box = make_collapsible_group_box(
+                title="Native collapsed",
+                collapsed=True,
+                checkable=False,
+            )
+
+        self.assertFalse(group_box.checkable)
+        self.assertTrue(group_box.collapsed)
+        self.assertFalse(collapsible_group_box_expanded(group_box))
+
     def test_fallback_non_checkable_group_box_is_reported_expanded(self):
         with patch.dict(
             sys.modules,

--- a/ui/widgets/__init__.py
+++ b/ui/widgets/__init__.py
@@ -1,9 +1,11 @@
 from .compat import (
     DateTimeRangeEdits,
     checked_list_values,
+    collapsible_group_box_expanded,
     datetime_range_values,
     file_widget_path,
     make_checkable_list,
+    make_collapsible_group_box,
     make_datetime_range_edits,
     make_file_widget,
     make_password_line_edit,
@@ -13,9 +15,11 @@ from .compat import (
 __all__ = [
     "DateTimeRangeEdits",
     "checked_list_values",
+    "collapsible_group_box_expanded",
     "datetime_range_values",
     "file_widget_path",
     "make_checkable_list",
+    "make_collapsible_group_box",
     "make_datetime_range_edits",
     "make_file_widget",
     "make_password_line_edit",

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -39,6 +39,48 @@ class _ScaledSignal:
             slot(*args)
 
 
+def make_collapsible_group_box(
+    *,
+    title: str = "",
+    collapsed: bool = False,
+    checkable: bool = True,
+    parent=None,
+):
+    """Create a collapsible group box with a Qt fallback.
+
+    The wizard spec calls for ``QgsCollapsibleGroupBox`` so sections expose a
+    standard QGIS chevron. Minimal test environments and older installs may not
+    provide it, so fallback to a checkable ``QGroupBox`` while preserving the
+    same construction API for future wizard pages.
+    """
+
+    gui = _import_optional_qgis_gui()
+    group_box_class = getattr(gui, "QgsCollapsibleGroupBox", None) if gui is not None else None
+    if group_box_class is not None:
+        group_box = _construct_group_box(group_box_class, title, parent)
+    else:
+        widgets = import_module("qgis.PyQt.QtWidgets")
+        group_box = _construct_group_box(widgets.QGroupBox, title, parent)
+
+    _configure_collapsible_group_box(
+        group_box,
+        title=title,
+        collapsed=collapsed,
+        checkable=checkable,
+    )
+    return group_box
+
+
+def collapsible_group_box_expanded(group_box) -> bool:
+    """Return whether a native or fallback collapsible group box is expanded."""
+
+    if hasattr(group_box, "isCollapsed"):
+        return not group_box.isCollapsed()
+    if hasattr(group_box, "isChecked"):
+        return bool(group_box.isChecked())
+    return True
+
+
 def make_checkable_list(
     options: Sequence[CheckableListOption],
     *,
@@ -223,6 +265,33 @@ def _import_optional_qgis_gui():
         if exc.name not in {"qgis", "qgis.gui"}:
             raise
         return None
+
+
+def _construct_group_box(group_box_class, title: str, parent):
+    try:
+        return group_box_class(title, parent)
+    except TypeError:
+        group_box = group_box_class(parent)
+        if title and hasattr(group_box, "setTitle"):
+            group_box.setTitle(title)
+        return group_box
+
+
+def _configure_collapsible_group_box(
+    group_box,
+    *,
+    title: str,
+    collapsed: bool,
+    checkable: bool,
+) -> None:
+    if title and hasattr(group_box, "setTitle"):
+        group_box.setTitle(title)
+    if hasattr(group_box, "setCheckable"):
+        group_box.setCheckable(checkable)
+    if hasattr(group_box, "setCollapsed"):
+        group_box.setCollapsed(collapsed)
+    elif hasattr(group_box, "setChecked"):
+        group_box.setChecked(not collapsed if checkable else True)
 
 
 def _configure_native_file_widget(

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -76,6 +76,8 @@ def collapsible_group_box_expanded(group_box) -> bool:
 
     if hasattr(group_box, "isCollapsed"):
         return not group_box.isCollapsed()
+    if hasattr(group_box, "isCheckable") and not group_box.isCheckable():
+        return True
     if hasattr(group_box, "isChecked"):
         return bool(group_box.isChecked())
     return True
@@ -287,11 +289,11 @@ def _configure_collapsible_group_box(
     if title and hasattr(group_box, "setTitle"):
         group_box.setTitle(title)
     if hasattr(group_box, "setCheckable"):
-        group_box.setCheckable(checkable)
+        group_box.setCheckable(checkable or collapsed)
     if hasattr(group_box, "setCollapsed"):
         group_box.setCollapsed(collapsed)
     elif hasattr(group_box, "setChecked"):
-        group_box.setChecked(not collapsed if checkable else True)
+        group_box.setChecked(not collapsed)
 
 
 def _configure_native_file_widget(

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -288,11 +288,13 @@ def _configure_collapsible_group_box(
 ) -> None:
     if title and hasattr(group_box, "setTitle"):
         group_box.setTitle(title)
-    if hasattr(group_box, "setCheckable"):
-        group_box.setCheckable(checkable or collapsed)
     if hasattr(group_box, "setCollapsed"):
+        if hasattr(group_box, "setCheckable"):
+            group_box.setCheckable(checkable)
         group_box.setCollapsed(collapsed)
     elif hasattr(group_box, "setChecked"):
+        if hasattr(group_box, "setCheckable"):
+            group_box.setCheckable(checkable or collapsed)
         group_box.setChecked(not collapsed)
 
 


### PR DESCRIPTION
## Summary

Add a wizard-neutral collapsible group box compatibility helper that prefers QGIS' native `QgsCollapsibleGroupBox` and falls back to a checkable Qt `QGroupBox` when the native widget is unavailable.

This prepares the #609 wizard direction without polishing or further entrenching the current long-scroll dock from #608.

## Changes

- add `make_collapsible_group_box()` and `collapsible_group_box_expanded()` to `ui.widgets.compat`
- export the new helper from `ui.widgets`
- cover native, fallback, and parent-only constructor paths in widget compatibility tests

## Testing

- `python3 -m pytest tests/test_ui_widget_compat.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
