### PR TITLE
feat: summarize map filters in wizard

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -191,12 +191,58 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             runtime_state=runtime_state,
             atlas_exported=atlas_exported,
         )
+        filters_active, filtered_activity_count = self._current_wizard_filter_facts()
         return build_wizard_progress_facts_from_runtime_state(
             runtime_state,
             connection_configured=self._has_configured_strava_connection(),
             atlas_exported=atlas_exported,
             atlas_output_path=atlas_export_output_path,
+            filters_active=filters_active,
+            filtered_activity_count=filtered_activity_count,
         )
+
+    def _current_wizard_filter_facts(self) -> tuple[bool, int | None]:
+        """Return the current map-filter facts the optional wizard can summarize."""
+
+        layer_filter_facts = self._current_wizard_layer_filter_facts()
+        if layer_filter_facts is not None:
+            return layer_filter_facts
+
+        activities = tuple(self.runtime_state.activities)
+        if not activities:
+            return False, None
+        selection_state = build_activity_preview_selection_state(
+            self._current_activity_preview_request()
+        )
+        filters_active = selection_state.filtered_count != len(activities)
+        if not filters_active:
+            return False, None
+        return True, selection_state.filtered_count
+
+    def _current_wizard_layer_filter_facts(self) -> tuple[bool, int | None] | None:
+        layer = self.runtime_state.activities_layer
+        if layer is None or not hasattr(layer, "subsetString"):
+            return None
+        try:
+            subset = (layer.subsetString() or "").strip()
+        except RuntimeError:
+            logger.debug("Failed to read activity layer subset", exc_info=True)
+            return None
+        if not subset:
+            return False, None
+        return True, self._current_wizard_layer_feature_count(layer)
+
+    def _current_wizard_layer_feature_count(self, layer) -> int | None:
+        if not hasattr(layer, "featureCount"):
+            return None
+        try:
+            count = layer.featureCount()
+        except RuntimeError:
+            logger.debug("Failed to read activity layer feature count", exc_info=True)
+            return None
+        if not isinstance(count, int):
+            return None
+        return max(count, 0)
 
     def _current_wizard_atlas_output_path(self, *, runtime_state, atlas_exported: bool):
         """Return the atlas output path the optional wizard should describe."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -192,6 +192,18 @@ class _FakeLayer:
         return self._id
 
 
+class _FakeSubsetLayer:
+    def __init__(self, subset="", feature_count=0):
+        self._subset = subset
+        self._feature_count = feature_count
+
+    def subsetString(self):
+        return self._subset
+
+    def featureCount(self):
+        return self._feature_count
+
+
 class _FakeLineEdit:
     def __init__(self, text=""):
         self._text = text
@@ -401,6 +413,38 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(facts.atlas_exported)
         self.assertTrue(facts.atlas_export_in_progress)
         self.assertEqual(facts.atlas_output_name, "running-atlas.pdf")
+
+    def test_current_wizard_filter_facts_prefers_loaded_layer_subset(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().set_activities([object(), object(), object()])
+        dock._runtime_store().load_dataset(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer=_FakeSubsetLayer('"activity_type" = \'Run\'', 2),
+        )
+
+        filters_active, filtered_count = (
+            self.module.QfitDockWidget._current_wizard_filter_facts(dock)
+        )
+
+        self.assertTrue(filters_active)
+        self.assertEqual(filtered_count, 2)
+
+    def test_current_wizard_filter_facts_treats_empty_loaded_subset_as_unfiltered(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().set_activities([object(), object(), object()])
+        dock._runtime_store().load_dataset(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer=_FakeSubsetLayer("", 3),
+        )
+
+        filters_active, filtered_count = (
+            self.module.QfitDockWidget._current_wizard_filter_facts(dock)
+        )
+
+        self.assertFalse(filters_active)
+        self.assertIsNone(filtered_count)
 
     def test_persist_wizard_step_index_clamps_and_saves_setting(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -121,6 +121,16 @@ class WizardProgressFactsTests(unittest.TestCase):
 
         self.assertEqual(facts.atlas_output_name, "qfit-atlas.pdf")
 
+    def test_runtime_state_adapter_preserves_explicit_map_filter_facts(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path="/tmp/qfit.gpkg"),
+            filters_active=True,
+            filtered_activity_count=3,
+        )
+
+        self.assertTrue(facts.filters_active)
+        self.assertEqual(facts.filtered_activity_count, 3)
+
     def test_defaults_keep_connection_current_with_no_completed_steps(self):
         progress = build_wizard_progress_from_facts(WizardProgressFacts())
 

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -356,6 +356,36 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.shell.footer_bar.text(),
         )
 
+    def test_loaded_map_page_summary_reports_visible_filter_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            filters_active=True,
+            filtered_activity_count=3,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.filter_summary_label.text(),
+            "Filters match 3 loaded activities",
+        )
+
+    def test_loaded_map_page_summary_reports_all_visible_when_unfiltered(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.filter_summary_label.text(),
+            "All loaded activities are visible",
+        )
+
     def test_progress_facts_drive_page_cta_prerequisites_without_marking_done(self):
         facts = self.composition.WizardProgressFacts(connection_configured=True)
 

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -31,6 +31,8 @@ class WizardProgressFacts:
     activity_count: int | None = None
     output_name: str | None = None
     atlas_output_name: str | None = None
+    filters_active: bool = False
+    filtered_activity_count: int | None = None
 
 
 def build_wizard_progress_facts_from_runtime_state(
@@ -40,6 +42,8 @@ def build_wizard_progress_facts_from_runtime_state(
     atlas_exported: bool = False,
     preferred_current_key: str | None = None,
     atlas_output_path: str | None = None,
+    filters_active: bool = False,
+    filtered_activity_count: int | None = None,
 ) -> WizardProgressFacts:
     """Derive #609 wizard progress facts from the dock runtime snapshot.
 
