### PR TITLE
feat: show wizard map output summary

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -223,7 +223,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertTrue(assembled.sync_content.sync_button.isEnabled())
         self.assertEqual(
             assembled.map_content.status_label.text(),
-            "Activity layers not loaded",
+            "Stored activities ready to load",
         )
         self.assertTrue(assembled.map_content.load_layers_button.isEnabled())
         self.assertEqual(
@@ -313,6 +313,47 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(
             assembled.sync_content.activity_summary_label.text(),
             "Activities stored in qfit.gpkg",
+        )
+
+    def test_map_page_summary_names_stored_output_before_layers_load(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            output_name="qfit.gpkg",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.status_label.text(),
+            "Stored activities ready to load",
+        )
+        self.assertEqual(
+            assembled.map_content.layer_summary_label.text(),
+            "Stored activities in qfit.gpkg are ready to load",
+        )
+        self.assertIn(
+            "Stored activities in qfit.gpkg are ready to load",
+            assembled.shell.footer_bar.text(),
+        )
+
+    def test_loaded_map_page_summary_names_source_output(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            output_name="qfit.gpkg",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.layer_summary_label.text(),
+            "Activity layers from qfit.gpkg are loaded on the map",
+        )
+        self.assertIn(
+            "Activity layers from qfit.gpkg are loaded on the map",
+            assembled.shell.footer_bar.text(),
         )
 
     def test_progress_facts_drive_page_cta_prerequisites_without_marking_done(self):

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -504,17 +504,31 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
     default = MapPageState()
     return MapPageState(
         loaded=facts.activity_layers_loaded,
-        status_text=(
-            "Activity layers loaded" if facts.activity_layers_loaded else default.status_text
-        ),
-        layer_summary_text=(
-            "Activity layers are loaded on the map"
-            if facts.activity_layers_loaded
-            else default.layer_summary_text
-        ),
+        status_text=_map_status_text(facts, default),
+        layer_summary_text=_map_layer_summary(facts, default),
         load_action_enabled=facts.activities_stored,
         apply_action_enabled=facts.activity_layers_loaded,
     )
+
+
+def _map_status_text(facts: WizardProgressFacts, default: MapPageState) -> str:
+    if facts.activity_layers_loaded:
+        return "Activity layers loaded"
+    if facts.activities_stored:
+        return "Stored activities ready to load"
+    return default.status_text
+
+
+def _map_layer_summary(facts: WizardProgressFacts, default: MapPageState) -> str:
+    if facts.activity_layers_loaded:
+        if facts.output_name is not None:
+            return f"Activity layers from {facts.output_name} are loaded on the map"
+        return "Activity layers are loaded on the map"
+    if facts.activities_stored:
+        if facts.output_name is not None:
+            return f"Stored activities in {facts.output_name} are ready to load"
+        return "Stored activities are ready to load"
+    return default.layer_summary_text
 
 
 def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:


### PR DESCRIPTION
## Summary

Makes the wizard map step more specific by carrying the stored GeoPackage name into the page and footer summaries before and after activity layers are loaded.

## Changes

- Show a ready-to-load map status once sync has produced stored activities.
- Include the output GeoPackage name in the map page summary when available.
- Keep loaded-layer summaries source-aware after layers are on the map.
- Add wizard composition coverage for the new map summary copy.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
