### PR TITLE
feat: restore wizard step from settings facts

### DIFF
--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -4,7 +4,9 @@ from qfit.ui.application.dock_workflow_sections import build_progress_wizard_ste
 from qfit.ui.application.wizard_progress import (
     WizardProgressFacts,
     build_wizard_progress_from_facts,
+    build_wizard_progress_from_facts_and_settings,
 )
+from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 
 class WizardProgressFactsTests(unittest.TestCase):
@@ -93,6 +95,42 @@ class WizardProgressFactsTests(unittest.TestCase):
             build_wizard_progress_from_facts(
                 WizardProgressFacts(preferred_current_key="review")
             )
+
+    def test_existing_settings_restore_reachable_preferred_step(self):
+        progress = build_wizard_progress_from_facts_and_settings(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+            ),
+            WizardSettingsSnapshot(wizard_version=1, last_step_index=2, first_launch=False),
+        )
+
+        self.assertEqual(progress.current_key, "map")
+        self.assertEqual(
+            progress.completed_keys,
+            frozenset({"connection", "sync", "map"}),
+        )
+
+    def test_first_launch_settings_keep_default_connection_step(self):
+        progress = build_wizard_progress_from_facts_and_settings(
+            WizardProgressFacts(connection_configured=True),
+            WizardSettingsSnapshot(wizard_version=1, last_step_index=4, first_launch=True),
+        )
+
+        self.assertEqual(progress.current_key, "sync")
+
+    def test_explicit_preferred_key_wins_over_persisted_step(self):
+        progress = build_wizard_progress_from_facts_and_settings(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                preferred_current_key="connection",
+            ),
+            WizardSettingsSnapshot(wizard_version=1, last_step_index=2, first_launch=False),
+        )
+
+        self.assertEqual(progress.current_key, "connection")
 
 
 if __name__ == "__main__":

--- a/tests/test_wizard_settings.py
+++ b/tests/test_wizard_settings.py
@@ -11,8 +11,10 @@ from qfit.ui.application.wizard_settings import (
     clamp_wizard_step_index,
     ensure_wizard_settings,
     load_wizard_settings,
+    preferred_current_key_from_settings,
     save_collapsed_groups,
     save_last_step_index,
+    wizard_step_key_for_index,
 )
 
 
@@ -106,6 +108,22 @@ class WizardSettingsTests(unittest.TestCase):
         snapshot = load_wizard_settings(settings)
 
         self.assertEqual(snapshot.collapsed_groups, ("layoutGroup", "temporalGroup"))
+
+    def test_persisted_step_index_maps_to_stable_wizard_key(self):
+        self.assertEqual(wizard_step_key_for_index(2), "map")
+        self.assertEqual(wizard_step_key_for_index(99), "atlas")
+
+    def test_first_launch_has_no_preferred_current_key(self):
+        snapshot = load_wizard_settings(FakeSettingsPort())
+
+        self.assertIsNone(preferred_current_key_from_settings(snapshot))
+
+    def test_existing_settings_restore_preferred_current_key(self):
+        snapshot = load_wizard_settings(
+            FakeSettingsPort({WIZARD_VERSION_KEY: WIZARD_VERSION, LAST_STEP_INDEX_KEY: 3})
+        )
+
+        self.assertEqual(preferred_current_key_from_settings(snapshot), "analysis")
 
 
 if __name__ == "__main__":

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -232,6 +232,44 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertFalse(assembled.map_content.apply_filters_button.isEnabled())
 
+    def test_existing_wizard_settings_restore_reachable_initial_step(self):
+        settings = self.composition.WizardSettingsSnapshot(
+            wizard_version=1,
+            last_step_index=3,
+            first_launch=False,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+            ),
+            wizard_settings=settings,
+        )
+
+        self.assertEqual(assembled.presenter.progress.current_key, "analysis")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 3)
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("done", "done", "done", "current", "locked"),
+        )
+
+    def test_first_launch_wizard_settings_do_not_restore_saved_step(self):
+        settings = self.composition.WizardSettingsSnapshot(
+            wizard_version=1,
+            last_step_index=4,
+            first_launch=True,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(),
+            wizard_settings=settings,
+        )
+
+        self.assertEqual(assembled.presenter.progress.current_key, "connection")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+
     def test_progress_facts_drive_page_cta_prerequisites_without_marking_done(self):
         facts = self.composition.WizardProgressFacts(connection_configured=True)
 
