### PR TITLE
feat: summarize wizard map basemap state

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -212,16 +212,19 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _current_wizard_background_facts(self, runtime_state) -> tuple[bool, bool, str | None]:
         """Return current basemap facts for the optional wizard map page."""
 
+        background_layer_loaded = runtime_state.background_layer is not None
+        if background_layer_loaded:
+            return True, True, None
+
         checkbox = getattr(self, "backgroundMapCheckBox", None)
         background_enabled = bool(
             checkbox is not None
             and hasattr(checkbox, "isChecked")
             and checkbox.isChecked()
         )
-        background_layer_loaded = runtime_state.background_layer is not None
         if not background_enabled:
-            return False, background_layer_loaded, None
-        return True, background_layer_loaded, self._current_wizard_background_name()
+            return False, False, None
+        return True, False, self._current_wizard_background_name()
 
     def _current_wizard_background_name(self) -> str | None:
         preset_combo = getattr(self, "backgroundPresetComboBox", None)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -191,15 +191,51 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             runtime_state=runtime_state,
             atlas_exported=atlas_exported,
         )
+        (
+            background_enabled,
+            background_layer_loaded,
+            background_name,
+        ) = self._current_wizard_background_facts(runtime_state)
         filters_active, filtered_activity_count = self._current_wizard_filter_facts()
         return build_wizard_progress_facts_from_runtime_state(
             runtime_state,
             connection_configured=self._has_configured_strava_connection(),
             atlas_exported=atlas_exported,
             atlas_output_path=atlas_export_output_path,
+            background_enabled=background_enabled,
+            background_layer_loaded=background_layer_loaded,
+            background_name=background_name,
             filters_active=filters_active,
             filtered_activity_count=filtered_activity_count,
         )
+
+    def _current_wizard_background_facts(self, runtime_state) -> tuple[bool, bool, str | None]:
+        """Return current basemap facts for the optional wizard map page."""
+
+        checkbox = getattr(self, "backgroundMapCheckBox", None)
+        background_enabled = bool(
+            checkbox is not None
+            and hasattr(checkbox, "isChecked")
+            and checkbox.isChecked()
+        )
+        background_layer_loaded = runtime_state.background_layer is not None
+        if not background_enabled:
+            return False, background_layer_loaded, None
+        return True, background_layer_loaded, self._current_wizard_background_name()
+
+    def _current_wizard_background_name(self) -> str | None:
+        preset_combo = getattr(self, "backgroundPresetComboBox", None)
+        if preset_combo is None or not hasattr(preset_combo, "currentText"):
+            return None
+        try:
+            preset_name = preset_combo.currentText()
+        except RuntimeError:
+            logger.debug("Failed to read wizard background preset", exc_info=True)
+            return None
+        if not isinstance(preset_name, str):
+            return None
+        stripped = preset_name.strip()
+        return stripped or None
 
     def _current_wizard_filter_facts(self) -> tuple[bool, int | None]:
         """Return the current map-filter facts the optional wizard can summarize."""

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -51,6 +51,12 @@ class MapPageContentTest(unittest.TestCase):
         )
         self.assertIn(COLOR_MUTED, content.layer_summary_label.styleSheet())
         self.assertEqual(
+            content.background_summary_label.objectName(),
+            "qfitWizardMapBackgroundSummary",
+        )
+        self.assertEqual(content.background_summary_label.text(), "Basemap disabled")
+        self.assertIn(COLOR_MUTED, content.background_summary_label.styleSheet())
+        self.assertEqual(
             content.filter_summary_label.objectName(),
             "qfitWizardMapFilterSummary",
         )
@@ -102,6 +108,7 @@ class MapPageContentTest(unittest.TestCase):
                 content.status_label,
                 content.detail_label,
                 content.layer_summary_label,
+                content.background_summary_label,
                 content.filter_summary_label,
                 content.action_row,
             ],
