### PR TITLE
feat: summarize wizard map activity style

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -207,7 +207,24 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             background_name=background_name,
             filters_active=filters_active,
             filtered_activity_count=filtered_activity_count,
+            activity_style_preset=self._current_wizard_activity_style_preset(),
         )
+
+    def _current_wizard_activity_style_preset(self) -> str | None:
+        """Return current activity style copy for the optional wizard map page."""
+
+        preset_combo = getattr(self, "stylePresetComboBox", None)
+        if preset_combo is None or not hasattr(preset_combo, "currentText"):
+            return None
+        try:
+            preset_name = preset_combo.currentText()
+        except RuntimeError:
+            logger.debug("Failed to read wizard activity style preset", exc_info=True)
+            return None
+        if not isinstance(preset_name, str):
+            return None
+        stripped = preset_name.strip()
+        return stripped or None
 
     def _current_wizard_background_facts(self, runtime_state) -> tuple[bool, bool, str | None]:
         """Return current basemap facts for the optional wizard map page."""

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -129,7 +129,7 @@ class MapPageContentTest(unittest.TestCase):
             detail_text="Use saved filters for the loaded activity layers.",
             layer_summary_text="4 layers loaded from qfit.gpkg",
             background_summary_text="Basemap loaded: Outdoors",
-            style_summary_text="Activity style applied: By activity type",
+            style_summary_text="Selected activity style: By activity type",
             filter_summary_text="42 activities · Ride and Run · 2026",
             load_action_label="Reload layers",
             primary_action_label="Apply saved filters",
@@ -153,7 +153,7 @@ class MapPageContentTest(unittest.TestCase):
         self.assertEqual(content.background_summary_label.property("mapState"), "loaded")
         self.assertEqual(
             content.style_summary_label.text(),
-            "Activity style applied: By activity type",
+            "Selected activity style: By activity type",
         )
         self.assertEqual(content.style_summary_label.property("mapState"), "loaded")
         self.assertEqual(

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -57,6 +57,12 @@ class MapPageContentTest(unittest.TestCase):
         self.assertEqual(content.background_summary_label.text(), "Basemap disabled")
         self.assertIn(COLOR_MUTED, content.background_summary_label.styleSheet())
         self.assertEqual(
+            content.style_summary_label.objectName(),
+            "qfitWizardMapStyleSummary",
+        )
+        self.assertEqual(content.style_summary_label.text(), "Default activity styling")
+        self.assertIn(COLOR_MUTED, content.style_summary_label.styleSheet())
+        self.assertEqual(
             content.filter_summary_label.objectName(),
             "qfitWizardMapFilterSummary",
         )
@@ -109,6 +115,7 @@ class MapPageContentTest(unittest.TestCase):
                 content.detail_label,
                 content.layer_summary_label,
                 content.background_summary_label,
+                content.style_summary_label,
                 content.filter_summary_label,
                 content.action_row,
             ],
@@ -122,6 +129,7 @@ class MapPageContentTest(unittest.TestCase):
             detail_text="Use saved filters for the loaded activity layers.",
             layer_summary_text="4 layers loaded from qfit.gpkg",
             background_summary_text="Basemap loaded: Outdoors",
+            style_summary_text="Activity style applied: By activity type",
             filter_summary_text="42 activities · Ride and Run · 2026",
             load_action_label="Reload layers",
             primary_action_label="Apply saved filters",
@@ -143,6 +151,11 @@ class MapPageContentTest(unittest.TestCase):
         self.assertEqual(content.layer_summary_label.property("mapState"), "loaded")
         self.assertEqual(content.background_summary_label.text(), "Basemap loaded: Outdoors")
         self.assertEqual(content.background_summary_label.property("mapState"), "loaded")
