### PR TITLE
fix: align wizard navigation cursors

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -48,8 +48,16 @@ class StepPageTest(unittest.TestCase):
         self.assertEqual(page.content_layout().contents_margins, (0, 0, 0, 0))
         self.assertEqual(page.back_button.text(), "Précédent")
         self.assertEqual(page.back_button.property("wizardActionRole"), "back")
+        self.assertEqual(
+            page.back_button.cursor().shape(),
+            self.step_page.Qt.PointingHandCursor,
+        )
         self.assertEqual(page.next_button.text(), "Suivant →")
         self.assertEqual(page.next_button.property("wizardActionRole"), "primary")
+        self.assertEqual(
+            page.next_button.cursor().shape(),
+            self.step_page.Qt.PointingHandCursor,
+        )
         self.assertFalse(page.status_pill.isVisible())
 
     def test_status_pill_can_be_shown_and_hidden_with_tone(self):

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -174,12 +174,14 @@ class StepPage(QWidget):
     def _build_back_button(self):
         button = QToolButton(self)
         button.setObjectName("qfitWizardStepBackButton")
+        _apply_wizard_navigation_cursor(button)
         button.clicked.connect(self.backRequested.emit)
         return button
 
     def _build_next_button(self):
         button = QToolButton(self)
         button.setObjectName("qfitWizardStepNextButton")
+        _apply_wizard_navigation_cursor(button)
         button.clicked.connect(self.nextRequested.emit)
         return button
 
@@ -359,6 +361,11 @@ class _LayoutWidget(QWidget):
         super().__init__(parent)
         if hasattr(self, "setLayout"):
             self.setLayout(layout)
+
+
+def _apply_wizard_navigation_cursor(button) -> None:
+    if hasattr(button, "setCursor"):
+        button.setCursor(Qt.PointingHandCursor)
 
 
 def _button_text(label: str, icon: str) -> str:


### PR DESCRIPTION
## Summary
- give wizard step Back and Next navigation buttons the same pointing-hand cursor as page action buttons
- keep the change scoped to StepPage navigation chrome
- add regression coverage for both navigation button cursors

Fixes #716.

## Testing
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