@@ -114,6 +121,7 @@ class MapPageContentTest(unittest.TestCase):
             status_text="Map ready",
             detail_text="Use saved filters for the loaded activity layers.",
             layer_summary_text="4 layers loaded from qfit.gpkg",
+            background_summary_text="Basemap loaded: Outdoors",
             filter_summary_text="42 activities · Ride and Run · 2026",
             load_action_label="Reload layers",
             primary_action_label="Apply saved filters",
@@ -133,6 +141,8 @@ class MapPageContentTest(unittest.TestCase):
             "4 layers loaded from qfit.gpkg",
         )
         self.assertEqual(content.layer_summary_label.property("mapState"), "loaded")
+        self.assertEqual(content.background_summary_label.text(), "Basemap loaded: Outdoors")
+        self.assertEqual(content.background_summary_label.property("mapState"), "loaded")
         self.assertEqual(
             content.filter_summary_label.text(),
             "42 activities · Ride and Run · 2026",

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -375,6 +375,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
         dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
         dock.atlasPdfPathLineEdit = _FakeLineEdit("/tmp/current-atlas.pdf")
+        dock.backgroundMapCheckBox = _FakeCheckBox(True)
+        dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
         dock._atlas_export_completed = True
         dock._atlas_export_output_path = "/tmp/exported-atlas.pdf"
 
@@ -386,6 +388,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             atlas_layer=object(),
         )
         dock._runtime_store().set_analysis_layer(object())
+        dock._runtime_store().set_background_layer(object())
 
         facts = self.module.QfitDockWidget._current_wizard_progress_facts(dock)
 
@@ -395,6 +398,36 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(facts.analysis_generated)
         self.assertTrue(facts.atlas_exported)
         self.assertEqual(facts.atlas_output_name, "exported-atlas.pdf")
