### PR TITLE
fix: skip configured connection wizard step

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -81,12 +81,14 @@ from .ui.application import (
     DockVisualWorkflowRequest,
     RunAnalysisAction,
     build_dock_summary_status,
+    build_startup_wizard_progress_facts,
     build_visual_layer_refs,
     build_wizard_filter_description,
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     load_wizard_settings,
     save_last_step_index,
+    step_index_for_key,
     build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
@@ -404,10 +406,20 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             connect_wizard_action_callbacks,
         )
 
+        progress_facts = self._current_wizard_progress_facts()
+        wizard_settings = load_wizard_settings(self.settings)
+        startup_progress_facts = build_startup_wizard_progress_facts(
+            progress_facts,
+            wizard_settings,
+        )
+        self._persist_startup_wizard_step_if_needed(
+            progress_facts=progress_facts,
+            startup_progress_facts=startup_progress_facts,
+        )
         composition = build_placeholder_wizard_shell(
             parent=self if parent is None else parent,
-            progress_facts=self._current_wizard_progress_facts(),
-            wizard_settings=load_wizard_settings(self.settings),
+            progress_facts=startup_progress_facts,
+            wizard_settings=wizard_settings,
             use_step_pages=True,
             on_current_step_changed=self._persist_wizard_step_index,
         )
@@ -427,6 +439,17 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._install_wizard_filter_controls(self._wizard_shell_composition)
         self._bind_wizard_analysis_mode_controls(self._wizard_shell_composition)
         return self._wizard_shell_composition
