### PR TITLE
Add wizard map page content

### DIFF
--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -1,0 +1,147 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+
+
+def _load_map_modules():
+    for name in (
+        "qfit.ui.dockwidget.map_page",
+        "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return (
+            importlib.import_module("qfit.ui.dockwidget.map_page"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_page"),
+        )
+
+
+class MapPageContentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.map_page, cls.wizard_page = _load_map_modules()
+
+    def test_builds_default_third_page_content(self):
+        content = self.map_page.MapPageContent()
+
+        self.assertEqual(content.objectName(), "qfitWizardMapPageContent")
+        self.assertEqual(content.status_label.objectName(), "qfitWizardMapStatus")
+        self.assertEqual(content.status_label.text(), "Activity layers not loaded")
+        self.assertEqual(content.status_label.property("mapState"), "not_loaded")
+        self.assertEqual(content.detail_label.objectName(), "qfitWizardMapDetail")
+        self.assertIn("apply filters", content.detail_label.text())
+        self.assertEqual(
+            content.layer_summary_label.objectName(),
+            "qfitWizardMapLayerSummary",
+        )
+        self.assertEqual(
+            content.layer_summary_label.text(),
+            "No activity layers on the map",
+        )
+        self.assertEqual(
+            content.filter_summary_label.objectName(),
+            "qfitWizardMapFilterSummary",
+        )
+        self.assertEqual(
+            content.filter_summary_label.text(),
+            "All stored activities visible once layers are loaded",
+        )
+        self.assertEqual(
+            content.load_layers_button.objectName(),
+            "qfitWizardMapLoadLayersButton",
+        )
+        self.assertEqual(content.load_layers_button.text(), "Load activity layers")
+        self.assertEqual(
+            content.load_layers_button.property("secondaryAction"),
+            "load_activity_layers",
+        )
+        self.assertEqual(
+            content.apply_filters_button.objectName(),
+            "qfitWizardMapApplyFiltersButton",
+        )
+        self.assertEqual(content.apply_filters_button.text(), "Apply filters")
+        self.assertEqual(
+            content.apply_filters_button.property("primaryAction"),
+            "apply_map_filters",
+        )
+        self.assertEqual(
+            content.outer_layout().widgets,
+            [
+                content.status_label,
+                content.detail_label,
+                content.layer_summary_label,
+                content.filter_summary_label,
+                content.load_layers_button,
+                content.apply_filters_button,
+            ],
+        )
+
+    def test_refreshes_loaded_state_without_rebuilding(self):
+        content = self.map_page.MapPageContent()
+        state = self.map_page.MapPageState(
+            loaded=True,
+            status_text="Map ready",
+            detail_text="Use saved filters for the loaded activity layers.",
+            layer_summary_text="4 layers loaded from qfit.gpkg",
+            filter_summary_text="42 activities · Ride and Run · 2026",
+            load_action_label="Reload layers",
+            primary_action_label="Apply saved filters",
+        )
+
+        content.set_state(state)
+
+        self.assertEqual(content.status_label.text(), "Map ready")
+        self.assertEqual(content.status_label.property("mapState"), "loaded")
+        self.assertEqual(
+            content.detail_label.text(),
+            "Use saved filters for the loaded activity layers.",
+        )
+        self.assertEqual(
+            content.layer_summary_label.text(),
+            "4 layers loaded from qfit.gpkg",
+        )
+        self.assertEqual(content.layer_summary_label.property("mapState"), "loaded")
+        self.assertEqual(
+            content.filter_summary_label.text(),
+            "42 activities · Ride and Run · 2026",
+        )
+        self.assertEqual(content.filter_summary_label.property("mapState"), "loaded")
+        self.assertEqual(content.load_layers_button.text(), "Reload layers")
+        self.assertEqual(content.apply_filters_button.text(), "Apply saved filters")
+
+    def test_buttons_emit_reusable_page_signals(self):
+        content = self.map_page.MapPageContent()
+        calls = []
+        content.loadLayersRequested.connect(lambda: calls.append("load"))
+        content.applyFiltersRequested.connect(lambda: calls.append("filter"))
+
+        content.load_layers_button.clicked.emit()
+        content.apply_filters_button.clicked.emit()
+
+        self.assertEqual(calls, ["load", "filter"])
+
+    def test_installs_only_on_map_wizard_page_body(self):
+        map_spec = next(spec for spec in build_default_wizard_page_specs() if spec.key == "map")
+        map_page = self.wizard_page.WizardPage(map_spec)
+
+        content = self.map_page.install_map_page_content(map_page)
+
+        self.assertIs(map_page.body_layout().widgets[-1], content)
+
+    def test_rejects_installing_on_other_wizard_page(self):
+        sync_spec = next(spec for spec in build_default_wizard_page_specs() if spec.key == "sync")
+        sync_page = self.wizard_page.WizardPage(sync_spec)
+
+        with self.assertRaisesRegex(ValueError, "map wizard page"):
+            self.map_page.install_map_page_content(sync_page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -14,6 +14,7 @@ def _load_wizard_composition_module():
         "qfit.ui.dockwidget.wizard_composition",
         "qfit.ui.dockwidget.connection_page",
         "qfit.ui.dockwidget.sync_page",
+        "qfit.ui.dockwidget.map_page",
         "qfit.ui.dockwidget.wizard_shell_presenter",
         "qfit.ui.dockwidget.wizard_page",
         "qfit.ui.dockwidget.wizard_shell",
@@ -61,6 +62,15 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.sync_content.status_label.text(),
             "Activities not synced yet",
         )
+        self.assertIsNotNone(assembled.map_content)
+        self.assertIs(
+            assembled.pages[2].body_layout().widgets[-1],
+            assembled.map_content,
+        )
+        self.assertEqual(
+            assembled.map_content.status_label.text(),
+            "Activity layers not loaded",
+        )
         self.assertEqual(
             assembled.shell.stepper_bar.states(),
             ("current", "locked", "locked", "locked", "locked"),
@@ -87,6 +97,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.pages, ())
         self.assertIsNone(assembled.connection_content)
         self.assertIsNone(assembled.sync_content)
+        self.assertIsNone(assembled.map_content)
         self.assertEqual(assembled.shell.page_count(), 0)
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), -1)
         self.assertEqual(assembled.presenter.progress.current_key, "connection")

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -59,9 +59,11 @@ class MapPageContent(QWidget):
         self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
         self.load_layers_button = QToolButton(self)
         self.load_layers_button.setObjectName("qfitWizardMapLoadLayersButton")
