### PR TITLE
feat: surface loaded basemap names in wizard facts

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -269,7 +269,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         background_layer_loaded = runtime_state.background_layer is not None
         if background_layer_loaded:
-            return True, True, None
+            return True, True, self._current_wizard_layer_name(
+                runtime_state.background_layer,
+                log_message="Failed to read wizard background layer name",
+            )
 
         checkbox = getattr(self, "backgroundMapCheckBox", None)
         background_enabled = bool(
@@ -280,6 +283,22 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if not background_enabled:
             return False, False, None
         return True, False, self._current_wizard_background_name()
+
+    def _current_wizard_layer_name(self, layer, *, log_message: str) -> str | None:
+        if layer is None:
+            return None
+        name_method = getattr(layer, "name", None)
+        if not callable(name_method):
+            return None
+        try:
+            layer_name = name_method()
+        except RuntimeError:
+            logger.debug(log_message, exc_info=True)
+            return None
+        if not isinstance(layer_name, str):
+            return None
+        stripped = layer_name.strip()
+        return stripped or None
 
     def _current_wizard_background_name(self) -> str | None:
         preset_combo = getattr(self, "backgroundPresetComboBox", None)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -391,7 +391,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             atlas_layer=object(),
         )
         dock._runtime_store().set_analysis_layer(object())
-        dock._runtime_store().set_background_layer(object())
+        dock._runtime_store().set_background_layer(_FakeLayer("Outdoors"))
 
         facts = self.module.QfitDockWidget._current_wizard_progress_facts(dock)
 
@@ -404,7 +404,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(facts.atlas_output_name, "exported-atlas.pdf")
         self.assertTrue(facts.background_enabled)
         self.assertTrue(facts.background_layer_loaded)
-        self.assertIsNone(facts.background_name)
+        self.assertEqual(facts.background_name, "Outdoors")
         self.assertEqual(facts.activity_style_preset, "By activity type")
         self.assertEqual(facts.last_sync_date, "2026-04-16")
 
@@ -436,7 +436,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._runtime_state_store = self.module.DockRuntimeStore()
         dock.backgroundMapCheckBox = _FakeCheckBox(False)
         dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
-        dock._runtime_store().set_background_layer(object())
+        dock._runtime_store().set_background_layer(_FakeLayer("Satellite"))
+
+        facts = self.module.QfitDockWidget._current_wizard_background_facts(
+            dock,
+            dock.runtime_state,
+        )
+
+        self.assertEqual(facts, (True, True, "Satellite"))
+
+    def test_current_wizard_background_facts_ignore_blank_loaded_layer_name(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.backgroundMapCheckBox = _FakeCheckBox(False)
+        dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
+        dock._runtime_store().set_background_layer(_FakeLayer("   "))
 
         facts = self.module.QfitDockWidget._current_wizard_background_facts(
             dock,


### PR DESCRIPTION
## Summary

Surface the loaded basemap layer name in the #609 wizard progress facts so the future map page can distinguish a concrete loaded basemap from a generic enabled state.

## Changes

- Read a safe, trimmed name from the loaded background layer when deriving wizard background facts.
- Keep loaded-layer facts independent from pending combo-box selections.
- Add regression coverage for named and blank loaded basemap layers.

## Testing

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
