### PR TITLE
feat: describe active wizard map filters

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -82,6 +82,7 @@ from .ui.application import (
     RunAnalysisAction,
     build_dock_summary_status,
     build_visual_layer_refs,
+    build_wizard_filter_description,
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     load_wizard_settings,
@@ -221,7 +222,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             background_layer_loaded,
             background_name,
         ) = self._current_wizard_background_facts(runtime_state)
-        filters_active, filtered_activity_count = self._current_wizard_filter_facts()
+        (
+            filters_active,
+            filtered_activity_count,
+            filter_description,
+        ) = self._current_wizard_filter_facts()
         return build_wizard_progress_facts_from_runtime_state(
             runtime_state,
             connection_configured=self._has_configured_strava_connection(),
@@ -232,6 +237,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             background_name=background_name,
             filters_active=filters_active,
             filtered_activity_count=filtered_activity_count,
+            filter_description=filter_description,
             activity_style_preset=self._current_wizard_activity_style_preset(),
             last_sync_date=self._current_wizard_last_sync_date(),
         )
@@ -314,23 +320,28 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         stripped = preset_name.strip()
         return stripped or None
 
-    def _current_wizard_filter_facts(self) -> tuple[bool, int | None]:
+    def _current_wizard_filter_facts(self) -> tuple[bool, int | None, str | None]:
         """Return the current map-filter facts the optional wizard can summarize."""
 
         layer_filter_facts = self._current_wizard_layer_filter_facts()
         if layer_filter_facts is not None:
-            return layer_filter_facts
+            filters_active, filtered_activity_count = layer_filter_facts
+            filter_description = "layer subset" if filters_active else None
+            return filters_active, filtered_activity_count, filter_description
 
         activities = tuple(self.runtime_state.activities)
         if not activities:
-            return False, None
-        selection_state = build_activity_preview_selection_state(
-            self._current_activity_preview_request()
-        )
+            return False, None, None
+        preview_request = self._current_activity_preview_request()
+        selection_state = build_activity_preview_selection_state(preview_request)
         filters_active = selection_state.filtered_count != len(activities)
         if not filters_active:
-            return False, None
-        return True, selection_state.filtered_count
+            return False, None, None
+        return (
+            True,
+            selection_state.filtered_count,
+            build_wizard_filter_description(preview_request),
+        )
 
     def _current_wizard_layer_filter_facts(self) -> tuple[bool, int | None] | None:
         layer = self.runtime_state.activities_layer

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -5,6 +5,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
+from qfit.activities.domain.activity_query import DETAILED_ROUTE_FILTER_MISSING
 
 
 class _AutoModule(ModuleType):
@@ -499,12 +500,13 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             activities_layer=_FakeSubsetLayer('"activity_type" = \'Run\'', 2),
         )
 
