### PR TITLE
fix: make wizard dock responsive

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -24,6 +24,22 @@ def _load_step_page_module():
         return step_page, wizard_shell
 
 
+class _FakeSize:
+    def __init__(self, width):
+        self._width = width
+
+    def width(self):
+        return self._width
+
+
+class _FakeResizeEvent:
+    def __init__(self, width):
+        self._size = _FakeSize(width)
+
+    def size(self):
+        return self._size
+
+
 class StepPageTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -145,6 +161,14 @@ class StepPageTest(unittest.TestCase):
         self.assertEqual(page._nav_layout.direction, self.step_page.QBoxLayout.LeftToRight)
         self.assertEqual(page.back_button.text(), "Précédent")
         self.assertEqual(page.next_button.text(), "Lancer l'analyse spatiale détaillée")
+
+    def test_resize_event_drives_narrow_step_page_mode(self):
+        page = self.step_page.StepPage(4, 5, "Analyse", "Calcule les sorties.")
+
+        page.resizeEvent(_FakeResizeEvent(320))
+
+        self.assertEqual(page.property("responsiveMode"), "narrow")
+        self.assertEqual(page._nav_layout.direction, self.step_page.QBoxLayout.TopToBottom)
 
     def test_extra_button_alignment_can_target_left_nav_cluster(self):
         page = self.step_page.StepPage(1, 5, "Connexion", "Configure qfit.")

--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -159,8 +159,11 @@ class StepPageTest(unittest.TestCase):
 
         self.assertEqual(page.property("responsiveMode"), "wide")
         self.assertEqual(page._nav_layout.direction, self.step_page.QBoxLayout.LeftToRight)
+        self.assertFalse(page.title_label.word_wrap)
         self.assertEqual(page.back_button.text(), "Précédent")
+        self.assertEqual(page.back_button.toolTip(), "")
         self.assertEqual(page.next_button.text(), "Lancer l'analyse spatiale détaillée")
+        self.assertEqual(page.next_button.toolTip(), "")
 
     def test_resize_event_drives_narrow_step_page_mode(self):
         page = self.step_page.StepPage(4, 5, "Analyse", "Calcule les sorties.")

--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -113,8 +113,38 @@ class StepPageTest(unittest.TestCase):
         page.content_layout().addWidget(content_widget)
 
         self.assertEqual(extra_button.property("wizardActionRole"), "extra")
+        self.assertEqual(extra_button.minimumWidth(), 0)
         self.assertIn(extra_button, page._extra_right_layout.widgets)
         self.assertIn(content_widget, page.content_layout().widgets)
+
+    def test_compacts_navigation_and_wraps_copy_for_narrow_docks(self):
+        page = self.step_page.StepPage(
+            4,
+            5,
+            "Spatial analysis with a long translated title",
+            "Long helper copy should wrap instead of widening the dock.",
+        )
+        page.set_next("Lancer l'analyse spatiale détaillée", icon="")
+
+        page.set_responsive_width(320)
+
+        self.assertEqual(page.property("responsiveMode"), "narrow")
+        self.assertEqual(page._nav_layout.direction, self.step_page.QBoxLayout.TopToBottom)
+        self.assertEqual(page.outer_layout().contents_margins, (8, 10, 8, 10))
+        self.assertTrue(page.title_label.word_wrap)
+        self.assertTrue(page.subtitle_label.word_wrap)
+        self.assertEqual(page.back_button.text(), "←")
+        self.assertEqual(page.back_button.toolTip(), "Précédent")
+        self.assertEqual(page.next_button.text(), "Lancer l'anal…")
+        self.assertEqual(page.next_button.toolTip(), "Lancer l'analyse spatiale détaillée")
+        self.assertEqual(page.next_button.minimumWidth(), 0)
+
+        page.set_responsive_width(600)
+
+        self.assertEqual(page.property("responsiveMode"), "wide")
+        self.assertEqual(page._nav_layout.direction, self.step_page.QBoxLayout.LeftToRight)
+        self.assertEqual(page.back_button.text(), "Précédent")
+        self.assertEqual(page.next_button.text(), "Lancer l'analyse spatiale détaillée")
 
     def test_extra_button_alignment_can_target_left_nav_cluster(self):
         page = self.step_page.StepPage(1, 5, "Connexion", "Configure qfit.")

--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -58,6 +58,7 @@ class _FakeWidget:
     def __init__(self, parent=None):
         self.parent = parent
         self._height = None
+        self._minimum_width = None
         self._object_name = ""
         self._properties = {}
         self._enabled = True
@@ -70,6 +71,12 @@ class _FakeWidget:
 
     def height(self):
         return self._height
+
+    def setMinimumWidth(self, value):  # noqa: N802
+        self._minimum_width = value
+
+    def minimumWidth(self):  # noqa: N802
+        return self._minimum_width
 
     def setObjectName(self, value):  # noqa: N802
         self._object_name = value
@@ -173,6 +180,8 @@ class _FakeHBoxLayout:
 class _FakeSizePolicy:
     Expanding = 1
     Fixed = 2
+    Ignored = 3
+    Preferred = 4
 
 
 def _fake_qt_modules():
@@ -326,6 +335,33 @@ class StepperBarTest(unittest.TestCase):
         buttons[3].click()
 
         self.assertEqual(requested, [0, 2])
