### PR TITLE
feat: drive wizard footer from progress facts

### DIFF
--- a/tests/test_wizard_footer_status.py
+++ b/tests/test_wizard_footer_status.py
@@ -2,7 +2,12 @@ import unittest
 
 from tests import _path  # noqa: F401
 
-from qfit.ui.application.wizard_footer_status import build_wizard_footer_status
+from qfit.ui.application.wizard_footer_status import (
+    WizardFooterFacts,
+    build_wizard_footer_facts_from_progress_facts,
+    build_wizard_footer_status,
+)
+from qfit.ui.application.wizard_progress import WizardProgressFacts
 
 
 class WizardFooterStatusTests(unittest.TestCase):
@@ -41,6 +46,53 @@ class WizardFooterStatusTests(unittest.TestCase):
                 atlas_status=None,
             ),
             "Ready",
+        )
+
+    def test_builds_explicit_footer_facts_from_progress_facts(self):
+        facts = WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            activity_count=12,
+            output_name="qfit.gpkg",
+            loaded_layer_count=4,
+        )
+
+        self.assertEqual(
+            build_wizard_footer_facts_from_progress_facts(facts),
+            WizardFooterFacts(
+                strava_connected=True,
+                activity_count=12,
+                layer_count=4,
+                gpkg_path="qfit.gpkg",
+            ),
+        )
+
+    def test_footer_facts_do_not_report_unstored_or_unloaded_counts(self):
+        facts = WizardProgressFacts(
+            connection_configured=True,
+            activities_fetched=True,
+            fetched_activity_count=5,
+            activity_count=99,
+            loaded_layer_count=4,
+        )
+
+        self.assertEqual(
+            build_wizard_footer_facts_from_progress_facts(facts),
+            WizardFooterFacts(
+                strava_connected=True,
+                activity_count=None,
+                layer_count=0,
+                gpkg_path=None,
+            ),
+        )
+
+    def test_footer_facts_fall_back_to_single_loaded_layer_when_count_unknown(self):
+        facts = WizardProgressFacts(activity_layers_loaded=True)
+
+        self.assertEqual(
+            build_wizard_footer_facts_from_progress_facts(facts).layer_count,
+            1,
         )
 
 

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -39,7 +39,7 @@ class WizardProgressFactsTests(unittest.TestCase):
     def test_runtime_state_adapter_defaults_to_no_completed_workflow_facts(self):
         facts = build_wizard_progress_facts_from_runtime_state(DockRuntimeState())
 
-        self.assertEqual(facts, WizardProgressFacts())
+        self.assertEqual(facts, WizardProgressFacts(loaded_layer_count=0))
 
     def test_runtime_state_adapter_maps_persisted_and_loaded_workflow_facts(self):
         activities_layer = object()

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -49,6 +49,9 @@ class WizardProgressFactsTests(unittest.TestCase):
             output_path="/tmp/qfit.gpkg",
             layers=DockRuntimeLayers(
                 activities=activities_layer,
+                starts=object(),
+                points=object(),
+                atlas=object(),
                 analysis=analysis_layer,
             ),
         )
@@ -74,8 +77,25 @@ class WizardProgressFactsTests(unittest.TestCase):
                 fetched_activity_count=2,
                 output_name="qfit.gpkg",
                 atlas_output_name="qfit-atlas.pdf",
+                loaded_layer_count=4,
             ),
         )
+
+    def test_runtime_state_adapter_counts_loaded_qfit_dataset_layers(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(
+                layers=DockRuntimeLayers(
+                    activities=object(),
+                    starts=object(),
+                    points=None,
+                    atlas=object(),
+                    background=object(),
+                    analysis=object(),
+                )
+            )
+        )
+
+        self.assertEqual(facts.loaded_layer_count, 3)
 
     def test_runtime_state_adapter_maps_running_workflow_tasks(self):
         cases = (

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -304,6 +304,9 @@ class WizardShellCompositionTest(unittest.TestCase):
             "12 activities stored in qfit.gpkg",
         )
         self.assertIn("12 activities stored in qfit.gpkg", assembled.shell.footer_bar.text())
+        self.assertEqual(assembled.shell.footer_bar.strava_pill.property("tone"), "ok")
+        self.assertEqual(assembled.shell.footer_bar.activity_pill.text(), "12 activities")
+        self.assertEqual(assembled.shell.footer_bar.path_label.text(), "qfit.gpkg")
 
     def test_sync_page_summary_uses_singular_activity_count(self):
         facts = self.composition.WizardProgressFacts(
@@ -881,6 +884,8 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.map_state.loaded)
         self.assertFalse(assembled.map_content.load_layers_button.isEnabled())
         self.assertFalse(assembled.map_content.apply_filters_button.isEnabled())
+        self.assertEqual(assembled.shell.footer_bar.activity_pill.text(), "— activities")
+        self.assertEqual(assembled.shell.footer_bar.layer_pill.text(), "0 layers")
         self.assertFalse(assembled.analysis_state.ready)
         self.assertFalse(assembled.analysis_content.run_analysis_button.isEnabled())
         self.assertFalse(assembled.atlas_state.ready)
