### PR TITLE
chore: enrich wizard analysis input facts

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -727,6 +727,40 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Filtered activity subset ready for analysis",
         )
 
+    def test_analysis_page_input_summary_names_source_and_loaded_layer_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            output_name="qfit.gpkg",
+            loaded_layer_count=4,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.analysis_content.input_summary_label.text(),
+            "Activity layer from qfit.gpkg ready for analysis · 4 qfit layers loaded",
+        )
+
+    def test_analysis_page_input_summary_includes_filter_description_and_layer_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            filters_active=True,
+            filtered_activity_count=2,
+            filter_description="type: Ride · distance: ≥ 20 km",
+            loaded_layer_count=1,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.analysis_content.input_summary_label.text(),
+            "2 filtered activities ready for analysis · type: Ride · distance: ≥ 20 km · 1 qfit layer loaded",
+        )
+
     def test_progress_facts_drive_page_cta_prerequisites_without_marking_done(self):
         facts = self.composition.WizardProgressFacts(connection_configured=True)
 

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -750,7 +750,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             activity_layers_loaded=True,
             filters_active=True,
             filtered_activity_count=2,
-            filter_description="type: Ride · distance: ≥ 20 km",
+            filter_description=" type: Ride · distance: ≥ 20 km ",
             loaded_layer_count=1,
         )
 
@@ -758,7 +758,26 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(
             assembled.analysis_content.input_summary_label.text(),
-            "2 filtered activities ready for analysis · type: Ride · distance: ≥ 20 km · 1 qfit layer loaded",
+            "2 filtered activities ready for analysis · "
+            "type: Ride · distance: ≥ 20 km · 1 qfit layer loaded",
+        )
+
+    def test_analysis_page_input_summary_drops_blank_filter_description(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            filters_active=True,
+            filtered_activity_count=2,
+            filter_description="   ",
+            loaded_layer_count=1,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.analysis_content.input_summary_label.text(),
+            "2 filtered activities ready for analysis · 1 qfit layer loaded",
         )
 
     def test_progress_facts_drive_page_cta_prerequisites_without_marking_done(self):

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -733,7 +733,7 @@ def _with_analysis_input_context(summary: str, *, facts: WizardProgressFacts) ->
     details = tuple(
         detail
         for detail in (
-            facts.filter_description if facts.filters_active else None,
+            _analysis_filter_description(facts),
             _analysis_loaded_layer_count_summary(facts),
         )
         if detail
@@ -741,6 +741,13 @@ def _with_analysis_input_context(summary: str, *, facts: WizardProgressFacts) ->
     if not details:
         return summary
     return f"{summary} · {' · '.join(details)}"
+
+
+def _analysis_filter_description(facts: WizardProgressFacts) -> str | None:
+    if not facts.filters_active:
+        return None
+    description = (facts.filter_description or "").strip()
+    return description or None
 
 
 def _analysis_loaded_layer_count_summary(facts: WizardProgressFacts) -> str | None:

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -704,11 +704,51 @@ def _analysis_input_summary(facts: WizardProgressFacts) -> str:
     if not facts.activity_layers_loaded:
         return "Load activity layers before running analysis"
     if facts.filters_active:
-        if facts.filtered_activity_count is None:
-            return "Filtered activity subset ready for analysis"
+        return _analysis_filtered_input_summary(facts)
+    return _with_analysis_input_context(
+        _analysis_loaded_activity_layer_summary(facts),
+        facts=facts,
+    )
+
+
+def _analysis_filtered_input_summary(facts: WizardProgressFacts) -> str:
+    if facts.filtered_activity_count is None:
+        summary = "Filtered activity subset ready for analysis"
+    else:
         noun = "activity" if facts.filtered_activity_count == 1 else "activities"
-        return f"{max(facts.filtered_activity_count, 0)} filtered {noun} ready for analysis"
-    return "Activity layers ready for analysis"
+        summary = (
+            f"{max(facts.filtered_activity_count, 0)} filtered {noun} "
+            "ready for analysis"
+        )
+    return _with_analysis_input_context(summary, facts=facts)
+
+
+def _analysis_loaded_activity_layer_summary(facts: WizardProgressFacts) -> str:
+    if facts.output_name is None:
+        return "Activity layer ready for analysis"
+    return f"Activity layer from {facts.output_name} ready for analysis"
+
+
+def _with_analysis_input_context(summary: str, *, facts: WizardProgressFacts) -> str:
+    details = tuple(
+        detail
+        for detail in (
+            facts.filter_description if facts.filters_active else None,
+            _analysis_loaded_layer_count_summary(facts),
+        )
+        if detail
+    )
+    if not details:
+        return summary
+    return f"{summary} · {' · '.join(details)}"
+
+
+def _analysis_loaded_layer_count_summary(facts: WizardProgressFacts) -> str | None:
+    if facts.loaded_layer_count is None:
+        return None
+    count = max(facts.loaded_layer_count, 0)
+    noun = "qfit layer" if count == 1 else "qfit layers"
+    return f"{count} {noun} loaded"
 
 
 def _analysis_result_summary(facts: WizardProgressFacts) -> str:


### PR DESCRIPTION
## Summary

- enrich the reusable wizard analysis page input summary with live source GeoPackage, loaded-layer count, and filter description context
- keep the change inside the #609 wizard composition/runtime-facts seam without changing the legacy long-scroll dock layout
- add regression coverage for the new analysis-page copy states

Refs #609
Refs #608

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
