### PR TITLE
ui: add wizard settings helpers

### DIFF
--- a/tests/test_wizard_settings.py
+++ b/tests/test_wizard_settings.py
@@ -1,0 +1,112 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.wizard_settings import (
+    COLLAPSED_GROUPS_KEY,
+    DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
+    LAST_STEP_INDEX_KEY,
+    WIZARD_VERSION,
+    WIZARD_VERSION_KEY,
+    clamp_wizard_step_index,
+    ensure_wizard_settings,
+    load_wizard_settings,
+    save_collapsed_groups,
+    save_last_step_index,
+)
+
+
+class FakeSettingsPort:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+        self.writes = []
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def get_bool(self, key, default=False):
+        return bool(self.get(key, default))
+
+    def set(self, key, value):
+        self.values[key] = value
+        self.writes.append((key, value))
+
+
+class WizardSettingsTests(unittest.TestCase):
+    def test_load_defaults_match_first_launch_wizard_spec(self):
+        snapshot = load_wizard_settings(FakeSettingsPort())
+
+        self.assertIsNone(snapshot.wizard_version)
+        self.assertTrue(snapshot.first_launch)
+        self.assertEqual(snapshot.last_step_index, 0)
+        self.assertEqual(snapshot.collapsed_groups, DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES)
+
+    def test_ensure_writes_version_and_collapsed_defaults_on_first_launch(self):
+        settings = FakeSettingsPort()
+
+        snapshot = ensure_wizard_settings(settings)
+
+        self.assertEqual(snapshot.wizard_version, WIZARD_VERSION)
+        self.assertTrue(snapshot.first_launch)
+        self.assertEqual(
+            settings.writes,
+            [
+                (WIZARD_VERSION_KEY, WIZARD_VERSION),
+                (COLLAPSED_GROUPS_KEY, list(DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES)),
+            ],
+        )
+
+    def test_ensure_does_not_overwrite_existing_wizard_settings(self):
+        settings = FakeSettingsPort(
+            {
+                WIZARD_VERSION_KEY: "1",
+                LAST_STEP_INDEX_KEY: "3",
+                COLLAPSED_GROUPS_KEY: ["temporalGroup"],
+            }
+        )
+
+        snapshot = ensure_wizard_settings(settings)
+
+        self.assertFalse(snapshot.first_launch)
+        self.assertEqual(snapshot.wizard_version, 1)
+        self.assertEqual(snapshot.last_step_index, 3)
+        self.assertEqual(snapshot.collapsed_groups, ("temporalGroup",))
+        self.assertEqual(settings.writes, [])
+
+    def test_step_index_is_clamped_for_restore_and_save(self):
+        settings = FakeSettingsPort({LAST_STEP_INDEX_KEY: "99"})
+        self.assertEqual(load_wizard_settings(settings).last_step_index, 4)
+        self.assertEqual(clamp_wizard_step_index("bad"), 0)
+        self.assertEqual(clamp_wizard_step_index(-2), 0)
+
+        saved = save_last_step_index(settings, 8)
+
+        self.assertEqual(saved, 4)
+        self.assertEqual(settings.values[LAST_STEP_INDEX_KEY], 4)
+
+    def test_collapsed_groups_are_saved_in_known_spec_order(self):
+        settings = FakeSettingsPort()
+
+        saved = save_collapsed_groups(
+            settings,
+            ["unknownGroup", "temporalGroup", "advancedOptionsGroup"],
+        )
+
+        self.assertEqual(saved, ("advancedOptionsGroup", "temporalGroup"))
+        self.assertEqual(
+            settings.values[COLLAPSED_GROUPS_KEY],
+            ["advancedOptionsGroup", "temporalGroup"],
+        )
+
+    def test_collapsed_groups_accept_qsettings_comma_string_values(self):
+        settings = FakeSettingsPort(
+            {COLLAPSED_GROUPS_KEY: "temporalGroup, layoutGroup, unknownGroup"}
+        )
+
+        snapshot = load_wizard_settings(settings)
+
+        self.assertEqual(snapshot.collapsed_groups, ("layoutGroup", "temporalGroup"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -38,6 +38,20 @@ from .dock_workflow_sections import (
     build_wizard_step_statuses,
     get_workflow_section,
 )
+from .wizard_settings import (
+    COLLAPSED_GROUPS_KEY,
+    DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
+    LAST_STEP_INDEX_KEY,
+    WIZARD_STEP_COUNT,
+    WIZARD_VERSION,
+    WIZARD_VERSION_KEY,
+    WizardSettingsSnapshot,
+    clamp_wizard_step_index,
+    ensure_wizard_settings,
+    load_wizard_settings,
+    save_collapsed_groups,
+    save_last_step_index,
+)
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -50,6 +64,8 @@ from .visual_workflow_action_builder import build_visual_workflow_settings_snaps
 
 __all__ = [
     "ApplyVisualizationAction",
+    "COLLAPSED_GROUPS_KEY",
+    "DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES",
     "DockActionDispatcher",
     "DockActionResult",
     "DockActivityWorkflowCoordinator",
@@ -68,11 +84,16 @@ __all__ = [
     "DockWorkflowStepState",
     "DockWorkflowStepStatus",
     "CURRENT_DOCK_SECTIONS",
+    "LAST_STEP_INDEX_KEY",
     "WIZARD_WORKFLOW_STEPS",
+    "WIZARD_STEP_COUNT",
+    "WIZARD_VERSION",
+    "WIZARD_VERSION_KEY",
     "RunAnalysisAction",
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",
     "VisualWorkflowSettingsSnapshot",
+    "WizardSettingsSnapshot",
     "build_current_dock_workflow_label",
     "build_dock_summary_status",
     "build_initial_wizard_step_statuses",
@@ -83,5 +104,10 @@ __all__ = [
     "build_visual_workflow_background_inputs",
     "build_visual_workflow_selection_state_handoff",
     "build_visual_workflow_settings_snapshot",
+    "clamp_wizard_step_index",
+    "ensure_wizard_settings",
     "get_workflow_section",
+    "load_wizard_settings",
+    "save_collapsed_groups",
+    "save_last_step_index",
 ]

--- a/ui/application/wizard_settings.py
+++ b/ui/application/wizard_settings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any
 
 from ...configuration.application.settings_port import SettingsPort
@@ -55,7 +55,12 @@ def ensure_wizard_settings(settings: SettingsPort) -> WizardSettingsSnapshot:
     if snapshot.first_launch:
         settings.set(WIZARD_VERSION_KEY, WIZARD_VERSION)
         settings.set(COLLAPSED_GROUPS_KEY, list(snapshot.collapsed_groups))
-        return replace(snapshot, wizard_version=WIZARD_VERSION)
+        return WizardSettingsSnapshot(
+            wizard_version=WIZARD_VERSION,
+            last_step_index=snapshot.last_step_index,
+            collapsed_groups=snapshot.collapsed_groups,
+            first_launch=snapshot.first_launch,
+        )
     return snapshot
 
 

--- a/ui/application/wizard_settings.py
+++ b/ui/application/wizard_settings.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from ...configuration.application.settings_port import SettingsPort
+
+WIZARD_VERSION = 1
+WIZARD_VERSION_KEY = "ui/wizard_version"
+LAST_STEP_INDEX_KEY = "ui/last_step_index"
+COLLAPSED_GROUPS_KEY = "ui/collapsed_groups"
+WIZARD_STEP_COUNT = 5
+
+DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES: tuple[str, ...] = (
+    "advancedOptionsGroup",
+    "layoutGroup",
+    "temporalGroup",
+)
+
+
+@dataclass(frozen=True)
+class WizardSettingsSnapshot:
+    """UI-neutral persisted settings for the future wizard dock shell."""
+
+    wizard_version: int | None
+    last_step_index: int = 0
+    collapsed_groups: tuple[str, ...] = DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
+    first_launch: bool = True
+
+
+def load_wizard_settings(settings: SettingsPort) -> WizardSettingsSnapshot:
+    """Load persisted wizard settings without writing defaults."""
+
+    raw_version = settings.get(WIZARD_VERSION_KEY)
+    wizard_version = _coerce_int(raw_version)
+    return WizardSettingsSnapshot(
+        wizard_version=wizard_version,
+        last_step_index=clamp_wizard_step_index(settings.get(LAST_STEP_INDEX_KEY, 0)),
+        collapsed_groups=_normalise_collapsed_groups(
+            settings.get(COLLAPSED_GROUPS_KEY, DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES)
+        ),
+        first_launch=wizard_version is None,
+    )
+
+
+def ensure_wizard_settings(settings: SettingsPort) -> WizardSettingsSnapshot:
+    """Write first-launch wizard defaults and return the pre-existing snapshot.
+
+    The wizard implementation can use ``first_launch`` from the returned
+    snapshot to apply the spec's initial step state while this helper persists
+    ``qfit/ui/wizard_version`` for subsequent launches.
+    """
+
+    snapshot = load_wizard_settings(settings)
+    if snapshot.first_launch:
+        settings.set(WIZARD_VERSION_KEY, WIZARD_VERSION)
+        settings.set(COLLAPSED_GROUPS_KEY, list(snapshot.collapsed_groups))
+        return replace(snapshot, wizard_version=WIZARD_VERSION)
+    return snapshot
+
+
+def save_last_step_index(settings: SettingsPort, index: int) -> int:
+    """Persist the wizard's last step index after clamping to the valid range."""
+
+    clamped_index = clamp_wizard_step_index(index)
+    settings.set(LAST_STEP_INDEX_KEY, clamped_index)
+    return clamped_index
+
+
+def save_collapsed_groups(settings: SettingsPort, object_names: list[str] | tuple[str, ...]) -> tuple[str, ...]:
+    """Persist known collapsible group object names in stable spec order."""
+
+    collapsed_groups = _normalise_collapsed_groups(object_names)
+    settings.set(COLLAPSED_GROUPS_KEY, list(collapsed_groups))
+    return collapsed_groups
+
+
+def clamp_wizard_step_index(value: Any) -> int:
+    """Coerce a persisted step index into the wizard's 0-based page range."""
+
+    step_index = _coerce_int(value) or 0
+    return min(max(step_index, 0), WIZARD_STEP_COUNT - 1)
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalise_collapsed_groups(value: Any) -> tuple[str, ...]:
+    raw_names = _as_string_sequence(value)
+    requested = {name for name in raw_names if name in DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES}
+    return tuple(name for name in DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES if name in requested)
+
+
+def _as_string_sequence(value: Any) -> tuple[str, ...]:
+    if value in (None, ""):
+        return DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
+    if isinstance(value, str):
+        if "," in value:
+            return tuple(part.strip() for part in value.split(",") if part.strip())
+        return (value,)
+    try:
+        return tuple(str(item) for item in value)
+    except TypeError:
+        return DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
+
+
+__all__ = [
+    "COLLAPSED_GROUPS_KEY",
+    "DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES",
+    "LAST_STEP_INDEX_KEY",
+    "WIZARD_STEP_COUNT",
+    "WIZARD_VERSION",
+    "WIZARD_VERSION_KEY",
+    "WizardSettingsSnapshot",
+    "clamp_wizard_step_index",
+    "ensure_wizard_settings",
+    "load_wizard_settings",
+    "save_collapsed_groups",
+    "save_last_step_index",
+]

--- a/ui/application/wizard_settings.py
+++ b/ui/application/wizard_settings.py
@@ -44,11 +44,12 @@ def load_wizard_settings(settings: SettingsPort) -> WizardSettingsSnapshot:
 
 
 def ensure_wizard_settings(settings: SettingsPort) -> WizardSettingsSnapshot:
-    """Write first-launch wizard defaults and return the pre-existing snapshot.
+    """Write first-launch defaults and return the populated wizard snapshot.
 
-    The wizard implementation can use ``first_launch`` from the returned
-    snapshot to apply the spec's initial step state while this helper persists
-    ``qfit/ui/wizard_version`` for subsequent launches.
+    On first launch, this persists ``qfit/ui/wizard_version`` and returns a
+    snapshot with ``wizard_version`` populated while preserving
+    ``first_launch=True`` so the wizard can still apply the spec's initial step
+    state. Existing wizard settings are returned unchanged.
     """
 
     snapshot = load_wizard_settings(settings)
@@ -83,7 +84,9 @@ def save_collapsed_groups(settings: SettingsPort, object_names: list[str] | tupl
 def clamp_wizard_step_index(value: Any) -> int:
     """Coerce a persisted step index into the wizard's 0-based page range."""
 
-    step_index = _coerce_int(value) or 0
+    step_index = _coerce_int(value)
+    if step_index is None:
+        step_index = 0
     return min(max(step_index, 0), WIZARD_STEP_COUNT - 1)
 
 


### PR DESCRIPTION
## Summary

Adds UI-neutral wizard settings helpers for the Option B dock migration without changing the current dock layout.

## Changes

- Define the wizard settings keys for `qfit/ui/wizard_version`, `qfit/ui/last_step_index`, and `qfit/ui/collapsed_groups`.
- Add helpers to load first-launch defaults, persist the wizard version, clamp the restored step index, and save known collapsed group object names in spec order.
- Export the helpers through `qfit.ui.application` for future wizard shell/page code.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
