### PR TITLE
fix: hide current wizard status pill

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -199,13 +199,16 @@ class StepPageTest(unittest.TestCase):
 
         self.assertEqual(
             [page.status_pill.text() for page in pages],
-            ["Done", "Done", "Current", "Available", "Locked"],
+            ["Done", "Done", "", "Available", "Locked"],
         )
         self.assertEqual(
             [page.status_pill.property("tone") for page in pages],
-            ["ok", "ok", "info", "neutral", "muted"],
+            ["ok", "ok", "muted", "neutral", "muted"],
         )
-        self.assertTrue(all(page.status_pill.isVisible() for page in pages))
+        self.assertFalse(pages[2].status_pill.isVisible())
+        self.assertTrue(
+            all(page.status_pill.isVisible() for index, page in enumerate(pages) if index != 2)
+        )
 
     def test_installs_wizard_step_pages_into_shell(self):
         shell = self.wizard_shell.WizardShell()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -59,7 +59,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.pages[0].next_button.isEnabled())
         self.assertEqual(
             [page.status_pill.text() for page in assembled.pages],
-            ["Current", "Locked", "Locked", "Locked", "Locked"],
+            ["", "Locked", "Locked", "Locked", "Locked"],
         )
         self.assertIsNotNone(assembled.connection_content)
         self.assertIs(
@@ -170,11 +170,11 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertEqual(
             [page.status_pill.text() for page in assembled.pages],
-            ["Done", "Done", "Current", "Locked", "Locked"],
+            ["Done", "Done", "", "Locked", "Locked"],
         )
         self.assertEqual(
             [page.status_pill.property("tone") for page in assembled.pages],
-            ["ok", "ok", "info", "muted", "muted"],
+            ["ok", "ok", "muted", "muted", "muted"],
         )
         self.assertTrue(assembled.pages[2].back_button.isEnabled())
         self.assertFalse(assembled.pages[2].next_button.isEnabled())
@@ -183,7 +183,7 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(assembled.presenter.progress.current_key, "sync")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
-        self.assertEqual(assembled.pages[1].status_pill.text(), "Current")
+        self.assertEqual(assembled.pages[1].status_pill.text(), "")
         self.assertEqual(assembled.pages[2].status_pill.text(), "Available")
         self.assertTrue(assembled.pages[1].next_button.isEnabled())
         self.assertEqual(
@@ -199,7 +199,7 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(assembled.presenter.progress.current_key, "map")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 2)
-        self.assertEqual(assembled.pages[2].status_pill.text(), "Current")
+        self.assertEqual(assembled.pages[2].status_pill.text(), "")
         self.assertEqual(
             assembled.pages[2].back_button.text(),
             "Précédent: Synchronization",
@@ -213,7 +213,7 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(assembled.presenter.progress.current_key, "sync")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
-        self.assertEqual(assembled.pages[1].status_pill.text(), "Current")
+        self.assertEqual(assembled.pages[1].status_pill.text(), "")
         self.assertEqual(assembled.pages[2].status_pill.text(), "Available")
         self.assertTrue(assembled.pages[1].next_button.isEnabled())
         self.assertEqual(
@@ -237,7 +237,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.presenter.progress.current_key, "map")
         self.assertEqual(
             [page.status_pill.text() for page in assembled.pages],
-            ["Done", "Done", "Current", "Locked", "Locked"],
+            ["Done", "Done", "", "Locked", "Locked"],
         )
         self.assertTrue(assembled.pages[2].back_button.isEnabled())
         self.assertFalse(assembled.pages[2].next_button.isEnabled())

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -338,11 +338,10 @@ def apply_wizard_step_page_statuses(
 ) -> None:
     """Render progress status pills on StepPage-backed wizard pages.
 
-    The stepper remains the source of truth for navigation state, but the richer
-    #609 page chrome also exposes a compact header pill. Keeping that mapping in
-    this reusable widget layer lets the future wizard dock show visible progress
-    without binding page widgets to ``QfitDockWidget`` or polishing the legacy
-    long-scroll layout.
+    The stepper remains the source of truth for current-step navigation state.
+    Header pills are therefore reserved for non-current states, avoiding a
+    redundant "Current" badge on the active page while preserving Done/Locked
+    context on neighbouring pages.
     """
 
     statuses_by_key = {status.key: status for status in statuses}
@@ -380,7 +379,7 @@ def _step_status_pill(state: DockWorkflowStepState) -> tuple[str, str]:
     if state == DockWorkflowStepState.DONE:
         return "Done", "ok"
     if state == DockWorkflowStepState.CURRENT:
-        return "Current", "info"
+        return "", "muted"
     if state == DockWorkflowStepState.UNLOCKED:
         return "Available", "neutral"
     return "Locked", "muted"


### PR DESCRIPTION
## Summary
- hide the active step's redundant `Current` header pill because the stepper already shows the current page
- keep non-current header pills for Done, Available, and Locked context
- update StepPage and wizard composition tests for the uncluttered current-step state

Fixes #717.

## Testing
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
