### PR TITLE
ui: compose placeholder wizard shell

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -1,0 +1,74 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.dock_workflow_sections import DockWizardProgress
+
+
+def _load_wizard_composition_module():
+    for name in (
+        "qfit.ui.dockwidget.wizard_composition",
+        "qfit.ui.dockwidget.wizard_shell_presenter",
+        "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.wizard_shell",
+        "qfit.ui.dockwidget.stepper_bar",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.wizard_composition")
+
+
+class WizardShellCompositionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.composition = _load_wizard_composition_module()
+
+    def test_builds_placeholder_shell_with_pages_before_presenter_renders(self):
+        assembled = self.composition.build_placeholder_wizard_shell(footer_text="Ready")
+
+        self.assertEqual(assembled.shell.objectName(), "qfitWizardShell")
+        self.assertEqual(assembled.shell.footer_bar.text(), "Ready")
+        self.assertEqual(assembled.shell.page_count(), 5)
+        self.assertEqual(
+            [page.spec.key for page in assembled.pages],
+            ["connection", "sync", "map", "analysis", "atlas"],
+        )
+        self.assertEqual(assembled.shell.pages_stack.widgets, list(assembled.pages))
+        self.assertEqual(assembled.presenter.progress.current_key, "connection")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("current", "locked", "locked", "locked", "locked"),
+        )
+
+    def test_initial_progress_selects_matching_installed_page(self):
+        progress = DockWizardProgress(
+            current_key="map",
+            completed_keys=frozenset({"connection", "sync"}),
+            visited_keys=frozenset({"map"}),
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress=progress)
+
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("done", "done", "current", "locked", "locked"),
+        )
+
+    def test_supports_explicit_empty_specs_without_binding_current_dock_controls(self):
+        assembled = self.composition.build_placeholder_wizard_shell(specs=())
+
+        self.assertEqual(assembled.pages, ())
+        self.assertEqual(assembled.shell.page_count(), 0)
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), -1)
+        self.assertEqual(assembled.presenter.progress.current_key, "connection")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/dockwidget/__init__.py
+++ b/ui/dockwidget/__init__.py
@@ -1,6 +1,14 @@
 """Dock widget components for the qfit wizard shell."""
 
 from .stepper_bar import STEPPER_LABELS, STEPPER_STATES, StepperBar
+from .wizard_composition import WizardShellComposition, build_placeholder_wizard_shell
 from .wizard_shell_presenter import WizardShellPresenter
 
-__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar", "WizardShellPresenter"]
+__all__ = [
+    "STEPPER_LABELS",
+    "STEPPER_STATES",
+    "StepperBar",
+    "WizardShellComposition",
+    "WizardShellPresenter",
+    "build_placeholder_wizard_shell",
+]

--- a/ui/dockwidget/__init__.py
+++ b/ui/dockwidget/__init__.py
@@ -1,14 +1,6 @@
 """Dock widget components for the qfit wizard shell."""
 
 from .stepper_bar import STEPPER_LABELS, STEPPER_STATES, StepperBar
-from .wizard_composition import WizardShellComposition, build_placeholder_wizard_shell
 from .wizard_shell_presenter import WizardShellPresenter
 
-__all__ = [
-    "STEPPER_LABELS",
-    "STEPPER_STATES",
-    "StepperBar",
-    "WizardShellComposition",
-    "WizardShellPresenter",
-    "build_placeholder_wizard_shell",
-]
+__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar", "WizardShellPresenter"]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from qfit.ui.application.dock_workflow_sections import DockWizardProgress
+from qfit.ui.application.wizard_page_specs import DockWizardPageSpec
+
+from .wizard_page import WizardPage, install_wizard_pages
+from .wizard_shell import WizardShell
+from .wizard_shell_presenter import WizardShellPresenter
+
+
+@dataclass(frozen=True)
+class WizardShellComposition:
+    """Concrete placeholder wizard assembly for the future dock replacement.
+
+    The composition keeps the shell, page placeholders, and presenter wiring in
+    one reusable unit without replacing the current production dock yet. That
+    gives #609 a safe integration seam for the eventual dock swap while keeping
+    this slice focused on wizard-forward UI structure.
+    """
+
+    shell: WizardShell
+    pages: tuple[WizardPage, ...]
+    presenter: WizardShellPresenter
+
+
+def build_placeholder_wizard_shell(
+    *,
+    parent=None,
+    footer_text: str = "",
+    progress: DockWizardProgress | None = None,
+    specs: Sequence[DockWizardPageSpec] | None = None,
+) -> WizardShellComposition:
+    """Build the placeholder #609 wizard shell with pages and presenter wired.
+
+    Pages are installed before the presenter renders so the initial progress
+    snapshot selects the matching visible page immediately. The helper does not
+    bind any current long-scroll dock controls into the shell; page content can
+    migrate later through the stable ``WizardPage.body_layout()`` seams.
+    """
+
+    shell = WizardShell(parent=parent, footer_text=footer_text)
+    pages = install_wizard_pages(shell, specs=specs)
+    presenter = WizardShellPresenter(shell, progress)
+    return WizardShellComposition(shell=shell, pages=pages, presenter=presenter)
+
+
+__all__ = ["WizardShellComposition", "build_placeholder_wizard_shell"]


### PR DESCRIPTION
## Summary

Adds a small composition helper that assembles the #609 placeholder wizard shell with its page containers and presenter wiring in one reusable unit.

## Changes

- Add `WizardShellComposition` and `build_placeholder_wizard_shell()` as a safe integration seam for the future dock replacement.
- Install placeholder wizard pages before presenter rendering so initial progress selects the correct visible page.
- Keep the helper import isolated so existing lightweight stepper tests do not import the page/shell Qt surface by accident.
- Cover default progress, non-default progress, and explicit empty specs in unit tests.

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608.
Refs #609.
