### PR TITLE
fix: expose map filter controls in wizard

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -417,7 +417,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 configure_connection=self._show_connection_configuration_hint,
                 sync_activities=self._run_wizard_sync_step,
                 load_activity_layers=self.on_load_layers_clicked,
-                edit_map_filters=self._set_wizard_filter_controls_visible,
+                edit_map_filters=self._update_status_for_filter_visibility,
                 apply_map_filters=self._run_wizard_map_step,
                 run_analysis=self.on_run_analysis_clicked,
                 set_analysis_mode=self._set_wizard_analysis_mode,
@@ -462,7 +462,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if parent_layout is not None and hasattr(parent_layout, "removeWidget"):
             parent_layout.removeWidget(widget)
 
-    def _set_wizard_filter_controls_visible(self, visible: bool) -> None:
+    def _update_status_for_filter_visibility(self, visible: bool) -> None:
         """Reflect wizard filter-panel visibility in concise dock status copy."""
 
         if visible:

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -417,15 +417,58 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 configure_connection=self._show_connection_configuration_hint,
                 sync_activities=self._run_wizard_sync_step,
                 load_activity_layers=self.on_load_layers_clicked,
+                edit_map_filters=self._set_wizard_filter_controls_visible,
                 apply_map_filters=self._run_wizard_map_step,
                 run_analysis=self.on_run_analysis_clicked,
                 set_analysis_mode=self._set_wizard_analysis_mode,
                 export_atlas=self.on_generate_atlas_pdf_clicked,
             ),
         )
+        self._install_wizard_filter_controls(self._wizard_shell_composition)
         self._bind_wizard_analysis_mode_controls(self._wizard_shell_composition)
         return self._wizard_shell_composition
 
+    def _install_wizard_filter_controls(self, composition) -> None:
+        """Move the live map-filter controls into the wizard map page."""
+
+        if getattr(self, "_wizard_filter_controls_installed", False):
+            return
+
+        map_content = getattr(composition, "map_content", None)
+        filter_group = getattr(self, "filterGroupBox", None)
+        if map_content is None or filter_group is None:
+            return
+        filter_controls_layout = getattr(map_content, "filter_controls_layout", None)
+        if not callable(filter_controls_layout):
+            return
+
+        self._remove_widget_from_current_layout(filter_group)
+        parent_panel = getattr(map_content, "filter_controls_panel", map_content)
+        if hasattr(filter_group, "setParent"):
+            filter_group.setParent(parent_panel)
+        filter_controls_layout().addWidget(filter_group)
+        if hasattr(filter_group, "show"):
+            filter_group.show()
+        elif hasattr(filter_group, "setVisible"):
+            filter_group.setVisible(True)
+        map_content.set_filter_controls_visible(False)
+        self._wizard_filter_controls_installed = True
+
+    def _remove_widget_from_current_layout(self, widget) -> None:
+        parent_widget = (
+            widget.parentWidget() if hasattr(widget, "parentWidget") else None
+        )
+        parent_layout = parent_widget.layout() if parent_widget is not None else None
+        if parent_layout is not None and hasattr(parent_layout, "removeWidget"):
+            parent_layout.removeWidget(widget)
+
+    def _set_wizard_filter_controls_visible(self, visible: bool) -> None:
+        """Reflect wizard filter-panel visibility in concise dock status copy."""
+
+        if visible:
+            self._set_status("Edit map filters, then apply filters when ready.")
+        else:
+            self._set_status("Map filter controls hidden.")
 
     def _bind_wizard_analysis_mode_controls(self, composition) -> None:
         """Expose the hidden backing analysis selector in the live wizard path."""

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -91,6 +91,34 @@ class MapPageContentTest(unittest.TestCase):
             content.apply_filters_button.objectName(),
             "qfitWizardMapApplyFiltersButton",
         )
