### PR TITLE
feat: add dock wizard composition builder

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -84,6 +84,7 @@ from .ui.application import (
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     load_wizard_settings,
+    save_last_step_index,
     build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
@@ -159,6 +160,26 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         return ensure_wizard_settings(self.settings)
 
+    def _persist_wizard_step_index(self, index: int) -> int:
+        """Persist the optional #609 wizard shell's current step."""
+
+        return save_last_step_index(self.settings, index)
+
+    def _show_connection_configuration_hint(self) -> None:
+        """Guide wizard users to the dedicated qfit configuration dialog."""
+
+        self._show_info(
+            "Configure qfit connection",
+            "Open qfit → Configuration from the QGIS plugin menu to edit Strava "
+            "credentials, then return to the dock to continue the workflow.",
+        )
+        self._set_status("Open qfit → Configuration to edit Strava credentials.")
+
+    def _run_wizard_sync_step(self) -> None:
+        """Run the storage action that completes the wizard sync milestone."""
+
+        self.on_load_clicked()
+
     def _current_wizard_progress_facts(self):
         """Return render-neutral #609 wizard facts from the live dock state."""
 
@@ -167,6 +188,40 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             connection_configured=self._has_configured_strava_connection(),
             atlas_exported=bool(getattr(self, "_atlas_export_completed", False)),
         )
+
+    def _build_wizard_shell_from_runtime(self, *, parent=None):
+        """Build the optional #609 wizard shell from current dock runtime facts.
+
+        The shell is not installed into the production dock yet; this seam lets
+        the eventual wizard-style dock swap create a live composition with
+        persisted navigation and concrete CTA callbacks without coupling the
+        reusable wizard widgets to ``QfitDockWidget``.
+        """
+
+        from .ui.dockwidget.wizard_composition import (
+            WizardActionCallbacks,
+            build_placeholder_wizard_shell,
+            connect_wizard_action_callbacks,
+        )
+
+        composition = build_placeholder_wizard_shell(
+            parent=self if parent is None else parent,
+            progress_facts=self._current_wizard_progress_facts(),
+            wizard_settings=load_wizard_settings(self.settings),
+            on_current_step_changed=self._persist_wizard_step_index,
+        )
+        self._wizard_shell_composition = connect_wizard_action_callbacks(
+            composition,
+            WizardActionCallbacks(
+                configure_connection=self._show_connection_configuration_hint,
+                sync_activities=self._run_wizard_sync_step,
+                load_activity_layers=self.on_load_layers_clicked,
+                apply_map_filters=self.on_apply_filters_clicked,
+                run_analysis=self.on_run_analysis_clicked,
+                export_atlas=self.on_generate_atlas_pdf_clicked,
+            ),
+        )
+        return self._wizard_shell_composition
 
     def _refresh_wizard_shell_from_runtime(self):
         """Refresh an optional #609 wizard shell composition from dock runtime facts."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -381,6 +381,109 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(facts.analysis_generated)
         self.assertTrue(facts.atlas_exported)
 
+    def test_persist_wizard_step_index_clamps_and_saves_setting(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.settings = _FakeSettings()
+
+        saved_index = self.module.QfitDockWidget._persist_wizard_step_index(dock, 99)
+
+        self.assertEqual(saved_index, 4)
+        self.assertEqual(dock.settings.get("ui/last_step_index"), 4)
+
+    def test_show_connection_configuration_hint_reports_menu_path(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._show_info = MagicMock()
+        dock._set_status = MagicMock()
+
+        self.module.QfitDockWidget._show_connection_configuration_hint(dock)
+
+        dock._show_info.assert_called_once_with(
+            "Configure qfit connection",
+            "Open qfit → Configuration from the QGIS plugin menu to edit Strava "
+            "credentials, then return to the dock to continue the workflow.",
+        )
+        dock._set_status.assert_called_once_with(
+            "Open qfit → Configuration to edit Strava credentials."
+        )
+
+    def test_run_wizard_sync_step_uses_storage_workflow(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.on_load_clicked = MagicMock()
+
+        self.module.QfitDockWidget._run_wizard_sync_step(dock)
+
+        dock.on_load_clicked.assert_called_once_with()
+
+    def test_build_wizard_shell_from_runtime_wires_persistence_and_callbacks(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock._atlas_export_completed = False
+        dock.settings = _FakeSettings(
+            {
+                "ui/wizard_version": 1,
+                "ui/last_step_index": 1,
+            }
+        )
+        parent = object()
+
+        class FakeWizardActionCallbacks(SimpleNamespace):
+            pass
+
+        fake_wizard_composition = ModuleType("qfit.ui.dockwidget.wizard_composition")
+        fake_wizard_composition.WizardActionCallbacks = FakeWizardActionCallbacks
+        fake_wizard_composition.build_placeholder_wizard_shell = MagicMock(
+            return_value="composition"
+        )
+        fake_wizard_composition.connect_wizard_action_callbacks = MagicMock(
+            return_value="connected-composition"
+        )
+
+        with patch.dict(
+            sys.modules,
+            {"qfit.ui.dockwidget.wizard_composition": fake_wizard_composition},
+        ):
+            composition = self.module.QfitDockWidget._build_wizard_shell_from_runtime(
+                dock,
+                parent=parent,
+            )
+
+        self.assertEqual(composition, "connected-composition")
+        self.assertEqual(dock._wizard_shell_composition, "connected-composition")
+        fake_wizard_composition.build_placeholder_wizard_shell.assert_called_once()
+        _args, kwargs = fake_wizard_composition.build_placeholder_wizard_shell.call_args
+        self.assertEqual(kwargs["parent"], parent)
+        self.assertTrue(kwargs["progress_facts"].connection_configured)
+        self.assertEqual(kwargs["wizard_settings"].last_step_index, 1)
+        self.assertFalse(kwargs["wizard_settings"].first_launch)
+        self.assertIs(kwargs["on_current_step_changed"].__self__, dock)
+        self.assertIs(
+            kwargs["on_current_step_changed"].__func__,
+            self.module.QfitDockWidget._persist_wizard_step_index,
+        )
+
+        fake_wizard_composition.connect_wizard_action_callbacks.assert_called_once()
+        connect_args = fake_wizard_composition.connect_wizard_action_callbacks.call_args.args
+        self.assertEqual(connect_args[0], "composition")
+        callbacks = connect_args[1]
+        expected_callbacks = {
+            "configure_connection": "_show_connection_configuration_hint",
+            "sync_activities": "_run_wizard_sync_step",
+            "load_activity_layers": "on_load_layers_clicked",
+            "apply_map_filters": "on_apply_filters_clicked",
+            "run_analysis": "on_run_analysis_clicked",
+            "export_atlas": "on_generate_atlas_pdf_clicked",
+        }
+        for callback_name, method_name in expected_callbacks.items():
+            callback = getattr(callbacks, callback_name)
+            self.assertIs(callback.__self__, dock)
+            self.assertIs(
+                callback.__func__,
+                getattr(self.module.QfitDockWidget, method_name),
+            )
+
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()


### PR DESCRIPTION
## Summary

Adds a dock-level seam for creating the #609 wizard shell from live qfit runtime state without installing it into the current production dock yet.

## Changes

- Add `_build_wizard_shell_from_runtime()` to assemble the wizard composition with current progress facts, persisted wizard settings, and step persistence.
- Wire wizard page CTA callbacks to existing dock actions where safe, with a connection CTA that points users to the dedicated qfit configuration dialog.
- Add tests for wizard-step persistence, connection configuration guidance, and composition/callback wiring.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
