### PR TITLE
Show atlas output names in wizard summaries

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -274,7 +274,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _mark_atlas_export_stale(self) -> None:
         self._atlas_export_completed = False
         self._atlas_export_output_path = None
-        self._atlas_export_task_output_path = None
+        if self.runtime_state.atlas_export_task is None:
+            self._atlas_export_task_output_path = None
 
     def _runtime_store(self) -> DockRuntimeStore:
         store = getattr(self, "_runtime_state_store", None)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -137,6 +137,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.iface = iface
         self._runtime_state_store = DockRuntimeStore()
         self._atlas_export_completed = False
+        self._atlas_export_output_path = None
+        self._atlas_export_task_output_path = None
         self._dependencies = dependencies or build_dockwidget_dependencies(iface)
         self._bind_dependencies(self._dependencies)
         self.setupUi(self)
@@ -183,11 +185,31 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _current_wizard_progress_facts(self):
         """Return render-neutral #609 wizard facts from the live dock state."""
 
-        return build_wizard_progress_facts_from_runtime_state(
-            self.runtime_state,
-            connection_configured=self._has_configured_strava_connection(),
-            atlas_exported=bool(getattr(self, "_atlas_export_completed", False)),
+        runtime_state = self.runtime_state
+        atlas_exported = bool(getattr(self, "_atlas_export_completed", False))
+        atlas_export_output_path = self._current_wizard_atlas_output_path(
+            runtime_state=runtime_state,
+            atlas_exported=atlas_exported,
         )
+        return build_wizard_progress_facts_from_runtime_state(
+            runtime_state,
+            connection_configured=self._has_configured_strava_connection(),
+            atlas_exported=atlas_exported,
+            atlas_output_path=atlas_export_output_path,
+        )
+
+    def _current_wizard_atlas_output_path(self, *, runtime_state, atlas_exported: bool):
+        """Return the atlas output path the optional wizard should describe."""
+
+        if runtime_state.atlas_export_task is not None:
+            return (
+                getattr(self, "_atlas_export_task_output_path", None)
+                or self._widget_text("atlasPdfPathLineEdit")
+            )
+        completed_output_path = getattr(self, "_atlas_export_output_path", None)
+        if atlas_exported and completed_output_path:
+            return completed_output_path
+        return self._widget_text("atlasPdfPathLineEdit")
 
     def _build_wizard_shell_from_runtime(self, *, parent=None):
         """Build the optional #609 wizard shell from current dock runtime facts.
@@ -251,6 +273,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _mark_atlas_export_stale(self) -> None:
         self._atlas_export_completed = False
+        self._atlas_export_output_path = None
+        self._atlas_export_task_output_path = None
 
     def _runtime_store(self) -> DockRuntimeStore:
         store = getattr(self, "_runtime_state_store", None)
@@ -1251,6 +1275,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             if not path.lower().endswith(".pdf"):
                 path = f"{path}.pdf"
             self.atlasPdfPathLineEdit.setText(path)
+            self._mark_atlas_export_stale()
+            self._refresh_summary_status()
 
     def on_generate_atlas_pdf_clicked(self):
         # Cancel any running export
@@ -1259,6 +1285,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_atlas_pdf_status("Atlas PDF export cancelled.")
             self._set_atlas_export_running(False)
             self._runtime_store().clear_atlas_export()
+            self._atlas_export_task_output_path = None
             return
 
         export_command = self._atlas_workflow_service().build_export_command(
@@ -1281,6 +1308,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             export_command,
         )
         self._runtime_store().begin_atlas_export(atlas_export_task)
+        self._atlas_export_task_output_path = prepared_export.output_path
 
         self._set_atlas_export_running(True)
         self._set_atlas_pdf_status(
@@ -1331,6 +1359,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         result = self.atlas_export_use_case.finish_export(output_path, error, cancelled, page_count)
         if not result.cancelled and result.error is None and result.output_path:
             self._atlas_export_completed = True
+            self._atlas_export_output_path = result.output_path
+        self._atlas_export_task_output_path = None
         self._set_atlas_pdf_status(result.pdf_status)
         self._set_status(result.main_status)
         if result.error is not None and not result.cancelled:

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1506,6 +1506,30 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIsNone(dock._atlas_export_task_output_path)
         dock._refresh_summary_status.assert_called_once_with()
 
+    def test_on_atlas_pdf_browse_preserves_running_export_output_path(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().set_atlas_export_task(object())
+        dock.atlasPdfPathLineEdit = _FakeLineEdit("/tmp/old-atlas.pdf")
+        dock._atlas_export_completed = True
+        dock._atlas_export_output_path = "/tmp/old-atlas.pdf"
+        dock._atlas_export_task_output_path = "/tmp/running-atlas.pdf"
+        dock._refresh_summary_status = MagicMock()
+
+        with patch.object(
+            self.module.QFileDialog,
+            "getSaveFileName",
+            return_value=("/tmp/new-atlas", "PDF files (*.pdf)"),
+            create=True,
+        ):
+            self.module.QfitDockWidget.on_atlas_pdf_browse_clicked(dock)
+
+        self.assertEqual(dock.atlasPdfPathLineEdit.text(), "/tmp/new-atlas.pdf")
+        self.assertFalse(dock._atlas_export_completed)
+        self.assertIsNone(dock._atlas_export_output_path)
+        self.assertEqual(dock._atlas_export_task_output_path, "/tmp/running-atlas.pdf")
+        dock._refresh_summary_status.assert_called_once_with()
+
     def test_on_clear_database_clicked_reports_missing_output_path_via_helper(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.outputPathLineEdit = _FakeLineEdit("")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -362,7 +362,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.clientIdLineEdit = _FakeLineEdit("client-id")
         dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
         dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock.atlasPdfPathLineEdit = _FakeLineEdit("/tmp/current-atlas.pdf")
         dock._atlas_export_completed = True
+        dock._atlas_export_output_path = "/tmp/exported-atlas.pdf"
 
         dock._runtime_store().load_dataset(
             output_path="/tmp/qfit.gpkg",
@@ -380,6 +382,25 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(facts.activity_layers_loaded)
         self.assertTrue(facts.analysis_generated)
         self.assertTrue(facts.atlas_exported)
+        self.assertEqual(facts.atlas_output_name, "exported-atlas.pdf")
+
+    def test_current_wizard_progress_facts_uses_frozen_atlas_path_during_export(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock.atlasPdfPathLineEdit = _FakeLineEdit("/tmp/new-atlas.pdf")
+        dock._atlas_export_completed = True
+        dock._atlas_export_output_path = "/tmp/old-atlas.pdf"
+        dock._atlas_export_task_output_path = "/tmp/running-atlas.pdf"
+        dock._runtime_store().set_atlas_export_task(object())
+
+        facts = self.module.QfitDockWidget._current_wizard_progress_facts(dock)
+
+        self.assertTrue(facts.atlas_exported)
+        self.assertTrue(facts.atlas_export_in_progress)
+        self.assertEqual(facts.atlas_output_name, "running-atlas.pdf")
 
     def test_persist_wizard_step_index_clamps_and_saves_setting(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -1298,6 +1319,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock = object.__new__(self.module.QfitDockWidget)
         running_task = MagicMock()
         dock._atlas_export_task = running_task
+        dock._atlas_export_task_output_path = "/tmp/running-atlas.pdf"
         dock._set_atlas_pdf_status = MagicMock()
         dock._set_atlas_export_running = MagicMock()
 
@@ -1305,6 +1327,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         running_task.cancel.assert_called_once_with()
         self.assertIsNone(dock._atlas_export_task)
+        self.assertIsNone(dock._atlas_export_task_output_path)
         dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF export cancelled.")
         dock._set_atlas_export_running.assert_called_once_with(False)
 
@@ -1401,6 +1424,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "command",
         )
         runtime_store.begin_atlas_export.assert_called_once_with("atlas-task")
+        self.assertEqual(dock._atlas_export_task_output_path, "/tmp/qfit-atlas.pdf")
         dock._set_atlas_export_running.assert_called_once_with(True)
         dock._set_atlas_pdf_status.assert_called_once_with("Exporting atlas (3 pages)…")
         dock._set_status.assert_called_once_with("Generating atlas PDF…")
@@ -1453,10 +1477,34 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         self.assertIsNone(dock._atlas_export_task)
         self.assertTrue(dock._atlas_export_completed)
+        self.assertEqual(dock._atlas_export_output_path, "/tmp/qfit-atlas.pdf")
+        self.assertIsNone(dock._atlas_export_task_output_path)
         dock._set_atlas_export_running.assert_called_once_with(False)
         dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF ready")
         dock._set_status.assert_called_once_with("Atlas created")
         dock._show_error.assert_not_called()
+
+    def test_on_atlas_pdf_browse_marks_export_stale_and_refreshes_wizard(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.atlasPdfPathLineEdit = _FakeLineEdit("/tmp/old-atlas.pdf")
+        dock._atlas_export_completed = True
+        dock._atlas_export_output_path = "/tmp/old-atlas.pdf"
+        dock._atlas_export_task_output_path = "/tmp/old-running-atlas.pdf"
+        dock._refresh_summary_status = MagicMock()
+
+        with patch.object(
+            self.module.QFileDialog,
+            "getSaveFileName",
+            return_value=("/tmp/new-atlas", "PDF files (*.pdf)"),
+            create=True,
+        ):
+            self.module.QfitDockWidget.on_atlas_pdf_browse_clicked(dock)
+
+        self.assertEqual(dock.atlasPdfPathLineEdit.text(), "/tmp/new-atlas.pdf")
+        self.assertFalse(dock._atlas_export_completed)
+        self.assertIsNone(dock._atlas_export_output_path)
+        self.assertIsNone(dock._atlas_export_task_output_path)
+        dock._refresh_summary_status.assert_called_once_with()
 
     def test_on_clear_database_clicked_reports_missing_output_path_via_helper(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -38,6 +38,7 @@ class WizardProgressFactsTests(unittest.TestCase):
             connection_configured=True,
             atlas_exported=True,
             preferred_current_key="atlas",
+            atlas_output_path="/tmp/qfit-atlas.pdf",
         )
 
         self.assertEqual(
@@ -50,6 +51,7 @@ class WizardProgressFactsTests(unittest.TestCase):
                 atlas_exported=True,
                 preferred_current_key="atlas",
                 output_name="qfit.gpkg",
+                atlas_output_name="qfit-atlas.pdf",
             ),
         )
 
@@ -110,6 +112,14 @@ class WizardProgressFactsTests(unittest.TestCase):
         )
 
         self.assertEqual(facts.output_name, "qfit.gpkg")
+
+    def test_runtime_state_adapter_normalises_atlas_output_filename(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(),
+            atlas_output_path=r"C:\\Users\\Emman\\qfit-atlas.pdf",
+        )
+
+        self.assertEqual(facts.atlas_output_name, "qfit-atlas.pdf")
 
     def test_defaults_keep_connection_current_with_no_completed_steps(self):
         progress = build_wizard_progress_from_facts(WizardProgressFacts())

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -456,6 +456,56 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertIn("Synchronization in progress", assembled.shell.footer_bar.text())
 
+    def test_atlas_page_summary_uses_configured_output_name_before_export(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                atlas_output_name="qfit-atlas.pdf",
+            )
+        )
+
+        self.assertEqual(
+            assembled.atlas_content.output_summary_label.text(),
+            "Ready to export qfit-atlas.pdf",
+        )
+
+    def test_busy_atlas_page_summary_uses_configured_output_name(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                atlas_export_in_progress=True,
+                atlas_output_name="qfit-atlas.pdf",
+            )
+        )
+
+        self.assertEqual(
+            assembled.atlas_content.output_summary_label.text(),
+            "Exporting qfit-atlas.pdf",
+        )
+
+    def test_exported_atlas_page_summary_uses_configured_output_name(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                atlas_exported=True,
+                atlas_output_name="qfit-atlas.pdf",
+            )
+        )
+
+        self.assertEqual(
+            assembled.atlas_content.output_summary_label.text(),
+            "Latest atlas PDF exported to qfit-atlas.pdf",
+        )
+
     def test_explicit_page_state_overrides_progress_fact_defaults(self):
         assembled = self.composition.build_placeholder_wizard_shell(
             progress_facts=self.composition.WizardProgressFacts(connection_configured=True),

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -30,6 +30,7 @@ class WizardProgressFacts:
     preferred_current_key: str | None = None
     activity_count: int | None = None
     output_name: str | None = None
+    atlas_output_name: str | None = None
 
 
 def build_wizard_progress_facts_from_runtime_state(
@@ -38,6 +39,7 @@ def build_wizard_progress_facts_from_runtime_state(
     connection_configured: bool = False,
     atlas_exported: bool = False,
     preferred_current_key: str | None = None,
+    atlas_output_path: str | None = None,
 ) -> WizardProgressFacts:
     """Derive #609 wizard progress facts from the dock runtime snapshot.
 
@@ -47,10 +49,13 @@ def build_wizard_progress_facts_from_runtime_state(
     connection is persisted in configuration settings, and atlas exports do not
     yet retain a durable output artifact after the task completes. The runtime
     ``activities`` tuple is a fetch payload, not a persisted dataset count, so
-    this adapter deliberately leaves ``activity_count`` unknown.
+    this adapter deliberately leaves ``activity_count`` unknown. Atlas output is
+    supplied separately because it currently lives in the dock export controls,
+    not the runtime snapshot.
     """
 
     output_name = _output_name(state.output_path)
+    atlas_output_name = _output_name(atlas_output_path)
     return WizardProgressFacts(
         connection_configured=connection_configured,
         activities_stored=_has_output_path(state),
@@ -62,6 +67,7 @@ def build_wizard_progress_facts_from_runtime_state(
         preferred_current_key=preferred_current_key,
         activity_count=None,
         output_name=output_name,
+        atlas_output_name=atlas_output_name,
     )
 
 
@@ -111,6 +117,7 @@ def build_wizard_progress_from_facts_and_settings(
             preferred_current_key=preferred_current_key_from_settings(settings),
             activity_count=facts.activity_count,
             output_name=facts.output_name,
+            atlas_output_name=facts.atlas_output_name,
         )
     )
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -426,6 +426,7 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         preferred_current_key=facts.preferred_current_key,
         activity_count=facts.activity_count,
         output_name=facts.output_name,
+        atlas_output_name=facts.atlas_output_name,
     )
 
 
@@ -553,15 +554,13 @@ def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:
 def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
     default = AtlasPageState()
     status_text = default.status_text
-    output_summary_text = default.output_summary_text
+    output_summary_text = _atlas_output_summary(facts, default)
     atlas_blocked_tooltip = default.primary_action_blocked_tooltip
     if facts.atlas_exported:
         status_text = "Atlas PDF exported"
-        output_summary_text = "Latest atlas PDF has been exported"
     primary_action_label = default.primary_action_label
     if facts.atlas_export_in_progress:
         status_text = "Atlas export in progress"
-        output_summary_text = "PDF export is running."
         primary_action_label = "Export in progress…"
         atlas_blocked_tooltip = "Wait for the current atlas export to finish."
     return AtlasPageState(
@@ -579,6 +578,23 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
         ),
         primary_action_blocked_tooltip=atlas_blocked_tooltip,
     )
+
+
+def _atlas_output_summary(
+    facts: WizardProgressFacts,
+    default: AtlasPageState,
+) -> str:
+    if facts.atlas_export_in_progress:
+        if facts.atlas_output_name is not None:
+            return f"Exporting {facts.atlas_output_name}"
+        return "PDF export is running."
+    if facts.atlas_exported:
+        if facts.atlas_output_name is not None:
+            return f"Latest atlas PDF exported to {facts.atlas_output_name}"
+        return "Latest atlas PDF has been exported"
+    if facts.atlas_output_name is not None:
+        return f"Ready to export {facts.atlas_output_name}"
+    return default.output_summary_text
 
 
 def _validate_progress_targets_installed_page(


### PR DESCRIPTION
## Summary

- carry the configured atlas PDF output path into wizard progress facts as a basename
- show that output name in the atlas wizard page before export, during export, and after export
- wire the live dock atlas PDF field into the optional wizard runtime refresh seam

## Tests

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
