### PR TITLE
feat: add wizard action hierarchy

### DIFF
--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -13,6 +13,7 @@ def _load_analysis_modules():
     for name in (
         "qfit.ui.dockwidget.analysis_page",
         "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.action_row",
         "qfit.ui.dockwidget",
     ):
         sys.modules.pop(name, None)
@@ -63,13 +64,22 @@ class AnalysisPageContentTest(unittest.TestCase):
             "run_analysis",
         )
         self.assertEqual(
+            content.run_analysis_button.property("wizardActionRole"),
+            "primary",
+        )
+        self.assertEqual(content.action_row.objectName(), "qfitWizardAnalysisActionRow")
+        self.assertEqual(
+            content.action_row.outer_layout().widgets,
+            [content.run_analysis_button],
+        )
+        self.assertEqual(
             content.outer_layout().widgets,
             [
                 content.status_label,
                 content.detail_label,
                 content.input_summary_label,
                 content.result_summary_label,
-                content.run_analysis_button,
+                content.action_row,
             ],
         )
 

--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -13,6 +13,7 @@ def _load_atlas_modules():
     for name in (
         "qfit.ui.dockwidget.atlas_page",
         "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.action_row",
         "qfit.ui.dockwidget",
     ):
         sys.modules.pop(name, None)
@@ -63,13 +64,22 @@ class AtlasPageContentTest(unittest.TestCase):
             "export_atlas_pdf",
         )
         self.assertEqual(
+            content.export_atlas_button.property("wizardActionRole"),
+            "primary",
+        )
+        self.assertEqual(content.action_row.objectName(), "qfitWizardAtlasActionRow")
+        self.assertEqual(
+            content.action_row.outer_layout().widgets,
+            [content.export_atlas_button],
+        )
+        self.assertEqual(
             content.outer_layout().widgets,
             [
                 content.status_label,
                 content.detail_label,
                 content.input_summary_label,
                 content.output_summary_label,
-                content.export_atlas_button,
+                content.action_row,
             ],
         )
 

--- a/tests/test_connection_page.py
+++ b/tests/test_connection_page.py
@@ -13,6 +13,7 @@ def _load_connection_modules():
     for name in (
         "qfit.ui.dockwidget.connection_page",
         "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.action_row",
         "qfit.ui.dockwidget",
     ):
         sys.modules.pop(name, None)
@@ -49,9 +50,15 @@ class ConnectionPageContentTest(unittest.TestCase):
             content.configure_button.property("primaryAction"),
             "configure_connection",
         )
+        self.assertEqual(content.configure_button.property("wizardActionRole"), "primary")
+        self.assertEqual(
+            content.action_row.objectName(),
+            "qfitWizardConnectionActionRow",
+        )
+        self.assertEqual(content.action_row.outer_layout().widgets, [content.configure_button])
         self.assertEqual(
             content.outer_layout().widgets,
-            [content.status_label, content.detail_label, content.configure_button],
+            [content.status_label, content.detail_label, content.action_row],
         )
 
     def test_refreshes_connected_state_without_rebuilding(self):

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -13,6 +13,7 @@ def _load_map_modules():
     for name in (
         "qfit.ui.dockwidget.map_page",
         "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.action_row",
         "qfit.ui.dockwidget",
     ):
         sys.modules.pop(name, None)
@@ -62,6 +63,7 @@ class MapPageContentTest(unittest.TestCase):
             content.load_layers_button.property("secondaryAction"),
             "load_activity_layers",
         )
+        self.assertEqual(content.load_layers_button.property("wizardActionRole"), "secondary")
         self.assertEqual(
             content.apply_filters_button.objectName(),
             "qfitWizardMapApplyFiltersButton",
@@ -71,6 +73,12 @@ class MapPageContentTest(unittest.TestCase):
             content.apply_filters_button.property("primaryAction"),
             "apply_map_filters",
         )
