### PR TITLE
feat: label wizard step navigation targets

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -131,6 +131,14 @@ class WizardShellCompositionTest(unittest.TestCase):
             ("done", "done", "current", "locked", "locked"),
         )
         self.assertEqual(
+            assembled.pages[2].back_button.text(),
+            "Précédent: Synchronization",
+        )
+        self.assertEqual(
+            assembled.pages[2].next_button.text(),
+            "Suivant: Spatial analysis →",
+        )
+        self.assertEqual(
             [page.status_pill.text() for page in assembled.pages],
             ["Done", "Done", "Current", "Locked", "Locked"],
         )
@@ -148,12 +156,28 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.pages[1].status_pill.text(), "Current")
         self.assertEqual(assembled.pages[2].status_pill.text(), "Available")
         self.assertTrue(assembled.pages[1].next_button.isEnabled())
+        self.assertEqual(
+            assembled.pages[1].back_button.text(),
+            "Précédent: Connection",
+        )
+        self.assertEqual(
+            assembled.pages[1].next_button.text(),
+            "Suivant: Map & filters →",
+        )
 
         assembled.pages[1].next_button.clicked.emit()
 
         self.assertEqual(assembled.presenter.progress.current_key, "map")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
         self.assertEqual(assembled.pages[2].status_pill.text(), "Current")
+        self.assertEqual(
+            assembled.pages[2].back_button.text(),
+            "Précédent: Synchronization",
+        )
+        self.assertEqual(
+            assembled.pages[2].next_button.text(),
+            "Suivant: Spatial analysis →",
+        )
 
         assembled.shell.stepper_bar.step_buttons()[1].clicked.emit()
 
@@ -161,6 +185,11 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
         self.assertEqual(assembled.pages[1].status_pill.text(), "Current")
         self.assertEqual(assembled.pages[2].status_pill.text(), "Available")
+        self.assertTrue(assembled.pages[1].next_button.isEnabled())
+        self.assertEqual(
+            assembled.pages[1].next_button.text(),
+            "Suivant: Map & filters →",
+        )
 
     def test_refresh_resyncs_spec_step_page_navigation_buttons(self):
         assembled = self.composition.build_placeholder_wizard_shell(use_step_pages=True)

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -855,8 +855,7 @@ def _connect_step_page_navigation(
     def request_and_sync(index: int | None) -> None:
         if index is not None:
             presenter.request_step(index)
-        _sync_step_page_navigation_buttons(pages, presenter)
-        _sync_step_page_status_pills(pages, presenter)
+        _sync_step_page_navigation_and_status(pages, presenter)
 
     for installed_index, page in step_pages:
         previous_index, next_index = _step_page_navigation_targets(
@@ -870,8 +869,15 @@ def _connect_step_page_navigation(
             lambda _checked=False, target=next_index: request_and_sync(target)
         )
     shell.stepper_bar.stepRequested.connect(
-        lambda _index: _sync_step_page_status_pills(pages, presenter)
+        lambda _index: _sync_step_page_navigation_and_status(pages, presenter)
     )
+    _sync_step_page_navigation_and_status(pages, presenter)
+
+
+def _sync_step_page_navigation_and_status(
+    pages: Sequence[WizardCompositionPage],
+    presenter: WizardShellPresenter,
+) -> None:
     _sync_step_page_navigation_buttons(pages, presenter)
     _sync_step_page_status_pills(pages, presenter)
 
@@ -882,6 +888,7 @@ def _sync_step_page_navigation_buttons(
 ) -> None:
     statuses = build_progress_wizard_step_statuses(presenter.progress)
     last_index = len(statuses) - 1
+    page_titles_by_index = _step_page_titles_by_workflow_index(pages)
     for installed_index, page in enumerate(pages):
         if not isinstance(page, WizardStepPage):
             continue
@@ -889,14 +896,54 @@ def _sync_step_page_navigation_buttons(
             pages,
             installed_index=installed_index,
         )
-        page.back_button.setEnabled(
-            previous_index is not None and can_request_step(statuses, previous_index)
+        page.set_back(
+            label=_navigation_label(
+                prefix="Précédent",
+                target_index=previous_index,
+                titles_by_index=page_titles_by_index,
+            ),
+            enabled=(
+                previous_index is not None
+                and can_request_step(statuses, previous_index)
+            ),
         )
-        page.next_button.setEnabled(
-            next_index is not None
-            and next_index <= last_index
-            and can_request_step(statuses, next_index)
+        page.set_next(
+            label=_navigation_label(
+                prefix="Suivant",
+                target_index=next_index,
+                titles_by_index=page_titles_by_index,
+            ),
+            icon="→",
+            enabled=(
+                next_index is not None
+                and next_index <= last_index
+                and can_request_step(statuses, next_index)
+            ),
         )
+
+
+def _navigation_label(
+    *,
+    prefix: str,
+    target_index: int | None,
+    titles_by_index: dict[int, str],
+) -> str:
+    target_title = (
+        titles_by_index.get(target_index) if target_index is not None else None
+    )
+    if target_title is None:
+        return prefix
+    return f"{prefix}: {target_title}"
+
+
+def _step_page_titles_by_workflow_index(
+    pages: Sequence[WizardCompositionPage],
+) -> dict[int, str]:
+    return {
+        step_index_for_key(page.spec.key): page.spec.title
+        for page in pages
+        if isinstance(page, WizardStepPage)
+    }
 
 
 def _sync_step_page_status_pills(


### PR DESCRIPTION
## Summary

Labels the StepPage-backed wizard navigation buttons with their target step titles, and keeps those labels/statuses synchronized when users navigate by back/next buttons or the stepper.

## Changes

- Reuse the StepPage navigation setters so the richer #609 wizard shell renders target-aware Back/Next labels.
- Refresh navigation labels and status pills together after button navigation and stepper clicks.
- Extend wizard composition tests to cover target labels across navigation paths.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short` — 1432 passed, 154 skipped, 9 subtests passed
- `python3 scripts/package_plugin.py` — built `dist/qfit-0.42.2.zip`

Refs #609
Refs #608
