### PR TITLE
fix: allow atlas without spatial analysis

### DIFF
--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -77,7 +77,7 @@ class AtlasPageContentTest(unittest.TestCase):
             content.export_atlas_button.property("wizardActionAvailability"),
             "blocked",
         )
-        self.assertIn("Run analysis", content.export_atlas_button.toolTip())
+        self.assertIn("Load activity layers", content.export_atlas_button.toolTip())
         self.assertEqual(content.action_row.objectName(), "qfitWizardAtlasActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,

--- a/tests/test_dock_workflow_sections.py
+++ b/tests/test_dock_workflow_sections.py
@@ -23,7 +23,7 @@ class DockWorkflowSectionsTests(unittest.TestCase):
         )
         self.assertEqual(
             [section.title for section in WIZARD_WORKFLOW_STEPS],
-            ["Connection", "Synchronization", "Map & filters", "Spatial analysis", "Atlas PDF"],
+            ["Connection", "Synchronization", "Map & filters", "Spatial analysis (optional)", "Atlas PDF"],
         )
 
     def test_current_dock_sections_reuse_wizard_steps_without_connection_page(self):
@@ -66,7 +66,7 @@ class DockWorkflowSectionsTests(unittest.TestCase):
                 ("connection", 0, "Connection", DockWorkflowStepState.DONE),
                 ("sync", 1, "Synchronization", DockWorkflowStepState.DONE),
                 ("map", 2, "Map & filters", DockWorkflowStepState.CURRENT),
-                ("analysis", 3, "Spatial analysis", DockWorkflowStepState.UNLOCKED),
+                ("analysis", 3, "Spatial analysis (optional)", DockWorkflowStepState.UNLOCKED),
                 ("atlas", 4, "Atlas PDF", DockWorkflowStepState.LOCKED),
             ],
         )

--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -245,8 +245,8 @@ class StepperBarTest(unittest.TestCase):
                 "Connection",
                 "Complete Connection before opening Synchronization.",
                 "Complete Synchronization before opening Map & filters.",
-                "Complete Map & filters before opening Spatial analysis.",
-                "Complete Spatial analysis before opening Atlas PDF.",
+                "Complete Map & filters before opening Spatial analysis (optional).",
+                "Complete Map & filters before opening Atlas PDF.",
             ],
         )
         self.assertEqual(bar.height(), 36)
@@ -254,7 +254,13 @@ class StepperBarTest(unittest.TestCase):
     def test_labels_come_from_shared_workflow_metadata(self):
         self.assertEqual(
             self.stepper.STEPPER_LABELS,
-            ("Connection", "Synchronization", "Map & filters", "Spatial analysis", "Atlas PDF"),
+            (
+                "Connection",
+                "Synchronization",
+                "Map & filters",
+                "Spatial analysis (optional)",
+                "Atlas PDF",
+            ),
         )
 
     def test_qt_import_guard_requires_all_widget_classes(self):
@@ -306,7 +312,7 @@ class StepperBarTest(unittest.TestCase):
         self.assertFalse(buttons[3].isEnabled())
         self.assertEqual(
             buttons[3].toolTip(),
-            "Complete Map & filters before opening Spatial analysis.",
+            "Complete Map & filters before opening Spatial analysis (optional).",
         )
         self.assertEqual(buttons[3].cursor().shape(), _FakeQt.ForbiddenCursor)
 

--- a/tests/test_stepper_presenter.py
+++ b/tests/test_stepper_presenter.py
@@ -35,7 +35,7 @@ class StepperPresenterTests(unittest.TestCase):
                 ("connection", 0, "Connection", STEPPER_STATE_DONE, True),
                 ("sync", 1, "Synchronization", STEPPER_STATE_DONE, True),
                 ("map", 2, "Map & filters", STEPPER_STATE_CURRENT, True),
