### PR TITLE
feat: summarize wizard footer status

### DIFF
--- a/tests/test_wizard_footer_status.py
+++ b/tests/test_wizard_footer_status.py
@@ -1,0 +1,48 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.wizard_footer_status import build_wizard_footer_status
+
+
+class WizardFooterStatusTests(unittest.TestCase):
+    def test_builds_compact_status_from_wizard_page_facts(self):
+        self.assertEqual(
+            build_wizard_footer_status(
+                connection_status="Strava connected",
+                activity_summary="12 activities stored",
+                map_summary="3 layers loaded",
+                analysis_status="Analysis ready",
+                atlas_status="Atlas PDF not exported yet",
+            ),
+            "Strava connected · 12 activities stored · 3 layers loaded · "
+            "Analysis ready · Atlas PDF not exported yet",
+        )
+
+    def test_omits_empty_and_duplicate_parts(self):
+        self.assertEqual(
+            build_wizard_footer_status(
+                connection_status="Ready",
+                activity_summary="",
+                map_summary=None,
+                analysis_status="Ready",
+                atlas_status=" ",
+            ),
+            "Ready",
+        )
+
+    def test_falls_back_to_ready_when_no_status_parts_are_available(self):
+        self.assertEqual(
+            build_wizard_footer_status(
+                connection_status="",
+                activity_summary=None,
+                map_summary=" ",
+                analysis_status="",
+                atlas_status=None,
+            ),
+            "Ready",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -161,8 +161,32 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertIsNone(assembled.analysis_content)
         self.assertIsNone(assembled.atlas_content)
         self.assertEqual(assembled.shell.page_count(), 0)
+        self.assertEqual(assembled.shell.footer_bar.text(), "Ready")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), -1)
         self.assertEqual(assembled.presenter.progress.current_key, "connection")
