### PR TITLE
feat: refresh wizard progress through composition

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -405,6 +405,27 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Hidden sync page should not affect footer",
         )
 
+    def test_refresh_can_update_progress_without_rebuilding_shell(self):
+        assembled = self.composition.build_placeholder_wizard_shell()
+        progress = DockWizardProgress(
+            current_key="map",
+            completed_keys=frozenset({"connection", "sync"}),
+            visited_keys=frozenset({"map"}),
+        )
+
+        refreshed = self.composition.refresh_wizard_shell_composition(
+            assembled,
+            progress=progress,
+        )
+
+        self.assertIs(refreshed, assembled)
+        self.assertEqual(assembled.presenter.progress, progress)
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("done", "done", "current", "locked", "locked"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -426,6 +426,34 @@ class WizardShellCompositionTest(unittest.TestCase):
             ("done", "done", "current", "locked", "locked"),
         )
 
+    def test_refresh_validates_progress_before_mutating_page_state(self):
+        assembled = self.composition.build_placeholder_wizard_shell()
+
+        with self.assertRaises(KeyError):
+            self.composition.refresh_wizard_shell_composition(
+                assembled,
+                connection_state=self.composition.ConnectionPageState(
+                    connected=True,
+                    status_text="Strava connected",
+                ),
+                footer_text="Changed footer",
+                progress=DockWizardProgress(current_key="review"),
+            )
+
+        self.assertEqual(
+            assembled.connection_content.status_label.text(),
+            "Strava not connected",
+        )
+        self.assertEqual(assembled.connection_state.status_text, "Strava not connected")
+        self.assertEqual(
+            assembled.shell.footer_bar.text(),
+            "Strava not connected · No activities stored · "
+            "No activity layers on the map · Analysis not run yet · "
+            "Atlas PDF not exported yet",
+        )
+        self.assertEqual(assembled.presenter.progress.current_key, "connection")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -454,6 +454,67 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.presenter.progress.current_key, "connection")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
 
+    def test_partial_refresh_rejects_progress_for_uninstalled_page(self):
+        specs = (
+            self.composition.DockWizardPageSpec(
+                key="connection",
+                title="Connection",
+                summary="Connect qfit to Strava.",
+                primary_action_hint="Primary action: configure connection",
+            ),
+        )
+        assembled = self.composition.build_placeholder_wizard_shell(specs=specs)
+
+        with self.assertRaises(ValueError):
+            self.composition.refresh_wizard_shell_composition(
+                assembled,
+                connection_state=self.composition.ConnectionPageState(
+                    connected=True,
+                    status_text="Strava connected",
+                ),
+                footer_text="Changed footer",
+                progress=DockWizardProgress(current_key="sync"),
+            )
+
+        self.assertEqual(
+            assembled.connection_content.status_label.text(),
+            "Strava not connected",
+        )
+        self.assertEqual(assembled.connection_state.status_text, "Strava not connected")
+        self.assertEqual(assembled.shell.footer_bar.text(), "Strava not connected")
+        self.assertEqual(assembled.presenter.progress.current_key, "connection")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+
+    def test_partial_progress_uses_installed_page_stack_index(self):
+        specs = (
+            self.composition.DockWizardPageSpec(
+                key="connection",
+                title="Connection",
+                summary="Connect qfit to Strava.",
+                primary_action_hint="Primary action: configure connection",
+            ),
+            self.composition.DockWizardPageSpec(
+                key="atlas",
+                title="Atlas PDF",
+                summary="Export a PDF atlas.",
+                primary_action_hint="Primary action: export atlas PDF",
+            ),
+        )
+        assembled = self.composition.build_placeholder_wizard_shell(specs=specs)
+        progress = DockWizardProgress(
+            current_key="atlas",
+            completed_keys=frozenset({"connection", "sync", "map", "analysis"}),
+            visited_keys=frozenset({"atlas"}),
+        )
+
+        self.composition.refresh_wizard_shell_composition(
+            assembled,
+            progress=progress,
+        )
+
+        self.assertEqual(assembled.presenter.progress, progress)
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -129,6 +129,67 @@ class WizardShellPresenterTest(unittest.TestCase):
             ("current", "locked", "locked", "locked", "locked"),
         )
 
