### PR TITLE
feat: add wizard dock container seam

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -423,6 +423,21 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         return self._wizard_shell_composition
 
+    def _build_wizard_dock_from_runtime(self, *, parent=None):
+        """Build the optional #609 QDockWidget container from runtime facts.
+
+        This is the dock-level seam for the eventual wizard swap: the reusable
+        shell composition remains independent, while this helper wraps it in the
+        real QDockWidget shape required by the Option B spec.
+        """
+
+        from .ui.dockwidget.wizard_dock import build_wizard_dock_widget
+
+        return build_wizard_dock_widget(
+            self._build_wizard_shell_from_runtime(parent=parent),
+            parent=parent,
+        )
+
     def _refresh_wizard_shell_from_runtime(self):
         """Refresh an optional #609 wizard shell composition from dock runtime facts."""
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -729,6 +729,28 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 getattr(self.module.QfitDockWidget, method_name),
             )
 
+    def test_build_wizard_dock_from_runtime_wraps_live_composition(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._build_wizard_shell_from_runtime = MagicMock(return_value="composition")
+        parent = object()
+        fake_wizard_dock = ModuleType("qfit.ui.dockwidget.wizard_dock")
+        fake_wizard_dock.build_wizard_dock_widget = MagicMock(
+            return_value="wizard-dock"
+        )
+
+        with patch.dict(sys.modules, {"qfit.ui.dockwidget.wizard_dock": fake_wizard_dock}):
+            result = self.module.QfitDockWidget._build_wizard_dock_from_runtime(
+                dock,
+                parent=parent,
+            )
+
+        self.assertEqual(result, "wizard-dock")
+        dock._build_wizard_shell_from_runtime.assert_called_once_with(parent=parent)
+        fake_wizard_dock.build_wizard_dock_widget.assert_called_once_with(
+            "composition",
+            parent=parent,
+        )
+
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()

--- a/tests/test_wizard_dock.py
+++ b/tests/test_wizard_dock.py
@@ -1,0 +1,107 @@
+import importlib
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _FakeWidget, _fake_qt_modules
+
+
+class _FakeDockWidget(_FakeWidget):
+    DockWidgetClosable = 1
+    DockWidgetMovable = 2
+    DockWidgetFloatable = 4
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._widget = None
+        self._features = None
+        self._allowed_areas = None
+        self._window_title = ""
+
+    def setWidget(self, widget):  # noqa: N802
+        self._widget = widget
+
+    def widget(self):
+        return self._widget
+
+    def setFeatures(self, features):  # noqa: N802
+        self._features = features
+
+    def features(self):
+        return self._features
+
+    def setAllowedAreas(self, allowed_areas):  # noqa: N802
+        self._allowed_areas = allowed_areas
+
+    def allowedAreas(self):  # noqa: N802
+        return self._allowed_areas
+
+    def setWindowTitle(self, title):  # noqa: N802
+        self._window_title = title
+
+    def windowTitle(self):  # noqa: N802
+        return self._window_title
+
+
+def _load_wizard_dock_module():
+    for name in (
+        "qfit.ui.dockwidget.wizard_dock",
+        "qfit.ui.dockwidget._qt_compat",
+    ):
+        sys.modules.pop(name, None)
+    modules = _fake_qt_modules()
+    modules["qgis.PyQt.QtCore"].Qt.LeftDockWidgetArea = 8
+    modules["qgis.PyQt.QtCore"].Qt.RightDockWidgetArea = 16
+    modules["qgis.PyQt.QtWidgets"].QDockWidget = _FakeDockWidget
+    with patch.dict(sys.modules, modules):
+        return importlib.import_module("qfit.ui.dockwidget.wizard_dock")
+
+
+class WizardDockWidgetTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.wizard_dock = _load_wizard_dock_module()
+
+    def test_builds_qgis_dock_container_for_wizard_shell_composition(self):
+        shell = _FakeWidget()
+        parent = _FakeWidget()
+        composition = SimpleNamespace(shell=shell)
+
+        dock = self.wizard_dock.build_wizard_dock_widget(
+            composition,
+            parent=parent,
+            title="qfit wizard",
+        )
+
+        self.assertEqual(dock.objectName(), "qfitWizardDockWidget")
+        self.assertEqual(dock.windowTitle(), "qfit wizard")
+        self.assertIs(dock.parent, parent)
+        self.assertIs(dock.composition, composition)
+        self.assertIs(dock.widget(), shell)
+        self.assertEqual(
+            dock.features(),
+            _FakeDockWidget.DockWidgetClosable
+            | _FakeDockWidget.DockWidgetMovable
+            | _FakeDockWidget.DockWidgetFloatable,
+        )
+        self.assertEqual(dock.allowedAreas(), 8 | 16)
+
+    def test_can_replace_hosted_wizard_composition_without_recreating_dock(self):
+        first = SimpleNamespace(shell=_FakeWidget())
+        second = SimpleNamespace(shell=_FakeWidget())
+        dock = self.wizard_dock.WizardDockWidget(first)
+
+        dock.set_composition(second)
+
+        self.assertIs(dock.composition, second)
+        self.assertIs(dock.widget(), second.shell)
+
+    def test_rejects_compositions_without_shell_widget(self):
+        with self.assertRaisesRegex(ValueError, "must expose a shell"):
+            self.wizard_dock.WizardDockWidget(SimpleNamespace(shell=None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/dockwidget/wizard_dock.py
+++ b/ui/dockwidget/wizard_dock.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from ._qt_compat import import_qt_module
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt",))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    ("QDockWidget",),
+)
+
+Qt = _qtcore.Qt
+QDockWidget = _qtwidgets.QDockWidget
+
+WIZARD_DOCK_OBJECT_NAME = "qfitWizardDockWidget"
+WIZARD_DOCK_TITLE = "qfit"
+WIZARD_DOCK_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
+WIZARD_DOCK_FEATURES = (
+    QDockWidget.DockWidgetClosable
+    | QDockWidget.DockWidgetMovable
+    | QDockWidget.DockWidgetFloatable
+)
+
+
+class WizardShellCompositionLike(Protocol):
+    """Small structural protocol for dock-hostable wizard compositions."""
+
+    shell: object
+
+
+class WizardDockWidget(QDockWidget):
+    """QDockWidget host for the #609 wizard shell composition.
+
+    The current production dock still uses the legacy ``.ui`` while the wizard
+    migrates page-by-page. This adapter captures the final dock-level shape from
+    the Option B spec now: a normal QGIS dock widget whose contents are the
+    reusable ``WizardShell`` composition, without coupling the shell back to the
+    long-scroll dock implementation.
+    """
+
+    def __init__(
+        self,
+        composition: WizardShellCompositionLike,
+        *,
+        parent=None,
+        title: str = WIZARD_DOCK_TITLE,
+    ) -> None:
+        super().__init__(parent)
+        self.composition: WizardShellCompositionLike | None = None
+        self.setObjectName(WIZARD_DOCK_OBJECT_NAME)
+        self.setWindowTitle(title)
+        self.setFeatures(WIZARD_DOCK_FEATURES)
+        self.setAllowedAreas(WIZARD_DOCK_ALLOWED_AREAS)
+        self.set_composition(composition)
+
+    def set_composition(self, composition: WizardShellCompositionLike) -> None:
+        """Install or replace the hosted wizard composition shell."""
+
+        shell = _composition_shell(composition)
+        self.composition = composition
+        self.setWidget(shell)
+
+
+def build_wizard_dock_widget(
+    composition: WizardShellCompositionLike,
+    *,
+    parent=None,
+    title: str = WIZARD_DOCK_TITLE,
+) -> WizardDockWidget:
+    """Build the dock-level container for a reusable wizard composition."""
+
+    return WizardDockWidget(composition, parent=parent, title=title)
+
+
+def _composition_shell(composition: WizardShellCompositionLike):
+    shell = getattr(composition, "shell", None)
+    if shell is None:
+        raise ValueError("Wizard dock compositions must expose a shell widget")
+    return shell
+
+
+__all__ = [
+    "WIZARD_DOCK_ALLOWED_AREAS",
+    "WIZARD_DOCK_FEATURES",
+    "WIZARD_DOCK_OBJECT_NAME",
+    "WIZARD_DOCK_TITLE",
+    "WizardDockWidget",
+    "build_wizard_dock_widget",
+]

--- a/ui/dockwidget/wizard_dock.py
+++ b/ui/dockwidget/wizard_dock.py
@@ -8,11 +8,12 @@ _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt",))
 _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
     "PyQt5.QtWidgets",
-    ("QDockWidget",),
+    ("QDockWidget", "QWidget"),
 )
 
 Qt = _qtcore.Qt
 QDockWidget = _qtwidgets.QDockWidget
+QWidget = _qtwidgets.QWidget
 
 WIZARD_DOCK_OBJECT_NAME = "qfitWizardDockWidget"
 WIZARD_DOCK_TITLE = "qfit"
@@ -27,7 +28,7 @@ WIZARD_DOCK_FEATURES = (
 class WizardShellCompositionLike(Protocol):
     """Small structural protocol for dock-hostable wizard compositions."""
 
-    shell: object
+    shell: QWidget
 
 
 class WizardDockWidget(QDockWidget):
@@ -59,8 +60,8 @@ class WizardDockWidget(QDockWidget):
         """Install or replace the hosted wizard composition shell."""
 
         shell = _composition_shell(composition)
-        self.composition = composition
         self.setWidget(shell)
+        self.composition = composition
 
 
 def build_wizard_dock_widget(


### PR DESCRIPTION
## Summary

Adds a small QDockWidget container seam for the #609 wizard shell so the reusable wizard composition can be hosted in the final dock-level shape without replacing the legacy dock yet.

## Changes

- Add `WizardDockWidget` and `build_wizard_dock_widget()` for hosting a wizard shell composition.
- Add a `QfitDockWidget` helper that wraps the live runtime-built wizard composition in the dock container.
- Cover the dock container and adapter seam with pure tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Refs #609
Refs #608
