### PR TITLE
feat: wire wizard shell navigation presenter

### DIFF
--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -1,0 +1,103 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+
+def _load_wizard_modules():
+    for name in (
+        "qfit.ui.dockwidget.wizard_shell_presenter",
+        "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.wizard_shell",
+        "qfit.ui.dockwidget.stepper_bar",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return (
+            importlib.import_module("qfit.ui.dockwidget.wizard_page"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_shell"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_shell_presenter"),
+        )
+
+
+class WizardShellPresenterTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.wizard_page, cls.wizard_shell, cls.presenter = _load_wizard_modules()
+
+    def _build_shell_with_pages(self):
+        shell = self.wizard_shell.WizardShell()
+        self.wizard_page.install_wizard_pages(shell)
+        return shell
+
+    def test_renders_initial_progress_without_entrenching_current_dock(self):
+        shell = self._build_shell_with_pages()
+
+        presenter = self.presenter.WizardShellPresenter(shell)
+
+        self.assertEqual(presenter.progress.current_key, "connection")
+        self.assertEqual(
+            shell.stepper_bar.states(),
+            ("current", "locked", "locked", "locked", "locked"),
+        )
+        self.assertEqual(shell.pages_stack.currentIndex(), 0)
+
+    def test_rejects_locked_step_requests_without_changing_page(self):
+        shell = self._build_shell_with_pages()
+        presenter = self.presenter.WizardShellPresenter(shell)
+
+        accepted = presenter.request_step(2)
+
+        self.assertFalse(accepted)
+        self.assertEqual(presenter.progress.current_key, "connection")
+        self.assertEqual(shell.pages_stack.currentIndex(), 0)
+        self.assertEqual(
+            shell.stepper_bar.states(),
+            ("current", "locked", "locked", "locked", "locked"),
+        )
+
+    def test_completion_unlocks_next_page_and_stepper_signal_navigates(self):
+        shell = self._build_shell_with_pages()
+        presenter = self.presenter.WizardShellPresenter(shell)
+
+        presenter.mark_step_done("connection")
+        shell.stepper_bar.stepRequested.emit(1)
+
+        self.assertEqual(presenter.progress.current_key, "sync")
+        self.assertIn("sync", presenter.progress.visited_keys)
+        self.assertEqual(shell.pages_stack.currentIndex(), 1)
+        self.assertEqual(
+            shell.stepper_bar.states(),
+            ("done", "current", "locked", "locked", "locked"),
+        )
+
+    def test_visited_uncompleted_pages_stay_unlocked_without_being_done(self):
+        shell = self._build_shell_with_pages()
+        presenter = self.presenter.WizardShellPresenter(shell)
+
+        presenter.mark_step_done("connection")
+        self.assertTrue(presenter.request_step(1))
+        self.assertTrue(presenter.request_step(0))
+
+        self.assertEqual(presenter.progress.current_key, "connection")
+        self.assertIn("sync", presenter.progress.visited_keys)
+        self.assertEqual(shell.pages_stack.currentIndex(), 0)
+        self.assertEqual(
+            shell.stepper_bar.states(),
+            ("current", "upcoming", "locked", "locked", "locked"),
+        )
+
+    def test_rejects_unknown_completed_step_key(self):
+        shell = self._build_shell_with_pages()
+        presenter = self.presenter.WizardShellPresenter(shell)
+
+        with self.assertRaises(KeyError):
+            presenter.mark_step_done("review")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/dockwidget/__init__.py
+++ b/ui/dockwidget/__init__.py
@@ -1,5 +1,6 @@
 """Dock widget components for the qfit wizard shell."""
 
 from .stepper_bar import STEPPER_LABELS, STEPPER_STATES, StepperBar
+from .wizard_shell_presenter import WizardShellPresenter
 
-__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar"]
+__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar", "WizardShellPresenter"]

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -55,6 +55,11 @@ class WizardShell(QWidget):
         """Mark the active step and show the matching page when it exists."""
 
         self.stepper_bar.set_current(index)
+        self.show_page(index)
+
+    def show_page(self, index: int) -> None:
+        """Show a page by stack index when that page has been installed."""
+
         if index < self.pages_stack.count():
             self.pages_stack.setCurrentIndex(index)
 

--- a/ui/dockwidget/wizard_shell_presenter.py
+++ b/ui/dockwidget/wizard_shell_presenter.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from qfit.ui.application.dock_workflow_sections import (
+    DockWizardProgress,
+    build_progress_wizard_step_statuses,
+)
+from qfit.ui.application.stepper_presenter import (
+    build_stepper_states,
+    can_request_step,
+    step_index_for_key,
+    step_key_for_index,
+)
+
+
+class WizardShellPresenter:
+    """Wire wizard progress state into a :class:`WizardShell`.
+
+    The presenter is intentionally shell-focused: it coordinates the reusable
+    stepper and page stack without knowing anything about the current long-scroll
+    dock controls. Completion facts can be supplied later by page-specific
+    workflows as those pages migrate into the shell.
+    """
+
+    def __init__(self, shell, progress: DockWizardProgress | None = None) -> None:
+        self._shell = shell
+        self._progress = progress or DockWizardProgress()
+        self._render()
+        self._shell.stepper_bar.stepRequested.connect(self.request_step)
+
+    @property
+    def progress(self) -> DockWizardProgress:
+        """Return the current render-neutral wizard progress snapshot."""
+
+        return self._progress
+
+    def request_step(self, index: int) -> bool:
+        """Move to ``index`` when the current workflow status allows it."""
+
+        statuses = self._statuses()
+        if not can_request_step(statuses, index):
+            return False
+        key = step_key_for_index(index)
+        self._progress = DockWizardProgress(
+            current_key=key,
+            completed_keys=self._progress.completed_keys,
+            visited_keys=self._progress.visited_keys | {key},
+        )
+        self._render()
+        return True
+
+    def mark_step_done(self, key: str) -> None:
+        """Record real workflow completion for ``key`` and refresh the shell."""
+
+        step_index_for_key(key)
+        self._progress = DockWizardProgress(
+            current_key=self._progress.current_key,
+            completed_keys=self._progress.completed_keys | {key},
+            visited_keys=self._progress.visited_keys,
+        )
+        self._render()
+
+    def _statuses(self):
+        return build_progress_wizard_step_statuses(self._progress)
+
+    def _render(self) -> None:
+        statuses = self._statuses()
+        self._shell.set_step_states(build_stepper_states(statuses))
+        self._shell.show_page(step_index_for_key(self._progress.current_key))
+
+
+__all__ = ["WizardShellPresenter"]


### PR DESCRIPTION
## Summary

Adds a reusable `WizardShellPresenter` that wires wizard progress into the existing shell and page stack without touching the current long-scroll dock.

## Changes

- Add shell presenter state/rendering for current, completed, visited, and locked wizard steps
- Connect `StepperBar.stepRequested` to guarded page navigation
- Add `WizardShell.show_page()` so presenters can change pages without resetting stepper state
- Cover initial state, locked-step rejection, completion unlocks, signal navigation, and visited-but-not-done pages

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
