### PR TITLE
feat: track stored activity count for wizard status

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1057,7 +1057,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status("GeoPackage export failed")
             return
 
-        self._runtime_store().finish_store(output_path=result.output_path)
+        self._runtime_store().finish_store(
+            output_path=result.output_path,
+            stored_activity_count=result.total_stored,
+        )
         self._mark_atlas_export_stale()
         self._update_stored_activities_summary(result.total_stored)
         self._set_status(result.status)
@@ -1083,6 +1086,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._runtime_store().load_dataset(
             output_path=result.output_path,
+            stored_activity_count=result.total_stored,
             activities_layer=result.activities_layer,
             starts_layer=result.starts_layer,
             points_layer=result.points_layer,

--- a/tests/test_dock_runtime_state.py
+++ b/tests/test_dock_runtime_state.py
@@ -32,12 +32,14 @@ class TestDockRuntimeStore(unittest.TestCase):
         store.begin_store(task)
         self.assertIs(store.state.store_task, task)
 
-        store.finish_store(output_path="/tmp/qfit.gpkg")
+        store.finish_store(output_path="/tmp/qfit.gpkg", stored_activity_count=12)
         self.assertIsNone(store.state.store_task)
         self.assertEqual(store.state.output_path, "/tmp/qfit.gpkg")
+        self.assertEqual(store.state.stored_activity_count, 12)
 
         store.load_dataset(
             output_path="/tmp/qfit.gpkg",
+            stored_activity_count=9,
             activities_layer=activities_layer,
             starts_layer=starts_layer,
             points_layer=points_layer,
@@ -47,6 +49,18 @@ class TestDockRuntimeStore(unittest.TestCase):
         self.assertIs(store.state.starts_layer, starts_layer)
         self.assertIs(store.state.points_layer, points_layer)
         self.assertIs(store.state.atlas_layer, atlas_layer)
+        self.assertEqual(store.state.stored_activity_count, 9)
+
+    def test_store_and_load_lifecycle_clamps_negative_activity_counts(self):
+        store = DockRuntimeStore()
+
+        store.finish_store(output_path="/tmp/qfit.gpkg", stored_activity_count=-3)
+
+        self.assertEqual(store.state.stored_activity_count, 0)
+
+        store.load_dataset(output_path="/tmp/qfit.gpkg", stored_activity_count=-5)
+
+        self.assertEqual(store.state.stored_activity_count, 0)
 
     def test_reset_loaded_dataset_clears_loaded_runtime_fields(self):
         store = DockRuntimeStore()
@@ -54,7 +68,7 @@ class TestDockRuntimeStore(unittest.TestCase):
         analysis_layer = object()
 
         store.finish_fetch(activities=["run"], metadata={"provider": "strava"})
-        store.finish_store(output_path="/tmp/qfit.gpkg")
+        store.finish_store(output_path="/tmp/qfit.gpkg", stored_activity_count=2)
         store.load_dataset(
             output_path="/tmp/qfit.gpkg",
             activities_layer=object(),
@@ -69,6 +83,7 @@ class TestDockRuntimeStore(unittest.TestCase):
 
         self.assertEqual(store.state.activities, ())
         self.assertIsNone(store.state.output_path)
+        self.assertIsNone(store.state.stored_activity_count)
         self.assertIsNone(store.state.activities_layer)
         self.assertIsNone(store.state.starts_layer)
         self.assertIsNone(store.state.points_layer)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -383,6 +383,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         dock._runtime_store().load_dataset(
             output_path="/tmp/qfit.gpkg",
+            stored_activity_count=4,
             activities_layer=object(),
             starts_layer=object(),
             points_layer=object(),
@@ -395,6 +396,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         self.assertTrue(facts.connection_configured)
         self.assertTrue(facts.activities_stored)
+        self.assertEqual(facts.activity_count, 4)
         self.assertTrue(facts.activity_layers_loaded)
         self.assertTrue(facts.analysis_generated)
         self.assertTrue(facts.atlas_exported)

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -130,6 +130,16 @@ class WizardProgressFactsTests(unittest.TestCase):
         self.assertIsNone(facts.activity_count)
         self.assertEqual(facts.output_name, "qfit.gpkg")
 
+    def test_runtime_state_adapter_maps_stored_activity_count(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(
+                output_path="/tmp/qfit.gpkg",
+                stored_activity_count=12,
+            )
+        )
+
+        self.assertEqual(facts.activity_count, 12)
+
     def test_runtime_state_adapter_does_not_treat_fetch_count_as_stored_count(self):
         facts = build_wizard_progress_facts_from_runtime_state(
             DockRuntimeState(

--- a/ui/application/dock_runtime_state.py
+++ b/ui/application/dock_runtime_state.py
@@ -81,6 +81,7 @@ class DockRuntimeTasks:
 class DockRuntimeState:
     activities: tuple[object, ...] = field(default_factory=tuple)
     output_path: str | None = None
+    stored_activity_count: int | None = None
     last_fetch_context: dict[str, Any] = field(default_factory=dict)
     layers: DockRuntimeLayers = field(default_factory=DockRuntimeLayers)
     tasks: DockRuntimeTasks = field(default_factory=DockRuntimeTasks)
@@ -214,10 +215,20 @@ class DockRuntimeStore:
     def begin_store(self, task) -> DockRuntimeState:
         return self.set_store_task(task)
 
-    def finish_store(self, *, output_path: str | None = None) -> DockRuntimeState:
+    def finish_store(
+        self,
+        *,
+        output_path: str | None = None,
+        stored_activity_count: int | None = None,
+    ) -> DockRuntimeState:
         next_state = replace(self._state, tasks=self._state.tasks.clear_store())
         if output_path is not None:
             next_state = replace(next_state, output_path=output_path)
+        if stored_activity_count is not None:
+            next_state = replace(
+                next_state,
+                stored_activity_count=max(int(stored_activity_count), 0),
+            )
         self._state = next_state
         return self._state
 
@@ -225,6 +236,7 @@ class DockRuntimeStore:
         self,
         *,
         output_path: str | None,
+        stored_activity_count: int | None = None,
         activities_layer=None,
         starts_layer=None,
         points_layer=None,
@@ -232,6 +244,11 @@ class DockRuntimeStore:
     ) -> DockRuntimeState:
         return self._replace_state(
             output_path=output_path,
+            stored_activity_count=(
+                None
+                if stored_activity_count is None
+                else max(int(stored_activity_count), 0)
+            ),
             layers=self._state.layers.with_dataset(
                 activities_layer=activities_layer,
                 starts_layer=starts_layer,
@@ -244,6 +261,7 @@ class DockRuntimeStore:
         self,
         *,
         output_path: str | None,
+        stored_activity_count: int | None = None,
         activities_layer=None,
         starts_layer=None,
         points_layer=None,
@@ -251,6 +269,7 @@ class DockRuntimeStore:
     ) -> DockRuntimeState:
         return self.load_dataset(
             output_path=output_path,
+            stored_activity_count=stored_activity_count,
             activities_layer=activities_layer,
             starts_layer=starts_layer,
             points_layer=points_layer,
@@ -261,6 +280,7 @@ class DockRuntimeStore:
         return self._replace_state(
             activities=(),
             output_path=None,
+            stored_activity_count=None,
             last_fetch_context={},
             layers=self._state.layers.clear_dataset(),
         )

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -65,9 +65,10 @@ def build_wizard_progress_facts_from_runtime_state(
     connection is persisted in configuration settings, and atlas exports do not
     yet retain a durable output artifact after the task completes. The runtime
     ``activities`` tuple is a fetch payload, not a persisted dataset count, so
-    this adapter reports it separately as fetched work while deliberately leaving
-    ``activity_count`` unknown. Atlas output is supplied separately because it
-    currently lives in the dock export controls, not the runtime snapshot.
+    this adapter reports it separately as fetched work. Persisted dataset totals
+    come from the stored activity count captured during store/load transitions.
+    Atlas output is supplied separately because it currently lives in the dock
+    export controls, not the runtime snapshot.
     """
 
     output_name = _output_name(state.output_path)
@@ -84,7 +85,7 @@ def build_wizard_progress_facts_from_runtime_state(
         atlas_export_in_progress=state.atlas_export_task is not None,
         preferred_current_key=preferred_current_key,
         fetched_activity_count=len(state.activities) if state.activities else None,
-        activity_count=None,
+        activity_count=_stored_activity_count(state),
         output_name=output_name,
         analysis_output_name=analysis_output_name,
         atlas_output_name=atlas_output_name,
@@ -209,6 +210,13 @@ def _has_output_path(state: DockRuntimeState) -> bool:
 
 def _has_sync_task(state: DockRuntimeState) -> bool:
     return state.fetch_task is not None or state.store_task is not None
+
+
+def _stored_activity_count(state: DockRuntimeState) -> int | None:
+    count = state.stored_activity_count
+    if count is None:
+        return None
+    return max(int(count), 0)
 
 
 def _loaded_dataset_layer_count(state: DockRuntimeState) -> int | None:


### PR DESCRIPTION
## Summary

Track the stored activity count in the render-neutral dock runtime state so the #609 wizard footer and synchronization page summaries can show real dataset totals without scraping the legacy dock labels.

## Changes

- Add `stored_activity_count` to `DockRuntimeState` and keep it updated after store/load transitions
- Feed the stored dataset count into `WizardProgressFacts.activity_count`
- Pass store/load result totals from `QfitDockWidget` into the runtime store
- Cover runtime state, wizard progress, and dock adapter behavior with tests

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609