-                ("analysis", 3, "Spatial analysis", STEPPER_STATE_UPCOMING, True),
+                ("analysis", 3, "Spatial analysis (optional)", STEPPER_STATE_UPCOMING, True),
                 ("atlas", 4, "Atlas PDF", STEPPER_STATE_LOCKED, False),
             ],
         )

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -21,7 +21,7 @@ class WizardPageSpecsTests(unittest.TestCase):
                 ("connection", "Connection"),
                 ("sync", "Synchronization"),
                 ("map", "Map & filters"),
-                ("analysis", "Spatial analysis"),
+                ("analysis", "Spatial analysis (optional)"),
                 ("atlas", "Atlas PDF"),
             ],
         )

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -368,6 +368,23 @@ class WizardProgressFactsTests(unittest.TestCase):
             frozenset({"connection", "sync", "map", "atlas"}),
         )
 
+    def test_atlas_export_without_analysis_keeps_optional_analysis_reachable(self):
+        progress = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                atlas_exported=True,
+                preferred_current_key="analysis",
+            )
+        )
+
+        self.assertEqual(progress.current_key, "analysis")
+        self.assertEqual(
+            progress.completed_keys,
+            frozenset({"connection", "sync", "map", "atlas"}),
+        )
+
     def test_rejects_unknown_preferred_current_key(self):
         with self.assertRaisesRegex(KeyError, "review"):
             build_wizard_progress_from_facts(

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -263,7 +263,7 @@ class WizardProgressFactsTests(unittest.TestCase):
         statuses = build_progress_wizard_step_statuses(progress)
         self.assertEqual(
             [status.state.value for status in statuses],
-            ["done", "done", "done", "current", "locked"],
+            ["done", "done", "done", "current", "unlocked"],
         )
 
     def test_local_geopackage_store_unlocks_map_without_strava_connection(self):
@@ -329,6 +329,43 @@ class WizardProgressFactsTests(unittest.TestCase):
         self.assertEqual(
             progress.completed_keys,
             frozenset({"connection", "sync", "map", "analysis", "atlas"}),
+        )
+
+    def test_map_completion_allows_preferred_atlas_without_analysis(self):
+        progress = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                preferred_current_key="atlas",
+            )
+        )
+
+        self.assertEqual(progress.current_key, "atlas")
+        self.assertEqual(
+            progress.completed_keys,
+            frozenset({"connection", "sync", "map"}),
+        )
+        statuses = build_progress_wizard_step_statuses(progress)
+        self.assertEqual(
+            [status.state.value for status in statuses],
+            ["done", "done", "done", "unlocked", "current"],
+        )
+
+    def test_atlas_export_can_complete_without_analysis(self):
+        progress = build_wizard_progress_from_facts(
+            WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                atlas_exported=True,
+            )
+        )
+
+        self.assertEqual(progress.current_key, "atlas")
+        self.assertEqual(
+            progress.completed_keys,
+            frozenset({"connection", "sync", "map", "atlas"}),
         )
 
     def test_rejects_unknown_preferred_current_key(self):

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -166,7 +166,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertEqual(
             assembled.pages[2].next_button.text(),
-            "Suivant: Spatial analysis →",
+            "Suivant: Spatial analysis (optional) →",
         )
         self.assertEqual(
             [page.status_pill.text() for page in assembled.pages],
@@ -206,7 +206,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertEqual(
             assembled.pages[2].next_button.text(),
-            "Suivant: Spatial analysis →",
+            "Suivant: Spatial analysis (optional) →",
         )
 
         assembled.shell.stepper_bar.step_buttons()[1].clicked.emit()
@@ -220,6 +220,30 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.pages[1].next_button.text(),
             "Suivant: Map & filters →",
         )
