### PR TITLE
feat: expose wizard CTA availability state

### DIFF
--- a/tests/test_connection_page.py
+++ b/tests/test_connection_page.py
@@ -55,6 +55,12 @@ class ConnectionPageContentTest(unittest.TestCase):
             "configure_connection",
         )
         self.assertEqual(content.configure_button.property("wizardActionRole"), "primary")
+        self.assertTrue(content.configure_button.isEnabled())
+        self.assertEqual(
+            content.configure_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.configure_button.toolTip(), "")
         self.assertEqual(
             content.action_row.objectName(),
             "qfitWizardConnectionActionRow",
@@ -81,6 +87,38 @@ class ConnectionPageContentTest(unittest.TestCase):
         self.assertEqual(content.status_label.property("tone"), "ok")
         self.assertEqual(content.detail_label.text(), "Credentials are ready.")
         self.assertEqual(content.configure_button.text(), "Review connection")
+
+    def test_can_block_configure_action_with_tooltip_copy(self):
+        content = self.connection_page.ConnectionPageContent(
+            self.connection_page.ConnectionPageState(
+                primary_action_enabled=False,
+                primary_action_blocked_tooltip="OAuth dialog is already open.",
+            )
+        )
+
+        self.assertFalse(content.configure_button.isEnabled())
+        self.assertEqual(
+            content.configure_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertEqual(
+            content.configure_button.toolTip(),
+            "OAuth dialog is already open.",
+        )
+
+        content.set_state(
+            self.connection_page.ConnectionPageState(
+                connected=True,
+                primary_action_label="Review connection",
+            )
+        )
+
+        self.assertTrue(content.configure_button.isEnabled())
+        self.assertEqual(
+            content.configure_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.configure_button.toolTip(), "")
 
     def test_configure_button_emits_reusable_page_signal(self):
         content = self.connection_page.ConnectionPageContent()

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -54,6 +54,12 @@ class SyncPageContentTest(unittest.TestCase):
             "sync_activities",
         )
         self.assertEqual(content.sync_button.property("wizardActionRole"), "primary")
+        self.assertTrue(content.sync_button.isEnabled())
+        self.assertEqual(
+            content.sync_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.sync_button.toolTip(), "")
         self.assertEqual(content.action_row.objectName(), "qfitWizardSyncActionRow")
         self.assertEqual(content.action_row.outer_layout().widgets, [content.sync_button])
         self.assertEqual(
@@ -91,6 +97,35 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.activity_summary_label.property("syncState"), "ready")
         self.assertEqual(content.sync_button.text(), "Fetch latest activities")
+
+    def test_can_block_sync_action_with_tooltip_copy(self):
+        content = self.sync_page.SyncPageContent(
+            self.sync_page.SyncPageState(
+                primary_action_enabled=False,
+                primary_action_blocked_tooltip="Configure Strava first.",
+            )
+        )
+
+        self.assertFalse(content.sync_button.isEnabled())
+        self.assertEqual(
+            content.sync_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertEqual(content.sync_button.toolTip(), "Configure Strava first.")
+
+        content.set_state(
+            self.sync_page.SyncPageState(
+                ready=True,
+                primary_action_label="Fetch latest activities",
+            )
+        )
+
+        self.assertTrue(content.sync_button.isEnabled())
+        self.assertEqual(
+            content.sync_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.sync_button.toolTip(), "")
 
     def test_sync_button_emits_reusable_page_signal(self):
         content = self.sync_page.SyncPageContent()

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ._qt_compat import import_qt_module
-from .action_row import build_wizard_action_row, style_primary_action_button
+from .action_row import (
+    build_wizard_action_row,
+    set_wizard_action_availability,
+    style_primary_action_button,
+)
 from .page_content_style import style_detail_label, style_status_pill
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -38,6 +42,10 @@ class ConnectionPageState:
     status_text: str = "Strava not connected"
     detail_text: str = "Configure qfit once, then continue to synchronization."
     primary_action_label: str = "Configure connection"
+    primary_action_enabled: bool = True
+    primary_action_blocked_tooltip: str = (
+        "Connection configuration is not available right now."
+    )
 
 
 class ConnectionPageContent(QWidget):
@@ -81,6 +89,11 @@ class ConnectionPageContent(QWidget):
         style_status_pill(self.status_label, active=state.connected)
         self.detail_label.setText(state.detail_text)
         self.configure_button.setText(state.primary_action_label)
+        set_wizard_action_availability(
+            self.configure_button,
+            enabled=state.primary_action_enabled,
+            tooltip=state.primary_action_blocked_tooltip,
+        )
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ._qt_compat import import_qt_module
-from .action_row import build_wizard_action_row, style_primary_action_button
+from .action_row import (
+    build_wizard_action_row,
+    set_wizard_action_availability,
+    style_primary_action_button,
+)
 from .page_content_style import (
     style_detail_label,
     style_status_pill,
@@ -38,6 +42,8 @@ class SyncPageState:
     detail_text: str = "Fetch Strava activities and store detailed routes in the GeoPackage."
     activity_summary_text: str = "No activities stored"
     primary_action_label: str = "Sync activities"
+    primary_action_enabled: bool = True
+    primary_action_blocked_tooltip: str = "Configure the Strava connection before syncing."
 
 
 class SyncPageContent(QWidget):
@@ -84,6 +90,11 @@ class SyncPageContent(QWidget):
         self.activity_summary_label.setText(state.activity_summary_text)
         self.activity_summary_label.setProperty("syncState", sync_state)
         self.sync_button.setText(state.primary_action_label)
+        set_wizard_action_availability(
+            self.sync_button,
+            enabled=state.primary_action_enabled,
+            tooltip=state.primary_action_blocked_tooltip,
+        )
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""


### PR DESCRIPTION
## Summary

Adds explicit availability state to the connection and synchronization wizard CTAs so future dock adapters can disable those actions with prerequisite/tooling copy without coupling the new wizard pages to the current long-scroll dock.

## Changes

- Adds `primary_action_enabled` and blocked-tooltip state to the connection page CTA.
- Adds the same availability seam to the synchronization page CTA.
- Covers default available and blocked/refresh behavior in page tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608.
Refs #609.
