### PR TITLE
feat: gate wizard page actions

### DIFF
--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -67,6 +67,12 @@ class AnalysisPageContentTest(unittest.TestCase):
             content.run_analysis_button.property("wizardActionRole"),
             "primary",
         )
+        self.assertFalse(content.run_analysis_button.isEnabled())
+        self.assertEqual(
+            content.run_analysis_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertIn("Load activity layers", content.run_analysis_button.toolTip())
         self.assertEqual(content.action_row.objectName(), "qfitWizardAnalysisActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,
@@ -113,6 +119,27 @@ class AnalysisPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.result_summary_label.property("analysisState"), "ready")
         self.assertEqual(content.run_analysis_button.text(), "Refresh analysis")
+        self.assertTrue(content.run_analysis_button.isEnabled())
+        self.assertEqual(
+            content.run_analysis_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.run_analysis_button.toolTip(), "")
+
+    def test_can_override_run_analysis_availability(self):
+        content = self.analysis_page.AnalysisPageContent(
+            self.analysis_page.AnalysisPageState(
+                ready=True,
+                primary_action_enabled=False,
+                primary_action_blocked_tooltip="Choose an analysis input layer.",
+            )
+        )
+
+        self.assertFalse(content.run_analysis_button.isEnabled())
+        self.assertEqual(
+            content.run_analysis_button.toolTip(),
+            "Choose an analysis input layer.",
+        )
 
     def test_button_emits_reusable_page_signal(self):
         content = self.analysis_page.AnalysisPageContent()

--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -67,6 +67,12 @@ class AtlasPageContentTest(unittest.TestCase):
             content.export_atlas_button.property("wizardActionRole"),
             "primary",
         )
+        self.assertFalse(content.export_atlas_button.isEnabled())
+        self.assertEqual(
+            content.export_atlas_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertIn("Select atlas inputs", content.export_atlas_button.toolTip())
         self.assertEqual(content.action_row.objectName(), "qfitWizardAtlasActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,
@@ -113,6 +119,27 @@ class AtlasPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.output_summary_label.property("atlasState"), "ready")
         self.assertEqual(content.export_atlas_button.text(), "Refresh atlas PDF")
+        self.assertTrue(content.export_atlas_button.isEnabled())
+        self.assertEqual(
+            content.export_atlas_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.export_atlas_button.toolTip(), "")
+
+    def test_can_override_export_availability(self):
+        content = self.atlas_page.AtlasPageContent(
+            self.atlas_page.AtlasPageState(
+                ready=True,
+                primary_action_enabled=False,
+                primary_action_blocked_tooltip="Choose a PDF output path.",
+            )
+        )
+
+        self.assertFalse(content.export_atlas_button.isEnabled())
+        self.assertEqual(
+            content.export_atlas_button.toolTip(),
+            "Choose a PDF output path.",
+        )
 
     def test_button_emits_reusable_page_signal(self):
         content = self.atlas_page.AtlasPageContent()

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -74,6 +74,12 @@ class MapPageContentTest(unittest.TestCase):
             "apply_map_filters",
         )
         self.assertEqual(content.apply_filters_button.property("wizardActionRole"), "primary")
