### PR TITLE
feat: summarize atlas analysis input in wizard

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -518,6 +518,37 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Analysis output qfit activity heatmap is available",
         )
 
+    def test_atlas_page_input_summary_names_analysis_output(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                analysis_output_name="qfit activity heatmap",
+            )
+        )
+
+        self.assertEqual(
+            assembled.atlas_content.input_summary_label.text(),
+            "Analysis output qfit activity heatmap ready for atlas export",
+        )
+
+    def test_atlas_page_input_summary_keeps_generic_copy_without_named_output(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+            )
+        )
+
+        self.assertEqual(
+            assembled.atlas_content.input_summary_label.text(),
+            "Analysis outputs ready for atlas export",
+        )
+
     def test_busy_atlas_page_summary_uses_configured_output_name(self):
         assembled = self.composition.build_placeholder_wizard_shell(
             progress_facts=self.composition.WizardProgressFacts(

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -587,11 +587,7 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
     return AtlasPageState(
         ready=facts.atlas_exported,
         status_text=status_text,
-        input_summary_text=(
-            "Analysis outputs ready for atlas export"
-            if facts.analysis_generated
-            else default.input_summary_text
-        ),
+        input_summary_text=_atlas_input_summary(facts, default),
         output_summary_text=output_summary_text,
         primary_action_label=primary_action_label,
         primary_action_enabled=(
@@ -599,6 +595,17 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
         ),
         primary_action_blocked_tooltip=atlas_blocked_tooltip,
     )
+
+
+def _atlas_input_summary(
+    facts: WizardProgressFacts,
+    default: AtlasPageState,
+) -> str:
+    if not facts.analysis_generated:
+        return default.input_summary_text
+    if facts.analysis_output_name is not None:
+        return f"Analysis output {facts.analysis_output_name} ready for atlas export"
+    return "Analysis outputs ready for atlas export"
 
 
 def _atlas_output_summary(


### PR DESCRIPTION
## Summary

- carries the generated analysis output name into the Atlas wizard page input summary
- keeps the existing generic Atlas copy when no named analysis output is available
- adds composition tests for both the named and generic Atlas input-summary states

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
