### PR TITLE
feat: clarify wizard prerequisite states

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from collections.abc import Callable
 from datetime import date
 
 logger = logging.getLogger(__name__)
@@ -130,11 +131,18 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     )
     STARTUP_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
 
-    def __init__(self, iface, parent=None, dependencies: DockWidgetDependencies | None = None):
+    def __init__(
+        self,
+        iface,
+        parent=None,
+        dependencies: DockWidgetDependencies | None = None,
+        open_configuration: Callable[[], None] | None = None,
+    ):
         if parent is None and iface is not None and hasattr(iface, "mainWindow"):
             parent = iface.mainWindow()
         super().__init__(parent)
         self.iface = iface
+        self._open_configuration = open_configuration
         self._runtime_state_store = DockRuntimeStore()
         self._atlas_export_completed = False
         self._atlas_export_output_path = None
@@ -168,7 +176,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return save_last_step_index(self.settings, index)
 
     def _show_connection_configuration_hint(self) -> None:
-        """Guide wizard users to the dedicated qfit configuration dialog."""
+        """Open or describe the dedicated qfit configuration dialog for wizard users."""
+
+        open_configuration = getattr(self, "_open_configuration", None)
+        if open_configuration is not None:
+            open_configuration()
+            self._set_status("qfit configuration opened; save credentials to continue.")
+            return
 
         self._show_info(
             "Configure qfit connection",

--- a/qfit_plugin.py
+++ b/qfit_plugin.py
@@ -53,7 +53,11 @@ class QfitPlugin:
 
     def show_dock(self):
         if self.dockwidget is None:
-            self.dockwidget = QfitDockWidget(self.iface, parent=self.iface.mainWindow())
+            self.dockwidget = QfitDockWidget(
+                self.iface,
+                parent=self.iface.mainWindow(),
+                open_configuration=self.show_config,
+            )
             self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dockwidget)
         self.dockwidget.show()
         self.dockwidget.raise_()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -513,7 +513,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(saved_index, 4)
         self.assertEqual(dock.settings.get("ui/last_step_index"), 4)
 
