### PR TITLE
feat: compose wizard shell with step pages

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -389,6 +389,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             parent=self if parent is None else parent,
             progress_facts=self._current_wizard_progress_facts(),
             wizard_settings=load_wizard_settings(self.settings),
+            use_step_pages=True,
             on_current_step_changed=self._persist_wizard_step_index,
         )
         self._wizard_shell_composition = connect_wizard_action_callbacks(

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -651,6 +651,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(kwargs["progress_facts"].connection_configured)
         self.assertEqual(kwargs["wizard_settings"].last_step_index, 1)
         self.assertFalse(kwargs["wizard_settings"].first_launch)
+        self.assertTrue(kwargs["use_step_pages"])
         self.assertIs(kwargs["on_current_step_changed"].__self__, dock)
         self.assertIs(
             kwargs["on_current_step_changed"].__func__,

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -17,6 +17,7 @@ def _load_wizard_composition_module():
         "qfit.ui.dockwidget.connection_page",
         "qfit.ui.dockwidget.sync_page",
         "qfit.ui.dockwidget.map_page",
+        "qfit.ui.dockwidget.step_page",
         "qfit.ui.dockwidget.wizard_shell_presenter",
         "qfit.ui.dockwidget.wizard_page",
         "qfit.ui.dockwidget.wizard_shell",
@@ -102,6 +103,32 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(
             assembled.shell.stepper_bar.states(),
             ("current", "locked", "locked", "locked", "locked"),
+        )
+
+    def test_can_build_shell_with_spec_step_pages(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            use_step_pages=True,
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                preferred_current_key="map",
+            ),
+        )
+
+        self.assertEqual(assembled.shell.page_count(), 5)
+        self.assertEqual(
+            [page.step_label.text() for page in assembled.pages],
+            ["ÉTAPE 1/5", "ÉTAPE 2/5", "ÉTAPE 3/5", "ÉTAPE 4/5", "ÉTAPE 5/5"],
+        )
+        self.assertEqual(assembled.pages[2].objectName(), "qfitWizardMapPage")
+        self.assertIs(
+            assembled.pages[2].body_layout().widgets[-1],
+            assembled.map_content,
+        )
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("done", "done", "current", "locked", "locked"),
         )
 
     def test_action_callbacks_are_wired_to_installed_page_ctas(self):

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -161,6 +161,29 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertTrue(assembled.pages[2].back_button.isEnabled())
         self.assertFalse(assembled.pages[2].next_button.isEnabled())
 
+    def test_step_page_navigation_uses_installed_page_keys(self):
+        specs = self.composition.build_default_wizard_page_specs()
+        assembled = self.composition.build_placeholder_wizard_shell(
+            use_step_pages=True,
+            specs=(specs[0], specs[4]),
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                preferred_current_key="atlas",
+            ),
+        )
+
+        self.assertEqual(assembled.presenter.progress.current_key, "atlas")
+        self.assertTrue(assembled.pages[1].back_button.isEnabled())
+        self.assertFalse(assembled.pages[1].next_button.isEnabled())
+
+        assembled.pages[1].back_button.clicked.emit()
+
+        self.assertEqual(assembled.presenter.progress.current_key, "connection")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+
     def test_action_callbacks_are_wired_to_installed_page_ctas(self):
         calls = []
         callbacks = self.composition.WizardActionCallbacks(

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -144,6 +144,23 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.presenter.progress.current_key, "map")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
 
+    def test_refresh_resyncs_spec_step_page_navigation_buttons(self):
+        assembled = self.composition.build_placeholder_wizard_shell(use_step_pages=True)
+        self.assertFalse(assembled.pages[2].back_button.isEnabled())
+
+        self.composition.refresh_wizard_shell_composition(
+            assembled,
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                preferred_current_key="map",
+            ),
+        )
+
+        self.assertEqual(assembled.presenter.progress.current_key, "map")
+        self.assertTrue(assembled.pages[2].back_button.isEnabled())
+        self.assertFalse(assembled.pages[2].next_button.isEnabled())
+
     def test_action_callbacks_are_wired_to_installed_page_ctas(self):
         calls = []
         callbacks = self.composition.WizardActionCallbacks(

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -130,6 +130,19 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.shell.stepper_bar.states(),
             ("done", "done", "current", "locked", "locked"),
         )
