### PR TITLE
feat: show last sync in wizard footer

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -233,7 +233,20 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             filters_active=filters_active,
             filtered_activity_count=filtered_activity_count,
             activity_style_preset=self._current_wizard_activity_style_preset(),
+            last_sync_date=self._current_wizard_last_sync_date(),
         )
+
+    def _current_wizard_last_sync_date(self) -> str | None:
+        """Return the persisted last sync date for wizard status summaries."""
+
+        settings = getattr(self, "settings", None)
+        get_value = getattr(settings, "get", None)
+        if not callable(get_value):
+            return None
+        value = get_value("last_sync_date", None)
+        if not isinstance(value, str):
+            return None
+        return value.strip() or None
 
     def _current_wizard_activity_style_preset(self) -> str | None:
         """Return current activity style copy for the optional wizard map page."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -378,6 +378,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.backgroundMapCheckBox = _FakeCheckBox(True)
         dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
         dock.stylePresetComboBox = _FakeComboBox(current_text="By activity type")
+        dock.settings = _FakeSettings({"last_sync_date": "2026-04-16"})
         dock._atlas_export_completed = True
         dock._atlas_export_output_path = "/tmp/exported-atlas.pdf"
 
@@ -405,6 +406,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(facts.background_layer_loaded)
         self.assertIsNone(facts.background_name)
         self.assertEqual(facts.activity_style_preset, "By activity type")
+        self.assertEqual(facts.last_sync_date, "2026-04-16")
 
     def test_current_wizard_activity_style_preset_reads_trimmed_combo_text(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_footer_status.py
+++ b/tests/test_wizard_footer_status.py
@@ -56,6 +56,7 @@ class WizardFooterStatusTests(unittest.TestCase):
             activity_count=12,
             output_name="qfit.gpkg",
             loaded_layer_count=4,
+            last_sync_date="2026-04-16",
         )
 
         self.assertEqual(
@@ -65,6 +66,7 @@ class WizardFooterStatusTests(unittest.TestCase):
                 activity_count=12,
                 layer_count=4,
                 gpkg_path="qfit.gpkg",
+                last_sync_date="2026-04-16",
             ),
         )
 
@@ -93,6 +95,13 @@ class WizardFooterStatusTests(unittest.TestCase):
         self.assertEqual(
             build_wizard_footer_facts_from_progress_facts(facts).layer_count,
             1,
+        )
+
+    def test_footer_facts_ignore_blank_last_sync_date(self):
+        facts = WizardProgressFacts(last_sync_date="   ")
+
+        self.assertIsNone(
+            build_wizard_footer_facts_from_progress_facts(facts).last_sync_date
         )
 
 

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -230,6 +230,14 @@ class WizardProgressFactsTests(unittest.TestCase):
 
         self.assertEqual(facts.activity_style_preset, "By activity type")
 
+    def test_runtime_state_adapter_preserves_explicit_last_sync_date(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path="/tmp/qfit.gpkg"),
+            last_sync_date=" 2026-04-16 ",
+        )
+
+        self.assertEqual(facts.last_sync_date, "2026-04-16")
+
     def test_defaults_keep_connection_current_with_no_completed_steps(self):
         progress = build_wizard_progress_from_facts(WizardProgressFacts())
 

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -364,6 +364,7 @@ class WizardShellTest(unittest.TestCase):
 
         footer.set_strava(True)
         footer.set_activity_count(1)
+        footer.set_sync_date("2026-04-16")
         footer.set_layer_count(3)
         footer.set_gpkg_path("/tmp/qfit-test/activities.gpkg")
 
@@ -372,6 +373,8 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(footer.strava_pill.property("tone"), "ok")
         self.assertEqual(footer.activity_pill.text(), "1 activity")
         self.assertEqual(footer.activity_pill.property("tone"), "info")
+        self.assertEqual(footer.sync_pill.text(), "sync 2026-04-16")
+        self.assertEqual(footer.sync_pill.property("tone"), "neutral")
         self.assertEqual(footer.layer_pill.text(), "3 layers")
         self.assertEqual(footer.layer_pill.property("tone"), "neutral")
         self.assertEqual(footer.path_label.text(), "activities.gpkg")
@@ -382,12 +385,15 @@ class WizardShellTest(unittest.TestCase):
 
         footer.set_strava(False)
         footer.set_activity_count(None)
+        footer.set_sync_date(None)
         footer.set_layer_count(0)
         footer.set_gpkg_path(None)
 
         self.assertEqual(footer.strava_pill.property("tone"), "danger")
         self.assertEqual(footer.activity_pill.text(), "— activities")
         self.assertEqual(footer.activity_pill.property("tone"), "muted")
+        self.assertEqual(footer.sync_pill.text(), "sync —")
+        self.assertEqual(footer.sync_pill.property("tone"), "muted")
         self.assertEqual(footer.layer_pill.text(), "0 layers")
         self.assertEqual(footer.layer_pill.property("tone"), "muted")
         self.assertEqual(footer.path_label.text(), "qfit.gpkg")

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -295,6 +295,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             activities_stored=True,
             activity_count=12,
             output_name="qfit.gpkg",
+            last_sync_date="2026-04-16",
         )
 
         assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
@@ -306,6 +307,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertIn("12 activities stored in qfit.gpkg", assembled.shell.footer_bar.text())
         self.assertEqual(assembled.shell.footer_bar.strava_pill.property("tone"), "ok")
         self.assertEqual(assembled.shell.footer_bar.activity_pill.text(), "12 activities")
+        self.assertEqual(assembled.shell.footer_bar.sync_pill.text(), "sync 2026-04-16")
         self.assertEqual(assembled.shell.footer_bar.path_label.text(), "qfit.gpkg")
 
     def test_sync_page_summary_uses_singular_activity_count(self):

--- a/ui/application/wizard_footer_status.py
+++ b/ui/application/wizard_footer_status.py
@@ -13,6 +13,7 @@ class WizardFooterFacts:
     activity_count: int | None = None
     layer_count: int = 0
     gpkg_path: str | None = None
+    last_sync_date: str | None = None
 
 
 def build_wizard_footer_status(
@@ -56,6 +57,7 @@ def build_wizard_footer_facts_from_progress_facts(
         activity_count=_stored_activity_count(facts),
         layer_count=_loaded_layer_count(facts),
         gpkg_path=facts.output_name,
+        last_sync_date=_optional_text(facts.last_sync_date),
     )
 
 
@@ -72,6 +74,11 @@ def _join_unique_status_parts(*values: str | None) -> str:
     if not parts:
         return "Ready"
     return " · ".join(parts)
+
+
+def _optional_text(value: str | None) -> str | None:
+    stripped = (value or "").strip()
+    return stripped or None
 
 
 def _stored_activity_count(facts) -> int | None:

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -41,6 +41,7 @@ class WizardProgressFacts:
     filtered_activity_count: int | None = None
     activity_style_preset: str | None = None
     loaded_layer_count: int | None = None
+    last_sync_date: str | None = None
 
 
 def build_wizard_progress_facts_from_runtime_state(
@@ -56,6 +57,7 @@ def build_wizard_progress_facts_from_runtime_state(
     filters_active: bool = False,
     filtered_activity_count: int | None = None,
     activity_style_preset: str | None = None,
+    last_sync_date: str | None = None,
 ) -> WizardProgressFacts:
     """Derive #609 wizard progress facts from the dock runtime snapshot.
 