+        self.assertEqual(
+            content.edit_filters_button.objectName(),
+            "qfitWizardMapEditFiltersButton",
+        )
+        self.assertEqual(content.edit_filters_button.text(), "Edit filters")
+        self.assertEqual(
+            content.edit_filters_button.property("secondaryAction"),
+            "edit_map_filters",
+        )
+        self.assertEqual(
+            content.edit_filters_button.property("wizardActionRole"),
+            "secondary",
+        )
+        self.assertFalse(content.edit_filters_button.isEnabled())
+        self.assertEqual(
+            content.edit_filters_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertIn("Sync activities", content.edit_filters_button.toolTip())
+        self.assertEqual(
+            content.filter_controls_panel.objectName(),
+            "qfitWizardMapFilterControlsPanel",
+        )
+        self.assertFalse(content.filter_controls_panel.isVisible())
+        self.assertEqual(
+            content.filter_controls_panel.property("filterControlsState"),
+            "collapsed",
+        )
         self.assertEqual(content.apply_filters_button.text(), "Apply filters")
         self.assertEqual(
             content.apply_filters_button.property("primaryAction"),
@@ -106,7 +134,11 @@ class MapPageContentTest(unittest.TestCase):
         self.assertEqual(content.action_row.objectName(), "qfitWizardMapActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,
-            [content.load_layers_button, content.apply_filters_button],
+            [
+                content.load_layers_button,
+                content.edit_filters_button,
+                content.apply_filters_button,
+            ],
         )
         self.assertEqual(
             content.outer_layout().widgets,
@@ -118,6 +150,7 @@ class MapPageContentTest(unittest.TestCase):
                 content.style_summary_label,
                 content.filter_summary_label,
                 content.action_row,
+                content.filter_controls_panel,
             ],
         )
 
@@ -132,6 +165,7 @@ class MapPageContentTest(unittest.TestCase):
             style_summary_text="Selected activity style: By activity type",
             filter_summary_text="42 activities · Ride and Run · 2026",
             load_action_label="Reload layers",
+            edit_filters_action_enabled=True,
             primary_action_label="Apply saved filters",
         )
 
@@ -168,6 +202,12 @@ class MapPageContentTest(unittest.TestCase):
             "available",
         )
         self.assertEqual(content.load_layers_button.toolTip(), "")
+        self.assertTrue(content.edit_filters_button.isEnabled())
+        self.assertEqual(
+            content.edit_filters_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.edit_filters_button.toolTip(), "")
         self.assertEqual(content.apply_filters_button.text(), "Apply saved filters")
         self.assertTrue(content.apply_filters_button.isEnabled())
         self.assertEqual(
@@ -209,16 +249,58 @@ class MapPageContentTest(unittest.TestCase):
             "Choose at least one activity layer.",
         )
 
+    def test_can_override_edit_filter_availability(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState(
+                edit_filters_action_enabled=True,
+            )
+        )
+
+        self.assertTrue(content.edit_filters_button.isEnabled())
+        self.assertEqual(
+            content.edit_filters_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.edit_filters_button.toolTip(), "")
+
+    def test_edit_filters_button_toggles_embedded_filter_controls(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState(edit_filters_action_enabled=True)
+        )
+        calls = []
+        content.editFiltersRequested.connect(lambda visible: calls.append(visible))
+
+        content.edit_filters_button.clicked.emit()
+
+        self.assertTrue(content.filter_controls_panel.isVisible())
+        self.assertEqual(
+            content.filter_controls_panel.property("filterControlsState"),
+            "expanded",
+        )
+        self.assertEqual(content.edit_filters_button.text(), "Hide filters")
+
+        content.edit_filters_button.clicked.emit()
+
+        self.assertFalse(content.filter_controls_panel.isVisible())
+        self.assertEqual(
+            content.filter_controls_panel.property("filterControlsState"),
+            "collapsed",
+        )
+        self.assertEqual(content.edit_filters_button.text(), "Edit filters")
+        self.assertEqual(calls, [True, False])
+
     def test_buttons_emit_reusable_page_signals(self):
         content = self.map_page.MapPageContent()
         calls = []
         content.loadLayersRequested.connect(lambda: calls.append("load"))
+        content.editFiltersRequested.connect(lambda _visible: calls.append("edit"))
         content.applyFiltersRequested.connect(lambda: calls.append("filter"))
 
         content.load_layers_button.clicked.emit()
+        content.edit_filters_button.clicked.emit()
         content.apply_filters_button.clicked.emit()
 