+        self.assertFalse(content.apply_filters_button.isEnabled())
+        self.assertEqual(
+            content.apply_filters_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertIn("Load activity layers", content.apply_filters_button.toolTip())
         self.assertEqual(content.action_row.objectName(), "qfitWizardMapActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,
@@ -122,6 +128,27 @@ class MapPageContentTest(unittest.TestCase):
         self.assertEqual(content.filter_summary_label.property("mapState"), "loaded")
         self.assertEqual(content.load_layers_button.text(), "Reload layers")
         self.assertEqual(content.apply_filters_button.text(), "Apply saved filters")
+        self.assertTrue(content.apply_filters_button.isEnabled())
+        self.assertEqual(
+            content.apply_filters_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.apply_filters_button.toolTip(), "")
+
+    def test_can_override_apply_filter_availability(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState(
+                loaded=True,
+                apply_action_enabled=False,
+                apply_action_blocked_tooltip="Choose at least one activity layer.",
+            )
+        )
+
+        self.assertFalse(content.apply_filters_button.isEnabled())
+        self.assertEqual(
+            content.apply_filters_button.toolTip(),
+            "Choose at least one activity layer.",
+        )
 
     def test_buttons_emit_reusable_page_signals(self):
         content = self.map_page.MapPageContent()

--- a/tests/test_wizard_action_row.py
+++ b/tests/test_wizard_action_row.py
@@ -67,6 +67,26 @@ class WizardActionRowTest(unittest.TestCase):
         self.assertIn("font-weight: 500", button.styleSheet())
         self.assertIsNotNone(button.cursor().shape())
 
+    def test_action_availability_marks_blocked_and_available_buttons(self):
+        button = self.action_row.QToolButton()
+
+        returned = self.action_row.set_wizard_action_availability(
+            button,
+            enabled=False,
+            tooltip="Load activity layers first.",
+        )
+
+        self.assertIs(returned, button)
+        self.assertFalse(button.isEnabled())
+        self.assertEqual(button.property("wizardActionAvailability"), "blocked")
+        self.assertEqual(button.toolTip(), "Load activity layers first.")
+
+        self.action_row.set_wizard_action_availability(button, enabled=True)
+
+        self.assertTrue(button.isEnabled())
+        self.assertEqual(button.property("wizardActionAvailability"), "available")
+        self.assertEqual(button.toolTip(), "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -94,6 +94,22 @@ def style_secondary_action_button(
     return button
 
 
+def set_wizard_action_availability(
+    button: QToolButton,
+    *,
+    enabled: bool,
+    tooltip: str = "",
+) -> QToolButton:
+    """Apply a wizard-specific availability state to an action button."""
+
+    button.setEnabled(enabled)
+    action_availability = "available" if enabled else "blocked"
+    button.setProperty("wizardActionAvailability", action_availability)
+    if hasattr(button, "setToolTip"):
+        button.setToolTip("" if enabled else tooltip)
+    return button
+
+
 def _apply_button_chrome(button: QToolButton, *, primary: bool) -> None:
     if hasattr(button, "setToolButtonStyle"):
         button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
@@ -140,6 +156,7 @@ def _button_stylesheet(*, primary: bool) -> str:
 __all__ = [
     "WizardActionRow",
     "build_wizard_action_row",
+    "set_wizard_action_availability",
     "style_primary_action_button",
     "style_secondary_action_button",
 ]

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -100,13 +100,16 @@ def set_wizard_action_availability(
     enabled: bool,
     tooltip: str = "",
 ) -> QToolButton:
-    """Apply a wizard-specific availability state to an action button."""
+    """Apply a wizard-specific availability state to an action button.
+
+    The tooltip is only shown while the action is blocked; available actions
+    clear it so stale prerequisite copy does not linger after state refreshes.
+    """
 
     button.setEnabled(enabled)
     action_availability = "available" if enabled else "blocked"
     button.setProperty("wizardActionAvailability", action_availability)
-    if hasattr(button, "setToolTip"):
-        button.setToolTip("" if enabled else tooltip)
+    button.setToolTip("" if enabled else tooltip)
     return button
 
 

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
 
 from ._qt_compat import import_qt_module
-from .action_row import build_wizard_action_row, style_primary_action_button
+from .action_row import (
+    build_wizard_action_row,
+    set_wizard_action_availability,
+    style_primary_action_button,
+)
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -38,6 +42,8 @@ class AnalysisPageState:
     input_summary_text: str = "No loaded activity layers available for analysis"
     result_summary_text: str = "Analysis outputs will appear in the project once generated"
     primary_action_label: str = "Run analysis"
+    primary_action_enabled: bool | None = None
+    primary_action_blocked_tooltip: str = "Load activity layers before running analysis."
 
 
 class AnalysisPageContent(QWidget):
@@ -89,6 +95,16 @@ class AnalysisPageContent(QWidget):
         self.result_summary_label.setText(state.result_summary_text)
         self.result_summary_label.setProperty("analysisState", analysis_state)
         self.run_analysis_button.setText(state.primary_action_label)
+        primary_action_enabled = (
+            state.ready
+            if state.primary_action_enabled is None
+            else state.primary_action_enabled
+        )
+        set_wizard_action_availability(
+            self.run_analysis_button,
+            enabled=primary_action_enabled,
+            tooltip=state.primary_action_blocked_tooltip,
+        )
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
 
 from ._qt_compat import import_qt_module
-from .action_row import build_wizard_action_row, style_primary_action_button
+from .action_row import (
+    build_wizard_action_row,
+    set_wizard_action_availability,
+    style_primary_action_button,
+)
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -36,6 +40,8 @@ class AtlasPageState:
     input_summary_text: str = "No atlas layer selected for export"
     output_summary_text: str = "PDF output path will be chosen before generation"
     primary_action_label: str = "Export atlas PDF"
+    primary_action_enabled: bool | None = None
+    primary_action_blocked_tooltip: str = "Select atlas inputs before exporting PDF."
 
 
 class AtlasPageContent(QWidget):
@@ -87,6 +93,16 @@ class AtlasPageContent(QWidget):
         self.output_summary_label.setText(state.output_summary_text)
         self.output_summary_label.setProperty("atlasState", atlas_state)
         self.export_atlas_button.setText(state.primary_action_label)
+        primary_action_enabled = (
+            state.ready
+            if state.primary_action_enabled is None
+            else state.primary_action_enabled
+        )
+        set_wizard_action_availability(
+            self.export_atlas_button,
+            enabled=primary_action_enabled,
+            tooltip=state.primary_action_blocked_tooltip,
+        )
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -7,6 +7,7 @@ from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
 from ._qt_compat import import_qt_module
 from .action_row import (
     build_wizard_action_row,
+    set_wizard_action_availability,
     style_primary_action_button,
     style_secondary_action_button,
 )
@@ -41,6 +42,8 @@ class MapPageState:
     filter_summary_text: str = "All stored activities visible once layers are loaded"
     load_action_label: str = "Load activity layers"
     primary_action_label: str = "Apply filters"
+    apply_action_enabled: bool | None = None
+    apply_action_blocked_tooltip: str = "Load activity layers before applying filters."
 
 
 class MapPageContent(QWidget):
@@ -102,6 +105,16 @@ class MapPageContent(QWidget):
         self.filter_summary_label.setProperty("mapState", map_state)
         self.load_layers_button.setText(state.load_action_label)
         self.apply_filters_button.setText(state.primary_action_label)
+        apply_action_enabled = (
+            state.loaded
+            if state.apply_action_enabled is None
+            else state.apply_action_enabled
+        )
+        set_wizard_action_availability(
+            self.apply_filters_button,
+            enabled=apply_action_enabled,
+            tooltip=state.apply_action_blocked_tooltip,
+        )
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""


### PR DESCRIPTION
## Summary

Adds reusable wizard action availability state so future wizard pages can visibly block unavailable CTAs instead of presenting every action as equally ready.

## Changes

- Added a shared `set_wizard_action_availability` helper for wizard CTA buttons.
- Gate Map, Analysis, and Atlas primary actions from page render state, with blocked tooltips for missing prerequisites.
- Added tests covering default blocked states, ready-state enablement, and adapter overrides.

## Testing

- `python3 -m pytest tests/test_wizard_action_row.py tests/test_map_page.py tests/test_analysis_page.py tests/test_atlas_page.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
