### PR TITLE
feat: default wizard shell to step pages

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -47,6 +47,20 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.shell.pages_stack.widgets, list(assembled.pages))
         self.assertEqual(assembled.presenter.progress.current_key, "connection")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+        self.assertEqual(
+            [page.step_label.text() for page in assembled.pages],
+            ["ÉTAPE 1/5", "ÉTAPE 2/5", "ÉTAPE 3/5", "ÉTAPE 4/5", "ÉTAPE 5/5"],
+        )
+        self.assertEqual(assembled.pages[0].back_button.text(), "Précédent")
+        self.assertEqual(
+            assembled.pages[0].next_button.text(),
+            "Suivant: Synchronization →",
+        )
+        self.assertFalse(assembled.pages[0].next_button.isEnabled())
+        self.assertEqual(
+            [page.status_pill.text() for page in assembled.pages],
+            ["Current", "Locked", "Locked", "Locked", "Locked"],
+        )
         self.assertIsNotNone(assembled.connection_content)
         self.assertIs(
             assembled.pages[0].body_layout().widgets[-1],
@@ -105,9 +119,25 @@ class WizardShellCompositionTest(unittest.TestCase):
             ("current", "locked", "locked", "locked", "locked"),
         )
 
+    def test_can_build_shell_with_legacy_placeholder_pages_for_compatibility(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            use_step_pages=False,
+        )
+
+        self.assertEqual(assembled.shell.page_count(), 5)
+        self.assertFalse(hasattr(assembled.pages[0], "step_label"))
+        self.assertEqual(assembled.pages[0].objectName(), "qfitWizardConnectionPage")
+        self.assertIs(
+            assembled.pages[0].body_layout().widgets[-1],
+            assembled.connection_content,
+        )
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("current", "locked", "locked", "locked", "locked"),
+        )
+
     def test_can_build_shell_with_spec_step_pages(self):
         assembled = self.composition.build_placeholder_wizard_shell(
-            use_step_pages=True,
             progress_facts=self.composition.WizardProgressFacts(
                 connection_configured=True,
                 activities_stored=True,
@@ -192,7 +222,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
 
     def test_refresh_resyncs_spec_step_page_navigation_buttons(self):
-        assembled = self.composition.build_placeholder_wizard_shell(use_step_pages=True)
+        assembled = self.composition.build_placeholder_wizard_shell()
         self.assertFalse(assembled.pages[2].back_button.isEnabled())
 
         self.composition.refresh_wizard_shell_composition(
@@ -215,7 +245,6 @@ class WizardShellCompositionTest(unittest.TestCase):
     def test_step_page_navigation_uses_installed_page_keys(self):
         specs = self.composition.build_default_wizard_page_specs()
         assembled = self.composition.build_placeholder_wizard_shell(
-            use_step_pages=True,
             specs=(specs[0], specs[4]),
             progress_facts=self.composition.WizardProgressFacts(
                 connection_configured=True,

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -118,7 +118,7 @@ def build_placeholder_wizard_shell(
     progress_facts: WizardProgressFacts | None = None,
     wizard_settings: WizardSettingsSnapshot | None = None,
     specs: Sequence[DockWizardPageSpec] | None = None,
-    use_step_pages: bool = False,
+    use_step_pages: bool = True,
     connection_state: ConnectionPageState | None = None,
     sync_state: SyncPageState | None = None,
     map_state: MapPageState | None = None,
@@ -133,9 +133,10 @@ def build_placeholder_wizard_shell(
     bind any current long-scroll dock controls into the shell; page content can
     migrate later through the stable ``WizardPage.body_layout()`` seams. The
     optional step-change callback is the future dock's seam for persisting
-    ``ui/last_step_index`` when users navigate the wizard. ``use_step_pages``
-    opts into the richer StepPage chrome from the Option B spec while preserving
-    the same content-installer and presenter seams.
+    ``ui/last_step_index`` when users navigate the wizard. The shell now uses
+    the richer StepPage chrome from the Option B spec by default while preserving
+    the same content-installer and presenter seams; pass ``use_step_pages=False``
+    only for legacy placeholder-page compatibility tests.
     """
 
     page_state_defaults = _page_state_defaults_from_progress_facts(progress_facts)


### PR DESCRIPTION
## Summary

Move the reusable #609 wizard shell to the richer `StepPage` chrome by default, so the placeholder assembly now shows the per-page header, status pill, and back/next navigation controls without replacing the production dock yet.

## Changes

- Default `build_placeholder_wizard_shell()` to StepPage-backed wizard pages.
- Keep the older placeholder `WizardPage` path available through `use_step_pages=False` for compatibility.
- Extend wizard composition tests for the default StepPage chrome and legacy opt-out path.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
Refs #608.
