### PR TITLE
fix: keep wizard footer paths compact

### DIFF
--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -380,6 +380,17 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(footer.path_label.text(), "activities.gpkg")
         self.assertEqual(footer.path_label.toolTip(), "/tmp/qfit-test/activities.gpkg")
 
+    def test_footer_bar_keeps_windows_paths_compact_on_non_windows_hosts(self):
+        footer = self.wizard_shell.FooterStatusBar(footer_text="Ready")
+
+        footer.set_gpkg_path(r"C:\Users\Emman\qfit\activities.gpkg")
+
+        self.assertEqual(footer.path_label.text(), "activities.gpkg")
+        self.assertEqual(
+            footer.path_label.toolTip(),
+            r"C:\Users\Emman\qfit\activities.gpkg",
+        )
+
     def test_footer_bar_uses_muted_copy_for_unknown_counts(self):
         footer = self.wizard_shell.FooterStatusBar()
 

--- a/ui/dockwidget/footer_status_bar.py
+++ b/ui/dockwidget/footer_status_bar.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from qfit.ui.tokens import COLOR_MUTED, COLOR_SEPARATOR, pill_tone_palette
 
@@ -156,7 +156,7 @@ class FooterStatusBar(QWidget):
             self.path_label.setText("qfit.gpkg")
             self.path_label.setToolTip("")
             return
-        self.path_label.setText(Path(path).name)
+        self.path_label.setText(_path_basename(path))
         self.path_label.setToolTip(path)
 
     def outer_layout(self):
@@ -203,6 +203,12 @@ def _set_footer_pill_tone(widget, tone: str, *, object_name: str) -> None:
         "font-weight: 600; "
         "}"
     )
+
+
+def _path_basename(path: str) -> str:
+    if "\\" in path:
+        return PureWindowsPath(path).name or path
+    return Path(path).name or path
 
 
 __all__ = ["FooterStatusBar"]


### PR DESCRIPTION
## Summary

Keep the #609 wizard footer GeoPackage label compact when it receives a Windows-style path on a non-Windows host.

## Changes

- Extract wizard footer path display names with `PureWindowsPath` when backslashes are present.
- Preserve the full path in the footer tooltip while showing only the basename.
- Add a regression test for Windows-style GeoPackage paths.

## Testing

- `python3 -m pytest tests/test_wizard_shell.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
