### PR TITLE
feat: add wizard synchronization page content

### DIFF
--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -1,0 +1,112 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+
+
+def _load_sync_modules():
+    for name in (
+        "qfit.ui.dockwidget.sync_page",
+        "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return (
+            importlib.import_module("qfit.ui.dockwidget.sync_page"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_page"),
+        )
+
+
+class SyncPageContentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sync_page, cls.wizard_page = _load_sync_modules()
+
+    def test_builds_default_second_page_content(self):
+        content = self.sync_page.SyncPageContent()
+
+        self.assertEqual(content.objectName(), "qfitWizardSyncPageContent")
+        self.assertEqual(content.status_label.objectName(), "qfitWizardSyncStatus")
+        self.assertEqual(content.status_label.text(), "Activities not synced yet")
+        self.assertEqual(content.status_label.property("syncState"), "not_synced")
+        self.assertEqual(content.detail_label.objectName(), "qfitWizardSyncDetail")
+        self.assertIn("GeoPackage", content.detail_label.text())
+        self.assertEqual(
+            content.activity_summary_label.objectName(),
+            "qfitWizardSyncActivitySummary",
+        )
+        self.assertEqual(content.activity_summary_label.text(), "No activities stored")
+        self.assertEqual(content.sync_button.objectName(), "qfitWizardSyncButton")
+        self.assertEqual(content.sync_button.text(), "Sync activities")
+        self.assertEqual(
+            content.sync_button.property("primaryAction"),
+            "sync_activities",
+        )
+        self.assertEqual(
+            content.outer_layout().widgets,
+            [
+                content.status_label,
+                content.detail_label,
+                content.activity_summary_label,
+                content.sync_button,
+            ],
+        )
+
+    def test_refreshes_ready_state_without_rebuilding(self):
+        content = self.sync_page.SyncPageContent()
+        state = self.sync_page.SyncPageState(
+            ready=True,
+            status_text="Ready to sync new activities",
+            detail_text="Use the latest saved Strava credentials.",
+            activity_summary_text="42 activities stored · 40 detailed routes",
+            primary_action_label="Fetch latest activities",
+        )
+
+        content.set_state(state)
+
+        self.assertEqual(content.status_label.text(), "Ready to sync new activities")
+        self.assertEqual(content.status_label.property("syncState"), "ready")
+        self.assertEqual(
+            content.detail_label.text(),
+            "Use the latest saved Strava credentials.",
+        )
+        self.assertEqual(
+            content.activity_summary_label.text(),
+            "42 activities stored · 40 detailed routes",
+        )
+        self.assertEqual(content.activity_summary_label.property("syncState"), "ready")
+        self.assertEqual(content.sync_button.text(), "Fetch latest activities")
+
+    def test_sync_button_emits_reusable_page_signal(self):
+        content = self.sync_page.SyncPageContent()
+        calls = []
+        content.syncRequested.connect(lambda: calls.append("sync"))
+
+        content.sync_button.clicked.emit()
+
+        self.assertEqual(calls, ["sync"])
+
+    def test_installs_only_on_sync_wizard_page_body(self):
+        sync_spec = build_default_wizard_page_specs()[1]
+        sync_page = self.wizard_page.WizardPage(sync_spec)
+
+        content = self.sync_page.install_sync_page_content(sync_page)
+
+        self.assertIs(sync_page.body_layout().widgets[-1], content)
+
+    def test_rejects_installing_on_other_wizard_page(self):
+        connection_spec = build_default_wizard_page_specs()[0]
+        connection_page = self.wizard_page.WizardPage(connection_spec)
+
+        with self.assertRaisesRegex(ValueError, "synchronization wizard page"):
+            self.sync_page.install_sync_page_content(connection_page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -93,7 +93,9 @@ class SyncPageContentTest(unittest.TestCase):
         self.assertEqual(calls, ["sync"])
 
     def test_installs_only_on_sync_wizard_page_body(self):
-        sync_spec = build_default_wizard_page_specs()[1]
+        sync_spec = next(
+            spec for spec in build_default_wizard_page_specs() if spec.key == "sync"
+        )
         sync_page = self.wizard_page.WizardPage(sync_spec)
 
         content = self.sync_page.install_sync_page_content(sync_page)
@@ -101,7 +103,9 @@ class SyncPageContentTest(unittest.TestCase):
         self.assertIs(sync_page.body_layout().widgets[-1], content)
 
     def test_rejects_installing_on_other_wizard_page(self):
-        connection_spec = build_default_wizard_page_specs()[0]
+        connection_spec = next(
+            spec for spec in build_default_wizard_page_specs() if spec.key == "connection"
+        )
         connection_page = self.wizard_page.WizardPage(connection_spec)
 
         with self.assertRaisesRegex(ValueError, "synchronization wizard page"):

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -13,6 +13,7 @@ def _load_wizard_composition_module():
     for name in (
         "qfit.ui.dockwidget.wizard_composition",
         "qfit.ui.dockwidget.connection_page",
+        "qfit.ui.dockwidget.sync_page",
         "qfit.ui.dockwidget.wizard_shell_presenter",
         "qfit.ui.dockwidget.wizard_page",
         "qfit.ui.dockwidget.wizard_shell",
@@ -51,6 +52,15 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.connection_content.status_label.text(),
             "Strava not connected",
         )
+        self.assertIsNotNone(assembled.sync_content)
+        self.assertIs(
+            assembled.pages[1].body_layout().widgets[-1],
+            assembled.sync_content,
+        )
+        self.assertEqual(
+            assembled.sync_content.status_label.text(),
+            "Activities not synced yet",
+        )
         self.assertEqual(
             assembled.shell.stepper_bar.states(),
             ("current", "locked", "locked", "locked", "locked"),
@@ -76,6 +86,7 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(assembled.pages, ())
         self.assertIsNone(assembled.connection_content)
+        self.assertIsNone(assembled.sync_content)
         self.assertEqual(assembled.shell.page_count(), 0)
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), -1)
         self.assertEqual(assembled.presenter.progress.current_key, "connection")

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
+
+from ._qt_compat import import_qt_module
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QLabel",
+        "QToolButton",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+pyqtSignal = _qtcore.pyqtSignal
+QLabel = _qtwidgets.QLabel
+QToolButton = _qtwidgets.QToolButton
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+@dataclass(frozen=True)
+class SyncPageState:
+    """Render facts for the #609 synchronization wizard page."""
+
+    ready: bool = False
+    status_text: str = "Activities not synced yet"
+    detail_text: str = "Fetch Strava activities and store detailed routes in the GeoPackage."
+    activity_summary_text: str = "No activities stored"
+    primary_action_label: str = "Sync activities"
+
+
+class SyncPageContent(QWidget):
+    """Reusable second-page content for the wizard synchronization step."""
+
+    syncRequested = pyqtSignal()
+
+    def __init__(self, state: SyncPageState | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitWizardSyncPageContent")
+        self.status_label = QLabel("", self)
+        self.status_label.setObjectName("qfitWizardSyncStatus")
+        self.detail_label = QLabel("", self)
+        self.detail_label.setObjectName("qfitWizardSyncDetail")
+        if hasattr(self.detail_label, "setWordWrap"):
+            self.detail_label.setWordWrap(True)
+        self.activity_summary_label = QLabel("", self)
+        self.activity_summary_label.setObjectName("qfitWizardSyncActivitySummary")
+        self.sync_button = QToolButton(self)
+        self.sync_button.setObjectName("qfitWizardSyncButton")
+        self.sync_button.clicked.connect(self.syncRequested.emit)
+        self._layout = self._build_layout()
+        self.set_state(state or SyncPageState())
+
+    def set_state(self, state: SyncPageState) -> None:
+        """Refresh copy and state properties without rebuilding the page."""
+
+        sync_state = "ready" if state.ready else "not_synced"
+        self.status_label.setText(state.status_text)
+        self.status_label.setProperty("syncState", sync_state)
+        self.status_label.setStyleSheet(_status_stylesheet(ready=state.ready))
+        self.detail_label.setText(state.detail_text)
+        self.detail_label.setStyleSheet(
+            f"QLabel#qfitWizardSyncDetail {{ color: {COLOR_MUTED}; }}"
+        )
+        self.activity_summary_label.setText(state.activity_summary_text)
+        self.activity_summary_label.setProperty("syncState", sync_state)
+        self.sync_button.setText(state.primary_action_label)
+        self.sync_button.setProperty("primaryAction", "sync_activities")
+
+    def outer_layout(self):
+        """Expose the layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardSyncPageContentLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        layout.addWidget(self.status_label)
+        layout.addWidget(self.detail_label)
+        layout.addWidget(self.activity_summary_label)
+        layout.addWidget(self.sync_button)
+        return layout
+
+
+def build_sync_page_content(
+    *,
+    parent=None,
+    state: SyncPageState | None = None,
+) -> SyncPageContent:
+    """Build the reusable synchronization-step content widget."""
+
+    return SyncPageContent(state=state, parent=parent)
+
+
+def install_sync_page_content(
+    page,
+    *,
+    state: SyncPageState | None = None,
+) -> SyncPageContent:
+    """Append synchronization content to the matching wizard page body layout."""
+
+    if page.spec.key != "sync":
+        raise ValueError(
+            "Sync page content can only be installed on the synchronization wizard page"
+        )
+    content = build_sync_page_content(parent=page, state=state)
+    page.body_layout().addWidget(content)
+    return content
+
+
+def _status_stylesheet(*, ready: bool) -> str:
+    color = COLOR_ACCENT if ready else COLOR_WARN
+    return (
+        "QLabel#qfitWizardSyncStatus { "
+        f"color: {color}; "
+        "font-weight: 700; "
+        "}"
+    )
+
+
+__all__ = [
+    "SyncPageContent",
+    "SyncPageState",
+    "build_sync_page_content",
+    "install_sync_page_content",
+]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -11,6 +11,7 @@ from .connection_page import (
     ConnectionPageState,
     install_connection_page_content,
 )
+from .sync_page import SyncPageContent, SyncPageState, install_sync_page_content
 from .wizard_page import WizardPage, install_wizard_pages
 from .wizard_shell import WizardShell
 from .wizard_shell_presenter import WizardShellPresenter
@@ -30,6 +31,7 @@ class WizardShellComposition:
     pages: tuple[WizardPage, ...]
     presenter: WizardShellPresenter
     connection_content: ConnectionPageContent | None = None
+    sync_content: SyncPageContent | None = None
 
 
 def build_placeholder_wizard_shell(
@@ -39,6 +41,7 @@ def build_placeholder_wizard_shell(
     progress: DockWizardProgress | None = None,
     specs: Sequence[DockWizardPageSpec] | None = None,
     connection_state: ConnectionPageState | None = None,
+    sync_state: SyncPageState | None = None,
 ) -> WizardShellComposition:
     """Build the placeholder #609 wizard shell with pages and presenter wired.
 
@@ -54,12 +57,14 @@ def build_placeholder_wizard_shell(
         pages,
         connection_state=connection_state,
     )
+    sync_content = _install_sync_content(pages, sync_state=sync_state)
     presenter = WizardShellPresenter(shell, progress)
     return WizardShellComposition(
         shell=shell,
         pages=pages,
         presenter=presenter,
         connection_content=connection_content,
+        sync_content=sync_content,
     )
 
 
@@ -71,6 +76,17 @@ def _install_connection_content(
     for page in pages:
         if page.spec.key == "connection":
             return install_connection_page_content(page, state=connection_state)
+    return None
+
+
+def _install_sync_content(
+    pages: Sequence[WizardPage],
+    *,
+    sync_state: SyncPageState | None,
+) -> SyncPageContent | None:
+    for page in pages:
+        if page.spec.key == "sync":
+            return install_sync_page_content(page, state=sync_state)
     return None
 
 


### PR DESCRIPTION
## Summary

Adds reusable content for the wizard synchronization page so the #609 shell now has visible first and second step content without binding to the current long-scroll dock.

## Changes

- Add `SyncPageState` and `SyncPageContent` for the wizard synchronization step.
- Wire synchronization content into the placeholder wizard shell composition.
- Cover default state, state refresh, signal emission, page installation, and shell composition.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
