### PR TITLE
feat: parse Strava route GPX geometry

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,13 +1,23 @@
 """Provider feature package."""
 
-from .domain import ActivityProvider, ProviderError, SavedRoute
+from .domain import (
+    ActivityProvider,
+    ProviderError,
+    RouteGpxParseError,
+    RouteProfilePoint,
+    SavedRoute,
+    parse_route_gpx,
+)
 from .infrastructure import StravaClient, StravaClientError, StravaProvider
 
 __all__ = [
     "ActivityProvider",
     "ProviderError",
+    "RouteGpxParseError",
+    "RouteProfilePoint",
     "SavedRoute",
     "StravaClient",
     "StravaClientError",
     "StravaProvider",
+    "parse_route_gpx",
 ]

--- a/providers/domain/__init__.py
+++ b/providers/domain/__init__.py
@@ -1,6 +1,14 @@
 """Provider domain contracts."""
 
 from .provider import ActivityProvider, ProviderError
-from .routes import SavedRoute
+from .route_gpx import RouteGpxParseError, parse_route_gpx
+from .routes import RouteProfilePoint, SavedRoute
 
-__all__ = ["ActivityProvider", "ProviderError", "SavedRoute"]
+__all__ = [
+    "ActivityProvider",
+    "ProviderError",
+    "RouteGpxParseError",
+    "RouteProfilePoint",
+    "SavedRoute",
+    "parse_route_gpx",
+]

--- a/providers/domain/route_gpx.py
+++ b/providers/domain/route_gpx.py
@@ -1,0 +1,130 @@
+from math import atan2, cos, radians, sin, sqrt
+from typing import Optional
+from xml.parsers import expat
+
+from .routes import RouteProfilePoint
+
+
+class RouteGpxParseError(ValueError):
+    pass
+
+
+def parse_route_gpx(gpx_text: str) -> list[RouteProfilePoint]:
+    if not gpx_text:
+        return []
+
+    raw_points: list[tuple[float, float, Optional[float]]] = []
+    current_point: dict[str, object] | None = None
+    element_stack: list[str] = []
+    elevation_chunks: list[str] = []
+
+    def start_element(name, attrs):
+        nonlocal current_point, elevation_chunks
+        local_name = _local_name(name)
+        element_stack.append(local_name)
+        if local_name in {"trkpt", "rtept"}:
+            current_point = {
+                "lat": _parse_required_float(attrs.get("lat"), "lat"),
+                "lon": _parse_required_float(attrs.get("lon"), "lon"),
+                "ele": None,
+            }
+            elevation_chunks = []
+        elif current_point is not None and local_name == "ele":
+            elevation_chunks = []
+
+    def character_data(data):
+        if (
+            current_point is not None
+            and element_stack
+            and element_stack[-1] == "ele"
+        ):
+            elevation_chunks.append(data)
+
+    def end_element(name):
+        nonlocal current_point, elevation_chunks
+        local_name = _local_name(name)
+        if current_point is not None and local_name == "ele":
+            elevation_text = "".join(elevation_chunks).strip()
+            current_point["ele"] = (
+                float(elevation_text) if elevation_text else None
+            )
+        elif current_point is not None and local_name in {"trkpt", "rtept"}:
+            raw_points.append(
+                (
+                    float(current_point["lat"]),
+                    float(current_point["lon"]),
+                    current_point["ele"],
+                )
+            )
+            current_point = None
+            elevation_chunks = []
+        if element_stack:
+            element_stack.pop()
+
+    parser = expat.ParserCreate(namespace_separator=" ")
+    parser.StartElementHandler = start_element
+    parser.CharacterDataHandler = character_data
+    parser.EndElementHandler = end_element
+
+    try:
+        parser.Parse(gpx_text, True)
+    except (expat.ExpatError, TypeError, ValueError) as exc:
+        raise RouteGpxParseError("Invalid route GPX") from exc
+
+    return _profile_points(raw_points)
+
+
+def _profile_points(
+    raw_points: list[tuple[float, float, Optional[float]]],
+) -> list[RouteProfilePoint]:
+    profile_points: list[RouteProfilePoint] = []
+    previous: tuple[float, float] | None = None
+    cumulative_distance_m = 0.0
+
+    for index, (lat, lon, altitude_m) in enumerate(raw_points):
+        if previous is not None:
+            cumulative_distance_m += _haversine_distance_m(
+                previous[0],
+                previous[1],
+                lat,
+                lon,
+            )
+        profile_points.append(
+            RouteProfilePoint(
+                point_index=index,
+                lat=lat,
+                lon=lon,
+                distance_m=cumulative_distance_m,
+                altitude_m=altitude_m,
+            )
+        )
+        previous = (lat, lon)
+
+    return profile_points
+
+
+def _parse_required_float(value, field_name):
+    if value is None:
+        raise RouteGpxParseError(
+            "GPX point missing {field_name}".format(field_name=field_name)
+        )
+    return float(value)
+
+
+def _local_name(name):
+    return str(name).split(" ")[-1]
+
+
+def _haversine_distance_m(lat_a, lon_a, lat_b, lon_b):
+    earth_radius_m = 6371000.0
+    lat_a_rad = radians(lat_a)
+    lat_b_rad = radians(lat_b)
+    delta_lat = radians(lat_b - lat_a)
+    delta_lon = radians(lon_b - lon_a)
+
+    haversine = (
+        sin(delta_lat / 2) ** 2
+        + cos(lat_a_rad) * cos(lat_b_rad) * sin(delta_lon / 2) ** 2
+    )
+    central_angle = 2 * atan2(sqrt(haversine), sqrt(1 - haversine))
+    return earth_radius_m * central_angle

