### PR TITLE
feat: derive wizard progress facts from runtime

### DIFF
--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -1,8 +1,10 @@
 import unittest
 
+from qfit.ui.application.dock_runtime_state import DockRuntimeLayers, DockRuntimeState
 from qfit.ui.application.dock_workflow_sections import build_progress_wizard_step_statuses
 from qfit.ui.application.wizard_progress import (
     WizardProgressFacts,
+    build_wizard_progress_facts_from_runtime_state,
     build_wizard_progress_from_facts,
     build_wizard_progress_from_facts_and_settings,
 )
@@ -10,6 +12,48 @@ from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 
 class WizardProgressFactsTests(unittest.TestCase):
+    def test_runtime_state_adapter_defaults_to_no_completed_workflow_facts(self):
+        facts = build_wizard_progress_facts_from_runtime_state(DockRuntimeState())
+
+        self.assertEqual(facts, WizardProgressFacts())
+
+    def test_runtime_state_adapter_maps_persisted_and_loaded_workflow_facts(self):
+        activities_layer = object()
+        analysis_layer = object()
+        state = DockRuntimeState(
+            output_path="/tmp/qfit.gpkg",
+            layers=DockRuntimeLayers(
+                activities=activities_layer,
+                analysis=analysis_layer,
+            ),
+        )
+
+        facts = build_wizard_progress_facts_from_runtime_state(
+            state,
+            connection_configured=True,
+            atlas_exported=True,
+            preferred_current_key="atlas",
+        )
+
+        self.assertEqual(
+            facts,
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                atlas_exported=True,
+                preferred_current_key="atlas",
+            ),
+        )
+
+    def test_runtime_state_adapter_treats_blank_output_path_as_not_stored(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path="   ")
+        )
+
+        self.assertFalse(facts.activities_stored)
+
     def test_defaults_keep_connection_current_with_no_completed_steps(self):
         progress = build_wizard_progress_from_facts(WizardProgressFacts())
 

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -71,6 +71,7 @@ from .wizard_settings import (
 )
 from .wizard_progress import (
     WizardProgressFacts,
+    build_wizard_progress_facts_from_runtime_state,
     build_wizard_progress_from_facts,
     build_wizard_progress_from_facts_and_settings,
 )
@@ -130,6 +131,7 @@ __all__ = [
     "build_progress_wizard_step_statuses",
     "build_stepper_items",
     "build_stepper_states",
+    "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts",
     "build_wizard_progress_from_facts_and_settings",
     "build_wizard_step_statuses",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -143,13 +143,13 @@ def _workflow_keys() -> tuple[str, ...]:
     return tuple(section.key for section in WIZARD_WORKFLOW_STEPS)
 
 
+def _has_output_path(state: DockRuntimeState) -> bool:
+    return bool((state.output_path or "").strip())
+
+
 __all__ = [
     "WizardProgressFacts",
     "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts_and_settings",
     "build_wizard_progress_from_facts",
 ]
-
-
-def _has_output_path(state: DockRuntimeState) -> bool:
-    return bool((state.output_path or "").strip())

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .dock_runtime_state import DockRuntimeState
 from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
 from .wizard_settings import (
     WizardSettingsSnapshot,
@@ -24,6 +25,32 @@ class WizardProgressFacts:
     analysis_generated: bool = False
     atlas_exported: bool = False
     preferred_current_key: str | None = None
+
+
+def build_wizard_progress_facts_from_runtime_state(
+    state: DockRuntimeState,
+    *,
+    connection_configured: bool = False,
+    atlas_exported: bool = False,
+    preferred_current_key: str | None = None,
+) -> WizardProgressFacts:
+    """Derive #609 wizard progress facts from the dock runtime snapshot.
+
+    The future wizard dock needs a small, render-neutral adapter from the real
+    workflow state into ``WizardProgressFacts``. Keep connection and atlas
+    completion explicit because they live outside the current runtime snapshot:
+    connection is persisted in configuration settings, and atlas exports do not
+    yet retain a durable output artifact after the task completes.
+    """
+
+    return WizardProgressFacts(
+        connection_configured=connection_configured,
+        activities_stored=_has_output_path(state),
+        activity_layers_loaded=state.activities_layer is not None,
+        analysis_generated=state.analysis_layer is not None,
+        atlas_exported=atlas_exported,
+        preferred_current_key=preferred_current_key,
+    )
 
 
 def build_wizard_progress_from_facts(facts: WizardProgressFacts) -> DockWizardProgress:
@@ -118,6 +145,11 @@ def _workflow_keys() -> tuple[str, ...]:
 
 __all__ = [
     "WizardProgressFacts",
+    "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts_and_settings",
     "build_wizard_progress_from_facts",
 ]
+
+
+def _has_output_path(state: DockRuntimeState) -> bool:
+    return bool((state.output_path or "").strip())


### PR DESCRIPTION
## Summary

Adds a render-neutral adapter that derives `WizardProgressFacts` from the dock runtime snapshot, giving the future #609 wizard shell a safe refresh input without reading long-scroll widget state.

## Changes

- Added `build_wizard_progress_facts_from_runtime_state()` for runtime-to-wizard progress derivation.
- Kept connection and atlas completion explicit because those facts are outside the current runtime snapshot.
- Exported the helper from `qfit.ui.application`.
- Added unit coverage for default, loaded, completed, preferred-step, and blank-output-path cases.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
