### PR TITLE
chore: bump plugin version to 0.50

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.42.2
+version=0.50
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.


### PR DESCRIPTION
## Summary
- bump qfit plugin metadata version to 0.50 for the UX-refresh test build

## Validation
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