--- a/providers/domain/route_gpx.py
+++ b/providers/domain/route_gpx.py
@@ -13,20 +13,29 @@ def parse_route_gpx(gpx_text: str) -> list[RouteProfilePoint]:
     if not gpx_text:
         return []
 
-    raw_points: list[tuple[float, float, Optional[float]]] = []
+    raw_points: list[tuple[float, float, Optional[float], int]] = []
     current_point: dict[str, object] | None = None
+    current_segment_index = 0
+    seen_track_segment = False
     element_stack: list[str] = []
     elevation_chunks: list[str] = []
 
     def start_element(name, attrs):
-        nonlocal current_point, elevation_chunks
+        nonlocal current_point, current_segment_index, elevation_chunks
+        nonlocal seen_track_segment
         local_name = _local_name(name)
         element_stack.append(local_name)
-        if local_name in {"trkpt", "rtept"}:
+        if local_name == "trkseg":
+            if seen_track_segment:
+                current_segment_index += 1
+            else:
+                seen_track_segment = True
+        elif local_name in {"trkpt", "rtept"}:
             current_point = {
                 "lat": _parse_required_float(attrs.get("lat"), "lat"),
                 "lon": _parse_required_float(attrs.get("lon"), "lon"),
                 "ele": None,
+                "segment_index": current_segment_index,
             }
             elevation_chunks = []
         elif current_point is not None and local_name == "ele":
@@ -54,6 +63,7 @@ def parse_route_gpx(gpx_text: str) -> list[RouteProfilePoint]:
                     float(current_point["lat"]),
                     float(current_point["lon"]),
                     current_point["ele"],
+                    int(current_point["segment_index"]),
                 )
             )
             current_point = None
@@ -68,6 +78,8 @@ def parse_route_gpx(gpx_text: str) -> list[RouteProfilePoint]:
 
     try:
         parser.Parse(gpx_text, True)
+    except RouteGpxParseError:
+        raise
     except (expat.ExpatError, TypeError, ValueError) as exc:
         raise RouteGpxParseError("Invalid route GPX") from exc
 
@@ -75,14 +87,15 @@ def parse_route_gpx(gpx_text: str) -> list[RouteProfilePoint]:
 
 
 def _profile_points(
-    raw_points: list[tuple[float, float, Optional[float]]],
+    raw_points: list[tuple[float, float, Optional[float], int]],
 ) -> list[RouteProfilePoint]:
     profile_points: list[RouteProfilePoint] = []
     previous: tuple[float, float] | None = None
+    previous_segment_index: int | None = None
     cumulative_distance_m = 0.0
 
-    for index, (lat, lon, altitude_m) in enumerate(raw_points):
-        if previous is not None:
+    for index, (lat, lon, altitude_m, segment_index) in enumerate(raw_points):
+        if previous is not None and previous_segment_index == segment_index:
             cumulative_distance_m += _haversine_distance_m(
                 previous[0],
                 previous[1],
@@ -95,10 +108,12 @@ def _profile_points(
                 lat=lat,
                 lon=lon,
                 distance_m=cumulative_distance_m,
+                segment_index=segment_index,
                 altitude_m=altitude_m,
             )
         )
         previous = (lat, lon)
