### PR TITLE
feat: wire wizard action callbacks

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -104,6 +104,85 @@ class WizardShellCompositionTest(unittest.TestCase):
             ("current", "locked", "locked", "locked", "locked"),
         )
 
+    def test_action_callbacks_are_wired_to_installed_page_ctas(self):
+        calls = []
+        callbacks = self.composition.WizardActionCallbacks(
+            configure_connection=lambda: calls.append("configure"),
+            sync_activities=lambda: calls.append("sync"),
+            load_activity_layers=lambda: calls.append("load"),
+            apply_map_filters=lambda: calls.append("filter"),
+            run_analysis=lambda: calls.append("analysis"),
+            export_atlas=lambda: calls.append("atlas"),
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(
+            map_state=self.composition.MapPageState(loaded=True),
+            analysis_state=self.composition.AnalysisPageState(ready=True),
+            atlas_state=self.composition.AtlasPageState(ready=True),
+        )
+
+        returned = self.composition.connect_wizard_action_callbacks(assembled, callbacks)
+
+        assembled.connection_content.configure_button.clicked.emit()
+        assembled.sync_content.sync_button.clicked.emit()
+        assembled.map_content.load_layers_button.clicked.emit()
+        assembled.map_content.apply_filters_button.clicked.emit()
+        assembled.analysis_content.run_analysis_button.clicked.emit()
+        assembled.atlas_content.export_atlas_button.clicked.emit()
+
+        self.assertIs(returned, assembled)
+        self.assertIs(assembled.action_callbacks, callbacks)
+        self.assertEqual(
+            calls,
+            ["configure", "sync", "load", "filter", "analysis", "atlas"],
+        )
+
+    def test_action_callbacks_are_only_wired_once_per_composition(self):
+        calls = []
+        assembled = self.composition.build_placeholder_wizard_shell()
+        first_callbacks = self.composition.WizardActionCallbacks(
+            configure_connection=lambda: calls.append("first"),
+        )
+        second_callbacks = self.composition.WizardActionCallbacks(
+            configure_connection=lambda: calls.append("second"),
+        )
+
+        self.composition.connect_wizard_action_callbacks(assembled, first_callbacks)
+        returned = self.composition.connect_wizard_action_callbacks(
+            assembled,
+            second_callbacks,
+        )
+        assembled.connection_content.configure_button.clicked.emit()
+
+        self.assertIs(returned, assembled)
+        self.assertIs(assembled.action_callbacks, first_callbacks)
+        self.assertEqual(calls, ["first"])
+
+    def test_action_callbacks_ignore_pages_missing_from_partial_specs(self):
+        calls = []
+        specs = (
+            self.composition.DockWizardPageSpec(
+                key="connection",
+                title="Connection",
+                summary="Connect qfit to Strava.",
+                primary_action_hint="Primary action: configure connection",
+            ),
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(specs=specs)
+        self.composition.connect_wizard_action_callbacks(
+            assembled,
+            self.composition.WizardActionCallbacks(
+                configure_connection=lambda: calls.append("configure"),
+                sync_activities=lambda: calls.append("sync"),
+            ),
+        )
+
+        assembled.connection_content.configure_button.clicked.emit()
+
+        self.assertEqual(calls, ["configure"])
+        self.assertIsNone(assembled.sync_content)
+
     def test_initial_progress_selects_matching_installed_page(self):
         progress = DockWizardProgress(
             current_key="map",

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -32,6 +32,23 @@ from .wizard_shell_presenter import WizardShellPresenter
 _StateT = TypeVar("_StateT")
 
 
+@dataclass(frozen=True)
+class WizardActionCallbacks:
+    """Optional adapters for concrete wizard page actions.
+
+    The placeholder shell can now expose visible CTAs without importing the
+    current dock widget. A future dock swap can pass bound methods here while
+    pure tests keep the page widgets independent from the long-scroll dock.
+    """
+
+    configure_connection: Callable[[], None] | None = None
+    sync_activities: Callable[[], None] | None = None
+    load_activity_layers: Callable[[], None] | None = None
+    apply_map_filters: Callable[[], None] | None = None
+    run_analysis: Callable[[], None] | None = None
+    export_atlas: Callable[[], None] | None = None
+
+
 @dataclass
 class WizardShellComposition:
     """Concrete placeholder wizard assembly for the future dock replacement.
@@ -50,6 +67,7 @@ class WizardShellComposition:
     map_content: MapPageContent | None = None
     analysis_content: AnalysisPageContent | None = None
     atlas_content: AtlasPageContent | None = None
+    action_callbacks: WizardActionCallbacks | None = None
     connection_state: ConnectionPageState | None = None
     sync_state: SyncPageState | None = None
     map_state: MapPageState | None = None
@@ -193,6 +211,55 @@ def refresh_wizard_shell_composition(
     return composition
 
 
+def connect_wizard_action_callbacks(
+    composition: WizardShellComposition,
+    callbacks: WizardActionCallbacks,
+) -> WizardShellComposition:
+    """Wire concrete action callbacks into an assembled wizard shell.
+
+    This keeps the reusable #609 shell decoupled from ``QfitDockWidget`` while
+    giving the future dock swap a single adapter seam for visible page CTAs.
+    Missing page content is skipped so partial wizard assemblies remain safe.
+    """
+
+    if composition.action_callbacks is not None:
+        return composition
+
+    _connect_action_callbacks(
+        connection_content=composition.connection_content,
+        sync_content=composition.sync_content,
+        map_content=composition.map_content,
+        analysis_content=composition.analysis_content,
+        atlas_content=composition.atlas_content,
+        callbacks=callbacks,
+    )
+    composition.action_callbacks = callbacks
+    return composition
+
+
+def _connect_action_callbacks(
+    *,
+    connection_content: ConnectionPageContent | None,
+    sync_content: SyncPageContent | None,
+    map_content: MapPageContent | None,
+    analysis_content: AnalysisPageContent | None,
+    atlas_content: AtlasPageContent | None,
+    callbacks: WizardActionCallbacks,
+) -> None:
+    if connection_content is not None and callbacks.configure_connection is not None:
+        connection_content.configureRequested.connect(callbacks.configure_connection)
+    if sync_content is not None and callbacks.sync_activities is not None:
+        sync_content.syncRequested.connect(callbacks.sync_activities)
+    if map_content is not None and callbacks.load_activity_layers is not None:
+        map_content.loadLayersRequested.connect(callbacks.load_activity_layers)
+    if map_content is not None and callbacks.apply_map_filters is not None:
+        map_content.applyFiltersRequested.connect(callbacks.apply_map_filters)
+    if analysis_content is not None and callbacks.run_analysis is not None:
+        analysis_content.runAnalysisRequested.connect(callbacks.run_analysis)
+    if atlas_content is not None and callbacks.export_atlas is not None:
+        atlas_content.exportAtlasRequested.connect(callbacks.export_atlas)
+
+
 def _resolve_state(
     provided: _StateT | None,
     existing: _StateT | None,
@@ -295,7 +362,9 @@ def _install_atlas_content(
 
 
 __all__ = [
+    "WizardActionCallbacks",
     "WizardShellComposition",
     "build_placeholder_wizard_shell",
+    "connect_wizard_action_callbacks",
     "refresh_wizard_shell_composition",
 ]


### PR DESCRIPTION
## Summary

Adds a wizard-forward adapter seam that lets the assembled #609 shell wire its visible page CTAs to concrete callbacks without importing or depending on the current long-scroll dock widget.

## Changes

- Added `WizardActionCallbacks` for connection, sync, map/filter, analysis, and atlas page actions.
- Added `connect_wizard_action_callbacks()` to attach callbacks to an existing wizard composition while safely skipping pages omitted from partial assemblies.
- Covered callback wiring and partial-spec behavior in wizard composition tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608.
Refs #609.
