### PR TITLE
feat: refresh dock after configuration saves

### DIFF
--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -8,7 +8,7 @@ specific Mapbox styling options, which belong in the main map workflow.
 
 import logging
 
-from qgis.PyQt.QtCore import Qt, QUrl
+from qgis.PyQt.QtCore import Qt, QUrl, pyqtSignal
 from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import (
     QApplication,
@@ -57,6 +57,8 @@ class QfitConfigDialog(QDialog):
     access token, run the Strava OAuth helper flow, and test provider
     connections before saving. Changes are persisted to QSettings on save.
     """
+
+    settingsSaved = pyqtSignal()
 
     def __init__(
         self,
@@ -241,9 +243,10 @@ class QfitConfigDialog(QDialog):
         self._mapbox_test_status_label.setText(_NOT_TESTED_LABEL)
 
     def _save(self) -> None:
-        """Persist edited fields to QSettings and refresh status labels."""
+        """Persist edited fields, refresh status labels, and notify live docks."""
         save_bindings(self._bindings, self._settings)
         self._refresh_status_labels()
+        self.settingsSaved.emit()
 
     def _refresh_status_labels(self) -> None:
         self._strava_status_label.setText(strava_status_text(self._settings))

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -192,6 +192,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self._set_status("Open qfit → Configuration to edit Strava credentials.")
 
+    def refresh_configuration_from_settings(self) -> None:
+        """Reload saved configuration and refresh live wizard connection state."""
+
+        self._load_settings()
+        self._update_connection_status()
+        self._refresh_summary_status()
+        self._set_status("Configuration saved; qfit dock connection state refreshed.")
+
     def _run_wizard_sync_step(self) -> None:
         """Run the next concrete action for the wizard synchronization step."""
 

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -197,7 +197,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._load_settings()
         self._update_connection_status()
-        self._refresh_summary_status()
         self._set_status("Configuration saved; qfit dock connection state refreshed.")
 
     def _run_wizard_sync_step(self) -> None:

--- a/qfit_plugin.py
+++ b/qfit_plugin.py
@@ -65,6 +65,11 @@ class QfitPlugin:
     def show_config(self):
         if self._config_dialog is None:
             self._config_dialog = QfitConfigDialog(parent=self.iface.mainWindow())
+            self._config_dialog.settingsSaved.connect(self._refresh_dock_configuration)
         self._config_dialog.show()
         self._config_dialog.raise_()
         self._config_dialog.activateWindow()
+
+    def _refresh_dock_configuration(self) -> None:
+        if self.dockwidget is not None:
+            self.dockwidget.refresh_configuration_from_settings()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 
@@ -106,6 +107,45 @@ class TestQfitPluginMenuStructure(unittest.TestCase):
         self.assertIsNone(plugin.activities_action)
         self.assertIsNone(plugin.config_action)
         self.assertIsNone(plugin.dockwidget)
+
+    def test_config_dialog_save_signal_refreshes_existing_dock(self):
+        plugin, _iface = self._make_plugin()
+        plugin.dockwidget = MagicMock()
+
+        class FakeSignal:
+            def __init__(self):
+                self.connected_slot = None
+
+            def connect(self, slot):
+                self.connected_slot = slot
+
+        class FakeConfigDialog:
+            created = []
+
+            def __init__(self, parent=None):
+                self.parent = parent
+                self.settingsSaved = FakeSignal()
+                self.show = MagicMock()
+                self.raise_ = MagicMock()
+                self.activateWindow = MagicMock()
+                FakeConfigDialog.created.append(self)
+
+        with patch("qfit.qfit_plugin.QfitConfigDialog", FakeConfigDialog):
+            plugin.show_config()
+
+        dialog = FakeConfigDialog.created[-1]
+        self.assertIs(
+            dialog.settingsSaved.connected_slot.__self__,
+            plugin,
+        )
+        self.assertIs(
+            dialog.settingsSaved.connected_slot.__func__,
+            QfitPlugin._refresh_dock_configuration,
+        )
+
+        dialog.settingsSaved.connected_slot()
+
+        plugin.dockwidget.refresh_configuration_from_settings.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -596,6 +596,22 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Open qfit → Configuration to edit Strava credentials."
         )
 
+    def test_refresh_configuration_from_settings_updates_live_connection_state(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._load_settings = MagicMock()
+        dock._update_connection_status = MagicMock()
+        dock._refresh_summary_status = MagicMock()
+        dock._set_status = MagicMock()
+
+        self.module.QfitDockWidget.refresh_configuration_from_settings(dock)
+
+        dock._load_settings.assert_called_once_with()
+        dock._update_connection_status.assert_called_once_with()
+        dock._refresh_summary_status.assert_called_once_with()
+        dock._set_status.assert_called_once_with(
+            "Configuration saved; qfit dock connection state refreshed."
+        )
+
     def test_run_wizard_sync_step_fetches_when_no_activities_are_ready(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -607,7 +607,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         dock._load_settings.assert_called_once_with()
         dock._update_connection_status.assert_called_once_with()
-        dock._refresh_summary_status.assert_called_once_with()
+        dock._refresh_summary_status.assert_not_called()
         dock._set_status.assert_called_once_with(
             "Configuration saved; qfit dock connection state refreshed."
         )

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -833,6 +833,25 @@ class QgisSmokeTests(unittest.TestCase):
             dialog.close()
             dialog.deleteLater()
 
+    def test_config_dialog_save_emits_settings_saved_signal(self):
+        dialog = QfitConfigDialog(
+            settings_service=SettingsService(
+                qsettings=_FakeQSettings(),
+                credential_store=InMemoryCredentialStore(),
+            )
+        )
+        try:
+            saves = []
+            dialog.settingsSaved.connect(lambda: saves.append("saved"))
+
+            dialog._client_id_edit.setText("client-id")
+            dialog._save()
+
+            self.assertEqual(saves, ["saved"])
+        finally:
+            dialog.close()
+            dialog.deleteLater()
+
     def test_config_dialog_open_authorize_clicked_builds_authorize_url_via_sync_controller(self):
         dialog = QfitConfigDialog(
             settings_service=SettingsService(


### PR DESCRIPTION
## Summary

Refresh the live dock after the dedicated qfit configuration dialog saves settings, so the wizard connection page and footer can immediately reflect newly saved Strava credentials without reopening the dock.

## Changes

- Emit a `settingsSaved` signal from `QfitConfigDialog` after persisted saves.
- Wire the plugin to reload dock settings, refresh connection status, and update the optional wizard shell when configuration is saved.
- Cover the dialog signal, plugin handoff, and dock refresh seam in tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609.
Refs #608.
