### PR TITLE
feat: sequence analysis and atlas wizard CTAs

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -752,6 +752,22 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Analysis output qfit activity heatmap is available",
         )
 
+    def test_analysis_page_cta_switches_to_refresh_after_generation(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+            )
+        )
+
+        self.assertEqual(
+            assembled.analysis_content.run_analysis_button.text(),
+            "Refresh analysis",
+        )
+        self.assertTrue(assembled.analysis_content.run_analysis_button.isEnabled())
+
     def test_atlas_page_input_summary_names_analysis_output(self):
         assembled = self.composition.build_placeholder_wizard_shell(
             progress_facts=self.composition.WizardProgressFacts(
@@ -816,6 +832,23 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.atlas_content.output_summary_label.text(),
             "Latest atlas PDF exported to qfit-atlas.pdf",
         )
+
+    def test_exported_atlas_page_cta_switches_to_refresh(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                atlas_exported=True,
+            )
+        )
+
+        self.assertEqual(
+            assembled.atlas_content.export_atlas_button.text(),
+            "Refresh atlas PDF",
+        )
+        self.assertTrue(assembled.atlas_content.export_atlas_button.isEnabled())
 
     def test_explicit_page_state_overrides_progress_fact_defaults(self):
         assembled = self.composition.build_placeholder_wizard_shell(

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -626,6 +626,9 @@ def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:
             if facts.analysis_generated
             else default.result_summary_text
         ),
+        primary_action_label=(
+            "Refresh analysis" if facts.analysis_generated else default.primary_action_label
+        ),
         primary_action_enabled=facts.activity_layers_loaded,
     )
 
@@ -663,7 +666,9 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
     status_text = _atlas_status_text(facts, default)
     output_summary_text = _atlas_output_summary(facts, default)
     atlas_blocked_tooltip = default.primary_action_blocked_tooltip
-    primary_action_label = default.primary_action_label
+    primary_action_label = (
+        "Refresh atlas PDF" if facts.atlas_exported else default.primary_action_label
+    )
     if facts.atlas_export_in_progress:
         status_text = "Atlas export in progress"
         primary_action_label = "Export in progress…"


### PR DESCRIPTION
## Summary

- switch the wizard analysis CTA to `Refresh analysis` once analysis output exists
- switch the atlas CTA to `Refresh atlas PDF` after an atlas export is recorded
- cover both progress-fact driven CTA labels in wizard shell composition tests

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #608
Refs #609
