### PR TITLE
Persist wizard settings during dock startup

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -81,6 +81,7 @@ from .ui.application import (
     RunAnalysisAction,
     build_dock_summary_status,
     build_visual_layer_refs,
+    ensure_wizard_settings,
     build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
@@ -149,6 +150,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._dock_visual_workflow = DockVisualWorkflowCoordinator(
             dispatcher=self._dock_action_dispatcher,
         )
+
+    def _ensure_wizard_settings(self):
+        """Persist first-launch wizard defaults for the #609 dock migration."""
+
+        return ensure_wizard_settings(self.settings)
 
     def _runtime_store(self) -> DockRuntimeStore:
         store = getattr(self, "_runtime_state_store", None)

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -642,6 +642,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 performed_steps=(
                     "set_features",
                     "set_allowed_areas",
+                    "ensure_wizard_settings",
                     "configure_starting_sections",
                     "remove_stale_qfit_layers",
                     "apply_contextual_help",
@@ -666,6 +667,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
             [
                 call.setFeatures(sentinel.features),
                 call.setAllowedAreas(sentinel.allowed_areas),
+                call._ensure_wizard_settings(),
                 call._remove_stale_qfit_layers(),
                 call._apply_contextual_help(),
                 call._configure_background_preset_options(),

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -25,6 +25,9 @@ class DockStartupCoordinator:
         dock.setAllowedAreas(dock.STARTUP_ALLOWED_AREAS)
         performed_steps.append("set_allowed_areas")
 
+        dock._ensure_wizard_settings()
+        performed_steps.append("ensure_wizard_settings")
+
         self.workflow_section_coordinator.configure_starting_sections()
         performed_steps.append("configure_starting_sections")
 


### PR DESCRIPTION
## Summary

Persist the #609 wizard settings defaults during dock startup so first launch writes the wizard version/default state through the existing settings port.

## Changes

- Add a small `QfitDockWidget._ensure_wizard_settings()` adapter around the existing application helper.
- Call that adapter from `DockStartupCoordinator` before section/UI startup work proceeds.
- Update startup orchestration coverage for the new step.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