+        self.assertEqual(
+            content.style_summary_label.text(),
+            "Activity style applied: By activity type",
+        )
+        self.assertEqual(content.style_summary_label.property("mapState"), "loaded")
         self.assertEqual(
             content.filter_summary_label.text(),
             "42 activities · Ride and Run · 2026",

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -377,6 +377,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasPdfPathLineEdit = _FakeLineEdit("/tmp/current-atlas.pdf")
         dock.backgroundMapCheckBox = _FakeCheckBox(True)
         dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
+        dock.stylePresetComboBox = _FakeComboBox(current_text="By activity type")
         dock._atlas_export_completed = True
         dock._atlas_export_output_path = "/tmp/exported-atlas.pdf"
 
@@ -401,6 +402,17 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(facts.background_enabled)
         self.assertTrue(facts.background_layer_loaded)
         self.assertIsNone(facts.background_name)
+        self.assertEqual(facts.activity_style_preset, "By activity type")
+
+    def test_current_wizard_activity_style_preset_reads_trimmed_combo_text(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.stylePresetComboBox = _FakeComboBox(current_text=" Simple lines ")
+
+        style_preset = (
+            self.module.QfitDockWidget._current_wizard_activity_style_preset(dock)
+        )
+
+        self.assertEqual(style_preset, "Simple lines")
 
     def test_current_wizard_background_facts_report_disabled_basemap(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -188,6 +188,14 @@ class WizardProgressFactsTests(unittest.TestCase):
         self.assertTrue(facts.background_layer_loaded)
         self.assertEqual(facts.background_name, "Outdoors")
 
+    def test_runtime_state_adapter_preserves_explicit_activity_style_preset(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path="/tmp/qfit.gpkg"),
+            activity_style_preset=" By activity type ",
+        )
+
+        self.assertEqual(facts.activity_style_preset, "By activity type")
+
     def test_defaults_keep_connection_current_with_no_completed_steps(self):
         progress = build_wizard_progress_from_facts(WizardProgressFacts())
 

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -404,7 +404,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Basemap loaded",
         )
 
-    def test_map_page_summary_reports_configured_activity_style_before_load(self):
+    def test_map_page_summary_reports_selected_activity_style_before_load(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,
             activities_stored=True,
@@ -415,10 +415,10 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(
             assembled.map_content.style_summary_label.text(),
-            "Activity style ready: By activity type",
+            "Selected activity style: By activity type",
         )
 
-    def test_map_page_summary_reports_applied_activity_style_after_load(self):
+    def test_map_page_summary_does_not_claim_loaded_style_is_applied(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,
             activities_stored=True,
@@ -430,7 +430,7 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(
             assembled.map_content.style_summary_label.text(),
-            "Activity style applied: Simple lines",
+            "Selected activity style: Simple lines",
         )
 
     def test_loaded_map_page_summary_reports_visible_filter_count(self):

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -404,6 +404,35 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Basemap loaded",
         )
 
+    def test_map_page_summary_reports_configured_activity_style_before_load(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_style_preset="By activity type",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.style_summary_label.text(),
+            "Activity style ready: By activity type",
+        )
+
+    def test_map_page_summary_reports_applied_activity_style_after_load(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            activity_style_preset="Simple lines",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.style_summary_label.text(),
+            "Activity style applied: Simple lines",
+        )
+
     def test_loaded_map_page_summary_reports_visible_filter_count(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -37,6 +37,7 @@ class WizardProgressFacts:
     background_name: str | None = None
     filters_active: bool = False
     filtered_activity_count: int | None = None
+    activity_style_preset: str | None = None
 
 
 def build_wizard_progress_facts_from_runtime_state(
@@ -51,6 +52,7 @@ def build_wizard_progress_facts_from_runtime_state(
     background_name: str | None = None,
     filters_active: bool = False,
     filtered_activity_count: int | None = None,
+    activity_style_preset: str | None = None,
 ) -> WizardProgressFacts:
     """Derive #609 wizard progress facts from the dock runtime snapshot.
 
@@ -86,6 +88,7 @@ def build_wizard_progress_facts_from_runtime_state(
         background_name=_optional_text(background_name),
         filters_active=filters_active,
         filtered_activity_count=filtered_activity_count,
+        activity_style_preset=_optional_text(activity_style_preset),
     )
 
 
@@ -142,6 +145,7 @@ def build_wizard_progress_from_facts_and_settings(
             background_name=facts.background_name,
             filters_active=facts.filters_active,
             filtered_activity_count=facts.filtered_activity_count,
+            activity_style_preset=facts.activity_style_preset,
         )
     )
 

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -43,6 +43,7 @@ class MapPageState:
     detail_text: str = "Load stored activities, choose map context, then apply filters."
     layer_summary_text: str = "No activity layers on the map"
     background_summary_text: str = "Basemap disabled"
+    style_summary_text: str = "Default activity styling"
     filter_summary_text: str = "All stored activities visible once layers are loaded"
     load_action_label: str = "Load activity layers"
     load_action_enabled: bool = True
@@ -74,6 +75,9 @@ class MapPageContent(QWidget):
         self.background_summary_label = QLabel("", self)
         self.background_summary_label.setObjectName("qfitWizardMapBackgroundSummary")
         style_summary_label(self.background_summary_label)
+        self.style_summary_label = QLabel("", self)
+        self.style_summary_label.setObjectName("qfitWizardMapStyleSummary")
+        style_summary_label(self.style_summary_label)
         self.filter_summary_label = QLabel("", self)
         self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
         style_summary_label(self.filter_summary_label)
@@ -112,6 +116,8 @@ class MapPageContent(QWidget):
         self.layer_summary_label.setProperty("mapState", map_state)
         self.background_summary_label.setText(state.background_summary_text)
         self.background_summary_label.setProperty("mapState", map_state)
+        self.style_summary_label.setText(state.style_summary_text)
+        self.style_summary_label.setProperty("mapState", map_state)
         self.filter_summary_label.setText(state.filter_summary_text)
         self.filter_summary_label.setProperty("mapState", map_state)
         self.load_layers_button.setText(state.load_action_label)
@@ -147,6 +153,7 @@ class MapPageContent(QWidget):
         layout.addWidget(self.detail_label)
         layout.addWidget(self.layer_summary_label)
         layout.addWidget(self.background_summary_label)
+        layout.addWidget(self.style_summary_label)
         layout.addWidget(self.filter_summary_label)
         layout.addWidget(self.action_row)
         return layout

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -433,6 +433,7 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         background_name=facts.background_name,
         filters_active=facts.filters_active,
         filtered_activity_count=facts.filtered_activity_count,
+        activity_style_preset=facts.activity_style_preset,
     )
 
 
@@ -514,6 +515,7 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
         status_text=_map_status_text(facts, default),
         layer_summary_text=_map_layer_summary(facts, default),
         background_summary_text=_map_background_summary(facts, default),
+        style_summary_text=_map_style_summary(facts, default),
         filter_summary_text=_map_filter_summary(facts, default),
         load_action_enabled=facts.activities_stored,
         apply_action_enabled=facts.activity_layers_loaded,
@@ -550,6 +552,14 @@ def _map_background_summary(facts: WizardProgressFacts, default: MapPageState) -
     if facts.background_name is not None:
         return f"Basemap ready to load: {facts.background_name}"
     return "Basemap enabled"
+
+
+def _map_style_summary(facts: WizardProgressFacts, default: MapPageState) -> str:
+    if facts.activity_style_preset is None:
+        return default.style_summary_text
+    if facts.activity_layers_loaded:
+        return f"Activity style applied: {facts.activity_style_preset}"
+    return f"Activity style ready: {facts.activity_style_preset}"
 
 
 def _map_filter_summary(facts: WizardProgressFacts, default: MapPageState) -> str:

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -557,9 +557,7 @@ def _map_background_summary(facts: WizardProgressFacts, default: MapPageState) -
 def _map_style_summary(facts: WizardProgressFacts, default: MapPageState) -> str:
     if facts.activity_style_preset is None:
         return default.style_summary_text
-    if facts.activity_layers_loaded:
-        return f"Activity style applied: {facts.activity_style_preset}"
-    return f"Activity style ready: {facts.activity_style_preset}"
+    return f"Selected activity style: {facts.activity_style_preset}"
 
 
 def _map_filter_summary(facts: WizardProgressFacts, default: MapPageState) -> str:


### PR DESCRIPTION
## Summary

Adds a small #609-compatible map-page summary for the selected activity style preset, so the wizard map step can show the current style choice without relying on the old long-scroll dock layout or claiming it has already been applied to loaded layers.

## Changes

- Extend wizard progress facts with a normalized `activity_style_preset` value.
- Surface an activity-style summary label on the reusable wizard map page.
- Read the current dock style preset into wizard runtime facts.
- Add tests for map page rendering, composition copy, runtime fact adaptation, and dock fact extraction.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