-        filters_active, filtered_count = (
+        filters_active, filtered_count, filter_description = (
             self.module.QfitDockWidget._current_wizard_filter_facts(dock)
         )
 
         self.assertTrue(filters_active)
         self.assertEqual(filtered_count, 2)
+        self.assertEqual(filter_description, "layer subset")
 
     def test_current_wizard_filter_facts_treats_empty_loaded_subset_as_unfiltered(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -515,12 +517,45 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             activities_layer=_FakeSubsetLayer("", 3),
         )
 
-        filters_active, filtered_count = (
+        filters_active, filtered_count, filter_description = (
             self.module.QfitDockWidget._current_wizard_filter_facts(dock)
         )
 
         self.assertFalse(filters_active)
         self.assertIsNone(filtered_count)
+        self.assertIsNone(filter_description)
+
+    def test_current_wizard_filter_facts_describes_preview_request_filters(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().set_activities([object(), object(), object()])
+        preview_request = SimpleNamespace(
+            activity_type="Run",
+            search_text="alps",
+            date_from="2026-04-01",
+            date_to=None,
+            min_distance_km=10,
+            max_distance_km=None,
+            detailed_route_filter=DETAILED_ROUTE_FILTER_MISSING,
+        )
+        dock._current_activity_preview_request = MagicMock(return_value=preview_request)
+
+        with patch.object(
+            self.module,
+            "build_activity_preview_selection_state",
+            return_value=SimpleNamespace(filtered_count=1),
+        ):
+            filters_active, filtered_count, filter_description = (
+                self.module.QfitDockWidget._current_wizard_filter_facts(dock)
+            )
+
+        self.assertTrue(filters_active)
+        self.assertEqual(filtered_count, 1)
+        self.assertEqual(
+            filter_description,
+            "type: Run · search: “alps” · dates: from 2026-04-01 · "
+            "distance: ≥ 10 km · routes: missing details",
+        )
 
     def test_persist_wizard_step_index_clamps_and_saves_setting(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_filter_summary.py
+++ b/tests/test_wizard_filter_summary.py
@@ -1,0 +1,66 @@
+import unittest
+from types import SimpleNamespace
+
+from qfit.activities.domain.activity_query import (
+    DETAILED_ROUTE_FILTER_ANY,
+    DETAILED_ROUTE_FILTER_MISSING,
+    DETAILED_ROUTE_FILTER_PRESENT,
+)
+from qfit.ui.application.wizard_filter_summary import build_wizard_filter_description
+
+
+class WizardFilterSummaryTests(unittest.TestCase):
+    def test_build_wizard_filter_description_skips_default_controls(self):
+        request = SimpleNamespace(
+            activity_type="All",
+            search_text="  ",
+            date_from=None,
+            date_to=None,
+            min_distance_km=0,
+            max_distance_km=None,
+            detailed_route_filter=DETAILED_ROUTE_FILTER_ANY,
+        )
+
+        self.assertIsNone(build_wizard_filter_description(request))
+
+    def test_build_wizard_filter_description_lists_active_controls_compactly(self):
+        request = SimpleNamespace(
+            activity_type="Run",
+            search_text="alps",
+            date_from="2026-04-01",
+            date_to="2026-04-30",
+            min_distance_km=5,
+            max_distance_km=42.5,
+            detailed_route_filter=DETAILED_ROUTE_FILTER_PRESENT,
+        )
+
+        description = build_wizard_filter_description(request)
+
+        self.assertEqual(
+            description,
+            "type: Run · search: “alps” · dates: 2026-04-01–2026-04-30 · "
+            "distance: 5–42.5 km · routes: detailed only",
+        )
+
+    def test_build_wizard_filter_description_handles_open_bounds_and_missing_routes(self):
+        request = SimpleNamespace(
+            activity_type="Ride",
+            search_text=None,
+            date_from=None,
+            date_to="2026-05-01",
+            min_distance_km=None,
+            max_distance_km=80,
+            detailed_route_filter=DETAILED_ROUTE_FILTER_MISSING,
+        )
+
+        description = build_wizard_filter_description(request)
+
+        self.assertEqual(
+            description,
+            "type: Ride · dates: until 2026-05-01 · distance: ≤ 80 km · "
+            "routes: missing details",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -633,6 +633,23 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Filters match 3 loaded activities",
         )
 
+    def test_loaded_map_page_summary_includes_filter_description_when_available(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            filters_active=True,
+            filtered_activity_count=3,
+            filter_description="type: Run · distance: ≥ 10 km",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.map_content.filter_summary_label.text(),
+            "Filters match 3 loaded activities · type: Run · distance: ≥ 10 km",
+        )
+
     def test_loaded_map_page_summary_reports_all_visible_when_unfiltered(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -53,6 +53,7 @@ from .stepper_presenter import (
     step_index_for_key,
     step_key_for_index,
 )
+from .wizard_filter_summary import build_wizard_filter_description
 from .wizard_settings import (
     COLLAPSED_GROUPS_KEY,
     DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
@@ -131,6 +132,7 @@ __all__ = [
     "build_progress_wizard_step_statuses",
     "build_stepper_items",
     "build_stepper_states",
+    "build_wizard_filter_description",
     "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts",
     "build_wizard_progress_from_facts_and_settings",

--- a/ui/application/wizard_filter_summary.py
+++ b/ui/application/wizard_filter_summary.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Any
+
+from qfit.activities.domain.activity_query import (
+    DETAILED_ROUTE_FILTER_ANY,
+    DETAILED_ROUTE_FILTER_MISSING,
+    DETAILED_ROUTE_FILTER_PRESENT,
+)
+
+ALL_ACTIVITY_TYPES = "All"
+
+
+def build_wizard_filter_description(request: Any) -> str | None:
+    """Describe active activity filters without depending on dock widgets.
+
+    The wizard map page needs compact, user-facing filter copy that can migrate
+    away from the current long-scroll controls. This helper reads the existing
+    activity preview request shape and returns short clauses suitable for a
+    status row; it intentionally skips default/unset controls.
+    """
+
+    parts = tuple(_filter_description_parts(request))
+    if not parts:
+        return None
+    return " · ".join(parts)
+
+
+def _filter_description_parts(request: Any) -> list[str]:
+    parts: list[str] = []
+    activity_type = _normalised_text(getattr(request, "activity_type", None))
+    if activity_type and activity_type != ALL_ACTIVITY_TYPES:
+        parts.append(f"type: {activity_type}")
+
+    search_text = _normalised_text(getattr(request, "search_text", None))
+    if search_text:
+        parts.append(f"search: {_quote(search_text)}")
+
+    date_part = _date_range_part(
+        _normalised_text(getattr(request, "date_from", None)),
+        _normalised_text(getattr(request, "date_to", None)),
+    )
+    if date_part is not None:
+        parts.append(date_part)
+
+    distance_part = _distance_range_part(
+        getattr(request, "min_distance_km", None),
+        getattr(request, "max_distance_km", None),
+    )
+    if distance_part is not None:
+        parts.append(distance_part)
+
+    route_part = _route_filter_part(
+        _normalised_text(getattr(request, "detailed_route_filter", None))
+    )
+    if route_part is not None:
+        parts.append(route_part)
+
+    return parts
+
+
+def _date_range_part(date_from: str | None, date_to: str | None) -> str | None:
+    if date_from and date_to:
+        return f"dates: {date_from}–{date_to}"
+    if date_from:
+        return f"dates: from {date_from}"
+    if date_to:
+        return f"dates: until {date_to}"
+    return None
+
+
+def _distance_range_part(
+    min_distance_km: float | int | None,
+    max_distance_km: float | int | None,
+) -> str | None:
+    minimum = _positive_number(min_distance_km)
+    maximum = _positive_number(max_distance_km)
+    if minimum is not None and maximum is not None:
+        return f"distance: {_format_km(minimum)}–{_format_km(maximum)} km"
+    if minimum is not None:
+        return f"distance: ≥ {_format_km(minimum)} km"
+    if maximum is not None:
+        return f"distance: ≤ {_format_km(maximum)} km"
+    return None
+
+
+def _route_filter_part(value: str | None) -> str | None:
+    if value in (None, "", DETAILED_ROUTE_FILTER_ANY):
+        return None
+    if value == DETAILED_ROUTE_FILTER_PRESENT:
+        return "routes: detailed only"
+    if value == DETAILED_ROUTE_FILTER_MISSING:
+        return "routes: missing details"
+    return f"routes: {value}"
+
+
+def _normalised_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    stripped = str(value).strip()
+    return stripped or None
+
+
+def _positive_number(value: float | int | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number
+
+
+def _format_km(value: float) -> str:
+    if value.is_integer():
+        return str(int(value))
+    return f"{value:g}"
+
+
+def _quote(value: str) -> str:
+    return f"“{value}”"
+
+
+__all__ = ["build_wizard_filter_description"]

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -39,6 +39,7 @@ class WizardProgressFacts:
     background_name: str | None = None
     filters_active: bool = False
     filtered_activity_count: int | None = None
+    filter_description: str | None = None
     activity_style_preset: str | None = None
     loaded_layer_count: int | None = None
     last_sync_date: str | None = None
@@ -56,6 +57,7 @@ def build_wizard_progress_facts_from_runtime_state(
     background_name: str | None = None,
     filters_active: bool = False,
     filtered_activity_count: int | None = None,
+    filter_description: str | None = None,
     activity_style_preset: str | None = None,
     last_sync_date: str | None = None,
 ) -> WizardProgressFacts:
@@ -96,6 +98,7 @@ def build_wizard_progress_facts_from_runtime_state(
         background_name=_optional_text(background_name),
         filters_active=filters_active,
         filtered_activity_count=filtered_activity_count,
+        filter_description=_optional_text(filter_description),
         activity_style_preset=_optional_text(activity_style_preset),
         loaded_layer_count=_loaded_dataset_layer_count(state),
         last_sync_date=_optional_text(last_sync_date),
@@ -157,6 +160,7 @@ def build_wizard_progress_from_facts_and_settings(
             background_name=facts.background_name,
             filters_active=facts.filters_active,
             filtered_activity_count=facts.filtered_activity_count,
+            filter_description=facts.filter_description,
             activity_style_preset=facts.activity_style_preset,
             loaded_layer_count=facts.loaded_layer_count,
             last_sync_date=facts.last_sync_date,

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -665,15 +665,10 @@ def _map_active_filter_summary(facts: WizardProgressFacts) -> str:
     else:
         noun = "activity" if facts.filtered_activity_count == 1 else "activities"
         summary = f"Filters match {max(facts.filtered_activity_count, 0)} loaded {noun}"
-    filter_description = _optional_text(facts.filter_description)
-    if filter_description is None:
+    filter_description = (facts.filter_description or "").strip()
+    if not filter_description:
         return summary
     return f"{summary} · {filter_description}"
-
-
-def _optional_text(value: str | None) -> str | None:
-    stripped = (value or "").strip()
-    return stripped or None
 
 
 def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -459,6 +459,7 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         background_name=facts.background_name,
         filters_active=facts.filters_active,
         filtered_activity_count=facts.filtered_activity_count,
+        filter_description=facts.filter_description,
         activity_style_preset=facts.activity_style_preset,
         loaded_layer_count=facts.loaded_layer_count,
         last_sync_date=facts.last_sync_date,
@@ -654,11 +655,25 @@ def _map_filter_summary(facts: WizardProgressFacts, default: MapPageState) -> st
     if not facts.activity_layers_loaded:
         return default.filter_summary_text
     if facts.filters_active:
-        if facts.filtered_activity_count is None:
-            return "Subset filters are active"
-        noun = "activity" if facts.filtered_activity_count == 1 else "activities"
-        return f"Filters match {max(facts.filtered_activity_count, 0)} loaded {noun}"
+        return _map_active_filter_summary(facts)
     return "All loaded activities are visible"
+
+
+def _map_active_filter_summary(facts: WizardProgressFacts) -> str:
+    if facts.filtered_activity_count is None:
+        summary = "Subset filters are active"
+    else:
+        noun = "activity" if facts.filtered_activity_count == 1 else "activities"
+        summary = f"Filters match {max(facts.filtered_activity_count, 0)} loaded {noun}"
+    filter_description = _optional_text(facts.filter_description)
+    if filter_description is None:
+        return summary
+    return f"{summary} · {filter_description}"
+
+
+def _optional_text(value: str | None) -> str | None:
+    stripped = (value or "").strip()
+    return stripped or None
 
 
 def _analysis_state_from_facts(facts: WizardProgressFacts) -> AnalysisPageState:


### PR DESCRIPTION
## Summary

Adds a wizard-forward map-filter summary helper so the #609 wizard map page can explain which existing activity filters are active without binding to the legacy long-scroll widgets.

Refs #609
Refs #608

## Changes

- Add a reusable `build_wizard_filter_description()` helper for concise activity filter copy.
- Carry the filter description through `WizardProgressFacts` into the map wizard page summary.
- Adapt live dock wizard facts to include preview-request filter descriptions or existing layer subsets.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short` — 1437 passed, 154 skipped, 9 subtests passed
- `python3 scripts/package_plugin.py` — built `dist/qfit-0.42.2.zip`

## Rendering proof

Not rendering/export-sensitive; this only changes wizard status text/facts for future dock pages.
