### PR TITLE
feat: show runtime sync summary in wizard facts

### DIFF
--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -21,6 +21,7 @@ class WizardProgressFactsTests(unittest.TestCase):
         activities_layer = object()
         analysis_layer = object()
         state = DockRuntimeState(
+            activities=(object(), object()),
             output_path="/tmp/qfit.gpkg",
             layers=DockRuntimeLayers(
                 activities=activities_layer,
@@ -44,6 +45,7 @@ class WizardProgressFactsTests(unittest.TestCase):
                 analysis_generated=True,
                 atlas_exported=True,
                 preferred_current_key="atlas",
+                output_name="qfit.gpkg",
             ),
         )
 
@@ -53,6 +55,39 @@ class WizardProgressFactsTests(unittest.TestCase):
         )
 
         self.assertFalse(facts.activities_stored)
+
+    def test_runtime_state_adapter_keeps_unknown_activity_count_for_loaded_file(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path="/tmp/qfit.gpkg")
+        )
+
+        self.assertIsNone(facts.activity_count)
+        self.assertEqual(facts.output_name, "qfit.gpkg")
+
+    def test_runtime_state_adapter_does_not_treat_fetch_count_as_stored_count(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(
+                activities=(object(), object(), object()),
+                output_path="/tmp/qfit.gpkg",
+            )
+        )
+
+        self.assertIsNone(facts.activity_count)
+        self.assertEqual(facts.output_name, "qfit.gpkg")
+
+    def test_runtime_state_adapter_normalises_windows_output_filename(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path="C:\\Users\\Emman\\qfit.gpkg")
+        )
+
+        self.assertEqual(facts.output_name, "qfit.gpkg")
+
+    def test_runtime_state_adapter_normalises_escaped_windows_output_filename(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path=r"C:\\Users\\Emman\\qfit.gpkg")
+        )
+
+        self.assertEqual(facts.output_name, "qfit.gpkg")
 
     def test_defaults_keep_connection_current_with_no_completed_steps(self):
         progress = build_wizard_progress_from_facts(WizardProgressFacts())

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -270,6 +270,51 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.presenter.progress.current_key, "connection")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
 
+    def test_sync_page_summary_uses_runtime_activity_count_and_output_name(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_count=12,
+            output_name="qfit.gpkg",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "12 activities stored in qfit.gpkg",
+        )
+        self.assertIn("12 activities stored in qfit.gpkg", assembled.shell.footer_bar.text())
+
+    def test_sync_page_summary_uses_singular_activity_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_count=1,
+            output_name="qfit.gpkg",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "1 activity stored in qfit.gpkg",
+        )
+
+    def test_sync_page_summary_omits_unknown_activity_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            output_name="qfit.gpkg",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "Activities stored in qfit.gpkg",
+        )
+
     def test_progress_facts_drive_page_cta_prerequisites_without_marking_done(self):
         facts = self.composition.WizardProgressFacts(connection_configured=True)
 

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
 
 from .dock_runtime_state import DockRuntimeState
 from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
@@ -25,6 +26,8 @@ class WizardProgressFacts:
     analysis_generated: bool = False
     atlas_exported: bool = False
     preferred_current_key: str | None = None
+    activity_count: int | None = None
+    output_name: str | None = None
 
 
 def build_wizard_progress_facts_from_runtime_state(
@@ -40,9 +43,12 @@ def build_wizard_progress_facts_from_runtime_state(
     workflow state into ``WizardProgressFacts``. Keep connection and atlas
     completion explicit because they live outside the current runtime snapshot:
     connection is persisted in configuration settings, and atlas exports do not
-    yet retain a durable output artifact after the task completes.
+    yet retain a durable output artifact after the task completes. The runtime
+    ``activities`` tuple is a fetch payload, not a persisted dataset count, so
+    this adapter deliberately leaves ``activity_count`` unknown.
     """
 
+    output_name = _output_name(state.output_path)
     return WizardProgressFacts(
         connection_configured=connection_configured,
         activities_stored=_has_output_path(state),
@@ -50,6 +56,8 @@ def build_wizard_progress_facts_from_runtime_state(
         analysis_generated=state.analysis_layer is not None,
         atlas_exported=atlas_exported,
         preferred_current_key=preferred_current_key,
+        activity_count=None,
+        output_name=output_name,
     )
 
 
@@ -95,6 +103,8 @@ def build_wizard_progress_from_facts_and_settings(
             analysis_generated=facts.analysis_generated,
             atlas_exported=facts.atlas_exported,
             preferred_current_key=preferred_current_key_from_settings(settings),
+            activity_count=facts.activity_count,
+            output_name=facts.output_name,
         )
     )
 
@@ -145,6 +155,15 @@ def _workflow_keys() -> tuple[str, ...]:
 
 def _has_output_path(state: DockRuntimeState) -> bool:
     return bool((state.output_path or "").strip())
+
+
+def _output_name(output_path: str | None) -> str | None:
+    stripped = (output_path or "").strip()
+    if not stripped:
+        return None
+    if "\\" in stripped:
+        return PureWindowsPath(stripped).name or stripped
+    return Path(stripped).name or stripped
 
 
 __all__ = [

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -422,6 +422,8 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         analysis_generated="analysis" in completed,
         atlas_exported="atlas" in completed,
         preferred_current_key=facts.preferred_current_key,
+        activity_count=facts.activity_count,
+        output_name=facts.output_name,
     )
 
 
@@ -449,12 +451,24 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
             else default.detail_text
         ),
         activity_summary_text=(
-            "Activities stored in GeoPackage"
+            _stored_activity_summary(facts)
             if facts.activities_stored
             else default.activity_summary_text
         ),
         primary_action_enabled=facts.connection_configured,
     )
+
+
+def _stored_activity_summary(facts: WizardProgressFacts) -> str:
+    if facts.activity_count is None and facts.output_name is None:
+        return "Activities stored in GeoPackage"
+    if facts.activity_count is None:
+        activity_summary = "Activities"
+    else:
+        noun = "activity" if facts.activity_count == 1 else "activities"
+        activity_summary = f"{max(facts.activity_count, 0)} {noun}"
+    output_summary = facts.output_name or "GeoPackage"
+    return f"{activity_summary} stored in {output_summary}"
 
 
 def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:


### PR DESCRIPTION
## Summary

- Carry the GeoPackage filename through wizard progress facts derived from live dock runtime state.
- Support optional activity counts in wizard sync summaries when a trustworthy count is provided, while avoiding misleading fetched/live-session counts for persisted files.
- Normalize Windows-style output paths to filenames before presenting them in wizard copy.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Part of #609 / #608.
