### PR TITLE
feat: add wizard step persistence callback seam

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -509,7 +509,10 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
 
     def test_refresh_can_update_progress_without_rebuilding_shell(self):
-        assembled = self.composition.build_placeholder_wizard_shell()
+        persisted_step_indexes = []
+        assembled = self.composition.build_placeholder_wizard_shell(
+            on_current_step_changed=persisted_step_indexes.append,
+        )
         progress = DockWizardProgress(
             current_key="map",
             completed_keys=frozenset({"connection", "sync"}),
@@ -528,6 +531,8 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.shell.stepper_bar.states(),
             ("done", "done", "current", "locked", "locked"),
         )
+        self.assertIsNotNone(assembled.on_current_step_changed)
+        self.assertEqual(persisted_step_indexes, [2])
 
     def test_refresh_can_update_progress_from_workflow_facts(self):
         assembled = self.composition.build_placeholder_wizard_shell()

--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -36,8 +36,12 @@ class WizardShellPresenterTest(unittest.TestCase):
 
     def test_renders_initial_progress_without_entrenching_current_dock(self):
         shell = self._build_shell_with_pages()
+        persisted_step_indexes = []
 
-        presenter = self.presenter.WizardShellPresenter(shell)
+        presenter = self.presenter.WizardShellPresenter(
+            shell,
+            on_current_step_changed=persisted_step_indexes.append,
+        )
 
         self.assertEqual(presenter.progress.current_key, "connection")
         self.assertEqual(
@@ -45,10 +49,15 @@ class WizardShellPresenterTest(unittest.TestCase):
             ("current", "locked", "locked", "locked", "locked"),
         )
         self.assertEqual(shell.pages_stack.currentIndex(), 0)
+        self.assertEqual(persisted_step_indexes, [])
 
     def test_rejects_locked_step_requests_without_changing_page(self):
         shell = self._build_shell_with_pages()
-        presenter = self.presenter.WizardShellPresenter(shell)
+        persisted_step_indexes = []
+        presenter = self.presenter.WizardShellPresenter(
+            shell,
+            on_current_step_changed=persisted_step_indexes.append,
+        )
 
         accepted = presenter.request_step(2)
 
@@ -59,10 +68,15 @@ class WizardShellPresenterTest(unittest.TestCase):
             shell.stepper_bar.states(),
             ("current", "locked", "locked", "locked", "locked"),
         )
+        self.assertEqual(persisted_step_indexes, [])
 
     def test_completion_unlocks_next_page_and_stepper_signal_navigates(self):
         shell = self._build_shell_with_pages()
-        presenter = self.presenter.WizardShellPresenter(shell)
+        persisted_step_indexes = []
+        presenter = self.presenter.WizardShellPresenter(
+            shell,
+            on_current_step_changed=persisted_step_indexes.append,
+        )
 
         presenter.mark_step_done("connection")
         shell.stepper_bar.stepRequested.emit(1)
@@ -74,6 +88,7 @@ class WizardShellPresenterTest(unittest.TestCase):
             shell.stepper_bar.states(),
             ("done", "current", "locked", "locked", "locked"),
         )
+        self.assertEqual(persisted_step_indexes, [1])
 
     def test_visited_uncompleted_pages_stay_unlocked_without_being_done(self):
         shell = self._build_shell_with_pages()
@@ -93,7 +108,11 @@ class WizardShellPresenterTest(unittest.TestCase):
 
     def test_set_progress_refreshes_stepper_and_visible_page(self):
         shell = self._build_shell_with_pages()
-        presenter = self.presenter.WizardShellPresenter(shell)
+        persisted_step_indexes = []
+        presenter = self.presenter.WizardShellPresenter(
+            shell,
+            on_current_step_changed=persisted_step_indexes.append,
+        )
         progress = self.presenter.DockWizardProgress(
             current_key="analysis",
             completed_keys=frozenset({"connection", "sync", "map"}),
@@ -108,6 +127,7 @@ class WizardShellPresenterTest(unittest.TestCase):
             shell.stepper_bar.states(),
             ("done", "done", "done", "current", "locked"),
         )
+        self.assertEqual(persisted_step_indexes, [3])
 
     def test_set_progress_rejects_unknown_keys_without_mutating_shell(self):
         shell = self._build_shell_with_pages()

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -91,6 +91,7 @@ class WizardShellComposition:
     map_state: MapPageState | None = None
     analysis_state: AnalysisPageState | None = None
     atlas_state: AtlasPageState | None = None