@@ -68,6 +72,8 @@ def build_wizard_progress_facts_from_runtime_state(
         activity_count=None,
         output_name=output_name,
         atlas_output_name=atlas_output_name,
+        filters_active=filters_active,
+        filtered_activity_count=filtered_activity_count,
     )
 
 
@@ -118,6 +124,8 @@ def build_wizard_progress_from_facts_and_settings(
             activity_count=facts.activity_count,
             output_name=facts.output_name,
             atlas_output_name=facts.atlas_output_name,
+            filters_active=facts.filters_active,
+            filtered_activity_count=facts.filtered_activity_count,
         )
     )
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -427,6 +427,8 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         activity_count=facts.activity_count,
         output_name=facts.output_name,
         atlas_output_name=facts.atlas_output_name,
+        filters_active=facts.filters_active,
+        filtered_activity_count=facts.filtered_activity_count,
     )
 
 
@@ -507,6 +509,7 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
         loaded=facts.activity_layers_loaded,
         status_text=_map_status_text(facts, default),
         layer_summary_text=_map_layer_summary(facts, default),
+        filter_summary_text=_map_filter_summary(facts, default),
         load_action_enabled=facts.activities_stored,
         apply_action_enabled=facts.activity_layers_loaded,
     )
@@ -530,6 +533,17 @@ def _map_layer_summary(facts: WizardProgressFacts, default: MapPageState) -> str
             return f"Stored activities in {facts.output_name} are ready to load"
         return "Stored activities are ready to load"
     return default.layer_summary_text
+
+
+def _map_filter_summary(facts: WizardProgressFacts, default: MapPageState) -> str:
+    if not facts.activity_layers_loaded:
+        return default.filter_summary_text
+    if facts.filters_active:
+        if facts.filtered_activity_count is None:
+            return "Subset filters are active"
+        noun = "activity" if facts.filtered_activity_count == 1 else "activities"
+        return f"Filters match {max(facts.filtered_activity_count, 0)} loaded {noun}"
+    return "All loaded activities are visible"
 
 
 def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:


### PR DESCRIPTION
## Summary

Adds map-filter facts to the wizard progress seam so the #609 wizard map page can show whether loaded activities are unfiltered or narrowed by the current visual filters.

## Changes

- Preserve explicit filter activity facts in `WizardProgressFacts`.
- Render map-page filter summaries for loaded wizard states.
- Feed the optional wizard shell from the dock's current preview filter selection when fetched activities are available.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