+        previous_segment_index = segment_index
 
     return profile_points
 

--- a/providers/domain/routes.py
+++ b/providers/domain/routes.py
@@ -2,6 +2,15 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 
+@dataclass(frozen=True)
+class RouteProfilePoint:
+    point_index: int
+    lat: float
+    lon: float
+    distance_m: float
+    altitude_m: Optional[float] = None
+
+
 @dataclass
 class SavedRoute:
     source: str
@@ -21,6 +30,7 @@ class SavedRoute:
     summary_polyline: Optional[str] = None
     geometry_source: Optional[str] = None
     geometry_points: List[Tuple[float, float]] = field(default_factory=list)
+    profile_points: List[RouteProfilePoint] = field(default_factory=list)
     details_json: Dict[str, Any] = field(default_factory=dict)
 
     def to_record(self) -> Dict[str, Any]:

--- a/providers/domain/routes.py
+++ b/providers/domain/routes.py
@@ -8,6 +8,7 @@ class RouteProfilePoint:
     lat: float
     lon: float
     distance_m: float
+    segment_index: int = 0
     altitude_m: Optional[float] = None
 
 

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -79,6 +79,7 @@ from ...detailed_route_strategy import (
     DEFAULT_DETAILED_ROUTE_STRATEGY,
     DETAILED_ROUTE_STRATEGY_RECENT,
 )
+from ..domain.route_gpx import RouteGpxParseError, parse_route_gpx
 from ..domain.routes import SavedRoute
 
 
@@ -94,6 +95,7 @@ class StravaClient:
     STREAMS_URL_TEMPLATE = "https://www.strava.com/api/v3/activities/{activity_id}/streams"
     ROUTES_URL_TEMPLATE = "https://www.strava.com/api/v3/athletes/{athlete_id}/routes"
     ROUTE_DETAIL_URL_TEMPLATE = "https://www.strava.com/api/v3/routes/{route_id}"
+    ROUTE_GPX_URL_TEMPLATE = "https://www.strava.com/api/v3/routes/{route_id}/export_gpx"
     DEFAULT_NETWORK_RETRY_ATTEMPTS = 3
     MIN_ACTIVITY_PAGE_SIZE = 5
     FULL_SYNC_MIN_SHORT_REMAINING = 3
@@ -305,7 +307,7 @@ class StravaClient:
             raise StravaClientError("Strava did not return an authenticated athlete id")
         return athlete_id
 
-    def fetch_route_detail(self, route_id):
+    def fetch_route_detail(self, route_id, use_gpx_geometry=False):
         token = self.get_access_token()
         payload = self._request_json(
             self.ROUTE_DETAIL_URL_TEMPLATE.format(route_id=route_id),
@@ -316,7 +318,25 @@ class StravaClient:
             raise StravaClientError(
                 "Fetching Strava route {route_id} returned an unexpected response".format(route_id=route_id)
             )
-        return self.normalize_route(payload)
+        route = self.normalize_route(payload)
+        if use_gpx_geometry:
+            self.enrich_route_with_gpx(route)
+        return route
+
+    def fetch_route_gpx(self, route_id):
+        token = self.get_access_token()
+        return self._request_text(
+            self.ROUTE_GPX_URL_TEMPLATE.format(route_id=route_id),
+            headers=self._build_request_headers(token=token, accept="application/gpx+xml, application/xml, text/xml"),
+            operation="Fetching Strava route {route_id} GPX".format(route_id=route_id),
+        )
+
+    def enrich_route_with_gpx(self, route):
+        gpx_text = self.fetch_route_gpx(route.source_route_id)
+        if self._apply_route_gpx_to_route(route, gpx_text):
+            return route
+        route.details_json["gpx_geometry_status"] = "empty"
+        return route
 
     def _fetch_activity_page(self, token, page, per_page, current_before, after, max_pages):
         while True:
@@ -546,9 +566,9 @@ class StravaClient:
         )
         return self._extract_stream_bundle(payload)
 
-    def _build_request_headers(self, token=None, content_type=None):
+    def _build_request_headers(self, token=None, content_type=None, accept="application/json"):
         headers = {
-            "Accept": "application/json",
+            "Accept": accept,
             "Connection": "close",
             "User-Agent": "qfit/{version}".format(version=self._plugin_version()),
         }
