### PR TITLE
feat: reflect busy wizard workflow actions

### DIFF
--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -77,7 +77,7 @@ class AtlasPageContentTest(unittest.TestCase):
             content.export_atlas_button.property("wizardActionAvailability"),
             "blocked",
         )
-        self.assertIn("Select atlas inputs", content.export_atlas_button.toolTip())
+        self.assertIn("Run analysis", content.export_atlas_button.toolTip())
         self.assertEqual(content.action_row.objectName(), "qfitWizardAtlasActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -1,6 +1,10 @@
 import unittest
 
-from qfit.ui.application.dock_runtime_state import DockRuntimeLayers, DockRuntimeState
+from qfit.ui.application.dock_runtime_state import (
+    DockRuntimeLayers,
+    DockRuntimeState,
+    DockRuntimeTasks,
+)
 from qfit.ui.application.dock_workflow_sections import build_progress_wizard_step_statuses
 from qfit.ui.application.wizard_progress import (
     WizardProgressFacts,
@@ -48,6 +52,24 @@ class WizardProgressFactsTests(unittest.TestCase):
                 output_name="qfit.gpkg",
             ),
         )
+
+    def test_runtime_state_adapter_maps_running_workflow_tasks(self):
+        cases = (
+            DockRuntimeTasks(fetch="fetch"),
+            DockRuntimeTasks(store="store"),
+            DockRuntimeTasks(fetch="fetch", store="store", atlas_export="atlas"),
+        )
+        for tasks in cases:
+            with self.subTest(tasks=tasks):
+                state = DockRuntimeState(tasks=tasks)
+
+                facts = build_wizard_progress_facts_from_runtime_state(state)
+
+                self.assertTrue(facts.sync_in_progress)
+                self.assertEqual(
+                    facts.atlas_export_in_progress,
+                    tasks.atlas_export is not None,
+                )
 
     def test_runtime_state_adapter_treats_blank_output_path_as_not_stored(self):
         facts = build_wizard_progress_facts_from_runtime_state(

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -340,6 +340,41 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertFalse(assembled.analysis_content.run_analysis_button.isEnabled())
         self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
+        self.assertEqual(
+            assembled.atlas_content.export_atlas_button.toolTip(),
+            "Run analysis before exporting atlas PDF.",
+        )
+
+    def test_progress_facts_disable_busy_sync_and_atlas_ctas(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                sync_in_progress=True,
+                atlas_export_in_progress=True,
+            )
+        )
+
+        self.assertEqual(
+            assembled.sync_content.status_label.text(),
+            "Synchronization in progress",
+        )
+        self.assertFalse(assembled.sync_content.sync_button.isEnabled())
+        self.assertEqual(
+            assembled.sync_content.sync_button.toolTip(),
+            "Wait for the current synchronization to finish.",
+        )
+        self.assertEqual(
+            assembled.atlas_content.status_label.text(),
+            "Atlas export in progress",
+        )
+        self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
+        self.assertEqual(
+            assembled.atlas_content.export_atlas_button.toolTip(),
+            "Wait for the current atlas export to finish.",
+        )
 
     def test_explicit_page_state_overrides_progress_fact_defaults(self):
         assembled = self.composition.build_placeholder_wizard_shell(

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -25,6 +25,8 @@ class WizardProgressFacts:
     activity_layers_loaded: bool = False
     analysis_generated: bool = False
     atlas_exported: bool = False
+    sync_in_progress: bool = False
+    atlas_export_in_progress: bool = False
     preferred_current_key: str | None = None
     activity_count: int | None = None
     output_name: str | None = None
@@ -55,6 +57,8 @@ def build_wizard_progress_facts_from_runtime_state(
         activity_layers_loaded=state.activities_layer is not None,
         analysis_generated=state.analysis_layer is not None,
         atlas_exported=atlas_exported,
+        sync_in_progress=_has_sync_task(state),
+        atlas_export_in_progress=state.atlas_export_task is not None,
         preferred_current_key=preferred_current_key,
         activity_count=None,
         output_name=output_name,
@@ -102,6 +106,8 @@ def build_wizard_progress_from_facts_and_settings(
             activity_layers_loaded=facts.activity_layers_loaded,
             analysis_generated=facts.analysis_generated,
             atlas_exported=facts.atlas_exported,
+            sync_in_progress=facts.sync_in_progress,
+            atlas_export_in_progress=facts.atlas_export_in_progress,
             preferred_current_key=preferred_current_key_from_settings(settings),
             activity_count=facts.activity_count,
             output_name=facts.output_name,
@@ -155,6 +161,10 @@ def _workflow_keys() -> tuple[str, ...]:
 
 def _has_output_path(state: DockRuntimeState) -> bool:
     return bool((state.output_path or "").strip())
+
+
+def _has_sync_task(state: DockRuntimeState) -> bool:
+    return state.fetch_task is not None or state.store_task is not None
 
 
 def _output_name(output_path: str | None) -> str | None:

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -44,7 +44,7 @@ class AtlasPageState:
     output_summary_text: str = "PDF output path will be chosen before generation"
     primary_action_label: str = "Export atlas PDF"
     primary_action_enabled: bool | None = None
-    primary_action_blocked_tooltip: str = "Select atlas inputs before exporting PDF."
+    primary_action_blocked_tooltip: str = "Run analysis before exporting atlas PDF."
 
 
 class AtlasPageContent(QWidget):

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -421,6 +421,8 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         activity_layers_loaded="map" in completed,
         analysis_generated="analysis" in completed,
         atlas_exported="atlas" in completed,
+        sync_in_progress=facts.sync_in_progress,
+        atlas_export_in_progress=facts.atlas_export_in_progress,
         preferred_current_key=facts.preferred_current_key,
         activity_count=facts.activity_count,
         output_name=facts.output_name,
@@ -442,20 +444,29 @@ def _connection_state_from_facts(facts: WizardProgressFacts) -> ConnectionPageSt
 
 def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
     default = SyncPageState()
+    status_text = default.status_text
+    detail_text = default.detail_text
+    sync_blocked_tooltip = default.primary_action_blocked_tooltip
+    if facts.activities_stored:
+        status_text = "Activities stored"
+        detail_text = "Stored activities are ready for map loading."
+    if facts.sync_in_progress:
+        status_text = "Synchronization in progress"
+        detail_text = (
+            "Wait for the current synchronization to finish before starting another sync."
+        )
+        sync_blocked_tooltip = "Wait for the current synchronization to finish."
     return SyncPageState(
         ready=facts.activities_stored,
-        status_text="Activities stored" if facts.activities_stored else default.status_text,
-        detail_text=(
-            "Stored activities are ready for map loading."
-            if facts.activities_stored
-            else default.detail_text
-        ),
+        status_text=status_text,
+        detail_text=detail_text,
         activity_summary_text=(
             _stored_activity_summary(facts)
             if facts.activities_stored
             else default.activity_summary_text
         ),
-        primary_action_enabled=facts.connection_configured,
+        primary_action_enabled=facts.connection_configured and not facts.sync_in_progress,
+        primary_action_blocked_tooltip=sync_blocked_tooltip,
     )
 
 
@@ -509,20 +520,29 @@ def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:
 
 def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
     default = AtlasPageState()
+    status_text = default.status_text
+    output_summary_text = default.output_summary_text
+    atlas_blocked_tooltip = default.primary_action_blocked_tooltip
+    if facts.atlas_exported:
+        status_text = "Atlas PDF exported"
+        output_summary_text = "Latest atlas PDF has been exported"
+    if facts.atlas_export_in_progress:
+        status_text = "Atlas export in progress"
+        output_summary_text = "PDF export is running."
+        atlas_blocked_tooltip = "Wait for the current atlas export to finish."
     return AtlasPageState(
         ready=facts.atlas_exported,
-        status_text="Atlas PDF exported" if facts.atlas_exported else default.status_text,
+        status_text=status_text,
         input_summary_text=(
             "Analysis outputs ready for atlas export"
             if facts.analysis_generated
             else default.input_summary_text
         ),
-        output_summary_text=(
-            "Latest atlas PDF has been exported"
-            if facts.atlas_exported
-            else default.output_summary_text
+        output_summary_text=output_summary_text,
+        primary_action_enabled=(
+            facts.analysis_generated and not facts.atlas_export_in_progress
         ),
-        primary_action_enabled=facts.analysis_generated,
+        primary_action_blocked_tooltip=atlas_blocked_tooltip,
     )
 
 


### PR DESCRIPTION
## Summary

Adds runtime task facts to the #609 wizard progress adapter so the future wizard shell can reflect active sync and atlas export work without enabling duplicate CTAs.

## Changes

- Adds `sync_in_progress` and `atlas_export_in_progress` to `WizardProgressFacts`.
- Maps fetch/store and atlas-export tasks from `DockRuntimeState` into wizard progress facts.
- Disables busy wizard CTAs with explicit status text and blocked tooltips.
- Covers the runtime adapter and page-state rendering in tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Closes #609.
