### PR TITLE
feat: add reusable wizard step page

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -1,0 +1,115 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+
+def _load_step_page_module():
+    for name in (
+        "qfit.ui.dockwidget.step_page",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.step_page")
+
+
+class StepPageTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.step_page = _load_step_page_module()
+
+    def test_builds_spec_step_chrome_with_header_content_and_nav(self):
+        page = self.step_page.StepPage(
+            2,
+            5,
+            "Synchronisation des activités",
+            "Récupération depuis Strava vers un GeoPackage.",
+        )
+
+        self.assertEqual(page.objectName(), "qfitWizardStepPage")
+        self.assertEqual(page.step_label.text(), "ÉTAPE 2/5")
+        self.assertEqual(page.title_label.text(), "Synchronisation des activités")
+        self.assertEqual(
+            page.subtitle_label.text(),
+            "Récupération depuis Strava vers un GeoPackage.",
+        )
+        self.assertEqual(page.content_container.objectName(), "qfitWizardStepContent")
+        self.assertEqual(page.content_layout().contents_margins, (0, 0, 0, 0))
+        self.assertEqual(page.back_button.text(), "Précédent")
+        self.assertEqual(page.back_button.property("wizardActionRole"), "back")
+        self.assertEqual(page.next_button.text(), "Suivant →")
+        self.assertEqual(page.next_button.property("wizardActionRole"), "primary")
+        self.assertFalse(page.status_pill.isVisible())
+
+    def test_status_pill_can_be_shown_and_hidden_with_tone(self):
+        page = self.step_page.StepPage(1, 5, "Connexion", "Configure qfit.")
+
+        page.set_status("Connecté", tone="ok")
+
+        self.assertTrue(page.status_pill.isVisible())
+        self.assertEqual(page.status_pill.text(), "Connecté")
+        self.assertEqual(page.status_pill.property("tone"), "ok")
+
+        page.set_status("  ")
+
+        self.assertFalse(page.status_pill.isVisible())
+        self.assertEqual(page.status_pill.text(), "")
+        self.assertEqual(page.status_pill.property("tone"), "muted")
+
+    def test_navigation_buttons_emit_dedicated_step_signals(self):
+        calls = []
+        page = self.step_page.StepPage(3, 5, "Carte", "Charge les couches.")
+        page.backRequested.connect(lambda: calls.append("back"))
+        page.nextRequested.connect(lambda: calls.append("next"))
+
+        page.back_button.clicked.emit()
+        page.next_button.clicked.emit()
+
+        self.assertEqual(calls, ["back", "next"])
+
+    def test_next_and_back_configuration_updates_roles_and_availability(self):
+        page = self.step_page.StepPage(4, 5, "Analyse", "Calcule les sorties.")
+
+        page.set_next("Lancer l'analyse", icon="", primary=False, enabled=False)
+        page.set_back("Retour", enabled=False)
+
+        self.assertEqual(page.next_button.text(), "Lancer l'analyse")
+        self.assertFalse(page.next_button.isEnabled())
+        self.assertEqual(page.next_button.property("wizardActionRole"), "secondary")
+        self.assertEqual(page.back_button.text(), "Retour")
+        self.assertFalse(page.back_button.isEnabled())
+
+    def test_content_and_extra_buttons_are_extensible_for_concrete_pages(self):
+        page = self.step_page.StepPage(5, 5, "Atlas PDF", "Configure l'export.")
+        extra_button = self.step_page.QToolButton(page)
+        content_widget = self.step_page.QWidget(page)
+
+        page.add_extra_button(extra_button)
+        page.content_layout().addWidget(content_widget)
+
+        self.assertEqual(extra_button.property("wizardActionRole"), "extra")
+        self.assertIn(extra_button, page._extra_right_layout.widgets)
+        self.assertIn(content_widget, page.content_layout().widgets)
+
+    def test_extra_button_alignment_can_target_left_nav_cluster(self):
+        page = self.step_page.StepPage(1, 5, "Connexion", "Configure qfit.")
+        extra_button = self.step_page.QToolButton(page)
+
+        page.add_extra_button(extra_button, align="left")
+
+        self.assertIn(extra_button, page._extra_left_layout.widgets)
+        self.assertNotIn(extra_button, page._extra_right_layout.widgets)
+
+    def test_rejects_unknown_extra_button_alignment(self):
+        page = self.step_page.StepPage(1, 5, "Connexion", "Configure qfit.")
+
+        with self.assertRaisesRegex(ValueError, "align must be 'left' or 'right'"):
+            page.add_extra_button(self.step_page.QToolButton(page), align="center")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -74,7 +74,7 @@ class StepPageTest(unittest.TestCase):
     def test_next_and_back_configuration_updates_roles_and_availability(self):
         page = self.step_page.StepPage(4, 5, "Analyse", "Calcule les sorties.")
 
-        page.set_next("Lancer l'analyse", icon="", primary=False, enabled=False)
+        page.set_next("Lancer l'analyse", primary=False, enabled=False)
         page.set_back("Retour", enabled=False)
 
         self.assertEqual(page.next_button.text(), "Lancer l'analyse")

--- a/ui/dockwidget/__init__.py
+++ b/ui/dockwidget/__init__.py
@@ -1,13 +1,6 @@
 """Dock widget components for the qfit wizard shell."""
 
-from .step_page import StepPage
 from .stepper_bar import STEPPER_LABELS, STEPPER_STATES, StepperBar
 from .wizard_shell_presenter import WizardShellPresenter
 
-__all__ = [
-    "STEPPER_LABELS",
-    "STEPPER_STATES",
-    "StepPage",
-    "StepperBar",
-    "WizardShellPresenter",
-]
+__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar", "WizardShellPresenter"]

--- a/ui/dockwidget/__init__.py
+++ b/ui/dockwidget/__init__.py
@@ -1,6 +1,13 @@
 """Dock widget components for the qfit wizard shell."""
 
+from .step_page import StepPage
 from .stepper_bar import STEPPER_LABELS, STEPPER_STATES, StepperBar
 from .wizard_shell_presenter import WizardShellPresenter
 
-__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar", "WizardShellPresenter"]
+__all__ = [
+    "STEPPER_LABELS",
+    "STEPPER_STATES",
+    "StepPage",
+    "StepperBar",
+    "WizardShellPresenter",
+]

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from ._qt_compat import import_qt_module
+from qfit.ui.widgets.pill import set_pill_tone
+from qfit.ui.widgets.tokens import (
+    COLOR_ACCENT,
+    COLOR_ACCENT_DARK,
+    COLOR_GROUP_BORDER,
+    COLOR_MUTED,
+    COLOR_PANEL,
+    COLOR_TEXT,
+)
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt", "pyqtSignal"))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QHBoxLayout",
+        "QLabel",
+        "QToolButton",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+Qt = _qtcore.Qt
+pyqtSignal = _qtcore.pyqtSignal
+QHBoxLayout = _qtwidgets.QHBoxLayout
+QLabel = _qtwidgets.QLabel
+QToolButton = _qtwidgets.QToolButton
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+class StepPage(QWidget):
+    """Shared #609 wizard page chrome: header, content area, and navigation.
+
+    Concrete pages can add controls to :meth:`content_layout` while reusing the
+    specified step header, status pill, back button, and single primary next CTA.
+    Keeping this as a standalone widget avoids further investment in the legacy
+    long-scroll dock while providing the base class named by the Option B spec.
+    """
+
+    backRequested = pyqtSignal()
+    nextRequested = pyqtSignal()
+
+    def __init__(
+        self,
+        step_num: int,
+        step_total: int,
+        title: str,
+        subtitle: str,
+        status_pill=None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.step_num = step_num
+        self.step_total = step_total
+        self.setObjectName("qfitWizardStepPage")
+        self.step_label = self._build_step_label(step_num, step_total)
+        self.title_label = self._build_title_label(title)
+        self.subtitle_label = self._build_subtitle_label(subtitle)
+        self.status_pill = status_pill or self._build_status_pill()
+        self.content_container = QWidget(self)
+        self.content_container.setObjectName("qfitWizardStepContent")
+        self._content_layout = self._build_content_layout(self.content_container)
+        self.back_button = self._build_back_button()
+        self.next_button = self._build_next_button()
+        self._extra_left_layout = self._build_extra_button_layout("qfitWizardStepLeftExtraLayout")
+        self._extra_right_layout = self._build_extra_button_layout("qfitWizardStepRightExtraLayout")
+        self._header_layout = self._build_header_layout()
+        self._nav_layout = self._build_nav_layout()
+        self._layout = self._build_layout()
+        self.set_status(None)
+        self.set_back()
+        self.set_next("Suivant")
+
+    def set_status(self, text: str | None, tone: str = "muted") -> None:
+        """Update the optional header status pill and hide it when text is blank."""
+
+        label = (text or "").strip()
+        self.status_pill.setText(label)
+        set_pill_tone(self.status_pill, tone, object_name="qfitWizardStepStatusPill")
+        self.status_pill.setVisible(bool(label))
+
+    def set_next(
+        self,
+        label: str,
+        icon: str = "→",
+        primary: bool = True,
+        enabled: bool = True,
+    ) -> None:
+        """Configure the right-side next/primary wizard action."""
+
+        self.next_button.setText(_button_text(label, icon))
+        self.next_button.setEnabled(enabled)
+        self.next_button.setProperty("wizardActionRole", "primary" if primary else "secondary")
+        self.next_button.setStyleSheet(
+            _primary_button_stylesheet() if primary else _ghost_button_stylesheet()
+        )
+
+    def set_back(self, label: str = "Précédent", enabled: bool = True) -> None:
+        """Configure the left-side back navigation action."""
+
+        self.back_button.setText(label)
+        self.back_button.setEnabled(enabled)
+        self.back_button.setProperty("wizardActionRole", "back")
+        self.back_button.setStyleSheet(_ghost_button_stylesheet())
+
+    def add_extra_button(self, btn, align: str = "right") -> None:
+        """Add a page-specific secondary button to the navigation row."""
+
+        btn.setProperty("wizardActionRole", "extra")
+        if align == "left":
+            self._extra_left_layout.addWidget(btn)
+            return
+        if align == "right":
+            self._extra_right_layout.addWidget(btn)
+            return
+        raise ValueError("align must be 'left' or 'right'")
+
+    def content_layout(self):
+        """Return the layout where concrete step pages install their controls."""
+
+        return self._content_layout
+
+    def outer_layout(self):
+        """Expose the full page layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_step_label(self, step_num: int, step_total: int):
+        label = QLabel(f"ÉTAPE {step_num}/{step_total}", self)
+        label.setObjectName("qfitWizardStepKickerLabel")
+        label.setStyleSheet(
+            f"QLabel#qfitWizardStepKickerLabel {{ color: {COLOR_MUTED}; "
+            "font-size: 10.5pt; font-weight: 600; letter-spacing: .5px; }}"
+        )
+        return label
+
+    def _build_title_label(self, title: str):
+        label = QLabel(title, self)
+        label.setObjectName("qfitWizardStepTitleLabel")
+        label.setStyleSheet(
+            f"QLabel#qfitWizardStepTitleLabel {{ color: {COLOR_TEXT}; "
+            "font-size: 14pt; font-weight: 600; }}"
+        )
+        return label
+
+    def _build_subtitle_label(self, subtitle: str):
+        label = QLabel(subtitle, self)
+        label.setObjectName("qfitWizardStepSubtitleLabel")
+        if hasattr(label, "setWordWrap"):
+            label.setWordWrap(True)
+        label.setStyleSheet(
+            f"QLabel#qfitWizardStepSubtitleLabel {{ color: {COLOR_MUTED}; "
+            "font-size: 11pt; margin-top: 3px; line-height: 1.45; }}"
+        )
+        return label
+
+    def _build_status_pill(self):
+        label = QLabel("", self)
+        label.setObjectName("qfitWizardStepStatusPill")
+        label.setAlignment(Qt.AlignCenter)
+        label.setMinimumHeight(18)
+        return label
+
+    def _build_back_button(self):
+        button = QToolButton(self)
+        button.setObjectName("qfitWizardStepBackButton")
+        button.clicked.connect(self.backRequested.emit)
+        return button
+
+    def _build_next_button(self):
+        button = QToolButton(self)
+        button.setObjectName("qfitWizardStepNextButton")
+        button.clicked.connect(self.nextRequested.emit)
+        return button
+
+    def _build_content_layout(self, parent):
+        layout = QVBoxLayout(parent)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardStepContentLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        return layout
+
+    def _build_header_layout(self):
+        layout = QHBoxLayout()
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardStepHeaderLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        layout.addWidget(self.step_label)
+        layout.addWidget(self.title_label)
+        layout.addStretch(1)
+        layout.addWidget(self.status_pill)
+        return layout
+
+    def _build_extra_button_layout(self, object_name: str):
+        layout = QHBoxLayout()
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName(object_name)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        return layout
+
+    def _build_nav_layout(self):
+        layout = QHBoxLayout()
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardStepNavLayout")
+        layout.setContentsMargins(0, 10, 0, 0)
+        layout.setSpacing(8)
+        layout.addWidget(self.back_button)
+        layout.addWidget(_LayoutWidget(self._extra_left_layout, self))
+        layout.addStretch(1)
+        layout.addWidget(_LayoutWidget(self._extra_right_layout, self))
+        layout.addWidget(self.next_button)
+        return layout
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardStepPageLayout")
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(10)
+        layout.addWidget(_LayoutWidget(self._header_layout, self))
+        layout.addWidget(self.subtitle_label)
+        layout.addWidget(self.content_container)
+        layout.addWidget(_LayoutWidget(self._nav_layout, self))
+        return layout
+
+
+class _LayoutWidget(QWidget):
+    """Small wrapper so fake and real Qt layouts can be inserted as widgets."""
+
+    def __init__(self, layout, parent=None) -> None:
+        super().__init__(parent)
+        if hasattr(self, "setLayout"):
+            self.setLayout(layout)
+
+
+def _button_text(label: str, icon: str) -> str:
+    stripped_label = label.strip()
+    stripped_icon = icon.strip()
+    if not stripped_icon:
+        return stripped_label
+    return f"{stripped_label} {stripped_icon}"
+
+
+def _primary_button_stylesheet() -> str:
+    return (
+        "QToolButton { "
+        f"background: {COLOR_ACCENT}; color: white; font-weight: 600; "
+        f"border: 1px solid {COLOR_ACCENT_DARK}; border-radius: 2px; "
+        "padding: 4px 12px; min-height: 22px; "
+        "}"
+    )
+
+
+def _ghost_button_stylesheet() -> str:
+    return (
+        "QToolButton { "
+        f"background: {COLOR_PANEL}; color: {COLOR_TEXT}; "
+        f"border: 1px solid {COLOR_GROUP_BORDER}; border-radius: 2px; "
+        "padding: 4px 12px; min-height: 22px; "
+        "}"
+    )
+
+
+__all__ = ["StepPage"]

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -74,7 +74,7 @@ class StepPage(QWidget):
         self._layout = self._build_layout()
         self.set_status(None)
         self.set_back()
-        self.set_next("Suivant")
+        self.set_next("Suivant", icon="→")
 
     def set_status(self, text: str | None, tone: str = "muted") -> None:
         """Update the optional header status pill and hide it when text is blank."""
@@ -87,7 +87,7 @@ class StepPage(QWidget):
     def set_next(
         self,
         label: str,
-        icon: str = "→",
+        icon: str = "",
         primary: bool = True,
         enabled: bool = True,
     ) -> None:


### PR DESCRIPTION
## Summary

Adds the reusable `StepPage` chrome described by the #609 Option B wizard spec: a shared header, status pill, content area, and back/next navigation row for future concrete wizard pages.

## Changes

- Add `ui.dockwidget.step_page.StepPage` with step header, status pill, content layout, and navigation API.
- Support primary/secondary next actions, back action state, and left/right extra navigation buttons.
- Keep package-level dockwidget imports lightweight so existing Qt stub tests do not import extra widget requirements.
- Cover the component with pure Qt-stub unit tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short` — 1423 passed, 154 skipped, 9 subtests passed.
- `python3 scripts/package_plugin.py` — built `dist/qfit-0.42.2.zip`.

Refs #609
Refs #608
