### PR TITLE
style: strengthen wizard page hierarchy

### DIFF
--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -8,6 +8,7 @@ from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application import wizard_page_specs
 from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.tokens import COLOR_MUTED, COLOR_TEXT
 
 
 class WizardPageSpecsTests(unittest.TestCase):
@@ -64,8 +65,13 @@ class WizardPageTest(unittest.TestCase):
         self.assertEqual(page.objectName(), "qfitWizardMapPage")
         self.assertEqual(page.title_label.objectName(), "qfitWizardMapPageTitle")
         self.assertEqual(page.title_label.text(), "Map & filters")
+        self.assertIn(COLOR_TEXT, page.title_label.styleSheet())
+        self.assertIn("font-weight: 700", page.title_label.styleSheet())
         self.assertEqual(page.summary_label.objectName(), "qfitWizardMapPageSummary")
         self.assertIn("background map", page.summary_label.text())
+        self.assertIn(COLOR_MUTED, page.summary_label.styleSheet())
+        self.assertIn(COLOR_MUTED, page.primary_hint_label.styleSheet())
+        self.assertIn("font-style: italic", page.primary_hint_label.styleSheet())
         self.assertEqual(page.body_container.objectName(), "qfitWizardMapPageBody")
         self.assertEqual(page.body_layout().contents_margins, (0, 0, 0, 0))
         self.assertEqual(page.primary_hint_label.objectName(), "qfitWizardMapPagePrimaryHint")

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -6,6 +6,7 @@ from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
     build_default_wizard_page_specs,
 )
+from qfit.ui.tokens import COLOR_MUTED, COLOR_TEXT
 
 from ._qt_compat import import_qt_module
 
@@ -23,6 +24,21 @@ QLabel = _qtwidgets.QLabel
 QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
 
+_TITLE_LABEL_QSS = (
+    "QLabel { "
+    f"color: {COLOR_TEXT}; "
+    "font-size: 15px; "
+    "font-weight: 700; "
+    "}"
+)
+_SUMMARY_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
+_PRIMARY_HINT_LABEL_QSS = (
+    "QLabel { "
+    f"color: {COLOR_MUTED}; "
+    "font-style: italic; "
+    "}"
+)
+
 
 class WizardPage(QWidget):
     """Reusable visible page container for the #609 wizard shell.
@@ -37,12 +53,21 @@ class WizardPage(QWidget):
         super().__init__(parent)
         self.spec = spec
         self.setObjectName(spec.page_object_name)
-        self.title_label = self._build_label(spec.title, spec.title_object_name)
-        self.summary_label = self._build_label(spec.summary, spec.summary_object_name)
+        self.title_label = self._build_label(
+            spec.title,
+            spec.title_object_name,
+            style=_TITLE_LABEL_QSS,
+        )
+        self.summary_label = self._build_label(
+            spec.summary,
+            spec.summary_object_name,
+            style=_SUMMARY_LABEL_QSS,
+        )
         self.body_container, self._body_layout = self._build_body_container()
         self.primary_hint_label = self._build_label(
             spec.primary_action_hint,
             spec.primary_hint_object_name,
+            style=_PRIMARY_HINT_LABEL_QSS,
         )
         self._layout = self._build_layout()
 
@@ -69,11 +94,13 @@ class WizardPage(QWidget):
 
         return self._layout
 
-    def _build_label(self, text: str, object_name: str):
+    def _build_label(self, text: str, object_name: str, *, style: str = ""):
         label = QLabel(text, self)
         label.setObjectName(object_name)
         if hasattr(label, "setWordWrap"):
             label.setWordWrap(True)
+        if style:
+            label.setStyleSheet(style)
         return label
 
     def _build_body_container(self):


### PR DESCRIPTION
## Summary

Strengthen the #609 wizard page hierarchy so each page has clearer title, summary, and retired placeholder CTA styling without touching the current long-scroll dock.

## Changes

- Add scoped label styling for wizard page titles, summaries, and placeholder CTA hints.
- Keep page-specific content seams unchanged for the ongoing wizard migration.
- Extend wizard page tests to lock the visual hierarchy contract.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