-    def test_show_connection_configuration_hint_reports_menu_path(self):
+    def test_show_connection_configuration_hint_opens_config_when_available(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._open_configuration = MagicMock()
+        dock._show_info = MagicMock()
+        dock._set_status = MagicMock()
+
+        self.module.QfitDockWidget._show_connection_configuration_hint(dock)
+
+        dock._open_configuration.assert_called_once_with()
+        dock._show_info.assert_not_called()
+        dock._set_status.assert_called_once_with(
+            "qfit configuration opened; save credentials to continue."
+        )
+
+    def test_show_connection_configuration_hint_reports_menu_path_without_opener(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._show_info = MagicMock()
         dock._set_status = MagicMock()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -570,6 +570,52 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Run analysis before exporting atlas PDF.",
         )
 
+    def test_progress_facts_explain_locked_page_prerequisites(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts()
+        )
+
+        self.assertEqual(
+            assembled.sync_content.status_label.text(),
+            "Connection required before sync",
+        )
+        self.assertEqual(
+            assembled.sync_content.detail_label.text(),
+            "Configure Strava credentials before syncing activities.",
+        )
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "Connect to Strava to enable synchronization",
+        )
+        self.assertEqual(
+            assembled.map_content.status_label.text(),
+            "Sync required before map loading",
+        )
+        self.assertEqual(
+            assembled.map_content.layer_summary_label.text(),
+            "Sync activities before loading map layers",
+        )
+        self.assertEqual(
+            assembled.analysis_content.status_label.text(),
+            "Map layers required before analysis",
+        )
+        self.assertEqual(
+            assembled.analysis_content.input_summary_label.text(),
+            "Load activity layers before running analysis",
+        )
+        self.assertEqual(
+            assembled.atlas_content.status_label.text(),
+            "Analysis required before atlas export",
+        )
+        self.assertEqual(
+            assembled.atlas_content.input_summary_label.text(),
+            "Run analysis before exporting atlas PDF",
+        )
+        self.assertIn(
+            "Connect to Strava to enable synchronization",
+            assembled.shell.footer_bar.text(),
+        )
+
     def test_progress_facts_disable_busy_sync_and_atlas_ctas(self):
         assembled = self.composition.build_placeholder_wizard_shell(
             progress_facts=self.composition.WizardProgressFacts(

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -456,7 +456,10 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
     status_text = default.status_text
     detail_text = default.detail_text
     sync_blocked_tooltip = default.primary_action_blocked_tooltip
-    if facts.activities_stored:
+    if not facts.connection_configured:
+        status_text = "Connection required before sync"
+        detail_text = "Configure Strava credentials before syncing activities."
+    elif facts.activities_stored:
         status_text = "Activities stored"
         detail_text = "Stored activities are ready for map loading."
     primary_action_label = default.primary_action_label
@@ -486,6 +489,8 @@ def _sync_activity_summary(
         return _sync_in_progress_summary(facts)
     if facts.activities_stored:
         return _stored_activity_summary(facts)
+    if not facts.connection_configured:
+        return "Connect to Strava to enable synchronization"
     return default.activity_summary_text
 
 
@@ -513,8 +518,8 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
     default = MapPageState()
     return MapPageState(
         loaded=facts.activity_layers_loaded,
-        status_text=_map_status_text(facts, default),
-        layer_summary_text=_map_layer_summary(facts, default),
+        status_text=_map_status_text(facts),
+        layer_summary_text=_map_layer_summary(facts),
         background_summary_text=_map_background_summary(facts, default),
         style_summary_text=_map_style_summary(facts, default),
         filter_summary_text=_map_filter_summary(facts, default),
@@ -523,15 +528,15 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
     )
 
 
-def _map_status_text(facts: WizardProgressFacts, default: MapPageState) -> str:
+def _map_status_text(facts: WizardProgressFacts) -> str:
     if facts.activity_layers_loaded:
         return "Activity layers loaded"
     if facts.activities_stored:
         return "Stored activities ready to load"
-    return default.status_text
+    return "Sync required before map loading"
 
 
-def _map_layer_summary(facts: WizardProgressFacts, default: MapPageState) -> str:
+def _map_layer_summary(facts: WizardProgressFacts) -> str:
     if facts.activity_layers_loaded:
         if facts.output_name is not None:
             return f"Activity layers from {facts.output_name} are loaded on the map"
@@ -540,7 +545,7 @@ def _map_layer_summary(facts: WizardProgressFacts, default: MapPageState) -> str
         if facts.output_name is not None:
             return f"Stored activities in {facts.output_name} are ready to load"
         return "Stored activities are ready to load"
-    return default.layer_summary_text
+    return "Sync activities before loading map layers"
 
 
 def _map_background_summary(facts: WizardProgressFacts, default: MapPageState) -> str:
@@ -576,8 +581,8 @@ def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:
     default = AnalysisPageState()
     return AnalysisPageState(
         ready=facts.analysis_generated,
-        status_text="Analysis ready" if facts.analysis_generated else default.status_text,
-        input_summary_text=_analysis_input_summary(facts, default),
+        status_text=_analysis_status_text(facts, default),
+        input_summary_text=_analysis_input_summary(facts),
         result_summary_text=(
             _analysis_result_summary(facts)
             if facts.analysis_generated
@@ -587,12 +592,20 @@ def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:
     )
 
 
-def _analysis_input_summary(
+def _analysis_status_text(
     facts: WizardProgressFacts,
     default: AnalysisPageState,
 ) -> str:
+    if facts.analysis_generated:
+        return "Analysis ready"
     if not facts.activity_layers_loaded:
-        return default.input_summary_text
+        return "Map layers required before analysis"
+    return default.status_text
+
+
+def _analysis_input_summary(facts: WizardProgressFacts) -> str:
+    if not facts.activity_layers_loaded:
+        return "Load activity layers before running analysis"
     if facts.filters_active:
         if facts.filtered_activity_count is None:
             return "Filtered activity subset ready for analysis"
@@ -609,11 +622,9 @@ def _analysis_result_summary(facts: WizardProgressFacts) -> str:
 
 def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
     default = AtlasPageState()
-    status_text = default.status_text
+    status_text = _atlas_status_text(facts, default)
     output_summary_text = _atlas_output_summary(facts, default)
     atlas_blocked_tooltip = default.primary_action_blocked_tooltip
-    if facts.atlas_exported:
-        status_text = "Atlas PDF exported"
     primary_action_label = default.primary_action_label
     if facts.atlas_export_in_progress:
         status_text = "Atlas export in progress"
@@ -622,7 +633,7 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
     return AtlasPageState(
         ready=facts.atlas_exported,
         status_text=status_text,
-        input_summary_text=_atlas_input_summary(facts, default),
+        input_summary_text=_atlas_input_summary(facts),
         output_summary_text=output_summary_text,
         primary_action_label=primary_action_label,
         primary_action_enabled=(
@@ -632,12 +643,17 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
     )
 
 
-def _atlas_input_summary(
-    facts: WizardProgressFacts,
-    default: AtlasPageState,
-) -> str:
+def _atlas_status_text(facts: WizardProgressFacts, default: AtlasPageState) -> str:
+    if facts.atlas_exported:
+        return "Atlas PDF exported"
     if not facts.analysis_generated:
-        return default.input_summary_text
+        return "Analysis required before atlas export"
+    return default.status_text
+
+
+def _atlas_input_summary(facts: WizardProgressFacts) -> str:
+    if not facts.analysis_generated:
+        return "Run analysis before exporting atlas PDF"
     if facts.analysis_output_name is not None:
         return f"Analysis output {facts.analysis_output_name} ready for atlas export"
     return "Analysis outputs ready for atlas export"


### PR DESCRIPTION
## Summary

Clarifies the future #609 wizard shell's locked-page states so downstream pages explain the missing prerequisite instead of showing generic empty-state copy.

## Changes

- Show a visible connection prerequisite on the synchronization page when Strava is not configured.
- Show sync/map/analysis prerequisites on locked downstream wizard pages.
- Preserve busy/export states and existing completed-state summaries.
- Add composition coverage for the locked-page prerequisite copy and footer summary.

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
