### PR TITLE
feat: sequence wizard sync actions

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -192,9 +192,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._set_status("Open qfit → Configuration to edit Strava credentials.")
 
     def _run_wizard_sync_step(self) -> None:
-        """Run the storage action that completes the wizard sync milestone."""
+        """Run the next concrete action for the wizard synchronization step."""
 
-        self.on_load_clicked()
+        if self.runtime_state.activities:
+            self.on_load_clicked()
+            return
+        self.on_refresh_clicked()
 
     def _current_wizard_progress_facts(self):
         """Return render-neutral #609 wizard facts from the live dock state."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -543,13 +543,28 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Open qfit → Configuration to edit Strava credentials."
         )
 
-    def test_run_wizard_sync_step_uses_storage_workflow(self):
+    def test_run_wizard_sync_step_fetches_when_no_activities_are_ready(self):
         dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.on_refresh_clicked = MagicMock()
+        dock.on_load_clicked = MagicMock()
+
+        self.module.QfitDockWidget._run_wizard_sync_step(dock)
+
+        dock.on_refresh_clicked.assert_called_once_with()
+        dock.on_load_clicked.assert_not_called()
+
+    def test_run_wizard_sync_step_stores_fetched_activities(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().set_activities([object()])
+        dock.on_refresh_clicked = MagicMock()
         dock.on_load_clicked = MagicMock()
 
         self.module.QfitDockWidget._run_wizard_sync_step(dock)
 
         dock.on_load_clicked.assert_called_once_with()
+        dock.on_refresh_clicked.assert_not_called()
 
     def test_build_wizard_shell_from_runtime_wires_persistence_and_callbacks(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -65,11 +65,13 @@ class WizardProgressFactsTests(unittest.TestCase):
             facts,
             WizardProgressFacts(
                 connection_configured=True,
+                activities_fetched=True,
                 activities_stored=True,
                 activity_layers_loaded=True,
                 analysis_generated=True,
                 atlas_exported=True,
                 preferred_current_key="atlas",
+                fetched_activity_count=2,
                 output_name="qfit.gpkg",
                 atlas_output_name="qfit-atlas.pdf",
             ),
@@ -116,6 +118,8 @@ class WizardProgressFactsTests(unittest.TestCase):
             )
         )
 
+        self.assertTrue(facts.activities_fetched)
+        self.assertEqual(facts.fetched_activity_count, 3)
         self.assertIsNone(facts.activity_count)
         self.assertEqual(facts.output_name, "qfit.gpkg")
 

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -329,6 +329,35 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Activities stored in qfit.gpkg",
         )
 
+    def test_sync_page_shows_fetched_activities_ready_to_store(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_fetched=True,
+            fetched_activity_count=3,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(assembled.presenter.progress.current_key, "sync")
+        self.assertEqual(assembled.sync_content.status_label.text(), "Activities fetched")
+        self.assertEqual(
+            assembled.sync_content.detail_label.text(),
+            "Store fetched activities in the GeoPackage to complete synchronization.",
+        )
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "3 fetched activities ready to store",
+        )
+        self.assertEqual(
+            assembled.sync_content.sync_button.text(),
+            "Store fetched activities",
+        )
+        self.assertTrue(assembled.sync_content.sync_button.isEnabled())
+        self.assertIn(
+            "3 fetched activities ready to store",
+            assembled.shell.footer_bar.text(),
+        )
+
     def test_map_page_summary_names_stored_output_before_layers_load(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -21,6 +21,7 @@ class WizardProgressFacts:
     """
 
     connection_configured: bool = False
+    activities_fetched: bool = False
     activities_stored: bool = False
     activity_layers_loaded: bool = False
     analysis_generated: bool = False
@@ -28,6 +29,7 @@ class WizardProgressFacts:
     sync_in_progress: bool = False
     atlas_export_in_progress: bool = False
     preferred_current_key: str | None = None
+    fetched_activity_count: int | None = None
     activity_count: int | None = None
     output_name: str | None = None
     analysis_output_name: str | None = None
