### PR TITLE
feat: add wizard atlas page content

### DIFF
--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -1,0 +1,137 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+
+
+def _load_atlas_modules():
+    for name in (
+        "qfit.ui.dockwidget.atlas_page",
+        "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return (
+            importlib.import_module("qfit.ui.dockwidget.atlas_page"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_page"),
+        )
+
+
+class AtlasPageContentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.atlas_page, cls.wizard_page = _load_atlas_modules()
+
+    def test_builds_default_fifth_page_content(self):
+        content = self.atlas_page.AtlasPageContent()
+
+        self.assertEqual(content.objectName(), "qfitWizardAtlasPageContent")
+        self.assertEqual(content.status_label.objectName(), "qfitWizardAtlasStatus")
+        self.assertEqual(content.status_label.text(), "Atlas PDF not exported yet")
+        self.assertEqual(content.status_label.property("atlasState"), "not_ready")
+        self.assertEqual(content.detail_label.objectName(), "qfitWizardAtlasDetail")
+        self.assertIn("PDF title", content.detail_label.text())
+        self.assertEqual(
+            content.input_summary_label.objectName(),
+            "qfitWizardAtlasInputSummary",
+        )
+        self.assertEqual(
+            content.input_summary_label.text(),
+            "No atlas layer selected for export",
+        )
+        self.assertEqual(
+            content.output_summary_label.objectName(),
+            "qfitWizardAtlasOutputSummary",
+        )
+        self.assertEqual(
+            content.output_summary_label.text(),
+            "PDF output path will be chosen before generation",
+        )
+        self.assertEqual(
+            content.export_atlas_button.objectName(),
+            "qfitWizardAtlasExportButton",
+        )
+        self.assertEqual(content.export_atlas_button.text(), "Export atlas PDF")
+        self.assertEqual(
+            content.export_atlas_button.property("primaryAction"),
+            "export_atlas_pdf",
+        )
+        self.assertEqual(
+            content.outer_layout().widgets,
+            [
+                content.status_label,
+                content.detail_label,
+                content.input_summary_label,
+                content.output_summary_label,
+                content.export_atlas_button,
+            ],
+        )
+
+    def test_refreshes_ready_state_without_rebuilding(self):
+        content = self.atlas_page.AtlasPageContent()
+        state = self.atlas_page.AtlasPageState(
+            ready=True,
+            status_text="Atlas ready",
+            detail_text="Export the filtered activity atlas to the selected PDF path.",
+            input_summary_text="42 activities selected for atlas export",
+            output_summary_text="/tmp/qfit-atlas.pdf · A4 landscape",
+            primary_action_label="Refresh atlas PDF",
+        )
+
+        content.set_state(state)
+
+        self.assertEqual(content.status_label.text(), "Atlas ready")
+        self.assertEqual(content.status_label.property("atlasState"), "ready")
+        self.assertEqual(
+            content.detail_label.text(),
+            "Export the filtered activity atlas to the selected PDF path.",
+        )
+        self.assertEqual(
+            content.input_summary_label.text(),
+            "42 activities selected for atlas export",
+        )
+        self.assertEqual(content.input_summary_label.property("atlasState"), "ready")
+        self.assertEqual(
+            content.output_summary_label.text(),
+            "/tmp/qfit-atlas.pdf · A4 landscape",
+        )
+        self.assertEqual(content.output_summary_label.property("atlasState"), "ready")
+        self.assertEqual(content.export_atlas_button.text(), "Refresh atlas PDF")
+
+    def test_button_emits_reusable_page_signal(self):
+        content = self.atlas_page.AtlasPageContent()
+        calls = []
+        content.exportAtlasRequested.connect(lambda: calls.append("export"))
+
+        content.export_atlas_button.clicked.emit()
+
+        self.assertEqual(calls, ["export"])
+
+    def test_installs_only_on_atlas_wizard_page_body(self):
+        atlas_spec = next(
+            spec for spec in build_default_wizard_page_specs() if spec.key == "atlas"
+        )
+        atlas_page = self.wizard_page.WizardPage(atlas_spec)
+
+        content = self.atlas_page.install_atlas_page_content(atlas_page)
+
+        self.assertIs(atlas_page.body_layout().widgets[-1], content)
+
+    def test_rejects_installing_on_other_wizard_page(self):
+        analysis_spec = next(
+            spec for spec in build_default_wizard_page_specs() if spec.key == "analysis"
+        )
+        analysis_page = self.wizard_page.WizardPage(analysis_spec)
+
+        with self.assertRaisesRegex(ValueError, "atlas wizard page"):
+            self.atlas_page.install_atlas_page_content(analysis_page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -13,6 +13,7 @@ def _load_wizard_composition_module():
     for name in (
         "qfit.ui.dockwidget.wizard_composition",
         "qfit.ui.dockwidget.analysis_page",
+        "qfit.ui.dockwidget.atlas_page",
         "qfit.ui.dockwidget.connection_page",
         "qfit.ui.dockwidget.sync_page",
         "qfit.ui.dockwidget.map_page",
@@ -81,6 +82,15 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.analysis_content.status_label.text(),
             "Analysis not run yet",
         )
+        self.assertIsNotNone(assembled.atlas_content)
+        self.assertIs(
+            assembled.pages[4].body_layout().widgets[-1],
+            assembled.atlas_content,
+        )
+        self.assertEqual(
+            assembled.atlas_content.status_label.text(),
+            "Atlas PDF not exported yet",
+        )
         self.assertEqual(
             assembled.shell.stepper_bar.states(),
             ("current", "locked", "locked", "locked", "locked"),
@@ -109,6 +119,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertIsNone(assembled.sync_content)
         self.assertIsNone(assembled.map_content)
         self.assertIsNone(assembled.analysis_content)
+        self.assertIsNone(assembled.atlas_content)
         self.assertEqual(assembled.shell.page_count(), 0)
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), -1)
         self.assertEqual(assembled.presenter.progress.current_key, "connection")

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
+
+from ._qt_compat import import_qt_module
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QLabel",
+        "QToolButton",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+pyqtSignal = _qtcore.pyqtSignal
+QLabel = _qtwidgets.QLabel
+QToolButton = _qtwidgets.QToolButton
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+@dataclass(frozen=True)
+class AtlasPageState:
+    """Render facts for the #609 atlas-export wizard page."""
+
+    ready: bool = False
+    status_text: str = "Atlas PDF not exported yet"
+    detail_text: str = "Configure PDF title, subtitle, page size, and export destination."
+    input_summary_text: str = "No atlas layer selected for export"
+    output_summary_text: str = "PDF output path will be chosen before generation"
+    primary_action_label: str = "Export atlas PDF"
+
+
+class AtlasPageContent(QWidget):
+    """Reusable fifth-page content for the wizard atlas-export step."""
+
+    exportAtlasRequested = pyqtSignal()
+
+    def __init__(self, state: AtlasPageState | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitWizardAtlasPageContent")
+        self.status_label = QLabel("", self)
+        self.status_label.setObjectName("qfitWizardAtlasStatus")
+        self.detail_label = QLabel("", self)
+        self.detail_label.setObjectName("qfitWizardAtlasDetail")
+        if hasattr(self.detail_label, "setWordWrap"):
+            self.detail_label.setWordWrap(True)
+        self.input_summary_label = QLabel("", self)
+        self.input_summary_label.setObjectName("qfitWizardAtlasInputSummary")
+        self.output_summary_label = QLabel("", self)
+        self.output_summary_label.setObjectName("qfitWizardAtlasOutputSummary")
+        self.export_atlas_button = QToolButton(self)
+        self.export_atlas_button.setObjectName("qfitWizardAtlasExportButton")
+        self.export_atlas_button.setProperty("primaryAction", "export_atlas_pdf")
+        self.export_atlas_button.clicked.connect(self.exportAtlasRequested.emit)
+        self._layout = self._build_layout()
+        self.set_state(state or AtlasPageState())
+
+    def set_state(self, state: AtlasPageState) -> None:
+        """Refresh copy and state properties without rebuilding the page."""
+
+        atlas_state = "ready" if state.ready else "not_ready"
+        self.status_label.setText(state.status_text)
+        self.status_label.setProperty("atlasState", atlas_state)
+        self.status_label.setStyleSheet(_status_stylesheet(ready=state.ready))
+        self.detail_label.setText(state.detail_text)
+        self.detail_label.setStyleSheet(
+            f"QLabel#qfitWizardAtlasDetail {{ color: {COLOR_MUTED}; }}"
+        )
+        self.input_summary_label.setText(state.input_summary_text)
+        self.input_summary_label.setProperty("atlasState", atlas_state)
+        self.output_summary_label.setText(state.output_summary_text)
+        self.output_summary_label.setProperty("atlasState", atlas_state)
+        self.export_atlas_button.setText(state.primary_action_label)
+
+    def outer_layout(self):
+        """Expose the layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardAtlasPageContentLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        for widget in (
+            self.status_label,
+            self.detail_label,
+            self.input_summary_label,
+            self.output_summary_label,
+            self.export_atlas_button,
+        ):
+            layout.addWidget(widget)
+        return layout
+
+
+def build_atlas_page_content(
+    *,
+    parent=None,
+    state: AtlasPageState | None = None,
+) -> AtlasPageContent:
+    """Build the reusable atlas-export-step content widget."""
+
+    return AtlasPageContent(state=state, parent=parent)
+
+
+def install_atlas_page_content(
+    page,
+    *,
+    state: AtlasPageState | None = None,
+) -> AtlasPageContent:
+    """Append atlas-export content to the matching wizard page body layout."""
+
+    if page.spec.key != "atlas":
+        raise ValueError(
+            "Atlas page content can only be installed on the atlas wizard page"
+        )
+    content = build_atlas_page_content(parent=page, state=state)
+    page.body_layout().addWidget(content)
+    return content
+
+
+def _status_stylesheet(*, ready: bool) -> str:
+    color = COLOR_ACCENT if ready else COLOR_WARN
+    return (
+        "QLabel#qfitWizardAtlasStatus { "
+        f"color: {color}; "
+        "font-weight: 700; "
+        "}"
+    )
+
+
+__all__ = [
+    "AtlasPageContent",
+    "AtlasPageState",
+    "build_atlas_page_content",
+    "install_atlas_page_content",
+]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -11,6 +11,7 @@ from .analysis_page import (
     AnalysisPageState,
     install_analysis_page_content,
 )
+from .atlas_page import AtlasPageContent, AtlasPageState, install_atlas_page_content
 from .connection_page import (
     ConnectionPageContent,
     ConnectionPageState,
@@ -40,6 +41,7 @@ class WizardShellComposition:
     sync_content: SyncPageContent | None = None
     map_content: MapPageContent | None = None
     analysis_content: AnalysisPageContent | None = None
+    atlas_content: AtlasPageContent | None = None
 
 
 def build_placeholder_wizard_shell(
@@ -52,6 +54,7 @@ def build_placeholder_wizard_shell(
     sync_state: SyncPageState | None = None,
     map_state: MapPageState | None = None,
     analysis_state: AnalysisPageState | None = None,
+    atlas_state: AtlasPageState | None = None,
 ) -> WizardShellComposition:
     """Build the placeholder #609 wizard shell with pages and presenter wired.
 
@@ -73,6 +76,7 @@ def build_placeholder_wizard_shell(
         pages,
         analysis_state=analysis_state,
     )
+    atlas_content = _install_atlas_content(pages, atlas_state=atlas_state)
     presenter = WizardShellPresenter(shell, progress)
     return WizardShellComposition(
         shell=shell,
@@ -82,6 +86,7 @@ def build_placeholder_wizard_shell(
         sync_content=sync_content,
         map_content=map_content,
         analysis_content=analysis_content,
+        atlas_content=atlas_content,
     )
 
 
@@ -126,6 +131,17 @@ def _install_analysis_content(
     for page in pages:
         if page.spec.key == "analysis":
             return install_analysis_page_content(page, state=analysis_state)
+    return None
+
+
+def _install_atlas_content(
+    pages: Sequence[WizardPage],
+    *,
+    atlas_state: AtlasPageState | None,
+) -> AtlasPageContent | None:
+    for page in pages:
+        if page.spec.key == "atlas":
+            return install_atlas_page_content(page, state=atlas_state)
     return None
 
 


### PR DESCRIPTION
## Summary

Adds reusable #609 wizard content for the Atlas PDF step so the placeholder wizard now has visible content for all five steps.

## Changes

- Add `AtlasPageState` and `AtlasPageContent` with status, detail, input/output summaries, and a reusable export signal.
- Wire atlas content into the wizard shell composition alongside connection, sync, map, and analysis content.
- Cover default rendering, state refresh, signal emission, install guards, and composition wiring with tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
