### PR TITLE
Add wizard connection credential summary

### DIFF
--- a/tests/test_connection_page.py
+++ b/tests/test_connection_page.py
@@ -46,6 +46,19 @@ class ConnectionPageContentTest(unittest.TestCase):
         self.assertIn("continue to synchronization", content.detail_label.text())
         self.assertIn(COLOR_MUTED, content.detail_label.styleSheet())
         self.assertEqual(
+            content.credential_summary_label.objectName(),
+            "qfitWizardConnectionCredentialSummary",
+        )
+        self.assertEqual(
+            content.credential_summary_label.text(),
+            "No Strava credentials configured",
+        )
+        self.assertEqual(
+            content.credential_summary_label.property("connectionState"),
+            "not_connected",
+        )
+        self.assertIn(COLOR_MUTED, content.credential_summary_label.styleSheet())
+        self.assertEqual(
             content.configure_button.objectName(),
             "qfitWizardConnectionConfigureButton",
         )
@@ -68,7 +81,12 @@ class ConnectionPageContentTest(unittest.TestCase):
         self.assertEqual(content.action_row.outer_layout().widgets, [content.configure_button])
         self.assertEqual(
             content.outer_layout().widgets,
-            [content.status_label, content.detail_label, content.action_row],
+            [
+                content.status_label,
+                content.detail_label,
+                content.credential_summary_label,
+                content.action_row,
+            ],
         )
 
     def test_refreshes_connected_state_without_rebuilding(self):
@@ -77,6 +95,7 @@ class ConnectionPageContentTest(unittest.TestCase):
             connected=True,
             status_text="Connected to Strava",
             detail_text="Credentials are ready.",
+            credential_summary_text="Refresh token saved for Strava sync",
             primary_action_label="Review connection",
         )
 
@@ -86,6 +105,14 @@ class ConnectionPageContentTest(unittest.TestCase):
         self.assertEqual(content.status_label.property("connectionState"), "connected")
         self.assertEqual(content.status_label.property("tone"), "ok")
         self.assertEqual(content.detail_label.text(), "Credentials are ready.")
+        self.assertEqual(
+            content.credential_summary_label.text(),
+            "Refresh token saved for Strava sync",
+        )
+        self.assertEqual(
+            content.credential_summary_label.property("connectionState"),
+            "connected",
+        )
         self.assertEqual(content.configure_button.text(), "Review connection")
 
     def test_can_block_configure_action_with_tooltip_copy(self):

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -270,6 +270,20 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.presenter.progress.current_key, "connection")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
 
+    def test_connection_page_summary_reports_configured_credentials(self):
+        facts = self.composition.WizardProgressFacts(connection_configured=True)
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.connection_content.credential_summary_label.text(),
+            "Strava OAuth credentials are stored in qfit settings",
+        )
+        self.assertEqual(
+            assembled.connection_content.credential_summary_label.property("connectionState"),
+            "connected",
+        )
+
     def test_sync_page_summary_uses_runtime_activity_count_and_output_name(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -8,7 +8,11 @@ from .action_row import (
     set_wizard_action_availability,
     style_primary_action_button,
 )
-from .page_content_style import style_detail_label, style_status_pill
+from .page_content_style import (
+    style_detail_label,
+    style_status_pill,
+    style_summary_label,
+)
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
 _qtwidgets = import_qt_module(
@@ -41,6 +45,7 @@ class ConnectionPageState:
     connected: bool = False
     status_text: str = "Strava not connected"
     detail_text: str = "Configure qfit once, then continue to synchronization."
+    credential_summary_text: str = "No Strava credentials configured"
     primary_action_label: str = "Configure connection"
     primary_action_enabled: bool = True
     primary_action_blocked_tooltip: str = (
@@ -63,6 +68,9 @@ class ConnectionPageContent(QWidget):
         if hasattr(self.detail_label, "setWordWrap"):
             self.detail_label.setWordWrap(True)
         style_detail_label(self.detail_label)
+        self.credential_summary_label = QLabel("", self)
+        self.credential_summary_label.setObjectName("qfitWizardConnectionCredentialSummary")
+        style_summary_label(self.credential_summary_label)
         self.configure_button = QToolButton(self)
         self.configure_button.setObjectName("qfitWizardConnectionConfigureButton")
         style_primary_action_button(
@@ -88,6 +96,11 @@ class ConnectionPageContent(QWidget):
         )
         style_status_pill(self.status_label, active=state.connected)
         self.detail_label.setText(state.detail_text)
+        self.credential_summary_label.setText(state.credential_summary_text)
+        self.credential_summary_label.setProperty(
+            "connectionState",
+            "connected" if state.connected else "not_connected",
+        )
         self.configure_button.setText(state.primary_action_label)
         set_wizard_action_availability(
             self.configure_button,
@@ -108,6 +121,7 @@ class ConnectionPageContent(QWidget):
         layout.setSpacing(8)
         layout.addWidget(self.status_label)
         layout.addWidget(self.detail_label)
+        layout.addWidget(self.credential_summary_label)
         layout.addWidget(self.action_row)
         return layout
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -445,6 +445,7 @@ def _connection_state_from_facts(facts: WizardProgressFacts) -> ConnectionPageSt
         connected=True,
         status_text="Strava connected",
         detail_text="Connection is configured; continue to synchronization.",
+        credential_summary_text="Strava OAuth credentials are stored in qfit settings",
         primary_action_label="Review connection",
         primary_action_enabled=True,
     )


### PR DESCRIPTION
## Summary

Adds a compact credential summary to the wizard connection page so the future #609 dock can distinguish setup status from the primary connection CTA without bringing the old OAuth field block forward.

## Changes

- Adds a styled connection credential summary label to `ConnectionPageContent`.
- Derives configured-credential copy from wizard progress facts.
- Covers the new page field and runtime-fact-derived summary in tests.

## Testing

- `python3 -m pytest tests/test_connection_page.py tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