+
+    def _persist_startup_wizard_step_if_needed(
+        self,
+        *,
+        progress_facts,
+        startup_progress_facts,
+    ) -> None:
+        startup_key = startup_progress_facts.preferred_current_key
+        if startup_key is None or startup_key == progress_facts.preferred_current_key:
+            return
+        self._persist_wizard_step_index(step_index_for_key(startup_key))
 
     def _install_wizard_filter_controls(self, composition) -> None:
         """Move the live map-filter controls into the wizard map page."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -741,6 +741,45 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 getattr(self.module.QfitDockWidget, method_name),
             )
 
+    def test_build_wizard_shell_from_runtime_skips_configured_startup_connection(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock._atlas_export_completed = False
+        dock.settings = _FakeSettings(
+            {
+                "ui/wizard_version": 1,
+                "ui/last_step_index": 0,
+            }
+        )
+
+        class FakeWizardActionCallbacks(SimpleNamespace):
+            pass
+
+        fake_wizard_composition = ModuleType("qfit.ui.dockwidget.wizard_composition")
+        fake_wizard_composition.WizardActionCallbacks = FakeWizardActionCallbacks
+        fake_wizard_composition.build_placeholder_wizard_shell = MagicMock(
+            return_value="composition"
+        )
+        fake_wizard_composition.connect_wizard_action_callbacks = MagicMock(
+            return_value="connected-composition"
+        )
+
+        with patch.dict(
+            sys.modules,
+            {"qfit.ui.dockwidget.wizard_composition": fake_wizard_composition},
+        ):
+            composition = self.module.QfitDockWidget._build_wizard_shell_from_runtime(
+                dock,
+            )
+
+        self.assertEqual(composition, "connected-composition")
+        _args, kwargs = fake_wizard_composition.build_placeholder_wizard_shell.call_args
+        self.assertEqual(kwargs["progress_facts"].preferred_current_key, "sync")
+        self.assertEqual(dock.settings.get("ui/last_step_index"), 1)
+
 
     def test_install_wizard_filter_controls_moves_live_filter_group_into_map_panel(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -352,6 +352,32 @@ class WizardProgressFactsTests(unittest.TestCase):
             frozenset({"connection", "sync", "map"}),
         )
 
+    def test_existing_connection_step_setting_does_not_block_configured_startup(self):
+        progress = build_wizard_progress_from_facts_and_settings(
+            WizardProgressFacts(connection_configured=True),
+            WizardSettingsSnapshot(
+                wizard_version=1,
+                last_step_index=0,
+                first_launch=False,
+            ),
+        )
+
+        self.assertEqual(progress.current_key, "sync")
+        self.assertEqual(progress.completed_keys, frozenset({"connection"}))
+
+    def test_existing_connection_step_setting_still_routes_missing_connection_to_connection(self):
+        progress = build_wizard_progress_from_facts_and_settings(
+            WizardProgressFacts(connection_configured=False),
+            WizardSettingsSnapshot(
+                wizard_version=1,
+                last_step_index=0,
+                first_launch=False,
+            ),
+        )
+
+        self.assertEqual(progress.current_key, "connection")
+        self.assertEqual(progress.completed_keys, frozenset())
+
     def test_first_launch_settings_keep_default_connection_step(self):
         progress = build_wizard_progress_from_facts_and_settings(
             WizardProgressFacts(connection_configured=True),

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -8,6 +8,7 @@ from qfit.ui.application.dock_runtime_state import (
 from qfit.ui.application.dock_workflow_sections import build_progress_wizard_step_statuses
 from qfit.ui.application.wizard_progress import (
     WizardProgressFacts,
+    build_startup_wizard_progress_facts,
     build_wizard_progress_facts_from_runtime_state,
     build_wizard_progress_from_facts,
     build_wizard_progress_from_facts_and_settings,
@@ -352,7 +353,7 @@ class WizardProgressFactsTests(unittest.TestCase):
             frozenset({"connection", "sync", "map"}),
         )
 
-    def test_existing_connection_step_setting_does_not_block_configured_startup(self):
+    def test_existing_connection_step_setting_remains_sticky_for_refresh(self):
         progress = build_wizard_progress_from_facts_and_settings(
             WizardProgressFacts(connection_configured=True),
             WizardSettingsSnapshot(
@@ -360,6 +361,25 @@ class WizardProgressFactsTests(unittest.TestCase):
                 last_step_index=0,
                 first_launch=False,
             ),
+        )
+
+        self.assertEqual(progress.current_key, "connection")
+        self.assertEqual(progress.completed_keys, frozenset({"connection"}))
+
+    def test_startup_facts_skip_configured_connection_restore_target(self):
+        settings = WizardSettingsSnapshot(
+            wizard_version=1,
+            last_step_index=0,
+            first_launch=False,
+        )
+        startup_facts = build_startup_wizard_progress_facts(
+            WizardProgressFacts(connection_configured=True),
+            settings,
+        )
+
+        progress = build_wizard_progress_from_facts_and_settings(
+            startup_facts,
+            settings,
         )
 
         self.assertEqual(progress.current_key, "sync")

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -221,6 +221,40 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Suivant: Map & filters →",
         )
 
+    def test_configured_connection_startup_opens_sync_but_keeps_connection_accessible(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+            ),
+            wizard_settings=self.composition.WizardSettingsSnapshot(
+                wizard_version=1,
+                last_step_index=0,
+                first_launch=False,
+            ),
+        )
+
+        self.assertEqual(assembled.presenter.progress.current_key, "sync")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("done", "current", "locked", "locked", "locked"),
+        )
+        self.assertTrue(assembled.pages[1].back_button.isEnabled())
+        self.assertEqual(
+            assembled.pages[1].back_button.text(),
+            "Précédent: Connection",
+        )
+
+        assembled.shell.stepper_bar.step_buttons()[0].clicked.emit()
+
+        self.assertEqual(assembled.presenter.progress.current_key, "connection")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+        self.assertTrue(assembled.pages[0].next_button.isEnabled())
+        self.assertEqual(
+            assembled.pages[0].next_button.text(),
+            "Suivant: Synchronization →",
+        )
+
     def test_refresh_resyncs_spec_step_page_navigation_buttons(self):
         assembled = self.composition.build_placeholder_wizard_shell()
         self.assertFalse(assembled.pages[2].back_button.isEnabled())

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -221,7 +221,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Suivant: Map & filters →",
         )
 
-    def test_configured_connection_startup_opens_sync_but_keeps_connection_accessible(self):
+    def test_configured_connection_restore_keeps_connection_page_accessible(self):
         assembled = self.composition.build_placeholder_wizard_shell(
             progress_facts=self.composition.WizardProgressFacts(
                 connection_configured=True,
@@ -233,26 +233,26 @@ class WizardShellCompositionTest(unittest.TestCase):
             ),
         )
 
-        self.assertEqual(assembled.presenter.progress.current_key, "sync")
-        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
-        self.assertEqual(
-            assembled.shell.stepper_bar.states(),
-            ("done", "current", "locked", "locked", "locked"),
-        )
-        self.assertTrue(assembled.pages[1].back_button.isEnabled())
-        self.assertEqual(
-            assembled.pages[1].back_button.text(),
-            "Précédent: Connection",
-        )
-
-        assembled.shell.stepper_bar.step_buttons()[0].clicked.emit()
-
         self.assertEqual(assembled.presenter.progress.current_key, "connection")
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 0)
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("current", "upcoming", "locked", "locked", "locked"),
+        )
         self.assertTrue(assembled.pages[0].next_button.isEnabled())
         self.assertEqual(
             assembled.pages[0].next_button.text(),
             "Suivant: Synchronization →",
+        )
+
+        assembled.pages[0].next_button.clicked.emit()
+
+        self.assertEqual(assembled.presenter.progress.current_key, "sync")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 1)
+        self.assertTrue(assembled.pages[1].back_button.isEnabled())
+        self.assertEqual(
+            assembled.pages[1].back_button.text(),
+            "Précédent: Connection",
         )
 
     def test_refresh_resyncs_spec_step_page_navigation_buttons(self):

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -72,6 +72,7 @@ from .wizard_settings import (
 )
 from .wizard_progress import (
     WizardProgressFacts,
+    build_startup_wizard_progress_facts,
     build_wizard_progress_facts_from_runtime_state,
     build_wizard_progress_from_facts,
     build_wizard_progress_from_facts_and_settings,
@@ -132,6 +133,7 @@ __all__ = [
     "build_progress_wizard_step_statuses",
     "build_stepper_items",
     "build_stepper_states",
+    "build_startup_wizard_progress_facts",
     "build_wizard_filter_description",
     "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -139,23 +139,33 @@ def build_wizard_progress_from_facts_and_settings(
 
     if facts.preferred_current_key is not None:
         return build_wizard_progress_from_facts(facts)
-    preferred_current_key = _startup_preferred_current_key(facts, settings)
     return build_wizard_progress_from_facts(
         _wizard_progress_facts_with_preferred_current_key(
             facts,
-            preferred_current_key=preferred_current_key,
+            preferred_current_key=preferred_current_key_from_settings(settings),
         )
     )
 
 
-def _startup_preferred_current_key(
+def build_startup_wizard_progress_facts(
     facts: WizardProgressFacts,
     settings: WizardSettingsSnapshot,
-) -> str | None:
+) -> WizardProgressFacts:
+    """Return startup-only facts for the first visible wizard page.
+
+    Persisted step settings still control normal refreshes. Startup is the one
+    place where a saved default Connection target should not make configured
+    users reconfirm an already-completed prerequisite before continuing.
+    """
+
     preferred_current_key = preferred_current_key_from_settings(settings)
     if preferred_current_key == "connection" and facts.connection_configured:
-        return None
-    return preferred_current_key
+        progress = build_wizard_progress_from_facts(facts)
+        return _wizard_progress_facts_with_preferred_current_key(
+            facts,
+            preferred_current_key=progress.current_key,
+        )
+    return facts
 
 
 def _wizard_progress_facts_with_preferred_current_key(
@@ -301,6 +311,7 @@ def _layer_name(layer) -> str | None:
 
 __all__ = [
     "WizardProgressFacts",
+    "build_startup_wizard_progress_facts",
     "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts_and_settings",
     "build_wizard_progress_from_facts",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -139,32 +139,54 @@ def build_wizard_progress_from_facts_and_settings(
 
     if facts.preferred_current_key is not None:
         return build_wizard_progress_from_facts(facts)
+    preferred_current_key = _startup_preferred_current_key(facts, settings)
     return build_wizard_progress_from_facts(
-        WizardProgressFacts(
-            connection_configured=facts.connection_configured,
-            activities_fetched=facts.activities_fetched,
-            activities_stored=facts.activities_stored,
-            activity_layers_loaded=facts.activity_layers_loaded,
-            analysis_generated=facts.analysis_generated,
-            atlas_exported=facts.atlas_exported,
-            sync_in_progress=facts.sync_in_progress,
-            atlas_export_in_progress=facts.atlas_export_in_progress,
-            preferred_current_key=preferred_current_key_from_settings(settings),
-            fetched_activity_count=facts.fetched_activity_count,
-            activity_count=facts.activity_count,
-            output_name=facts.output_name,
-            analysis_output_name=facts.analysis_output_name,
-            atlas_output_name=facts.atlas_output_name,
-            background_enabled=facts.background_enabled,
-            background_layer_loaded=facts.background_layer_loaded,
-            background_name=facts.background_name,
-            filters_active=facts.filters_active,
-            filtered_activity_count=facts.filtered_activity_count,
-            filter_description=facts.filter_description,
-            activity_style_preset=facts.activity_style_preset,
-            loaded_layer_count=facts.loaded_layer_count,
-            last_sync_date=facts.last_sync_date,
+        _wizard_progress_facts_with_preferred_current_key(
+            facts,
+            preferred_current_key=preferred_current_key,
         )
+    )
+
+
+def _startup_preferred_current_key(
+    facts: WizardProgressFacts,
+    settings: WizardSettingsSnapshot,
+) -> str | None:
+    preferred_current_key = preferred_current_key_from_settings(settings)
+    if preferred_current_key == "connection" and facts.connection_configured:
+        return None
+    return preferred_current_key
+
+
+def _wizard_progress_facts_with_preferred_current_key(
+    facts: WizardProgressFacts,
+    *,
+    preferred_current_key: str | None,
+) -> WizardProgressFacts:
+    return WizardProgressFacts(
+        connection_configured=facts.connection_configured,
+        activities_fetched=facts.activities_fetched,
+        activities_stored=facts.activities_stored,
+        activity_layers_loaded=facts.activity_layers_loaded,
+        analysis_generated=facts.analysis_generated,
+        atlas_exported=facts.atlas_exported,
+        sync_in_progress=facts.sync_in_progress,
+        atlas_export_in_progress=facts.atlas_export_in_progress,
+        preferred_current_key=preferred_current_key,
+        fetched_activity_count=facts.fetched_activity_count,
+        activity_count=facts.activity_count,
+        output_name=facts.output_name,
+        analysis_output_name=facts.analysis_output_name,
+        atlas_output_name=facts.atlas_output_name,
+        background_enabled=facts.background_enabled,
+        background_layer_loaded=facts.background_layer_loaded,
+        background_name=facts.background_name,
+        filters_active=facts.filters_active,
+        filtered_activity_count=facts.filtered_activity_count,
+        filter_description=facts.filter_description,
+        activity_style_preset=facts.activity_style_preset,
+        loaded_layer_count=facts.loaded_layer_count,
+        last_sync_date=facts.last_sync_date,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes startup wizard step selection so a completed Strava connection no longer keeps the wizard on the redundant Connection step when the saved wizard step is still the default first page.

## Changes

- Ignore a persisted Connection restore target when current workflow facts show the connection is already configured.
- Continue routing missing/unconfigured credentials to Connection.
- Add regression coverage for configured startup selecting Synchronization while keeping Connection reachable for review.

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Fixes #719