+
+    def test_compacts_step_labels_for_narrow_docks(self):
+        bar = self.stepper.StepperBar()
+        bar.set_state(["done", "current", "upcoming", "locked", "upcoming"])
+
+        bar.set_responsive_width(320)
+
+        self.assertEqual(bar.property("responsiveMode"), "compact")
+        self.assertEqual(bar.height(), self.stepper.STEPPER_COMPACT_HEIGHT)
+        self.assertEqual(
+            [button.text() for button in bar.step_buttons()],
+            ["✓", "2", "3", "4", "5"],
+        )
+        self.assertEqual(
+            [button.property("responsiveMode") for button in bar.step_buttons()],
+            ["compact"] * 5,
+        )
+        self.assertEqual([connector.fixed_width for connector in bar._connectors], [4, 4, 4, 4])
+        self.assertEqual(bar._layout.contents_margins, (2, 2, 6, 2))
+        self.assertEqual(bar._layout.spacing, 2)
+
+        bar.set_responsive_width(800)
+
+        self.assertEqual(bar.property("responsiveMode"), "wide")
+        self.assertEqual(bar.height(), self.stepper.STEPPER_WIDE_HEIGHT)
+        self.assertEqual(bar.step_buttons()[1].text(), "2  Synchronization")
+        self.assertEqual([connector.fixed_width for connector in bar._connectors], [8, 8, 8, 8])
 
 
 if __name__ == "__main__":

--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -213,6 +213,22 @@ def _load_stepper_module():
         return importlib.import_module("qfit.ui.dockwidget.stepper_bar")
 
 
+class _FakeSize:
+    def __init__(self, width):
+        self._width = width
+
+    def width(self):
+        return self._width
+
+
+class _FakeResizeEvent:
+    def __init__(self, width):
+        self._size = _FakeSize(width)
+
+    def size(self):
+        return self._size
+
+
 class StepperBarTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -362,6 +378,14 @@ class StepperBarTest(unittest.TestCase):
         self.assertEqual(bar.height(), self.stepper.STEPPER_WIDE_HEIGHT)
         self.assertEqual(bar.step_buttons()[1].text(), "2  Synchronization")
         self.assertEqual([connector.fixed_width for connector in bar._connectors], [8, 8, 8, 8])
+
+    def test_resize_event_drives_compact_stepper_mode(self):
+        bar = self.stepper.StepperBar()
+
+        bar.resizeEvent(_FakeResizeEvent(320))
+
+        self.assertEqual(bar.property("responsiveMode"), "compact")
+        self.assertEqual(bar.height(), self.stepper.STEPPER_COMPACT_HEIGHT)
 
 
 if __name__ == "__main__":

--- a/tests/test_wizard_action_row.py
+++ b/tests/test_wizard_action_row.py
@@ -17,6 +17,22 @@ def _load_action_row_module():
         return importlib.import_module("qfit.ui.dockwidget.action_row")
 
 
+class _FakeSize:
+    def __init__(self, width):
+        self._width = width
+
+    def width(self):
+        return self._width
+
+
+class _FakeResizeEvent:
+    def __init__(self, width):
+        self._size = _FakeSize(width)
+
+    def size(self):
+        return self._size
+
+
 class WizardActionRowTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -56,6 +72,14 @@ class WizardActionRowTest(unittest.TestCase):
         self.assertEqual(row.property("responsiveMode"), "wide")
         self.assertEqual(row.outer_layout().direction, self.action_row.QBoxLayout.LeftToRight)
         self.assertEqual(row.outer_layout().spacing, 8)
+
+    def test_resize_event_drives_narrow_action_row_mode(self):
+        row = self.action_row.build_wizard_action_row(self.action_row.QToolButton())
+
+        row.resizeEvent(_FakeResizeEvent(320))
+
+        self.assertEqual(row.property("responsiveMode"), "narrow")
+        self.assertEqual(row.outer_layout().direction, self.action_row.QBoxLayout.TopToBottom)
 
     def test_primary_action_button_gets_cta_role_and_chrome(self):
         button = self.action_row.QToolButton()

--- a/tests/test_wizard_action_row.py
+++ b/tests/test_wizard_action_row.py
@@ -37,6 +37,25 @@ class WizardActionRowTest(unittest.TestCase):
         self.assertEqual(row.outer_layout().contents_margins, (0, 4, 0, 0))
         self.assertEqual(row.outer_layout().spacing, 8)
         self.assertEqual(row.outer_layout().widgets, [secondary, primary])
+        self.assertEqual(primary.minimumWidth(), 0)
+        self.assertEqual(secondary.minimumWidth(), 0)
+
+    def test_action_row_stacks_buttons_when_dock_is_narrow(self):
+        primary = self.action_row.QToolButton()
+        secondary = self.action_row.QToolButton()
+        row = self.action_row.build_wizard_action_row(secondary, primary)
+
+        row.set_responsive_width(320)
+
+        self.assertEqual(row.property("responsiveMode"), "narrow")
+        self.assertEqual(row.outer_layout().direction, self.action_row.QBoxLayout.TopToBottom)
+        self.assertEqual(row.outer_layout().spacing, 6)
+
+        row.set_responsive_width(600)
+
+        self.assertEqual(row.property("responsiveMode"), "wide")
+        self.assertEqual(row.outer_layout().direction, self.action_row.QBoxLayout.LeftToRight)
+        self.assertEqual(row.outer_layout().spacing, 8)
 
     def test_primary_action_button_gets_cta_role_and_chrome(self):
         button = self.action_row.QToolButton()

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -356,6 +356,22 @@ def _load_wizard_shell_module():
         return importlib.import_module("qfit.ui.dockwidget.wizard_shell")
 
 
