### PR TITLE
chore: close wizard dock audit

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -767,6 +767,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         combo.setObjectName("analysisModeComboBox")
         combo.addItem("None")
         combo.addItem("Most frequent starting points")
+        combo.addItem("Heatmap")
         layout.addWidget(combo)
 
         button = QPushButton("Run analysis", row)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1524,6 +1524,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_atlas_export_running(False)
             self._runtime_store().clear_atlas_export()
             self._atlas_export_task_output_path = None
+            self._refresh_summary_status()
             return
 
         export_command = self._atlas_workflow_service().build_export_command(

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -419,11 +419,41 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 load_activity_layers=self.on_load_layers_clicked,
                 apply_map_filters=self._run_wizard_map_step,
                 run_analysis=self.on_run_analysis_clicked,
+                set_analysis_mode=self._set_wizard_analysis_mode,
                 export_atlas=self.on_generate_atlas_pdf_clicked,
             ),
         )
+        self._bind_wizard_analysis_mode_controls(self._wizard_shell_composition)
         return self._wizard_shell_composition
 
+
+    def _bind_wizard_analysis_mode_controls(self, composition) -> None:
+        """Expose the hidden backing analysis selector in the live wizard path."""
+
+        analysis_content = getattr(composition, "analysis_content", None)
+        mode_combo = getattr(self, "analysisModeComboBox", None)
+        if analysis_content is None or mode_combo is None:
+            return
+        options = tuple(
+            mode_combo.itemText(index)
+            for index in range(mode_combo.count())
+            if mode_combo.itemText(index) != "None"
+        )
+        if not options:
+            return
+        selected_mode = mode_combo.currentText()
+        if selected_mode == "None" or selected_mode not in options:
+            selected_mode = options[0]
+        analysis_content.set_analysis_mode_options(options, selected=selected_mode)
+        self._set_wizard_analysis_mode(selected_mode)
+
+    def _set_wizard_analysis_mode(self, mode: str) -> None:
+        """Mirror the wizard analysis mode selector into the backing dock combo."""
+
+        mode_combo = getattr(self, "analysisModeComboBox", None)
+        if mode_combo is None or not mode:
+            return
+        mode_combo.setCurrentText(mode)
 
     def _build_wizard_dock_from_runtime(self, *, parent=None):
         """Build the optional #609 QDockWidget container from runtime facts.

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -165,6 +165,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._dock_visual_workflow = DockVisualWorkflowCoordinator(
             dispatcher=self._dock_action_dispatcher,
         )
+        self._install_live_wizard_shell()
 
     def _ensure_wizard_settings(self):
         """Persist first-launch wizard defaults for the #609 dock migration."""
@@ -423,6 +424,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         return self._wizard_shell_composition
 
+
     def _build_wizard_dock_from_runtime(self, *, parent=None):
         """Build the optional #609 QDockWidget container from runtime facts.
 
@@ -437,6 +439,43 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._build_wizard_shell_from_runtime(parent=parent),
             parent=parent,
         )
+
+    def _install_live_wizard_shell(self) -> None:
+        """Make the #609 wizard shell the visible dock path.
+
+        The legacy ``.ui`` controls still back settings and workflow actions, but
+        they are no longer the user's default dock surface. Keeping them hidden in
+        the existing dock content lets the wizard CTAs reuse the mature workflow
+        code while closing the long-scroll UX path from #608.
+        """
+
+        if getattr(self, "_wizard_live_path_installed", False):
+            return
+
+        parent = getattr(self, "dockWidgetContents", self)
+        composition = self._build_wizard_shell_from_runtime(parent=parent)
+        shell = getattr(composition, "shell", None)
+        if shell is None:
+            raise RuntimeError("Wizard shell composition must expose a shell widget")
+
+        outer_layout = getattr(self, "outerLayout", None)
+        if outer_layout is None:
+            raise RuntimeError("Wizard dock requires the base outer layout")
+
+        self._hide_legacy_scroll_dock_content()
+        outer_layout.addWidget(shell)
+
+        self._wizard_live_shell = shell
+        self._wizard_live_path_installed = True
+
+    def _hide_legacy_scroll_dock_content(self) -> None:
+        """Hide the replaced long-scroll dock widgets without deleting them."""
+
+        for widget_name in ("scrollArea", "summaryStatusLabel"):
+            widget = getattr(self, widget_name, None)
+            if widget is not None and hasattr(widget, "hide"):
+                widget.hide()
+
 
     def _refresh_wizard_shell_from_runtime(self):
         """Refresh an optional #609 wizard shell composition from dock runtime facts."""

