### PR TITLE
feat: summarize analysis filter input in wizard

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -402,6 +402,38 @@ class WizardShellCompositionTest(unittest.TestCase):
             "2 filtered activities ready for analysis",
         )
 
+    def test_analysis_page_input_summary_reports_singular_filtered_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            filters_active=True,
+            filtered_activity_count=1,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.analysis_content.input_summary_label.text(),
+            "1 filtered activity ready for analysis",
+        )
+
+    def test_analysis_page_input_summary_reports_zero_filtered_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            filters_active=True,
+            filtered_activity_count=0,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.analysis_content.input_summary_label.text(),
+            "0 filtered activities ready for analysis",
+        )
+
     def test_analysis_page_input_summary_reports_filtered_subset_without_count(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -386,6 +386,37 @@ class WizardShellCompositionTest(unittest.TestCase):
             "All loaded activities are visible",
         )
 
+    def test_analysis_page_input_summary_reports_filtered_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            filters_active=True,
+            filtered_activity_count=2,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.analysis_content.input_summary_label.text(),
+            "2 filtered activities ready for analysis",
+        )
+
+    def test_analysis_page_input_summary_reports_filtered_subset_without_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            filters_active=True,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.analysis_content.input_summary_label.text(),
+            "Filtered activity subset ready for analysis",
+        )
+
     def test_progress_facts_drive_page_cta_prerequisites_without_marking_done(self):
         facts = self.composition.WizardProgressFacts(connection_configured=True)
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -552,11 +552,7 @@ def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:
     return AnalysisPageState(
         ready=facts.analysis_generated,
         status_text="Analysis ready" if facts.analysis_generated else default.status_text,
-        input_summary_text=(
-            "Activity layers ready for analysis"
-            if facts.activity_layers_loaded
-            else default.input_summary_text
-        ),
+        input_summary_text=_analysis_input_summary(facts, default),
         result_summary_text=(
             _analysis_result_summary(facts)
             if facts.analysis_generated
@@ -564,6 +560,20 @@ def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:
         ),
         primary_action_enabled=facts.activity_layers_loaded,
     )
+
+
+def _analysis_input_summary(
+    facts: WizardProgressFacts,
+    default: AnalysisPageState,
+) -> str:
+    if not facts.activity_layers_loaded:
+        return default.input_summary_text
+    if facts.filters_active:
+        if facts.filtered_activity_count is None:
+            return "Filtered activity subset ready for analysis"
+        noun = "activity" if facts.filtered_activity_count == 1 else "activities"
+        return f"{max(facts.filtered_activity_count, 0)} filtered {noun} ready for analysis"
+    return "Activity layers ready for analysis"
 
 
 def _analysis_result_summary(facts: WizardProgressFacts) -> str:


### PR DESCRIPTION
## Summary

- shows active map-filter context on the Analysis wizard page input summary
- keeps the existing generic analysis input copy when no filters are active
- adds composition tests for filtered counts and unknown filtered subset counts

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