@@ -646,6 +666,29 @@ class StravaClient:
                 "distance_m": activity.distance_m,
             },
         )
+
+    def _apply_route_gpx_to_route(self, route, gpx_text):
+        try:
+            profile_points = parse_route_gpx(gpx_text)
+        except RouteGpxParseError as exc:
+            raise StravaClientError("Strava route GPX was invalid") from exc
+        if not profile_points:
+            return False
+
+        route.profile_points = profile_points
+        route.geometry_points = [(point.lat, point.lon) for point in profile_points]
+        route.geometry_source = "export_gpx"
+        route.details_json["gpx_geometry_status"] = "downloaded"
+        route.details_json["gpx_point_count"] = len(profile_points)
+        route.details_json["gpx_enriched_at"] = datetime.now(UTC).isoformat()
+        altitude_values = [point.altitude_m for point in profile_points if point.altitude_m is not None]
+        if altitude_values:
+            route.details_json["gpx_min_altitude_m"] = min(altitude_values)
+            route.details_json["gpx_max_altitude_m"] = max(altitude_values)
+        else:
+            route.details_json.pop("gpx_min_altitude_m", None)
+            route.details_json.pop("gpx_max_altitude_m", None)
+        return True
 
     def _apply_stream_bundle_to_activity(self, activity, stream_bundle):
         points = self._extract_stream_points(stream_bundle)
@@ -809,6 +852,31 @@ class StravaClient:
         return value[0], value[1]
 
     def _request_json(self, url, method="GET", data=None, headers=None, operation="Request to Strava"):
+        response = self._request_response(
+            url,
+            method=method,
+            data=data,
+            headers=headers,
+            operation=operation,
+        )
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise StravaClientError(
+                "{operation} returned invalid JSON: {exc}".format(operation=operation, exc=exc)
+            ) from exc
+
+    def _request_text(self, url, method="GET", data=None, headers=None, operation="Request to Strava"):
+        response = self._request_response(
+            url,
+            method=method,
+            data=data,
+            headers=headers,
+            operation=operation,
+        )
+        return response.text
+
+    def _request_response(self, url, method="GET", data=None, headers=None, operation="Request to Strava"):
         attempts = max(1, int(self.DEFAULT_NETWORK_RETRY_ATTEMPTS))
         last_error = None
 
@@ -817,7 +885,7 @@ class StravaClient:
                 response = self.session.request(method=method, url=url, data=data, headers=headers, timeout=60)
                 self.last_rate_limit = self._extract_rate_limit(response.headers)
                 response.raise_for_status()
-                return response.json()
+                return response
             except requests.HTTPError as exc:
                 response = getattr(exc, "response", None)
                 status_code = response.status_code if response is not None else "unknown"
@@ -837,10 +905,6 @@ class StravaClient:
                     time.sleep(self._retry_delay_seconds(attempt))
                     continue
                 raise StravaClientError(self._format_network_error(operation, exc, attempts)) from exc
-            except ValueError as exc:
-                raise StravaClientError(
-                    "{operation} returned invalid JSON: {exc}".format(operation=operation, exc=exc)
-                ) from exc
 
         raise StravaClientError(self._format_network_error(operation, last_error, attempts))
 

--- a/providers/infrastructure/strava_provider.py
+++ b/providers/infrastructure/strava_provider.py
@@ -88,10 +88,10 @@ class StravaProvider:
         except StravaClientError as exc:
             raise ProviderError(str(exc)) from exc
 
-    def fetch_route_detail(self, route_id):
+    def fetch_route_detail(self, route_id, use_gpx_geometry=False):
         """Fetch detailed metadata for one Strava route."""
         try:
-            return self._client.fetch_route_detail(route_id)
+            return self._client.fetch_route_detail(route_id, use_gpx_geometry=use_gpx_geometry)
         except StravaClientError as exc:
             raise ProviderError(str(exc)) from exc
 

--- a/tests/test_route_gpx.py
+++ b/tests/test_route_gpx.py
@@ -22,10 +22,31 @@ class RouteGpxParserTests(unittest.TestCase):
         self.assertEqual(points[0].lat, 46.5)
         self.assertEqual(points[0].lon, 6.6)
         self.assertEqual(points[0].altitude_m, 400.5)