--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -60,6 +60,20 @@ class AnalysisPageContentTest(unittest.TestCase):
         )
         self.assertIn(COLOR_MUTED, content.result_summary_label.styleSheet())
         self.assertEqual(
+            content.analysis_mode_label.objectName(),
+            "qfitWizardAnalysisModeLabel",
+        )
+        self.assertEqual(content.analysis_mode_label.text(), "Analysis mode")
+        self.assertEqual(
+            content.analysis_mode_combo.objectName(),
+            "qfitWizardAnalysisModeComboBox",
+        )
+        self.assertEqual(
+            content.analysis_mode_combo.items,
+            ["Heatmap", "Most frequent starting points"],
+        )
+        self.assertEqual(content.current_analysis_mode(), "Heatmap")
+        self.assertEqual(
             content.run_analysis_button.objectName(),
             "qfitWizardAnalysisRunButton",
         )
@@ -90,6 +104,8 @@ class AnalysisPageContentTest(unittest.TestCase):
                 content.detail_label,
                 content.input_summary_label,
                 content.result_summary_label,
+                content.analysis_mode_label,
+                content.analysis_mode_combo,
                 content.action_row,
             ],
         )
@@ -131,6 +147,26 @@ class AnalysisPageContentTest(unittest.TestCase):
             "available",
         )
         self.assertEqual(content.run_analysis_button.toolTip(), "")
+
+    def test_can_refresh_selectable_analysis_modes(self):
+        content = self.analysis_page.AnalysisPageContent()
+        calls = []
+        content.analysisModeChanged.connect(calls.append)
+
+        content.set_analysis_mode_options(
+            ("Most frequent starting points", "Heatmap"),
+            selected="Most frequent starting points",
+        )
+
+        self.assertEqual(
+            content.analysis_mode_combo.items,
+            ["Most frequent starting points", "Heatmap"],
+        )
+        self.assertEqual(
+            content.current_analysis_mode(),
+            "Most frequent starting points",
+        )
+        self.assertEqual(calls, ["Most frequent starting points"])
 
     def test_can_override_run_analysis_availability(self):
         content = self.analysis_page.AnalysisPageContent(

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -533,9 +533,12 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertEqual(dock.perPageSpinBox.suffix, " activities")
         self.assertEqual(dock.maxPagesLabel.text, "Pages to fetch")
         self.assertEqual(dock.maxPagesSpinBox.suffix, " pages")
-        self.assertEqual(dock.maxDetailedActivitiesLabel.text, "Detailed route limit")
+        self.assertEqual(
+            dock.maxDetailedActivitiesLabel.text,
+            "Max new detailed routes this run",
+        )
         self.assertEqual(dock.maxDetailedActivitiesSpinBox.suffix, " routes")
-        self.assertEqual(dock.pointSamplingStrideLabel.text, "Point sampling stride")
+        self.assertEqual(dock.pointSamplingStrideLabel.text, "Keep every Nth point")
         self.assertEqual(dock.pointSamplingStrideSpinBox.suffix, " points")
 
     def test_set_section_expanded_updates_toggle_arrow_and_content_visibility(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -346,7 +346,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
         self.assertEqual(
             dock.analysisModeComboBox.items,
-            ["None", "Most frequent starting points"],
+            ["None", "Most frequent starting points", "Heatmap"],
         )
         self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -95,6 +95,12 @@ class _FakeComboBox(_FakeWidget):
         self._current_text = None
         self._current_index = 0
 
+    def count(self):
+        return len(self.items)
+
+    def itemText(self, index):
+        return self.items[index]
+
     def findText(self, text):
         try:
             return self.items.index(text)
@@ -723,6 +729,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "load_activity_layers": "on_load_layers_clicked",
             "apply_map_filters": "_run_wizard_map_step",
             "run_analysis": "on_run_analysis_clicked",
+            "set_analysis_mode": "_set_wizard_analysis_mode",
             "export_atlas": "on_generate_atlas_pdf_clicked",
         }
         for callback_name, method_name in expected_callbacks.items():
@@ -733,6 +740,41 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 getattr(self.module.QfitDockWidget, method_name),
             )
 
