### PR TITLE
feat: show wizard step page status pills

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
+from qfit.ui.application.dock_workflow_sections import build_wizard_step_statuses
 from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
 
 
@@ -171,6 +172,26 @@ class StepPageTest(unittest.TestCase):
         pages = self.step_page.build_wizard_step_pages(specs=())
 
         self.assertEqual(pages, ())
+
+    def test_applies_progress_status_pills_to_step_pages(self):
+        pages = self.step_page.build_wizard_step_pages()
+        statuses = build_wizard_step_statuses(
+            current_key="map",
+            completed_keys={"connection", "sync"},
+            unlocked_keys={"analysis"},
+        )
+
+        self.step_page.apply_wizard_step_page_statuses(pages, statuses)
+
+        self.assertEqual(
+            [page.status_pill.text() for page in pages],
+            ["Done", "Done", "Current", "Available", "Locked"],
+        )
+        self.assertEqual(
+            [page.status_pill.property("tone") for page in pages],
+            ["ok", "ok", "info", "neutral", "muted"],
+        )
+        self.assertTrue(all(page.status_pill.isVisible() for page in pages))
 
     def test_installs_wizard_step_pages_into_shell(self):
         shell = self.wizard_shell.WizardShell()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -155,6 +155,13 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
         self.assertEqual(assembled.pages[2].status_pill.text(), "Current")
 
+        assembled.shell.stepper_bar.step_buttons()[1].clicked.emit()
+
+        self.assertEqual(assembled.presenter.progress.current_key, "sync")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
+        self.assertEqual(assembled.pages[1].status_pill.text(), "Current")
+        self.assertEqual(assembled.pages[2].status_pill.text(), "Available")
+
     def test_refresh_resyncs_spec_step_page_navigation_buttons(self):
         assembled = self.composition.build_placeholder_wizard_shell(use_step_pages=True)
         self.assertFalse(assembled.pages[2].back_button.isEnabled())

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -130,6 +130,14 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.shell.stepper_bar.states(),
             ("done", "done", "current", "locked", "locked"),
         )
+        self.assertEqual(
+            [page.status_pill.text() for page in assembled.pages],
+            ["Done", "Done", "Current", "Locked", "Locked"],
+        )
+        self.assertEqual(
+            [page.status_pill.property("tone") for page in assembled.pages],
+            ["ok", "ok", "info", "muted", "muted"],
+        )
         self.assertTrue(assembled.pages[2].back_button.isEnabled())
         self.assertFalse(assembled.pages[2].next_button.isEnabled())
 
@@ -137,12 +145,15 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(assembled.presenter.progress.current_key, "sync")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
+        self.assertEqual(assembled.pages[1].status_pill.text(), "Current")
+        self.assertEqual(assembled.pages[2].status_pill.text(), "Available")
         self.assertTrue(assembled.pages[1].next_button.isEnabled())
 
         assembled.pages[1].next_button.clicked.emit()
 
         self.assertEqual(assembled.presenter.progress.current_key, "map")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
+        self.assertEqual(assembled.pages[2].status_pill.text(), "Current")
 
     def test_refresh_resyncs_spec_step_page_navigation_buttons(self):
         assembled = self.composition.build_placeholder_wizard_shell(use_step_pages=True)
@@ -158,6 +169,10 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
 
         self.assertEqual(assembled.presenter.progress.current_key, "map")
+        self.assertEqual(
+            [page.status_pill.text() for page in assembled.pages],
+            ["Done", "Done", "Current", "Locked", "Locked"],
+        )
         self.assertTrue(assembled.pages[2].back_button.isEnabled())
         self.assertFalse(assembled.pages[2].next_button.isEnabled())
 

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from qfit.ui.application.dock_workflow_sections import (
+    DockWorkflowStepState,
+    DockWorkflowStepStatus,
+)
 from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
     build_default_wizard_page_specs,
