### PR TITLE
fix: hide final wizard next action

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -81,11 +81,17 @@ class StepPageTest(unittest.TestCase):
     def test_next_and_back_configuration_updates_roles_and_availability(self):
         page = self.step_page.StepPage(4, 5, "Analyse", "Calcule les sorties.")
 
-        page.set_next("Lancer l'analyse", primary=False, enabled=False)
+        page.set_next(
+            "Lancer l'analyse",
+            primary=False,
+            enabled=False,
+            visible=False,
+        )
         page.set_back("Retour", enabled=False)
 
         self.assertEqual(page.next_button.text(), "Lancer l'analyse")
         self.assertFalse(page.next_button.isEnabled())
+        self.assertFalse(page.next_button.isVisible())
         self.assertEqual(page.next_button.property("wizardActionRole"), "secondary")
         self.assertEqual(page.back_button.text(), "Retour")
         self.assertFalse(page.back_button.isEnabled())

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -258,11 +258,13 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.presenter.progress.current_key, "atlas")
         self.assertTrue(assembled.pages[1].back_button.isEnabled())
         self.assertFalse(assembled.pages[1].next_button.isEnabled())
+        self.assertFalse(assembled.pages[1].next_button.isVisible())
 
         assembled.pages[1].back_button.clicked.emit()
 
         self.assertEqual(assembled.presenter.progress.current_key, "connection")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+        self.assertTrue(assembled.pages[0].next_button.isVisible())
 
     def test_action_callbacks_are_wired_to_installed_page_ctas(self):
         calls = []
@@ -1047,6 +1049,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.atlas_content.input_summary_label.text(),
             "Analysis outputs ready for atlas export",
         )
+        self.assertFalse(assembled.pages[4].next_button.isVisible())
 
     def test_busy_atlas_page_summary_uses_configured_output_name(self):
         assembled = self.composition.build_placeholder_wizard_shell(

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -100,11 +100,13 @@ class StepPage(QWidget):
         icon: str = "",
         primary: bool = True,
         enabled: bool = True,
+        visible: bool = True,
     ) -> None:
         """Configure the right-side next/primary wizard action."""
 
         self.next_button.setText(_button_text(label, icon))
         self.next_button.setEnabled(enabled)
+        self.next_button.setVisible(visible)
         self.next_button.setProperty("wizardActionRole", "primary" if primary else "secondary")
         self.next_button.setStyleSheet(
             _primary_button_stylesheet() if primary else _ghost_button_stylesheet()

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -994,6 +994,7 @@ def _sync_step_page_navigation_buttons(
                 and can_request_step(statuses, previous_index)
             ),
         )
+        has_next_page = next_index is not None
         page.set_next(
             label=_navigation_label(
                 prefix="Suivant",
@@ -1002,10 +1003,11 @@ def _sync_step_page_navigation_buttons(
             ),
             icon="→",
             enabled=(
-                next_index is not None
+                has_next_page
                 and next_index <= last_index
                 and can_request_step(statuses, next_index)
             ),
+            visible=has_next_page,
         )
 
 


### PR DESCRIPTION
## Summary
- hide the wizard `Next` navigation button on the final Atlas PDF step so it no longer presents a dead-end action
- keep the Atlas export CTA as the discoverable final-step action while preserving Back navigation
- add regression coverage for final-step navigation visibility

Fixes #715.

## Testing
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