+        self.assertEqual(points[0].segment_index, 0)
         self.assertEqual(points[0].distance_m, 0.0)
         self.assertGreater(points[1].distance_m, 90.0)
         self.assertLess(points[1].distance_m, 110.0)
         self.assertEqual(points[1].altitude_m, 410.0)
+
+    def test_does_not_add_synthetic_distance_between_track_segments(self):
+        points = parse_route_gpx(
+            """
+            <gpx><trk>
+              <trkseg>
+                <trkpt lat="46.0" lon="6.0" />
+                <trkpt lat="46.001" lon="6.0" />
+              </trkseg>
+              <trkseg>
+                <trkpt lat="47.0" lon="7.0" />
+                <trkpt lat="47.001" lon="7.0" />
+              </trkseg>
+            </trk></gpx>
+            """
+        )
+
+        self.assertEqual([point.segment_index for point in points], [0, 0, 1, 1])
+        self.assertAlmostEqual(points[2].distance_m, points[1].distance_m)
+        self.assertGreater(points[3].distance_m, points[2].distance_m)
 
     def test_parses_route_points_without_namespace_or_elevation(self):
         points = parse_route_gpx(
@@ -51,6 +72,10 @@ class RouteGpxParserTests(unittest.TestCase):
     def test_invalid_gpx_raises_parse_error(self):
         with self.assertRaises(RouteGpxParseError):
             parse_route_gpx("<gpx><trkpt lat='bad' lon='6.6' /></gpx>")
+
+    def test_missing_coordinate_keeps_specific_parse_error(self):
+        with self.assertRaisesRegex(RouteGpxParseError, "missing lat"):
+            parse_route_gpx("<gpx><trkpt lon='6.6' /></gpx>")
 
 
 if __name__ == "__main__":

--- a/tests/test_route_gpx.py
+++ b/tests/test_route_gpx.py
@@ -1,0 +1,57 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.providers.domain import RouteGpxParseError, parse_route_gpx
+
+
+class RouteGpxParserTests(unittest.TestCase):
+    def test_parses_track_points_with_elevation_and_distance(self):
+        points = parse_route_gpx(
+            """
+            <gpx xmlns="http://www.topografix.com/GPX/1/1">
+              <trk><trkseg>
+                <trkpt lat="46.5000" lon="6.6000"><ele>400.5</ele></trkpt>
+                <trkpt lat="46.5009" lon="6.6000"><ele>410.0</ele></trkpt>
+              </trkseg></trk>
+            </gpx>
+            """
+        )
+
+        self.assertEqual(len(points), 2)
+        self.assertEqual(points[0].point_index, 0)
+        self.assertEqual(points[0].lat, 46.5)
+        self.assertEqual(points[0].lon, 6.6)
+        self.assertEqual(points[0].altitude_m, 400.5)
+        self.assertEqual(points[0].distance_m, 0.0)
+        self.assertGreater(points[1].distance_m, 90.0)
+        self.assertLess(points[1].distance_m, 110.0)
+        self.assertEqual(points[1].altitude_m, 410.0)
+
+    def test_parses_route_points_without_namespace_or_elevation(self):
+        points = parse_route_gpx(
+            """
+            <gpx>
+              <rte>
+                <rtept lat="46.5" lon="6.6" />
+                <rtept lat="46.6" lon="6.7" />
+              </rte>
+            </gpx>
+            """
+        )
+
+        self.assertEqual(
+            [(point.lat, point.lon) for point in points],
+            [(46.5, 6.6), (46.6, 6.7)],
+        )
+        self.assertIsNone(points[0].altitude_m)
+
+    def test_empty_gpx_returns_no_points(self):
+        self.assertEqual(parse_route_gpx(""), [])
+
+    def test_invalid_gpx_raises_parse_error(self):
+        with self.assertRaises(RouteGpxParseError):
+            parse_route_gpx("<gpx><trkpt lat='bad' lon='6.6' /></gpx>")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -298,9 +298,17 @@ class StravaClientTests(unittest.TestCase):
         headers = client._build_request_headers(token="abc", content_type="application/x-www-form-urlencoded")
 
         self.assertEqual(headers["Connection"], "close")
+        self.assertEqual(headers["Accept"], "application/json")
         self.assertEqual(headers["Authorization"], "Bearer abc")
         self.assertEqual(headers["Content-Type"], "application/x-www-form-urlencoded")
         self.assertIn("qfit/", headers["User-Agent"])
+
+    def test_build_request_headers_accepts_custom_accept_header(self):
+        client = StravaClient()
+
+        headers = client._build_request_headers(accept="application/gpx+xml")
+
+        self.assertEqual(headers["Accept"], "application/gpx+xml")
 
     def test_fetch_activities_paginates_until_last_page(self):
         """max_pages=0 should fetch all pages, stopping when a short page is received."""
@@ -461,6 +469,60 @@ class StravaClientTests(unittest.TestCase):
 
         with self.assertRaisesRegex(StravaClientError, "unexpected response"):
             client.fetch_route_detail(42)
+
+    def test_fetch_route_gpx_uses_export_endpoint(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        seen = []
+
+        def fake_request_text(request, operation=None, headers=None, **kwargs):
+            seen.append((request, headers, operation))
+            return "<gpx />"
+
+        client.access_token = "fake_token"
+        client._request_text = fake_request_text
+
+        gpx = client.fetch_route_gpx(42)
+
+        self.assertEqual(gpx, "<gpx />")
+        self.assertEqual(seen[0][0], "https://www.strava.com/api/v3/routes/42/export_gpx")
+        self.assertIn("application/gpx+xml", seen[0][1]["Accept"])
+        self.assertEqual(seen[0][2], "Fetching Strava route 42 GPX")
+
+    def test_fetch_route_detail_can_enrich_with_gpx_geometry(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        call_count = [0]
+
+        def fake_request_json(request, operation=None, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return {"access_token": "fake_token"}
+            return {"id": 42, "name": "Detailed route"}
+
+        client._request_json = fake_request_json
+        client._request_text = lambda *args, **kwargs: """
+            <gpx><trk><trkseg>
+              <trkpt lat="46.5" lon="6.6"><ele>400</ele></trkpt>
+              <trkpt lat="46.6" lon="6.7"><ele>450</ele></trkpt>
+            </trkseg></trk></gpx>
+        """
+
+        route = client.fetch_route_detail(42, use_gpx_geometry=True)
+
+        self.assertEqual(route.geometry_source, "export_gpx")
+        self.assertEqual(route.geometry_points, [(46.5, 6.6), (46.6, 6.7)])
+        self.assertEqual(len(route.profile_points), 2)
+        self.assertEqual(route.details_json["gpx_geometry_status"], "downloaded")
+        self.assertEqual(route.details_json["gpx_point_count"], 2)
+        self.assertEqual(route.details_json["gpx_min_altitude_m"], 400.0)
+        self.assertEqual(route.details_json["gpx_max_altitude_m"], 450.0)
+
+    def test_apply_route_gpx_reports_invalid_gpx_as_client_error(self):
+        client = StravaClient()
+        route = client.normalize_route({"id": 42, "name": "Detailed route"})
+
+        with self.assertRaisesRegex(StravaClientError, "GPX was invalid"):
+            client._apply_route_gpx_to_route(route, "<gpx><trkpt lat='bad' lon='6.6' /></gpx>")
 
     def test_fetch_activities_full_sync_uses_before_cursor(self):
         client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")

--- a/tests/test_strava_provider.py
+++ b/tests/test_strava_provider.py
@@ -101,9 +101,9 @@ class TestStravaProviderFetchRoutes(unittest.TestCase):
         provider = self._make_provider()
         provider._client.fetch_route_detail.return_value = object()
 
-        result = provider.fetch_route_detail(42)
+        result = provider.fetch_route_detail(42, use_gpx_geometry=True)
 
-        provider._client.fetch_route_detail.assert_called_once_with(42)
+        provider._client.fetch_route_detail.assert_called_once_with(42, use_gpx_geometry=True)
         self.assertIs(result, provider._client.fetch_route_detail.return_value)
 
     def test_fetch_route_detail_translates_strava_client_error(self):


### PR DESCRIPTION
## Summary

- Add pure GPX parsing for Strava saved-route exports into ordered route profile points.
- Add route profile points to `SavedRoute` and apply GPX geometry/elevation metadata without mixing routes into activity sync.
- Add Strava route GPX export fetching and optional route-detail enrichment via `use_gpx_geometry`.

Part of #733. This is the detailed-geometry client/parser slice; GeoPackage route persistence and QGIS route-layer loading remain follow-up work.

## Validation

- `python3 -m pytest tests/test_route_gpx.py tests/test_strava_client.py tests/test_strava_provider.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