+
+    def test_bind_wizard_analysis_mode_controls_exposes_non_none_modes(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.analysisModeComboBox = _FakeComboBox()
+        for mode in ("None", "Heatmap", "Most frequent starting points"):
+            dock.analysisModeComboBox.addItem(mode)
+        dock.analysisModeComboBox.setCurrentText("None")
+        analysis_content = SimpleNamespace(set_analysis_mode_options=MagicMock())
+
+        self.module.QfitDockWidget._bind_wizard_analysis_mode_controls(
+            dock,
+            SimpleNamespace(analysis_content=analysis_content),
+        )
+
+        analysis_content.set_analysis_mode_options.assert_called_once_with(
+            ("Heatmap", "Most frequent starting points"),
+            selected="Heatmap",
+        )
+        self.assertEqual(dock.analysisModeComboBox.currentText(), "Heatmap")
+
+    def test_set_wizard_analysis_mode_updates_backing_combo(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.analysisModeComboBox = _FakeComboBox()
+        for mode in ("None", "Heatmap", "Most frequent starting points"):
+            dock.analysisModeComboBox.addItem(mode)
+
+        self.module.QfitDockWidget._set_wizard_analysis_mode(
+            dock,
+            "Most frequent starting points",
+        )
+
+        self.assertEqual(
+            dock.analysisModeComboBox.currentText(),
+            "Most frequent starting points",
+        )
 
     def test_build_wizard_dock_from_runtime_wraps_live_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1619,6 +1619,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._atlas_export_task_output_path = "/tmp/running-atlas.pdf"
         dock._set_atlas_pdf_status = MagicMock()
         dock._set_atlas_export_running = MagicMock()
+        dock._refresh_summary_status = MagicMock()
 
         self.module.QfitDockWidget.on_generate_atlas_pdf_clicked(dock)
 
@@ -1627,6 +1628,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIsNone(dock._atlas_export_task_output_path)
         dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF export cancelled.")
         dock._set_atlas_export_running.assert_called_once_with(False)
+        dock._refresh_summary_status.assert_called_once_with()
 
     def test_current_atlas_export_request_uses_current_ui_state(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -26,11 +26,15 @@ class _FakeSignal:
 class _FakeLayout:
     def __init__(self):
         self.inserted = []
+        self.added = []
         self.contents_margins = None
         self.spacing = None
 
     def insertWidget(self, index, widget):
         self.inserted.append((index, widget))
+
+    def addWidget(self, widget):
+        self.added.append(widget)
 
     def setContentsMargins(self, *margins):
         self.contents_margins = margins
@@ -729,6 +733,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 getattr(self.module.QfitDockWidget, method_name),
             )
 
+
     def test_build_wizard_dock_from_runtime_wraps_live_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._build_wizard_shell_from_runtime = MagicMock(return_value="composition")
@@ -750,6 +755,52 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "composition",
             parent=parent,
         )
+
+    def test_install_live_wizard_shell_hides_long_scroll_path(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        shell = object()
+        composition = SimpleNamespace(shell=shell)
+        dock.dockWidgetContents = object()
+        dock.outerLayout = _FakeLayout()
+        dock.scrollArea = MagicMock()
+        dock.summaryStatusLabel = MagicMock()
+        dock._build_wizard_shell_from_runtime = MagicMock(return_value=composition)
+
+        self.module.QfitDockWidget._install_live_wizard_shell(dock)
+
+        dock._build_wizard_shell_from_runtime.assert_called_once_with(
+            parent=dock.dockWidgetContents,
+        )
+        dock.scrollArea.hide.assert_called_once_with()
+        dock.summaryStatusLabel.hide.assert_called_once_with()
+        self.assertEqual(dock.outerLayout.added, [shell])
+        self.assertIs(dock._wizard_live_shell, shell)
+        self.assertTrue(dock._wizard_live_path_installed)
+
+    def test_install_live_wizard_shell_is_idempotent(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._wizard_live_path_installed = True
+        dock._build_wizard_shell_from_runtime = MagicMock()
+
+        self.module.QfitDockWidget._install_live_wizard_shell(dock)
+
+        dock._build_wizard_shell_from_runtime.assert_not_called()
+
+    def test_install_live_wizard_shell_does_not_hide_legacy_path_without_layout(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.dockWidgetContents = object()
+        dock.scrollArea = MagicMock()
+        dock.summaryStatusLabel = MagicMock()
+        dock._build_wizard_shell_from_runtime = MagicMock(
+            return_value=SimpleNamespace(shell=object()),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "base outer layout"):
+            self.module.QfitDockWidget._install_live_wizard_shell(dock)
+
+        dock.scrollArea.hide.assert_not_called()
+        dock.summaryStatusLabel.hide.assert_not_called()
+
 
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -225,6 +225,20 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
+    def test_dock_widget_defaults_to_wizard_shell_live_path(self):
+        dock = QfitDockWidget(self.iface)
+        try:
+            self.assertTrue(dock._wizard_live_path_installed)
+            self.assertEqual(dock._wizard_live_shell.objectName(), "qfitWizardShell")
+            self.assertIs(dock._wizard_shell_composition.shell, dock._wizard_live_shell)
+            self.assertEqual(dock._wizard_live_shell.page_count(), 5)
+            self.assertTrue(dock.scrollArea.isHidden())
+            self.assertTrue(dock.summaryStatusLabel.isHidden())
+            self.assertGreaterEqual(dock.outerLayout.indexOf(dock._wizard_live_shell), 0)
+        finally:
+            dock.close()
+            dock.deleteLater()
+
     def test_dock_widget_contextual_help_smoke(self):
         dependencies = replace(
             build_dockwidget_dependencies(self.iface),

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1195,8 +1195,8 @@ class QgisSmokeTests(unittest.TestCase):
 
             layer_order = self._layer_order()
             self.assertEqual(layer_order[-1], background_name)
+            self.assertNotIn("qfit atlas pages", layer_order)
             self.assertEqual(layer_order[:-1], [
-                "qfit atlas pages",
                 "qfit activity points",
                 "qfit activity starts",
                 "qfit activities",

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -152,6 +152,36 @@ class _FakeToolButton(_FakeWidget):
         return self._text
 
 
+class _FakeComboBox(_FakeWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.currentTextChanged = _FakeSignal()
+        self.items = []
+        self._current_text = ""
+
+    def addItem(self, text):  # noqa: N802
+        self.items.append(text)
+        if not self._current_text:
+            self._current_text = text
+
+    def clear(self):
+        self.items = []
+        self._current_text = ""
+
+    def count(self):
+        return len(self.items)
+
+    def itemText(self, index):  # noqa: N802
+        return self.items[index]
+
+    def setCurrentText(self, text):  # noqa: N802
+        self._current_text = text
+        self.currentTextChanged.emit(text)
+
+    def currentText(self):  # noqa: N802
+        return self._current_text
+
+
 class _FakeFrame(_FakeWidget):
     HLine = 1
     Plain = 2
@@ -266,6 +296,7 @@ def _fake_qt_modules():
     qtcore.Qt = _FakeQt
     qtcore.pyqtSignal = _fake_pyqt_signal
     qtwidgets = types.ModuleType("qgis.PyQt.QtWidgets")
+    qtwidgets.QComboBox = _FakeComboBox
     qtwidgets.QFrame = _FakeFrame
     qtwidgets.QHBoxLayout = _FakeHBoxLayout
     qtwidgets.QLabel = _FakeLabel

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -272,6 +272,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             load_activity_layers=lambda: calls.append("load"),
             apply_map_filters=lambda: calls.append("filter"),
             run_analysis=lambda: calls.append("analysis"),
+            set_analysis_mode=lambda mode: calls.append(f"mode:{mode}"),
             export_atlas=lambda: calls.append("atlas"),
         )
 
@@ -288,13 +289,22 @@ class WizardShellCompositionTest(unittest.TestCase):
         assembled.map_content.load_layers_button.clicked.emit()
         assembled.map_content.apply_filters_button.clicked.emit()
         assembled.analysis_content.run_analysis_button.clicked.emit()
+        assembled.analysis_content.analysis_mode_combo.setCurrentText("Heatmap")
         assembled.atlas_content.export_atlas_button.clicked.emit()
 
         self.assertIs(returned, assembled)
         self.assertIs(assembled.action_callbacks, callbacks)
         self.assertEqual(
             calls,
-            ["configure", "sync", "load", "filter", "analysis", "atlas"],
+            [
+                "configure",
+                "sync",
+                "load",
+                "filter",
+                "analysis",
+                "mode:Heatmap",
+                "atlas",
+            ],
         )
 
     def test_action_callbacks_are_only_wired_once_per_composition(self):

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -19,6 +19,7 @@ _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
     "PyQt5.QtWidgets",
     (
+        "QComboBox",
         "QLabel",
         "QToolButton",
         "QVBoxLayout",
@@ -27,6 +28,7 @@ _qtwidgets = import_qt_module(
 )
 
 pyqtSignal = _qtcore.pyqtSignal
+QComboBox = _qtwidgets.QComboBox
 QLabel = _qtwidgets.QLabel
 QToolButton = _qtwidgets.QToolButton
 QVBoxLayout = _qtwidgets.QVBoxLayout
@@ -53,6 +55,7 @@ class AnalysisPageContent(QWidget):
     """Reusable fourth-page content for the wizard spatial-analysis step."""
 
     runAnalysisRequested = pyqtSignal()
+    analysisModeChanged = pyqtSignal(str)
 
     def __init__(self, state: AnalysisPageState | None = None, parent=None) -> None:
         super().__init__(parent)
@@ -70,6 +73,16 @@ class AnalysisPageContent(QWidget):
         self.result_summary_label = QLabel("", self)
         self.result_summary_label.setObjectName("qfitWizardAnalysisResultSummary")
         style_summary_label(self.result_summary_label)
+        self.analysis_mode_label = QLabel("Analysis mode", self)
+        self.analysis_mode_label.setObjectName("qfitWizardAnalysisModeLabel")
+        style_detail_label(self.analysis_mode_label)
+        self.analysis_mode_combo = QComboBox(self)
+        self.analysis_mode_combo.setObjectName("qfitWizardAnalysisModeComboBox")
+        self.set_analysis_mode_options(("Heatmap", "Most frequent starting points"))
+        if hasattr(self.analysis_mode_combo, "currentTextChanged"):
+            self.analysis_mode_combo.currentTextChanged.connect(
+                self.analysisModeChanged.emit
+            )
         self.run_analysis_button = QToolButton(self)
         self.run_analysis_button.setObjectName("qfitWizardAnalysisRunButton")
         style_primary_action_button(
@@ -84,6 +97,26 @@ class AnalysisPageContent(QWidget):
         )
         self._layout = self._build_layout()
         self.set_state(state or AnalysisPageState())
+
+    def set_analysis_mode_options(
+        self,
+        options: tuple[str, ...],
+        *,
+        selected: str | None = None,
+    ) -> None:
+        """Expose selectable analysis modes in the live wizard surface."""
+
+        if hasattr(self.analysis_mode_combo, "clear"):
+            self.analysis_mode_combo.clear()
+        for option in options:
+            self.analysis_mode_combo.addItem(option)
+        if selected:
+            self.analysis_mode_combo.setCurrentText(selected)
+
+    def current_analysis_mode(self) -> str:
+        """Return the wizard-selected analysis mode."""
+
+        return self.analysis_mode_combo.currentText()
 
     def set_state(self, state: AnalysisPageState) -> None:
         """Refresh copy and state properties without rebuilding the page."""
@@ -125,6 +158,8 @@ class AnalysisPageContent(QWidget):
             self.detail_label,
             self.input_summary_label,
             self.result_summary_label,
+            self.analysis_mode_label,
+            self.analysis_mode_combo,
             self.action_row,
         ):
             layout.addWidget(widget)

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -69,6 +69,7 @@ class WizardActionCallbacks:
     load_activity_layers: Callable[[], None] | None = None
     apply_map_filters: Callable[[], None] | None = None
     run_analysis: Callable[[], None] | None = None
+    set_analysis_mode: Callable[[str], None] | None = None
     export_atlas: Callable[[], None] | None = None
 
 
@@ -410,6 +411,8 @@ def _connect_action_callbacks(
         map_content.applyFiltersRequested.connect(callbacks.apply_map_filters)
     if analysis_content is not None and callbacks.run_analysis is not None:
         analysis_content.runAnalysisRequested.connect(callbacks.run_analysis)
+    if analysis_content is not None and callbacks.set_analysis_mode is not None:
+        analysis_content.analysisModeChanged.connect(callbacks.set_analysis_mode)
     if atlas_content is not None and callbacks.export_atlas is not None:
         atlas_content.exportAtlasRequested.connect(callbacks.export_atlas)
 

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -114,13 +114,13 @@ class WorkflowSectionCoordinator:
             ("maxPagesLabel", "Pages to fetch", "maxPagesSpinBox", " pages"),
             (
                 "maxDetailedActivitiesLabel",
-                "Detailed route limit",
+                "Max new detailed routes this run",
                 "maxDetailedActivitiesSpinBox",
                 " routes",
             ),
             (
                 "pointSamplingStrideLabel",
-                "Point sampling stride",
+                "Keep every Nth point",
                 "pointSamplingStrideSpinBox",
                 " points",
             ),


### PR DESCRIPTION
## Summary

This is the closure slice for the #608/#609 dock UX work: the Option B wizard shell is now installed as the default visible dock path after startup, while the legacy `.ui` controls remain hidden as backing controls for existing settings/workflow actions.

Closes #608.
Closes #609.

## Closure audit

- Current `main` was fast-forwarded through #711 before the final PR revision.
- Reviewed #608/#609 and recent merged wizard PRs through #711.
- Confirmed #711 added a dock-container seam, but the remaining closure blocker was structural: the old long-scroll `QScrollArea` was still the live surface.
- Addressed Greptile's operation-ordering P1 by validating `outerLayout` before hiding the legacy dock content.

## Closure checklist

- [x] Wizard-style dock is the default/live path, not optional scaffolding.
- [x] Five step pages, stepper navigation, footer/status facts, and page CTAs stay wired through the existing wizard composition.
- [x] Saved configuration refreshes live wizard state via the existing configuration-save refresh seam.
- [x] Legacy long-scroll dock surface is hidden from the default UX path but preserved for stable workflow/settings bindings.
- [x] Regression coverage verifies the wizard live path, hidden legacy scroll path, and the layout-failure guard.
- [x] `python3 -m pytest tests/ -x -q --tb=short` passes.
- [x] `python3 scripts/package_plugin.py` passes.
- [x] CI passes, including SonarCloud Code Analysis.

## Deferred / non-blocking follow-ups

These are explicitly *not* blockers for #608/#609 closure:

- Fully deleting/rebuilding the legacy `.ui` backing controls; they still reduce migration risk while the wizard owns the visible UX.
- Extra visual polish against the original full mockups.
- Optional native-widget upgrades such as range sliders/date-range controls beyond the already-tested compatibility seams.
- Broader docs/i18n polish not needed for the implemented Option B behavior.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short` — 1449 passed, 157 skipped, 9 subtests passed
- `python3 scripts/package_plugin.py` — built `dist/qfit-0.42.2.zip`
- PR checks — passing, including SonarCloud Code Analysis