+
+    def test_map_next_button_skips_optional_analysis_when_atlas_is_reachable(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                preferred_current_key="map",
+            ),
+        )
+
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("done", "done", "current", "upcoming", "upcoming"),
+        )
+        self.assertEqual(
+            assembled.pages[2].next_button.text(),
+            "Suivant: Atlas PDF →",
+        )
+
+        assembled.pages[2].next_button.clicked.emit()
+
+        self.assertEqual(assembled.presenter.progress.current_key, "atlas")
+        self.assertEqual(assembled.shell.pages_stack.currentIndex(), 4)
 
     def test_configured_connection_restore_keeps_connection_page_accessible(self):
         assembled = self.composition.build_placeholder_wizard_shell(
@@ -499,7 +523,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 3)
         self.assertEqual(
             assembled.shell.stepper_bar.states(),
-            ("done", "done", "done", "current", "locked"),
+            ("done", "done", "done", "current", "upcoming"),
         )
 
     def test_first_launch_wizard_settings_do_not_restore_saved_step(self):
@@ -918,7 +942,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
         self.assertEqual(
             assembled.atlas_content.export_atlas_button.toolTip(),
-            "Run analysis before exporting atlas PDF.",
+            "Load activity layers before exporting atlas PDF.",
         )
 
     def test_progress_facts_explain_locked_page_prerequisites(self):
@@ -956,11 +980,11 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertEqual(
             assembled.atlas_content.status_label.text(),
-            "Analysis required before atlas export",
+            "Map layers required before atlas export",
         )
         self.assertEqual(
             assembled.atlas_content.input_summary_label.text(),
-            "Run analysis before exporting atlas PDF",
+            "Load activity layers before exporting atlas PDF",
         )
         self.assertIn(
             "Connect to Strava to enable synchronization",
@@ -1084,6 +1108,50 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Refresh analysis",
         )
         self.assertTrue(assembled.analysis_content.run_analysis_button.isEnabled())
+
+    def test_atlas_page_is_available_after_map_without_analysis(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                preferred_current_key="atlas",
+            )
+        )
+
+        self.assertEqual(assembled.presenter.progress.current_key, "atlas")
+        self.assertEqual(
+            assembled.shell.stepper_bar.states(),
+            ("done", "done", "done", "upcoming", "current"),
+        )
+        self.assertEqual(
+            assembled.atlas_content.status_label.text(),
+            "Atlas PDF not exported yet",
+        )
+        self.assertEqual(
+            assembled.atlas_content.input_summary_label.text(),
+            "Activity layers ready for atlas export",
+        )
+        self.assertTrue(assembled.atlas_content.export_atlas_button.isEnabled())
+
+    def test_atlas_page_input_summary_describes_filtered_layers_without_analysis(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                filters_active=True,
+                filtered_activity_count=2,
+                filter_description="layer subset",
+                loaded_layer_count=4,
+                preferred_current_key="atlas",
+            )
+        )
+
+        self.assertEqual(
+            assembled.atlas_content.input_summary_label.text(),
+            "2 filtered activities ready for atlas export · layer subset · 4 qfit layers loaded",
+        )
 
     def test_atlas_page_input_summary_names_analysis_output(self):
         assembled = self.composition.build_placeholder_wizard_shell(
@@ -1469,7 +1537,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.shell.pages_stack.currentIndex(), 3)
         self.assertEqual(
             assembled.shell.stepper_bar.states(),
-            ("done", "done", "done", "current", "locked"),
+            ("done", "done", "done", "current", "upcoming"),
         )
         self.assertEqual(assembled.connection_content.status_label.text(), "Strava connected")
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
@@ -1483,7 +1551,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.shell.footer_bar.layer_pill.text(), "1 layer")
         self.assertFalse(assembled.analysis_state.ready)
         self.assertTrue(assembled.analysis_content.run_analysis_button.isEnabled())
