### PR TITLE
feat: refresh wizard shell from dock runtime

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -194,6 +194,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
         )
 
+    def _mark_atlas_export_stale(self) -> None:
+        self._atlas_export_completed = False
+
     def _runtime_store(self) -> DockRuntimeStore:
         store = getattr(self, "_runtime_state_store", None)
         if store is None:
@@ -848,6 +851,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self._runtime_store().finish_store(output_path=result.output_path)
+        self._mark_atlas_export_stale()
         self._update_stored_activities_summary(result.total_stored)
         self._set_status(result.status)
 
@@ -877,6 +881,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             points_layer=result.points_layer,
             atlas_layer=result.atlas_layer,
         )
+        self._mark_atlas_export_stale()
 
         self._populate_activity_types_from_layer()
         visual_status = self._apply_visual_configuration(apply_subset_filters=False)
@@ -926,6 +931,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._runtime_store().reset_loaded_dataset()
         self._clear_analysis_layer()
+        self._mark_atlas_export_stale()
 
         self._update_cleared_activities_summary()
         self._set_status(result.status)
@@ -1048,6 +1054,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
 
     def _clear_analysis_layer(self):
+        self._mark_atlas_export_stale()
         project = QgsProject.instance()
         if self.analysis_layer is not None:
             try:
@@ -1267,7 +1274,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._set_atlas_export_running(False)
 
         result = self.atlas_export_use_case.finish_export(output_path, error, cancelled, page_count)
