### PR TITLE
feat: add spec-backed wizard step pages

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -125,8 +125,13 @@ class StepPageTest(unittest.TestCase):
         self.assertEqual(page.objectName(), "qfitWizardMapPage")
         self.assertEqual(page.step_label.text(), "ÉTAPE 3/5")
         self.assertEqual(page.title_label.objectName(), "qfitWizardMapPageTitle")
+        self.assertIn("QLabel#qfitWizardMapPageTitle", page.title_label.styleSheet())
         self.assertEqual(page.summary_label.objectName(), "qfitWizardMapPageSummary")
         self.assertEqual(page.summary_label.text(), spec.summary)
+        self.assertIn(
+            "QLabel#qfitWizardMapPageSummary",
+            page.summary_label.styleSheet(),
+        )
         self.assertIs(page.body_container, page.content_container)
         self.assertEqual(page.body_container.objectName(), "qfitWizardMapPageBody")
         self.assertIs(page.body_layout(), page.content_layout())

--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -6,21 +6,27 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
+from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+
 
 def _load_step_page_module():
     for name in (
         "qfit.ui.dockwidget.step_page",
+        "qfit.ui.dockwidget.wizard_shell",
+        "qfit.ui.dockwidget.stepper_bar",
         "qfit.ui.dockwidget",
     ):
         sys.modules.pop(name, None)
     with patch.dict(sys.modules, _fake_qt_modules()):
-        return importlib.import_module("qfit.ui.dockwidget.step_page")
+        step_page = importlib.import_module("qfit.ui.dockwidget.step_page")
+        wizard_shell = importlib.import_module("qfit.ui.dockwidget.wizard_shell")
+        return step_page, wizard_shell
 
 
 class StepPageTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.step_page = _load_step_page_module()
+        cls.step_page, cls.wizard_shell = _load_step_page_module()
 
     def test_builds_spec_step_chrome_with_header_content_and_nav(self):
         page = self.step_page.StepPage(
@@ -109,6 +115,69 @@ class StepPageTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "align must be 'left' or 'right'"):
             page.add_extra_button(self.step_page.QToolButton(page), align="center")