+class _FakeSize:
+    def __init__(self, width):
+        self._width = width
+
+    def width(self):
+        return self._width
+
+
+class _FakeResizeEvent:
+    def __init__(self, width):
+        self._size = _FakeSize(width)
+
+    def size(self):
+        return self._size
+
+
 class WizardShellTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -421,6 +437,25 @@ class WizardShellTest(unittest.TestCase):
         shell.add_page(page)
 
         shell.set_responsive_width(320)
+
+        self.assertEqual(shell.property("responsiveMode"), "narrow")
+        self.assertEqual(shell.stepper_bar.property("responsiveMode"), "compact")
+        self.assertEqual(page.widths, [320])
+
+    def test_resize_event_propagates_responsive_width_to_pages(self):
+        class ResponsivePage(_FakeWidget):
+            def __init__(self):
+                super().__init__()
+                self.widths = []
+
+            def set_responsive_width(self, width):
+                self.widths.append(width)
+
+        shell = self.wizard_shell.WizardShell()
+        page = ResponsivePage()
+        shell.add_page(page)
+
+        shell.resizeEvent(_FakeResizeEvent(320))
 
         self.assertEqual(shell.property("responsiveMode"), "narrow")
         self.assertEqual(shell.stepper_bar.property("responsiveMode"), "compact")

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -61,6 +61,7 @@ class _FakeWidget:
         self.parent = parent
         self._height = None
         self._minimum_height = None
+        self._minimum_width = None
         self._object_name = ""
         self._properties = {}
         self._enabled = True
@@ -84,6 +85,12 @@ class _FakeWidget:
 
     def minimumHeight(self):  # noqa: N802
         return self._minimum_height
+
+    def setMinimumWidth(self, value):  # noqa: N802
+        self._minimum_width = value
+
+    def minimumWidth(self):  # noqa: N802
+        return self._minimum_width
 
     def height(self):
         return self._height
@@ -207,12 +214,16 @@ class _FakeLabel(_FakeWidget):
     def __init__(self, text="", parent=None):
         super().__init__(parent)
         self._text = text
+        self.word_wrap = False
 
     def setText(self, value):  # noqa: N802
         self._text = value
 
     def text(self):
         return self._text
+
+    def setWordWrap(self, value):  # noqa: N802
+        self.word_wrap = value
 
 
 class _FakeScrollArea(_FakeWidget):
@@ -253,6 +264,9 @@ class _FakeStackedWidget(_FakeWidget):
     def currentIndex(self):  # noqa: N802
         return self.current_index
 
+    def widget(self, index):
+        return self.widgets[index]
+
 
 class _FakeVBoxLayout:
     def __init__(self, parent=None):
@@ -260,6 +274,7 @@ class _FakeVBoxLayout:
         self.object_name = ""
         self.contents_margins = None
         self.spacing = None
+        self.direction = None
         self.widgets = []
         self.stretches = []
 
@@ -272,6 +287,9 @@ class _FakeVBoxLayout:
     def setSpacing(self, value):  # noqa: N802
         self.spacing = value
 
+    def setDirection(self, value):  # noqa: N802
+        self.direction = value
+
     def addWidget(self, widget):  # noqa: N802
         self.widgets.append(widget)
 
@@ -283,9 +301,16 @@ class _FakeHBoxLayout(_FakeVBoxLayout):
     pass
 
 
+class _FakeBoxLayout:
+    LeftToRight = 1
+    TopToBottom = 2
+
+
 class _FakeSizePolicy:
     Expanding = 1
     Fixed = 2
+    Ignored = 3
+    Preferred = 4
 
 
 def _fake_qt_modules():
@@ -296,6 +321,7 @@ def _fake_qt_modules():
     qtcore.Qt = _FakeQt
     qtcore.pyqtSignal = _fake_pyqt_signal
     qtwidgets = types.ModuleType("qgis.PyQt.QtWidgets")
+    qtwidgets.QBoxLayout = _FakeBoxLayout
     qtwidgets.QComboBox = _FakeComboBox
     qtwidgets.QFrame = _FakeFrame
     qtwidgets.QHBoxLayout = _FakeHBoxLayout
@@ -380,6 +406,25 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(shell.page_count(), 2)
         self.assertEqual(shell.stepper_bar.states(), ("upcoming", "current", "upcoming", "upcoming", "upcoming"))
         self.assertEqual(shell.pages_stack.currentIndex(), 1)