+        self.assertTrue(facts.background_enabled)
+        self.assertTrue(facts.background_layer_loaded)
+        self.assertEqual(facts.background_name, "Outdoors")
+
+    def test_current_wizard_background_facts_report_disabled_basemap(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.backgroundMapCheckBox = _FakeCheckBox(False)
+        dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
+        dock._runtime_store().set_background_layer(object())
+
+        facts = self.module.QfitDockWidget._current_wizard_background_facts(
+            dock,
+            dock.runtime_state,
+        )
+
+        self.assertEqual(facts, (False, True, None))
+
+    def test_current_wizard_background_facts_report_enabled_basemap_name(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.backgroundMapCheckBox = _FakeCheckBox(True)
+        dock.backgroundPresetComboBox = _FakeComboBox(current_text=" Satellite ")
+
+        facts = self.module.QfitDockWidget._current_wizard_background_facts(
+            dock,
+            dock.runtime_state,
+        )
+
+        self.assertEqual(facts, (True, False, "Satellite"))
 
     def test_current_wizard_progress_facts_uses_frozen_atlas_path_during_export(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -400,9 +400,22 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(facts.atlas_output_name, "exported-atlas.pdf")
         self.assertTrue(facts.background_enabled)
         self.assertTrue(facts.background_layer_loaded)
-        self.assertEqual(facts.background_name, "Outdoors")
+        self.assertIsNone(facts.background_name)
 
     def test_current_wizard_background_facts_report_disabled_basemap(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.backgroundMapCheckBox = _FakeCheckBox(False)
+        dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
+
+        facts = self.module.QfitDockWidget._current_wizard_background_facts(
+            dock,
+            dock.runtime_state,
+        )
+
+        self.assertEqual(facts, (False, False, None))
+
+    def test_current_wizard_background_facts_prefers_loaded_layer_over_pending_ui(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()
         dock.backgroundMapCheckBox = _FakeCheckBox(False)
@@ -414,7 +427,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             dock.runtime_state,
         )
 
-        self.assertEqual(facts, (False, True, None))
+        self.assertEqual(facts, (True, True, None))
 
     def test_current_wizard_background_facts_report_enabled_basemap_name(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -176,6 +176,18 @@ class WizardProgressFactsTests(unittest.TestCase):
         self.assertTrue(facts.filters_active)
         self.assertEqual(facts.filtered_activity_count, 3)
 
+    def test_runtime_state_adapter_preserves_explicit_background_facts(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path="/tmp/qfit.gpkg"),
+            background_enabled=True,
+            background_layer_loaded=True,
+            background_name=" Outdoors ",
+        )
+
+        self.assertTrue(facts.background_enabled)
+        self.assertTrue(facts.background_layer_loaded)
+        self.assertEqual(facts.background_name, "Outdoors")
+
     def test_defaults_keep_connection_current_with_no_completed_steps(self):
         progress = build_wizard_progress_from_facts(WizardProgressFacts())
 

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -356,6 +356,38 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.shell.footer_bar.text(),
         )
 
+    def test_map_page_summary_reports_enabled_basemap_before_load(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            background_enabled=True,
+            background_name="Outdoors",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.background_summary_label.text(),
+            "Basemap ready to load: Outdoors",
+        )
+
+    def test_map_page_summary_reports_loaded_basemap(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            background_enabled=True,
+            background_layer_loaded=True,
+            background_name="Satellite",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.background_summary_label.text(),
+            "Basemap loaded: Satellite",
+        )
+
     def test_loaded_map_page_summary_reports_visible_filter_count(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -388,6 +388,22 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Basemap loaded: Satellite",
         )
 
+    def test_map_page_summary_reports_loaded_basemap_without_stale_name(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            background_enabled=True,
+            background_layer_loaded=True,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.background_summary_label.text(),
+            "Basemap loaded",
+        )
+
     def test_loaded_map_page_summary_reports_visible_filter_count(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -32,6 +32,9 @@ class WizardProgressFacts:
     output_name: str | None = None
     analysis_output_name: str | None = None
     atlas_output_name: str | None = None
+    background_enabled: bool = False
+    background_layer_loaded: bool = False
+    background_name: str | None = None
     filters_active: bool = False
     filtered_activity_count: int | None = None
 
@@ -43,6 +46,9 @@ def build_wizard_progress_facts_from_runtime_state(
     atlas_exported: bool = False,
     preferred_current_key: str | None = None,
     atlas_output_path: str | None = None,
+    background_enabled: bool = False,
+    background_layer_loaded: bool = False,
+    background_name: str | None = None,
     filters_active: bool = False,
     filtered_activity_count: int | None = None,
 ) -> WizardProgressFacts:
@@ -75,6 +81,9 @@ def build_wizard_progress_facts_from_runtime_state(
         output_name=output_name,
         analysis_output_name=analysis_output_name,
         atlas_output_name=atlas_output_name,
+        background_enabled=background_enabled,
+        background_layer_loaded=background_layer_loaded,
+        background_name=_optional_text(background_name),
         filters_active=filters_active,
         filtered_activity_count=filtered_activity_count,
     )
@@ -128,6 +137,9 @@ def build_wizard_progress_from_facts_and_settings(
             output_name=facts.output_name,
             analysis_output_name=facts.analysis_output_name,
             atlas_output_name=facts.atlas_output_name,
+            background_enabled=facts.background_enabled,
+            background_layer_loaded=facts.background_layer_loaded,
+            background_name=facts.background_name,
             filters_active=facts.filters_active,
             filtered_activity_count=facts.filtered_activity_count,
         )
@@ -193,6 +205,11 @@ def _output_name(output_path: str | None) -> str | None:
     if "\\" in stripped:
         return PureWindowsPath(stripped).name or stripped
     return Path(stripped).name or stripped
+
+
+def _optional_text(value: str | None) -> str | None:
+    stripped = (value or "").strip()
+    return stripped or None
 
 
 def _layer_name(layer) -> str | None:

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -42,6 +42,7 @@ class MapPageState:
     status_text: str = "Activity layers not loaded"
     detail_text: str = "Load stored activities, choose map context, then apply filters."
     layer_summary_text: str = "No activity layers on the map"
+    background_summary_text: str = "Basemap disabled"
     filter_summary_text: str = "All stored activities visible once layers are loaded"
     load_action_label: str = "Load activity layers"
     load_action_enabled: bool = True
@@ -70,6 +71,9 @@ class MapPageContent(QWidget):
         self.layer_summary_label = QLabel("", self)
         self.layer_summary_label.setObjectName("qfitWizardMapLayerSummary")
         style_summary_label(self.layer_summary_label)
+        self.background_summary_label = QLabel("", self)
+        self.background_summary_label.setObjectName("qfitWizardMapBackgroundSummary")
+        style_summary_label(self.background_summary_label)
         self.filter_summary_label = QLabel("", self)
         self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
         style_summary_label(self.filter_summary_label)
@@ -106,6 +110,8 @@ class MapPageContent(QWidget):
         self.detail_label.setText(state.detail_text)
         self.layer_summary_label.setText(state.layer_summary_text)
         self.layer_summary_label.setProperty("mapState", map_state)
+        self.background_summary_label.setText(state.background_summary_text)
+        self.background_summary_label.setProperty("mapState", map_state)
         self.filter_summary_label.setText(state.filter_summary_text)
         self.filter_summary_label.setProperty("mapState", map_state)
         self.load_layers_button.setText(state.load_action_label)
@@ -140,6 +146,7 @@ class MapPageContent(QWidget):
         layout.addWidget(self.status_label)
         layout.addWidget(self.detail_label)
         layout.addWidget(self.layer_summary_label)
+        layout.addWidget(self.background_summary_label)
         layout.addWidget(self.filter_summary_label)
         layout.addWidget(self.action_row)
         return layout

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -428,6 +428,9 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         output_name=facts.output_name,
         analysis_output_name=facts.analysis_output_name,
         atlas_output_name=facts.atlas_output_name,
+        background_enabled=facts.background_enabled,
+        background_layer_loaded=facts.background_layer_loaded,
+        background_name=facts.background_name,
         filters_active=facts.filters_active,
         filtered_activity_count=facts.filtered_activity_count,
     )
@@ -510,6 +513,7 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
         loaded=facts.activity_layers_loaded,
         status_text=_map_status_text(facts, default),
         layer_summary_text=_map_layer_summary(facts, default),
+        background_summary_text=_map_background_summary(facts, default),
         filter_summary_text=_map_filter_summary(facts, default),
         load_action_enabled=facts.activities_stored,
         apply_action_enabled=facts.activity_layers_loaded,
@@ -534,6 +538,18 @@ def _map_layer_summary(facts: WizardProgressFacts, default: MapPageState) -> str
             return f"Stored activities in {facts.output_name} are ready to load"
         return "Stored activities are ready to load"
     return default.layer_summary_text
+
+
+def _map_background_summary(facts: WizardProgressFacts, default: MapPageState) -> str:
+    if not facts.background_enabled:
+        return default.background_summary_text
+    if facts.background_layer_loaded:
+        if facts.background_name is not None:
+            return f"Basemap loaded: {facts.background_name}"
+        return "Basemap loaded"
+    if facts.background_name is not None:
+        return f"Basemap ready to load: {facts.background_name}"
+    return "Basemap enabled"
 
 
 def _map_filter_summary(facts: WizardProgressFacts, default: MapPageState) -> str:


### PR DESCRIPTION
## Summary

Adds a small #609-compatible visible seam for the future wizard Map & filters page: it now summarizes the current Mapbox basemap state alongside layer and filter facts.

## Changes

- Adds render-neutral wizard background facts for enabled/loaded basemap state and preset name.
- Surfaces a dedicated basemap summary label in the wizard map page content.
- Wires live dock background controls into the optional wizard shell refresh facts.
- Covers the new page rendering, fact adapter, composition, and dock fact extraction paths with tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
Refs #608.