@@ -1157,9 +1162,39 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertTrue(assembled.map_content.load_layers_button.isEnabled())
         self.assertEqual(assembled.map_content.apply_filters_button.text(), "Apply filters")
         self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
+        self.assertEqual(assembled.shell.footer_bar.strava_pill.property("tone"), "ok")
+        self.assertEqual(assembled.shell.footer_bar.activity_pill.text(), "— activities")
+        self.assertEqual(assembled.shell.footer_bar.layer_pill.text(), "1 layer")
         self.assertFalse(assembled.analysis_state.ready)
         self.assertTrue(assembled.analysis_content.run_analysis_button.isEnabled())
         self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
+
+    def test_progress_facts_drive_explicit_footer_controls_on_build_and_refresh(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                activity_count=42,
+                output_name="activities.gpkg",
+                loaded_layer_count=4,
+            )
+        )
+
+        self.assertEqual(assembled.shell.footer_bar.strava_pill.property("tone"), "ok")
+        self.assertEqual(assembled.shell.footer_bar.activity_pill.text(), "42 activities")
+        self.assertEqual(assembled.shell.footer_bar.layer_pill.text(), "4 layers")
+        self.assertEqual(assembled.shell.footer_bar.path_label.text(), "activities.gpkg")
+
+        self.composition.refresh_wizard_shell_composition(
+            assembled,
+            progress_facts=self.composition.WizardProgressFacts(),
+        )
+
+        self.assertEqual(assembled.shell.footer_bar.strava_pill.property("tone"), "danger")
+        self.assertEqual(assembled.shell.footer_bar.activity_pill.text(), "— activities")
+        self.assertEqual(assembled.shell.footer_bar.layer_pill.text(), "0 layers")
+        self.assertEqual(assembled.shell.footer_bar.path_label.text(), "qfit.gpkg")
 
     def test_refresh_can_update_progress_from_settings_and_workflow_facts(self):
         assembled = self.composition.build_placeholder_wizard_shell()

--- a/ui/application/wizard_footer_status.py
+++ b/ui/application/wizard_footer_status.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from qfit.ui.application.wizard_progress import WizardProgressFacts
+
 
 @dataclass(frozen=True)
 class WizardFooterFacts:
@@ -38,7 +40,9 @@ def build_wizard_footer_status(
     )
 
 
-def build_wizard_footer_facts_from_progress_facts(facts) -> WizardFooterFacts:
+def build_wizard_footer_facts_from_progress_facts(
+    facts: WizardProgressFacts,
+) -> WizardFooterFacts:
     """Build footer pill/path facts from the shared wizard progress facts.
 
     The compact text summary remains as a compatibility seam for the placeholder

--- a/ui/application/wizard_footer_status.py
+++ b/ui/application/wizard_footer_status.py
@@ -1,5 +1,17 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WizardFooterFacts:
+    """Render-neutral facts for the explicit #609 wizard footer controls."""
+
+    strava_connected: bool = False
+    activity_count: int | None = None
+    layer_count: int = 0
+    gpkg_path: str | None = None
+
 
 def build_wizard_footer_status(
     *,
@@ -26,6 +38,23 @@ def build_wizard_footer_status(
     )
 
 
+def build_wizard_footer_facts_from_progress_facts(facts) -> WizardFooterFacts:
+    """Build footer pill/path facts from the shared wizard progress facts.
+
+    The compact text summary remains as a compatibility seam for the placeholder
+    shell. This adapter drives the footer's explicit Strava/activity/layer/path
+    controls from the same render-neutral state used by wizard pages, avoiding
+    any dependency on current long-scroll dock widgets.
+    """
+
+    return WizardFooterFacts(
+        strava_connected=facts.connection_configured,
+        activity_count=_stored_activity_count(facts),
+        layer_count=_loaded_layer_count(facts),
+        gpkg_path=facts.output_name,
+    )
+
+
 def _join_unique_status_parts(*values: str | None) -> str:
     parts: list[str] = []
     seen: set[str] = set()
@@ -41,4 +70,22 @@ def _join_unique_status_parts(*values: str | None) -> str:
     return " · ".join(parts)
 
 
-__all__ = ["build_wizard_footer_status"]
+def _stored_activity_count(facts) -> int | None:
+    if not facts.activities_stored or facts.activity_count is None:
+        return None
+    return max(int(facts.activity_count), 0)
+
+
+def _loaded_layer_count(facts) -> int:
+    if not facts.activity_layers_loaded:
+        return 0
+    if facts.loaded_layer_count is None:
+        return 1
+    return max(int(facts.loaded_layer_count), 0)
+
+
+__all__ = [
+    "WizardFooterFacts",
+    "build_wizard_footer_facts_from_progress_facts",
+    "build_wizard_footer_status",
+]

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -40,6 +40,7 @@ class WizardProgressFacts:
     filters_active: bool = False
     filtered_activity_count: int | None = None
     activity_style_preset: str | None = None
+    loaded_layer_count: int | None = None
 
 
 def build_wizard_progress_facts_from_runtime_state(
@@ -93,6 +94,7 @@ def build_wizard_progress_facts_from_runtime_state(
         filters_active=filters_active,
         filtered_activity_count=filtered_activity_count,
         activity_style_preset=_optional_text(activity_style_preset),
+        loaded_layer_count=_loaded_dataset_layer_count(state),
     )
 
 
@@ -152,6 +154,7 @@ def build_wizard_progress_from_facts_and_settings(
             filters_active=facts.filters_active,
             filtered_activity_count=facts.filtered_activity_count,
             activity_style_preset=facts.activity_style_preset,
+            loaded_layer_count=facts.loaded_layer_count,
         )
     )
 
@@ -206,6 +209,19 @@ def _has_output_path(state: DockRuntimeState) -> bool:
 
 def _has_sync_task(state: DockRuntimeState) -> bool:
     return state.fetch_task is not None or state.store_task is not None
+
+
+def _loaded_dataset_layer_count(state: DockRuntimeState) -> int | None:
+    count = sum(
+        layer is not None
+        for layer in (
+            state.activities_layer,
+            state.starts_layer,
+            state.points_layer,
+            state.atlas_layer,
+        )
+    )
+    return count or None
 
 
 def _output_name(output_path: str | None) -> str | None:

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -221,7 +221,7 @@ def _loaded_dataset_layer_count(state: DockRuntimeState) -> int | None:
             state.atlas_layer,
         )
     )