+
+    def test_propagates_responsive_width_to_stepper_and_pages(self):
+        class ResponsivePage(_FakeWidget):
+            def __init__(self):
+                super().__init__()
+                self.widths = []
+
+            def set_responsive_width(self, width):
+                self.widths.append(width)
+
+        shell = self.wizard_shell.WizardShell()
+        page = ResponsivePage()
+        shell.add_page(page)
+
+        shell.set_responsive_width(320)
+
+        self.assertEqual(shell.property("responsiveMode"), "narrow")
+        self.assertEqual(shell.stepper_bar.property("responsiveMode"), "compact")
+        self.assertEqual(page.widths, [320])
 
     def test_updates_footer_text_without_rebuilding_shell(self):
         shell = self.wizard_shell.WizardShell(footer_text="Starting")

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -461,6 +461,23 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(shell.stepper_bar.property("responsiveMode"), "compact")
         self.assertEqual(page.widths, [320])
 
+    def test_new_pages_receive_current_responsive_width_after_resize(self):
+        class ResponsivePage(_FakeWidget):
+            def __init__(self):
+                super().__init__()
+                self.widths = []
+
+            def set_responsive_width(self, width):
+                self.widths.append(width)
+
+        shell = self.wizard_shell.WizardShell()
+        shell.set_responsive_width(320)
+        page = ResponsivePage()
+
+        shell.add_page(page)
+
+        self.assertEqual(page.widths, [320])
+
     def test_updates_footer_text_without_rebuilding_shell(self):
         shell = self.wizard_shell.WizardShell(footer_text="Starting")
 

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -17,14 +17,17 @@ _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt",))
 _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
     "PyQt5.QtWidgets",
-    ("QHBoxLayout", "QSizePolicy", "QToolButton", "QWidget"),
+    ("QBoxLayout", "QHBoxLayout", "QSizePolicy", "QToolButton", "QWidget"),
 )
 
 Qt = _qtcore.Qt
+QBoxLayout = _qtwidgets.QBoxLayout
 QHBoxLayout = _qtwidgets.QHBoxLayout
 QSizePolicy = _qtwidgets.QSizePolicy
 QToolButton = _qtwidgets.QToolButton
 QWidget = _qtwidgets.QWidget
+
+ACTION_ROW_NARROW_WIDTH = 360
 
 
 class WizardActionRow(QWidget):
@@ -33,14 +36,44 @@ class WizardActionRow(QWidget):
     def __init__(self, buttons: Iterable[QToolButton] = (), parent=None) -> None:
         super().__init__(parent)
         self.setObjectName("qfitWizardActionRow")
+        self._responsive_mode = "wide"
         self._layout = self._build_layout()
+        self.setProperty("responsiveMode", "wide")
         for button in buttons:
             self.add_button(button)
 
     def add_button(self, button: QToolButton) -> None:
         """Append an action button and let Qt re-parent it into the row."""
 
+        _allow_button_shrink(button)
         self._layout.addWidget(button)
+
+    def set_responsive_width(self, width: int) -> None:
+        """Stack page CTA rows when narrow docks cannot fit full labels."""
+
+        narrow = int(width) < ACTION_ROW_NARROW_WIDTH
+        mode = "narrow" if narrow else "wide"
+        if mode == self._responsive_mode:
+            return
+        self._responsive_mode = mode
+        self.setProperty("responsiveMode", mode)
+        if hasattr(self._layout, "setDirection"):
+            self._layout.setDirection(
+                QBoxLayout.TopToBottom if narrow else QBoxLayout.LeftToRight
+            )
+        self._layout.setSpacing(6 if narrow else 8)
+
+    def resizeEvent(self, event) -> None:  # noqa: N802
+        """Keep the action row liquid as the dock width changes."""
+
+        size = event.size() if hasattr(event, "size") else None
+        if size is not None and hasattr(size, "width"):
+            self.set_responsive_width(size.width())
+        elif hasattr(self, "width"):
+            self.set_responsive_width(self.width())
+        parent_resize = getattr(super(), "resizeEvent", None)
+        if parent_resize is not None:
+            parent_resize(event)
 
     def outer_layout(self):
         """Expose the row layout for adapter wiring and pure tests."""
@@ -113,11 +146,17 @@ def set_wizard_action_availability(
     return button
 
 
+def _allow_button_shrink(button: QToolButton) -> None:
+    if hasattr(button, "setMinimumWidth"):
+        button.setMinimumWidth(0)
+    if hasattr(button, "setSizePolicy"):
+        button.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
+
+
 def _apply_button_chrome(button: QToolButton, *, primary: bool) -> None:
     if hasattr(button, "setToolButtonStyle"):
         button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-    if hasattr(button, "setSizePolicy"):
-        button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+    _allow_button_shrink(button)
     if hasattr(button, "setCursor"):
         button.setCursor(Qt.PointingHandCursor)
     if hasattr(button, "setStyleSheet"):

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -138,13 +138,14 @@ class StepPage(QWidget):
     def _apply_navigation_button_texts(self) -> None:
         narrow = self._responsive_mode == "narrow"
         self.back_button.setText("←" if narrow else self._back_label)
-        self.back_button.setToolTip(self._back_label)
+        self.back_button.setToolTip(self._back_label if narrow else "")
+        full_next_text = _button_text(self._next_label, self._next_icon)
         self.next_button.setText(
             _compact_button_text(self._next_label, self._next_icon)
             if narrow
-            else _button_text(self._next_label, self._next_icon)
+            else full_next_text
         )
-        self.next_button.setToolTip(_button_text(self._next_label, self._next_icon))
+        self.next_button.setToolTip(full_next_text if narrow else "")
 
     def add_extra_button(self, btn, align: str = "right") -> None:
         """Add a page-specific secondary button to the navigation row."""
@@ -184,6 +185,8 @@ class StepPage(QWidget):
             8 if narrow else 12,
             10 if narrow else 12,
         )
