### PR TITLE
fix: add local GeoPackage load action to wizard sync

### DIFF
--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -60,8 +60,27 @@ class SyncPageContentTest(unittest.TestCase):
             "available",
         )
         self.assertEqual(content.sync_button.toolTip(), "")
+        self.assertEqual(content.load_button.objectName(), "qfitWizardSyncLoadButton")
+        self.assertEqual(content.load_button.text(), "Load activities")
+        self.assertEqual(
+            content.load_button.property("secondaryAction"),
+            "load_activities",
+        )
+        self.assertEqual(content.load_button.property("wizardActionRole"), "secondary")
+        self.assertFalse(content.load_button.isEnabled())
+        self.assertEqual(
+            content.load_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertEqual(
+            content.load_button.toolTip(),
+            "Select an existing GeoPackage before loading activities.",
+        )
         self.assertEqual(content.action_row.objectName(), "qfitWizardSyncActionRow")
-        self.assertEqual(content.action_row.outer_layout().widgets, [content.sync_button])
+        self.assertEqual(
+            content.action_row.outer_layout().widgets,
+            [content.load_button, content.sync_button],
+        )
         self.assertEqual(
             content.outer_layout().widgets,
             [
@@ -80,6 +99,7 @@ class SyncPageContentTest(unittest.TestCase):
             detail_text="Use the latest saved Strava credentials.",
             activity_summary_text="42 activities stored · 40 detailed routes",
             primary_action_label="Fetch latest activities",
+            local_action_enabled=True,
         )
 
         content.set_state(state)
@@ -97,6 +117,8 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.activity_summary_label.property("syncState"), "ready")
         self.assertEqual(content.sync_button.text(), "Fetch latest activities")
+        self.assertTrue(content.load_button.isEnabled())
+        self.assertEqual(content.load_button.toolTip(), "")
 
     def test_can_block_sync_action_with_tooltip_copy(self):
         content = self.sync_page.SyncPageContent(
@@ -135,6 +157,17 @@ class SyncPageContentTest(unittest.TestCase):
         content.sync_button.clicked.emit()
 
         self.assertEqual(calls, ["sync"])
+
+    def test_load_button_emits_reusable_page_signal(self):
+        content = self.sync_page.SyncPageContent(
+            self.sync_page.SyncPageState(local_action_enabled=True)
+        )
+        calls = []
+        content.loadActivitiesRequested.connect(lambda: calls.append("load"))
+
+        content.load_button.clicked.emit()
+
+        self.assertEqual(calls, ["load"])
 
     def test_installs_only_on_sync_wizard_page_body(self):
         sync_spec = next(

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -265,6 +265,18 @@ class WizardProgressFactsTests(unittest.TestCase):
             ["done", "done", "done", "current", "locked"],
         )
 
+    def test_local_geopackage_store_unlocks_map_without_strava_connection(self):
+        progress = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=False,
+                activities_stored=True,
+                preferred_current_key="map",
+            )
+        )
+
+        self.assertEqual(progress.current_key, "map")
+        self.assertEqual(progress.completed_keys, frozenset({"connection", "sync"}))
+
     def test_ignores_later_completed_facts_until_prerequisites_are_done(self):
         progress = build_wizard_progress_from_facts(
             WizardProgressFacts(

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -417,6 +417,34 @@ class WizardShellCompositionTest(unittest.TestCase):
             "available",
         )
 
+    def test_local_geopackage_flow_reaches_map_without_strava_connection(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=False,
+            activities_stored=True,
+            output_name="offline.gpkg",
+            preferred_current_key="map",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(assembled.presenter.progress.current_key, "map")
+        self.assertEqual(
+            assembled.presenter.progress.completed_keys,
+            frozenset({"connection", "sync"}),
+        )
+        self.assertEqual(
+            assembled.connection_content.status_label.text(),
+            "Local GeoPackage available",
+        )
+        self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
+        self.assertFalse(assembled.sync_content.sync_button.isEnabled())
+        self.assertTrue(assembled.sync_content.load_button.isEnabled())
+        self.assertEqual(
+            assembled.map_content.status_label.text(),
+            "Stored activities ready to load",
+        )
+        self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
+
     def test_existing_wizard_settings_restore_reachable_initial_step(self):
         settings = self.composition.WizardSettingsSnapshot(
             wizard_version=1,
@@ -1122,7 +1150,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         assembled = self.composition.build_placeholder_wizard_shell(
             progress_facts=self.composition.WizardProgressFacts(
                 connection_configured=False,
-                activities_stored=True,
+                activities_stored=False,
                 activity_layers_loaded=True,
                 analysis_generated=True,
                 atlas_exported=True,

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -289,6 +289,7 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         assembled.connection_content.configure_button.clicked.emit()
         assembled.sync_content.sync_button.clicked.emit()
+        assembled.sync_content.load_button.clicked.emit()
         assembled.map_content.load_layers_button.clicked.emit()
         assembled.map_content.edit_filters_button.clicked.emit()
         assembled.map_content.apply_filters_button.clicked.emit()
@@ -303,6 +304,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             [
                 "configure",
                 "sync",
+                "load",
                 "load",
                 "edit:True",
                 "filter",
@@ -396,6 +398,8 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.connection_content.configure_button.text(), "Review connection")
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
         self.assertTrue(assembled.sync_content.sync_button.isEnabled())
+        self.assertTrue(assembled.sync_content.load_button.isEnabled())
+        self.assertEqual(assembled.sync_content.load_button.text(), "Load activities")
         self.assertEqual(
             assembled.map_content.status_label.text(),
             "Stored activities ready to load",

--- a/ui/application/wizard_page_specs.py
+++ b/ui/application/wizard_page_specs.py
@@ -47,8 +47,8 @@ _PAGE_COPY_BY_KEY = {
         "Primary action: configure connection",
     ),
     "sync": (
-        "Fetch activities and store detailed routes in the GeoPackage.",
-        "Primary action: sync activities",
+        "Sync Strava activities or load an existing GeoPackage.",
+        "Primary action: sync activities; secondary action: load activities",
     ),
     "map": (
         "Load activity layers, choose a background map, and refine filters.",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -169,9 +169,10 @@ def build_wizard_progress_from_facts_and_settings(
 
 
 def _completed_keys_from_facts(facts: WizardProgressFacts) -> tuple[str, ...]:
+    connection_complete = facts.connection_configured or facts.activities_stored
     completed: list[str] = []
     for key, complete in (
-        ("connection", facts.connection_configured),
+        ("connection", connection_complete),
         ("sync", facts.activities_stored),
         ("map", facts.activity_layers_loaded),
         ("analysis", facts.analysis_generated),

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -7,6 +7,7 @@ from .action_row import (
     build_wizard_action_row,
     set_wizard_action_availability,
     style_primary_action_button,
+    style_secondary_action_button,
 )
 from .page_content_style import (
     style_detail_label,
@@ -39,17 +40,21 @@ class SyncPageState:
 
     ready: bool = False
     status_text: str = "Activities not synced yet"
-    detail_text: str = "Fetch Strava activities and store detailed routes in the GeoPackage."
+    detail_text: str = "Sync Strava activities or load an existing GeoPackage."
     activity_summary_text: str = "No activities stored"
     primary_action_label: str = "Sync activities"
     primary_action_enabled: bool = True
     primary_action_blocked_tooltip: str = "Configure the Strava connection before syncing."
+    local_action_label: str = "Load activities"
+    local_action_enabled: bool = False
+    local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading activities."
 
 
 class SyncPageContent(QWidget):
     """Reusable second-page content for the wizard synchronization step."""
 
     syncRequested = pyqtSignal()
+    loadActivitiesRequested = pyqtSignal()
 
     def __init__(self, state: SyncPageState | None = None, parent=None) -> None:
         super().__init__(parent)
@@ -71,7 +76,15 @@ class SyncPageContent(QWidget):
             action_name="sync_activities",
         )
         self.sync_button.clicked.connect(self.syncRequested.emit)
+        self.load_button = QToolButton(self)
+        self.load_button.setObjectName("qfitWizardSyncLoadButton")
+        style_secondary_action_button(
+            self.load_button,
+            action_name="load_activities",
+        )
+        self.load_button.clicked.connect(self.loadActivitiesRequested.emit)
         self.action_row = build_wizard_action_row(
+            self.load_button,
             self.sync_button,
             parent=self,
             object_name="qfitWizardSyncActionRow",
@@ -94,6 +107,12 @@ class SyncPageContent(QWidget):
             self.sync_button,
             enabled=state.primary_action_enabled,
             tooltip=state.primary_action_blocked_tooltip,
+        )
+        self.load_button.setText(state.local_action_label)
+        set_wizard_action_availability(
+            self.load_button,
+            enabled=state.local_action_enabled,
+            tooltip=state.local_action_blocked_tooltip,
         )
 
     def outer_layout(self):

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -474,7 +474,7 @@ def _page_state_defaults_from_progress_facts(
 def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
     completed = build_wizard_progress_from_facts(facts).completed_keys
     return WizardProgressFacts(
-        connection_configured="connection" in completed,
+        connection_configured=facts.connection_configured,
         activities_fetched=facts.activities_fetched,
         activities_stored="sync" in completed,
         activity_layers_loaded="map" in completed,
@@ -522,16 +522,29 @@ def _apply_footer_facts(footer_bar, footer_facts: WizardFooterFacts | None) -> N
 
 def _connection_state_from_facts(facts: WizardProgressFacts) -> ConnectionPageState:
     default = ConnectionPageState()
-    if not facts.connection_configured:
-        return default
-    return ConnectionPageState(
-        connected=True,
-        status_text="Strava connected",
-        detail_text="Connection is configured; continue to synchronization.",
-        credential_summary_text="Strava OAuth credentials are stored in qfit settings",
-        primary_action_label="Review connection",
-        primary_action_enabled=True,
-    )
+    if facts.connection_configured:
+        return ConnectionPageState(
+            connected=True,
+            status_text="Strava connected",
+            detail_text="Connection is configured; continue to synchronization.",
+            credential_summary_text="Strava OAuth credentials are stored in qfit settings",
+            primary_action_label="Review connection",
+            primary_action_enabled=True,
+        )
+    if facts.activities_stored:
+        return ConnectionPageState(
+            connected=True,
+            status_text="Local GeoPackage available",
+            detail_text=(
+                "Strava credentials are optional while loading existing activities."
+            ),
+            credential_summary_text=(
+                "Using an existing GeoPackage; configure Strava only to sync new data"
+            ),
+            primary_action_label="Configure Strava",
+            primary_action_enabled=True,
+        )
+    return default
 
 
 def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
@@ -539,12 +552,14 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
     status_text = default.status_text
     detail_text = default.detail_text
     sync_blocked_tooltip = default.primary_action_blocked_tooltip
-    if not facts.connection_configured:
+    if facts.activities_stored:
+        status_text = "Activities stored"
+        detail_text = (
+            "Stored activities are ready to load from the existing GeoPackage."
+        )
+    elif not facts.connection_configured:
         status_text = "Connection required before sync"
         detail_text = "Configure Strava credentials before syncing activities."
-    elif facts.activities_stored:
-        status_text = "Activities stored"
-        detail_text = "Stored activities are ready for map loading."
     elif facts.activities_fetched:
         status_text = "Activities fetched"
         detail_text = (

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -409,6 +409,11 @@ def _connect_action_callbacks(
     )
     _connect_optional_signal(sync_content, "syncRequested", callbacks.sync_activities)
     _connect_optional_signal(
+        sync_content,
+        "loadActivitiesRequested",
+        callbacks.load_activity_layers,
+    )
+    _connect_optional_signal(
         map_content,
         "loadLayersRequested",
         callbacks.load_activity_layers,
@@ -563,7 +568,20 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
         primary_action_label=primary_action_label,
         primary_action_enabled=facts.connection_configured and not facts.sync_in_progress,
         primary_action_blocked_tooltip=sync_blocked_tooltip,
+        local_action_enabled=facts.activities_stored and not facts.sync_in_progress,
+        local_action_blocked_tooltip=_sync_local_action_blocked_tooltip(facts, default),
     )
+
+
+def _sync_local_action_blocked_tooltip(
+    facts: WizardProgressFacts,
+    default: SyncPageState,
+) -> str:
+    if facts.sync_in_progress:
+        return "Wait for the current synchronization to finish."
+    if not facts.activities_stored:
+        return default.local_action_blocked_tooltip
+    return ""
 
 
 def _sync_activity_summary(


### PR DESCRIPTION
## Summary

Adds a wizard-native offline/local path on the Synchronization step so users can load activities from an already configured GeoPackage without running a fresh Strava sync.

## Changes

- Adds a secondary `Load activities` action to the Synchronization page.
- Wires that action to the existing GeoPackage layer-loading workflow.
- Updates synchronization wizard copy to mention the local GeoPackage path.
- Covers the new button state, signal wiring, and composition callback path in tests.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Fixes #718