+        self.assertTrue(assembled.pages[2].back_button.isEnabled())
+        self.assertFalse(assembled.pages[2].next_button.isEnabled())
+
+        assembled.pages[2].back_button.clicked.emit()
+
+        self.assertEqual(assembled.presenter.progress.current_key, "sync")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
+        self.assertTrue(assembled.pages[1].next_button.isEnabled())
+
+        assembled.pages[1].next_button.clicked.emit()
+
+        self.assertEqual(assembled.presenter.progress.current_key, "map")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
 
     def test_action_callbacks_are_wired_to_installed_page_ctas(self):
         calls = []

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -325,6 +325,7 @@ def refresh_wizard_shell_composition(
     _apply_footer_facts(composition.shell.footer_bar, footer_facts)
     if resolved_progress is not None:
         composition.presenter.set_progress(resolved_progress)
+        _sync_step_page_navigation_buttons(composition.pages, composition.presenter)
 
     composition.connection_state = next_connection_state
     composition.sync_state = next_sync_state
@@ -842,20 +843,9 @@ def _connect_step_page_navigation(
     if not step_pages:
         return
 
-    def sync_navigation_buttons() -> None:
-        statuses = build_progress_wizard_step_statuses(presenter.progress)
-        last_index = len(statuses) - 1
-        for index, page in step_pages:
-            page.back_button.setEnabled(
-                index > 0 and can_request_step(statuses, index - 1)
-            )
-            page.next_button.setEnabled(
-                index < last_index and can_request_step(statuses, index + 1)
-            )
-
     def request_and_sync(index: int) -> None:
         presenter.request_step(index)
-        sync_navigation_buttons()
+        _sync_step_page_navigation_buttons(pages, presenter)
 
     for index, page in step_pages:
         page.backRequested.connect(
@@ -864,7 +854,24 @@ def _connect_step_page_navigation(
         page.nextRequested.connect(
             lambda _checked=False, target=index + 1: request_and_sync(target)
         )
-    sync_navigation_buttons()
+    _sync_step_page_navigation_buttons(pages, presenter)
+
+
+def _sync_step_page_navigation_buttons(
+    pages: Sequence[WizardCompositionPage],
+    presenter: WizardShellPresenter,
+) -> None:
+    statuses = build_progress_wizard_step_statuses(presenter.progress)
+    last_index = len(statuses) - 1
+    for index, page in enumerate(pages):
+        if not isinstance(page, WizardStepPage):
+            continue
+        page.back_button.setEnabled(
+            index > 0 and can_request_step(statuses, index - 1)
+        )
+        page.next_button.setEnabled(
+            index < last_index and can_request_step(statuses, index + 1)
+        )
 
 
 def _install_connection_content(

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -37,6 +37,7 @@ from .connection_page import (
 )
 from .map_page import MapPageContent, MapPageState, install_map_page_content
 from .sync_page import SyncPageContent, SyncPageState, install_sync_page_content
+from .step_page import install_wizard_step_pages
 from .wizard_page import WizardPage, install_wizard_pages
 from .wizard_shell import WizardShell
 from .wizard_shell_presenter import WizardShellPresenter
@@ -108,6 +109,7 @@ def build_placeholder_wizard_shell(
     progress_facts: WizardProgressFacts | None = None,
     wizard_settings: WizardSettingsSnapshot | None = None,
     specs: Sequence[DockWizardPageSpec] | None = None,
+    use_step_pages: bool = False,
     connection_state: ConnectionPageState | None = None,
     sync_state: SyncPageState | None = None,
     map_state: MapPageState | None = None,
@@ -122,7 +124,9 @@ def build_placeholder_wizard_shell(
     bind any current long-scroll dock controls into the shell; page content can
     migrate later through the stable ``WizardPage.body_layout()`` seams. The
     optional step-change callback is the future dock's seam for persisting
-    ``ui/last_step_index`` when users navigate the wizard.
+    ``ui/last_step_index`` when users navigate the wizard. ``use_step_pages``
+    opts into the richer StepPage chrome from the Option B spec while preserving
+    the same content-installer and presenter seams.
     """
 
     page_state_defaults = _page_state_defaults_from_progress_facts(progress_facts)
@@ -171,7 +175,7 @@ def build_placeholder_wizard_shell(
         ),
     )
     _apply_footer_facts(shell.footer_bar, footer_facts)
-    pages = install_wizard_pages(shell, specs=page_specs)
+    pages = _install_shell_pages(shell, specs=page_specs, use_step_pages=use_step_pages)
     connection_content = _install_connection_content(
         pages,
         connection_state=connection_state,
@@ -808,6 +812,17 @@ def _build_default_footer_text(
         ),
         atlas_status=atlas_state.status_text if "atlas" in installed_keys else None,
     )
+
+
+def _install_shell_pages(
+    shell: WizardShell,
+    *,
+    specs: Sequence[DockWizardPageSpec],
+    use_step_pages: bool,
+):
+    if use_step_pages:
+        return install_wizard_step_pages(shell, specs=specs)
+    return install_wizard_pages(shell, specs=specs)
 
 
 def _install_connection_content(

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -8,6 +8,7 @@ from qfit.ui.application.dock_workflow_sections import (
     DockWizardProgress,
     build_progress_wizard_step_statuses,
 )
+from qfit.ui.application.stepper_presenter import can_request_step
 from qfit.ui.application.wizard_footer_status import (
     WizardFooterFacts,
     build_wizard_footer_facts_from_progress_facts,
@@ -37,13 +38,14 @@ from .connection_page import (
 )
 from .map_page import MapPageContent, MapPageState, install_map_page_content
 from .sync_page import SyncPageContent, SyncPageState, install_sync_page_content
-from .step_page import install_wizard_step_pages
+from .step_page import WizardStepPage, install_wizard_step_pages
 from .wizard_page import WizardPage, install_wizard_pages
 from .wizard_shell import WizardShell
 from .wizard_shell_presenter import WizardShellPresenter
 
 
 _StateT = TypeVar("_StateT")
+WizardCompositionPage = WizardPage | WizardStepPage
 
 
 @dataclass(frozen=True)
@@ -85,7 +87,7 @@ class WizardShellComposition:
     """
 
     shell: WizardShell
-    pages: tuple[WizardPage, ...]
+    pages: tuple[WizardCompositionPage, ...]
     presenter: WizardShellPresenter
     connection_content: ConnectionPageContent | None = None
     sync_content: SyncPageContent | None = None
@@ -194,6 +196,7 @@ def build_placeholder_wizard_shell(
         page_indices_by_key=_build_page_indices_by_key(pages),
         on_current_step_changed=on_current_step_changed,
     )
+    _connect_step_page_navigation(pages, presenter)
     return WizardShellComposition(
         shell=shell,
         pages=pages,
@@ -755,7 +758,7 @@ def _atlas_output_summary(
 
 def _validate_progress_targets_installed_page(
     progress: DockWizardProgress | None,
-    pages: Sequence[WizardPage],
+    pages: Sequence[WizardCompositionPage],
 ) -> None:
     if progress is None:
         return
@@ -764,7 +767,9 @@ def _validate_progress_targets_installed_page(
         raise ValueError(f"No installed wizard page for {progress.current_key!r}")
 
 
-def _build_page_indices_by_key(pages: Sequence[WizardPage]) -> dict[str, int]:
+def _build_page_indices_by_key(
+    pages: Sequence[WizardCompositionPage],
+) -> dict[str, int]:
     return {page.spec.key: index for index, page in enumerate(pages)}
 
 
@@ -819,14 +824,51 @@ def _install_shell_pages(
     *,
     specs: Sequence[DockWizardPageSpec],
     use_step_pages: bool,
-):
+) -> tuple[WizardCompositionPage, ...]:
     if use_step_pages:
         return install_wizard_step_pages(shell, specs=specs)
     return install_wizard_pages(shell, specs=specs)
 
 
+def _connect_step_page_navigation(
+    pages: Sequence[WizardCompositionPage],
+    presenter: WizardShellPresenter,
+) -> None:
+    step_pages = tuple(
+        (index, page)
+        for index, page in enumerate(pages)
+        if isinstance(page, WizardStepPage)
+    )
+    if not step_pages:
+        return
+
+    def sync_navigation_buttons() -> None:
+        statuses = build_progress_wizard_step_statuses(presenter.progress)
+        last_index = len(statuses) - 1
+        for index, page in step_pages:
+            page.back_button.setEnabled(
+                index > 0 and can_request_step(statuses, index - 1)
+            )
+            page.next_button.setEnabled(
+                index < last_index and can_request_step(statuses, index + 1)
+            )
+
+    def request_and_sync(index: int) -> None:
+        presenter.request_step(index)
+        sync_navigation_buttons()
+
+    for index, page in step_pages:
+        page.backRequested.connect(
+            lambda _checked=False, target=index - 1: request_and_sync(target)
+        )
+        page.nextRequested.connect(
+            lambda _checked=False, target=index + 1: request_and_sync(target)
+        )
+    sync_navigation_buttons()
+
+
 def _install_connection_content(
-    pages: Sequence[WizardPage],
+    pages: Sequence[WizardCompositionPage],
     *,
     connection_state: ConnectionPageState | None,
 ) -> ConnectionPageContent | None:
@@ -837,7 +879,7 @@ def _install_connection_content(
 
 
 def _install_sync_content(
-    pages: Sequence[WizardPage],
+    pages: Sequence[WizardCompositionPage],
     *,
     sync_state: SyncPageState | None,
 ) -> SyncPageContent | None:
@@ -848,7 +890,7 @@ def _install_sync_content(
 
 
 def _install_map_content(
-    pages: Sequence[WizardPage],
+    pages: Sequence[WizardCompositionPage],
     *,
     map_state: MapPageState | None,
 ) -> MapPageContent | None:
@@ -859,7 +901,7 @@ def _install_map_content(
 
 
 def _install_analysis_content(
-    pages: Sequence[WizardPage],
+    pages: Sequence[WizardCompositionPage],
     *,
     analysis_state: AnalysisPageState | None,
 ) -> AnalysisPageContent | None:
@@ -870,7 +912,7 @@ def _install_analysis_content(
 
 
 def _install_atlas_content(
-    pages: Sequence[WizardPage],
+    pages: Sequence[WizardCompositionPage],
     *,
     atlas_state: AtlasPageState | None,
 ) -> AtlasPageContent | None:

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -8,7 +8,10 @@ from qfit.ui.application.dock_workflow_sections import (
     DockWizardProgress,
     build_progress_wizard_step_statuses,
 )
-from qfit.ui.application.stepper_presenter import can_request_step
+from qfit.ui.application.stepper_presenter import (
+    can_request_step,
+    step_index_for_key,
+)
 from qfit.ui.application.wizard_footer_status import (
     WizardFooterFacts,
     build_wizard_footer_facts_from_progress_facts,
@@ -843,16 +846,21 @@ def _connect_step_page_navigation(
     if not step_pages:
         return
 
-    def request_and_sync(index: int) -> None:
-        presenter.request_step(index)
+    def request_and_sync(index: int | None) -> None:
+        if index is not None:
+            presenter.request_step(index)
         _sync_step_page_navigation_buttons(pages, presenter)
 
-    for index, page in step_pages:
+    for installed_index, page in step_pages:
+        previous_index, next_index = _step_page_navigation_targets(
+            pages,
+            installed_index=installed_index,
+        )
         page.backRequested.connect(
-            lambda _checked=False, target=index - 1: request_and_sync(target)
+            lambda _checked=False, target=previous_index: request_and_sync(target)
         )
         page.nextRequested.connect(
-            lambda _checked=False, target=index + 1: request_and_sync(target)
+            lambda _checked=False, target=next_index: request_and_sync(target)
         )
     _sync_step_page_navigation_buttons(pages, presenter)
 
@@ -863,15 +871,41 @@ def _sync_step_page_navigation_buttons(
 ) -> None:
     statuses = build_progress_wizard_step_statuses(presenter.progress)
     last_index = len(statuses) - 1
-    for index, page in enumerate(pages):
+    for installed_index, page in enumerate(pages):
         if not isinstance(page, WizardStepPage):
             continue
+        previous_index, next_index = _step_page_navigation_targets(
+            pages,
+            installed_index=installed_index,
+        )
         page.back_button.setEnabled(
-            index > 0 and can_request_step(statuses, index - 1)
+            previous_index is not None and can_request_step(statuses, previous_index)
         )
         page.next_button.setEnabled(
-            index < last_index and can_request_step(statuses, index + 1)
+            next_index is not None
+            and next_index <= last_index
+            and can_request_step(statuses, next_index)
         )
+
+
+def _step_page_navigation_targets(
+    pages: Sequence[WizardCompositionPage],
+    *,
+    installed_index: int,
+) -> tuple[int | None, int | None]:
+    previous_page = pages[installed_index - 1] if installed_index > 0 else None
+    next_page = (
+        pages[installed_index + 1]
+        if installed_index + 1 < len(pages)
+        else None
+    )
+    return _workflow_index_for_page(previous_page), _workflow_index_for_page(next_page)
+
+
+def _workflow_index_for_page(page: WizardCompositionPage | None) -> int | None:
+    if page is None:
+        return None
+    return step_index_for_key(page.spec.key)
 
 
 def _install_connection_content(


### PR DESCRIPTION
## Summary

- lets the reusable wizard shell composition install the richer spec-backed `StepPage` page chrome
- switches the live `QfitDockWidget` wizard composition seam to use StepPage-backed pages
- keeps the existing content installer, presenter, persistence, and CTA callback seams intact

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