+        if hasattr(self.title_label, "setWordWrap"):
+            self.title_label.setWordWrap(narrow)
         self._apply_navigation_button_texts()
 
     def resizeEvent(self, event) -> None:  # noqa: N802
@@ -213,7 +216,7 @@ class StepPage(QWidget):
     def _build_title_label(self, title: str):
         label = QLabel(title, self)
         label.setObjectName("qfitWizardStepTitleLabel")
-        _allow_label_wrap(label)
+        _allow_horizontal_shrink(label)
         label.setStyleSheet(_step_title_label_stylesheet(label.objectName()))
         return label
 

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -26,8 +26,10 @@ _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
     "PyQt5.QtWidgets",
     (
+        "QBoxLayout",
         "QHBoxLayout",
         "QLabel",
+        "QSizePolicy",
         "QToolButton",
         "QVBoxLayout",
         "QWidget",
@@ -36,11 +38,15 @@ _qtwidgets = import_qt_module(
 
 Qt = _qtcore.Qt
 pyqtSignal = _qtcore.pyqtSignal
+QBoxLayout = _qtwidgets.QBoxLayout
 QHBoxLayout = _qtwidgets.QHBoxLayout
 QLabel = _qtwidgets.QLabel
+QSizePolicy = _qtwidgets.QSizePolicy
 QToolButton = _qtwidgets.QToolButton
 QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
+
+STEP_PAGE_NARROW_WIDTH = 360
 
 
 class StepPage(QWidget):
@@ -74,7 +80,13 @@ class StepPage(QWidget):
         self.status_pill = status_pill or self._build_status_pill()
         self.content_container = QWidget(self)
         self.content_container.setObjectName("qfitWizardStepContent")
+        _allow_horizontal_shrink(self.content_container)
         self._content_layout = self._build_content_layout(self.content_container)
+        self._responsive_mode = "wide"
+        self.setProperty("responsiveMode", "wide")
+        self._back_label = "Précédent"
+        self._next_label = "Suivant"
+        self._next_icon = "→"
         self.back_button = self._build_back_button()
         self.next_button = self._build_next_button()
         self._extra_left_layout = self._build_extra_button_layout("qfitWizardStepLeftExtraLayout")
@@ -104,7 +116,9 @@ class StepPage(QWidget):
     ) -> None:
         """Configure the right-side next/primary wizard action."""
 
-        self.next_button.setText(_button_text(label, icon))
+        self._next_label = label
+        self._next_icon = icon
+        self._apply_navigation_button_texts()
         self.next_button.setEnabled(enabled)
         self.next_button.setVisible(visible)
         self.next_button.setProperty("wizardActionRole", "primary" if primary else "secondary")
@@ -115,15 +129,28 @@ class StepPage(QWidget):
     def set_back(self, label: str = "Précédent", enabled: bool = True) -> None:
         """Configure the left-side back navigation action."""
 
-        self.back_button.setText(label)
+        self._back_label = label
+        self._apply_navigation_button_texts()
         self.back_button.setEnabled(enabled)
         self.back_button.setProperty("wizardActionRole", "back")
         self.back_button.setStyleSheet(_ghost_button_stylesheet())
+
+    def _apply_navigation_button_texts(self) -> None:
+        narrow = self._responsive_mode == "narrow"
+        self.back_button.setText("←" if narrow else self._back_label)
+        self.back_button.setToolTip(self._back_label)
+        self.next_button.setText(
+            _compact_button_text(self._next_label, self._next_icon)
+            if narrow
+            else _button_text(self._next_label, self._next_icon)
+        )
+        self.next_button.setToolTip(_button_text(self._next_label, self._next_icon))
 
     def add_extra_button(self, btn, align: str = "right") -> None:
         """Add a page-specific secondary button to the navigation row."""
 
         btn.setProperty("wizardActionRole", "extra")
+        _configure_responsive_button(btn)
         if align == "left":
             self._extra_left_layout.addWidget(btn)
             return
@@ -137,6 +164,40 @@ class StepPage(QWidget):
 
         return self._content_layout
 
+    def set_responsive_width(self, width: int) -> None:
+        """Stack/compact page chrome when the dock is narrowed."""
+
+        narrow = int(width) < STEP_PAGE_NARROW_WIDTH
+        mode = "narrow" if narrow else "wide"
+        if mode == self._responsive_mode:
+            return
+        self._responsive_mode = mode
+        self.setProperty("responsiveMode", mode)
+        if hasattr(self._nav_layout, "setDirection"):
+            self._nav_layout.setDirection(
+                QBoxLayout.TopToBottom if narrow else QBoxLayout.LeftToRight
+            )
+        self._nav_layout.setSpacing(6 if narrow else 8)
+        self._layout.setContentsMargins(
+            8 if narrow else 12,
+            10 if narrow else 12,
+            8 if narrow else 12,
+            10 if narrow else 12,
+        )
+        self._apply_navigation_button_texts()
+
+    def resizeEvent(self, event) -> None:  # noqa: N802
+        """Respond to live dock resizes instead of preserving wide size hints."""
+
+        size = event.size() if hasattr(event, "size") else None
+        if size is not None and hasattr(size, "width"):
+            self.set_responsive_width(size.width())
+        elif hasattr(self, "width"):
+            self.set_responsive_width(self.width())
+        parent_resize = getattr(super(), "resizeEvent", None)
+        if parent_resize is not None:
+            parent_resize(event)
+
     def outer_layout(self):
         """Expose the full page layout for adapter wiring and pure tests."""
 
@@ -145,20 +206,21 @@ class StepPage(QWidget):
     def _build_step_label(self, step_num: int, step_total: int):
         label = QLabel(f"ÉTAPE {step_num}/{step_total}", self)
         label.setObjectName("qfitWizardStepKickerLabel")
+        _allow_horizontal_shrink(label)
         label.setStyleSheet(_step_kicker_label_stylesheet(label.objectName()))
         return label
 
     def _build_title_label(self, title: str):
         label = QLabel(title, self)
         label.setObjectName("qfitWizardStepTitleLabel")
+        _allow_label_wrap(label)
         label.setStyleSheet(_step_title_label_stylesheet(label.objectName()))
         return label
 
     def _build_subtitle_label(self, subtitle: str):
         label = QLabel(subtitle, self)
         label.setObjectName("qfitWizardStepSubtitleLabel")
-        if hasattr(label, "setWordWrap"):
-            label.setWordWrap(True)
+        _allow_label_wrap(label)
         label.setStyleSheet(
             _step_subtitle_label_stylesheet(label.objectName())
         )
@@ -169,11 +231,13 @@ class StepPage(QWidget):
         label.setObjectName("qfitWizardStepStatusPill")
         label.setAlignment(Qt.AlignCenter)
         label.setMinimumHeight(18)
+        _allow_horizontal_shrink(label)
         return label
 
     def _build_back_button(self):
         button = QToolButton(self)
         button.setObjectName("qfitWizardStepBackButton")
+        _configure_responsive_button(button)
         _apply_wizard_navigation_cursor(button)
         button.clicked.connect(self.backRequested.emit)
         return button
@@ -181,6 +245,7 @@ class StepPage(QWidget):
     def _build_next_button(self):
         button = QToolButton(self)
         button.setObjectName("qfitWizardStepNextButton")
+        _configure_responsive_button(button)
         _apply_wizard_navigation_cursor(button)
         button.clicked.connect(self.nextRequested.emit)
         return button
@@ -362,6 +427,28 @@ class _LayoutWidget(QWidget):
             self.setLayout(layout)
 
 
+def _allow_horizontal_shrink(widget) -> None:
+    if hasattr(widget, "setMinimumWidth"):
+        widget.setMinimumWidth(0)
+    if hasattr(widget, "setSizePolicy"):
+        widget.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+
+
+def _allow_label_wrap(label) -> None:
+    if hasattr(label, "setWordWrap"):
+        label.setWordWrap(True)
+    _allow_horizontal_shrink(label)
+
+
+def _configure_responsive_button(button) -> None:
+    if hasattr(button, "setToolButtonStyle"):
+        button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+    if hasattr(button, "setMinimumWidth"):
+        button.setMinimumWidth(0)
+    if hasattr(button, "setSizePolicy"):
+        button.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
+
+
 def _apply_wizard_navigation_cursor(button) -> None:
     if hasattr(button, "setCursor"):
         button.setCursor(Qt.PointingHandCursor)
@@ -373,6 +460,16 @@ def _button_text(label: str, icon: str) -> str:
     if not stripped_icon:
         return stripped_label
     return f"{stripped_label} {stripped_icon}"
+
+
+def _compact_button_text(label: str, icon: str = "", *, max_chars: int = 14) -> str:
+    stripped_icon = icon.strip()
+    if stripped_icon:
+        return stripped_icon
+    stripped_label = label.strip()
+    if len(stripped_label) <= max_chars:
+        return stripped_label
+    return f"{stripped_label[: max_chars - 1].rstrip()}…"
 
 
 def _step_status_pill(state: DockWorkflowStepState) -> tuple[str, str]:

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -39,6 +39,10 @@ QSizePolicy = _qtwidgets.QSizePolicy
 QToolButton = _qtwidgets.QToolButton
 QWidget = _qtwidgets.QWidget
 
+STEPPER_COMPACT_WIDTH = 520
+STEPPER_WIDE_HEIGHT = 36
+STEPPER_COMPACT_HEIGHT = 32
+
 
 class StepperBar(QWidget):
     """Compact clickable five-step wizard stepper for the future dock shell."""
@@ -50,10 +54,40 @@ class StepperBar(QWidget):
         self._buttons: list[QToolButton] = []
         self._connectors: list[QFrame] = []
         self._states = ["locked"] * len(STEPPER_LABELS)
-        self._build_layout()
-        self.setFixedHeight(36)
+        self._compact = False
+        self._layout = self._build_layout()
+        self.setFixedHeight(STEPPER_WIDE_HEIGHT)
         self.setObjectName("qfitStepperBar")
+        self.setProperty("responsiveMode", "wide")
         self.set_state(["current", "locked", "locked", "locked", "locked"])
+
+    def set_responsive_width(self, width: int) -> None:
+        """Compact step labels when the dock becomes too narrow for full copy."""
+
+        compact = int(width) < STEPPER_COMPACT_WIDTH
+        if compact == self._compact:
+            return
+        self._compact = compact
+        self.setProperty("responsiveMode", "compact" if compact else "wide")
+        self.setFixedHeight(STEPPER_COMPACT_HEIGHT if compact else STEPPER_WIDE_HEIGHT)
+        self._layout.setContentsMargins(2 if compact else 4, 2, 6 if compact else 10, 2)
+        self._layout.setSpacing(2 if compact else 4)
+        connector_width = 4 if compact else 8
+        for connector in self._connectors:
+            connector.setFixedWidth(connector_width)
+        self.set_state(self._states)
+
+    def resizeEvent(self, event) -> None:  # noqa: N802
+        """Track live Qt resizes so the stepper does not enforce a wide dock."""
+
+        size = event.size() if hasattr(event, "size") else None
+        if size is not None and hasattr(size, "width"):
+            self.set_responsive_width(size.width())
+        elif hasattr(self, "width"):
+            self.set_responsive_width(self.width())
+        parent_resize = getattr(super(), "resizeEvent", None)
+        if parent_resize is not None:
+            parent_resize(event)
 
     def set_state(self, states: Sequence[str]) -> None:
         """Apply one render state per wizard step."""
@@ -85,7 +119,7 @@ class StepperBar(QWidget):
 
         return tuple(self._buttons)
 
-    def _build_layout(self) -> None:
+    def _build_layout(self):
         layout = QHBoxLayout(self)
         layout.setContentsMargins(4, 2, 10, 2)
         layout.setSpacing(4)
@@ -93,8 +127,12 @@ class StepperBar(QWidget):
             button = QToolButton(self)
             button.setObjectName(f"qfitStepperStep{index + 1}")
             button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-            button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-            button.clicked.connect(lambda _checked=False, step_index=index: self._request_step(step_index))
+            button.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
+            if hasattr(button, "setMinimumWidth"):
+                button.setMinimumWidth(0)
+            button.clicked.connect(
+                lambda _checked=False, step_index=index: self._request_step(step_index)
+            )
             self._buttons.append(button)
             layout.addWidget(button)
             if index < len(STEPPER_LABELS) - 1:
@@ -106,22 +144,30 @@ class StepperBar(QWidget):
                 connector.setFixedHeight(1)
                 self._connectors.append(connector)
                 layout.addWidget(connector)
+        return layout
 
     def _configure_button(self, button: QToolButton, index: int, state: str) -> None:
-        button.setText(_button_text(index, state))
+        button.setText(_button_text(index, state, compact=self._compact))
         button.setProperty("stepIndex", index)
         button.setProperty("wizardState", state)
+        button.setProperty("responsiveMode", "compact" if self._compact else "wide")
         button.setEnabled(state != "locked")
-        button.setCursor(Qt.ForbiddenCursor if state == "locked" else Qt.PointingHandCursor)
+        button.setCursor(
+            Qt.ForbiddenCursor if state == "locked" else Qt.PointingHandCursor
+        )
         button.setToolTip(_button_tooltip(index, state))
-        button.setStyleSheet(_button_stylesheet(state))
+        button.setStyleSheet(_button_stylesheet(state, compact=self._compact))
 
     def _configure_connectors(self) -> None:
         for index, connector in enumerate(self._connectors):
             previous_step_is_done = self._states[index] == "done"
             color = COLOR_ACCENT if previous_step_is_done else COLOR_SEPARATOR
-            connector.setProperty("wizardState", "done" if previous_step_is_done else "upcoming")
-            connector.setStyleSheet(f"QFrame#{connector.objectName()} {{ border: 0; background: {color}; }}")
+            connector.setProperty(
+                "wizardState", "done" if previous_step_is_done else "upcoming"
+            )
+            connector.setStyleSheet(
+                f"QFrame#{connector.objectName()} {{ border: 0; background: {color}; }}"
+            )
 
     def _request_step(self, index: int) -> None:
         if self._states[index] != "locked":
@@ -139,8 +185,10 @@ def _validate_states(states: Sequence[str]) -> tuple[str, ...]:
     return values
 
 
-def _button_text(index: int, state: str) -> str:
+def _button_text(index: int, state: str, *, compact: bool = False) -> str:
     prefix = "✓" if state == "done" else str(index + 1)
+    if compact:
+        return prefix
     return f"{prefix}  {STEPPER_LABELS[index]}"
 
 
@@ -154,7 +202,7 @@ def _button_tooltip(index: int, state: str) -> str:
     return label
 
 
-def _button_stylesheet(state: str) -> str:
+def _button_stylesheet(state: str, *, compact: bool = False) -> str:
     if state == "done":
         background = "transparent"
         color = COLOR_TEXT
@@ -180,10 +228,10 @@ def _button_stylesheet(state: str) -> str:
         f"background: {background}; "
         f"color: {color}; "
         f"border: {border}; "
-        "border-radius: 8px; "
-        "padding: 2px 6px; "
+        f"border-radius: {'6px' if compact else '8px'}; "
+        f"padding: {'2px 4px' if compact else '2px 6px'}; "
         f"font-weight: {font_weight}; "
-        "font-size: 9.5pt; "
+        f"font-size: {'9pt' if compact else '9.5pt'}; "
         "} "
         f"QToolButton:hover:enabled {{ background: {COLOR_HOVER}; color: {COLOR_TEXT}; }}"    )
 

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -47,6 +47,7 @@ class WizardShell(QWidget):
         self._outer_layout = self._build_layout()
         self._responsive_mode = "wide"
         self._stepper_responsive_mode = "wide"