+
+    def test_wizard_step_page_adapts_canonical_spec_to_step_chrome(self):
+        spec = build_default_wizard_page_specs()[2]
+
+        page = self.step_page.WizardStepPage(spec, step_num=3, step_total=5)
+
+        self.assertIs(page.spec, spec)
+        self.assertEqual(page.objectName(), "qfitWizardMapPage")
+        self.assertEqual(page.step_label.text(), "ÉTAPE 3/5")
+        self.assertEqual(page.title_label.objectName(), "qfitWizardMapPageTitle")
+        self.assertEqual(page.summary_label.objectName(), "qfitWizardMapPageSummary")
+        self.assertEqual(page.summary_label.text(), spec.summary)
+        self.assertIs(page.body_container, page.content_container)
+        self.assertEqual(page.body_container.objectName(), "qfitWizardMapPageBody")
+        self.assertIs(page.body_layout(), page.content_layout())
+        self.assertEqual(
+            page.primary_hint_label.objectName(),
+            "qfitWizardMapPagePrimaryHint",
+        )
+        self.assertFalse(page.primary_hint_label.isVisible())
+
+    def test_wizard_step_page_retire_primary_hint_is_installer_compatible(self):
+        spec = build_default_wizard_page_specs()[0]
+        page = self.step_page.WizardStepPage(spec, step_num=1, step_total=5)
+
+        page.primary_hint_label.setVisible(True)
+        page.retire_primary_action_hint()
+
+        self.assertEqual(page.primary_hint_label.text(), "")
+        self.assertEqual(
+            page.primary_hint_label.property("wizardPlaceholderHint"),
+            "retired",
+        )
+        self.assertFalse(page.primary_hint_label.isVisible())
+
+    def test_builds_wizard_step_pages_from_default_specs(self):
+        pages = self.step_page.build_wizard_step_pages()
+
+        self.assertEqual(
+            [page.spec.key for page in pages],
+            ["connection", "sync", "map", "analysis", "atlas"],
+        )
+        self.assertEqual(
+            [page.step_label.text() for page in pages],
+            ["ÉTAPE 1/5", "ÉTAPE 2/5", "ÉTAPE 3/5", "ÉTAPE 4/5", "ÉTAPE 5/5"],
+        )
+
+    def test_build_wizard_step_pages_preserves_explicit_empty_specs(self):
+        pages = self.step_page.build_wizard_step_pages(specs=())
+
+        self.assertEqual(pages, ())
+
+    def test_installs_wizard_step_pages_into_shell(self):
+        shell = self.wizard_shell.WizardShell()
+
+        pages = self.step_page.install_wizard_step_pages(shell)
+
+        self.assertEqual(shell.page_count(), 5)
+        self.assertEqual(shell.pages_stack.widgets, list(pages))
+
+        shell.set_current_step(4)
+
+        self.assertEqual(shell.pages_stack.currentIndex(), 4)
 
 
 if __name__ == "__main__":

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
+from qfit.ui.application.wizard_page_specs import (
+    DockWizardPageSpec,
+    build_default_wizard_page_specs,
+)
 from ._qt_compat import import_qt_module
 from qfit.ui.widgets.pill import set_pill_tone
 from qfit.ui.widgets.tokens import (
@@ -232,6 +238,93 @@ class StepPage(QWidget):
         return layout
 
 
+class WizardStepPage(StepPage):
+    """Step-page adapter backed by the canonical #609 page spec.
+
+    ``WizardPage`` still powers the current placeholder shell, but the final
+    dock swap needs spec-keyed pages with the richer ``StepPage`` chrome. This
+    adapter keeps that future page shape compatible with the existing
+    ``body_layout()`` and ``retire_primary_action_hint()`` seams used by the
+    concrete page-content installers, without making the old long-scroll dock
+    any more permanent.
+    """
+
+    def __init__(
+        self,
+        spec: DockWizardPageSpec,
+        *,
+        step_num: int,
+        step_total: int,
+        parent=None,
+    ) -> None:
+        super().__init__(
+            step_num,
+            step_total,
+            spec.title,
+            spec.summary,
+            parent=parent,
+        )
+        self.spec = spec
+        self.setObjectName(spec.page_object_name)
+        self.title_label.setObjectName(spec.title_object_name)
+        self.summary_label = self.subtitle_label
+        self.summary_label.setObjectName(spec.summary_object_name)
+        self.body_container = self.content_container
+        self.body_container.setObjectName(spec.body_object_name)
+        self.primary_hint_label = self._build_primary_hint_label(spec.primary_action_hint)
+
+    def body_layout(self):
+        """Expose the content seam expected by concrete wizard page installers."""
+
+        return self.content_layout()
+
+    def retire_primary_action_hint(self) -> None:
+        """Keep compatibility with placeholder pages while avoiding extra copy."""
+
+        self.primary_hint_label.setText("")
+        self.primary_hint_label.setProperty("wizardPlaceholderHint", "retired")
+        self.primary_hint_label.setVisible(False)
+
+    def _build_primary_hint_label(self, text: str):
+        label = QLabel(text, self)
+        label.setObjectName(self.spec.primary_hint_object_name)
+        label.setProperty("wizardPlaceholderHint", "retired")
+        label.setVisible(False)
+        return label
+
+
+def build_wizard_step_pages(
+    *,
+    parent=None,
+    specs: Sequence[DockWizardPageSpec] | None = None,
+) -> tuple[WizardStepPage, ...]:
+    """Build StepPage-backed pages in stable #609 wizard order."""
+
+    page_specs = build_default_wizard_page_specs() if specs is None else tuple(specs)
+    step_total = len(page_specs)
+    return tuple(
+        WizardStepPage(
+            spec,
+            step_num=index + 1,
+            step_total=step_total,
+            parent=parent,
+        )
+        for index, spec in enumerate(page_specs)
+    )
+
+
+def install_wizard_step_pages(
+    shell,
+    specs: Sequence[DockWizardPageSpec] | None = None,
+) -> tuple[WizardStepPage, ...]:
+    """Create StepPage-backed wizard pages and append them to a shell."""
+
+    pages = build_wizard_step_pages(parent=shell, specs=specs)
+    for page in pages:
+        shell.add_page(page)
+    return pages
+
+
 class _LayoutWidget(QWidget):
     """Small wrapper so fake and real Qt layouts can be inserted as widgets."""
 
@@ -269,4 +362,9 @@ def _ghost_button_stylesheet() -> str:
     )
 
 