-        if not result.cancelled and result.error is None and getattr(result, "output_path", None):
+        if not result.cancelled and result.error is None and result.output_path:
             self._atlas_export_completed = True
         self._set_atlas_pdf_status(result.pdf_status)
         self._set_status(result.main_status)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -81,7 +81,9 @@ from .ui.application import (
     RunAnalysisAction,
     build_dock_summary_status,
     build_visual_layer_refs,
+    build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
+    load_wizard_settings,
     build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
@@ -133,6 +135,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         super().__init__(parent)
         self.iface = iface
         self._runtime_state_store = DockRuntimeStore()
+        self._atlas_export_completed = False
         self._dependencies = dependencies or build_dockwidget_dependencies(iface)
         self._bind_dependencies(self._dependencies)
         self.setupUi(self)
@@ -155,6 +158,41 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         """Persist first-launch wizard defaults for the #609 dock migration."""
 
         return ensure_wizard_settings(self.settings)
+
+    def _current_wizard_progress_facts(self):
+        """Return render-neutral #609 wizard facts from the live dock state."""
+
+        return build_wizard_progress_facts_from_runtime_state(
+            self.runtime_state,
+            connection_configured=self._has_configured_strava_connection(),
+            atlas_exported=bool(getattr(self, "_atlas_export_completed", False)),
+        )
+
+    def _refresh_wizard_shell_from_runtime(self):
+        """Refresh an optional #609 wizard shell composition from dock runtime facts."""
+
+        composition = getattr(self, "_wizard_shell_composition", None)
+        if composition is None:
+            return None
+
+        from .ui.dockwidget.wizard_composition import refresh_wizard_shell_composition
+
+        self._wizard_shell_composition = refresh_wizard_shell_composition(
+            composition,
+            progress_facts=self._current_wizard_progress_facts(),
+            wizard_settings=load_wizard_settings(self.settings),
+        )
+        return self._wizard_shell_composition
+
+    def _has_configured_strava_connection(self) -> bool:
+        return all(
+            self._widget_text(name).strip()
+            for name in (
+                "clientIdLineEdit",
+                "clientSecretLineEdit",
+                "refreshTokenLineEdit",
+            )
+        )
 
     def _runtime_store(self) -> DockRuntimeStore:
         store = getattr(self, "_runtime_state_store", None)
@@ -1229,6 +1267,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._set_atlas_export_running(False)
 
         result = self.atlas_export_use_case.finish_export(output_path, error, cancelled, page_count)
+        if not result.cancelled and result.error is None and getattr(result, "output_path", None):
+            self._atlas_export_completed = True
         self._set_atlas_pdf_status(result.pdf_status)
         self._set_status(result.main_status)
         if result.error is not None and not result.cancelled:
@@ -1245,23 +1285,25 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _refresh_summary_status(self) -> None:
         label = getattr(self, "summaryStatusLabel", None)
-        if label is None:
-            return
-
-        label.setText(
-            build_dock_summary_status(
-                connection_status=self._label_text("connectionStatusLabel"),
-                activity_summary=self._label_text("countLabel"),
-                query_summary=self._label_text("querySummaryLabel"),
-                workflow_status=self._label_text("statusLabel"),
+        if label is not None:
+            label.setText(
+                build_dock_summary_status(
+                    connection_status=self._label_text("connectionStatusLabel"),
+                    activity_summary=self._label_text("countLabel"),
+                    query_summary=self._label_text("querySummaryLabel"),
+                    workflow_status=self._label_text("statusLabel"),
+                )
             )
-        )
+        self._refresh_wizard_shell_from_runtime()
 
     def _label_text(self, name: str) -> str:
-        label = getattr(self, name, None)
-        if label is None:
+        return self._widget_text(name)
+
+    def _widget_text(self, name: str) -> str:
+        widget = getattr(self, name, None)
+        if widget is None:
             return ""
-        text = getattr(label, "text", "")
+        text = getattr(widget, "text", "")
         if callable(text):
             return text()
         return text or ""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -356,6 +356,82 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         dock.project_hygiene_service.remove_stale_qfit_layers.assert_called_once_with()
 
+    def test_current_wizard_progress_facts_reads_live_dock_runtime(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock._atlas_export_completed = True
+
+        dock._runtime_store().load_dataset(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer=object(),
+            starts_layer=object(),
+            points_layer=object(),
+            atlas_layer=object(),
+        )
+        dock._runtime_store().set_analysis_layer(object())
+
+        facts = self.module.QfitDockWidget._current_wizard_progress_facts(dock)
+
+        self.assertTrue(facts.connection_configured)
+        self.assertTrue(facts.activities_stored)
+        self.assertTrue(facts.activity_layers_loaded)
+        self.assertTrue(facts.analysis_generated)
+        self.assertTrue(facts.atlas_exported)
+
+    def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock.settings = _FakeSettings(
+            {
+                "ui/wizard_version": 1,
+                "ui/last_step_index": 1,
+            }
+        )
+        composition = object()
+        dock._wizard_shell_composition = composition
+        fake_wizard_composition = ModuleType("qfit.ui.dockwidget.wizard_composition")
+        fake_wizard_composition.refresh_wizard_shell_composition = MagicMock(
+            return_value="refreshed"
+        )
+
+        with patch.dict(
+            sys.modules,
+            {"qfit.ui.dockwidget.wizard_composition": fake_wizard_composition},
+        ):
+            refreshed = self.module.QfitDockWidget._refresh_wizard_shell_from_runtime(dock)
+
+        self.assertEqual(refreshed, "refreshed")
+        self.assertEqual(dock._wizard_shell_composition, "refreshed")
+        fake_wizard_composition.refresh_wizard_shell_composition.assert_called_once()
+        args, kwargs = fake_wizard_composition.refresh_wizard_shell_composition.call_args
+        self.assertEqual(args, (composition,))
+        self.assertTrue(kwargs["progress_facts"].connection_configured)
+        self.assertEqual(kwargs["wizard_settings"].last_step_index, 1)
+        self.assertFalse(kwargs["wizard_settings"].first_launch)
+
+    def test_refresh_summary_status_notifies_optional_wizard_shell_refresh(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.summaryStatusLabel = _FakeLabel("")
+        dock.connectionStatusLabel = _FakeLabel("Strava connection: ready")
+        dock.countLabel = _FakeLabel("12 activities")
+        dock.querySummaryLabel = _FakeLabel("filtered")
+        dock.statusLabel = _FakeLabel("Ready")
+        dock._refresh_wizard_shell_from_runtime = MagicMock()
+
+        self.module.QfitDockWidget._refresh_summary_status(dock)
+
+        self.assertEqual(
+            dock.summaryStatusLabel.text(),
+            "Strava connection: ready · 12 activities · filtered · Ready",
+        )
+        dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
+
     def test_on_apply_filters_clicked_dispatches_apply_visualization_action(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._dispatch_dock_action = MagicMock()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1021,11 +1021,13 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             {"one": stale_layer, "two": _FakeLayer("other"), "three": stale_heatmap_layer}
         )
         dock.analysis_layer = current_layer
+        dock._atlas_export_completed = True
 
         with patch.object(self.module.QgsProject, "instance", return_value=project):
             self.module.QfitDockWidget._clear_analysis_layer(dock)
 
         self.assertIsNone(dock.analysis_layer)
+        self.assertFalse(dock._atlas_export_completed)
         self.assertEqual(
             project.removed,
             [current_layer.id(), stale_layer.id(), stale_heatmap_layer.id()],
@@ -1084,6 +1086,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.countLabel = _FakeLabel("")
         dock._update_stored_activities_summary = MagicMock()
         dock._set_status = MagicMock()
+        dock._atlas_export_completed = True
         result = SimpleNamespace(output_path="/tmp/qfit.gpkg", total_stored=12, status="Stored 12 activities")
 
         self.module.QfitDockWidget._handle_store_task_finished(dock, result, None, False)
@@ -1092,6 +1095,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(dock.loadButton.isEnabled())
         self.assertEqual(dock.loadButton.text(), "Store activities")
         self.assertEqual(dock.output_path, "/tmp/qfit.gpkg")
+        self.assertFalse(dock._atlas_export_completed)
         dock._update_stored_activities_summary.assert_called_once_with(12)
         dock._set_status.assert_called_once_with("Stored 12 activities")
 
@@ -1159,6 +1163,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._apply_visual_configuration = MagicMock(return_value="Styled layers")
         dock._update_loaded_activities_summary = MagicMock()
         dock._set_status = MagicMock()
+        dock._atlas_export_completed = True
         workflow = MagicMock()
         workflow.build_load_existing_request.return_value = "load-request"
         result = SimpleNamespace(
@@ -1180,6 +1185,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.starts_layer, "starts-layer")
         self.assertEqual(dock.points_layer, "points-layer")
         self.assertEqual(dock.atlas_layer, "atlas-layer")
+        self.assertFalse(dock._atlas_export_completed)
         dock._populate_activity_types_from_layer.assert_called_once_with()
         dock._apply_visual_configuration.assert_called_once_with(apply_subset_filters=False)
         dock._update_loaded_activities_summary.assert_called_once_with(12)
@@ -1327,6 +1333,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._show_error = MagicMock()
         dock.atlas_export_use_case = MagicMock()
         dock.atlas_export_use_case.finish_export.return_value = SimpleNamespace(
+            output_path="/tmp/qfit-atlas.pdf",
             pdf_status="Atlas PDF ready",
             main_status="Atlas created",
             error=None,
@@ -1342,6 +1349,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
 
         self.assertIsNone(dock._atlas_export_task)
+        self.assertTrue(dock._atlas_export_completed)
         dock._set_atlas_export_running.assert_called_once_with(False)
         dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF ready")
         dock._set_status.assert_called_once_with("Atlas created")
@@ -1476,6 +1484,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._update_cleared_activities_summary = MagicMock()
         dock._set_status = MagicMock()
         dock._show_error = MagicMock()
+        dock._atlas_export_completed = True
         dock.load_workflow = MagicMock()
         dock.load_workflow.build_clear_database_request.return_value = "clear-request"
         dock.load_workflow.clear_database_request.return_value = SimpleNamespace(status="Database cleared")
@@ -1493,6 +1502,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.activities, [])
         self.assertIsNone(dock.activities_layer)
         self.assertIsNone(dock.output_path)
+        self.assertFalse(dock._atlas_export_completed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add a dock-level runtime refresh seam for the future #609 wizard shell so an installed wizard composition can be updated from the live dock runtime, persisted wizard settings, and Strava connection fields without binding the placeholder shell to the long-scroll dock.

## Changes

- derive current wizard progress facts from `QfitDockWidget` runtime state and configured connection fields
- refresh an optional `_wizard_shell_composition` from those facts plus persisted wizard settings
- track successful atlas PDF export completion as a wizard progress fact
- keep the existing summary-status refresh path as the trigger for optional wizard refreshes
- cover the new dock-level seams with pure unit tests

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Part of #609 and compatible with #608.