+        self._responsive_width: int | None = None
         self.setProperty("responsiveMode", "wide")
 
     def set_step_states(self, states: Sequence[str]) -> None:
@@ -69,7 +70,10 @@ class WizardShell(QWidget):
     def add_page(self, page: QWidget) -> int:
         """Append a wizard page and return its stack index."""
 
-        return self.pages_stack.addWidget(page)
+        index = self.pages_stack.addWidget(page)
+        if self._responsive_width is not None and hasattr(page, "set_responsive_width"):
+            page.set_responsive_width(self._responsive_width)
+        return index
 
     def page_count(self) -> int:
         """Return the number of pages currently installed in the shell."""
@@ -85,6 +89,7 @@ class WizardShell(QWidget):
         """Propagate dock width changes to responsive wizard chrome."""
 
         width = int(width)
+        self._responsive_width = width
         mode = "narrow" if width < STEP_PAGE_NARROW_WIDTH else "wide"
         stepper_mode = "compact" if width < STEPPER_COMPACT_WIDTH else "wide"
         if mode == self._responsive_mode and stepper_mode == self._stepper_responsive_mode:

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -44,6 +44,7 @@ class WizardShell(QWidget):
         self.footer_bar = self._build_footer_bar(footer_text)
         self.content_scroll.setWidget(self.pages_stack)
         self._outer_layout = self._build_layout()
