### PR TITLE
ui: style wizard page status content

### DIFF
--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -7,6 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.tokens import COLOR_MUTED
 
 
 def _load_analysis_modules():
@@ -36,8 +37,10 @@ class AnalysisPageContentTest(unittest.TestCase):
         self.assertEqual(content.status_label.objectName(), "qfitWizardAnalysisStatus")
         self.assertEqual(content.status_label.text(), "Analysis not run yet")
         self.assertEqual(content.status_label.property("analysisState"), "not_ready")
+        self.assertEqual(content.status_label.property("tone"), "warn")
         self.assertEqual(content.detail_label.objectName(), "qfitWizardAnalysisDetail")
         self.assertIn("heatmaps", content.detail_label.text())
+        self.assertIn(COLOR_MUTED, content.detail_label.styleSheet())
         self.assertEqual(
             content.input_summary_label.objectName(),
             "qfitWizardAnalysisInputSummary",
@@ -46,6 +49,7 @@ class AnalysisPageContentTest(unittest.TestCase):
             content.input_summary_label.text(),
             "No loaded activity layers available for analysis",
         )
+        self.assertIn(COLOR_MUTED, content.input_summary_label.styleSheet())
         self.assertEqual(
             content.result_summary_label.objectName(),
             "qfitWizardAnalysisResultSummary",
@@ -54,6 +58,7 @@ class AnalysisPageContentTest(unittest.TestCase):
             content.result_summary_label.text(),
             "Analysis outputs will appear in the project once generated",
         )
