### PR TITLE
ui: add wizard page containers

### DIFF
--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -67,6 +67,11 @@ class WizardPageTest(unittest.TestCase):
             [page.title_label, page.summary_label, page.body_container, page.primary_hint_label],
         )
 
+    def test_build_pages_preserves_explicit_empty_specs(self):
+        pages = self.wizard_page.build_wizard_pages(specs=())
+
+        self.assertEqual(pages, ())
+
     def test_installs_default_pages_into_wizard_shell(self):
         shell = self.wizard_shell.WizardShell()
 

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -1,0 +1,85 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+
+
+class WizardPageSpecsTests(unittest.TestCase):
+    def test_default_specs_follow_stable_wizard_order(self):
+        specs = build_default_wizard_page_specs()
+
+        self.assertEqual(
+            [(spec.key, spec.title) for spec in specs],
+            [
+                ("connection", "Connection"),
+                ("sync", "Synchronization"),
+                ("map", "Map & filters"),
+                ("analysis", "Spatial analysis"),
+                ("atlas", "Atlas PDF"),
+            ],
+        )
+        self.assertEqual(specs[0].page_object_name, "qfitWizardConnectionPage")
+        self.assertEqual(specs[0].body_object_name, "qfitWizardConnectionPageBody")
+        self.assertIn("configure connection", specs[0].primary_action_hint)
+
+
+def _load_wizard_modules():
+    for name in (
+        "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.wizard_shell",
+        "qfit.ui.dockwidget.stepper_bar",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return (
+            importlib.import_module("qfit.ui.dockwidget.wizard_page"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_shell"),
+        )
+
+
+class WizardPageTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.wizard_page, cls.wizard_shell = _load_wizard_modules()
+
+    def test_page_container_builds_visible_placeholder_chrome(self):
+        spec = build_default_wizard_page_specs()[2]
+
+        page = self.wizard_page.WizardPage(spec)
+
+        self.assertEqual(page.objectName(), "qfitWizardMapPage")
+        self.assertEqual(page.title_label.objectName(), "qfitWizardMapPageTitle")
+        self.assertEqual(page.title_label.text(), "Map & filters")
+        self.assertEqual(page.summary_label.objectName(), "qfitWizardMapPageSummary")
+        self.assertIn("background map", page.summary_label.text())
+        self.assertEqual(page.body_container.objectName(), "qfitWizardMapPageBody")
+        self.assertEqual(page.body_layout().contents_margins, (0, 0, 0, 0))
+        self.assertEqual(page.primary_hint_label.objectName(), "qfitWizardMapPagePrimaryHint")
+        self.assertIn("apply map filters", page.primary_hint_label.text())
+        self.assertEqual(
+            page.outer_layout().widgets,
+            [page.title_label, page.summary_label, page.body_container, page.primary_hint_label],
+        )
+
+    def test_installs_default_pages_into_wizard_shell(self):
+        shell = self.wizard_shell.WizardShell()
+
+        pages = self.wizard_page.install_wizard_pages(shell)
+
+        self.assertEqual(shell.page_count(), 5)
+        self.assertEqual([page.spec.key for page in pages], ["connection", "sync", "map", "analysis", "atlas"])
+        self.assertEqual(shell.pages_stack.widgets, list(pages))
+
+        shell.set_current_step(3)
+
+        self.assertEqual(shell.pages_stack.currentIndex(), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
+from qfit.ui.application import wizard_page_specs
 from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
 
 
@@ -26,6 +27,13 @@ class WizardPageSpecsTests(unittest.TestCase):
         self.assertEqual(specs[0].page_object_name, "qfitWizardConnectionPage")
         self.assertEqual(specs[0].body_object_name, "qfitWizardConnectionPageBody")
         self.assertIn("configure connection", specs[0].primary_action_hint)
+
+    def test_default_specs_reject_missing_page_copy_with_clear_message(self):
+        unknown_step = type("UnknownStep", (), {"key": "review", "title": "Review"})()
+
+        with patch.object(wizard_page_specs, "WIZARD_WORKFLOW_STEPS", (unknown_step,)):
+            with self.assertRaisesRegex(KeyError, "No page copy found for wizard step 'review'"):
+                build_default_wizard_page_specs()
 
 
 def _load_wizard_modules():

--- a/ui/application/wizard_page_specs.py
+++ b/ui/application/wizard_page_specs.py
@@ -70,6 +70,11 @@ def build_default_wizard_page_specs() -> tuple[DockWizardPageSpec, ...]:
 
     specs = []
     for step in WIZARD_WORKFLOW_STEPS:
+        if step.key not in _PAGE_COPY_BY_KEY:
+            raise KeyError(
+                f"No page copy found for wizard step {step.key!r}. "
+                "Add an entry to _PAGE_COPY_BY_KEY."
+            )
         summary, primary_action_hint = _PAGE_COPY_BY_KEY[step.key]
         specs.append(
             DockWizardPageSpec(

--- a/ui/application/wizard_page_specs.py
+++ b/ui/application/wizard_page_specs.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .dock_workflow_sections import WIZARD_WORKFLOW_STEPS
+
+
+@dataclass(frozen=True)
+class DockWizardPageSpec:
+    """Render-neutral metadata for one wizard page placeholder.
+
+    The page spec is intentionally small: it gives the wizard shell stable page
+    keys, object names, and visible copy without deciding the final controls for
+    each page. That lets the dock migrate page-by-page toward #609 without
+    entrenching the current long-scroll UI.
+    """
+
+    key: str
+    title: str
+    summary: str
+    primary_action_hint: str
+
+    @property
+    def page_object_name(self) -> str:
+        return f"qfitWizard{_camel_case_key(self.key)}Page"
+
+    @property
+    def title_object_name(self) -> str:
+        return f"{self.page_object_name}Title"
+
+    @property
+    def summary_object_name(self) -> str:
+        return f"{self.page_object_name}Summary"
+
+    @property
+    def body_object_name(self) -> str:
+        return f"{self.page_object_name}Body"
+
+    @property
+    def primary_hint_object_name(self) -> str:
+        return f"{self.page_object_name}PrimaryHint"
+
+
+_PAGE_COPY_BY_KEY = {
+    "connection": (
+        "Connect qfit to Strava before syncing activities.",
+        "Primary action: configure connection",
+    ),
+    "sync": (
+        "Fetch activities and store detailed routes in the GeoPackage.",
+        "Primary action: sync activities",
+    ),
+    "map": (
+        "Load activity layers, choose a background map, and refine filters.",
+        "Primary action: apply map filters",
+    ),
+    "analysis": (
+        "Run heatmap, corridor, and start-point analysis from loaded data.",
+        "Primary action: run analysis",
+    ),
+    "atlas": (
+        "Configure and export multi-activity PDF atlases.",
+        "Primary action: export atlas PDF",
+    ),
+}
+
+
+def build_default_wizard_page_specs() -> tuple[DockWizardPageSpec, ...]:
+    """Return the first page placeholders in stable #609 wizard order."""
+
+    specs = []
+    for step in WIZARD_WORKFLOW_STEPS:
+        summary, primary_action_hint = _PAGE_COPY_BY_KEY[step.key]
+        specs.append(
+            DockWizardPageSpec(
+                key=step.key,
+                title=step.title,
+                summary=summary,
+                primary_action_hint=primary_action_hint,
+            )
+        )
+    return tuple(specs)
+
+
+def _camel_case_key(key: str) -> str:
+    return "".join(part.capitalize() for part in key.split("_"))
+
+
+__all__ = ["DockWizardPageSpec", "build_default_wizard_page_specs"]

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from qfit.ui.application.wizard_page_specs import (
+    DockWizardPageSpec,
+    build_default_wizard_page_specs,
+)
+
+from ._qt_compat import import_qt_module
+
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QLabel",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+QLabel = _qtwidgets.QLabel
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+class WizardPage(QWidget):
+    """Reusable visible page container for the #609 wizard shell.
+
+    The container supplies stable chrome for the future wizard pages while
+    leaving real page controls to later focused slices. It is deliberately not
+    wired into the current dock yet, so it remains compatible with the shell
+    structure without locking in the old scroll layout.
+    """
+
+    def __init__(self, spec: DockWizardPageSpec, parent=None) -> None:
+        super().__init__(parent)
+        self.spec = spec
+        self.setObjectName(spec.page_object_name)
+        self.title_label = self._build_label(spec.title, spec.title_object_name)
+        self.summary_label = self._build_label(spec.summary, spec.summary_object_name)
+        self.body_container = self._build_body_container()
+        self.primary_hint_label = self._build_label(
+            spec.primary_action_hint,
+            spec.primary_hint_object_name,
+        )
+        self._layout = self._build_layout()
+
+    def body_layout(self):
+        """Expose the empty content layout for future page-specific controls."""
+
+        return self._body_layout
+
+    def outer_layout(self):
+        """Expose the page layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_label(self, text: str, object_name: str):
+        label = QLabel(text, self)
+        label.setObjectName(object_name)
+        if hasattr(label, "setWordWrap"):
+            label.setWordWrap(True)
+        return label
+
+    def _build_body_container(self):
+        body = QWidget(self)
+        body.setObjectName(self.spec.body_object_name)
+        self._body_layout = QVBoxLayout(body)
+        self._body_layout.setContentsMargins(0, 0, 0, 0)
+        self._body_layout.setSpacing(8)
+        return body
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName(f"{self.spec.page_object_name}Layout")
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(8)
+        layout.addWidget(self.title_label)
+        layout.addWidget(self.summary_label)
+        layout.addWidget(self.body_container)
+        layout.addWidget(self.primary_hint_label)
+        return layout
+
+
+def build_wizard_pages(
+    *,
+    parent=None,
+    specs: Sequence[DockWizardPageSpec] | None = None,
+) -> tuple[WizardPage, ...]:
+    """Build visible wizard page containers from render-neutral specs."""
+
+    page_specs = tuple(specs or build_default_wizard_page_specs())
+    return tuple(WizardPage(spec, parent) for spec in page_specs)
+
+
+def install_wizard_pages(shell, specs: Sequence[DockWizardPageSpec] | None = None) -> tuple[WizardPage, ...]:
+    """Create default wizard pages and append them to a :class:`WizardShell`."""
+
+    pages = build_wizard_pages(parent=shell, specs=specs)
+    for page in pages:
+        shell.add_page(page)
+    return pages
+
+
+__all__ = ["WizardPage", "build_wizard_pages", "install_wizard_pages"]

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -39,7 +39,7 @@ class WizardPage(QWidget):
         self.setObjectName(spec.page_object_name)
         self.title_label = self._build_label(spec.title, spec.title_object_name)
         self.summary_label = self._build_label(spec.summary, spec.summary_object_name)
-        self.body_container = self._build_body_container()
+        self.body_container, self._body_layout = self._build_body_container()
         self.primary_hint_label = self._build_label(
             spec.primary_action_hint,
             spec.primary_hint_object_name,
@@ -66,10 +66,10 @@ class WizardPage(QWidget):
     def _build_body_container(self):
         body = QWidget(self)
         body.setObjectName(self.spec.body_object_name)
-        self._body_layout = QVBoxLayout(body)
-        self._body_layout.setContentsMargins(0, 0, 0, 0)
-        self._body_layout.setSpacing(8)
-        return body
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+        body_layout.setSpacing(8)
+        return body, body_layout
 
     def _build_layout(self):
         layout = QVBoxLayout(self)

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -91,7 +91,7 @@ def build_wizard_pages(
 ) -> tuple[WizardPage, ...]:
     """Build visible wizard page containers from render-neutral specs."""
 
-    page_specs = tuple(specs or build_default_wizard_page_specs())
+    page_specs = build_default_wizard_page_specs() if specs is None else tuple(specs)
     return tuple(WizardPage(spec, parent) for spec in page_specs)
 
 


### PR DESCRIPTION
## Summary

Adds the first reusable wizard page container layer that can be installed into the existing `WizardShell` without wiring the full wizard into the current dock.

## Changes

- Added render-neutral wizard page specs in the stable #609 step order.
- Added a Qt `WizardPage` placeholder container with title, summary, empty body area, and primary-action hint.
- Added an installer helper that appends the default pages to `WizardShell`.
- Covered the page specs, container structure, and shell installation with tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608.
Refs #609.
