### PR TITLE
feat: show busy sync summary in wizard

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -361,6 +361,11 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.sync_content.status_label.text(),
             "Synchronization in progress",
         )
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "Updating stored activities",
+        )
+        self.assertIn("Updating stored activities", assembled.shell.footer_bar.text())
         self.assertFalse(assembled.sync_content.sync_button.isEnabled())
         self.assertEqual(
             assembled.sync_content.sync_button.toolTip(),
@@ -375,6 +380,36 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.atlas_content.export_atlas_button.toolTip(),
             "Wait for the current atlas export to finish.",
         )
+
+    def test_busy_sync_summary_uses_output_name_when_available(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                sync_in_progress=True,
+                output_name="qfit.gpkg",
+            )
+        )
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "Updating activities in qfit.gpkg",
+        )
+        self.assertIn("Updating activities in qfit.gpkg", assembled.shell.footer_bar.text())
+
+    def test_busy_sync_without_stored_activities_replaces_empty_summary(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                sync_in_progress=True,
+            )
+        )
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "Synchronization in progress",
+        )
+        self.assertIn("Synchronization in progress", assembled.shell.footer_bar.text())
 
     def test_explicit_page_state_overrides_progress_fact_defaults(self):
         assembled = self.composition.build_placeholder_wizard_shell(

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -460,14 +460,29 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
         ready=facts.activities_stored,
         status_text=status_text,
         detail_text=detail_text,
-        activity_summary_text=(
-            _stored_activity_summary(facts)
-            if facts.activities_stored
-            else default.activity_summary_text
-        ),
+        activity_summary_text=_sync_activity_summary(facts, default),
         primary_action_enabled=facts.connection_configured and not facts.sync_in_progress,
         primary_action_blocked_tooltip=sync_blocked_tooltip,
     )
+
+
+def _sync_activity_summary(
+    facts: WizardProgressFacts,
+    default: SyncPageState,
+) -> str:
+    if facts.sync_in_progress:
+        return _sync_in_progress_summary(facts)
+    if facts.activities_stored:
+        return _stored_activity_summary(facts)
+    return default.activity_summary_text
+
+
+def _sync_in_progress_summary(facts: WizardProgressFacts) -> str:
+    if not facts.activities_stored:
+        return "Synchronization in progress"
+    if facts.output_name is None:
+        return "Updating stored activities"
+    return f"Updating activities in {facts.output_name}"
 
 
 def _stored_activity_summary(facts: WizardProgressFacts) -> str:


### PR DESCRIPTION
## Summary

Keep the #609 wizard footer/status area honest while synchronization or storage is actively running.

## Changes

- Derive a busy synchronization activity summary from wizard runtime facts.
- Show `Synchronization in progress`, `Updating stored activities`, or `Updating activities in <file>` in the sync page and footer depending on available facts.
- Cover busy sync summaries with wizard shell composition tests.

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