+        self.setProperty("responsiveMode", "wide")
 
     def set_step_states(self, states: Sequence[str]) -> None:
         """Delegate validated step state rendering to the shared stepper."""
@@ -76,6 +77,29 @@ class WizardShell(QWidget):
         """Update the compact persistent status/footer text."""
 
         self.footer_bar.set_status_text(text)
+
+    def set_responsive_width(self, width: int) -> None:
+        """Propagate dock width changes to responsive wizard chrome."""
+
+        mode = "narrow" if int(width) < 360 else "wide"
+        self.setProperty("responsiveMode", mode)
+        self.stepper_bar.set_responsive_width(width)
+        for index in range(self.pages_stack.count()):
+            page = self.pages_stack.widget(index) if hasattr(self.pages_stack, "widget") else None
+            if page is not None and hasattr(page, "set_responsive_width"):
+                page.set_responsive_width(width)
+
+    def resizeEvent(self, event) -> None:  # noqa: N802
+        """Let the shell react to dock resizes without wide-page size hints."""
+
+        size = event.size() if hasattr(event, "size") else None
+        if size is not None and hasattr(size, "width"):
+            self.set_responsive_width(size.width())
+        elif hasattr(self, "width"):
+            self.set_responsive_width(self.width())
+        parent_resize = getattr(super(), "resizeEvent", None)
+        if parent_resize is not None:
+            parent_resize(event)
 
     def outer_layout(self):
         """Expose the structural layout for adapter wiring and pure tests."""

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -4,7 +4,8 @@ from typing import Sequence
 
 from ._qt_compat import import_qt_module
 from .footer_status_bar import FooterStatusBar