+        self.load_layers_button.setProperty("secondaryAction", "load_activity_layers")
         self.load_layers_button.clicked.connect(self.loadLayersRequested.emit)
         self.apply_filters_button = QToolButton(self)
         self.apply_filters_button.setObjectName("qfitWizardMapApplyFiltersButton")
+        self.apply_filters_button.setProperty("primaryAction", "apply_map_filters")
         self.apply_filters_button.clicked.connect(self.applyFiltersRequested.emit)
         self._layout = self._build_layout()
         self.set_state(state or MapPageState())
@@ -82,9 +84,7 @@ class MapPageContent(QWidget):
         self.filter_summary_label.setText(state.filter_summary_text)
         self.filter_summary_label.setProperty("mapState", map_state)
         self.load_layers_button.setText(state.load_action_label)
-        self.load_layers_button.setProperty("secondaryAction", "load_activity_layers")
         self.apply_filters_button.setText(state.primary_action_label)
-        self.apply_filters_button.setProperty("primaryAction", "apply_map_filters")
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
+
+from ._qt_compat import import_qt_module
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QLabel",
+        "QToolButton",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+pyqtSignal = _qtcore.pyqtSignal
+QLabel = _qtwidgets.QLabel
+QToolButton = _qtwidgets.QToolButton
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+@dataclass(frozen=True)
+class MapPageState:
+    """Render facts for the #609 map-and-filters wizard page."""
+
+    loaded: bool = False
+    status_text: str = "Activity layers not loaded"
+    detail_text: str = "Load stored activities, choose map context, then apply filters."
+    layer_summary_text: str = "No activity layers on the map"
+    filter_summary_text: str = "All stored activities visible once layers are loaded"
+    load_action_label: str = "Load activity layers"
+    primary_action_label: str = "Apply filters"
+
+
+class MapPageContent(QWidget):
+    """Reusable third-page content for the wizard map-and-filters step."""
+
+    loadLayersRequested = pyqtSignal()
+    applyFiltersRequested = pyqtSignal()
+
+    def __init__(self, state: MapPageState | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitWizardMapPageContent")
+        self.status_label = QLabel("", self)
+        self.status_label.setObjectName("qfitWizardMapStatus")
+        self.detail_label = QLabel("", self)
+        self.detail_label.setObjectName("qfitWizardMapDetail")
+        if hasattr(self.detail_label, "setWordWrap"):
+            self.detail_label.setWordWrap(True)
+        self.layer_summary_label = QLabel("", self)
+        self.layer_summary_label.setObjectName("qfitWizardMapLayerSummary")
+        self.filter_summary_label = QLabel("", self)
+        self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
+        self.load_layers_button = QToolButton(self)
+        self.load_layers_button.setObjectName("qfitWizardMapLoadLayersButton")
+        self.load_layers_button.clicked.connect(self.loadLayersRequested.emit)
+        self.apply_filters_button = QToolButton(self)
+        self.apply_filters_button.setObjectName("qfitWizardMapApplyFiltersButton")
+        self.apply_filters_button.clicked.connect(self.applyFiltersRequested.emit)
+        self._layout = self._build_layout()
+        self.set_state(state or MapPageState())
+
+    def set_state(self, state: MapPageState) -> None:
+        """Refresh copy and state properties without rebuilding the page."""
+
+        map_state = "loaded" if state.loaded else "not_loaded"
+        self.status_label.setText(state.status_text)
+        self.status_label.setProperty("mapState", map_state)
+        self.status_label.setStyleSheet(_status_stylesheet(loaded=state.loaded))
+        self.detail_label.setText(state.detail_text)
+        self.detail_label.setStyleSheet(
+            f"QLabel#qfitWizardMapDetail {{ color: {COLOR_MUTED}; }}"
+        )
+        self.layer_summary_label.setText(state.layer_summary_text)
+        self.layer_summary_label.setProperty("mapState", map_state)
+        self.filter_summary_label.setText(state.filter_summary_text)
+        self.filter_summary_label.setProperty("mapState", map_state)
+        self.load_layers_button.setText(state.load_action_label)
+        self.load_layers_button.setProperty("secondaryAction", "load_activity_layers")
+        self.apply_filters_button.setText(state.primary_action_label)
+        self.apply_filters_button.setProperty("primaryAction", "apply_map_filters")
+
+    def outer_layout(self):
+        """Expose the layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardMapPageContentLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        layout.addWidget(self.status_label)
+        layout.addWidget(self.detail_label)
+        layout.addWidget(self.layer_summary_label)
+        layout.addWidget(self.filter_summary_label)
+        layout.addWidget(self.load_layers_button)
+        layout.addWidget(self.apply_filters_button)
+        return layout
+
+
+def build_map_page_content(
+    *,
+    parent=None,
+    state: MapPageState | None = None,
+) -> MapPageContent:
+    """Build the reusable map-and-filters-step content widget."""
+
+    return MapPageContent(state=state, parent=parent)
+
+
+def install_map_page_content(
+    page,
+    *,
+    state: MapPageState | None = None,
+) -> MapPageContent:
+    """Append map-and-filters content to the matching wizard page body layout."""
+
+    if page.spec.key != "map":
+        raise ValueError("Map page content can only be installed on the map wizard page")
+    content = build_map_page_content(parent=page, state=state)
+    page.body_layout().addWidget(content)
+    return content
+
+
+def _status_stylesheet(*, loaded: bool) -> str:
+    color = COLOR_ACCENT if loaded else COLOR_WARN
+    return (
+        "QLabel#qfitWizardMapStatus { "
+        f"color: {color}; "
+        "font-weight: 700; "
+        "}"
+    )
+
+
+__all__ = [
+    "MapPageContent",
+    "MapPageState",
+    "build_map_page_content",
+    "install_map_page_content",
+]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -11,6 +11,7 @@ from .connection_page import (
     ConnectionPageState,
     install_connection_page_content,
 )
+from .map_page import MapPageContent, MapPageState, install_map_page_content
 from .sync_page import SyncPageContent, SyncPageState, install_sync_page_content
 from .wizard_page import WizardPage, install_wizard_pages
 from .wizard_shell import WizardShell
@@ -32,6 +33,7 @@ class WizardShellComposition:
     presenter: WizardShellPresenter
     connection_content: ConnectionPageContent | None = None
     sync_content: SyncPageContent | None = None
+    map_content: MapPageContent | None = None
 
 
 def build_placeholder_wizard_shell(
@@ -42,6 +44,7 @@ def build_placeholder_wizard_shell(
     specs: Sequence[DockWizardPageSpec] | None = None,
     connection_state: ConnectionPageState | None = None,
     sync_state: SyncPageState | None = None,
+    map_state: MapPageState | None = None,
 ) -> WizardShellComposition:
     """Build the placeholder #609 wizard shell with pages and presenter wired.
 
@@ -58,6 +61,7 @@ def build_placeholder_wizard_shell(
         connection_state=connection_state,
     )
     sync_content = _install_sync_content(pages, sync_state=sync_state)
+    map_content = _install_map_content(pages, map_state=map_state)
     presenter = WizardShellPresenter(shell, progress)
     return WizardShellComposition(
         shell=shell,
@@ -65,6 +69,7 @@ def build_placeholder_wizard_shell(
         presenter=presenter,
         connection_content=connection_content,
         sync_content=sync_content,
+        map_content=map_content,
     )
 
 
@@ -87,6 +92,17 @@ def _install_sync_content(
     for page in pages:
         if page.spec.key == "sync":
             return install_sync_page_content(page, state=sync_state)
+    return None
+
+
+def _install_map_content(
+    pages: Sequence[WizardPage],
+    *,
+    map_state: MapPageState | None,
+) -> MapPageContent | None:
+    for page in pages:
+        if page.spec.key == "map":
+            return install_map_page_content(page, state=map_state)
     return None
 
 


### PR DESCRIPTION
## Summary

Adds reusable content for the #609 wizard-style Map & filters page, continuing the existing connection/synchronization wizard shell without binding new work to the legacy long-scroll dock.

## Changes

- Added `MapPageState` and `MapPageContent` with stable object names, page-level state properties, and reusable load/apply-filter signals.
- Installed the map page content in the placeholder wizard shell composition.
- Added unit coverage for default rendering, state refreshes, signals, install guards, and composition wiring.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
