### PR TITLE
Open config from wizard connection CTA

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from collections.abc import Callable
 from datetime import date
 
 logger = logging.getLogger(__name__)
@@ -130,11 +131,18 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     )
     STARTUP_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
 
-    def __init__(self, iface, parent=None, dependencies: DockWidgetDependencies | None = None):
+    def __init__(
+        self,
+        iface,
+        parent=None,
+        dependencies: DockWidgetDependencies | None = None,
+        open_configuration: Callable[[], None] | None = None,
+    ):
         if parent is None and iface is not None and hasattr(iface, "mainWindow"):
             parent = iface.mainWindow()
         super().__init__(parent)
         self.iface = iface
+        self._open_configuration = open_configuration
         self._runtime_state_store = DockRuntimeStore()
         self._atlas_export_completed = False
         self._atlas_export_output_path = None
@@ -168,7 +176,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return save_last_step_index(self.settings, index)
 
     def _show_connection_configuration_hint(self) -> None:
-        """Guide wizard users to the dedicated qfit configuration dialog."""
+        """Open or describe the dedicated qfit configuration dialog for wizard users."""
+
+        open_configuration = getattr(self, "_open_configuration", None)
+        if open_configuration is not None:
+            open_configuration()
+            self._set_status("qfit configuration opened; save credentials to continue.")
+            return
 
         self._show_info(
             "Configure qfit connection",

--- a/qfit_plugin.py
+++ b/qfit_plugin.py
@@ -53,7 +53,11 @@ class QfitPlugin:
 
     def show_dock(self):
         if self.dockwidget is None:
-            self.dockwidget = QfitDockWidget(self.iface, parent=self.iface.mainWindow())
+            self.dockwidget = QfitDockWidget(
+                self.iface,
+                parent=self.iface.mainWindow(),
+                open_configuration=self.show_config,
+            )
             self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dockwidget)
         self.dockwidget.show()
         self.dockwidget.raise_()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -513,7 +513,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(saved_index, 4)
         self.assertEqual(dock.settings.get("ui/last_step_index"), 4)
 
-    def test_show_connection_configuration_hint_reports_menu_path(self):
+    def test_show_connection_configuration_hint_opens_config_when_available(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._open_configuration = MagicMock()
+        dock._show_info = MagicMock()
+        dock._set_status = MagicMock()
+
+        self.module.QfitDockWidget._show_connection_configuration_hint(dock)
+
+        dock._open_configuration.assert_called_once_with()
+        dock._show_info.assert_not_called()
+        dock._set_status.assert_called_once_with(
+            "qfit configuration opened; save credentials to continue."
+        )
+
+    def test_show_connection_configuration_hint_reports_menu_path_without_opener(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._show_info = MagicMock()
         dock._set_status = MagicMock()


### PR DESCRIPTION
## Summary
- wire the wizard connection CTA to open qfit's Configuration dialog when the dock is launched by the plugin
- keep the existing menu-path hint as a fallback when no opener callback is available
- cover both opener and fallback paths in pure dock widget tests

## Tests
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Addresses #609 and supports the #608 dock UX redesign direction by making the wizard connection step an actionable entry point instead of a static hint.
