### PR TITLE
feat: sequence wizard map actions

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -199,6 +199,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
         self.on_refresh_clicked()
 
+    def _run_wizard_map_step(self) -> None:
+        """Run the next concrete action for the wizard map-and-filters step."""
+
+        if self.runtime_state.activities_layer is None:
+            self.on_load_layers_clicked()
+            return
+        self.on_apply_filters_clicked()
+
     def _current_wizard_progress_facts(self):
         """Return render-neutral #609 wizard facts from the live dock state."""
 
@@ -357,7 +365,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 configure_connection=self._show_connection_configuration_hint,
                 sync_activities=self._run_wizard_sync_step,
                 load_activity_layers=self.on_load_layers_clicked,
-                apply_map_filters=self.on_apply_filters_clicked,
+                apply_map_filters=self._run_wizard_map_step,
                 run_analysis=self.on_run_analysis_clicked,
                 export_atlas=self.on_generate_atlas_pdf_clicked,
             ),

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -566,6 +566,29 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.on_load_clicked.assert_called_once_with()
         dock.on_refresh_clicked.assert_not_called()
 
+    def test_run_wizard_map_step_loads_layers_before_filters_are_available(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.on_load_layers_clicked = MagicMock()
+        dock.on_apply_filters_clicked = MagicMock()
+
+        self.module.QfitDockWidget._run_wizard_map_step(dock)
+
+        dock.on_load_layers_clicked.assert_called_once_with()
+        dock.on_apply_filters_clicked.assert_not_called()
+
+    def test_run_wizard_map_step_applies_filters_after_layers_are_loaded(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().set_dataset_layers(activities_layer=object())
+        dock.on_load_layers_clicked = MagicMock()
+        dock.on_apply_filters_clicked = MagicMock()
+
+        self.module.QfitDockWidget._run_wizard_map_step(dock)
+
+        dock.on_apply_filters_clicked.assert_called_once_with()
+        dock.on_load_layers_clicked.assert_not_called()
+
     def test_build_wizard_shell_from_runtime_wires_persistence_and_callbacks(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()
@@ -624,7 +647,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "configure_connection": "_show_connection_configuration_hint",
             "sync_activities": "_run_wizard_sync_step",
             "load_activity_layers": "on_load_layers_clicked",
-            "apply_map_filters": "on_apply_filters_clicked",
+            "apply_map_filters": "_run_wizard_map_step",
             "run_analysis": "on_run_analysis_clicked",
             "export_atlas": "on_generate_atlas_pdf_clicked",
         }

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -225,12 +225,17 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.map_content.status_label.text(),
             "Stored activities ready to load",
         )
-        self.assertTrue(assembled.map_content.load_layers_button.isEnabled())
+        self.assertFalse(assembled.map_content.load_layers_button.isEnabled())
         self.assertEqual(
-            assembled.map_content.load_layers_button.property("wizardActionAvailability"),
+            assembled.map_content.load_layers_button.toolTip(),
+            "Use the primary action to load activity layers.",
+        )
+        self.assertEqual(assembled.map_content.apply_filters_button.text(), "Load activity layers")
+        self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
+        self.assertEqual(
+            assembled.map_content.apply_filters_button.property("wizardActionAvailability"),
             "available",
         )
-        self.assertFalse(assembled.map_content.apply_filters_button.isEnabled())
 
     def test_existing_wizard_settings_restore_reachable_initial_step(self):
         settings = self.composition.WizardSettingsSnapshot(
@@ -1115,7 +1120,9 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.connection_content.status_label.text(), "Strava connected")
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
         self.assertEqual(assembled.map_content.status_label.text(), "Activity layers loaded")
+        self.assertEqual(assembled.map_content.load_layers_button.text(), "Reload activity layers")
         self.assertTrue(assembled.map_content.load_layers_button.isEnabled())
+        self.assertEqual(assembled.map_content.apply_filters_button.text(), "Apply filters")
         self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
         self.assertFalse(assembled.analysis_state.ready)
         self.assertTrue(assembled.analysis_content.run_analysis_button.isEnabled())

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -534,15 +534,35 @@ def _fetched_activity_summary(facts: WizardProgressFacts) -> str:
 
 def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
     default = MapPageState()
+    activity_layers_loaded = facts.activity_layers_loaded
+    stored_without_loaded_layers = facts.activities_stored and not activity_layers_loaded
     return MapPageState(
-        loaded=facts.activity_layers_loaded,
+        loaded=activity_layers_loaded,
         status_text=_map_status_text(facts),
         layer_summary_text=_map_layer_summary(facts),
         background_summary_text=_map_background_summary(facts, default),
         style_summary_text=_map_style_summary(facts, default),
         filter_summary_text=_map_filter_summary(facts, default),
-        load_action_enabled=facts.activities_stored,
-        apply_action_enabled=facts.activity_layers_loaded,
+        load_action_label=(
+            "Reload activity layers" if activity_layers_loaded else default.load_action_label
+        ),
+        load_action_enabled=activity_layers_loaded,
+        load_action_blocked_tooltip=(
+            "Use the primary action to load activity layers."
+            if stored_without_loaded_layers
+            else default.load_action_blocked_tooltip
+        ),
+        primary_action_label=(
+            "Load activity layers"
+            if stored_without_loaded_layers
+            else default.primary_action_label
+        ),
+        apply_action_enabled=facts.activities_stored,
+        apply_action_blocked_tooltip=(
+            "Sync activities before loading map layers."
+            if not facts.activities_stored
+            else default.apply_action_blocked_tooltip
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

Sequences the optional #609 wizard map CTA so it loads activity layers before applying filters, matching the visible wizard workflow instead of leaving the primary map action blocked until layers already exist.

## Changes

- Make stored-but-not-loaded map facts present a primary “Load activity layers” CTA.
- Keep layer reload as the secondary action once map layers are already loaded.
- Route the wizard map primary callback through a dock dispatcher that loads layers first, then applies filters after layers exist.
- Add tests for the map page CTA state and dock callback sequencing.

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