+        self.assertEqual(content.apply_filters_button.property("wizardActionRole"), "primary")
+        self.assertEqual(content.action_row.objectName(), "qfitWizardMapActionRow")
+        self.assertEqual(
+            content.action_row.outer_layout().widgets,
+            [content.load_layers_button, content.apply_filters_button],
+        )
         self.assertEqual(
             content.outer_layout().widgets,
             [
@@ -78,8 +86,7 @@ class MapPageContentTest(unittest.TestCase):
                 content.detail_label,
                 content.layer_summary_label,
                 content.filter_summary_label,
-                content.load_layers_button,
-                content.apply_filters_button,
+                content.action_row,
             ],
         )
 

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -13,6 +13,7 @@ def _load_sync_modules():
     for name in (
         "qfit.ui.dockwidget.sync_page",
         "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.action_row",
         "qfit.ui.dockwidget",
     ):
         sys.modules.pop(name, None)
@@ -48,13 +49,16 @@ class SyncPageContentTest(unittest.TestCase):
             content.sync_button.property("primaryAction"),
             "sync_activities",
         )
+        self.assertEqual(content.sync_button.property("wizardActionRole"), "primary")
+        self.assertEqual(content.action_row.objectName(), "qfitWizardSyncActionRow")
+        self.assertEqual(content.action_row.outer_layout().widgets, [content.sync_button])
         self.assertEqual(
             content.outer_layout().widgets,
             [
                 content.status_label,
                 content.detail_label,
                 content.activity_summary_label,
-                content.sync_button,
+                content.action_row,
             ],
         )
 

