### PR TITLE
feat: summarize wizard analysis outputs

### DIFF
--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -25,7 +25,7 @@ class _NamedLayer:
 
 class _BrokenLayerName:
     def name(self):
-        raise RuntimeError("layer has been deleted")
+        raise ValueError("layer has been deleted")
 
 
 class WizardProgressFactsTests(unittest.TestCase):

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -15,6 +15,19 @@ from qfit.ui.application.wizard_progress import (
 from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 
+class _NamedLayer:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _BrokenLayerName:
+    def name(self):
+        raise RuntimeError("layer has been deleted")
+
+
 class WizardProgressFactsTests(unittest.TestCase):
     def test_runtime_state_adapter_defaults_to_no_completed_workflow_facts(self):
         facts = build_wizard_progress_facts_from_runtime_state(DockRuntimeState())
@@ -120,6 +133,24 @@ class WizardProgressFactsTests(unittest.TestCase):
         )
 
         self.assertEqual(facts.atlas_output_name, "qfit-atlas.pdf")
+
+    def test_runtime_state_adapter_names_analysis_output_layer(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(
+                layers=DockRuntimeLayers(
+                    analysis=_NamedLayer(" qfit activity heatmap ")
+                ),
+            )
+        )
+
+        self.assertEqual(facts.analysis_output_name, "qfit activity heatmap")
+
+    def test_runtime_state_adapter_ignores_unreadable_analysis_output_name(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(layers=DockRuntimeLayers(analysis=_BrokenLayerName())),
+        )
+
+        self.assertIsNone(facts.analysis_output_name)
 
     def test_runtime_state_adapter_preserves_explicit_map_filter_facts(self):
         facts = build_wizard_progress_facts_from_runtime_state(

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -28,6 +28,13 @@ class _BrokenLayerName:
         raise ValueError("layer has been deleted")
 
 
+class _DeletedLayerWrapper:
+    def __getattribute__(self, name):
+        if name == "name":
+            raise RuntimeError("wrapped C++ object has been deleted")
+        return super().__getattribute__(name)
+
+
 class WizardProgressFactsTests(unittest.TestCase):
     def test_runtime_state_adapter_defaults_to_no_completed_workflow_facts(self):
         facts = build_wizard_progress_facts_from_runtime_state(DockRuntimeState())
@@ -148,6 +155,13 @@ class WizardProgressFactsTests(unittest.TestCase):
     def test_runtime_state_adapter_ignores_unreadable_analysis_output_name(self):
         facts = build_wizard_progress_facts_from_runtime_state(
             DockRuntimeState(layers=DockRuntimeLayers(analysis=_BrokenLayerName())),
+        )
+
+        self.assertIsNone(facts.analysis_output_name)
+
+    def test_runtime_state_adapter_ignores_deleted_layer_name_attribute(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(layers=DockRuntimeLayers(analysis=_DeletedLayerWrapper())),
         )
 
         self.assertIsNone(facts.analysis_output_name)

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -502,6 +502,22 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Ready to export qfit-atlas.pdf",
         )
 
