### PR TITLE
ui: add wizard stepper bar

### DIFF
--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -244,6 +244,20 @@ class StepperBarTest(unittest.TestCase):
 
         self.assertIs(module, fallback_qtwidgets)
 
+    def test_set_state_does_not_require_python310_zip_strict_keyword(self):
+        original_zip = zip
+
+        def python39_zip(*args, **kwargs):
+            if kwargs:
+                raise TypeError("zip() takes no keyword arguments")
+            return original_zip(*args)
+
+        bar = self.stepper.StepperBar()
+        with patch("builtins.zip", python39_zip):
+            bar.set_state(["done", "current", "upcoming", "locked", "upcoming"])
+
+        self.assertEqual(bar.states(), ("done", "current", "upcoming", "locked", "upcoming"))
+
     def test_applies_state_properties_and_labels(self):
         bar = self.stepper.StepperBar()
 

--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -1,0 +1,267 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+
+class _FakeSignal:
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+        return slot
+
+    def emit(self, *args):
+        for slot in list(self._slots):
+            slot(*args)
+
+
+class _FakeSignalDescriptor:
+    def __set_name__(self, owner, name):
+        self.name = f"_{name}_signal"
+
+    def __get__(self, instance, _owner):
+        if instance is None:
+            return self
+        signal = instance.__dict__.get(self.name)
+        if signal is None:
+            signal = _FakeSignal()
+            instance.__dict__[self.name] = signal
+        return signal
+
+
+def _fake_pyqt_signal(*_args, **_kwargs):
+    return _FakeSignalDescriptor()
+
+
+class _FakeCursor:
+    def __init__(self, shape):
+        self._shape = shape
+
+    def shape(self):
+        return self._shape
+
+
+class _FakeQt:
+    ForbiddenCursor = 10
+    PointingHandCursor = 11
+    ToolButtonTextBesideIcon = 12
+    Horizontal = 13
+    Orientation = int
+
+
+class _FakeWidget:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self._height = None
+        self._object_name = ""
+        self._properties = {}
+        self._enabled = True
+        self._cursor = _FakeCursor(None)
+        self._tooltip = ""
+        self._stylesheet = ""
+
+    def setFixedHeight(self, value):  # noqa: N802
+        self._height = value
+
+    def height(self):
+        return self._height
+
+    def setObjectName(self, value):  # noqa: N802
+        self._object_name = value
+
+    def objectName(self):  # noqa: N802
+        return self._object_name
+
+    def setProperty(self, name, value):  # noqa: N802
+        self._properties[name] = value
+
+    def property(self, name):
+        return self._properties.get(name)
+
+    def setEnabled(self, enabled):  # noqa: N802
+        self._enabled = enabled
+
+    def isEnabled(self):  # noqa: N802
+        return self._enabled
+
+    def setCursor(self, shape):  # noqa: N802
+        self._cursor = _FakeCursor(shape)
+
+    def cursor(self):
+        return self._cursor
+
+    def setToolTip(self, value):  # noqa: N802
+        self._tooltip = value
+
+    def toolTip(self):  # noqa: N802
+        return self._tooltip
+
+    def setStyleSheet(self, value):  # noqa: N802
+        self._stylesheet = value
+
+    def styleSheet(self):  # noqa: N802
+        return self._stylesheet
+
+
+class _FakeToolButton(_FakeWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.clicked = _FakeSignal()
+        self._text = ""
+        self.tool_button_style = None
+        self.size_policy = None
+
+    def setToolButtonStyle(self, value):  # noqa: N802
+        self.tool_button_style = value
+
+    def setSizePolicy(self, horizontal, vertical):  # noqa: N802
+        self.size_policy = (horizontal, vertical)
+
+    def setText(self, value):  # noqa: N802
+        self._text = value
+
+    def text(self):
+        return self._text
+
+    def click(self):
+        if self.isEnabled():
+            self.clicked.emit(False)
+
+
+class _FakeFrame(_FakeWidget):
+    HLine = 1
+    Plain = 2
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.frame_shape = None
+        self.frame_shadow = None
+        self.fixed_width = None
+
+    def setFrameShape(self, value):  # noqa: N802
+        self.frame_shape = value
+
+    def setFrameShadow(self, value):  # noqa: N802
+        self.frame_shadow = value
+
+    def setFixedWidth(self, value):  # noqa: N802
+        self.fixed_width = value
+
+
+class _FakeHBoxLayout:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.contents_margins = None
+        self.spacing = None
+        self.widgets = []
+
+    def setContentsMargins(self, *values):  # noqa: N802
+        self.contents_margins = values
+
+    def setSpacing(self, value):  # noqa: N802
+        self.spacing = value
+
+    def addWidget(self, widget):  # noqa: N802
+        self.widgets.append(widget)
+
+
+class _FakeSizePolicy:
+    Expanding = 1
+    Fixed = 2
+
+
+def _fake_qt_modules():
+    qgis = types.ModuleType("qgis")
+    pyqt = types.ModuleType("qgis.PyQt")
+    pyqt.__path__ = []
+    qtcore = types.ModuleType("qgis.PyQt.QtCore")
+    qtcore.Qt = _FakeQt
+    qtcore.pyqtSignal = _fake_pyqt_signal
+    qtwidgets = types.ModuleType("qgis.PyQt.QtWidgets")
+    qtwidgets.QFrame = _FakeFrame
+    qtwidgets.QHBoxLayout = _FakeHBoxLayout
+    qtwidgets.QSizePolicy = _FakeSizePolicy
+    qtwidgets.QToolButton = _FakeToolButton
+    qtwidgets.QWidget = _FakeWidget
+    qgis.PyQt = pyqt
+    return {
+        "qgis": qgis,
+        "qgis.PyQt": pyqt,
+        "qgis.PyQt.QtCore": qtcore,
+        "qgis.PyQt.QtWidgets": qtwidgets,
+    }
+
+
+def _load_stepper_module():
+    for name in ("qfit.ui.dockwidget.stepper_bar", "qfit.ui.dockwidget"):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.stepper_bar")
+
+
+class StepperBarTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.stepper = _load_stepper_module()
+
+    def test_initial_state_matches_first_launch_spec(self):
+        bar = self.stepper.StepperBar()
+
+        self.assertEqual(bar.states(), ("current", "locked", "locked", "locked", "locked"))
+        self.assertEqual(len(bar.step_buttons()), 5)
+        self.assertEqual([button.toolTip() for button in bar.step_buttons()], list(self.stepper.STEPPER_LABELS))
+        self.assertEqual(bar.height(), 36)
+
+    def test_applies_state_properties_and_labels(self):
+        bar = self.stepper.StepperBar()
+
+        bar.set_state(["done", "current", "upcoming", "locked", "upcoming"])
+
+        buttons = bar.step_buttons()
+        self.assertEqual(bar.states(), ("done", "current", "upcoming", "locked", "upcoming"))
+        self.assertTrue(buttons[0].text().startswith("✓"))
+        self.assertEqual(buttons[1].property("wizardState"), "current")
+        self.assertTrue(buttons[2].isEnabled())
+        self.assertFalse(buttons[3].isEnabled())
+        self.assertEqual(buttons[3].cursor().shape(), _FakeQt.ForbiddenCursor)
+
+    def test_set_current_marks_other_steps_upcoming(self):
+        bar = self.stepper.StepperBar()
+
+        bar.set_current(2)
+
+        self.assertEqual(bar.states(), ("upcoming", "upcoming", "current", "upcoming", "upcoming"))
+
+    def test_rejects_invalid_state_payloads(self):
+        bar = self.stepper.StepperBar()
+
+        with self.assertRaisesRegex(ValueError, "requires 5 states"):
+            bar.set_state(["current"])
+
+        with self.assertRaisesRegex(ValueError, "Unknown stepper state"):
+            bar.set_state(["current", "done", "waiting", "locked", "upcoming"])
+
+        with self.assertRaisesRegex(ValueError, "outside 0..4"):
+            bar.set_current(5)
+
+    def test_emits_requested_index_only_for_unlocked_steps(self):
+        bar = self.stepper.StepperBar()
+        requested = []
+        bar.stepRequested.connect(requested.append)
+        bar.set_state(["done", "current", "upcoming", "locked", "upcoming"])
+
+        buttons = bar.step_buttons()
+        buttons[0].click()
+        buttons[2].click()
+        buttons[3].click()
+
+        self.assertEqual(requested, [0, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -217,6 +217,33 @@ class StepperBarTest(unittest.TestCase):
         self.assertEqual([button.toolTip() for button in bar.step_buttons()], list(self.stepper.STEPPER_LABELS))
         self.assertEqual(bar.height(), 36)
 
+    def test_labels_come_from_shared_workflow_metadata(self):
+        self.assertEqual(
+            self.stepper.STEPPER_LABELS,
+            ("Connection", "Synchronization", "Map & filters", "Spatial analysis", "Atlas PDF"),
+        )
+
+    def test_qt_import_guard_requires_all_widget_classes(self):
+        incomplete_qtwidgets = types.ModuleType("qgis.PyQt.QtWidgets")
+        incomplete_qtwidgets.QWidget = object
+        fallback_qtwidgets = types.ModuleType("fallback.QtWidgets")
+        fallback_qtwidgets.QWidget = object
+        fallback_qtwidgets.QFrame = object
+        with patch.dict(
+            sys.modules,
+            {
+                "qgis.PyQt.QtWidgets": incomplete_qtwidgets,
+                "fallback.QtWidgets": fallback_qtwidgets,
+            },
+        ):
+            module = self.stepper._import_qt_module(
+                "qgis.PyQt.QtWidgets",
+                "fallback.QtWidgets",
+                ("QWidget", "QFrame"),
+            )
+
+        self.assertIs(module, fallback_qtwidgets)
+
     def test_applies_state_properties_and_labels(self):
         bar = self.stepper.StepperBar()
 

--- a/ui/dockwidget/__init__.py
+++ b/ui/dockwidget/__init__.py
@@ -1,0 +1,5 @@
+"""Dock widget components for the qfit wizard shell."""
+
+from .stepper_bar import STEPPER_LABELS, STEPPER_STATES, StepperBar
+
+__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar"]

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Sequence
+
+from qfit.ui.widgets.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
+
+STEPPER_LABELS = ("Connexion", "Synchronisation", "Carte", "Analyse", "Atlas")
+STEPPER_STATES = frozenset({"done", "current", "upcoming", "locked"})
+
+
+def _import_qt_module(qgis_module: str, pyqt_module: str, required_attribute: str):
+    try:
+        module = import_module(qgis_module)
+    except ModuleNotFoundError as exc:
+        if not str(exc).startswith("No module named 'qgis"):
+            raise
+        return import_module(pyqt_module)
+    if hasattr(module, required_attribute):
+        return module
+    # Some pure tests temporarily register tiny qgis.PyQt stubs. Fall back to
+    # PyQt5 when those stubs do not provide the widget APIs needed here.
+    return import_module(pyqt_module)
+
+
+_qtcore = _import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", "pyqtSignal")
+_qtwidgets = _import_qt_module("qgis.PyQt.QtWidgets", "PyQt5.QtWidgets", "QWidget")
+
+Qt = _qtcore.Qt
+pyqtSignal = _qtcore.pyqtSignal
+QFrame = _qtwidgets.QFrame
+QHBoxLayout = _qtwidgets.QHBoxLayout
+QSizePolicy = _qtwidgets.QSizePolicy
+QToolButton = _qtwidgets.QToolButton
+QWidget = _qtwidgets.QWidget
+
+
+class StepperBar(QWidget):
+    """Compact clickable five-step wizard stepper for the future dock shell."""
+
+    stepRequested = pyqtSignal(int)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._buttons: list[QToolButton] = []
+        self._connectors: list[QFrame] = []
+        self._states = ["locked"] * len(STEPPER_LABELS)
+        self._build_layout()
+        self.setFixedHeight(36)
+        self.setObjectName("qfitStepperBar")
+        self.set_state(["current", "locked", "locked", "locked", "locked"])
+
+    def set_state(self, states: Sequence[str]) -> None:
+        """Apply one render state per wizard step."""
+
+        validated_states = _validate_states(states)
+        self._states = list(validated_states)
+        for index, (button, state) in enumerate(zip(self._buttons, self._states, strict=True)):
+            self._configure_button(button, index, state)
+        self._configure_connectors()
+
+    def set_current(self, index: int) -> None:
+        """Mark one step current and leave all other steps dim/upcoming."""
+
+        if index < 0 or index >= len(STEPPER_LABELS):
+            raise ValueError(f"Stepper index {index} is outside 0..{len(STEPPER_LABELS) - 1}")
+        self.set_state(["current" if step_index == index else "upcoming" for step_index in range(len(STEPPER_LABELS))])
+
+    def states(self) -> tuple[str, ...]:
+        """Return the currently rendered states in step order."""
+
+        return tuple(self._states)
+
+    def step_buttons(self) -> tuple[QToolButton, ...]:
+        """Return the step buttons for adapter wiring and tests."""
+
+        return tuple(self._buttons)
+
+    def _build_layout(self) -> None:
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(4, 2, 10, 2)
+        layout.setSpacing(4)
+        for index, label in enumerate(STEPPER_LABELS):
+            button = QToolButton(self)
+            button.setObjectName(f"qfitStepperStep{index + 1}")
+            button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+            button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+            button.clicked.connect(lambda _checked=False, step_index=index: self._request_step(step_index))
+            self._buttons.append(button)
+            layout.addWidget(button)
+            if index < len(STEPPER_LABELS) - 1:
+                connector = QFrame(self)
+                connector.setObjectName(f"qfitStepperConnector{index + 1}")
+                connector.setFrameShape(QFrame.HLine)
+                connector.setFrameShadow(QFrame.Plain)
+                connector.setFixedWidth(8)
+                connector.setFixedHeight(1)
+                self._connectors.append(connector)
+                layout.addWidget(connector)
+
+    def _configure_button(self, button: QToolButton, index: int, state: str) -> None:
+        button.setText(_button_text(index, state))
+        button.setProperty("stepIndex", index)
+        button.setProperty("wizardState", state)
+        button.setEnabled(state != "locked")
+        button.setCursor(Qt.ForbiddenCursor if state == "locked" else Qt.PointingHandCursor)
+        button.setToolTip(STEPPER_LABELS[index])
+        button.setStyleSheet(_button_stylesheet(state))
+
+    def _configure_connectors(self) -> None:
+        for index, connector in enumerate(self._connectors):
+            previous_step_is_done = self._states[index] == "done"
+            color = COLOR_ACCENT if previous_step_is_done else "#d0d3d8"
+            connector.setProperty("wizardState", "done" if previous_step_is_done else "upcoming")
+            connector.setStyleSheet(f"QFrame#{connector.objectName()} {{ border: 0; background: {color}; }}")
+
+    def _request_step(self, index: int) -> None:
+        if self._states[index] != "locked":
+            self.stepRequested.emit(index)
+
+
+def _validate_states(states: Sequence[str]) -> tuple[str, ...]:
+    values = tuple(states)
+    if len(values) != len(STEPPER_LABELS):
+        raise ValueError(f"StepperBar requires {len(STEPPER_LABELS)} states; got {len(values)}")
+    invalid_states = sorted(set(values) - STEPPER_STATES)
+    if invalid_states:
+        known = ", ".join(sorted(STEPPER_STATES))
+        raise ValueError(f"Unknown stepper state(s): {', '.join(invalid_states)}; expected one of: {known}")
+    return values
+
+
+def _button_text(index: int, state: str) -> str:
+    prefix = "✓" if state == "done" else str(index + 1)
+    return f"{prefix}  {STEPPER_LABELS[index]}"
+
+
+def _button_stylesheet(state: str) -> str:
+    if state == "done":
+        background = "transparent"
+        color = COLOR_TEXT
+        border = "0"
+        font_weight = "500"
+    elif state == "current":
+        background = COLOR_ACCENT
+        color = "white"
+        border = f"1px solid {COLOR_ACCENT}"
+        font_weight = "700"
+    elif state == "locked":
+        background = "transparent"
+        color = COLOR_MUTED
+        border = "0"
+        font_weight = "400"
+    else:
+        background = "transparent"
+        color = COLOR_MUTED
+        border = f"1px solid {COLOR_SEPARATOR}"
+        font_weight = "400"
+    return (
+        "QToolButton { "
+        f"background: {background}; "
+        f"color: {color}; "
+        f"border: {border}; "
+        "border-radius: 8px; "
+        "padding: 2px 6px; "
+        f"font-weight: {font_weight}; "
+        "font-size: 9.5pt; "
+        "} "
+        "QToolButton:hover:enabled { background: #e8e8e8; color: #202124; }"
+    )
+
+
+__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar"]

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -3,28 +3,46 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Sequence
 
+from qfit.ui.application.dock_workflow_sections import WIZARD_WORKFLOW_STEPS
+from qfit.ui.application.stepper_presenter import (
+    STEPPER_STATE_CURRENT,
+    STEPPER_STATE_DONE,
+    STEPPER_STATE_LOCKED,
+    STEPPER_STATE_UPCOMING,
+)
 from qfit.ui.widgets.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
 
-STEPPER_LABELS = ("Connexion", "Synchronisation", "Carte", "Analyse", "Atlas")
-STEPPER_STATES = frozenset({"done", "current", "upcoming", "locked"})
+STEPPER_LABELS = tuple(section.title for section in WIZARD_WORKFLOW_STEPS)
+STEPPER_STATES = frozenset(
+    {
+        STEPPER_STATE_DONE,
+        STEPPER_STATE_CURRENT,
+        STEPPER_STATE_UPCOMING,
+        STEPPER_STATE_LOCKED,
+    }
+)
 
 
-def _import_qt_module(qgis_module: str, pyqt_module: str, required_attribute: str):
+def _import_qt_module(qgis_module: str, pyqt_module: str, required_attributes: Sequence[str]):
     try:
         module = import_module(qgis_module)
     except ModuleNotFoundError as exc:
         if not str(exc).startswith("No module named 'qgis"):
             raise
         return import_module(pyqt_module)
-    if hasattr(module, required_attribute):
+    if all(hasattr(module, attribute) for attribute in required_attributes):
         return module
     # Some pure tests temporarily register tiny qgis.PyQt stubs. Fall back to
-    # PyQt5 when those stubs do not provide the widget APIs needed here.
+    # PyQt5 when those stubs do not provide every widget API needed here.
     return import_module(pyqt_module)
 
 
-_qtcore = _import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", "pyqtSignal")
-_qtwidgets = _import_qt_module("qgis.PyQt.QtWidgets", "PyQt5.QtWidgets", "QWidget")
+_qtcore = _import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt", "pyqtSignal"))
+_qtwidgets = _import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    ("QFrame", "QHBoxLayout", "QSizePolicy", "QToolButton", "QWidget"),
+)
 
 Qt = _qtcore.Qt
 pyqtSignal = _qtcore.pyqtSignal

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -102,7 +102,7 @@ class StepperBar(QWidget):
         layout = QHBoxLayout(self)
         layout.setContentsMargins(4, 2, 10, 2)
         layout.setSpacing(4)
-        for index, label in enumerate(STEPPER_LABELS):
+        for index, _label in enumerate(STEPPER_LABELS):
             button = QToolButton(self)
             button.setObjectName(f"qfitStepperStep{index + 1}")
             button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -73,7 +73,7 @@ class StepperBar(QWidget):
 
         validated_states = _validate_states(states)
         self._states = list(validated_states)
-        for index, (button, state) in enumerate(zip(self._buttons, self._states, strict=True)):
+        for index, (button, state) in enumerate(zip(self._buttons, self._states)):
             self._configure_button(button, index, state)
         self._configure_connectors()
 

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -10,7 +10,7 @@ from qfit.ui.application.stepper_presenter import (
     STEPPER_STATE_LOCKED,
     STEPPER_STATE_UPCOMING,
 )
-from qfit.ui.widgets.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
+from qfit.ui.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
 
 STEPPER_LABELS = tuple(section.title for section in WIZARD_WORKFLOW_STEPS)
 STEPPER_STATES = frozenset(

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Sequence
 
-from qfit.ui.widgets.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
+from qfit.ui.widgets.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
 
 STEPPER_LABELS = ("Connexion", "Synchronisation", "Carte", "Analyse", "Atlas")
 STEPPER_STATES = frozenset({"done", "current", "upcoming", "locked"})
@@ -60,7 +60,11 @@ class StepperBar(QWidget):
         self._configure_connectors()
 
     def set_current(self, index: int) -> None:
-        """Mark one step current and leave all other steps dim/upcoming."""
+        """Mark one step current and leave all other steps dim/upcoming.
+
+        Use ``set_state`` instead when navigation must preserve completed-step
+        history.
+        """
 
         if index < 0 or index >= len(STEPPER_LABELS):
             raise ValueError(f"Stepper index {index} is outside 0..{len(STEPPER_LABELS) - 1}")
@@ -110,7 +114,7 @@ class StepperBar(QWidget):
     def _configure_connectors(self) -> None:
         for index, connector in enumerate(self._connectors):
             previous_step_is_done = self._states[index] == "done"
-            color = COLOR_ACCENT if previous_step_is_done else "#d0d3d8"
+            color = COLOR_ACCENT if previous_step_is_done else COLOR_SEPARATOR
             connector.setProperty("wizardState", "done" if previous_step_is_done else "upcoming")
             connector.setStyleSheet(f"QFrame#{connector.objectName()} {{ border: 0; background: {color}; }}")
 
@@ -166,8 +170,7 @@ def _button_stylesheet(state: str) -> str:
         f"font-weight: {font_weight}; "
         "font-size: 9.5pt; "
         "} "
-        "QToolButton:hover:enabled { background: #e8e8e8; color: #202124; }"
-    )
+        f"QToolButton:hover:enabled {{ background: {COLOR_HOVER}; color: {COLOR_TEXT}; }}"    )
 
 
 __all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar"]

--- a/ui/tokens.py
+++ b/ui/tokens.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+COLOR_BG = "#f3f3f3"
+COLOR_PANEL = "#fafafa"
+COLOR_GROUP_BORDER = "#c4c4c4"
+COLOR_TEXT = "#202124"
+COLOR_MUTED = "#6b6f76"
+COLOR_ACCENT = "#589632"
+COLOR_ACCENT_DARK = "#3f6e22"
+COLOR_LINK = "#1a5fb4"
+COLOR_DANGER = "#c01c28"
+COLOR_WARN = "#b67204"
+COLOR_INPUT_BORDER = "#b0b4ba"
+COLOR_INPUT_BG = "#ffffff"
+COLOR_SEPARATOR = "#dcdcdc"
+COLOR_HOVER = "#e8e8e8"
+COLOR_TITLE_BAR = "#e4e4e7"
+
+PILL_TONES: dict[str, tuple[str, str]] = {
+    "ok": ("#dcefd0", "#2e6318"),
+    "info": ("#d6e7f7", "#124c8c"),
+    "warn": ("#fbe7c3", "#7a4f00"),
+    "danger": ("#f6d4d4", "#8a121b"),
+    "muted": ("#eef0f2", "#6b6f76"),
+    "neutral": ("#e4e4e7", "#3f3f46"),
+}
+
+PRIMARY_BTN_QSS = """
+QPushButton[role="primary"] {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                stop:0 #68ad3e, stop:1 #4e8a2b);
+    color: white; font-weight: 600;
+    border: 1px solid #3f6e22; border-radius: 2px;
+    padding: 4px 12px; min-height: 22px;
+}
+QPushButton[role="primary"]:hover { background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                stop:0 #72ba45, stop:1 #579530); }
+QPushButton[role="primary"]:disabled { background: #b0c9a0; border-color: #8aaa78; }
+""".strip()
+
+
+def pill_tone_palette(tone: str) -> tuple[str, str]:
+    """Return the background/foreground palette for a named pill tone."""
+
+    try:
+        return PILL_TONES[tone]
+    except KeyError as exc:
+        known = ", ".join(sorted(PILL_TONES))
+        raise ValueError(f"Unknown pill tone {tone!r}; expected one of: {known}") from exc
+
+
+__all__ = [
+    "COLOR_ACCENT",
+    "COLOR_ACCENT_DARK",
+    "COLOR_BG",
+    "COLOR_DANGER",
+    "COLOR_GROUP_BORDER",
+    "COLOR_HOVER",
+    "COLOR_INPUT_BG",
+    "COLOR_INPUT_BORDER",
+    "COLOR_LINK",
+    "COLOR_MUTED",
+    "COLOR_PANEL",
+    "COLOR_SEPARATOR",
+    "COLOR_TEXT",
+    "COLOR_TITLE_BAR",
+    "COLOR_WARN",
+    "PILL_TONES",
+    "PRIMARY_BTN_QSS",
+    "pill_tone_palette",
+]

--- a/ui/widgets/tokens.py
+++ b/ui/widgets/tokens.py
@@ -1,53 +1,25 @@
 from __future__ import annotations
 
-COLOR_BG = "#f3f3f3"
-COLOR_PANEL = "#fafafa"
-COLOR_GROUP_BORDER = "#c4c4c4"
-COLOR_TEXT = "#202124"
-COLOR_MUTED = "#6b6f76"
-COLOR_ACCENT = "#589632"
-COLOR_ACCENT_DARK = "#3f6e22"
-COLOR_LINK = "#1a5fb4"
-COLOR_DANGER = "#c01c28"
-COLOR_WARN = "#b67204"
-COLOR_INPUT_BORDER = "#b0b4ba"
-COLOR_INPUT_BG = "#ffffff"
-COLOR_SEPARATOR = "#dcdcdc"
-COLOR_HOVER = "#e8e8e8"
-COLOR_TITLE_BAR = "#e4e4e7"
-
-PILL_TONES: dict[str, tuple[str, str]] = {
-    "ok": ("#dcefd0", "#2e6318"),
-    "info": ("#d6e7f7", "#124c8c"),
-    "warn": ("#fbe7c3", "#7a4f00"),
-    "danger": ("#f6d4d4", "#8a121b"),
-    "muted": ("#eef0f2", "#6b6f76"),
-    "neutral": ("#e4e4e7", "#3f3f46"),
-}
-
-PRIMARY_BTN_QSS = """
-QPushButton[role="primary"] {
-    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-                stop:0 #68ad3e, stop:1 #4e8a2b);
-    color: white; font-weight: 600;
-    border: 1px solid #3f6e22; border-radius: 2px;
-    padding: 4px 12px; min-height: 22px;
-}
-QPushButton[role="primary"]:hover { background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-                stop:0 #72ba45, stop:1 #579530); }
-QPushButton[role="primary"]:disabled { background: #b0c9a0; border-color: #8aaa78; }
-""".strip()
-
-
-def pill_tone_palette(tone: str) -> tuple[str, str]:
-    """Return the background/foreground palette for a named pill tone."""
-
-    try:
-        return PILL_TONES[tone]
-    except KeyError as exc:
-        known = ", ".join(sorted(PILL_TONES))
-        raise ValueError(f"Unknown pill tone {tone!r}; expected one of: {known}") from exc
-
+from qfit.ui.tokens import (
+    COLOR_ACCENT,
+    COLOR_ACCENT_DARK,
+    COLOR_BG,
+    COLOR_DANGER,
+    COLOR_GROUP_BORDER,
+    COLOR_HOVER,
+    COLOR_INPUT_BG,
+    COLOR_INPUT_BORDER,
+    COLOR_LINK,
+    COLOR_MUTED,
+    COLOR_PANEL,
+    COLOR_SEPARATOR,
+    COLOR_TEXT,
+    COLOR_TITLE_BAR,
+    COLOR_WARN,
+    PILL_TONES,
+    PRIMARY_BTN_QSS,
+    pill_tone_palette,
+)
 
 __all__ = [
     "COLOR_ACCENT",


### PR DESCRIPTION
## Summary

Adds the standalone wizard StepperBar widget from the #609 dock redesign spec without replacing the current dock layout.

## Changes

- Add `ui/dockwidget/stepper_bar.py` with the five fixed wizard steps, state validation, locked-step handling, and `stepRequested(int)` emission.
- Add the `ui.dockwidget` package export for future dock shell wiring.
- Cover initial state, state rendering, validation, current-step shortcut, and click emission behavior.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short` — 1231 passed, 154 skipped, 6 subtests passed
- `python3 scripts/package_plugin.py` — built `dist/qfit-0.42.2.zip`

Refs #609
Refs #608