+    on_current_step_changed: Callable[[int], None] | None = None
 
 
 def build_placeholder_wizard_shell(
@@ -105,13 +106,16 @@ def build_placeholder_wizard_shell(
     map_state: MapPageState | None = None,
     analysis_state: AnalysisPageState | None = None,
     atlas_state: AtlasPageState | None = None,
+    on_current_step_changed: Callable[[int], None] | None = None,
 ) -> WizardShellComposition:
     """Build the placeholder #609 wizard shell with pages and presenter wired.
 
     Pages are installed before the presenter renders so the initial progress
     snapshot selects the matching visible page immediately. The helper does not
     bind any current long-scroll dock controls into the shell; page content can
-    migrate later through the stable ``WizardPage.body_layout()`` seams.
+    migrate later through the stable ``WizardPage.body_layout()`` seams. The
+    optional step-change callback is the future dock's seam for persisting
+    ``ui/last_step_index`` when users navigate the wizard.
     """
 
     page_state_defaults = _page_state_defaults_from_progress_facts(progress_facts)
@@ -174,6 +178,7 @@ def build_placeholder_wizard_shell(
         shell,
         resolved_progress,
         page_indices_by_key=_build_page_indices_by_key(pages),
+        on_current_step_changed=on_current_step_changed,
     )
     return WizardShellComposition(
         shell=shell,
@@ -189,6 +194,7 @@ def build_placeholder_wizard_shell(
         map_state=map_state,
         analysis_state=analysis_state,
         atlas_state=atlas_state,
+        on_current_step_changed=on_current_step_changed,
     )
 
 

--- a/ui/dockwidget/wizard_shell_presenter.py
+++ b/ui/dockwidget/wizard_shell_presenter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from qfit.ui.application.dock_workflow_sections import (
     DockWizardProgress,
     build_progress_wizard_step_statuses,
@@ -27,9 +29,11 @@ class WizardShellPresenter:
         progress: DockWizardProgress | None = None,
         *,
         page_indices_by_key: dict[str, int] | None = None,
+        on_current_step_changed: Callable[[int], None] | None = None,
     ) -> None:
         self._shell = shell
         self._page_indices_by_key = page_indices_by_key
+        self._on_current_step_changed = on_current_step_changed
         self._progress = progress or DockWizardProgress()
         self._render()
         self._shell.stepper_bar.stepRequested.connect(self.request_step)
@@ -41,15 +45,23 @@ class WizardShellPresenter:
         return self._progress
 
     def set_progress(self, progress: DockWizardProgress) -> None:
-        """Replace the current progress snapshot and refresh the shell."""
+        """Replace the current progress snapshot and refresh the shell.
+
+        The optional step-change callback is notified only when the current
+        wizard key changes. This gives the future dock a small persistence seam
+        for ``ui/last_step_index`` without writing settings during initial
+        presenter construction.
+        """
 
         # Reuse the render path for validation so invalid workflow keys fail
         # before the shell state is mutated.
         build_progress_wizard_step_statuses(progress)
         if self._page_index_for_key(progress.current_key) is None:
             raise ValueError(f"No installed wizard page for {progress.current_key!r}")
+        previous_key = self._progress.current_key
         self._progress = progress
         self._render()
+        self._notify_current_step_changed(previous_key=previous_key)
 
     def request_step(self, index: int) -> bool:
         """Move to ``index`` when the current workflow status allows it."""
@@ -60,12 +72,14 @@ class WizardShellPresenter:
         key = step_key_for_index(index)
         if self._page_index_for_key(key) is None:
             return False
+        previous_key = self._progress.current_key
         self._progress = DockWizardProgress(
             current_key=key,
             completed_keys=self._progress.completed_keys,
             visited_keys=self._progress.visited_keys | {key},
         )
         self._render()
+        self._notify_current_step_changed(previous_key=previous_key)
         return True
 
     def mark_step_done(self, key: str) -> None:
@@ -88,6 +102,14 @@ class WizardShellPresenter:
         page_index = self._page_index_for_key(self._progress.current_key)
         if page_index is not None:
             self._shell.show_page(page_index)
+
+    def _notify_current_step_changed(self, *, previous_key: str) -> None:
+        if self._on_current_step_changed is None:
+            return
+        current_key = self._progress.current_key
+        if current_key == previous_key:
+            return
+        self._on_current_step_changed(step_index_for_key(current_key))
 
     def _page_index_for_key(self, key: str) -> int | None:
         if self._page_indices_by_key is None:


### PR DESCRIPTION
## Summary

Adds a small wizard presenter/composition seam for persisting the current wizard step index when users navigate the future #609 stepper.

## Changes

- Add an optional `on_current_step_changed(index)` callback to `WizardShellPresenter`.
- Forward the callback through `build_placeholder_wizard_shell()` and store it on the composition.
- Notify the callback only after accepted step navigation or progress changes, not during initial render or rejected locked-step requests.
- Cover the new behavior in presenter and composition tests.

## Testing

- `python3 -m pytest tests/test_wizard_shell_presenter.py tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