-from .stepper_bar import STEPPER_LABELS, StepperBar
+from .step_page import STEP_PAGE_NARROW_WIDTH
+from .stepper_bar import STEPPER_COMPACT_WIDTH, STEPPER_LABELS, StepperBar
 
 _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
@@ -44,6 +45,8 @@ class WizardShell(QWidget):
         self.footer_bar = self._build_footer_bar(footer_text)
         self.content_scroll.setWidget(self.pages_stack)
         self._outer_layout = self._build_layout()
+        self._responsive_mode = "wide"
+        self._stepper_responsive_mode = "wide"
         self.setProperty("responsiveMode", "wide")
 
     def set_step_states(self, states: Sequence[str]) -> None:
@@ -81,7 +84,13 @@ class WizardShell(QWidget):
     def set_responsive_width(self, width: int) -> None:
         """Propagate dock width changes to responsive wizard chrome."""
 
-        mode = "narrow" if int(width) < 360 else "wide"
+        width = int(width)
+        mode = "narrow" if width < STEP_PAGE_NARROW_WIDTH else "wide"
+        stepper_mode = "compact" if width < STEPPER_COMPACT_WIDTH else "wide"
+        if mode == self._responsive_mode and stepper_mode == self._stepper_responsive_mode:
+            return
+        self._responsive_mode = mode
+        self._stepper_responsive_mode = stepper_mode
         self.setProperty("responsiveMode", mode)
         self.stepper_bar.set_responsive_width(width)
         for index in range(self.pages_stack.count()):


### PR DESCRIPTION
## Summary

- make the wizard stepper compact itself at narrow dock widths while keeping full labels in tooltips
- allow step pages, navigation, and CTA rows to shrink/stack instead of preserving wide button and label size hints
- propagate responsive dock width changes from the wizard shell to installed step pages

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Fixes #724