-__all__ = ["StepPage"]
+__all__ = [
+    "StepPage",
+    "WizardStepPage",
+    "build_wizard_step_pages",
+    "install_wizard_step_pages",
+]

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -139,19 +139,13 @@ class StepPage(QWidget):
     def _build_step_label(self, step_num: int, step_total: int):
         label = QLabel(f"ÉTAPE {step_num}/{step_total}", self)
         label.setObjectName("qfitWizardStepKickerLabel")
-        label.setStyleSheet(
-            f"QLabel#qfitWizardStepKickerLabel {{ color: {COLOR_MUTED}; "
-            "font-size: 10.5pt; font-weight: 600; letter-spacing: .5px; }}"
-        )
+        label.setStyleSheet(_step_kicker_label_stylesheet(label.objectName()))
         return label
 
     def _build_title_label(self, title: str):
         label = QLabel(title, self)
         label.setObjectName("qfitWizardStepTitleLabel")
-        label.setStyleSheet(
-            f"QLabel#qfitWizardStepTitleLabel {{ color: {COLOR_TEXT}; "
-            "font-size: 14pt; font-weight: 600; }}"
-        )
+        label.setStyleSheet(_step_title_label_stylesheet(label.objectName()))
         return label
 
     def _build_subtitle_label(self, subtitle: str):
@@ -160,8 +154,7 @@ class StepPage(QWidget):
         if hasattr(label, "setWordWrap"):
             label.setWordWrap(True)
         label.setStyleSheet(
-            f"QLabel#qfitWizardStepSubtitleLabel {{ color: {COLOR_MUTED}; "
-            "font-size: 11pt; margin-top: 3px; line-height: 1.45; }}"
+            _step_subtitle_label_stylesheet(label.objectName())
         )
         return label
 
@@ -267,8 +260,14 @@ class WizardStepPage(StepPage):
         self.spec = spec
         self.setObjectName(spec.page_object_name)
         self.title_label.setObjectName(spec.title_object_name)
+        self.title_label.setStyleSheet(
+            _step_title_label_stylesheet(spec.title_object_name)
+        )
         self.summary_label = self.subtitle_label
         self.summary_label.setObjectName(spec.summary_object_name)
+        self.summary_label.setStyleSheet(
+            _step_subtitle_label_stylesheet(spec.summary_object_name)
+        )
         self.body_container = self.content_container
         self.body_container.setObjectName(spec.body_object_name)
         self.primary_hint_label = self._build_primary_hint_label(spec.primary_action_hint)
@@ -340,6 +339,27 @@ def _button_text(label: str, icon: str) -> str:
     if not stripped_icon:
         return stripped_label
     return f"{stripped_label} {stripped_icon}"
+
+
+def _step_kicker_label_stylesheet(object_name: str) -> str:
+    return (
+        f"QLabel#{object_name} {{ color: {COLOR_MUTED}; "
+        "font-size: 10.5pt; font-weight: 600; letter-spacing: .5px; }}"
+    )
+
+
+def _step_title_label_stylesheet(object_name: str) -> str:
+    return (
+        f"QLabel#{object_name} {{ color: {COLOR_TEXT}; "
+        "font-size: 14pt; font-weight: 600; }}"
+    )
+
+
+def _step_subtitle_label_stylesheet(object_name: str) -> str:
+    return (
+        f"QLabel#{object_name} {{ color: {COLOR_MUTED}; "
+        "font-size: 11pt; margin-top: 3px; line-height: 1.45; }}"
+    )
 
 
 def _primary_button_stylesheet() -> str:


### PR DESCRIPTION
## Summary

Adds a spec-backed `WizardStepPage` adapter so the #609 reusable step chrome can be created from the canonical wizard page specs without replacing the current production dock yet.

## Changes

- Add `WizardStepPage` with stable spec keys/object names plus the existing `body_layout()` and `retire_primary_action_hint()` seams used by page-content installers.
- Add helpers to build/install StepPage-backed pages in the canonical 5-step wizard order.
- Extend step-page tests to cover spec adaptation, hidden placeholder-hint compatibility, default ordering, empty specs, and shell installation.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