-        self.assertEqual(calls, ["load", "filter"])
+        self.assertEqual(calls, ["load", "edit", "filter"])
 
     def test_installs_only_on_map_wizard_page_body(self):
         map_spec = next(spec for spec in build_default_wizard_page_specs() if spec.key == "map")

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -263,6 +263,21 @@ class MapPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.edit_filters_button.toolTip(), "")
 
+    def test_disabling_edit_filters_collapses_embedded_filter_controls(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState(edit_filters_action_enabled=True)
+        )
+        content.set_filter_controls_visible(True)
+
+        content.set_state(self.map_page.MapPageState(edit_filters_action_enabled=False))
+
+        self.assertFalse(content.filter_controls_panel.isVisible())
+        self.assertEqual(
+            content.filter_controls_panel.property("filterControlsState"),
+            "collapsed",
+        )
+        self.assertEqual(content.edit_filters_button.text(), "Edit filters")
+
     def test_edit_filters_button_toggles_embedded_filter_controls(self):
         content = self.map_page.MapPageContent(
             self.map_page.MapPageState(edit_filters_action_enabled=True)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -727,7 +727,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "configure_connection": "_show_connection_configuration_hint",
             "sync_activities": "_run_wizard_sync_step",
             "load_activity_layers": "on_load_layers_clicked",
-            "edit_map_filters": "_set_wizard_filter_controls_visible",
+            "edit_map_filters": "_update_status_for_filter_visibility",
             "apply_map_filters": "_run_wizard_map_step",
             "run_analysis": "on_run_analysis_clicked",
             "set_analysis_mode": "_set_wizard_analysis_mode",
@@ -782,12 +782,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         map_content.filter_controls_layout.assert_not_called()
 
-    def test_set_wizard_filter_controls_visible_updates_status_copy(self):
+    def test_update_status_for_filter_visibility_updates_status_copy(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._set_status = MagicMock()
 
-        self.module.QfitDockWidget._set_wizard_filter_controls_visible(dock, True)
-        self.module.QfitDockWidget._set_wizard_filter_controls_visible(dock, False)
+        self.module.QfitDockWidget._update_status_for_filter_visibility(dock, True)
+        self.module.QfitDockWidget._update_status_for_filter_visibility(dock, False)
 
         dock._set_status.assert_any_call(
             "Edit map filters, then apply filters when ready."

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -727,6 +727,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "configure_connection": "_show_connection_configuration_hint",
             "sync_activities": "_run_wizard_sync_step",
             "load_activity_layers": "on_load_layers_clicked",
+            "edit_map_filters": "_set_wizard_filter_controls_visible",
             "apply_map_filters": "_run_wizard_map_step",
             "run_analysis": "on_run_analysis_clicked",
             "set_analysis_mode": "_set_wizard_analysis_mode",
@@ -739,6 +740,59 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 callback.__func__,
                 getattr(self.module.QfitDockWidget, method_name),
             )
+
+
+    def test_install_wizard_filter_controls_moves_live_filter_group_into_map_panel(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        parent_layout = MagicMock()
+        parent_widget = SimpleNamespace(layout=lambda: parent_layout)
+        filter_group = MagicMock()
+        filter_group.parentWidget.return_value = parent_widget
+        dock.filterGroupBox = filter_group
+        panel = object()
+        filter_layout = MagicMock()
+        map_content = SimpleNamespace(
+            filter_controls_panel=panel,
+            filter_controls_layout=MagicMock(return_value=filter_layout),
+            set_filter_controls_visible=MagicMock(),
+        )
+
+        self.module.QfitDockWidget._install_wizard_filter_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
+        parent_layout.removeWidget.assert_called_once_with(filter_group)
+        filter_group.setParent.assert_called_once_with(panel)
+        filter_layout.addWidget.assert_called_once_with(filter_group)
+        filter_group.show.assert_called_once_with()
+        map_content.set_filter_controls_visible.assert_called_once_with(False)
+        self.assertTrue(dock._wizard_filter_controls_installed)
+
+    def test_install_wizard_filter_controls_is_idempotent(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._wizard_filter_controls_installed = True
+        dock.filterGroupBox = MagicMock()
+        map_content = SimpleNamespace(filter_controls_layout=MagicMock())
+
+        self.module.QfitDockWidget._install_wizard_filter_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
+        map_content.filter_controls_layout.assert_not_called()
+
+    def test_set_wizard_filter_controls_visible_updates_status_copy(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._set_status = MagicMock()
+
+        self.module.QfitDockWidget._set_wizard_filter_controls_visible(dock, True)
+        self.module.QfitDockWidget._set_wizard_filter_controls_visible(dock, False)
+
+        dock._set_status.assert_any_call(
+            "Edit map filters, then apply filters when ready."
+        )
+        dock._set_status.assert_any_call("Map filter controls hidden.")
 
 
     def test_bind_wizard_analysis_mode_controls_exposes_non_none_modes(self):

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -270,6 +270,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             configure_connection=lambda: calls.append("configure"),
             sync_activities=lambda: calls.append("sync"),
             load_activity_layers=lambda: calls.append("load"),
+            edit_map_filters=lambda visible: calls.append(f"edit:{visible}"),
             apply_map_filters=lambda: calls.append("filter"),
             run_analysis=lambda: calls.append("analysis"),
             set_analysis_mode=lambda mode: calls.append(f"mode:{mode}"),
@@ -287,6 +288,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         assembled.connection_content.configure_button.clicked.emit()
         assembled.sync_content.sync_button.clicked.emit()
         assembled.map_content.load_layers_button.clicked.emit()
+        assembled.map_content.edit_filters_button.clicked.emit()
         assembled.map_content.apply_filters_button.clicked.emit()
         assembled.analysis_content.run_analysis_button.clicked.emit()
         assembled.analysis_content.analysis_mode_combo.setCurrentText("Heatmap")
@@ -300,6 +302,7 @@ class WizardShellCompositionTest(unittest.TestCase):
                 "configure",
                 "sync",
                 "load",
+                "edit:True",
                 "filter",
                 "analysis",
                 "mode:Heatmap",
@@ -401,6 +404,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Use the primary action to load activity layers.",
         )
         self.assertEqual(assembled.map_content.apply_filters_button.text(), "Load activity layers")
+        self.assertTrue(assembled.map_content.edit_filters_button.isEnabled())
         self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
         self.assertEqual(
             assembled.map_content.apply_filters_button.property("wizardActionAvailability"),
@@ -1125,6 +1129,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.sync_content.sync_button.isEnabled())
         self.assertFalse(assembled.map_state.loaded)
         self.assertFalse(assembled.map_content.load_layers_button.isEnabled())
+        self.assertFalse(assembled.map_content.edit_filters_button.isEnabled())
         self.assertFalse(assembled.map_content.apply_filters_button.isEnabled())
         self.assertEqual(assembled.shell.footer_bar.activity_pill.text(), "— activities")
         self.assertEqual(assembled.shell.footer_bar.layer_pill.text(), "0 layers")

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -48,6 +48,11 @@ class MapPageState:
     load_action_label: str = "Load activity layers"
     load_action_enabled: bool = True
     load_action_blocked_tooltip: str = "Sync activities before loading map layers."
+    edit_filters_action_label: str = "Edit filters"
+    edit_filters_action_enabled: bool = False
+    edit_filters_action_blocked_tooltip: str = (
+        "Sync activities before editing map filters."
+    )
     primary_action_label: str = "Apply filters"
     apply_action_enabled: bool | None = None
     apply_action_blocked_tooltip: str = "Load activity layers before applying filters."
@@ -57,6 +62,7 @@ class MapPageContent(QWidget):
     """Reusable third-page content for the wizard map-and-filters step."""
 
     loadLayersRequested = pyqtSignal()
+    editFiltersRequested = pyqtSignal(bool)
     applyFiltersRequested = pyqtSignal()
 
     def __init__(self, state: MapPageState | None = None, parent=None) -> None:
@@ -88,6 +94,13 @@ class MapPageContent(QWidget):
             action_name="load_activity_layers",
         )
         self.load_layers_button.clicked.connect(self.loadLayersRequested.emit)
+        self.edit_filters_button = QToolButton(self)
+        self.edit_filters_button.setObjectName("qfitWizardMapEditFiltersButton")
+        style_secondary_action_button(
+            self.edit_filters_button,
+            action_name="edit_map_filters",
+        )
+        self.edit_filters_button.clicked.connect(self._toggle_filter_controls)
         self.apply_filters_button = QToolButton(self)
         self.apply_filters_button.setObjectName("qfitWizardMapApplyFiltersButton")
         style_primary_action_button(
@@ -97,10 +110,16 @@ class MapPageContent(QWidget):
         self.apply_filters_button.clicked.connect(self.applyFiltersRequested.emit)
         self.action_row = build_wizard_action_row(
             self.load_layers_button,
+            self.edit_filters_button,
             self.apply_filters_button,
             parent=self,
             object_name="qfitWizardMapActionRow",
         )
+        self.filter_controls_panel = QWidget(self)
+        self.filter_controls_panel.setObjectName("qfitWizardMapFilterControlsPanel")
+        self.filter_controls_panel.setVisible(False)
+        self.filter_controls_panel.setProperty("filterControlsState", "collapsed")
+        self._filter_controls_layout = self._build_filter_controls_layout()
         self._layout = self._build_layout()
         self.set_state(state or MapPageState())
 
@@ -126,6 +145,14 @@ class MapPageContent(QWidget):
             enabled=state.load_action_enabled,
             tooltip=state.load_action_blocked_tooltip,
         )
+        self.edit_filters_button.setText(state.edit_filters_action_label)
+        set_wizard_action_availability(
+            self.edit_filters_button,
+            enabled=state.edit_filters_action_enabled,
+            tooltip=state.edit_filters_action_blocked_tooltip,
+        )
+        if self.filter_controls_panel.isVisible():
+            self.edit_filters_button.setText("Hide filters")
         self.apply_filters_button.setText(state.primary_action_label)
         apply_action_enabled = (
             state.loaded
@@ -138,10 +165,38 @@ class MapPageContent(QWidget):
             tooltip=state.apply_action_blocked_tooltip,
         )
 
+    def filter_controls_layout(self):
+        """Expose the wizard panel slot for live map-filter controls."""
+
+        return self._filter_controls_layout
+
+    def set_filter_controls_visible(self, visible: bool) -> None:
+        """Show or hide the embedded filter controls without rebuilding the page."""
+
+        self.filter_controls_panel.setVisible(visible)
+        self.filter_controls_panel.setProperty(
+            "filterControlsState",
+            "expanded" if visible else "collapsed",
+        )
+        self.edit_filters_button.setText("Hide filters" if visible else "Edit filters")
+
+    def _toggle_filter_controls(self) -> None:
+        next_visible = not self.filter_controls_panel.isVisible()
+        self.set_filter_controls_visible(next_visible)
+        self.editFiltersRequested.emit(next_visible)
+
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""
 
         return self._layout
+
+    def _build_filter_controls_layout(self):
+        layout = QVBoxLayout(self.filter_controls_panel)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardMapFilterControlsLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        return layout
 
     def _build_layout(self):
         layout = QVBoxLayout(self)
@@ -156,6 +211,7 @@ class MapPageContent(QWidget):
         layout.addWidget(self.style_summary_label)
         layout.addWidget(self.filter_summary_label)
         layout.addWidget(self.action_row)
+        layout.addWidget(self.filter_controls_panel)
         return layout
 
 

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -151,7 +151,9 @@ class MapPageContent(QWidget):
             enabled=state.edit_filters_action_enabled,
             tooltip=state.edit_filters_action_blocked_tooltip,
         )
-        if self.filter_controls_panel.isVisible():
+        if not state.edit_filters_action_enabled and self.filter_controls_panel.isVisible():
+            self.set_filter_controls_visible(False)
+        elif self.filter_controls_panel.isVisible():
             self.edit_filters_button.setText("Hide filters")
         self.apply_filters_button.setText(state.primary_action_label)
         apply_action_enabled = (

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -67,6 +67,7 @@ class WizardActionCallbacks:
     configure_connection: Callable[[], None] | None = None
     sync_activities: Callable[[], None] | None = None
     load_activity_layers: Callable[[], None] | None = None
+    edit_map_filters: Callable[[bool], None] | None = None
     apply_map_filters: Callable[[], None] | None = None
     run_analysis: Callable[[], None] | None = None
     set_analysis_mode: Callable[[str], None] | None = None
@@ -407,6 +408,8 @@ def _connect_action_callbacks(
         sync_content.syncRequested.connect(callbacks.sync_activities)
     if map_content is not None and callbacks.load_activity_layers is not None:
         map_content.loadLayersRequested.connect(callbacks.load_activity_layers)
+    if map_content is not None and callbacks.edit_map_filters is not None:
+        map_content.editFiltersRequested.connect(callbacks.edit_map_filters)
     if map_content is not None and callbacks.apply_map_filters is not None:
         map_content.applyFiltersRequested.connect(callbacks.apply_map_filters)
     if analysis_content is not None and callbacks.run_analysis is not None:
@@ -608,6 +611,7 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
             if stored_without_loaded_layers
             else default.primary_action_label
         ),
+        edit_filters_action_enabled=facts.activities_stored,
         apply_action_enabled=facts.activities_stored,
         apply_action_blocked_tooltip=(
             "Sync activities before loading map layers."

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -402,22 +402,44 @@ def _connect_action_callbacks(
     atlas_content: AtlasPageContent | None,
     callbacks: WizardActionCallbacks,
 ) -> None:
-    if connection_content is not None and callbacks.configure_connection is not None:
-        connection_content.configureRequested.connect(callbacks.configure_connection)
-    if sync_content is not None and callbacks.sync_activities is not None:
-        sync_content.syncRequested.connect(callbacks.sync_activities)
-    if map_content is not None and callbacks.load_activity_layers is not None:
-        map_content.loadLayersRequested.connect(callbacks.load_activity_layers)
-    if map_content is not None and callbacks.edit_map_filters is not None:
-        map_content.editFiltersRequested.connect(callbacks.edit_map_filters)
-    if map_content is not None and callbacks.apply_map_filters is not None:
-        map_content.applyFiltersRequested.connect(callbacks.apply_map_filters)
-    if analysis_content is not None and callbacks.run_analysis is not None:
-        analysis_content.runAnalysisRequested.connect(callbacks.run_analysis)
-    if analysis_content is not None and callbacks.set_analysis_mode is not None:
-        analysis_content.analysisModeChanged.connect(callbacks.set_analysis_mode)
-    if atlas_content is not None and callbacks.export_atlas is not None:
-        atlas_content.exportAtlasRequested.connect(callbacks.export_atlas)
+    _connect_optional_signal(
+        connection_content,
+        "configureRequested",
+        callbacks.configure_connection,
+    )
+    _connect_optional_signal(sync_content, "syncRequested", callbacks.sync_activities)
+    _connect_optional_signal(
+        map_content,
+        "loadLayersRequested",
+        callbacks.load_activity_layers,
+    )
+    _connect_optional_signal(
+        map_content,
+        "editFiltersRequested",
+        callbacks.edit_map_filters,
+    )
+    _connect_optional_signal(
+        map_content,
+        "applyFiltersRequested",
+        callbacks.apply_map_filters,
+    )
+    _connect_optional_signal(
+        analysis_content,
+        "runAnalysisRequested",
+        callbacks.run_analysis,
+    )
+    _connect_optional_signal(
+        analysis_content,
+        "analysisModeChanged",
+        callbacks.set_analysis_mode,
+    )
+    _connect_optional_signal(atlas_content, "exportAtlasRequested", callbacks.export_atlas)
+
+
+def _connect_optional_signal(content, signal_name: str, callback) -> None:
+    if content is None or callback is None:
+        return
+    getattr(content, signal_name).connect(callback)
 
 
 def _resolve_progress(


### PR DESCRIPTION
## Summary

Adds a wizard-native `Edit filters` secondary action to the Map & filters step so users can reveal the live filter controls without returning to the legacy long-scroll dock.

## Changes

- Adds an embedded, collapsible filter-controls panel to the map wizard page.
- Moves the existing live `Filters` group into that wizard panel during dock shell assembly.
- Wires the new affordance through wizard callbacks and status copy while preserving the existing Apply filters workflow.
- Adds regression coverage for the affordance, callback wiring, and live-control installation.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Fixes #714