+    def test_analysis_page_summary_names_generated_output(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                analysis_output_name="qfit activity heatmap",
+            )
+        )
+
+        self.assertEqual(
+            assembled.analysis_content.result_summary_label.text(),
+            "Analysis output qfit activity heatmap is available",
+        )
+
     def test_busy_atlas_page_summary_uses_configured_output_name(self):
         assembled = self.composition.build_placeholder_wizard_shell(
             progress_facts=self.composition.WizardProgressFacts(

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -200,7 +200,10 @@ def _layer_name(layer) -> str | None:
         return None
     try:
         name = layer.name()
-    except RuntimeError:
+    except Exception:
+        # QGIS/Qt wrapper objects may raise different exception types once the
+        # underlying C++ layer has been deleted. The layer name is optional
+        # summary copy, so keep wizard refreshes resilient.
         return None
     if not isinstance(name, str):
         return None

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -196,14 +196,20 @@ def _output_name(output_path: str | None) -> str | None:
 
 
 def _layer_name(layer) -> str | None:
-    if layer is None or not hasattr(layer, "name"):
+    if layer is None:
         return None
     try:
-        name = layer.name()
+        name_method = layer.name
     except Exception:
         # QGIS/Qt wrapper objects may raise different exception types once the
         # underlying C++ layer has been deleted. The layer name is optional
         # summary copy, so keep wizard refreshes resilient.
+        return None
+    if not callable(name_method):
+        return None
+    try:
+        name = name_method()
+    except Exception:
         return None
     if not isinstance(name, str):
         return None

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -30,6 +30,7 @@ class WizardProgressFacts:
     preferred_current_key: str | None = None
     activity_count: int | None = None
     output_name: str | None = None
+    analysis_output_name: str | None = None
     atlas_output_name: str | None = None
     filters_active: bool = False
     filtered_activity_count: int | None = None
@@ -59,6 +60,7 @@ def build_wizard_progress_facts_from_runtime_state(
     """
 
     output_name = _output_name(state.output_path)
+    analysis_output_name = _layer_name(state.analysis_layer)
     atlas_output_name = _output_name(atlas_output_path)
     return WizardProgressFacts(
         connection_configured=connection_configured,
@@ -71,6 +73,7 @@ def build_wizard_progress_facts_from_runtime_state(
         preferred_current_key=preferred_current_key,
         activity_count=None,
         output_name=output_name,
+        analysis_output_name=analysis_output_name,
         atlas_output_name=atlas_output_name,
         filters_active=filters_active,
         filtered_activity_count=filtered_activity_count,
@@ -123,6 +126,7 @@ def build_wizard_progress_from_facts_and_settings(
             preferred_current_key=preferred_current_key_from_settings(settings),
             activity_count=facts.activity_count,
             output_name=facts.output_name,
+            analysis_output_name=facts.analysis_output_name,
             atlas_output_name=facts.atlas_output_name,
             filters_active=facts.filters_active,
             filtered_activity_count=facts.filtered_activity_count,
@@ -189,6 +193,19 @@ def _output_name(output_path: str | None) -> str | None:
     if "\\" in stripped:
         return PureWindowsPath(stripped).name or stripped
     return Path(stripped).name or stripped
+
+
+def _layer_name(layer) -> str | None:
+    if layer is None or not hasattr(layer, "name"):
+        return None
+    try:
+        name = layer.name()
+    except RuntimeError:
+        return None
+    if not isinstance(name, str):
+        return None
+    stripped = name.strip()
+    return stripped or None
 
 
 __all__ = [

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -426,6 +426,7 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         preferred_current_key=facts.preferred_current_key,
         activity_count=facts.activity_count,
         output_name=facts.output_name,
+        analysis_output_name=facts.analysis_output_name,
         atlas_output_name=facts.atlas_output_name,
         filters_active=facts.filters_active,
         filtered_activity_count=facts.filtered_activity_count,
@@ -557,12 +558,18 @@ def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:
             else default.input_summary_text
         ),
         result_summary_text=(
-            "Analysis outputs are available"
+            _analysis_result_summary(facts)
             if facts.analysis_generated
             else default.result_summary_text
         ),
         primary_action_enabled=facts.activity_layers_loaded,
     )
+
+
+def _analysis_result_summary(facts: WizardProgressFacts) -> str:
+    if facts.analysis_output_name is not None:
+        return f"Analysis output {facts.analysis_output_name} is available"
+    return "Analysis outputs are available"
 
 
 def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:


### PR DESCRIPTION
## Summary

Adds a wizard-forward analysis output summary fact so the #609 analysis page can name the generated analysis layer when one is available.

## Changes

- derive `analysis_output_name` from the runtime analysis layer in render-neutral wizard progress facts
- preserve that fact through gated page-state derivation
- show the generated analysis output name in the wizard analysis page summary
- cover layer-name extraction, deleted-layer resilience, and analysis page copy in tests

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
