### PR TITLE
feat: add wizard footer status bar

### DIFF
--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -392,6 +392,32 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(footer.layer_pill.property("tone"), "muted")
         self.assertEqual(footer.path_label.text(), "qfit.gpkg")
 
+    def test_footer_bar_uses_muted_tone_for_zero_activities(self):
+        footer = self.wizard_shell.FooterStatusBar()
+
+        footer.set_activity_count(0)
+
+        self.assertEqual(footer.activity_pill.text(), "0 activities")
+        self.assertEqual(footer.activity_pill.property("tone"), "muted")
+
+    def test_footer_status_text_can_clear_compatibility_label(self):
+        footer = self.wizard_shell.FooterStatusBar(footer_text="Ready")
+
+        footer.set_status_text("")
+
+        self.assertEqual(footer.text(), "")
+        self.assertEqual(footer.path_label.text(), "")
+        self.assertEqual(footer.toolTip(), "")
+
+    def test_explicit_empty_gpkg_path_is_not_overwritten_by_status_refresh(self):
+        footer = self.wizard_shell.FooterStatusBar(footer_text="Ready")
+
+        footer.set_gpkg_path(None)
+        footer.set_status_text("Connected · 42 activities")
+
+        self.assertEqual(footer.text(), "Connected · 42 activities")
+        self.assertEqual(footer.path_label.text(), "qfit.gpkg")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -47,21 +47,27 @@ class _FakeCursor:
 
 
 class _FakeQt:
+    AlignCenter = 9
     ForbiddenCursor = 10
+    Horizontal = 13
+    Orientation = int
     PointingHandCursor = 11
     ToolButtonTextBesideIcon = 12
+    Vertical = 14
 
 
 class _FakeWidget:
     def __init__(self, parent=None):
         self.parent = parent
         self._height = None
+        self._minimum_height = None
         self._object_name = ""
         self._properties = {}
         self._enabled = True
         self._cursor = _FakeCursor(None)
         self._tooltip = ""
         self._stylesheet = ""
+        self._alignment = None
         self._visible = True
 
     def setVisible(self, value):  # noqa: N802
@@ -72,6 +78,12 @@ class _FakeWidget:
 
     def setFixedHeight(self, value):  # noqa: N802
         self._height = value
+
+    def setMinimumHeight(self, value):  # noqa: N802
+        self._minimum_height = value
+
+    def minimumHeight(self):  # noqa: N802
+        return self._minimum_height
 
     def height(self):
         return self._height
@@ -105,6 +117,12 @@ class _FakeWidget:
 
     def toolTip(self):  # noqa: N802
         return self._tooltip
+
+    def setAlignment(self, value):  # noqa: N802
+        self._alignment = value
+
+    def alignment(self):
+        return self._alignment
 
     def setStyleSheet(self, value):  # noqa: N802
         self._stylesheet = value
@@ -213,6 +231,7 @@ class _FakeVBoxLayout:
         self.contents_margins = None
         self.spacing = None
         self.widgets = []
+        self.stretches = []
 
     def setObjectName(self, value):  # noqa: N802
         self.object_name = value
@@ -225,6 +244,9 @@ class _FakeVBoxLayout:
 
     def addWidget(self, widget):  # noqa: N802
         self.widgets.append(widget)
+
+    def addStretch(self, stretch=0):  # noqa: N802
+        self.stretches.append(stretch)
 
 
 class _FakeHBoxLayout(_FakeVBoxLayout):
@@ -265,7 +287,11 @@ def _fake_qt_modules():
 def _load_wizard_shell_module():
     for name in (
         "qfit.ui.dockwidget.wizard_shell",
+        "qfit.ui.dockwidget.footer_status_bar",
         "qfit.ui.dockwidget.stepper_bar",
+        "qfit.ui.widgets.pill",
+        "qfit.ui.widgets.compat",
+        "qfit.ui.widgets",
         "qfit.ui.dockwidget",
     ):
         sys.modules.pop(name, None)
@@ -294,6 +320,7 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(shell.footer_bar.objectName(), "qfitWizardFooterBar")
         self.assertEqual(shell.footer_bar.height(), 28)
         self.assertEqual(shell.footer_bar.text(), "Ready")