@@ -566,6 +604,25 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.analysis_state.ready)
         self.assertTrue(assembled.analysis_content.run_analysis_button.isEnabled())
         self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
+
+    def test_refresh_can_update_progress_from_settings_and_workflow_facts(self):
+        assembled = self.composition.build_placeholder_wizard_shell()
+
+        self.composition.refresh_wizard_shell_composition(
+            assembled,
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+            ),
+            wizard_settings=self.composition.WizardSettingsSnapshot(
+                wizard_version=1,
+                last_step_index=2,
+                first_launch=False,
+            ),
+        )
+
+        self.assertEqual(assembled.presenter.progress.current_key, "map")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
 
     def test_refresh_progress_facts_replace_previous_default_state(self):
         assembled = self.composition.build_placeholder_wizard_shell()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -64,10 +64,16 @@ from .wizard_settings import (
     clamp_wizard_step_index,
     ensure_wizard_settings,
     load_wizard_settings,
+    preferred_current_key_from_settings,
     save_collapsed_groups,
     save_last_step_index,
+    wizard_step_key_for_index,
 )
-from .wizard_progress import WizardProgressFacts, build_wizard_progress_from_facts
+from .wizard_progress import (
+    WizardProgressFacts,
+    build_wizard_progress_from_facts,
+    build_wizard_progress_from_facts_and_settings,
+)
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -125,6 +131,7 @@ __all__ = [
     "build_stepper_items",
     "build_stepper_states",
     "build_wizard_progress_from_facts",
+    "build_wizard_progress_from_facts_and_settings",
     "build_wizard_step_statuses",
     "build_visual_layer_refs",
     "build_visual_workflow_action",
@@ -137,8 +144,10 @@ __all__ = [
     "ensure_wizard_settings",
     "get_workflow_section",
     "load_wizard_settings",
+    "preferred_current_key_from_settings",
     "save_collapsed_groups",
     "save_last_step_index",
     "step_index_for_key",
     "step_key_for_index",
+    "wizard_step_key_for_index",
 ]

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
+from .wizard_settings import (
+    WizardSettingsSnapshot,
+    preferred_current_key_from_settings,
+)
 
 
 @dataclass(frozen=True)
@@ -40,6 +44,31 @@ def build_wizard_progress_from_facts(facts: WizardProgressFacts) -> DockWizardPr
         current_key=current_key,
         completed_keys=frozenset(completed_keys),
         visited_keys=frozenset({current_key}),
+    )
+
+
+def build_wizard_progress_from_facts_and_settings(
+    facts: WizardProgressFacts,
+    settings: WizardSettingsSnapshot,
+) -> DockWizardProgress:
+    """Build wizard progress while honoring a persisted step preference.
+
+    The persisted step is a preference, not an unlock rule. The normal progress
+    builder still gates it behind completed prerequisites so the wizard cannot
+    restore into a page that should remain locked.
+    """
+
+    if facts.preferred_current_key is not None:
+        return build_wizard_progress_from_facts(facts)
+    return build_wizard_progress_from_facts(
+        WizardProgressFacts(
+            connection_configured=facts.connection_configured,
+            activities_stored=facts.activities_stored,
+            activity_layers_loaded=facts.activity_layers_loaded,
+            analysis_generated=facts.analysis_generated,
+            atlas_exported=facts.atlas_exported,
+            preferred_current_key=preferred_current_key_from_settings(settings),
+        )
     )
 
 
@@ -89,5 +118,6 @@ def _workflow_keys() -> tuple[str, ...]:
 
 __all__ = [
     "WizardProgressFacts",
+    "build_wizard_progress_from_facts_and_settings",
     "build_wizard_progress_from_facts",
 ]

--- a/ui/application/wizard_settings.py
+++ b/ui/application/wizard_settings.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ...configuration.application.settings_port import SettingsPort
+from .dock_workflow_sections import WIZARD_WORKFLOW_STEPS
 
 WIZARD_VERSION = 1
 WIZARD_VERSION_KEY = "ui/wizard_version"