+    def test_partial_page_mapping_renders_installed_page_stack_index(self):
+        shell = self.wizard_shell.WizardShell()
+        pages = self.wizard_page.install_wizard_pages(
+            shell,
+            specs=(
+                self.wizard_page.DockWizardPageSpec(
+                    key="connection",
+                    title="Connection",
+                    summary="Connect qfit to Strava.",
+                    primary_action_hint="Primary action: configure connection",
+                ),
+                self.wizard_page.DockWizardPageSpec(
+                    key="atlas",
+                    title="Atlas PDF",
+                    summary="Export a PDF atlas.",
+                    primary_action_hint="Primary action: export atlas PDF",
+                ),
+            ),
+        )
+        page_indices = {page.spec.key: index for index, page in enumerate(pages)}
+        presenter = self.presenter.WizardShellPresenter(
+            shell,
+            page_indices_by_key=page_indices,
+        )
+
+        presenter.set_progress(
+            self.presenter.DockWizardProgress(
+                current_key="atlas",
+                completed_keys=frozenset({"connection", "sync", "map", "analysis"}),
+                visited_keys=frozenset({"atlas"}),
+            )
+        )
+
+        self.assertEqual(shell.pages_stack.currentIndex(), 1)
+        self.assertEqual(presenter.progress.current_key, "atlas")
+
+    def test_partial_page_mapping_rejects_uninstalled_current_step(self):
+        shell = self.wizard_shell.WizardShell()
+        pages = self.wizard_page.install_wizard_pages(
+            shell,
+            specs=(
+                self.wizard_page.DockWizardPageSpec(
+                    key="connection",
+                    title="Connection",
+                    summary="Connect qfit to Strava.",
+                    primary_action_hint="Primary action: configure connection",
+                ),
+            ),
+        )
+        page_indices = {page.spec.key: index for index, page in enumerate(pages)}
+        presenter = self.presenter.WizardShellPresenter(
+            shell,
+            page_indices_by_key=page_indices,
+        )
+
+        with self.assertRaises(ValueError):
+            presenter.set_progress(self.presenter.DockWizardProgress(current_key="sync"))
+
+        self.assertEqual(presenter.progress.current_key, "connection")
+        self.assertEqual(shell.pages_stack.currentIndex(), 0)
+
     def test_rejects_unknown_completed_step_key(self):
         shell = self._build_shell_with_pages()
         presenter = self.presenter.WizardShellPresenter(shell)

--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -91,6 +91,44 @@ class WizardShellPresenterTest(unittest.TestCase):
             ("current", "upcoming", "locked", "locked", "locked"),
         )
 
+    def test_set_progress_refreshes_stepper_and_visible_page(self):
+        shell = self._build_shell_with_pages()
+        presenter = self.presenter.WizardShellPresenter(shell)
+        progress = self.presenter.DockWizardProgress(
+            current_key="analysis",
+            completed_keys=frozenset({"connection", "sync", "map"}),
+            visited_keys=frozenset({"analysis"}),
+        )
+
+        presenter.set_progress(progress)
+
+        self.assertEqual(presenter.progress, progress)
+        self.assertEqual(shell.pages_stack.currentIndex(), 3)
+        self.assertEqual(
+            shell.stepper_bar.states(),
+            ("done", "done", "done", "current", "locked"),
+        )
+
+    def test_set_progress_rejects_unknown_keys_without_mutating_shell(self):
+        shell = self._build_shell_with_pages()
+        presenter = self.presenter.WizardShellPresenter(shell)
+
+        with self.assertRaises(KeyError):
+            presenter.set_progress(
+                self.presenter.DockWizardProgress(
+                    current_key="review",
+                    completed_keys=frozenset(),
+                    visited_keys=frozenset(),
+                )
+            )
+
+        self.assertEqual(presenter.progress.current_key, "connection")
+        self.assertEqual(shell.pages_stack.currentIndex(), 0)
+        self.assertEqual(
+            shell.stepper_bar.states(),
+            ("current", "locked", "locked", "locked", "locked"),
+        )
+
     def test_rejects_unknown_completed_step_key(self):
         shell = self._build_shell_with_pages()
         presenter = self.presenter.WizardShellPresenter(shell)

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -152,13 +152,15 @@ def refresh_wizard_shell_composition(
     analysis_state: AnalysisPageState | None = None,
     atlas_state: AtlasPageState | None = None,
     footer_text: str | None = None,
+    progress: DockWizardProgress | None = None,
 ) -> WizardShellComposition:
     """Refresh installed wizard page state without rebuilding the shell.
 
     This is the small adapter seam the future dock can use when real workflow
     facts change: update only the installed page widgets, then refresh the
-    persistent footer from the same render-neutral state snapshots. Missing page
-    content is skipped so partial/spec-filtered wizard assemblies remain valid.
+    persistent footer and optional stepper progress from the same render-neutral
+    state snapshots. Missing page content is skipped so partial/spec-filtered
+    wizard assemblies remain valid.
     """
 
     next_connection_state = _resolve_state(
@@ -202,6 +204,8 @@ def refresh_wizard_shell_composition(
             atlas_state=next_atlas_state,
         )
     )
+    if progress is not None:
+        composition.presenter.set_progress(progress)
 
     composition.connection_state = next_connection_state
     composition.sync_state = next_sync_state

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -4,7 +4,10 @@ from collections.abc import Callable, Collection, Sequence
 from dataclasses import dataclass
 from typing import TypeVar
 
-from qfit.ui.application.dock_workflow_sections import DockWizardProgress
+from qfit.ui.application.dock_workflow_sections import (
+    DockWizardProgress,
+    build_progress_wizard_step_statuses,
+)
 from qfit.ui.application.wizard_footer_status import build_wizard_footer_status
 from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
@@ -180,6 +183,8 @@ def refresh_wizard_shell_composition(
         composition.atlas_state,
         AtlasPageState,
     )
