### PR TITLE
ui: retire wizard placeholder CTA hints

### DIFF
--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -75,6 +75,19 @@ class WizardPageTest(unittest.TestCase):
             [page.title_label, page.summary_label, page.body_container, page.primary_hint_label],
         )
 
+    def test_retiring_primary_hint_removes_placeholder_copy(self):
+        spec = build_default_wizard_page_specs()[1]
+        page = self.wizard_page.WizardPage(spec)
+
+        page.retire_primary_action_hint()
+
+        self.assertEqual(page.primary_hint_label.text(), "")
+        self.assertEqual(
+            page.primary_hint_label.property("wizardPlaceholderHint"),
+            "retired",
+        )
+        self.assertFalse(page.primary_hint_label.isVisible())
+
     def test_build_pages_preserves_explicit_empty_specs(self):
         pages = self.wizard_page.build_wizard_pages(specs=())
 

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -62,6 +62,13 @@ class _FakeWidget:
         self._cursor = _FakeCursor(None)
         self._tooltip = ""
         self._stylesheet = ""
+        self._visible = True
+
+    def setVisible(self, value):  # noqa: N802
+        self._visible = value
+
+    def isVisible(self):  # noqa: N802
+        return self._visible
 
     def setFixedHeight(self, value):  # noqa: N802
         self._height = value

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -55,6 +55,8 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.connection_content.status_label.text(),
             "Strava not connected",
         )
+        self.assertEqual(assembled.pages[0].primary_hint_label.text(), "")
+        self.assertFalse(assembled.pages[0].primary_hint_label.isVisible())
         self.assertIsNotNone(assembled.sync_content)
         self.assertIs(
             assembled.pages[1].body_layout().widgets[-1],
@@ -90,6 +92,12 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(
             assembled.atlas_content.status_label.text(),
             "Atlas PDF not exported yet",
+        )
+        self.assertTrue(
+            all(
+                page.primary_hint_label.property("wizardPlaceholderHint") == "retired"
+                for page in assembled.pages
+            )
         )
         self.assertEqual(
             assembled.shell.stepper_bar.states(),

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -135,6 +135,7 @@ def install_analysis_page_content(
         )
     content = build_analysis_page_content(parent=page, state=state)
     page.body_layout().addWidget(content)
+    page.retire_primary_action_hint()
     return content
 
 

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -133,6 +133,7 @@ def install_atlas_page_content(
         )
     content = build_atlas_page_content(parent=page, state=state)
     page.body_layout().addWidget(content)
+    page.retire_primary_action_hint()
     return content
 
 

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -125,6 +125,7 @@ def install_connection_page_content(
         )
     content = build_connection_page_content(parent=page, state=state)
     page.body_layout().addWidget(content)
+    page.retire_primary_action_hint()
     return content
 
 

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -143,6 +143,7 @@ def install_map_page_content(
         raise ValueError("Map page content can only be installed on the map wizard page")
     content = build_map_page_content(parent=page, state=state)
     page.body_layout().addWidget(content)
+    page.retire_primary_action_hint()
     return content
 
 

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -124,6 +124,7 @@ def install_sync_page_content(
         )
     content = build_sync_page_content(parent=page, state=state)
     page.body_layout().addWidget(content)
+    page.retire_primary_action_hint()
     return content
 
 

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -51,6 +51,19 @@ class WizardPage(QWidget):
 
         return self._body_layout
 
+    def retire_primary_action_hint(self) -> None:
+        """Hide placeholder CTA copy once concrete page actions are installed.
+
+        The first wizard slices used a textual primary-action hint as a safe
+        placeholder. Once a page owns real action buttons, keeping that hint
+        visible competes with the single primary CTA and adds the textual noise
+        called out in #608.
+        """
+
+        self.primary_hint_label.setText("")
+        self.primary_hint_label.setProperty("wizardPlaceholderHint", "retired")
+        self.primary_hint_label.setVisible(False)
+
     def outer_layout(self):
         """Expose the page layout for adapter wiring and pure tests."""
 


### PR DESCRIPTION
## Summary

- Hide wizard page placeholder primary-action hints after concrete page content installs real CTA buttons.
- Mark retired placeholder hints with a stable widget property for tests/future styling.
- Extend wizard tests to cover hint retirement in individual pages and composed shell content.

## Validation

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