+        self.assertEqual(shell.footer_bar.path_label.text(), "Ready")
 
     def test_outer_layout_matches_wizard_spec_order(self):
         shell = self.wizard_shell.WizardShell()
@@ -329,6 +356,41 @@ class WizardShellTest(unittest.TestCase):
         shell.set_footer_text("Connected · 42 activities")
 
         self.assertEqual(shell.footer_bar.text(), "Connected · 42 activities")
+        self.assertEqual(shell.footer_bar.path_label.text(), "Connected · 42 activities")
+        self.assertEqual(shell.footer_bar.toolTip(), "Connected · 42 activities")
+
+    def test_footer_bar_exposes_spec_pill_and_path_api(self):
+        footer = self.wizard_shell.FooterStatusBar(footer_text="Ready")
+
+        footer.set_strava(True)
+        footer.set_activity_count(1)
+        footer.set_layer_count(3)
+        footer.set_gpkg_path("/tmp/qfit-test/activities.gpkg")
+
+        self.assertEqual(footer.strava_pill.objectName(), "qfitWizardFooterStravaPill")
+        self.assertEqual(footer.strava_pill.text(), "● Strava")
+        self.assertEqual(footer.strava_pill.property("tone"), "ok")
+        self.assertEqual(footer.activity_pill.text(), "1 activity")
+        self.assertEqual(footer.activity_pill.property("tone"), "info")
+        self.assertEqual(footer.layer_pill.text(), "3 layers")
+        self.assertEqual(footer.layer_pill.property("tone"), "neutral")
+        self.assertEqual(footer.path_label.text(), "activities.gpkg")
+        self.assertEqual(footer.path_label.toolTip(), "/tmp/qfit-test/activities.gpkg")
+
+    def test_footer_bar_uses_muted_copy_for_unknown_counts(self):
+        footer = self.wizard_shell.FooterStatusBar()
+
+        footer.set_strava(False)
+        footer.set_activity_count(None)
+        footer.set_layer_count(0)
+        footer.set_gpkg_path(None)
+
+        self.assertEqual(footer.strava_pill.property("tone"), "danger")
+        self.assertEqual(footer.activity_pill.text(), "— activities")
+        self.assertEqual(footer.activity_pill.property("tone"), "muted")
+        self.assertEqual(footer.layer_pill.text(), "0 layers")
+        self.assertEqual(footer.layer_pill.property("tone"), "muted")
+        self.assertEqual(footer.path_label.text(), "qfit.gpkg")
 
 
 if __name__ == "__main__":