+        self.assertIn(COLOR_MUTED, content.result_summary_label.styleSheet())
         self.assertEqual(
             content.run_analysis_button.objectName(),
             "qfitWizardAnalysisRunButton",
@@ -104,6 +109,7 @@ class AnalysisPageContentTest(unittest.TestCase):
 
         self.assertEqual(content.status_label.text(), "Analysis ready")
         self.assertEqual(content.status_label.property("analysisState"), "ready")
+        self.assertEqual(content.status_label.property("tone"), "ok")
         self.assertEqual(
             content.detail_label.text(),
             "Run analysis using the loaded filtered activity layers.",

--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -7,6 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.tokens import COLOR_MUTED
 
 
 def _load_atlas_modules():
@@ -36,8 +37,10 @@ class AtlasPageContentTest(unittest.TestCase):
         self.assertEqual(content.status_label.objectName(), "qfitWizardAtlasStatus")
         self.assertEqual(content.status_label.text(), "Atlas PDF not exported yet")
         self.assertEqual(content.status_label.property("atlasState"), "not_ready")
+        self.assertEqual(content.status_label.property("tone"), "warn")
         self.assertEqual(content.detail_label.objectName(), "qfitWizardAtlasDetail")
         self.assertIn("PDF title", content.detail_label.text())
+        self.assertIn(COLOR_MUTED, content.detail_label.styleSheet())
         self.assertEqual(
             content.input_summary_label.objectName(),
             "qfitWizardAtlasInputSummary",
@@ -46,6 +49,7 @@ class AtlasPageContentTest(unittest.TestCase):
             content.input_summary_label.text(),
             "No atlas layer selected for export",
         )
+        self.assertIn(COLOR_MUTED, content.input_summary_label.styleSheet())
         self.assertEqual(
             content.output_summary_label.objectName(),
             "qfitWizardAtlasOutputSummary",
@@ -54,6 +58,7 @@ class AtlasPageContentTest(unittest.TestCase):
             content.output_summary_label.text(),
             "PDF output path will be chosen before generation",
         )
+        self.assertIn(COLOR_MUTED, content.output_summary_label.styleSheet())
         self.assertEqual(
             content.export_atlas_button.objectName(),
             "qfitWizardAtlasExportButton",
@@ -104,6 +109,7 @@ class AtlasPageContentTest(unittest.TestCase):
 
         self.assertEqual(content.status_label.text(), "Atlas ready")
         self.assertEqual(content.status_label.property("atlasState"), "ready")
+        self.assertEqual(content.status_label.property("tone"), "ok")
         self.assertEqual(
             content.detail_label.text(),
             "Export the filtered activity atlas to the selected PDF path.",

--- a/tests/test_connection_page.py
+++ b/tests/test_connection_page.py
@@ -7,6 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.tokens import COLOR_MUTED
 
 
 def _load_connection_modules():
@@ -39,8 +40,11 @@ class ConnectionPageContentTest(unittest.TestCase):
             content.status_label.property("connectionState"),
             "not_connected",
         )
+        self.assertEqual(content.status_label.property("tone"), "warn")
+        self.assertIn("QLabel#qfitWizardConnectionStatus", content.status_label.styleSheet())
         self.assertEqual(content.detail_label.objectName(), "qfitWizardConnectionDetail")
         self.assertIn("continue to synchronization", content.detail_label.text())
+        self.assertIn(COLOR_MUTED, content.detail_label.styleSheet())
         self.assertEqual(
             content.configure_button.objectName(),
             "qfitWizardConnectionConfigureButton",
@@ -74,6 +78,7 @@ class ConnectionPageContentTest(unittest.TestCase):
 
         self.assertEqual(content.status_label.text(), "Connected to Strava")
         self.assertEqual(content.status_label.property("connectionState"), "connected")
+        self.assertEqual(content.status_label.property("tone"), "ok")
         self.assertEqual(content.detail_label.text(), "Credentials are ready.")
         self.assertEqual(content.configure_button.text(), "Review connection")
 

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -7,6 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.tokens import COLOR_MUTED
 
 
 def _load_map_modules():
@@ -36,8 +37,10 @@ class MapPageContentTest(unittest.TestCase):
         self.assertEqual(content.status_label.objectName(), "qfitWizardMapStatus")
         self.assertEqual(content.status_label.text(), "Activity layers not loaded")
         self.assertEqual(content.status_label.property("mapState"), "not_loaded")
+        self.assertEqual(content.status_label.property("tone"), "warn")
         self.assertEqual(content.detail_label.objectName(), "qfitWizardMapDetail")
         self.assertIn("apply filters", content.detail_label.text())
+        self.assertIn(COLOR_MUTED, content.detail_label.styleSheet())
         self.assertEqual(
             content.layer_summary_label.objectName(),
             "qfitWizardMapLayerSummary",
@@ -46,6 +49,7 @@ class MapPageContentTest(unittest.TestCase):
             content.layer_summary_label.text(),
             "No activity layers on the map",
         )
+        self.assertIn(COLOR_MUTED, content.layer_summary_label.styleSheet())
         self.assertEqual(
             content.filter_summary_label.objectName(),
             "qfitWizardMapFilterSummary",
@@ -54,6 +58,7 @@ class MapPageContentTest(unittest.TestCase):
             content.filter_summary_label.text(),
             "All stored activities visible once layers are loaded",
         )
+        self.assertIn(COLOR_MUTED, content.filter_summary_label.styleSheet())
         self.assertEqual(
             content.load_layers_button.objectName(),
             "qfitWizardMapLoadLayersButton",
@@ -112,6 +117,7 @@ class MapPageContentTest(unittest.TestCase):
 
         self.assertEqual(content.status_label.text(), "Map ready")
         self.assertEqual(content.status_label.property("mapState"), "loaded")
+        self.assertEqual(content.status_label.property("tone"), "ok")
         self.assertEqual(
             content.detail_label.text(),
             "Use saved filters for the loaded activity layers.",

--- a/tests/test_page_content_style.py
+++ b/tests/test_page_content_style.py
@@ -1,0 +1,67 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.dockwidget.page_content_style import (
+    style_detail_label,
+    style_status_pill,
+    style_summary_label,
+)
+from qfit.ui.tokens import COLOR_MUTED
+
+
+class PageContentStyleTest(unittest.TestCase):
+    def test_styles_detail_and_summary_labels_with_muted_tokens(self):
+        detail = _FakeLabel(object_name="detailLabel")
+        summary = _FakeLabel(object_name="summaryLabel")
+
+        style_detail_label(detail)
+        style_summary_label(summary)
+
+        self.assertIn(COLOR_MUTED, detail.styleSheet())
+        self.assertIn(COLOR_MUTED, summary.styleSheet())
+        self.assertIn("padding: 1px 0", summary.styleSheet())
+
+    def test_styles_status_labels_as_scoped_token_pills(self):
+        label = _FakeLabel(object_name="statusLabel")
+
+        style_status_pill(label, active=False)
+
+        self.assertEqual(label.objectName(), "statusLabel")
+        self.assertEqual(label.property("tone"), "warn")
+        self.assertIn("QLabel#statusLabel", label.styleSheet())
+        self.assertIn("#fbe7c3", label.styleSheet())
+
+        style_status_pill(label, active=True)
+
+        self.assertEqual(label.property("tone"), "ok")
+        self.assertIn("#dcefd0", label.styleSheet())
+
+
+class _FakeLabel:
+    def __init__(self, *, object_name=""):
+        self._object_name = object_name
+        self._properties = {}
+        self._stylesheet = ""
+
+    def setObjectName(self, object_name):  # noqa: N802
+        self._object_name = object_name
+
+    def objectName(self):  # noqa: N802
+        return self._object_name
+
+    def setProperty(self, name, value):  # noqa: N802
+        self._properties[name] = value
+
+    def property(self, name):
+        return self._properties.get(name)
+
+    def setStyleSheet(self, stylesheet):  # noqa: N802
+        self._stylesheet = stylesheet
+
+    def styleSheet(self):  # noqa: N802
+        return self._stylesheet
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_page_content_style.py
+++ b/tests/test_page_content_style.py
@@ -1,22 +1,36 @@
+import importlib
+import sys
 import unittest
+from unittest.mock import patch
 
 from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
 
-from qfit.ui.dockwidget.page_content_style import (
-    style_detail_label,
-    style_status_pill,
-    style_summary_label,
-)
 from qfit.ui.tokens import COLOR_MUTED
 
 
+def _load_page_content_style_module():
+    for name in (
+        "qfit.ui.dockwidget.page_content_style",
+        "qfit.ui.dockwidget.stepper_bar",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.page_content_style")
+
+
 class PageContentStyleTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.page_content_style = _load_page_content_style_module()
+
     def test_styles_detail_and_summary_labels_with_muted_tokens(self):
         detail = _FakeLabel(object_name="detailLabel")
         summary = _FakeLabel(object_name="summaryLabel")
 
-        style_detail_label(detail)
-        style_summary_label(summary)
+        self.page_content_style.style_detail_label(detail)
+        self.page_content_style.style_summary_label(summary)
 
         self.assertIn(COLOR_MUTED, detail.styleSheet())
         self.assertIn(COLOR_MUTED, summary.styleSheet())
@@ -25,14 +39,14 @@ class PageContentStyleTest(unittest.TestCase):
     def test_styles_status_labels_as_scoped_token_pills(self):
         label = _FakeLabel(object_name="statusLabel")
 
-        style_status_pill(label, active=False)
+        self.page_content_style.style_status_pill(label, active=False)
 
         self.assertEqual(label.objectName(), "statusLabel")
         self.assertEqual(label.property("tone"), "warn")
         self.assertIn("QLabel#statusLabel", label.styleSheet())
         self.assertIn("#fbe7c3", label.styleSheet())
 
-        style_status_pill(label, active=True)
+        self.page_content_style.style_status_pill(label, active=True)
 
         self.assertEqual(label.property("tone"), "ok")
         self.assertIn("#dcefd0", label.styleSheet())

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -7,6 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.tokens import COLOR_MUTED
 
 
 def _load_sync_modules():
@@ -36,13 +37,16 @@ class SyncPageContentTest(unittest.TestCase):
         self.assertEqual(content.status_label.objectName(), "qfitWizardSyncStatus")
         self.assertEqual(content.status_label.text(), "Activities not synced yet")
         self.assertEqual(content.status_label.property("syncState"), "not_synced")
+        self.assertEqual(content.status_label.property("tone"), "warn")
         self.assertEqual(content.detail_label.objectName(), "qfitWizardSyncDetail")
         self.assertIn("GeoPackage", content.detail_label.text())
+        self.assertIn(COLOR_MUTED, content.detail_label.styleSheet())
         self.assertEqual(
             content.activity_summary_label.objectName(),
             "qfitWizardSyncActivitySummary",
         )
         self.assertEqual(content.activity_summary_label.text(), "No activities stored")
+        self.assertIn(COLOR_MUTED, content.activity_summary_label.styleSheet())
         self.assertEqual(content.sync_button.objectName(), "qfitWizardSyncButton")
         self.assertEqual(content.sync_button.text(), "Sync activities")
         self.assertEqual(
@@ -76,6 +80,7 @@ class SyncPageContentTest(unittest.TestCase):
 
         self.assertEqual(content.status_label.text(), "Ready to sync new activities")
         self.assertEqual(content.status_label.property("syncState"), "ready")
+        self.assertEqual(content.status_label.property("tone"), "ok")
         self.assertEqual(
             content.detail_label.text(),
             "Use the latest saved Strava credentials.",

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
-
 from ._qt_compat import import_qt_module
 from .action_row import (
     build_wizard_action_row,
     set_wizard_action_availability,
     style_primary_action_button,
+)
+from .page_content_style import (
+    style_detail_label,
+    style_status_pill,
+    style_summary_label,
 )
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -60,10 +63,13 @@ class AnalysisPageContent(QWidget):
         self.detail_label.setObjectName("qfitWizardAnalysisDetail")
         if hasattr(self.detail_label, "setWordWrap"):
             self.detail_label.setWordWrap(True)
+        style_detail_label(self.detail_label)
         self.input_summary_label = QLabel("", self)
         self.input_summary_label.setObjectName("qfitWizardAnalysisInputSummary")
+        style_summary_label(self.input_summary_label)
         self.result_summary_label = QLabel("", self)
         self.result_summary_label.setObjectName("qfitWizardAnalysisResultSummary")
+        style_summary_label(self.result_summary_label)
         self.run_analysis_button = QToolButton(self)
         self.run_analysis_button.setObjectName("qfitWizardAnalysisRunButton")
         style_primary_action_button(
@@ -85,11 +91,8 @@ class AnalysisPageContent(QWidget):
         analysis_state = "ready" if state.ready else "not_ready"
         self.status_label.setText(state.status_text)
         self.status_label.setProperty("analysisState", analysis_state)
-        self.status_label.setStyleSheet(_status_stylesheet(ready=state.ready))
+        style_status_pill(self.status_label, active=state.ready)
         self.detail_label.setText(state.detail_text)
-        self.detail_label.setStyleSheet(
-            f"QLabel#qfitWizardAnalysisDetail {{ color: {COLOR_MUTED}; }}"
-        )
         self.input_summary_label.setText(state.input_summary_text)
         self.input_summary_label.setProperty("analysisState", analysis_state)
         self.result_summary_label.setText(state.result_summary_text)
@@ -153,16 +156,6 @@ def install_analysis_page_content(
     page.body_layout().addWidget(content)
     page.retire_primary_action_hint()
     return content
-
-
-def _status_stylesheet(*, ready: bool) -> str:
-    color = COLOR_ACCENT if ready else COLOR_WARN
-    return (
-        "QLabel#qfitWizardAnalysisStatus { "
-        f"color: {color}; "
-        "font-weight: 700; "
-        "}"
-    )
 
 
 __all__ = [

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
-
 from ._qt_compat import import_qt_module
 from .action_row import (
     build_wizard_action_row,
     set_wizard_action_availability,
     style_primary_action_button,
+)
+from .page_content_style import (
+    style_detail_label,
+    style_status_pill,
+    style_summary_label,
 )
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -58,10 +61,13 @@ class AtlasPageContent(QWidget):
         self.detail_label.setObjectName("qfitWizardAtlasDetail")
         if hasattr(self.detail_label, "setWordWrap"):
             self.detail_label.setWordWrap(True)
+        style_detail_label(self.detail_label)
         self.input_summary_label = QLabel("", self)
         self.input_summary_label.setObjectName("qfitWizardAtlasInputSummary")
+        style_summary_label(self.input_summary_label)
         self.output_summary_label = QLabel("", self)
         self.output_summary_label.setObjectName("qfitWizardAtlasOutputSummary")
+        style_summary_label(self.output_summary_label)
         self.export_atlas_button = QToolButton(self)
         self.export_atlas_button.setObjectName("qfitWizardAtlasExportButton")
         style_primary_action_button(
@@ -83,11 +89,8 @@ class AtlasPageContent(QWidget):
         atlas_state = "ready" if state.ready else "not_ready"
         self.status_label.setText(state.status_text)
         self.status_label.setProperty("atlasState", atlas_state)
-        self.status_label.setStyleSheet(_status_stylesheet(ready=state.ready))
+        style_status_pill(self.status_label, active=state.ready)
         self.detail_label.setText(state.detail_text)
-        self.detail_label.setStyleSheet(
-            f"QLabel#qfitWizardAtlasDetail {{ color: {COLOR_MUTED}; }}"
-        )
         self.input_summary_label.setText(state.input_summary_text)
         self.input_summary_label.setProperty("atlasState", atlas_state)
         self.output_summary_label.setText(state.output_summary_text)
@@ -151,16 +154,6 @@ def install_atlas_page_content(
     page.body_layout().addWidget(content)
     page.retire_primary_action_hint()
     return content
-
-
-def _status_stylesheet(*, ready: bool) -> str:
-    color = COLOR_ACCENT if ready else COLOR_WARN
-    return (
-        "QLabel#qfitWizardAtlasStatus { "
-        f"color: {color}; "
-        "font-weight: 700; "
-        "}"
-    )
 
 
 __all__ = [

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
-
 from ._qt_compat import import_qt_module
 from .action_row import build_wizard_action_row, style_primary_action_button
+from .page_content_style import style_detail_label, style_status_pill
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -55,6 +54,7 @@ class ConnectionPageContent(QWidget):
         self.detail_label.setObjectName("qfitWizardConnectionDetail")
         if hasattr(self.detail_label, "setWordWrap"):
             self.detail_label.setWordWrap(True)
+        style_detail_label(self.detail_label)
         self.configure_button = QToolButton(self)
         self.configure_button.setObjectName("qfitWizardConnectionConfigureButton")
         style_primary_action_button(
@@ -78,11 +78,8 @@ class ConnectionPageContent(QWidget):
             "connectionState",
             "connected" if state.connected else "not_connected",
         )
-        self.status_label.setStyleSheet(_status_stylesheet(connected=state.connected))
+        style_status_pill(self.status_label, active=state.connected)
         self.detail_label.setText(state.detail_text)
-        self.detail_label.setStyleSheet(
-            f"QLabel#qfitWizardConnectionDetail {{ color: {COLOR_MUTED}; }}"
-        )
         self.configure_button.setText(state.primary_action_label)
 
     def outer_layout(self):
@@ -127,16 +124,6 @@ def install_connection_page_content(
     page.body_layout().addWidget(content)
     page.retire_primary_action_hint()
     return content
-
-
-def _status_stylesheet(*, connected: bool) -> str:
-    color = COLOR_ACCENT if connected else COLOR_WARN
-    return (
-        "QLabel#qfitWizardConnectionStatus { "
-        f"color: {color}; "
-        "font-weight: 700; "
-        "}"
-    )
 
 
 __all__ = [

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
-
 from ._qt_compat import import_qt_module
 from .action_row import (
     build_wizard_action_row,
     set_wizard_action_availability,
     style_primary_action_button,
     style_secondary_action_button,
+)
+from .page_content_style import (
+    style_detail_label,
+    style_status_pill,
+    style_summary_label,
 )
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -61,10 +64,13 @@ class MapPageContent(QWidget):
         self.detail_label.setObjectName("qfitWizardMapDetail")
         if hasattr(self.detail_label, "setWordWrap"):
             self.detail_label.setWordWrap(True)
+        style_detail_label(self.detail_label)
         self.layer_summary_label = QLabel("", self)
         self.layer_summary_label.setObjectName("qfitWizardMapLayerSummary")
+        style_summary_label(self.layer_summary_label)
         self.filter_summary_label = QLabel("", self)
         self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
+        style_summary_label(self.filter_summary_label)
         self.load_layers_button = QToolButton(self)
         self.load_layers_button.setObjectName("qfitWizardMapLoadLayersButton")
         style_secondary_action_button(
@@ -94,11 +100,8 @@ class MapPageContent(QWidget):
         map_state = "loaded" if state.loaded else "not_loaded"
         self.status_label.setText(state.status_text)
         self.status_label.setProperty("mapState", map_state)
-        self.status_label.setStyleSheet(_status_stylesheet(loaded=state.loaded))
+        style_status_pill(self.status_label, active=state.loaded)
         self.detail_label.setText(state.detail_text)
-        self.detail_label.setStyleSheet(
-            f"QLabel#qfitWizardMapDetail {{ color: {COLOR_MUTED}; }}"
-        )
         self.layer_summary_label.setText(state.layer_summary_text)
         self.layer_summary_label.setProperty("mapState", map_state)
         self.filter_summary_label.setText(state.filter_summary_text)
@@ -158,16 +161,6 @@ def install_map_page_content(
     page.body_layout().addWidget(content)
     page.retire_primary_action_hint()
     return content
-
-
-def _status_stylesheet(*, loaded: bool) -> str:
-    color = COLOR_ACCENT if loaded else COLOR_WARN
-    return (
-        "QLabel#qfitWizardMapStatus { "
-        f"color: {color}; "
-        "font-weight: 700; "
-        "}"
-    )
 
 
 __all__ = [

--- a/ui/dockwidget/page_content_style.py
+++ b/ui/dockwidget/page_content_style.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from qfit.ui.tokens import COLOR_MUTED
-from qfit.ui.widgets.pill import set_pill_tone
+from qfit.ui.tokens import COLOR_MUTED, pill_tone_palette
 
 _DETAIL_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 _SUMMARY_LABEL_QSS = (
@@ -27,10 +26,22 @@ def style_summary_label(label) -> None:
 def style_status_pill(label, *, active: bool) -> None:
     """Render a wizard page status label as an ok/warn token pill."""
 
-    set_pill_tone(
-        label,
-        "ok" if active else "warn",
-        object_name=label.objectName(),
+    tone = "ok" if active else "warn"
+    label.setProperty("tone", tone)
+    label.setStyleSheet(_status_pill_stylesheet(tone, object_name=label.objectName()))
+
+
+def _status_pill_stylesheet(tone: str, *, object_name: str) -> str:
+    background, foreground = pill_tone_palette(tone)
+    return (
+        f"QLabel#{object_name} {{ "
+        f"background: {background}; "
+        f"color: {foreground}; "
+        "border: 0; "
+        "border-radius: 8px; "
+        "padding: 1px 6px; "
+        "font-weight: 600; "
+        "}"
     )
 
 

--- a/ui/dockwidget/page_content_style.py
+++ b/ui/dockwidget/page_content_style.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from qfit.ui.tokens import COLOR_MUTED
+from qfit.ui.widgets.pill import set_pill_tone
+
+_DETAIL_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
+_SUMMARY_LABEL_QSS = (
+    "QLabel { "
+    f"color: {COLOR_MUTED}; "
+    "padding: 1px 0; "
+    "}"
+)
+
+
+def style_detail_label(label) -> None:
+    """Apply muted explanatory text styling to a wizard page detail label."""
+
+    label.setStyleSheet(_DETAIL_LABEL_QSS)
+
+
+def style_summary_label(label) -> None:
+    """Apply consistent compact summary styling for wizard page status facts."""
+
+    label.setStyleSheet(_SUMMARY_LABEL_QSS)
+
+
+def style_status_pill(label, *, active: bool) -> None:
+    """Render a wizard page status label as an ok/warn token pill."""
+
+    set_pill_tone(
+        label,
+        "ok" if active else "warn",
+        object_name=label.objectName(),
+    )
+
+
+__all__ = [
+    "style_detail_label",
+    "style_status_pill",
+    "style_summary_label",
+]

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from qfit.ui.tokens import COLOR_ACCENT, COLOR_MUTED, COLOR_WARN
-
 from ._qt_compat import import_qt_module
 from .action_row import build_wizard_action_row, style_primary_action_button
+from .page_content_style import (
+    style_detail_label,
+    style_status_pill,
+    style_summary_label,
+)
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -51,8 +54,10 @@ class SyncPageContent(QWidget):
         self.detail_label.setObjectName("qfitWizardSyncDetail")
         if hasattr(self.detail_label, "setWordWrap"):
             self.detail_label.setWordWrap(True)
+        style_detail_label(self.detail_label)
         self.activity_summary_label = QLabel("", self)
         self.activity_summary_label.setObjectName("qfitWizardSyncActivitySummary")
+        style_summary_label(self.activity_summary_label)
         self.sync_button = QToolButton(self)
         self.sync_button.setObjectName("qfitWizardSyncButton")
         style_primary_action_button(
@@ -74,11 +79,8 @@ class SyncPageContent(QWidget):
         sync_state = "ready" if state.ready else "not_synced"
         self.status_label.setText(state.status_text)
         self.status_label.setProperty("syncState", sync_state)
-        self.status_label.setStyleSheet(_status_stylesheet(ready=state.ready))
+        style_status_pill(self.status_label, active=state.ready)
         self.detail_label.setText(state.detail_text)
-        self.detail_label.setStyleSheet(
-            f"QLabel#qfitWizardSyncDetail {{ color: {COLOR_MUTED}; }}"
-        )
         self.activity_summary_label.setText(state.activity_summary_text)
         self.activity_summary_label.setProperty("syncState", sync_state)
         self.sync_button.setText(state.primary_action_label)
@@ -126,16 +128,6 @@ def install_sync_page_content(
     page.body_layout().addWidget(content)
     page.retire_primary_action_hint()
     return content
-
-
-def _status_stylesheet(*, ready: bool) -> str:
-    color = COLOR_ACCENT if ready else COLOR_WARN
-    return (
-        "QLabel#qfitWizardSyncStatus { "
-        f"color: {color}; "
-        "font-weight: 700; "
-        "}"
-    )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- add shared wizard page content styling for status, detail, and summary labels
- render page status labels with existing token pill tones for clearer ok/warn hierarchy
- apply muted summary styling consistently across connection, sync, map, analysis, and atlas wizard content

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Part of #608 and compatible with #609.
