### PR TITLE
fix: gate wizard presenter completion prerequisites

### DIFF
--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -210,6 +210,36 @@ class WizardShellPresenterTest(unittest.TestCase):
         self.assertEqual(presenter.progress.current_key, "connection")
         self.assertEqual(shell.pages_stack.currentIndex(), 0)
 
+    def test_rejects_completion_before_prerequisites_are_done(self):
+        shell = self._build_shell_with_pages()
+        presenter = self.presenter.WizardShellPresenter(shell)
+
+        with self.assertRaises(ValueError):
+            presenter.mark_step_done("map")
+
+        self.assertEqual(presenter.progress.completed_keys, frozenset())
+        self.assertEqual(shell.pages_stack.currentIndex(), 0)
+        self.assertEqual(
+            shell.stepper_bar.states(),
+            ("current", "locked", "locked", "locked", "locked"),
+        )
+
+    def test_allows_completion_when_prerequisites_are_done(self):
+        shell = self._build_shell_with_pages()
+        presenter = self.presenter.WizardShellPresenter(shell)
+
+        presenter.mark_step_done("connection")
+        presenter.mark_step_done("sync")
+
+        self.assertEqual(
+            presenter.progress.completed_keys,
+            frozenset({"connection", "sync"}),
+        )
+        self.assertEqual(
+            shell.stepper_bar.states(),
+            ("current", "done", "upcoming", "locked", "locked"),
+        )
+
     def test_rejects_unknown_completed_step_key(self):
         shell = self._build_shell_with_pages()
         presenter = self.presenter.WizardShellPresenter(shell)

--- a/ui/dockwidget/wizard_shell_presenter.py
+++ b/ui/dockwidget/wizard_shell_presenter.py
@@ -83,9 +83,19 @@ class WizardShellPresenter:
         return True
 
     def mark_step_done(self, key: str) -> None:
-        """Record real workflow completion for ``key`` and refresh the shell."""
+        """Record real workflow completion for ``key`` and refresh the shell.
 
-        step_index_for_key(key)
+        Completion remains prerequisite-aware: downstream milestones cannot be
+        marked done until every earlier wizard step has actually completed.
+        """
+
+        missing_prerequisites = _missing_completion_prerequisites(
+            key,
+            completed_keys=self._progress.completed_keys,
+        )
+        if missing_prerequisites:
+            missing = ", ".join(missing_prerequisites)
+            raise ValueError(f"Cannot mark {key!r} done before {missing}")
         self._progress = DockWizardProgress(
             current_key=self._progress.current_key,
             completed_keys=self._progress.completed_keys | {key},
@@ -115,6 +125,22 @@ class WizardShellPresenter:
         if self._page_indices_by_key is None:
             return step_index_for_key(key)
         return self._page_indices_by_key.get(key)
+
+
+def _missing_completion_prerequisites(
+    key: str,
+    *,
+    completed_keys: frozenset[str],
+) -> tuple[str, ...]:
+    target_index = step_index_for_key(key)
+    prerequisite_keys = tuple(
+        step_key_for_index(index) for index in range(target_index)
+    )
+    return tuple(
+        prerequisite_key
+        for prerequisite_key in prerequisite_keys
+        if prerequisite_key not in completed_keys
+    )
 
 
 __all__ = ["WizardShellPresenter"]


### PR DESCRIPTION
## Summary

- Make the reusable wizard shell presenter reject downstream completion before earlier wizard milestones are done.
- Preserve the existing distinction between reachable/upcoming pages and truly completed workflow steps.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Part of #609 / #608.