@@ -96,6 +98,7 @@ def build_wizard_progress_facts_from_runtime_state(
         filtered_activity_count=filtered_activity_count,
         activity_style_preset=_optional_text(activity_style_preset),
         loaded_layer_count=_loaded_dataset_layer_count(state),
+        last_sync_date=_optional_text(last_sync_date),
     )
 
 
@@ -156,6 +159,7 @@ def build_wizard_progress_from_facts_and_settings(
             filtered_activity_count=facts.filtered_activity_count,
             activity_style_preset=facts.activity_style_preset,
             loaded_layer_count=facts.loaded_layer_count,
+            last_sync_date=facts.last_sync_date,
         )
     )
 

--- a/ui/dockwidget/footer_status_bar.py
+++ b/ui/dockwidget/footer_status_bar.py
@@ -48,6 +48,12 @@ class FooterStatusBar(QWidget):
             object_name="qfitWizardFooterActivityPill",
             parent=self,
         )
+        self.sync_pill = _make_footer_pill(
+            "sync —",
+            "muted",
+            object_name="qfitWizardFooterSyncPill",
+            parent=self,
+        )
         self.layer_pill = _make_footer_pill(
             "0 layers",
             "muted",
@@ -114,6 +120,22 @@ class FooterStatusBar(QWidget):
             object_name="qfitWizardFooterActivityPill",
         )
 
+    def set_sync_date(self, value: str | None) -> None:
+        """Update the last-sync pill from a persisted sync date string."""
+
+        sync_date = (value or "").strip()
+        if not sync_date:
+            self.sync_pill.setText("sync —")
+            tone = "muted"
+        else:
+            self.sync_pill.setText(f"sync {sync_date}")
+            tone = "neutral"
+        _set_footer_pill_tone(
+            self.sync_pill,
+            tone,
+            object_name="qfitWizardFooterSyncPill",
+        )
+
     def set_layer_count(self, m: int) -> None:
         """Update the qfit layer-count pill."""
 
@@ -150,6 +172,7 @@ class FooterStatusBar(QWidget):
         layout.setSpacing(6)
         layout.addWidget(self.strava_pill)
         layout.addWidget(self.activity_pill)
+        layout.addWidget(self.sync_pill)
         layout.addWidget(self.layer_pill)
         if hasattr(layout, "addStretch"):
             layout.addStretch(1)

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -445,6 +445,7 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         filtered_activity_count=facts.filtered_activity_count,
         activity_style_preset=facts.activity_style_preset,
         loaded_layer_count=facts.loaded_layer_count,
+        last_sync_date=facts.last_sync_date,
     )
 
 
@@ -463,6 +464,7 @@ def _apply_footer_facts(footer_bar, footer_facts: WizardFooterFacts | None) -> N
         return
     footer_bar.set_strava(footer_facts.strava_connected)
     footer_bar.set_activity_count(footer_facts.activity_count)
+    footer_bar.set_sync_date(footer_facts.last_sync_date)
     footer_bar.set_layer_count(footer_facts.layer_count)
     footer_bar.set_gpkg_path(footer_facts.gpkg_path)
 


### PR DESCRIPTION
## Summary

Adds the persisted last-sync date to the wizard-forward footer status model so the #609 shell can show Strava, activity count, sync freshness, layer count, and GeoPackage path from render-neutral facts.

## Changes

- Carry `last_sync_date` through wizard progress and footer facts.
- Add an explicit `sync …` footer pill to the reusable wizard footer bar.
- Feed the dock's persisted `last_sync_date` into optional wizard shell facts.
- Cover the new facts, footer pill, composition wiring, and dock adapter behavior with tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
Refs #608.
