### PR TITLE
feat: add wizard analysis page content

### DIFF
--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -1,0 +1,137 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+
+
+def _load_analysis_modules():
+    for name in (
+        "qfit.ui.dockwidget.analysis_page",
+        "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return (
+            importlib.import_module("qfit.ui.dockwidget.analysis_page"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_page"),
+        )
+
+
+class AnalysisPageContentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.analysis_page, cls.wizard_page = _load_analysis_modules()
+
+    def test_builds_default_fourth_page_content(self):
+        content = self.analysis_page.AnalysisPageContent()
+
+        self.assertEqual(content.objectName(), "qfitWizardAnalysisPageContent")
+        self.assertEqual(content.status_label.objectName(), "qfitWizardAnalysisStatus")
+        self.assertEqual(content.status_label.text(), "Analysis not run yet")
+        self.assertEqual(content.status_label.property("analysisState"), "not_ready")
+        self.assertEqual(content.detail_label.objectName(), "qfitWizardAnalysisDetail")
+        self.assertIn("heatmaps", content.detail_label.text())
+        self.assertEqual(
+            content.input_summary_label.objectName(),
+            "qfitWizardAnalysisInputSummary",
+        )
+        self.assertEqual(
+            content.input_summary_label.text(),
+            "No loaded activity layers available for analysis",
+        )
+        self.assertEqual(
+            content.result_summary_label.objectName(),
+            "qfitWizardAnalysisResultSummary",
+        )
+        self.assertEqual(
+            content.result_summary_label.text(),
+            "Analysis outputs will appear in the project once generated",
+        )
+        self.assertEqual(
+            content.run_analysis_button.objectName(),
+            "qfitWizardAnalysisRunButton",
+        )
+        self.assertEqual(content.run_analysis_button.text(), "Run analysis")
+        self.assertEqual(
+            content.run_analysis_button.property("primaryAction"),
+            "run_analysis",
+        )
+        self.assertEqual(
+            content.outer_layout().widgets,
+            [
+                content.status_label,
+                content.detail_label,
+                content.input_summary_label,
+                content.result_summary_label,
+                content.run_analysis_button,
+            ],
+        )
+
+    def test_refreshes_ready_state_without_rebuilding(self):
+        content = self.analysis_page.AnalysisPageContent()
+        state = self.analysis_page.AnalysisPageState(
+            ready=True,
+            status_text="Analysis ready",
+            detail_text="Run analysis using the loaded filtered activity layers.",
+            input_summary_text="4 layers loaded · 42 selected activities",
+            result_summary_text="Heatmap and start-point layers can be refreshed",
+            primary_action_label="Refresh analysis",
+        )
+
+        content.set_state(state)
+
+        self.assertEqual(content.status_label.text(), "Analysis ready")
+        self.assertEqual(content.status_label.property("analysisState"), "ready")
+        self.assertEqual(
+            content.detail_label.text(),
+            "Run analysis using the loaded filtered activity layers.",
+        )
+        self.assertEqual(
+            content.input_summary_label.text(),
+            "4 layers loaded · 42 selected activities",
+        )
+        self.assertEqual(content.input_summary_label.property("analysisState"), "ready")
+        self.assertEqual(
+            content.result_summary_label.text(),
+            "Heatmap and start-point layers can be refreshed",
+        )
+        self.assertEqual(content.result_summary_label.property("analysisState"), "ready")
+        self.assertEqual(content.run_analysis_button.text(), "Refresh analysis")
+
+    def test_button_emits_reusable_page_signal(self):
+        content = self.analysis_page.AnalysisPageContent()
+        calls = []
+        content.runAnalysisRequested.connect(lambda: calls.append("run"))
+
+        content.run_analysis_button.clicked.emit()
+
+        self.assertEqual(calls, ["run"])
+
+    def test_installs_only_on_analysis_wizard_page_body(self):
+        analysis_spec = next(
+            spec for spec in build_default_wizard_page_specs() if spec.key == "analysis"
+        )
+        analysis_page = self.wizard_page.WizardPage(analysis_spec)
+
+        content = self.analysis_page.install_analysis_page_content(analysis_page)
+
+        self.assertIs(analysis_page.body_layout().widgets[-1], content)
+
+    def test_rejects_installing_on_other_wizard_page(self):
+        map_spec = next(
+            spec for spec in build_default_wizard_page_specs() if spec.key == "map"
+        )
+        map_page = self.wizard_page.WizardPage(map_spec)
+
+        with self.assertRaisesRegex(ValueError, "analysis wizard page"):
+            self.analysis_page.install_analysis_page_content(map_page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -12,6 +12,7 @@ from qfit.ui.application.dock_workflow_sections import DockWizardProgress
 def _load_wizard_composition_module():
     for name in (
         "qfit.ui.dockwidget.wizard_composition",
+        "qfit.ui.dockwidget.analysis_page",
         "qfit.ui.dockwidget.connection_page",
         "qfit.ui.dockwidget.sync_page",
         "qfit.ui.dockwidget.map_page",
@@ -71,6 +72,15 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.map_content.status_label.text(),
             "Activity layers not loaded",
         )
+        self.assertIsNotNone(assembled.analysis_content)
+        self.assertIs(
+            assembled.pages[3].body_layout().widgets[-1],
+            assembled.analysis_content,
+        )
+        self.assertEqual(
+            assembled.analysis_content.status_label.text(),
+            "Analysis not run yet",
+        )
         self.assertEqual(
             assembled.shell.stepper_bar.states(),
             ("current", "locked", "locked", "locked", "locked"),
@@ -98,6 +108,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertIsNone(assembled.connection_content)
         self.assertIsNone(assembled.sync_content)
         self.assertIsNone(assembled.map_content)
+        self.assertIsNone(assembled.analysis_content)
         self.assertEqual(assembled.shell.page_count(), 0)
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), -1)
         self.assertEqual(assembled.presenter.progress.current_key, "connection")

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
+
+from ._qt_compat import import_qt_module
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QLabel",
+        "QToolButton",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+pyqtSignal = _qtcore.pyqtSignal
+QLabel = _qtwidgets.QLabel
+QToolButton = _qtwidgets.QToolButton
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+@dataclass(frozen=True)
+class AnalysisPageState:
+    """Render facts for the #609 spatial-analysis wizard page."""
+
+    ready: bool = False
+    status_text: str = "Analysis not run yet"
+    detail_text: str = (
+        "Use loaded activity layers to calculate heatmaps, corridors, and start points."
+    )
+    input_summary_text: str = "No loaded activity layers available for analysis"
+    result_summary_text: str = "Analysis outputs will appear in the project once generated"
+    primary_action_label: str = "Run analysis"
+
+
+class AnalysisPageContent(QWidget):
+    """Reusable fourth-page content for the wizard spatial-analysis step."""
+
+    runAnalysisRequested = pyqtSignal()
+
+    def __init__(self, state: AnalysisPageState | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitWizardAnalysisPageContent")
+        self.status_label = QLabel("", self)
+        self.status_label.setObjectName("qfitWizardAnalysisStatus")
+        self.detail_label = QLabel("", self)
+        self.detail_label.setObjectName("qfitWizardAnalysisDetail")
+        if hasattr(self.detail_label, "setWordWrap"):
+            self.detail_label.setWordWrap(True)
+        self.input_summary_label = QLabel("", self)
+        self.input_summary_label.setObjectName("qfitWizardAnalysisInputSummary")
+        self.result_summary_label = QLabel("", self)
+        self.result_summary_label.setObjectName("qfitWizardAnalysisResultSummary")
+        self.run_analysis_button = QToolButton(self)
+        self.run_analysis_button.setObjectName("qfitWizardAnalysisRunButton")
+        self.run_analysis_button.setProperty("primaryAction", "run_analysis")
+        self.run_analysis_button.clicked.connect(self.runAnalysisRequested.emit)
+        self._layout = self._build_layout()
+        self.set_state(state or AnalysisPageState())
+
+    def set_state(self, state: AnalysisPageState) -> None:
+        """Refresh copy and state properties without rebuilding the page."""
+
+        analysis_state = "ready" if state.ready else "not_ready"
+        self.status_label.setText(state.status_text)
+        self.status_label.setProperty("analysisState", analysis_state)
+        self.status_label.setStyleSheet(_status_stylesheet(ready=state.ready))
+        self.detail_label.setText(state.detail_text)
+        self.detail_label.setStyleSheet(
+            f"QLabel#qfitWizardAnalysisDetail {{ color: {COLOR_MUTED}; }}"
+        )
+        self.input_summary_label.setText(state.input_summary_text)
+        self.input_summary_label.setProperty("analysisState", analysis_state)
+        self.result_summary_label.setText(state.result_summary_text)
+        self.result_summary_label.setProperty("analysisState", analysis_state)
+        self.run_analysis_button.setText(state.primary_action_label)
+
+    def outer_layout(self):
+        """Expose the layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardAnalysisPageContentLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        for widget in (
+            self.status_label,
+            self.detail_label,
+            self.input_summary_label,
+            self.result_summary_label,
+            self.run_analysis_button,
+        ):
+            layout.addWidget(widget)
+        return layout
+
+
+def build_analysis_page_content(
+    *,
+    parent=None,
+    state: AnalysisPageState | None = None,
+) -> AnalysisPageContent:
+    """Build the reusable spatial-analysis-step content widget."""
+
+    return AnalysisPageContent(state=state, parent=parent)
+
+
+def install_analysis_page_content(
+    page,
+    *,
+    state: AnalysisPageState | None = None,
+) -> AnalysisPageContent:
+    """Append spatial-analysis content to the matching wizard page body layout."""
+
+    if page.spec.key != "analysis":
+        raise ValueError(
+            "Analysis page content can only be installed on the analysis wizard page"
+        )
+    content = build_analysis_page_content(parent=page, state=state)
+    page.body_layout().addWidget(content)
+    return content
+
+
+def _status_stylesheet(*, ready: bool) -> str:
+    color = COLOR_ACCENT if ready else COLOR_WARN
+    return (
+        "QLabel#qfitWizardAnalysisStatus { "
+        f"color: {color}; "
+        "font-weight: 700; "
+        "}"
+    )
+
+
+__all__ = [
+    "AnalysisPageContent",
+    "AnalysisPageState",
+    "build_analysis_page_content",
+    "install_analysis_page_content",
+]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass
 from qfit.ui.application.dock_workflow_sections import DockWizardProgress
 from qfit.ui.application.wizard_page_specs import DockWizardPageSpec
 
+from .analysis_page import (
+    AnalysisPageContent,
+    AnalysisPageState,
+    install_analysis_page_content,
+)
 from .connection_page import (
     ConnectionPageContent,
     ConnectionPageState,
@@ -34,6 +39,7 @@ class WizardShellComposition:
     connection_content: ConnectionPageContent | None = None
     sync_content: SyncPageContent | None = None
     map_content: MapPageContent | None = None
+    analysis_content: AnalysisPageContent | None = None
 
 
 def build_placeholder_wizard_shell(
@@ -45,6 +51,7 @@ def build_placeholder_wizard_shell(
     connection_state: ConnectionPageState | None = None,
     sync_state: SyncPageState | None = None,
     map_state: MapPageState | None = None,
+    analysis_state: AnalysisPageState | None = None,
 ) -> WizardShellComposition:
     """Build the placeholder #609 wizard shell with pages and presenter wired.
 
@@ -62,6 +69,10 @@ def build_placeholder_wizard_shell(
     )
     sync_content = _install_sync_content(pages, sync_state=sync_state)
     map_content = _install_map_content(pages, map_state=map_state)
+    analysis_content = _install_analysis_content(
+        pages,
+        analysis_state=analysis_state,
+    )
     presenter = WizardShellPresenter(shell, progress)
     return WizardShellComposition(
         shell=shell,
@@ -70,6 +81,7 @@ def build_placeholder_wizard_shell(
         connection_content=connection_content,
         sync_content=sync_content,
         map_content=map_content,
+        analysis_content=analysis_content,
     )
 
 
@@ -103,6 +115,17 @@ def _install_map_content(
     for page in pages:
         if page.spec.key == "map":
             return install_map_page_content(page, state=map_state)
+    return None
+
+
+def _install_analysis_content(
+    pages: Sequence[WizardPage],
+    *,
+    analysis_state: AnalysisPageState | None,
+) -> AnalysisPageContent | None:
+    for page in pages:
+        if page.spec.key == "analysis":
+            return install_analysis_page_content(page, state=analysis_state)
     return None
 
 


### PR DESCRIPTION
## Summary

Adds reusable wizard-page content for the #609 spatial analysis step, keeping the current dock untouched while extending the new wizard shell composition beyond connection/sync/map.

## Changes

- Added `AnalysisPageState` and `AnalysisPageContent` with status, input/result summaries, and a primary run-analysis action signal.
- Installed the analysis content into the placeholder wizard shell composition.
- Added focused pure Qt-fake tests for default rendering, state refresh, signal emission, page installation, and shell composition.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
