### PR TITLE
feat: derive wizard progress from workflow facts

### DIFF
--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -1,0 +1,99 @@
+import unittest
+
+from qfit.ui.application.dock_workflow_sections import build_progress_wizard_step_statuses
+from qfit.ui.application.wizard_progress import (
+    WizardProgressFacts,
+    build_wizard_progress_from_facts,
+)
+
+
+class WizardProgressFactsTests(unittest.TestCase):
+    def test_defaults_keep_connection_current_with_no_completed_steps(self):
+        progress = build_wizard_progress_from_facts(WizardProgressFacts())
+
+        self.assertEqual(progress.current_key, "connection")
+        self.assertEqual(progress.completed_keys, frozenset())
+        self.assertEqual(progress.visited_keys, frozenset({"connection"}))
+
+    def test_selects_first_incomplete_step_from_completed_prefix(self):
+        progress = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+            )
+        )
+
+        self.assertEqual(progress.current_key, "analysis")
+        self.assertEqual(
+            progress.completed_keys,
+            frozenset({"connection", "sync", "map"}),
+        )
+        statuses = build_progress_wizard_step_statuses(progress)
+        self.assertEqual(
+            [status.state.value for status in statuses],
+            ["done", "done", "done", "current", "locked"],
+        )
+
+    def test_ignores_later_completed_facts_until_prerequisites_are_done(self):
+        progress = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=False,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                atlas_exported=True,
+            )
+        )
+
+        self.assertEqual(progress.current_key, "sync")
+        self.assertEqual(progress.completed_keys, frozenset({"connection"}))
+
+    def test_accepts_preferred_current_key_only_when_reachable(self):
+        progress = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                preferred_current_key="connection",
+            )
+        )
+
+        self.assertEqual(progress.current_key, "connection")
+        self.assertEqual(progress.completed_keys, frozenset({"connection", "sync"}))
+
+        clamped = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=True,
+                preferred_current_key="analysis",
+            )
+        )
+
+        self.assertEqual(clamped.current_key, "sync")
+        self.assertEqual(clamped.completed_keys, frozenset({"connection"}))
+
+    def test_fully_completed_progress_keeps_atlas_current(self):
+        progress = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                atlas_exported=True,
+            )
+        )
+
+        self.assertEqual(progress.current_key, "atlas")
+        self.assertEqual(
+            progress.completed_keys,
+            frozenset({"connection", "sync", "map", "analysis", "atlas"}),
+        )
+
+    def test_rejects_unknown_preferred_current_key(self):
+        with self.assertRaisesRegex(KeyError, "review"):
+            build_wizard_progress_from_facts(
+                WizardProgressFacts(preferred_current_key="review")
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -67,6 +67,7 @@ from .wizard_settings import (
     save_collapsed_groups,
     save_last_step_index,
 )
+from .wizard_progress import WizardProgressFacts, build_wizard_progress_from_facts
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -115,6 +116,7 @@ __all__ = [
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",
     "VisualWorkflowSettingsSnapshot",
+    "WizardProgressFacts",
     "WizardSettingsSnapshot",
     "build_current_dock_workflow_label",
     "build_dock_summary_status",
@@ -122,6 +124,7 @@ __all__ = [
     "build_progress_wizard_step_statuses",
     "build_stepper_items",
     "build_stepper_states",
+    "build_wizard_progress_from_facts",
     "build_wizard_step_statuses",
     "build_visual_layer_refs",
     "build_visual_workflow_action",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
+
+
+@dataclass(frozen=True)
+class WizardProgressFacts:
+    """Render-neutral workflow facts for deriving #609 wizard progress.
+
+    The facts deliberately model completed work, not enabled buttons. This keeps
+    the future wizard stepper from marking a step done just because a downstream
+    page is reachable.
+    """
+
+    connection_configured: bool = False
+    activities_stored: bool = False
+    activity_layers_loaded: bool = False
+    analysis_generated: bool = False
+    atlas_exported: bool = False
+    preferred_current_key: str | None = None
+
+
+def build_wizard_progress_from_facts(facts: WizardProgressFacts) -> DockWizardProgress:
+    """Build a safe wizard progress snapshot from current workflow facts.
+
+    Completed steps are prefix-gated so a later fact cannot make the stepper
+    skip over an incomplete prerequisite. The preferred current key is accepted
+    only while that page is reachable from the completed prefix; otherwise the
+    first incomplete step remains current.
+    """
+
+    completed_keys = _completed_keys_from_facts(facts)
+    current_key = _resolve_current_key(
+        completed_keys=completed_keys,
+        preferred_current_key=facts.preferred_current_key,
+    )
+    return DockWizardProgress(
+        current_key=current_key,
+        completed_keys=frozenset(completed_keys),
+        visited_keys=frozenset({current_key}),
+    )
+
+
+def _completed_keys_from_facts(facts: WizardProgressFacts) -> tuple[str, ...]:
+    completed: list[str] = []
+    for key, complete in (
+        ("connection", facts.connection_configured),
+        ("sync", facts.activities_stored),
+        ("map", facts.activity_layers_loaded),
+        ("analysis", facts.analysis_generated),
+        ("atlas", facts.atlas_exported),
+    ):
+        if not complete:
+            break
+        completed.append(key)
+    return tuple(completed)
+
+
+def _resolve_current_key(
+    *,
+    completed_keys: tuple[str, ...],
+    preferred_current_key: str | None,
+) -> str:
+    known_keys = _workflow_keys()
+    completed = set(completed_keys)
+    first_incomplete_key = _first_incomplete_key(completed)
+    if preferred_current_key is None:
+        return first_incomplete_key
+    if preferred_current_key not in known_keys:
+        raise KeyError(preferred_current_key)
+    reachable_keys = completed | {first_incomplete_key}
+    if preferred_current_key in reachable_keys:
+        return preferred_current_key
+    return first_incomplete_key
+
+
+def _first_incomplete_key(completed_keys: set[str]) -> str:
+    for key in _workflow_keys():
+        if key not in completed_keys:
+            return key
+    return _workflow_keys()[-1]
+
+
+def _workflow_keys() -> tuple[str, ...]:
+    return tuple(section.key for section in WIZARD_WORKFLOW_STEPS)
+
+
+__all__ = [
+    "WizardProgressFacts",
+    "build_wizard_progress_from_facts",
+]


### PR DESCRIPTION
## Summary

Adds a small render-neutral progress builder for the #609 wizard path so the future dock can derive `DockWizardProgress` from workflow completion facts without binding to the current long-scroll dock.

## Changes

- Added `WizardProgressFacts` and `build_wizard_progress_from_facts`.
- Prefix-gated completed steps so downstream facts cannot skip incomplete prerequisites.
- Preserved a reachable preferred current step for saved/active wizard navigation.
- Added focused coverage for defaults, prerequisite clamping, preferred-step handling, and full completion.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