--- a/tests/test_wizard_action_row.py
+++ b/tests/test_wizard_action_row.py
@@ -1,0 +1,71 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+
+def _load_action_row_module():
+    for name in (
+        "qfit.ui.dockwidget.action_row",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.action_row")
+
+
+class WizardActionRowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.action_row = _load_action_row_module()
+
+    def test_builds_scoped_row_with_supplied_buttons(self):
+        primary = self.action_row.QToolButton()
+        secondary = self.action_row.QToolButton()
+
+        row = self.action_row.build_wizard_action_row(
+            secondary,
+            primary,
+            object_name="qfitWizardMapActionRow",
+        )
+
+        self.assertEqual(row.objectName(), "qfitWizardMapActionRow")
+        self.assertEqual(row.outer_layout().object_name, "qfitWizardActionRowLayout")
+        self.assertEqual(row.outer_layout().contents_margins, (0, 4, 0, 0))
+        self.assertEqual(row.outer_layout().spacing, 8)
+        self.assertEqual(row.outer_layout().widgets, [secondary, primary])
+
+    def test_primary_action_button_gets_cta_role_and_chrome(self):
+        button = self.action_row.QToolButton()
+
+        returned = self.action_row.style_primary_action_button(
+            button,
+            action_name="sync_activities",
+        )
+
+        self.assertIs(returned, button)
+        self.assertEqual(button.property("primaryAction"), "sync_activities")
+        self.assertEqual(button.property("wizardActionRole"), "primary")
+        self.assertIn("font-weight: 700", button.styleSheet())
+        self.assertIsNotNone(button.cursor().shape())
+
+    def test_secondary_action_button_gets_secondary_role_and_chrome(self):
+        button = self.action_row.QToolButton()
+
+        returned = self.action_row.style_secondary_action_button(
+            button,
+            action_name="load_activity_layers",
+        )
+
+        self.assertIs(returned, button)
+        self.assertEqual(button.property("secondaryAction"), "load_activity_layers")
+        self.assertEqual(button.property("wizardActionRole"), "secondary")
+        self.assertIn("font-weight: 500", button.styleSheet())
+        self.assertIsNotNone(button.cursor().shape())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_action_row.py
+++ b/tests/test_wizard_action_row.py
@@ -50,6 +50,7 @@ class WizardActionRowTest(unittest.TestCase):
         self.assertEqual(button.property("primaryAction"), "sync_activities")
         self.assertEqual(button.property("wizardActionRole"), "primary")
         self.assertIn("font-weight: 700", button.styleSheet())
+        self.assertIn("QToolButton:disabled", button.styleSheet())
         self.assertIsNotNone(button.cursor().shape())
 
     def test_secondary_action_button_gets_secondary_role_and_chrome(self):

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from qfit.ui.tokens import (
+    COLOR_ACCENT,
+    COLOR_ACCENT_DARK,
+    COLOR_HOVER,
+    COLOR_MUTED,
+    COLOR_SEPARATOR,
+    COLOR_TEXT,
+)
+
+from ._qt_compat import import_qt_module
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt",))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    ("QHBoxLayout", "QSizePolicy", "QToolButton", "QWidget"),
+)
+
+Qt = _qtcore.Qt
+QHBoxLayout = _qtwidgets.QHBoxLayout
+QSizePolicy = _qtwidgets.QSizePolicy
+QToolButton = _qtwidgets.QToolButton
+QWidget = _qtwidgets.QWidget
+
+
+class WizardActionRow(QWidget):
+    """Compact action container for one wizard page CTA area."""
+
+    def __init__(self, buttons: Iterable[QToolButton] = (), parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitWizardActionRow")
+        self._layout = self._build_layout()
+        for button in buttons:
+            self.add_button(button)
+
+    def add_button(self, button: QToolButton) -> None:
+        """Append an action button to the row without changing ownership."""
+
+        self._layout.addWidget(button)
+
+    def outer_layout(self):
+        """Expose the row layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_layout(self):
+        layout = QHBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardActionRowLayout")
+        layout.setContentsMargins(0, 4, 0, 0)
+        layout.setSpacing(8)
+        return layout
+
+
+def build_wizard_action_row(
+    *buttons: QToolButton,
+    parent=None,
+    object_name: str = "qfitWizardActionRow",
+) -> WizardActionRow:
+    """Build a scoped action row for wizard page buttons."""
+
+    row = WizardActionRow(buttons, parent=parent)
+    row.setObjectName(object_name)
+    return row
+
+
+def style_primary_action_button(
+    button: QToolButton,
+    *,
+    action_name: str,
+) -> QToolButton:
+    """Mark a wizard button as the one primary CTA for its page."""
+
+    button.setProperty("primaryAction", action_name)
+    button.setProperty("wizardActionRole", "primary")
+    _apply_button_chrome(button, primary=True)
+    return button
+
+
+def style_secondary_action_button(
+    button: QToolButton,
+    *,
+    action_name: str,
+) -> QToolButton:
+    """Mark a wizard button as a secondary page action."""
+
+    button.setProperty("secondaryAction", action_name)
+    button.setProperty("wizardActionRole", "secondary")
+    _apply_button_chrome(button, primary=False)
+    return button
+
+
+def _apply_button_chrome(button: QToolButton, *, primary: bool) -> None:
+    if hasattr(button, "setToolButtonStyle"):
+        button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+    if hasattr(button, "setSizePolicy"):
+        button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+    button.setCursor(Qt.PointingHandCursor)
+    button.setStyleSheet(_button_stylesheet(primary=primary))
+
+
+def _button_stylesheet(*, primary: bool) -> str:
+    if primary:
+        return (
+            "QToolButton { "
+            f"background: {COLOR_ACCENT}; "
+            "color: white; "
+            f"border: 1px solid {COLOR_ACCENT_DARK}; "
+            "border-radius: 6px; "
+            "padding: 5px 10px; "
+            "font-weight: 700; "
+            "} "
+            f"QToolButton:hover:enabled {{ background: {COLOR_ACCENT_DARK}; }}"
+        )
+    return (
+        "QToolButton { "
+        "background: transparent; "
+        f"color: {COLOR_TEXT}; "
+        f"border: 1px solid {COLOR_SEPARATOR}; "
+        "border-radius: 6px; "
+        "padding: 5px 10px; "
+        "font-weight: 500; "
+        "} "
+        f"QToolButton:hover:enabled {{ background: {COLOR_HOVER}; }} "
+        f"QToolButton:disabled {{ color: {COLOR_MUTED}; }}"
+    )
+
+
+__all__ = [
+    "WizardActionRow",
+    "build_wizard_action_row",
+    "style_primary_action_button",
+    "style_secondary_action_button",
+]

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -38,7 +38,7 @@ class WizardActionRow(QWidget):
             self.add_button(button)
 
     def add_button(self, button: QToolButton) -> None:
-        """Append an action button to the row without changing ownership."""
+        """Append an action button and let Qt re-parent it into the row."""
 
         self._layout.addWidget(button)
 
@@ -99,8 +99,10 @@ def _apply_button_chrome(button: QToolButton, *, primary: bool) -> None:
         button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
     if hasattr(button, "setSizePolicy"):
         button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-    button.setCursor(Qt.PointingHandCursor)
-    button.setStyleSheet(_button_stylesheet(primary=primary))
+    if hasattr(button, "setCursor"):
+        button.setCursor(Qt.PointingHandCursor)
+    if hasattr(button, "setStyleSheet"):
+        button.setStyleSheet(_button_stylesheet(primary=primary))
 
 
 def _button_stylesheet(*, primary: bool) -> str:
@@ -114,7 +116,12 @@ def _button_stylesheet(*, primary: bool) -> str:
             "padding: 5px 10px; "
             "font-weight: 700; "
             "} "
-            f"QToolButton:hover:enabled {{ background: {COLOR_ACCENT_DARK}; }}"
+            f"QToolButton:hover:enabled {{ background: {COLOR_ACCENT_DARK}; }} "
+            "QToolButton:disabled { "
+            f"background: {COLOR_SEPARATOR}; "
+            f"border-color: {COLOR_SEPARATOR}; "
+            f"color: {COLOR_MUTED}; "
+            "}"
         )
     return (
         "QToolButton { "

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
 
 from ._qt_compat import import_qt_module
+from .action_row import build_wizard_action_row, style_primary_action_button
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -59,8 +60,16 @@ class AnalysisPageContent(QWidget):
         self.result_summary_label.setObjectName("qfitWizardAnalysisResultSummary")
         self.run_analysis_button = QToolButton(self)
         self.run_analysis_button.setObjectName("qfitWizardAnalysisRunButton")
-        self.run_analysis_button.setProperty("primaryAction", "run_analysis")
+        style_primary_action_button(
+            self.run_analysis_button,
+            action_name="run_analysis",
+        )
         self.run_analysis_button.clicked.connect(self.runAnalysisRequested.emit)
+        self.action_row = build_wizard_action_row(
+            self.run_analysis_button,
+            parent=self,
+            object_name="qfitWizardAnalysisActionRow",
+        )
         self._layout = self._build_layout()
         self.set_state(state or AnalysisPageState())
 
@@ -97,7 +106,7 @@ class AnalysisPageContent(QWidget):
             self.detail_label,
             self.input_summary_label,
             self.result_summary_label,
-            self.run_analysis_button,
+            self.action_row,
         ):
             layout.addWidget(widget)
         return layout

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
 
 from ._qt_compat import import_qt_module
+from .action_row import build_wizard_action_row, style_primary_action_button
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -57,8 +58,16 @@ class AtlasPageContent(QWidget):
         self.output_summary_label.setObjectName("qfitWizardAtlasOutputSummary")
         self.export_atlas_button = QToolButton(self)
         self.export_atlas_button.setObjectName("qfitWizardAtlasExportButton")
-        self.export_atlas_button.setProperty("primaryAction", "export_atlas_pdf")
+        style_primary_action_button(
+            self.export_atlas_button,
+            action_name="export_atlas_pdf",
+        )
         self.export_atlas_button.clicked.connect(self.exportAtlasRequested.emit)
+        self.action_row = build_wizard_action_row(
+            self.export_atlas_button,
+            parent=self,
+            object_name="qfitWizardAtlasActionRow",
+        )
         self._layout = self._build_layout()
         self.set_state(state or AtlasPageState())
 
@@ -95,7 +104,7 @@ class AtlasPageContent(QWidget):
             self.detail_label,
             self.input_summary_label,
             self.output_summary_label,
-            self.export_atlas_button,
+            self.action_row,
         ):
             layout.addWidget(widget)
         return layout

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
 
 from ._qt_compat import import_qt_module
+from .action_row import build_wizard_action_row, style_primary_action_button
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -56,7 +57,16 @@ class ConnectionPageContent(QWidget):
             self.detail_label.setWordWrap(True)
         self.configure_button = QToolButton(self)
         self.configure_button.setObjectName("qfitWizardConnectionConfigureButton")
+        style_primary_action_button(
+            self.configure_button,
+            action_name="configure_connection",
+        )
         self.configure_button.clicked.connect(self.configureRequested.emit)
+        self.action_row = build_wizard_action_row(
+            self.configure_button,
+            parent=self,
+            object_name="qfitWizardConnectionActionRow",
+        )
         self._layout = self._build_layout()
         self.set_state(state or ConnectionPageState())
 
@@ -74,7 +84,6 @@ class ConnectionPageContent(QWidget):
             f"QLabel#qfitWizardConnectionDetail {{ color: {COLOR_MUTED}; }}"
         )
         self.configure_button.setText(state.primary_action_label)
-        self.configure_button.setProperty("primaryAction", "configure_connection")
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""
@@ -89,7 +98,7 @@ class ConnectionPageContent(QWidget):
         layout.setSpacing(8)
         layout.addWidget(self.status_label)
         layout.addWidget(self.detail_label)
-        layout.addWidget(self.configure_button)
+        layout.addWidget(self.action_row)
         return layout
 
 

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
 
 from ._qt_compat import import_qt_module
+from .action_row import (
+    build_wizard_action_row,
+    style_primary_action_button,
+    style_secondary_action_button,
+)
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -59,12 +64,24 @@ class MapPageContent(QWidget):
         self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
         self.load_layers_button = QToolButton(self)
         self.load_layers_button.setObjectName("qfitWizardMapLoadLayersButton")
-        self.load_layers_button.setProperty("secondaryAction", "load_activity_layers")
+        style_secondary_action_button(
+            self.load_layers_button,
+            action_name="load_activity_layers",
+        )
         self.load_layers_button.clicked.connect(self.loadLayersRequested.emit)
         self.apply_filters_button = QToolButton(self)
         self.apply_filters_button.setObjectName("qfitWizardMapApplyFiltersButton")
-        self.apply_filters_button.setProperty("primaryAction", "apply_map_filters")
+        style_primary_action_button(
+            self.apply_filters_button,
+            action_name="apply_map_filters",
+        )
         self.apply_filters_button.clicked.connect(self.applyFiltersRequested.emit)
+        self.action_row = build_wizard_action_row(
+            self.load_layers_button,
+            self.apply_filters_button,
+            parent=self,
+            object_name="qfitWizardMapActionRow",
+        )
         self._layout = self._build_layout()
         self.set_state(state or MapPageState())
 
@@ -101,8 +118,7 @@ class MapPageContent(QWidget):
         layout.addWidget(self.detail_label)
         layout.addWidget(self.layer_summary_label)
         layout.addWidget(self.filter_summary_label)
-        layout.addWidget(self.load_layers_button)
-        layout.addWidget(self.apply_filters_button)
+        layout.addWidget(self.action_row)
         return layout
 
 

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
 
 from ._qt_compat import import_qt_module
+from .action_row import build_wizard_action_row, style_primary_action_button
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -54,7 +55,16 @@ class SyncPageContent(QWidget):
         self.activity_summary_label.setObjectName("qfitWizardSyncActivitySummary")
         self.sync_button = QToolButton(self)
         self.sync_button.setObjectName("qfitWizardSyncButton")
+        style_primary_action_button(
+            self.sync_button,
+            action_name="sync_activities",
+        )
         self.sync_button.clicked.connect(self.syncRequested.emit)
+        self.action_row = build_wizard_action_row(
+            self.sync_button,
+            parent=self,
+            object_name="qfitWizardSyncActionRow",
+        )
         self._layout = self._build_layout()
         self.set_state(state or SyncPageState())
 
@@ -72,7 +82,6 @@ class SyncPageContent(QWidget):
         self.activity_summary_label.setText(state.activity_summary_text)
         self.activity_summary_label.setProperty("syncState", sync_state)
         self.sync_button.setText(state.primary_action_label)
-        self.sync_button.setProperty("primaryAction", "sync_activities")
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""
@@ -88,7 +97,7 @@ class SyncPageContent(QWidget):
         layout.addWidget(self.status_label)
         layout.addWidget(self.detail_label)
         layout.addWidget(self.activity_summary_label)
-        layout.addWidget(self.sync_button)
+        layout.addWidget(self.action_row)
         return layout
 
 


### PR DESCRIPTION
## Summary

Adds a shared wizard action-row helper and scoped CTA styling for the #609 placeholder wizard pages. This gives each page a clear primary action area without touching the existing long-scroll production dock.

## Changes

- Added `WizardActionRow` plus primary/secondary `QToolButton` styling helpers.
- Wrapped connection, sync, map/filter, analysis, and atlas page actions in scoped wizard action rows.
- Marked wizard CTAs with stable `wizardActionRole` properties for tests and future adapter wiring.
- Added unit coverage for the helper and updated page tests for the new action hierarchy.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
