### PR TITLE
ui: add wizard shell structure

### DIFF
--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -236,7 +236,7 @@ class StepperBarTest(unittest.TestCase):
                 "fallback.QtWidgets": fallback_qtwidgets,
             },
         ):
-            module = self.stepper._import_qt_module(
+            module = self.stepper.import_qt_module(
                 "qgis.PyQt.QtWidgets",
                 "fallback.QtWidgets",
                 ("QWidget", "QFrame"),

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -1,0 +1,326 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+
+class _FakeSignal:
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+        return slot
+
+    def emit(self, *args):
+        for slot in list(self._slots):
+            slot(*args)
+
+
+class _FakeSignalDescriptor:
+    def __set_name__(self, owner, name):
+        self.name = f"_{name}_signal"
+
+    def __get__(self, instance, _owner):
+        if instance is None:
+            return self
+        signal = instance.__dict__.get(self.name)
+        if signal is None:
+            signal = _FakeSignal()
+            instance.__dict__[self.name] = signal
+        return signal
+
+
+def _fake_pyqt_signal(*_args, **_kwargs):
+    return _FakeSignalDescriptor()
+
+
+class _FakeCursor:
+    def __init__(self, shape):
+        self._shape = shape
+
+    def shape(self):
+        return self._shape
+
+
+class _FakeQt:
+    ForbiddenCursor = 10
+    PointingHandCursor = 11
+    ToolButtonTextBesideIcon = 12
+
+
+class _FakeWidget:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self._height = None
+        self._object_name = ""
+        self._properties = {}
+        self._enabled = True
+        self._cursor = _FakeCursor(None)
+        self._tooltip = ""
+        self._stylesheet = ""
+
+    def setFixedHeight(self, value):  # noqa: N802
+        self._height = value
+
+    def height(self):
+        return self._height
+
+    def setObjectName(self, value):  # noqa: N802
+        self._object_name = value
+
+    def objectName(self):  # noqa: N802
+        return self._object_name
+
+    def setProperty(self, name, value):  # noqa: N802
+        self._properties[name] = value
+
+    def property(self, name):
+        return self._properties.get(name)
+
+    def setEnabled(self, enabled):  # noqa: N802
+        self._enabled = enabled
+
+    def isEnabled(self):  # noqa: N802
+        return self._enabled
+
+    def setCursor(self, shape):  # noqa: N802
+        self._cursor = _FakeCursor(shape)
+
+    def cursor(self):
+        return self._cursor
+
+    def setToolTip(self, value):  # noqa: N802
+        self._tooltip = value
+
+    def toolTip(self):  # noqa: N802
+        return self._tooltip
+
+    def setStyleSheet(self, value):  # noqa: N802
+        self._stylesheet = value
+
+    def styleSheet(self):  # noqa: N802
+        return self._stylesheet
+
+
+class _FakeToolButton(_FakeWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.clicked = _FakeSignal()
+        self._text = ""
+        self.tool_button_style = None
+        self.size_policy = None
+
+    def setToolButtonStyle(self, value):  # noqa: N802
+        self.tool_button_style = value
+
+    def setSizePolicy(self, horizontal, vertical):  # noqa: N802
+        self.size_policy = (horizontal, vertical)
+
+    def setText(self, value):
+        self._text = value
+
+    def text(self):
+        return self._text
+
+
+class _FakeFrame(_FakeWidget):
+    HLine = 1
+    Plain = 2
+    NoFrame = 3
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.frame_shape = None
+        self.frame_shadow = None
+        self.fixed_width = None
+
+    def setFrameShape(self, value):  # noqa: N802
+        self.frame_shape = value
+
+    def setFrameShadow(self, value):  # noqa: N802
+        self.frame_shadow = value
+
+    def setFixedWidth(self, value):  # noqa: N802
+        self.fixed_width = value
+
+
+class _FakeLabel(_FakeWidget):
+    def __init__(self, text="", parent=None):
+        super().__init__(parent)
+        self._text = text
+
+    def setText(self, value):  # noqa: N802
+        self._text = value
+
+    def text(self):
+        return self._text
+
+
+class _FakeScrollArea(_FakeWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.widget_resizable = False
+        self.widget = None
+        self.frame_shape = None
+
+    def setWidgetResizable(self, value):  # noqa: N802
+        self.widget_resizable = value
+
+    def setWidget(self, widget):  # noqa: N802
+        self.widget = widget
+
+    def setFrameShape(self, value):  # noqa: N802
+        self.frame_shape = value
+
+
+class _FakeStackedWidget(_FakeWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.widgets = []
+        self.current_index = -1
+
+    def addWidget(self, widget):  # noqa: N802
+        self.widgets.append(widget)
+        if self.current_index == -1:
+            self.current_index = 0
+        return len(self.widgets) - 1
+
+    def count(self):
+        return len(self.widgets)
+
+    def setCurrentIndex(self, index):  # noqa: N802
+        self.current_index = index
+
+    def currentIndex(self):  # noqa: N802
+        return self.current_index
+
+
+class _FakeVBoxLayout:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.object_name = ""
+        self.contents_margins = None
+        self.spacing = None
+        self.widgets = []
+
+    def setObjectName(self, value):  # noqa: N802
+        self.object_name = value
+
+    def setContentsMargins(self, *values):  # noqa: N802
+        self.contents_margins = values
+
+    def setSpacing(self, value):  # noqa: N802
+        self.spacing = value
+
+    def addWidget(self, widget):  # noqa: N802
+        self.widgets.append(widget)
+
+
+class _FakeHBoxLayout(_FakeVBoxLayout):
+    pass
+
+
+class _FakeSizePolicy:
+    Expanding = 1
+    Fixed = 2
+
+
+def _fake_qt_modules():
+    qgis = types.ModuleType("qgis")
+    pyqt = types.ModuleType("qgis.PyQt")
+    pyqt.__path__ = []
+    qtcore = types.ModuleType("qgis.PyQt.QtCore")
+    qtcore.Qt = _FakeQt
+    qtcore.pyqtSignal = _fake_pyqt_signal
+    qtwidgets = types.ModuleType("qgis.PyQt.QtWidgets")
+    qtwidgets.QFrame = _FakeFrame
+    qtwidgets.QHBoxLayout = _FakeHBoxLayout
+    qtwidgets.QLabel = _FakeLabel
+    qtwidgets.QScrollArea = _FakeScrollArea
+    qtwidgets.QSizePolicy = _FakeSizePolicy
+    qtwidgets.QStackedWidget = _FakeStackedWidget
+    qtwidgets.QToolButton = _FakeToolButton
+    qtwidgets.QVBoxLayout = _FakeVBoxLayout
+    qtwidgets.QWidget = _FakeWidget
+    qgis.PyQt = pyqt
+    return {
+        "qgis": qgis,
+        "qgis.PyQt": pyqt,
+        "qgis.PyQt.QtCore": qtcore,
+        "qgis.PyQt.QtWidgets": qtwidgets,
+    }
+
+
+def _load_wizard_shell_module():
+    for name in (
+        "qfit.ui.dockwidget.wizard_shell",
+        "qfit.ui.dockwidget.stepper_bar",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.wizard_shell")
+
+
+class WizardShellTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.wizard_shell = _load_wizard_shell_module()
+
+    def test_builds_spec_shell_structure_with_empty_pages_stack(self):
+        shell = self.wizard_shell.WizardShell(footer_text="Ready")
+
+        self.assertEqual(shell.objectName(), "qfitWizardShell")
+        self.assertEqual(shell.stepper_bar.objectName(), "qfitStepperBar")
+        self.assertEqual(shell.separator.objectName(), "qfitWizardShellSeparator")
+        self.assertEqual(shell.separator.frame_shape, _FakeFrame.HLine)
+        self.assertEqual(shell.content_scroll.objectName(), "qfitWizardContentScroll")
+        self.assertTrue(shell.content_scroll.widget_resizable)
+        self.assertEqual(shell.content_scroll.frame_shape, _FakeFrame.NoFrame)
+        self.assertIs(shell.content_scroll.widget, shell.pages_stack)
+        self.assertEqual(shell.pages_stack.objectName(), "qfitWizardPagesStack")
+        self.assertEqual(shell.page_count(), 0)
+        self.assertEqual(shell.footer_bar.objectName(), "qfitWizardFooterBar")
+        self.assertEqual(shell.footer_bar.height(), 28)
+        self.assertEqual(shell.footer_bar.text(), "Ready")
+
+    def test_outer_layout_matches_wizard_spec_order(self):
+        shell = self.wizard_shell.WizardShell()
+        layout = shell.outer_layout()
+
+        self.assertEqual(layout.object_name, "qfitWizardOuterLayout")
+        self.assertEqual(layout.contents_margins, (0, 0, 0, 0))
+        self.assertEqual(layout.spacing, 0)
+        self.assertEqual(
+            layout.widgets,
+            [shell.stepper_bar, shell.separator, shell.content_scroll, shell.footer_bar],
+        )
+
+    def test_delegates_stepper_state_and_page_selection(self):
+        shell = self.wizard_shell.WizardShell()
+        first_page = _FakeWidget()
+        second_page = _FakeWidget()
+
+        self.assertEqual(shell.add_page(first_page), 0)
+        self.assertEqual(shell.add_page(second_page), 1)
+        shell.set_step_states(["done", "current", "upcoming", "locked", "locked"])
+        shell.set_current_step(1)
+
+        self.assertEqual(shell.page_count(), 2)
+        self.assertEqual(shell.stepper_bar.states(), ("upcoming", "current", "upcoming", "upcoming", "upcoming"))
+        self.assertEqual(shell.pages_stack.currentIndex(), 1)
+
+    def test_updates_footer_text_without_rebuilding_shell(self):
+        shell = self.wizard_shell.WizardShell(footer_text="Starting")
+
+        shell.set_footer_text("Connected · 42 activities")
+
+        self.assertEqual(shell.footer_bar.text(), "Connected · 42 activities")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -308,6 +308,8 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(shell.add_page(first_page), 0)
         self.assertEqual(shell.add_page(second_page), 1)
         shell.set_step_states(["done", "current", "upcoming", "locked", "locked"])
+        self.assertEqual(shell.stepper_bar.states(), ("done", "current", "upcoming", "locked", "locked"))
+
         shell.set_current_step(1)
 
         self.assertEqual(shell.page_count(), 2)

--- a/ui/dockwidget/_qt_compat.py
+++ b/ui/dockwidget/_qt_compat.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Sequence
+
+
+def import_qt_module(qgis_module: str, pyqt_module: str, required_attributes: Sequence[str]):
+    """Import a QGIS PyQt module, falling back to PyQt5 for incomplete test stubs."""
+
+    try:
+        module = import_module(qgis_module)
+    except ModuleNotFoundError as exc:
+        if not str(exc).startswith("No module named 'qgis"):
+            raise
+        return import_module(pyqt_module)
+    if all(hasattr(module, attribute) for attribute in required_attributes):
+        return module
+    # Some pure tests temporarily register tiny qgis.PyQt stubs. Fall back to
+    # PyQt5 when those stubs do not provide every widget API needed here.
+    return import_module(pyqt_module)
+
+
+__all__ = ["import_qt_module"]

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from importlib import import_module
 from typing import Sequence
 
 from qfit.ui.application.dock_workflow_sections import WIZARD_WORKFLOW_STEPS
@@ -11,6 +10,8 @@ from qfit.ui.application.stepper_presenter import (
     STEPPER_STATE_UPCOMING,
 )
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
+
+from ._qt_compat import import_qt_module
 
 STEPPER_LABELS = tuple(section.title for section in WIZARD_WORKFLOW_STEPS)
 STEPPER_STATES = frozenset(
@@ -23,22 +24,8 @@ STEPPER_STATES = frozenset(
 )
 
 
-def _import_qt_module(qgis_module: str, pyqt_module: str, required_attributes: Sequence[str]):
-    try:
-        module = import_module(qgis_module)
-    except ModuleNotFoundError as exc:
-        if not str(exc).startswith("No module named 'qgis"):
-            raise
-        return import_module(pyqt_module)
-    if all(hasattr(module, attribute) for attribute in required_attributes):
-        return module
-    # Some pure tests temporarily register tiny qgis.PyQt stubs. Fall back to
-    # PyQt5 when those stubs do not provide every widget API needed here.
-    return import_module(pyqt_module)
-
-
-_qtcore = _import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt", "pyqtSignal"))
-_qtwidgets = _import_qt_module(
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt", "pyqtSignal"))
+_qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
     "PyQt5.QtWidgets",
     ("QFrame", "QHBoxLayout", "QSizePolicy", "QToolButton", "QWidget"),
@@ -191,4 +178,4 @@ def _button_stylesheet(state: str) -> str:
         f"QToolButton:hover:enabled {{ background: {COLOR_HOVER}; color: {COLOR_TEXT}; }}"    )
 
 
-__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar"]
+__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar", "import_qt_module"]

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from .stepper_bar import STEPPER_LABELS, StepperBar, _import_qt_module
+
+_qtwidgets = _import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QFrame",
+        "QLabel",
+        "QScrollArea",
+        "QStackedWidget",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+QFrame = _qtwidgets.QFrame
+QLabel = _qtwidgets.QLabel
+QScrollArea = _qtwidgets.QScrollArea
+QStackedWidget = _qtwidgets.QStackedWidget
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+class WizardShell(QWidget):
+    """Reusable dock shell matching the #609 wizard page structure.
+
+    The shell intentionally owns only the structural chrome: stepper, separator,
+    scrollable stacked pages, and compact footer. Page content remains external so
+    the future wizard can migrate one page at a time without binding the current
+    long-scroll dock to another round of cosmetic changes.
+    """
+
+    def __init__(self, parent=None, *, footer_text: str = "") -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitWizardShell")
+        self.stepper_bar = StepperBar(self)
+        self.separator = self._build_separator()
+        self.content_scroll = self._build_content_scroll()
+        self.pages_stack = self._build_pages_stack()
+        self.footer_bar = self._build_footer_bar(footer_text)
+        self.content_scroll.setWidget(self.pages_stack)
+        self._outer_layout = self._build_layout()
+
+    def set_step_states(self, states: Sequence[str]) -> None:
+        """Delegate validated step state rendering to the shared stepper."""
+
+        self.stepper_bar.set_state(states)
+
+    def set_current_step(self, index: int) -> None:
+        """Mark the active step and show the matching page when it exists."""
+
+        self.stepper_bar.set_current(index)
+        if index < self.pages_stack.count():
+            self.pages_stack.setCurrentIndex(index)
+
+    def add_page(self, page: QWidget) -> int:
+        """Append a wizard page and return its stack index."""
+
+        return self.pages_stack.addWidget(page)
+
+    def page_count(self) -> int:
+        """Return the number of pages currently installed in the shell."""
+
+        return self.pages_stack.count()
+
+    def set_footer_text(self, text: str) -> None:
+        """Update the compact persistent status/footer text."""
+
+        self.footer_bar.setText(text)
+
+    def outer_layout(self):
+        """Expose the structural layout for adapter wiring and pure tests."""
+
+        return self._outer_layout
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardOuterLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.stepper_bar)
+        layout.addWidget(self.separator)
+        layout.addWidget(self.content_scroll)
+        layout.addWidget(self.footer_bar)
+        return layout
+
+    def _build_separator(self):
+        separator = QFrame(self)
+        separator.setObjectName("qfitWizardShellSeparator")
+        separator.setFrameShape(QFrame.HLine)
+        separator.setFrameShadow(QFrame.Plain)
+        separator.setFixedHeight(1)
+        return separator
+
+    def _build_content_scroll(self):
+        scroll = QScrollArea(self)
+        scroll.setObjectName("qfitWizardContentScroll")
+        scroll.setWidgetResizable(True)
+        if hasattr(QFrame, "NoFrame") and hasattr(scroll, "setFrameShape"):
+            scroll.setFrameShape(QFrame.NoFrame)
+        return scroll
+
+    def _build_pages_stack(self):
+        stack = QStackedWidget(self)
+        stack.setObjectName("qfitWizardPagesStack")
+        return stack
+
+    def _build_footer_bar(self, footer_text: str):
+        footer = QLabel(footer_text, self)
+        footer.setObjectName("qfitWizardFooterBar")
+        footer.setFixedHeight(28)
+        footer.setStyleSheet(
+            "QLabel#qfitWizardFooterBar { "
+            "border-top: 1px solid palette(mid); "
+            "padding: 4px 8px; "
+            "}"
+        )
+        return footer
+
+
+__all__ = ["STEPPER_LABELS", "WizardShell"]

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from .stepper_bar import STEPPER_LABELS, StepperBar, _import_qt_module
+from ._qt_compat import import_qt_module
+from .stepper_bar import STEPPER_LABELS, StepperBar
 
-_qtwidgets = _import_qt_module(
+_qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
     "PyQt5.QtWidgets",
     (
@@ -101,8 +102,7 @@ class WizardShell(QWidget):
         scroll = QScrollArea(self)
         scroll.setObjectName("qfitWizardContentScroll")
         scroll.setWidgetResizable(True)
-        if hasattr(QFrame, "NoFrame") and hasattr(scroll, "setFrameShape"):
-            scroll.setFrameShape(QFrame.NoFrame)
+        scroll.setFrameShape(QFrame.NoFrame)
         return scroll
 
     def _build_pages_stack(self):


### PR DESCRIPTION
## Summary

Add a reusable wizard shell widget for the #609 dock redesign without replacing the current dock or implementing the full wizard flow.

## Changes

- Add `WizardShell` with the target structural chrome: `StepperBar`, separator, scrollable `QStackedWidget`, and compact footer bar.
- Keep page content external so future wizard pages can migrate one at a time without entrenching the current long-scroll dock.
- Add pure Qt-fake tests covering the shell object names, layout order, empty initial page stack, footer updates, and page selection helpers.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
