### PR TITLE
fix: gate wizard map load CTA on sync state

### DIFF
--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -69,6 +69,12 @@ class MapPageContentTest(unittest.TestCase):
             "load_activity_layers",
         )
         self.assertEqual(content.load_layers_button.property("wizardActionRole"), "secondary")
+        self.assertTrue(content.load_layers_button.isEnabled())
+        self.assertEqual(
+            content.load_layers_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.load_layers_button.toolTip(), "")
         self.assertEqual(
             content.apply_filters_button.objectName(),
             "qfitWizardMapApplyFiltersButton",
@@ -133,6 +139,12 @@ class MapPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.filter_summary_label.property("mapState"), "loaded")
         self.assertEqual(content.load_layers_button.text(), "Reload layers")
+        self.assertTrue(content.load_layers_button.isEnabled())
+        self.assertEqual(
+            content.load_layers_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.load_layers_button.toolTip(), "")
         self.assertEqual(content.apply_filters_button.text(), "Apply saved filters")
         self.assertTrue(content.apply_filters_button.isEnabled())
         self.assertEqual(
@@ -140,6 +152,24 @@ class MapPageContentTest(unittest.TestCase):
             "available",
         )
         self.assertEqual(content.apply_filters_button.toolTip(), "")
+
+    def test_can_block_load_layers_until_sync_prerequisite_is_ready(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState(
+                load_action_enabled=False,
+                load_action_blocked_tooltip="Store activities before loading layers.",
+            )
+        )
+
+        self.assertFalse(content.load_layers_button.isEnabled())
+        self.assertEqual(
+            content.load_layers_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertEqual(
+            content.load_layers_button.toolTip(),
+            "Store activities before loading layers.",
+        )
 
     def test_can_override_apply_filter_availability(self):
         content = self.map_page.MapPageContent(

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -225,6 +225,11 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.map_content.status_label.text(),
             "Activity layers not loaded",
         )
+        self.assertTrue(assembled.map_content.load_layers_button.isEnabled())
+        self.assertEqual(
+            assembled.map_content.load_layers_button.property("wizardActionAvailability"),
+            "available",
+        )
         self.assertFalse(assembled.map_content.apply_filters_button.isEnabled())
 
     def test_progress_facts_drive_page_cta_prerequisites_without_marking_done(self):
@@ -244,6 +249,11 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(
             assembled.sync_content.sync_button.property("wizardActionAvailability"),
             "available",
+        )
+        self.assertFalse(assembled.map_content.load_layers_button.isEnabled())
+        self.assertEqual(
+            assembled.map_content.load_layers_button.toolTip(),
+            "Sync activities before loading map layers.",
         )
         self.assertFalse(assembled.analysis_content.run_analysis_button.isEnabled())
         self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
@@ -277,6 +287,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.sync_state.ready)
         self.assertFalse(assembled.sync_content.sync_button.isEnabled())
         self.assertFalse(assembled.map_state.loaded)
+        self.assertFalse(assembled.map_content.load_layers_button.isEnabled())
         self.assertFalse(assembled.map_content.apply_filters_button.isEnabled())
         self.assertFalse(assembled.analysis_state.ready)
         self.assertFalse(assembled.analysis_content.run_analysis_button.isEnabled())
@@ -545,6 +556,8 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.connection_content.status_label.text(), "Strava connected")
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
         self.assertEqual(assembled.map_content.status_label.text(), "Activity layers loaded")
+        self.assertTrue(assembled.map_content.load_layers_button.isEnabled())
+        self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
         self.assertFalse(assembled.analysis_state.ready)
         self.assertTrue(assembled.analysis_content.run_analysis_button.isEnabled())
         self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -44,6 +44,8 @@ class MapPageState:
     layer_summary_text: str = "No activity layers on the map"
     filter_summary_text: str = "All stored activities visible once layers are loaded"
     load_action_label: str = "Load activity layers"
+    load_action_enabled: bool = True
+    load_action_blocked_tooltip: str = "Sync activities before loading map layers."
     primary_action_label: str = "Apply filters"
     apply_action_enabled: bool | None = None
     apply_action_blocked_tooltip: str = "Load activity layers before applying filters."
@@ -107,6 +109,11 @@ class MapPageContent(QWidget):
         self.filter_summary_label.setText(state.filter_summary_text)
         self.filter_summary_label.setProperty("mapState", map_state)
         self.load_layers_button.setText(state.load_action_label)
+        set_wizard_action_availability(
+            self.load_layers_button,
+            enabled=state.load_action_enabled,
+            tooltip=state.load_action_blocked_tooltip,
+        )
         self.apply_filters_button.setText(state.primary_action_label)
         apply_action_enabled = (
             state.loaded

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -453,6 +453,7 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
             if facts.activity_layers_loaded
             else default.layer_summary_text
         ),
+        load_action_enabled=facts.activities_stored,
         apply_action_enabled=facts.activity_layers_loaded,
     )
 


### PR DESCRIPTION
## Summary

Gate the wizard map page's "Load activity layers" CTA on stored activity prerequisites so future #609 pages expose clear, prerequisite-aware availability without relying on the legacy long-scroll dock.

## Changes

- Add load-action availability and blocked-tooltip state to `MapPageState`.
- Apply wizard action availability styling to the map load-layers button.
- Derive the load-layers CTA prerequisite from `WizardProgressFacts.activities_stored`.
- Extend map page and wizard composition tests for available/blocked load-layer CTA states.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
Refs #608.
