### PR TITLE
ui: explain locked wizard steps

### DIFF
--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -214,7 +214,16 @@ class StepperBarTest(unittest.TestCase):
 
         self.assertEqual(bar.states(), ("current", "locked", "locked", "locked", "locked"))
         self.assertEqual(len(bar.step_buttons()), 5)
-        self.assertEqual([button.toolTip() for button in bar.step_buttons()], list(self.stepper.STEPPER_LABELS))
+        self.assertEqual(
+            [button.toolTip() for button in bar.step_buttons()],
+            [
+                "Connection",
+                "Complete Connection before opening Synchronization.",
+                "Complete Synchronization before opening Map & filters.",
+                "Complete Map & filters before opening Spatial analysis.",
+                "Complete Spatial analysis before opening Atlas PDF.",
+            ],
+        )
         self.assertEqual(bar.height(), 36)
 
     def test_labels_come_from_shared_workflow_metadata(self):
@@ -268,7 +277,12 @@ class StepperBarTest(unittest.TestCase):
         self.assertTrue(buttons[0].text().startswith("✓"))
         self.assertEqual(buttons[1].property("wizardState"), "current")
         self.assertTrue(buttons[2].isEnabled())
+        self.assertEqual(buttons[2].toolTip(), "Map & filters")
         self.assertFalse(buttons[3].isEnabled())
+        self.assertEqual(
+            buttons[3].toolTip(),
+            "Complete Map & filters before opening Spatial analysis.",
+        )
         self.assertEqual(buttons[3].cursor().shape(), _FakeQt.ForbiddenCursor)
 
     def test_set_current_marks_other_steps_upcoming(self):
@@ -277,6 +291,16 @@ class StepperBarTest(unittest.TestCase):
         bar.set_current(2)
 
         self.assertEqual(bar.states(), ("upcoming", "upcoming", "current", "upcoming", "upcoming"))
+
+    def test_locked_first_step_gets_generic_unavailable_tooltip(self):
+        bar = self.stepper.StepperBar()
+
+        bar.set_state(["locked", "locked", "locked", "locked", "locked"])
+
+        self.assertEqual(
+            bar.step_buttons()[0].toolTip(),
+            "This step is not yet available.",
+        )
 
     def test_rejects_invalid_state_payloads(self):
         bar = self.stepper.StepperBar()

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -113,7 +113,7 @@ class StepperBar(QWidget):
         button.setProperty("wizardState", state)
         button.setEnabled(state != "locked")
         button.setCursor(Qt.ForbiddenCursor if state == "locked" else Qt.PointingHandCursor)
-        button.setToolTip(STEPPER_LABELS[index])
+        button.setToolTip(_button_tooltip(index, state))
         button.setStyleSheet(_button_stylesheet(state))
 
     def _configure_connectors(self) -> None:
@@ -142,6 +142,16 @@ def _validate_states(states: Sequence[str]) -> tuple[str, ...]:
 def _button_text(index: int, state: str) -> str:
     prefix = "✓" if state == "done" else str(index + 1)
     return f"{prefix}  {STEPPER_LABELS[index]}"
+
+
+def _button_tooltip(index: int, state: str) -> str:
+    label = STEPPER_LABELS[index]
+    if state == "locked":
+        if index == 0:
+            return "This step is not yet available."
+        previous_label = STEPPER_LABELS[index - 1]
+        return f"Complete {previous_label} before opening {label}."
+    return label
 
 
 def _button_stylesheet(state: str) -> str:


### PR DESCRIPTION
## Summary

Adds prerequisite-focused tooltips to locked wizard stepper buttons so the #609 shell explains why a step is unavailable instead of only repeating the step name.

## Changes

- Keep enabled/current/upcoming stepper tooltips unchanged.
- Show locked-step guidance such as “Complete Synchronization before opening Map & filters.”
- Cover the first-launch and refreshed stepper states in unit tests.

## Testing

- `python3 -m pytest tests/test_stepper_bar.py tests/test_wizard_shell_presenter.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Part of #608 and #609.