--- a/ui/dockwidget/footer_status_bar.py
+++ b/ui/dockwidget/footer_status_bar.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from qfit.ui.tokens import COLOR_MUTED, COLOR_SEPARATOR, pill_tone_palette
+
+from ._qt_compat import import_qt_module
+
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QHBoxLayout",
+        "QLabel",
+        "QWidget",
+    ),
+)
+
+QHBoxLayout = _qtwidgets.QHBoxLayout
+QLabel = _qtwidgets.QLabel
+QWidget = _qtwidgets.QWidget
+
+
+class FooterStatusBar(QWidget):
+    """Compact persistent status footer for the #609 wizard shell.
+
+    The widget exposes the explicit pill/path API from the wizard spec while
+    retaining a tiny ``set_status_text`` compatibility seam for the existing
+    placeholder shell composition. That lets the dock keep using render-neutral
+    summary text until the final production swap wires live counts and paths.
+    """
+
+    def __init__(self, parent=None, *, footer_text: str = "") -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitWizardFooterBar")
+        self.setFixedHeight(28)
+        self._summary_text = footer_text
+        self._has_explicit_gpkg_path = False
+        self.strava_pill = _make_footer_pill(
+            "● Strava",
+            "muted",
+            object_name="qfitWizardFooterStravaPill",
+            parent=self,
+        )
+        self.activity_pill = _make_footer_pill(
+            "— activities",
+            "muted",
+            object_name="qfitWizardFooterActivityPill",
+            parent=self,
+        )
+        self.layer_pill = _make_footer_pill(
+            "0 layers",
+            "muted",
+            object_name="qfitWizardFooterLayerPill",
+            parent=self,
+        )
+        self.path_label = QLabel("", self)
+        self.path_label.setObjectName("qfitWizardFooterPath")
+        self.path_label.setStyleSheet(
+            "QLabel#qfitWizardFooterPath { "
+            f"color: {COLOR_MUTED}; "
+            "font-family: monospace; "
+            "font-size: 10.5pt; "
+            "}"
+        )
+        self._layout = self._build_layout()
+        self.set_status_text(footer_text)
+        self.setStyleSheet(
+            "QWidget#qfitWizardFooterBar { "
+            f"border-top: 1px solid {COLOR_SEPARATOR}; "
+            "padding: 4px 10px; "
+            "background: #f7f7f7; "
+            "}"
+        )
+
+    def set_status_text(self, text: str) -> None:
+        """Store compatibility footer text and expose it as a tooltip."""
+
+        self._summary_text = text
+        if hasattr(self, "setToolTip"):
+            self.setToolTip(text)
+        if text and not self._has_explicit_gpkg_path:
+            self.path_label.setText(text)
+
+    def text(self) -> str:
+        """Return the compatibility footer summary text."""
+
+        return self._summary_text
+
+    def set_strava(self, connected: bool) -> None:
+        """Update the Strava connection pill."""
+
+        self.strava_pill.setText("● Strava")
+        _set_footer_pill_tone(
+            self.strava_pill,
+            "ok" if connected else "danger",
+            object_name="qfitWizardFooterStravaPill",
+        )
+
+    def set_activity_count(self, n: int | None) -> None:
+        """Update the activity-count pill, using muted state for unknown counts."""
+
+        if n is None:
+            self.activity_pill.setText("— activities")
+            tone = "muted"
+        else:
+            count = max(int(n), 0)
+            noun = "activity" if count == 1 else "activities"
+            self.activity_pill.setText(f"{count} {noun}")
+            tone = "info"
+        _set_footer_pill_tone(
+            self.activity_pill,
+            tone,
+            object_name="qfitWizardFooterActivityPill",
+        )
+
+    def set_layer_count(self, m: int) -> None:
+        """Update the qfit layer-count pill."""
+
+        count = max(int(m), 0)
+        noun = "layer" if count == 1 else "layers"
+        self.layer_pill.setText(f"{count} {noun}")
+        _set_footer_pill_tone(
+            self.layer_pill,
+            "neutral" if count else "muted",
+            object_name="qfitWizardFooterLayerPill",
+        )
+
+    def set_gpkg_path(self, path: str | None) -> None:
+        """Display only the GeoPackage basename while keeping the full path in a tooltip."""
+
+        if not path:
+            self._has_explicit_gpkg_path = False
+            self.path_label.setText("qfit.gpkg")
+            self.path_label.setToolTip("")
+            return
+        self._has_explicit_gpkg_path = True
+        self.path_label.setText(Path(path).name)
+        self.path_label.setToolTip(path)
+
+    def outer_layout(self):
+        """Expose the footer layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_layout(self):
+        layout = QHBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardFooterLayout")
+        layout.setContentsMargins(4, 4, 10, 4)
+        layout.setSpacing(6)
+        layout.addWidget(self.strava_pill)
+        layout.addWidget(self.activity_pill)
+        layout.addWidget(self.layer_pill)
+        if hasattr(layout, "addStretch"):
+            layout.addStretch(1)
+        layout.addWidget(self.path_label)
+        return layout
+
+
+def _make_footer_pill(text: str, tone: str, *, object_name: str, parent=None):
+    label = QLabel(text, parent)
+    _set_footer_pill_tone(label, tone, object_name=object_name)
+    if hasattr(label, "setMinimumHeight"):
+        label.setMinimumHeight(18)
+    return label
+
+
+def _set_footer_pill_tone(widget, tone: str, *, object_name: str) -> None:
+    background, foreground = pill_tone_palette(tone)
+    widget.setObjectName(object_name)
+    widget.setProperty("tone", tone)
+    widget.setStyleSheet(
+        f"QLabel#{object_name} {{ "
+        f"background: {background}; "
+        f"color: {foreground}; "
+        "border: 0; "
+        "border-radius: 8px; "
+        "padding: 1px 6px; "
+        "font-size: 10.5pt; "
+        "font-weight: 600; "
+        "}"
+    )
+
+
+__all__ = ["FooterStatusBar"]

--- a/ui/dockwidget/footer_status_bar.py
+++ b/ui/dockwidget/footer_status_bar.py
@@ -35,7 +35,7 @@ class FooterStatusBar(QWidget):
         self.setObjectName("qfitWizardFooterBar")
         self.setFixedHeight(28)
         self._summary_text = footer_text
-        self._has_explicit_gpkg_path = False
+        self._path_label_owned_by_status = True
         self.strava_pill = _make_footer_pill(
             "● Strava",
             "muted",
@@ -79,7 +79,7 @@ class FooterStatusBar(QWidget):
         self._summary_text = text
         if hasattr(self, "setToolTip"):
             self.setToolTip(text)
-        if text and not self._has_explicit_gpkg_path:
+        if self._path_label_owned_by_status:
             self.path_label.setText(text)
 
     def text(self) -> str:
@@ -107,7 +107,7 @@ class FooterStatusBar(QWidget):
             count = max(int(n), 0)
             noun = "activity" if count == 1 else "activities"
             self.activity_pill.setText(f"{count} {noun}")
-            tone = "info"
+            tone = "info" if count else "muted"
         _set_footer_pill_tone(
             self.activity_pill,
             tone,
@@ -129,12 +129,11 @@ class FooterStatusBar(QWidget):
     def set_gpkg_path(self, path: str | None) -> None:
         """Display only the GeoPackage basename while keeping the full path in a tooltip."""
 
+        self._path_label_owned_by_status = False
         if not path:
-            self._has_explicit_gpkg_path = False
             self.path_label.setText("qfit.gpkg")
             self.path_label.setToolTip("")
             return
-        self._has_explicit_gpkg_path = True
         self.path_label.setText(Path(path).name)
         self.path_label.setToolTip(path)
 

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Sequence
 
 from ._qt_compat import import_qt_module
+from .footer_status_bar import FooterStatusBar
 from .stepper_bar import STEPPER_LABELS, StepperBar
 
 _qtwidgets = import_qt_module(
@@ -10,7 +11,6 @@ _qtwidgets = import_qt_module(
     "PyQt5.QtWidgets",
     (
         "QFrame",
-        "QLabel",
         "QScrollArea",
         "QStackedWidget",
         "QVBoxLayout",
@@ -19,7 +19,6 @@ _qtwidgets = import_qt_module(
 )
 
 QFrame = _qtwidgets.QFrame
-QLabel = _qtwidgets.QLabel
 QScrollArea = _qtwidgets.QScrollArea
 QStackedWidget = _qtwidgets.QStackedWidget
 QVBoxLayout = _qtwidgets.QVBoxLayout
@@ -76,7 +75,7 @@ class WizardShell(QWidget):
     def set_footer_text(self, text: str) -> None:
         """Update the compact persistent status/footer text."""
 
-        self.footer_bar.setText(text)
+        self.footer_bar.set_status_text(text)
 
     def outer_layout(self):
         """Expose the structural layout for adapter wiring and pure tests."""
@@ -116,16 +115,7 @@ class WizardShell(QWidget):
         return stack
 
     def _build_footer_bar(self, footer_text: str):
-        footer = QLabel(footer_text, self)
-        footer.setObjectName("qfitWizardFooterBar")
-        footer.setFixedHeight(28)
-        footer.setStyleSheet(
-            "QLabel#qfitWizardFooterBar { "
-            "border-top: 1px solid palette(mid); "
-            "padding: 4px 8px; "
-            "}"
-        )
-        return footer
+        return FooterStatusBar(self, footer_text=footer_text)
 
 
 __all__ = ["STEPPER_LABELS", "WizardShell"]


### PR DESCRIPTION
## Summary

Adds a reusable wizard `FooterStatusBar` for the #609 Option B shell, replacing the placeholder footer label with explicit Strava/activity/layer/path status APIs while preserving the existing render-neutral `set_footer_text` seam.

## Changes

- Add `ui.dockwidget.footer_status_bar.FooterStatusBar` with status pill methods and GeoPackage basename display.
- Integrate the footer widget into `WizardShell` without changing page composition behavior.
- Keep `qfit.ui.dockwidget` package imports lightweight for pure tests that stub only the stepper dependencies.
- Extend wizard shell tests to cover footer structure, compatibility text, pill tones, count copy, and path tooltip behavior.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609 and #608.