@@ -62,9 +64,9 @@ def build_wizard_progress_facts_from_runtime_state(
     connection is persisted in configuration settings, and atlas exports do not
     yet retain a durable output artifact after the task completes. The runtime
     ``activities`` tuple is a fetch payload, not a persisted dataset count, so
-    this adapter deliberately leaves ``activity_count`` unknown. Atlas output is
-    supplied separately because it currently lives in the dock export controls,
-    not the runtime snapshot.
+    this adapter reports it separately as fetched work while deliberately leaving
+    ``activity_count`` unknown. Atlas output is supplied separately because it
+    currently lives in the dock export controls, not the runtime snapshot.
     """
 
     output_name = _output_name(state.output_path)
@@ -72,6 +74,7 @@ def build_wizard_progress_facts_from_runtime_state(
     atlas_output_name = _output_name(atlas_output_path)
     return WizardProgressFacts(
         connection_configured=connection_configured,
+        activities_fetched=bool(state.activities),
         activities_stored=_has_output_path(state),
         activity_layers_loaded=state.activities_layer is not None,
         analysis_generated=state.analysis_layer is not None,
@@ -79,6 +82,7 @@ def build_wizard_progress_facts_from_runtime_state(
         sync_in_progress=_has_sync_task(state),
         atlas_export_in_progress=state.atlas_export_task is not None,
         preferred_current_key=preferred_current_key,
+        fetched_activity_count=len(state.activities) if state.activities else None,
         activity_count=None,
         output_name=output_name,
         analysis_output_name=analysis_output_name,
@@ -129,6 +133,7 @@ def build_wizard_progress_from_facts_and_settings(
     return build_wizard_progress_from_facts(
         WizardProgressFacts(
             connection_configured=facts.connection_configured,
+            activities_fetched=facts.activities_fetched,
             activities_stored=facts.activities_stored,
             activity_layers_loaded=facts.activity_layers_loaded,
             analysis_generated=facts.analysis_generated,
@@ -136,6 +141,7 @@ def build_wizard_progress_from_facts_and_settings(
             sync_in_progress=facts.sync_in_progress,
             atlas_export_in_progress=facts.atlas_export_in_progress,
             preferred_current_key=preferred_current_key_from_settings(settings),
+            fetched_activity_count=facts.fetched_activity_count,
             activity_count=facts.activity_count,
             output_name=facts.output_name,
             analysis_output_name=facts.analysis_output_name,

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -417,6 +417,7 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
     completed = build_wizard_progress_from_facts(facts).completed_keys
     return WizardProgressFacts(
         connection_configured="connection" in completed,
+        activities_fetched=facts.activities_fetched,
         activities_stored="sync" in completed,
         activity_layers_loaded="map" in completed,
         analysis_generated="analysis" in completed,
@@ -424,6 +425,7 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         sync_in_progress=facts.sync_in_progress,
         atlas_export_in_progress=facts.atlas_export_in_progress,
         preferred_current_key=facts.preferred_current_key,
+        fetched_activity_count=facts.fetched_activity_count,
         activity_count=facts.activity_count,
         output_name=facts.output_name,
         analysis_output_name=facts.analysis_output_name,
@@ -462,7 +464,14 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
     elif facts.activities_stored:
         status_text = "Activities stored"
         detail_text = "Stored activities are ready for map loading."
+    elif facts.activities_fetched:
+        status_text = "Activities fetched"
+        detail_text = (
+            "Store fetched activities in the GeoPackage to complete synchronization."
+        )
     primary_action_label = default.primary_action_label
+    if facts.activities_fetched and not facts.activities_stored:
+        primary_action_label = "Store fetched activities"
     if facts.sync_in_progress:
         status_text = "Synchronization in progress"
         detail_text = (
@@ -491,6 +500,8 @@ def _sync_activity_summary(
         return _stored_activity_summary(facts)
     if not facts.connection_configured:
         return "Connect to Strava to enable synchronization"
+    if facts.activities_fetched:
+        return _fetched_activity_summary(facts)
     return default.activity_summary_text
 
 
@@ -512,6 +523,13 @@ def _stored_activity_summary(facts: WizardProgressFacts) -> str:
         activity_summary = f"{max(facts.activity_count, 0)} {noun}"
     output_summary = facts.output_name or "GeoPackage"
     return f"{activity_summary} stored in {output_summary}"
+
+
+def _fetched_activity_summary(facts: WizardProgressFacts) -> str:
+    if facts.fetched_activity_count is None:
+        return "Fetched activities ready to store"
+    noun = "activity" if facts.fetched_activity_count == 1 else "activities"
+    return f"{max(facts.fetched_activity_count, 0)} fetched {noun} ready to store"
 
 
 def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:


### PR DESCRIPTION
## Summary

Makes the optional #609 wizard synchronization CTA follow the actual fetch-then-store sequence instead of always jumping straight to storage.

## Changes

- Track fetched-but-not-yet-stored activities separately from stored activity counts in wizard progress facts.
- Update the wizard sync page copy and CTA to show when fetched activities are ready to store.
- Dispatch the wizard sync CTA to fetch first when no activities are loaded, then store once fetched activities exist.
- Add tests for the runtime facts, sync page copy, and dock callback dispatch.

## Testing

- `python3 -m pytest tests/test_wizard_progress.py tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
