### PR TITLE
feat: add Strava saved route client

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,11 +1,12 @@
 """Provider feature package."""
 
-from .domain import ActivityProvider, ProviderError
+from .domain import ActivityProvider, ProviderError, SavedRoute
 from .infrastructure import StravaClient, StravaClientError, StravaProvider
 
 __all__ = [
     "ActivityProvider",
     "ProviderError",
+    "SavedRoute",
     "StravaClient",
     "StravaClientError",
     "StravaProvider",

--- a/providers/domain/__init__.py
+++ b/providers/domain/__init__.py
@@ -1,3 +1,6 @@
 """Provider domain contracts."""
 
 from .provider import ActivityProvider, ProviderError
+from .routes import SavedRoute
+
+__all__ = ["ActivityProvider", "ProviderError", "SavedRoute"]

--- a/providers/domain/routes.py
+++ b/providers/domain/routes.py
@@ -1,0 +1,27 @@
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class SavedRoute:
+    source: str
+    source_route_id: str
+    external_id: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    private: Optional[bool] = None
+    starred: Optional[bool] = None
+    distance_m: Optional[float] = None
+    elevation_gain_m: Optional[float] = None
+    estimated_moving_time_s: Optional[int] = None
+    route_type: Optional[int] = None
+    sub_type: Optional[int] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    summary_polyline: Optional[str] = None
+    geometry_source: Optional[str] = None
+    geometry_points: List[Tuple[float, float]] = field(default_factory=list)
+    details_json: Dict[str, Any] = field(default_factory=dict)
+
+    def to_record(self) -> Dict[str, Any]:
+        return asdict(self)

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -298,6 +298,8 @@ class StravaClient:
 
     def fetch_authenticated_athlete_id(self, token=None):
         payload = self.fetch_authenticated_athlete(token=token)
+        if not isinstance(payload, dict):
+            raise StravaClientError("Fetching authenticated Strava athlete returned an unexpected response")
         athlete_id = (payload or {}).get("id")
         if athlete_id is None:
             raise StravaClientError("Strava did not return an authenticated athlete id")

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -259,7 +259,7 @@ class StravaClient:
         before paginating ``GET /athletes/{id}/routes``.
         """
         token = self.get_access_token()
-        route_athlete_id = athlete_id or self.fetch_authenticated_athlete_id(token=token)
+        route_athlete_id = athlete_id if athlete_id is not None else self.fetch_authenticated_athlete_id(token=token)
         routes = []
         current_per_page = max(1, int(per_page))
         self.last_fetch_notice = None
@@ -283,7 +283,7 @@ class StravaClient:
             if max_pages == 0 and self._should_pause_full_sync_for_rate_limit():
                 self.last_fetch_notice = self._rate_limit_pause_notice()
                 break
-            self._sleep_between_activity_pages()
+            self._sleep_between_route_pages()
             page += 1
 
         return routes
@@ -310,6 +310,10 @@ class StravaClient:
             headers=self._build_request_headers(token=token),
             operation="Fetching Strava route {route_id}".format(route_id=route_id),
         )
+        if not isinstance(payload, dict):
+            raise StravaClientError(
+                "Fetching Strava route {route_id} returned an unexpected response".format(route_id=route_id)
+            )
         return self.normalize_route(payload)
 
     def _fetch_activity_page(self, token, page, per_page, current_before, after, max_pages):
@@ -592,10 +596,15 @@ class StravaClient:
         )
 
     def normalize_route(self, payload):
+        if not isinstance(payload, dict):
+            raise StravaClientError("Strava route payload must be an object")
+        route_id = payload.get("id")
+        if route_id is None:
+            raise StravaClientError("Strava route payload did not include an id")
         summary_polyline, geometry_source = self._extract_route_polyline(payload)
         return SavedRoute(
             source="strava",
-            source_route_id=str(payload.get("id")),
+            source_route_id=str(route_id),
             external_id=payload.get("id_str"),
             name=payload.get("name"),
             description=payload.get("description"),
@@ -877,6 +886,11 @@ class StravaClient:
         delay = float(self.PAGE_REQUEST_DELAY_SECONDS)
         if delay > 0:
             time.sleep(delay)
+
+    def _sleep_between_route_pages(self):
+        # Route list pagination uses the same conservative pacing as activity
+        # pagination until route sync gets its own rate-limit tuning.
+        self._sleep_between_activity_pages()
 
     def _reduced_activity_page_size(self, current_per_page, exc, *, max_pages):
         if max_pages != 0:

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -79,6 +79,7 @@ from ...detailed_route_strategy import (
     DEFAULT_DETAILED_ROUTE_STRATEGY,
     DETAILED_ROUTE_STRATEGY_RECENT,
 )
+from ..domain.routes import SavedRoute
 
 
 class StravaClientError(RuntimeError):
@@ -88,8 +89,11 @@ class StravaClientError(RuntimeError):
 class StravaClient:
     AUTHORIZE_URL = "https://www.strava.com/oauth/authorize"
     TOKEN_URL = "https://www.strava.com/oauth/token"
+    ATHLETE_URL = "https://www.strava.com/api/v3/athlete"
     ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"
     STREAMS_URL_TEMPLATE = "https://www.strava.com/api/v3/activities/{activity_id}/streams"
+    ROUTES_URL_TEMPLATE = "https://www.strava.com/api/v3/athletes/{athlete_id}/routes"
+    ROUTE_DETAIL_URL_TEMPLATE = "https://www.strava.com/api/v3/routes/{route_id}"
     DEFAULT_NETWORK_RETRY_ATTEMPTS = 3
     MIN_ACTIVITY_PAGE_SIZE = 5
     FULL_SYNC_MIN_SHORT_REMAINING = 3
@@ -247,6 +251,67 @@ class StravaClient:
 
         return activities
 
+    def fetch_routes(self, athlete_id=None, per_page=200, max_pages=0):
+        """Fetch the authenticated athlete's saved Strava routes.
+
+        ``athlete_id`` may be supplied by callers that already know it.  When it
+        is omitted, qfit resolves the authenticated athlete via ``GET /athlete``
+        before paginating ``GET /athletes/{id}/routes``.
+        """
+        token = self.get_access_token()
+        route_athlete_id = athlete_id or self.fetch_authenticated_athlete_id(token=token)
+        routes = []
+        current_per_page = max(1, int(per_page))
+        self.last_fetch_notice = None
+
+        page = 1
+        while not max_pages or page <= max_pages:
+            url = self._routes_page_url(route_athlete_id, page, current_per_page)
+            payload = self._request_json(
+                url,
+                headers=self._build_request_headers(token=token),
+                operation="Fetching Strava routes page {page}".format(page=page),
+            )
+            if not isinstance(payload, list):
+                raise StravaClientError(
+                    "Fetching Strava routes page {page} returned an unexpected response".format(page=page)
+                )
+
+            routes.extend(self.normalize_route(item) for item in payload)
+            if len(payload) < current_per_page:
+                break
+            if max_pages == 0 and self._should_pause_full_sync_for_rate_limit():
+                self.last_fetch_notice = self._rate_limit_pause_notice()
+                break
+            self._sleep_between_activity_pages()
+            page += 1
+
+        return routes
+
+    def fetch_authenticated_athlete(self, token=None):
+        access_token = token or self.get_access_token()
+        return self._request_json(
+            self.ATHLETE_URL,
+            headers=self._build_request_headers(token=access_token),
+            operation="Fetching authenticated Strava athlete",
+        )
+
+    def fetch_authenticated_athlete_id(self, token=None):
+        payload = self.fetch_authenticated_athlete(token=token)
+        athlete_id = (payload or {}).get("id")
+        if athlete_id is None:
+            raise StravaClientError("Strava did not return an authenticated athlete id")
+        return athlete_id
+
+    def fetch_route_detail(self, route_id):
+        token = self.get_access_token()
+        payload = self._request_json(
+            self.ROUTE_DETAIL_URL_TEMPLATE.format(route_id=route_id),
+            headers=self._build_request_headers(token=token),
+            operation="Fetching Strava route {route_id}".format(route_id=route_id),
+        )
+        return self.normalize_route(payload)
+
     def _fetch_activity_page(self, token, page, per_page, current_before, after, max_pages):
         while True:
             payload = None
@@ -272,6 +337,13 @@ class StravaClient:
         if after is not None:
             params["after"] = int(after)
         return "{base}?{query}".format(base=self.ACTIVITIES_URL, query=urlencode(params))
+
+    def _routes_page_url(self, athlete_id, page, per_page):
+        params = {"page": page, "per_page": per_page}
+        return "{base}?{query}".format(
+            base=self.ROUTES_URL_TEMPLATE.format(athlete_id=athlete_id),
+            query=urlencode(params),
+        )
 
     def _next_full_sync_before(self, current_before, batch, max_pages):
         if max_pages != 0:
@@ -519,6 +591,28 @@ class StravaClient:
             details_json=self._extract_details_json(payload),
         )
 
+    def normalize_route(self, payload):
+        summary_polyline, geometry_source = self._extract_route_polyline(payload)
+        return SavedRoute(
+            source="strava",
+            source_route_id=str(payload.get("id")),
+            external_id=payload.get("id_str"),
+            name=payload.get("name"),
+            description=payload.get("description"),
+            private=payload.get("private"),
+            starred=payload.get("starred"),
+            distance_m=payload.get("distance"),
+            elevation_gain_m=payload.get("elevation_gain"),
+            estimated_moving_time_s=payload.get("estimated_moving_time"),
+            route_type=payload.get("type"),
+            sub_type=payload.get("sub_type"),
+            created_at=payload.get("created_at"),
+            updated_at=payload.get("updated_at"),
+            summary_polyline=summary_polyline,
+            geometry_source=geometry_source,
+            details_json=self._extract_route_details_json(payload),
+        )
+
     def _load_cached_stream_bundle(self, activity):
         if self.cache is None:
             return None
@@ -587,6 +681,14 @@ class StravaClient:
             return "start_end"
         return None
 
+    def _extract_route_polyline(self, payload):
+        route_map = (payload or {}).get("map") or {}
+        if route_map.get("polyline"):
+            return route_map.get("polyline"), "route_polyline"
+        if route_map.get("summary_polyline"):
+            return route_map.get("summary_polyline"), "summary_polyline"
+        return None, None
+
     def _extract_stream_bundle(self, payload):
         streams = {}
         if isinstance(payload, dict):
@@ -633,6 +735,28 @@ class StravaClient:
             "start_latlng",
             "end_latlng",
             "map",
+        }
+        filtered = {key: value for key, value in payload.items() if key not in excluded}
+        filtered["normalized_at"] = datetime.now(UTC).isoformat()
+        return filtered
+
+    def _extract_route_details_json(self, payload):
+        excluded = {
+            "id",
+            "id_str",
+            "name",
+            "description",
+            "private",
+            "starred",
+            "distance",
+            "elevation_gain",
+            "estimated_moving_time",
+            "type",
+            "sub_type",
+            "created_at",
+            "updated_at",
+            "map",
+            "athlete",
         }
         filtered = {key: value for key, value in payload.items() if key not in excluded}
         filtered["normalized_at"] = datetime.now(UTC).isoformat()

--- a/providers/infrastructure/strava_provider.py
+++ b/providers/infrastructure/strava_provider.py
@@ -72,6 +72,29 @@ class StravaProvider:
         except StravaClientError as exc:
             raise ProviderError(str(exc)) from exc
 
+    def fetch_routes(self, athlete_id=None, per_page=200, max_pages=0):
+        """Fetch saved routes from Strava.
+
+        This is intentionally separate from :meth:`fetch_activities` so the UI
+        can later make route-catalog sync an explicit action with its own API
+        usage expectations.
+        """
+        try:
+            return self._client.fetch_routes(
+                athlete_id=athlete_id,
+                per_page=per_page,
+                max_pages=max_pages,
+            )
+        except StravaClientError as exc:
+            raise ProviderError(str(exc)) from exc
+
+    def fetch_route_detail(self, route_id):
+        """Fetch detailed metadata for one Strava route."""
+        try:
+            return self._client.fetch_route_detail(route_id)
+        except StravaClientError as exc:
+            raise ProviderError(str(exc)) from exc
+
     # ------------------------------------------------------------------
     # Strava-specific: OAuth authorisation helpers
     # ------------------------------------------------------------------

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -53,6 +53,53 @@ class StravaClientTests(unittest.TestCase):
         self.assertEqual(activity.details_json["private_note"], "keep me in details")
         self.assertIn("normalized_at", activity.details_json)
 
+    def test_normalize_route_maps_core_fields(self):
+        client = StravaClient()
+        route = client.normalize_route(
+            {
+                "id": 123,
+                "id_str": "route-123",
+                "name": "Lake loop",
+                "description": "Planning ride",
+                "private": True,
+                "starred": False,
+                "distance": 45678.9,
+                "elevation_gain": 987.6,
+                "estimated_moving_time": 7200,
+                "type": 1,
+                "sub_type": 3,
+                "created_at": "2026-04-01T10:00:00Z",
+                "updated_at": "2026-04-02T10:00:00Z",
+                "map": {"polyline": "detailed", "summary_polyline": "summary"},
+                "segments": [{"id": 1}],
+                "athlete": {"id": 99},
+            }
+        )
+
+        self.assertEqual(route.source, "strava")
+        self.assertEqual(route.source_route_id, "123")
+        self.assertEqual(route.external_id, "route-123")
+        self.assertEqual(route.name, "Lake loop")
+        self.assertTrue(route.private)
+        self.assertEqual(route.distance_m, 45678.9)
+        self.assertEqual(route.elevation_gain_m, 987.6)
+        self.assertEqual(route.estimated_moving_time_s, 7200)
+        self.assertEqual(route.route_type, 1)
+        self.assertEqual(route.sub_type, 3)
+        self.assertEqual(route.summary_polyline, "detailed")
+        self.assertEqual(route.geometry_source, "route_polyline")
+        self.assertEqual(route.details_json["segments"], [{"id": 1}])
+        self.assertNotIn("athlete", route.details_json)
+        self.assertIn("normalized_at", route.details_json)
+        self.assertEqual(route.to_record()["source_route_id"], "123")
+
+    def test_normalize_route_falls_back_to_summary_polyline(self):
+        client = StravaClient()
+        route = client.normalize_route({"id": 123, "map": {"summary_polyline": "summary"}})
+
+        self.assertEqual(route.summary_polyline, "summary")
+        self.assertEqual(route.geometry_source, "summary_polyline")
+
     def test_extract_stream_bundle_supports_dict_and_list_payloads(self):
         client = StravaClient()
 
@@ -272,6 +319,99 @@ class StravaClientTests(unittest.TestCase):
 
         activities = client.fetch_activities(per_page=200, max_pages=0)
         self.assertEqual(len(activities), 203)
+
+    def test_fetch_routes_resolves_athlete_and_paginates_until_last_page(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        seen_urls = []
+        call_count = [0]
+
+        def fake_request_json(request, operation=None, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return {"access_token": "fake_token"}
+            seen_urls.append(request)
+            if idx == 1:
+                return {"id": 999}
+            if idx == 2:
+                return [{"id": 1, "name": "Route 1"}, {"id": 2, "name": "Route 2"}]
+            return [{"id": 3, "name": "Route 3"}]
+
+        client._request_json = fake_request_json
+
+        with patch("qfit.providers.infrastructure.strava_client.time.sleep"):
+            routes = client.fetch_routes(per_page=2, max_pages=0)
+
+        self.assertEqual([route.source_route_id for route in routes], ["1", "2", "3"])
+        self.assertIn("/athlete", seen_urls[0])
+        self.assertIn("/athletes/999/routes?page=1&per_page=2", seen_urls[1])
+        self.assertIn("/athletes/999/routes?page=2&per_page=2", seen_urls[2])
+
+    def test_fetch_routes_accepts_known_athlete_id(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        seen_urls = []
+        call_count = [0]
+
+        def fake_request_json(request, operation=None, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return {"access_token": "fake_token"}
+            seen_urls.append(request)
+            return [{"id": 7, "name": "Known athlete route"}]
+
+        client._request_json = fake_request_json
+
+        routes = client.fetch_routes(athlete_id=999, per_page=10, max_pages=1)
+
+        self.assertEqual(len(routes), 1)
+        self.assertEqual(seen_urls, ["https://www.strava.com/api/v3/athletes/999/routes?page=1&per_page=10"])
+
+    def test_fetch_routes_rejects_unexpected_response(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        call_count = [0]
+
+        def fake_request_json(request, operation=None, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return {"access_token": "fake_token"}
+            if idx == 1:
+                return {"id": 999}
+            return {"not": "a list"}
+
+        client._request_json = fake_request_json
+
+        with self.assertRaisesRegex(StravaClientError, "unexpected response"):
+            client.fetch_routes(per_page=10, max_pages=1)
+
+    def test_fetch_authenticated_athlete_id_requires_id(self):
+        client = StravaClient()
+        client._request_json = lambda *args, **kwargs: {"username": "athlete"}
+
+        with self.assertRaisesRegex(StravaClientError, "athlete id"):
+            client.fetch_authenticated_athlete_id(token="fake_token")
+
+    def test_fetch_route_detail_normalizes_payload(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        seen_urls = []
+        call_count = [0]
+
+        def fake_request_json(request, operation=None, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return {"access_token": "fake_token"}
+            seen_urls.append(request)
+            return {"id": 42, "name": "Detailed route", "map": {"polyline": "abc"}}
+
+        client._request_json = fake_request_json
+
+        route = client.fetch_route_detail(42)
+
+        self.assertEqual(route.source_route_id, "42")
+        self.assertEqual(route.summary_polyline, "abc")
+        self.assertEqual(seen_urls, ["https://www.strava.com/api/v3/routes/42"])
 
     def test_fetch_activities_full_sync_uses_before_cursor(self):
         client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -100,6 +100,12 @@ class StravaClientTests(unittest.TestCase):
         self.assertEqual(route.summary_polyline, "summary")
         self.assertEqual(route.geometry_source, "summary_polyline")
 
+    def test_normalize_route_requires_route_id(self):
+        client = StravaClient()
+
+        with self.assertRaisesRegex(StravaClientError, "did not include an id"):
+            client.normalize_route({"name": "Missing id"})
+
     def test_extract_stream_bundle_supports_dict_and_list_payloads(self):
         client = StravaClient()
 
@@ -367,6 +373,26 @@ class StravaClientTests(unittest.TestCase):
         self.assertEqual(len(routes), 1)
         self.assertEqual(seen_urls, ["https://www.strava.com/api/v3/athletes/999/routes?page=1&per_page=10"])
 
+    def test_fetch_routes_does_not_resolve_falsy_known_athlete_id(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        seen_urls = []
+        call_count = [0]
+
+        def fake_request_json(request, operation=None, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return {"access_token": "fake_token"}
+            seen_urls.append(request)
+            return [{"id": 7, "name": "Known athlete route"}]
+
+        client._request_json = fake_request_json
+
+        routes = client.fetch_routes(athlete_id=0, per_page=10, max_pages=1)
+
+        self.assertEqual(len(routes), 1)
+        self.assertEqual(seen_urls, ["https://www.strava.com/api/v3/athletes/0/routes?page=1&per_page=10"])
+
     def test_fetch_routes_rejects_unexpected_response(self):
         client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
         call_count = [0]
@@ -412,6 +438,22 @@ class StravaClientTests(unittest.TestCase):
         self.assertEqual(route.source_route_id, "42")
         self.assertEqual(route.summary_polyline, "abc")
         self.assertEqual(seen_urls, ["https://www.strava.com/api/v3/routes/42"])
+
+    def test_fetch_route_detail_rejects_unexpected_response(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        call_count = [0]
+
+        def fake_request_json(request, operation=None, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return {"access_token": "fake_token"}
+            return None
+
+        client._request_json = fake_request_json
+
+        with self.assertRaisesRegex(StravaClientError, "unexpected response"):
+            client.fetch_route_detail(42)
 
     def test_fetch_activities_full_sync_uses_before_cursor(self):
         client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -418,6 +418,13 @@ class StravaClientTests(unittest.TestCase):
         with self.assertRaisesRegex(StravaClientError, "athlete id"):
             client.fetch_authenticated_athlete_id(token="fake_token")
 
+    def test_fetch_authenticated_athlete_id_rejects_unexpected_response(self):
+        client = StravaClient()
+        client._request_json = lambda *args, **kwargs: []
+
+        with self.assertRaisesRegex(StravaClientError, "unexpected response"):
+            client.fetch_authenticated_athlete_id(token="fake_token")
+
     def test_fetch_route_detail_normalizes_payload(self):
         client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
         seen_urls = []

--- a/tests/test_strava_provider.py
+++ b/tests/test_strava_provider.py
@@ -65,6 +65,59 @@ class TestStravaProviderFetchActivities(unittest.TestCase):
             self.assertIs(exc.__cause__, original)
 
 
+class TestStravaProviderFetchRoutes(unittest.TestCase):
+    """Route fetch helpers delegate to StravaClient and translate errors."""
+
+    def _make_provider(self):
+        provider = StravaProvider(client_id="id", client_secret="secret", refresh_token="token")
+        provider._client = MagicMock()
+        return provider
+
+    def test_fetch_routes_delegates_to_client(self):
+        provider = self._make_provider()
+        provider._client.fetch_routes.return_value = []
+
+        result = provider.fetch_routes(athlete_id=123, per_page=50, max_pages=2)
+
+        provider._client.fetch_routes.assert_called_once_with(
+            athlete_id=123,
+            per_page=50,
+            max_pages=2,
+        )
+        self.assertEqual(result, [])
+
+    def test_fetch_routes_translates_strava_client_error(self):
+        from qfit.providers.infrastructure.strava_client import StravaClientError
+
+        provider = self._make_provider()
+        provider._client.fetch_routes.side_effect = StravaClientError("route API error")
+
+        with self.assertRaises(ProviderError) as ctx:
+            provider.fetch_routes()
+
+        self.assertIn("route API error", str(ctx.exception))
+
+    def test_fetch_route_detail_delegates_to_client(self):
+        provider = self._make_provider()
+        provider._client.fetch_route_detail.return_value = object()
+
+        result = provider.fetch_route_detail(42)
+
+        provider._client.fetch_route_detail.assert_called_once_with(42)
+        self.assertIs(result, provider._client.fetch_route_detail.return_value)
+
+    def test_fetch_route_detail_translates_strava_client_error(self):
+        from qfit.providers.infrastructure.strava_client import StravaClientError
+
+        provider = self._make_provider()
+        provider._client.fetch_route_detail.side_effect = StravaClientError("bad route")
+
+        with self.assertRaises(ProviderError) as ctx:
+            provider.fetch_route_detail(42)
+
+        self.assertIn("bad route", str(ctx.exception))
+
+
 class TestStravaProviderProperties(unittest.TestCase):
     """last_stream_enrichment_stats and last_rate_limit proxy to the client."""
 


### PR DESCRIPTION
## Summary

- Add a provider-domain `SavedRoute` model for Strava saved/planned routes.
- Add Strava client support for resolving the authenticated athlete, paginating saved routes, and fetching individual route details.
- Expose route fetch helpers through `StravaProvider` without mixing routes into activity sync.

Part of #733. This is the first route-catalog slice; GeoPackage persistence, GPX/profile parsing, and QGIS route-layer loading remain follow-up work.

## Validation

- `python3 -m pytest tests/test_strava_client.py tests/test_strava_provider.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