@@ -324,6 +328,28 @@ def install_wizard_step_pages(
     return pages
 
 
+def apply_wizard_step_page_statuses(
+    pages: Sequence[WizardStepPage],
+    statuses: Sequence[DockWorkflowStepStatus],
+) -> None:
+    """Render progress status pills on StepPage-backed wizard pages.
+
+    The stepper remains the source of truth for navigation state, but the richer
+    #609 page chrome also exposes a compact header pill. Keeping that mapping in
+    this reusable widget layer lets the future wizard dock show visible progress
+    without binding page widgets to ``QfitDockWidget`` or polishing the legacy
+    long-scroll layout.
+    """
+
+    statuses_by_key = {status.key: status for status in statuses}
+    for page in pages:
+        status = statuses_by_key.get(page.spec.key)
+        if status is None:
+            continue
+        text, tone = _step_status_pill(status.state)
+        page.set_status(text, tone=tone)
+
+
 class _LayoutWidget(QWidget):
     """Small wrapper so fake and real Qt layouts can be inserted as widgets."""
 
@@ -339,6 +365,16 @@ def _button_text(label: str, icon: str) -> str:
     if not stripped_icon:
         return stripped_label
     return f"{stripped_label} {stripped_icon}"
+
+
+def _step_status_pill(state: DockWorkflowStepState) -> tuple[str, str]:
+    if state == DockWorkflowStepState.DONE:
+        return "Done", "ok"
+    if state == DockWorkflowStepState.CURRENT:
+        return "Current", "info"
+    if state == DockWorkflowStepState.UNLOCKED:
+        return "Available", "neutral"
+    return "Locked", "muted"
 
 
 def _step_kicker_label_stylesheet(object_name: str) -> str:
@@ -385,6 +421,7 @@ def _ghost_button_stylesheet() -> str:
 __all__ = [
     "StepPage",
     "WizardStepPage",
+    "apply_wizard_step_page_statuses",
     "build_wizard_step_pages",
     "install_wizard_step_pages",
 ]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -41,7 +41,11 @@ from .connection_page import (
 )
 from .map_page import MapPageContent, MapPageState, install_map_page_content
 from .sync_page import SyncPageContent, SyncPageState, install_sync_page_content
-from .step_page import WizardStepPage, install_wizard_step_pages
+from .step_page import (
+    WizardStepPage,
+    apply_wizard_step_page_statuses,
+    install_wizard_step_pages,
+)
 from .wizard_page import WizardPage, install_wizard_pages
 from .wizard_shell import WizardShell
 from .wizard_shell_presenter import WizardShellPresenter
@@ -329,6 +333,7 @@ def refresh_wizard_shell_composition(
     if resolved_progress is not None:
         composition.presenter.set_progress(resolved_progress)
         _sync_step_page_navigation_buttons(composition.pages, composition.presenter)
+        _sync_step_page_status_pills(composition.pages, composition.presenter)
 
     composition.connection_state = next_connection_state
     composition.sync_state = next_sync_state
@@ -850,6 +855,7 @@ def _connect_step_page_navigation(
         if index is not None:
             presenter.request_step(index)
         _sync_step_page_navigation_buttons(pages, presenter)
+        _sync_step_page_status_pills(pages, presenter)
 
     for installed_index, page in step_pages:
         previous_index, next_index = _step_page_navigation_targets(
@@ -863,6 +869,7 @@ def _connect_step_page_navigation(
             lambda _checked=False, target=next_index: request_and_sync(target)
         )
     _sync_step_page_navigation_buttons(pages, presenter)
+    _sync_step_page_status_pills(pages, presenter)
 
 
 def _sync_step_page_navigation_buttons(
@@ -886,6 +893,19 @@ def _sync_step_page_navigation_buttons(
             and next_index <= last_index
             and can_request_step(statuses, next_index)
         )
+
+
+def _sync_step_page_status_pills(
+    pages: Sequence[WizardCompositionPage],
+    presenter: WizardShellPresenter,
+) -> None:
+    step_pages = tuple(page for page in pages if isinstance(page, WizardStepPage))
+    if not step_pages:
+        return
+    apply_wizard_step_page_statuses(
+        step_pages,
+        build_progress_wizard_step_statuses(presenter.progress),
+    )
 
 
 def _step_page_navigation_targets(

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -203,7 +203,7 @@ def build_placeholder_wizard_shell(
         page_indices_by_key=_build_page_indices_by_key(pages),
         on_current_step_changed=on_current_step_changed,
     )
-    _connect_step_page_navigation(pages, presenter)
+    _connect_step_page_navigation(shell, pages, presenter)
     return WizardShellComposition(
         shell=shell,
         pages=pages,
@@ -840,6 +840,7 @@ def _install_shell_pages(
 
 
 def _connect_step_page_navigation(
+    shell: WizardShell,
     pages: Sequence[WizardCompositionPage],
     presenter: WizardShellPresenter,
 ) -> None:
@@ -868,6 +869,9 @@ def _connect_step_page_navigation(
         page.nextRequested.connect(
             lambda _checked=False, target=next_index: request_and_sync(target)
         )
+    shell.stepper_bar.stepRequested.connect(
+        lambda _index: _sync_step_page_status_pills(pages, presenter)
+    )
     _sync_step_page_navigation_buttons(pages, presenter)
     _sync_step_page_status_pills(pages, presenter)
 


### PR DESCRIPTION
## Summary

Adds visible status pills to the StepPage-backed wizard shell so each #609 page header reflects the same render-neutral progress state as the stepper.

## Changes

- Map wizard step states to reusable StepPage header pill copy and tones.
- Sync StepPage status pills when the wizard composition is built, refreshed, or navigated.
- Cover the standalone StepPage mapping and composition navigation/refresh behavior in tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short` — 1432 passed, 154 skipped, 9 subtests passed
- `python3 scripts/package_plugin.py` — built `dist/qfit-0.42.2.zip`

Refs #609
Refs #608