@@ -81,6 +82,28 @@ def save_collapsed_groups(settings: SettingsPort, object_names: list[str] | tupl
     return collapsed_groups
 
 
+def wizard_step_key_for_index(index: int) -> str:
+    """Return the stable wizard step key for a persisted step index."""
+
+    return WIZARD_WORKFLOW_STEPS[clamp_wizard_step_index(index)].key
+
+
+def preferred_current_key_from_settings(
+    snapshot: WizardSettingsSnapshot,
+) -> str | None:
+    """Return the restore target from persisted wizard settings.
+
+    First launch intentionally has no restore target: the #609 spec requires the
+    connection page to be current with all other steps locked. Once wizard
+    settings already exist, the saved index becomes a preferred target that
+    progress derivation can still gate behind incomplete prerequisites.
+    """
+
+    if snapshot.first_launch:
+        return None
+    return wizard_step_key_for_index(snapshot.last_step_index)
+
+
 def clamp_wizard_step_index(value: Any) -> int:
     """Coerce a persisted step index into the wizard's 0-based page range."""
 
@@ -131,4 +154,6 @@ __all__ = [
     "load_wizard_settings",
     "save_collapsed_groups",
     "save_last_step_index",
+    "preferred_current_key_from_settings",
+    "wizard_step_key_for_index",
 ]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -15,8 +15,10 @@ from qfit.ui.application.wizard_page_specs import (
 )
 from qfit.ui.application.wizard_progress import (
     WizardProgressFacts,
+    build_wizard_progress_from_facts_and_settings,
     build_wizard_progress_from_facts,
 )
+from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 from .analysis_page import (
     AnalysisPageContent,
@@ -100,6 +102,7 @@ def build_placeholder_wizard_shell(
     footer_text: str = "",
     progress: DockWizardProgress | None = None,
     progress_facts: WizardProgressFacts | None = None,
+    wizard_settings: WizardSettingsSnapshot | None = None,
     specs: Sequence[DockWizardPageSpec] | None = None,
     connection_state: ConnectionPageState | None = None,
     sync_state: SyncPageState | None = None,
@@ -147,6 +150,7 @@ def build_placeholder_wizard_shell(
     resolved_progress = _resolve_progress(
         progress=progress,
         progress_facts=progress_facts,
+        wizard_settings=wizard_settings,
     )
     page_specs = _resolve_page_specs(specs)
     shell = WizardShell(
@@ -209,6 +213,7 @@ def refresh_wizard_shell_composition(
     footer_text: str | None = None,
     progress: DockWizardProgress | None = None,
     progress_facts: WizardProgressFacts | None = None,
+    wizard_settings: WizardSettingsSnapshot | None = None,
 ) -> WizardShellComposition:
     """Refresh installed wizard page state without rebuilding the shell.
 
@@ -276,6 +281,7 @@ def refresh_wizard_shell_composition(
     resolved_progress = _resolve_progress(
         progress=progress,
         progress_facts=progress_facts,
+        wizard_settings=wizard_settings,
     )
     _validate_progress_targets_installed_page(resolved_progress, composition.pages)
 
@@ -387,12 +393,16 @@ def _resolve_progress(
     *,
     progress: DockWizardProgress | None,
     progress_facts: WizardProgressFacts | None,
+    wizard_settings: WizardSettingsSnapshot | None,
 ) -> DockWizardProgress | None:
-    if progress is not None and progress_facts is not None:
-        raise ValueError("Pass progress or progress_facts, not both")
-    if progress_facts is None:
+    if progress is not None and (progress_facts is not None or wizard_settings is not None):
+        raise ValueError("Pass progress or progress_facts/wizard_settings, not both")
+    if progress_facts is None and wizard_settings is None:
         return progress
-    return build_wizard_progress_from_facts(progress_facts)
+    facts = progress_facts or WizardProgressFacts()
+    if wizard_settings is not None:
+        return build_wizard_progress_from_facts_and_settings(facts, wizard_settings)
+    return build_wizard_progress_from_facts(facts)
 
 
 def _page_state_defaults_from_progress_facts(
@@ -622,6 +632,7 @@ __all__ = [
     "WizardActionCallbacks",
     "WizardPageStateSnapshots",
     "WizardProgressFacts",
+    "WizardSettingsSnapshot",
     "WizardShellComposition",
     "build_placeholder_wizard_shell",
     "build_wizard_page_states_from_facts",


### PR DESCRIPTION
## Summary

Adds a wizard-forward settings/progress seam so the future #609 dock can restore a persisted wizard step while still respecting prerequisite-gated workflow facts.

## Changes

- Map persisted wizard step indexes to stable wizard step keys.
- Add a progress builder that combines workflow facts with existing wizard settings.
- Let wizard shell composition build/refresh paths accept wizard settings alongside progress facts.
- Cover first-launch behavior, explicit preferred-step precedence, and composition refresh/build restoration paths.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