-        self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
+        self.assertTrue(assembled.atlas_content.export_atlas_button.isEnabled())
 
     def test_progress_facts_drive_explicit_footer_controls_on_build_and_refresh(self):
         assembled = self.composition.build_placeholder_wizard_shell(

--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -125,7 +125,7 @@ class WizardShellPresenterTest(unittest.TestCase):
         self.assertEqual(shell.pages_stack.currentIndex(), 3)
         self.assertEqual(
             shell.stepper_bar.states(),
-            ("done", "done", "done", "current", "locked"),
+            ("done", "done", "done", "current", "upcoming"),
         )
         self.assertEqual(persisted_step_indexes, [3])
 

--- a/ui/application/dock_workflow_sections.py
+++ b/ui/application/dock_workflow_sections.py
@@ -71,7 +71,7 @@ WIZARD_WORKFLOW_STEPS: tuple[DockWorkflowSection, ...] = (
     ),
     DockWorkflowSection(
         key="analysis",
-        title="Spatial analysis",
+        title="Spatial analysis (optional)",
         current_dock_title="Analyze",
     ),
     DockWorkflowSection(
@@ -183,6 +183,8 @@ def _derive_unlocked_step_keys(
     for previous, section in zip(WIZARD_WORKFLOW_STEPS, WIZARD_WORKFLOW_STEPS[1:]):
         if previous.key in completed_keys:
             unlocked.add(section.key)
+    if "map" in completed_keys:
+        unlocked.add("atlas")
     return unlocked
 
 

--- a/ui/application/wizard_page_specs.py
+++ b/ui/application/wizard_page_specs.py
@@ -55,8 +55,8 @@ _PAGE_COPY_BY_KEY = {
         "Primary action: apply map filters",
     ),
     "analysis": (
-        "Run heatmap, corridor, and start-point analysis from loaded data.",
-        "Primary action: run analysis",
+        "Optionally run heatmap, corridor, and start-point analysis from loaded data.",
+        "Optional action: run spatial analysis",
     ),
     "atlas": (
         "Configure and export multi-activity PDF atlases.",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -251,7 +251,7 @@ def _reachable_preferred_keys(
 ) -> set[str]:
     reachable = completed_keys | {first_incomplete_key}
     if "map" in completed_keys:
-        reachable.add("atlas")
+        reachable.update({"analysis", "atlas"})
     return reachable
 
 

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -211,12 +211,15 @@ def _completed_keys_from_facts(facts: WizardProgressFacts) -> tuple[str, ...]:
         ("connection", connection_complete),
         ("sync", facts.activities_stored),
         ("map", facts.activity_layers_loaded),
-        ("analysis", facts.analysis_generated),
-        ("atlas", facts.atlas_exported),
     ):
         if not complete:
-            break
+            return tuple(completed)
         completed.append(key)
+
+    if facts.analysis_generated:
+        completed.append("analysis")
+    if facts.atlas_exported:
+        completed.append("atlas")
     return tuple(completed)
 
 
@@ -232,13 +235,29 @@ def _resolve_current_key(
         return first_incomplete_key
     if preferred_current_key not in known_keys:
         raise KeyError(preferred_current_key)
-    reachable_keys = completed | {first_incomplete_key}
+    reachable_keys = _reachable_preferred_keys(
+        completed_keys=completed,
+        first_incomplete_key=first_incomplete_key,
+    )
     if preferred_current_key in reachable_keys:
         return preferred_current_key
     return first_incomplete_key
 
 
+def _reachable_preferred_keys(
+    *,
+    completed_keys: set[str],
+    first_incomplete_key: str,
+) -> set[str]:
+    reachable = completed_keys | {first_incomplete_key}
+    if "map" in completed_keys:
+        reachable.add("atlas")
+    return reachable
+
+
 def _first_incomplete_key(completed_keys: set[str]) -> str:
+    if "atlas" in completed_keys:
+        return "atlas"
     for key in _workflow_keys():
         if key not in completed_keys:
             return key

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -42,7 +42,7 @@ class AnalysisPageState:
     ready: bool = False
     status_text: str = "Analysis not run yet"
     detail_text: str = (
-        "Use loaded activity layers to calculate heatmaps, corridors, and start points."
+        "Optional: calculate heatmaps, corridors, and start points from loaded data."
     )
     input_summary_text: str = "No loaded activity layers available for analysis"
     result_summary_text: str = "Analysis outputs will appear in the project once generated"

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -44,7 +44,7 @@ class AtlasPageState:
     output_summary_text: str = "PDF output path will be chosen before generation"
     primary_action_label: str = "Export atlas PDF"
     primary_action_enabled: bool | None = None
-    primary_action_blocked_tooltip: str = "Run analysis before exporting atlas PDF."
+    primary_action_blocked_tooltip: str = "Load activity layers before exporting atlas PDF."
 
 
 class AtlasPageContent(QWidget):

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -8,6 +8,8 @@ from qfit.ui.application.stepper_presenter import (
     STEPPER_STATE_DONE,
     STEPPER_STATE_LOCKED,
     STEPPER_STATE_UPCOMING,
+    step_index_for_key,
+    step_key_for_index,
 )
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
 
@@ -198,8 +200,8 @@ def _button_tooltip(index: int, state: str) -> str:
         if index == 0:
             return "This step is not yet available."
         prerequisite_index = index - 1
-        if label == "Atlas PDF":
-            prerequisite_index = 2
+        if step_key_for_index(index) == "atlas":
+            prerequisite_index = step_index_for_key("map")
         previous_label = STEPPER_LABELS[prerequisite_index]
         return f"Complete {previous_label} before opening {label}."
     return label

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -197,7 +197,10 @@ def _button_tooltip(index: int, state: str) -> str:
     if state == "locked":
         if index == 0:
             return "This step is not yet available."
-        previous_label = STEPPER_LABELS[index - 1]
+        prerequisite_index = index - 1
+        if label == "Atlas PDF":
+            prerequisite_index = 2
+        previous_label = STEPPER_LABELS[prerequisite_index]
         return f"Complete {previous_label} before opening {label}."
     return label
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -6,6 +6,7 @@ from typing import TypeVar
 
 from qfit.ui.application.dock_workflow_sections import (
     DockWizardProgress,
+    DockWorkflowStepStatus,
     build_progress_wizard_step_statuses,
 )
 from qfit.ui.application.stepper_presenter import (
@@ -846,7 +847,7 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
         output_summary_text=output_summary_text,
         primary_action_label=primary_action_label,
         primary_action_enabled=(
-            facts.analysis_generated and not facts.atlas_export_in_progress
+            facts.activity_layers_loaded and not facts.atlas_export_in_progress
         ),
         primary_action_blocked_tooltip=atlas_blocked_tooltip,
     )
@@ -855,17 +856,46 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
 def _atlas_status_text(facts: WizardProgressFacts, default: AtlasPageState) -> str:
     if facts.atlas_exported:
         return "Atlas PDF exported"
-    if not facts.analysis_generated:
-        return "Analysis required before atlas export"
+    if not facts.activity_layers_loaded:
+        return "Map layers required before atlas export"
     return default.status_text
 
 
 def _atlas_input_summary(facts: WizardProgressFacts) -> str:
-    if not facts.analysis_generated:
-        return "Run analysis before exporting atlas PDF"
+    if not facts.activity_layers_loaded:
+        return "Load activity layers before exporting atlas PDF"
     if facts.analysis_output_name is not None:
         return f"Analysis output {facts.analysis_output_name} ready for atlas export"
-    return "Analysis outputs ready for atlas export"
+    if facts.analysis_generated:
+        return "Analysis outputs ready for atlas export"
+    return _atlas_activity_layer_input_summary(facts)
+
+
+def _atlas_activity_layer_input_summary(facts: WizardProgressFacts) -> str:
+    if facts.filters_active:
+        summary = _atlas_filtered_activity_layer_summary(facts)
+    elif facts.output_name is not None:
+        summary = f"Activity layers from {facts.output_name} ready for atlas export"
+    else:
+        summary = "Activity layers ready for atlas export"
+    details = tuple(
+        detail
+        for detail in (
+            _analysis_filter_description(facts),
+            _analysis_loaded_layer_count_summary(facts),
+        )
+        if detail
+    )
+    if not details:
+        return summary
+    return f"{summary} · {' · '.join(details)}"
+
+
+def _atlas_filtered_activity_layer_summary(facts: WizardProgressFacts) -> str:
+    if facts.filtered_activity_count is None:
+        return "Filtered activity subset ready for atlas export"
+    noun = "activity" if facts.filtered_activity_count == 1 else "activities"
+    return f"{max(facts.filtered_activity_count, 0)} filtered {noun} ready for atlas export"
 
 
 def _atlas_output_summary(
@@ -977,16 +1007,24 @@ def _connect_step_page_navigation(
             presenter.request_step(index)
         _sync_step_page_navigation_and_status(pages, presenter)
 
-    for installed_index, page in step_pages:
+    def navigation_target(installed_index: int, direction: str) -> int | None:
         previous_index, next_index = _step_page_navigation_targets(
             pages,
             installed_index=installed_index,
+            statuses=build_progress_wizard_step_statuses(presenter.progress),
         )
+        return previous_index if direction == "previous" else next_index
+
+    for installed_index, page in step_pages:
         page.backRequested.connect(
-            lambda _checked=False, target=previous_index: request_and_sync(target)
+            lambda _checked=False, page_index=installed_index: request_and_sync(
+                navigation_target(page_index, "previous")
+            )
         )
         page.nextRequested.connect(
-            lambda _checked=False, target=next_index: request_and_sync(target)
+            lambda _checked=False, page_index=installed_index: request_and_sync(
+                navigation_target(page_index, "next")
+            )
         )
     shell.stepper_bar.stepRequested.connect(
         lambda _index: _sync_step_page_navigation_and_status(pages, presenter)
@@ -1015,6 +1053,7 @@ def _sync_step_page_navigation_buttons(
         previous_index, next_index = _step_page_navigation_targets(
             pages,
             installed_index=installed_index,
+            statuses=statuses,
         )
         page.set_back(
             label=_navigation_label(
@@ -1085,14 +1124,44 @@ def _step_page_navigation_targets(
     pages: Sequence[WizardCompositionPage],
     *,
     installed_index: int,
+    statuses: Sequence[DockWorkflowStepStatus] | None = None,
 ) -> tuple[int | None, int | None]:
+    current_page = pages[installed_index]
     previous_page = pages[installed_index - 1] if installed_index > 0 else None
     next_page = (
         pages[installed_index + 1]
         if installed_index + 1 < len(pages)
         else None
     )
+    if _should_skip_optional_analysis_to_atlas(
+        pages,
+        current_page=current_page,
+        next_page=next_page,
+        installed_index=installed_index,
+        statuses=statuses,
+    ):
+        next_page = pages[installed_index + 2]
     return _workflow_index_for_page(previous_page), _workflow_index_for_page(next_page)
+
+
+def _should_skip_optional_analysis_to_atlas(
+    pages: Sequence[WizardCompositionPage],
+    *,
+    current_page: WizardCompositionPage,
+    next_page: WizardCompositionPage | None,
+    installed_index: int,
+    statuses: Sequence[DockWorkflowStepStatus] | None,
+) -> bool:
+    if not (
+        current_page.spec.key == "map"
+        and next_page is not None
+        and next_page.spec.key == "analysis"
+        and installed_index + 2 < len(pages)
+        and pages[installed_index + 2].spec.key == "atlas"
+    ):
+        return False
+    atlas_index = step_index_for_key("atlas")
+    return statuses is not None and can_request_step(statuses, atlas_index)
 
 
 def _workflow_index_for_page(page: WizardCompositionPage | None) -> int | None:

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -1160,6 +1160,8 @@ def _should_skip_optional_analysis_to_atlas(
         and pages[installed_index + 2].spec.key == "atlas"
     ):
         return False
+    # The default wizard order is map -> optional analysis -> atlas; +2 is the
+    # atlas page that follows the optional analysis page checked above.
     atlas_index = step_index_for_key("atlas")
     return statuses is not None and can_request_step(statuses, atlas_index)
 


### PR DESCRIPTION
## Summary

- mark Spatial analysis as optional in wizard/stepper copy
- unlock Atlas PDF once map/activity layers are loaded, without requiring analysis output
- make Map → Next jump directly to Atlas PDF when atlas is reachable while keeping Spatial analysis selectable

## Testing

- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Fixes #729