+    if progress is not None:
+        build_progress_wizard_step_statuses(progress)
 
     if composition.connection_content is not None:
         composition.connection_content.set_state(next_connection_state)

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -128,7 +128,12 @@ def build_placeholder_wizard_shell(
         analysis_state=analysis_state,
     )
     atlas_content = _install_atlas_content(pages, atlas_state=atlas_state)
-    presenter = WizardShellPresenter(shell, progress)
+    _validate_progress_targets_installed_page(progress, pages)
+    presenter = WizardShellPresenter(
+        shell,
+        progress,
+        page_indices_by_key=_build_page_indices_by_key(pages),
+    )
     return WizardShellComposition(
         shell=shell,
         pages=pages,
@@ -183,8 +188,7 @@ def refresh_wizard_shell_composition(
         composition.atlas_state,
         AtlasPageState,
     )
-    if progress is not None:
-        build_progress_wizard_step_statuses(progress)
+    _validate_progress_targets_installed_page(progress, composition.pages)
 
     if composition.connection_content is not None:
         composition.connection_content.set_state(next_connection_state)
@@ -267,6 +271,21 @@ def _connect_action_callbacks(
         analysis_content.runAnalysisRequested.connect(callbacks.run_analysis)
     if atlas_content is not None and callbacks.export_atlas is not None:
         atlas_content.exportAtlasRequested.connect(callbacks.export_atlas)
+
+
+def _validate_progress_targets_installed_page(
+    progress: DockWizardProgress | None,
+    pages: Sequence[WizardPage],
+) -> None:
+    if progress is None:
+        return
+    build_progress_wizard_step_statuses(progress)
+    if progress.current_key not in {page.spec.key for page in pages}:
+        raise ValueError(f"No installed wizard page for {progress.current_key!r}")
+
+
+def _build_page_indices_by_key(pages: Sequence[WizardPage]) -> dict[str, int]:
+    return {page.spec.key: index for index, page in enumerate(pages)}
 
 
 def _resolve_state(

--- a/ui/dockwidget/wizard_shell_presenter.py
+++ b/ui/dockwidget/wizard_shell_presenter.py
@@ -33,6 +33,15 @@ class WizardShellPresenter:
 
         return self._progress
 
+    def set_progress(self, progress: DockWizardProgress) -> None:
+        """Replace the current progress snapshot and refresh the shell."""
+
+        # Reuse the render path for validation so invalid workflow keys fail
+        # before the shell state is mutated.
+        build_progress_wizard_step_statuses(progress)
+        self._progress = progress
+        self._render()
+
     def request_step(self, index: int) -> bool:
         """Move to ``index`` when the current workflow status allows it."""
 

--- a/ui/dockwidget/wizard_shell_presenter.py
+++ b/ui/dockwidget/wizard_shell_presenter.py
@@ -21,8 +21,15 @@ class WizardShellPresenter:
     workflows as those pages migrate into the shell.
     """
 
-    def __init__(self, shell, progress: DockWizardProgress | None = None) -> None:
+    def __init__(
+        self,
+        shell,
+        progress: DockWizardProgress | None = None,
+        *,
+        page_indices_by_key: dict[str, int] | None = None,
+    ) -> None:
         self._shell = shell
+        self._page_indices_by_key = page_indices_by_key
         self._progress = progress or DockWizardProgress()
         self._render()
         self._shell.stepper_bar.stepRequested.connect(self.request_step)
@@ -39,6 +46,8 @@ class WizardShellPresenter:
         # Reuse the render path for validation so invalid workflow keys fail
         # before the shell state is mutated.
         build_progress_wizard_step_statuses(progress)
+        if self._page_index_for_key(progress.current_key) is None:
+            raise ValueError(f"No installed wizard page for {progress.current_key!r}")
         self._progress = progress
         self._render()
 
@@ -49,6 +58,8 @@ class WizardShellPresenter:
         if not can_request_step(statuses, index):
             return False
         key = step_key_for_index(index)
+        if self._page_index_for_key(key) is None:
+            return False
         self._progress = DockWizardProgress(
             current_key=key,
             completed_keys=self._progress.completed_keys,
@@ -74,7 +85,14 @@ class WizardShellPresenter:
     def _render(self) -> None:
         statuses = self._statuses()
         self._shell.set_step_states(build_stepper_states(statuses))
-        self._shell.show_page(step_index_for_key(self._progress.current_key))
+        page_index = self._page_index_for_key(self._progress.current_key)
+        if page_index is not None:
+            self._shell.show_page(page_index)
+
+    def _page_index_for_key(self, key: str) -> int | None:
+        if self._page_indices_by_key is None:
+            return step_index_for_key(key)
+        return self._page_indices_by_key.get(key)
 
 
 __all__ = ["WizardShellPresenter"]


### PR DESCRIPTION
## Summary

- add a `WizardShellPresenter.set_progress()` API for replacing the wizard progress snapshot safely
- let `refresh_wizard_shell_composition()` refresh stepper/page progress without rebuilding the shell
- cover progress refresh and invalid-key rollback behavior in wizard shell/composition tests

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Part of #609 and keeps the #608 UX-audit work moving toward the wizard-style dock without deepening the current long-scroll layout.