-    return count or None
+    return count
 
 
 def _output_name(output_path: str | None) -> str | None:

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -8,7 +8,11 @@ from qfit.ui.application.dock_workflow_sections import (
     DockWizardProgress,
     build_progress_wizard_step_statuses,
 )
-from qfit.ui.application.wizard_footer_status import build_wizard_footer_status
+from qfit.ui.application.wizard_footer_status import (
+    WizardFooterFacts,
+    build_wizard_footer_facts_from_progress_facts,
+    build_wizard_footer_status,
+)
 from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
     build_default_wizard_page_specs,
@@ -152,6 +156,7 @@ def build_placeholder_wizard_shell(
         progress_facts=progress_facts,
         wizard_settings=wizard_settings,
     )
+    footer_facts = _footer_facts_from_progress_facts(progress_facts)
     page_specs = _resolve_page_specs(specs)
     shell = WizardShell(
         parent=parent,
@@ -165,6 +170,7 @@ def build_placeholder_wizard_shell(
             atlas_state=atlas_state,
         ),
     )
+    _apply_footer_facts(shell.footer_bar, footer_facts)
     pages = install_wizard_pages(shell, specs=page_specs)
     connection_content = _install_connection_content(
         pages,
@@ -283,6 +289,7 @@ def refresh_wizard_shell_composition(
         progress_facts=progress_facts,
         wizard_settings=wizard_settings,
     )
+    footer_facts = _footer_facts_from_progress_facts(progress_facts)
     _validate_progress_targets_installed_page(resolved_progress, composition.pages)
 
     if composition.connection_content is not None:
@@ -308,6 +315,7 @@ def refresh_wizard_shell_composition(
             atlas_state=next_atlas_state,
         )
     )
+    _apply_footer_facts(composition.shell.footer_bar, footer_facts)
     if resolved_progress is not None:
         composition.presenter.set_progress(resolved_progress)
 
@@ -436,7 +444,27 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         filters_active=facts.filters_active,
         filtered_activity_count=facts.filtered_activity_count,
         activity_style_preset=facts.activity_style_preset,
+        loaded_layer_count=facts.loaded_layer_count,
     )
+
+
+def _footer_facts_from_progress_facts(
+    progress_facts: WizardProgressFacts | None,
+) -> WizardFooterFacts | None:
+    if progress_facts is None:
+        return None
+    return build_wizard_footer_facts_from_progress_facts(
+        _completed_prefix_facts(progress_facts)
+    )
+
+
+def _apply_footer_facts(footer_bar, footer_facts: WizardFooterFacts | None) -> None:
+    if footer_facts is None:
+        return
+    footer_bar.set_strava(footer_facts.strava_connected)
+    footer_bar.set_activity_count(footer_facts.activity_count)
+    footer_bar.set_layer_count(footer_facts.layer_count)
+    footer_bar.set_gpkg_path(footer_facts.gpkg_path)
 
 
 def _connection_state_from_facts(facts: WizardProgressFacts) -> ConnectionPageState:


### PR DESCRIPTION
## Summary

Adds a small #609 wizard-forward footer adapter so the persistent wizard footer pills/path are driven by render-neutral workflow facts, not just compatibility summary text.

## Changes

- add `WizardFooterFacts` and a progress-facts adapter for footer pill/path state
- carry loaded qfit dataset layer counts through wizard progress facts
- apply footer facts during wizard shell build/refresh while keeping completion-prefix gating
- cover build, refresh, runtime adapter, and footer fact behavior with tests

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs ebelo/qfit#609

