### PR TITLE
feat: add wizard connection page content

### DIFF
--- a/tests/test_connection_page.py
+++ b/tests/test_connection_page.py
@@ -1,0 +1,99 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+
+
+def _load_connection_modules():
+    for name in (
+        "qfit.ui.dockwidget.connection_page",
+        "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return (
+            importlib.import_module("qfit.ui.dockwidget.connection_page"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_page"),
+        )
+
+
+class ConnectionPageContentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.connection_page, cls.wizard_page = _load_connection_modules()
+
+    def test_builds_default_first_page_content(self):
+        content = self.connection_page.ConnectionPageContent()
+
+        self.assertEqual(content.objectName(), "qfitWizardConnectionPageContent")
+        self.assertEqual(content.status_label.objectName(), "qfitWizardConnectionStatus")
+        self.assertEqual(content.status_label.text(), "Strava not connected")
+        self.assertEqual(
+            content.status_label.property("connectionState"),
+            "not_connected",
+        )
+        self.assertEqual(content.detail_label.objectName(), "qfitWizardConnectionDetail")
+        self.assertIn("continue to synchronization", content.detail_label.text())
+        self.assertEqual(
+            content.configure_button.objectName(),
+            "qfitWizardConnectionConfigureButton",
+        )
+        self.assertEqual(content.configure_button.text(), "Configure connection")
+        self.assertEqual(
+            content.configure_button.property("primaryAction"),
+            "configure_connection",
+        )
+        self.assertEqual(
+            content.outer_layout().widgets,
+            [content.status_label, content.detail_label, content.configure_button],
+        )
+
+    def test_refreshes_connected_state_without_rebuilding(self):
+        content = self.connection_page.ConnectionPageContent()
+        state = self.connection_page.ConnectionPageState(
+            connected=True,
+            status_text="Connected to Strava",
+            detail_text="Credentials are ready.",
+            primary_action_label="Review connection",
+        )
+
+        content.set_state(state)
+
+        self.assertEqual(content.status_label.text(), "Connected to Strava")
+        self.assertEqual(content.status_label.property("connectionState"), "connected")
+        self.assertEqual(content.detail_label.text(), "Credentials are ready.")
+        self.assertEqual(content.configure_button.text(), "Review connection")
+
+    def test_configure_button_emits_reusable_page_signal(self):
+        content = self.connection_page.ConnectionPageContent()
+        calls = []
+        content.configureRequested.connect(lambda: calls.append("configure"))
+
+        content.configure_button.clicked.emit()
+
+        self.assertEqual(calls, ["configure"])
+
+    def test_installs_only_on_connection_wizard_page_body(self):
+        connection_spec = build_default_wizard_page_specs()[0]
+        connection_page = self.wizard_page.WizardPage(connection_spec)
+
+        content = self.connection_page.install_connection_page_content(connection_page)
+
+        self.assertIs(connection_page.body_layout().widgets[-1], content)
+
+    def test_rejects_installing_on_other_wizard_page(self):
+        map_spec = build_default_wizard_page_specs()[2]
+        map_page = self.wizard_page.WizardPage(map_spec)
+
+        with self.assertRaisesRegex(ValueError, "connection wizard page"):
+            self.connection_page.install_connection_page_content(map_page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -12,6 +12,7 @@ from qfit.ui.application.dock_workflow_sections import DockWizardProgress
 def _load_wizard_composition_module():
     for name in (
         "qfit.ui.dockwidget.wizard_composition",
+        "qfit.ui.dockwidget.connection_page",
         "qfit.ui.dockwidget.wizard_shell_presenter",
         "qfit.ui.dockwidget.wizard_page",
         "qfit.ui.dockwidget.wizard_shell",
@@ -41,6 +42,15 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.shell.pages_stack.widgets, list(assembled.pages))
         self.assertEqual(assembled.presenter.progress.current_key, "connection")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+        self.assertIsNotNone(assembled.connection_content)
+        self.assertIs(
+            assembled.pages[0].body_layout().widgets[-1],
+            assembled.connection_content,
+        )
+        self.assertEqual(
+            assembled.connection_content.status_label.text(),
+            "Strava not connected",
+        )
         self.assertEqual(
             assembled.shell.stepper_bar.states(),
             ("current", "locked", "locked", "locked", "locked"),
@@ -65,6 +75,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         assembled = self.composition.build_placeholder_wizard_shell(specs=())
 
         self.assertEqual(assembled.pages, ())
+        self.assertIsNone(assembled.connection_content)
         self.assertEqual(assembled.shell.page_count(), 0)
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), -1)
         self.assertEqual(assembled.presenter.progress.current_key, "connection")

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
+
+from ._qt_compat import import_qt_module
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QLabel",
+        "QToolButton",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+pyqtSignal = _qtcore.pyqtSignal
+QLabel = _qtwidgets.QLabel
+QToolButton = _qtwidgets.QToolButton
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+@dataclass(frozen=True)
+class ConnectionPageState:
+    """Render facts for the first #609 wizard page.
+
+    The state is intentionally UI-facing and small. It lets the future dock
+    adapter update the connection page without binding the page to the current
+    long-scroll dock implementation.
+    """
+
+    connected: bool = False
+    status_text: str = "Strava not connected"
+    detail_text: str = "Configure qfit once, then continue to synchronization."
+    primary_action_label: str = "Configure connection"
+
+
+class ConnectionPageContent(QWidget):
+    """Reusable first-page content for the wizard connection step."""
+
+    configureRequested = pyqtSignal()
+
+    def __init__(self, state: ConnectionPageState | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitWizardConnectionPageContent")
+        self.status_label = QLabel("", self)
+        self.status_label.setObjectName("qfitWizardConnectionStatus")
+        self.detail_label = QLabel("", self)
+        self.detail_label.setObjectName("qfitWizardConnectionDetail")
+        if hasattr(self.detail_label, "setWordWrap"):
+            self.detail_label.setWordWrap(True)
+        self.configure_button = QToolButton(self)
+        self.configure_button.setObjectName("qfitWizardConnectionConfigureButton")
+        self.configure_button.clicked.connect(self.configureRequested.emit)
+        self._layout = self._build_layout()
+        self.set_state(state or ConnectionPageState())
+
+    def set_state(self, state: ConnectionPageState) -> None:
+        """Refresh copy and state properties without rebuilding the page."""
+
+        self.status_label.setText(state.status_text)
+        self.status_label.setProperty(
+            "connectionState",
+            "connected" if state.connected else "not_connected",
+        )
+        self.status_label.setStyleSheet(_status_stylesheet(connected=state.connected))
+        self.detail_label.setText(state.detail_text)
+        self.detail_label.setStyleSheet(
+            f"QLabel#qfitWizardConnectionDetail {{ color: {COLOR_MUTED}; }}"
+        )
+        self.configure_button.setText(state.primary_action_label)
+        self.configure_button.setProperty("primaryAction", "configure_connection")
+
+    def outer_layout(self):
+        """Expose the layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardConnectionPageContentLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        layout.addWidget(self.status_label)
+        layout.addWidget(self.detail_label)
+        layout.addWidget(self.configure_button)
+        return layout
+
+
+def build_connection_page_content(
+    *,
+    parent=None,
+    state: ConnectionPageState | None = None,
+) -> ConnectionPageContent:
+    """Build the reusable connection-step content widget."""
+
+    return ConnectionPageContent(state=state, parent=parent)
+
+
+def install_connection_page_content(
+    page,
+    *,
+    state: ConnectionPageState | None = None,
+) -> ConnectionPageContent:
+    """Append connection content to the matching wizard page body layout."""
+
+    if page.spec.key != "connection":
+        raise ValueError(
+            "Connection page content can only be installed on the connection wizard page"
+        )
+    content = build_connection_page_content(parent=page, state=state)
+    page.body_layout().addWidget(content)
+    return content
+
+
+def _status_stylesheet(*, connected: bool) -> str:
+    color = COLOR_ACCENT if connected else COLOR_WARN
+    return (
+        "QLabel#qfitWizardConnectionStatus { "
+        f"color: {color}; "
+        "font-weight: 700; "
+        "}"
+    )
+
+
+__all__ = [
+    "ConnectionPageContent",
+    "ConnectionPageState",
+    "build_connection_page_content",
+    "install_connection_page_content",
+]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass
 from qfit.ui.application.dock_workflow_sections import DockWizardProgress
 from qfit.ui.application.wizard_page_specs import DockWizardPageSpec
 
+from .connection_page import (
+    ConnectionPageContent,
+    ConnectionPageState,
+    install_connection_page_content,
+)
 from .wizard_page import WizardPage, install_wizard_pages
 from .wizard_shell import WizardShell
 from .wizard_shell_presenter import WizardShellPresenter
@@ -24,6 +29,7 @@ class WizardShellComposition:
     shell: WizardShell
     pages: tuple[WizardPage, ...]
     presenter: WizardShellPresenter
+    connection_content: ConnectionPageContent | None = None
 
 
 def build_placeholder_wizard_shell(
@@ -32,6 +38,7 @@ def build_placeholder_wizard_shell(
     footer_text: str = "",
     progress: DockWizardProgress | None = None,
     specs: Sequence[DockWizardPageSpec] | None = None,
+    connection_state: ConnectionPageState | None = None,
 ) -> WizardShellComposition:
     """Build the placeholder #609 wizard shell with pages and presenter wired.
 
@@ -43,8 +50,28 @@ def build_placeholder_wizard_shell(
 
     shell = WizardShell(parent=parent, footer_text=footer_text)
     pages = install_wizard_pages(shell, specs=specs)
+    connection_content = _install_connection_content(
+        pages,
+        connection_state=connection_state,
+    )
     presenter = WizardShellPresenter(shell, progress)
-    return WizardShellComposition(shell=shell, pages=pages, presenter=presenter)
+    return WizardShellComposition(
+        shell=shell,
+        pages=pages,
+        presenter=presenter,
+        connection_content=connection_content,
+    )
+
+
+def _install_connection_content(
+    pages: Sequence[WizardPage],
+    *,
+    connection_state: ConnectionPageState | None,
+) -> ConnectionPageContent | None:
+    for page in pages:
+        if page.spec.key == "connection":
+            return install_connection_page_content(page, state=connection_state)
+    return None
 
 
 __all__ = ["WizardShellComposition", "build_placeholder_wizard_shell"]


### PR DESCRIPTION
## Summary

Add the first reusable wizard-page content slice for the #609 dock redesign: a connection-step content widget with status copy, a configure action signal, and install helper wiring inside the placeholder wizard shell composition.

## Changes

- Added `ConnectionPageState` and `ConnectionPageContent` for the future connection wizard page.
- Installed connection content into the placeholder wizard shell composition without replacing or binding the current long-scroll dock.
- Added pure Qt-stub tests for default/connected states, configure signal emission, install validation, and composition wiring.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
Compatible with #608.