+
+    def test_default_footer_only_summarizes_installed_pages(self):
+        specs = (
+            self.composition.DockWizardPageSpec(
+                key="connection",
+                title="Connection",
+                summary="Connect qfit to Strava.",
+                primary_action_hint="Primary action: configure connection",
+            ),
+            self.composition.DockWizardPageSpec(
+                key="atlas",
+                title="Atlas PDF",
+                summary="Export a PDF atlas.",
+                primary_action_hint="Primary action: export atlas PDF",
+            ),
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(specs=specs)
+
+        self.assertEqual(
+            assembled.shell.footer_bar.text(),
+            "Strava not connected · Atlas PDF not exported yet",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -111,6 +111,46 @@ class WizardShellCompositionTest(unittest.TestCase):
             ("done", "done", "current", "locked", "locked"),
         )
 
+    def test_builds_default_footer_from_page_status_facts(self):
+        assembled = self.composition.build_placeholder_wizard_shell()
+
+        self.assertEqual(
+            assembled.shell.footer_bar.text(),
+            "Strava not connected · No activities stored · "
+            "No activity layers on the map · Analysis not run yet · "
+            "Atlas PDF not exported yet",
+        )
+
+    def test_page_state_inputs_drive_default_footer_text(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            connection_state=self.composition.ConnectionPageState(
+                connected=True,
+                status_text="Strava connected",
+            ),
+            sync_state=self.composition.SyncPageState(
+                ready=True,
+                activity_summary_text="12 activities stored",
+            ),
+            map_state=self.composition.MapPageState(
+                loaded=True,
+                layer_summary_text="3 activity layers loaded",
+            ),
+            analysis_state=self.composition.AnalysisPageState(
+                ready=True,
+                status_text="Analysis ready",
+            ),
+            atlas_state=self.composition.AtlasPageState(
+                ready=True,
+                status_text="Atlas ready",
+            ),
+        )
+
+        self.assertEqual(
+            assembled.shell.footer_bar.text(),
+            "Strava connected · 12 activities stored · 3 activity layers loaded · "
+            "Analysis ready · Atlas ready",
+        )
+
     def test_supports_explicit_empty_specs_without_binding_current_dock_controls(self):
         assembled = self.composition.build_placeholder_wizard_shell(specs=())
 

--- a/ui/application/wizard_footer_status.py
+++ b/ui/application/wizard_footer_status.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+
+def build_wizard_footer_status(
+    *,
+    connection_status: str | None,
+    activity_summary: str | None,
+    map_summary: str | None,
+    analysis_status: str | None,
+    atlas_status: str | None,
+) -> str:
+    """Build the compact persistent footer text for the #609 wizard shell.
+
+    The footer deliberately summarizes page-level render facts instead of
+    reading current dock widgets. That keeps the wizard replacement path free to
+    migrate one page at a time while still giving users the one-glance status
+    requested by the #608 UX audit.
+    """
+
+    return _join_unique_status_parts(
+        connection_status,
+        activity_summary,
+        map_summary,
+        analysis_status,
+        atlas_status,
+    )
+
+
+def _join_unique_status_parts(*values: str | None) -> str:
+    parts: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        part = (value or "").strip()
+        if not part or part in seen:
+            continue
+        parts.append(part)
+        seen.add(part)
+
+    if not parts:
+        return "Ready"
+    return " · ".join(parts)
+
+
+__all__ = ["build_wizard_footer_status"]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 
 from qfit.ui.application.dock_workflow_sections import DockWizardProgress
 from qfit.ui.application.wizard_footer_status import build_wizard_footer_status
-from qfit.ui.application.wizard_page_specs import DockWizardPageSpec
+from qfit.ui.application.wizard_page_specs import (
+    DockWizardPageSpec,
+    build_default_wizard_page_specs,
+)
 
 from .analysis_page import (
     AnalysisPageContent,
@@ -70,10 +73,12 @@ def build_placeholder_wizard_shell(
     map_state = map_state or MapPageState()
     analysis_state = analysis_state or AnalysisPageState()
     atlas_state = atlas_state or AtlasPageState()
+    page_specs = _resolve_page_specs(specs)
     shell = WizardShell(
         parent=parent,
         footer_text=footer_text
         or _build_default_footer_text(
+            installed_keys={spec.key for spec in page_specs},
             connection_state=connection_state,
             sync_state=sync_state,
             map_state=map_state,
@@ -81,7 +86,7 @@ def build_placeholder_wizard_shell(
             atlas_state=atlas_state,
         ),
     )
-    pages = install_wizard_pages(shell, specs=specs)
+    pages = install_wizard_pages(shell, specs=page_specs)
     connection_content = _install_connection_content(
         pages,
         connection_state=connection_state,
@@ -106,8 +111,17 @@ def build_placeholder_wizard_shell(
     )
 
 
+def _resolve_page_specs(
+    specs: Sequence[DockWizardPageSpec] | None,
+) -> tuple[DockWizardPageSpec, ...]:
+    if specs is None:
+        return build_default_wizard_page_specs()
+    return tuple(specs)
+
+
 def _build_default_footer_text(
     *,
+    installed_keys: Collection[str],
     connection_state: ConnectionPageState,
     sync_state: SyncPageState,
     map_state: MapPageState,
@@ -115,11 +129,19 @@ def _build_default_footer_text(
     atlas_state: AtlasPageState,
 ) -> str:
     return build_wizard_footer_status(
-        connection_status=connection_state.status_text,
-        activity_summary=sync_state.activity_summary_text,
-        map_summary=map_state.layer_summary_text,
-        analysis_status=analysis_state.status_text,
-        atlas_status=atlas_state.status_text,
+        connection_status=(
+            connection_state.status_text if "connection" in installed_keys else None
+        ),
+        activity_summary=(
+            sync_state.activity_summary_text if "sync" in installed_keys else None
+        ),
+        map_summary=(
+            map_state.layer_summary_text if "map" in installed_keys else None
+        ),
+        analysis_status=(
+            analysis_state.status_text if "analysis" in installed_keys else None
+        ),
+        atlas_status=atlas_state.status_text if "atlas" in installed_keys else None,
     )
 
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from qfit.ui.application.dock_workflow_sections import DockWizardProgress
+from qfit.ui.application.wizard_footer_status import build_wizard_footer_status
 from qfit.ui.application.wizard_page_specs import DockWizardPageSpec
 
 from .analysis_page import (
@@ -64,7 +65,22 @@ def build_placeholder_wizard_shell(
     migrate later through the stable ``WizardPage.body_layout()`` seams.
     """
 
-    shell = WizardShell(parent=parent, footer_text=footer_text)
+    connection_state = connection_state or ConnectionPageState()
+    sync_state = sync_state or SyncPageState()
+    map_state = map_state or MapPageState()
+    analysis_state = analysis_state or AnalysisPageState()
+    atlas_state = atlas_state or AtlasPageState()
+    shell = WizardShell(
+        parent=parent,
+        footer_text=footer_text
+        or _build_default_footer_text(
+            connection_state=connection_state,
+            sync_state=sync_state,
+            map_state=map_state,
+            analysis_state=analysis_state,
+            atlas_state=atlas_state,
+        ),
+    )
     pages = install_wizard_pages(shell, specs=specs)
     connection_content = _install_connection_content(
         pages,
@@ -87,6 +103,23 @@ def build_placeholder_wizard_shell(
         map_content=map_content,
         analysis_content=analysis_content,
         atlas_content=atlas_content,
+    )
+
+
+def _build_default_footer_text(
+    *,
+    connection_state: ConnectionPageState,
+    sync_state: SyncPageState,
+    map_state: MapPageState,
+    analysis_state: AnalysisPageState,
+    atlas_state: AtlasPageState,
+) -> str:
+    return build_wizard_footer_status(
+        connection_status=connection_state.status_text,
+        activity_summary=sync_state.activity_summary_text,
+        map_summary=map_state.layer_summary_text,
+        analysis_status=analysis_state.status_text,
+        atlas_status=atlas_state.status_text,
     )
 
 


### PR DESCRIPTION
## Summary

Adds a render-neutral wizard footer status builder and wires the placeholder #609 wizard shell to populate its footer from page-level status facts by default.

## Changes

- Add `build_wizard_footer_status()` for compact, de-duplicated wizard footer text.
- Derive the placeholder wizard shell footer from connection, sync, map, analysis, and atlas page states when no explicit footer text is provided.
- Cover the footer builder and composition behavior with unit tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608.
Refs #609.
