### PR TITLE
feat: build route catalog layers

### DIFF
--- a/activities/infrastructure/geopackage/gpkg_route_layer_builders.py
+++ b/activities/infrastructure/geopackage/gpkg_route_layer_builders.py
@@ -1,0 +1,222 @@
+"""
+GeoPackage route catalog layer builders for qfit.
+
+This module builds in-memory QGIS layers for saved/planned routes.  It does
+not perform GeoPackage I/O; storage orchestration can write the returned layers
+once route catalog persistence is wired in.
+"""
+
+import json
+
+from qgis.core import (
+    QgsFeature,
+    QgsGeometry,
+    QgsPointXY,
+    QgsVectorLayer,
+)
+
+from .gpkg_schema import (
+    ROUTE_POINT_FIELDS,
+    ROUTE_TRACK_FIELDS,
+    make_qgs_fields,
+)
+from ....polyline_utils import decode_polyline
+
+__all__ = [
+    "build_route_point_layer",
+    "build_route_track_layer",
+    "route_feature_key",
+    "_route_geometry",
+]
+
+
+def build_route_track_layer(records):
+    """Build and return a memory ``QgsVectorLayer`` of saved route tracks."""
+    layer = QgsVectorLayer(
+        "LineString?crs=EPSG:4326",
+        "route_tracks",
+        "memory",
+    )
+    provider = layer.dataProvider()
+    provider.addAttributes(make_qgs_fields(ROUTE_TRACK_FIELDS))
+    layer.updateFields()
+
+    features = []
+    for record in records:
+        geometry, geometry_source, geometry_point_count = _route_geometry(
+            record
+        )
+        route_key = route_feature_key(record)
+        if geometry is None or route_key is None:
+            continue
+
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(geometry)
+        feature["route_fk"] = route_key
+        feature["source"] = record.get("source")
+        feature["source_route_id"] = record.get("source_route_id")
+        feature["external_id"] = record.get("external_id")
+        feature["name"] = record.get("name")
+        feature["description"] = record.get("description")
+        feature["private"] = _bool_as_int(record.get("private"))
+        feature["starred"] = _bool_as_int(record.get("starred"))
+        feature["distance_m"] = record.get("distance_m")
+        feature["elevation_gain_m"] = record.get("elevation_gain_m")
+        feature["estimated_moving_time_s"] = record.get(
+            "estimated_moving_time_s"
+        )
+        feature["route_type"] = record.get("route_type")
+        feature["sub_type"] = record.get("sub_type")
+        feature["created_at"] = record.get("created_at")
+        feature["updated_at"] = record.get("updated_at")
+        feature["summary_polyline"] = record.get("summary_polyline")
+        feature["geometry_source"] = geometry_source
+        feature["geometry_point_count"] = geometry_point_count
+        feature["details_json"] = json.dumps(
+            record.get("details_json") or {},
+            sort_keys=True,
+        )
+        features.append(feature)
+
+    provider.addFeatures(features)
+    layer.updateExtents()
+    return layer
+
+
+def build_route_point_layer(records):
+    """Build and return a memory ``QgsVectorLayer`` of saved route samples."""
+    layer = QgsVectorLayer("Point?crs=EPSG:4326", "route_points", "memory")
+    provider = layer.dataProvider()
+    provider.addAttributes(make_qgs_fields(ROUTE_POINT_FIELDS))
+    layer.updateFields()
+
+    features = []
+    for record in records:
+        route_key = route_feature_key(record)
+        if route_key is None:
+            continue
+
+        track_geometry, _, _ = _route_geometry(record)
+        if track_geometry is None:
+            continue
+
+        profile_points = record.get("profile_points") or []
+        for point in profile_points:
+            lat = _point_value(point, "lat")
+            lon = _point_value(point, "lon")
+            if lat is None or lon is None:
+                continue
+
+            feature = QgsFeature(layer.fields())
+            feature.setGeometry(
+                QgsGeometry.fromPointXY(QgsPointXY(float(lon), float(lat)))
+            )
+            feature["route_fk"] = route_key
+            feature["source"] = record.get("source")
+            feature["source_route_id"] = record.get("source_route_id")
+            feature["name"] = record.get("name")
+            feature["point_index"] = _point_value(point, "point_index")
+            feature["segment_index"] = (
+                _point_value(point, "segment_index") or 0
+            )
+            feature["distance_m"] = _point_value(point, "distance_m")
+            feature["altitude_m"] = _point_value(point, "altitude_m")
+            feature["geometry_source"] = (
+                record.get("geometry_source") or "profile"
+            )
+            features.append(feature)
+
+    provider.addFeatures(features)
+    layer.updateExtents()
+    return layer
+
+
+def route_feature_key(record):
+    """Return the stable feature key used to join route tracks and samples."""
+    source = record.get("source")
+    source_route_id = record.get("source_route_id")
+    if source in (None, "") or source_route_id in (None, ""):
+        return None
+    return json.dumps(
+        [str(source), str(source_route_id)],
+        separators=(",", ":"),
+    )
+
+
+def _route_geometry(record):
+    profile_points = record.get("profile_points") or []
+    geometry, point_count = _geometry_from_profile_points(profile_points)
+    if geometry is not None:
+        return (
+            geometry,
+            record.get("geometry_source") or "profile",
+            point_count,
+        )
+
+    geometry_points = record.get("geometry_points") or []
+    geometry, point_count = _geometry_from_lat_lon_pairs(geometry_points)
+    if geometry is not None:
+        return (
+            geometry,
+            record.get("geometry_source") or "geometry_points",
+            point_count,
+        )
+
+    polyline_points = decode_polyline(record.get("summary_polyline"))
+    geometry, point_count = _geometry_from_lat_lon_pairs(polyline_points)
+    if geometry is not None:
+        return (
+            geometry,
+            record.get("geometry_source") or "summary_polyline",
+            point_count,
+        )
+
+    geometry = _fallback_route_geometry(record)
+    if geometry is not None:
+        return geometry, record.get("geometry_source") or "start_end", 2
+
+    return None, None, 0
+
+
+def _geometry_from_profile_points(points):
+    lat_lon_pairs = [
+        (_point_value(point, "lat"), _point_value(point, "lon"))
+        for point in points
+    ]
+    return _geometry_from_lat_lon_pairs(lat_lon_pairs)
+
+
+def _geometry_from_lat_lon_pairs(points):
+    valid_points = [
+        QgsPointXY(float(lon), float(lat))
+        for lat, lon in points
+        if lat is not None and lon is not None
+    ]
+    if len(valid_points) < 2:
+        return None, len(valid_points)
+    return QgsGeometry.fromPolylineXY(valid_points), len(valid_points)
+
+
+def _fallback_route_geometry(record):
+    start_lat = record.get("start_lat")
+    start_lon = record.get("start_lon")
+    end_lat = record.get("end_lat")
+    end_lon = record.get("end_lon")
+    if None in (start_lat, start_lon, end_lat, end_lon):
+        return None
+    return QgsGeometry.fromPolylineXY([
+        QgsPointXY(start_lon, start_lat),
+        QgsPointXY(end_lon, end_lat),
+    ])
+
+
+def _point_value(point, key):
+    if isinstance(point, dict):
+        return point.get(key)
+    return getattr(point, key, None)
+
+
+def _bool_as_int(value):
+    if value is None:
+        return None
+    return int(bool(value))

--- a/activities/infrastructure/geopackage/gpkg_schema.py
+++ b/activities/infrastructure/geopackage/gpkg_schema.py
@@ -4,7 +4,8 @@ GeoPackage schema definitions for qfit.
 This module owns:
 
 - Field-definition constants for every layer and table written to the .gpkg
-- ``make_qgs_fields`` — converts a field-definition list to a ``QgsFields`` object
+- ``make_qgs_fields`` — converts a field-definition list to a ``QgsFields``
+  object
 - ``GPKG_LAYER_SCHEMA`` — the authoritative description of every layer/table in
   the file (geometry type, kind, field names, primary-key hints)
 
@@ -91,6 +92,40 @@ POINT_FIELDS = [
     ("distance_m", QVariant.Double),
     ("geometry_source", QVariant.String),
     ("last_synced_at", QVariant.String),
+]
+
+ROUTE_TRACK_FIELDS = [
+    ("route_fk", QVariant.String),
+    ("source", QVariant.String),
+    ("source_route_id", QVariant.String),
+    ("external_id", QVariant.String),
+    ("name", QVariant.String),
+    ("description", QVariant.String),
+    ("private", QVariant.Int),
+    ("starred", QVariant.Int),
+    ("distance_m", QVariant.Double),
+    ("elevation_gain_m", QVariant.Double),
+    ("estimated_moving_time_s", QVariant.Int),
+    ("route_type", QVariant.Int),
+    ("sub_type", QVariant.Int),
+    ("created_at", QVariant.String),
+    ("updated_at", QVariant.String),
+    ("summary_polyline", QVariant.String),
+    ("geometry_source", QVariant.String),
+    ("geometry_point_count", QVariant.Int),
+    ("details_json", QVariant.String),
+]
+
+ROUTE_POINT_FIELDS = [
+    ("route_fk", QVariant.String),
+    ("source", QVariant.String),
+    ("source_route_id", QVariant.String),
+    ("name", QVariant.String),
+    ("point_index", QVariant.Int),
+    ("segment_index", QVariant.Int),
+    ("distance_m", QVariant.Double),
+    ("altitude_m", QVariant.Double),
+    ("geometry_source", QVariant.String),
 ]
 
 ATLAS_FIELDS = [
@@ -247,6 +282,16 @@ GPKG_LAYER_SCHEMA = {
         "geometry": "POINT",
         "kind": "layer",
         "fields": [name for name, _ in POINT_FIELDS],
+    },
+    "route_tracks": {
+        "geometry": "LINESTRING",
+        "kind": "layer",
+        "fields": [name for name, _ in ROUTE_TRACK_FIELDS],
+    },
+    "route_points": {
+        "geometry": "POINT",
+        "kind": "layer",
+        "fields": [name for name, _ in ROUTE_POINT_FIELDS],
     },
     "activity_atlas_pages": {
         "geometry": "POLYGON",

--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -24,6 +24,10 @@ from .gpkg_layer_builders import (
     build_track_layer,
 )
 from .gpkg_point_layer_builder import build_point_layer
+from .gpkg_route_layer_builders import (
+    build_route_point_layer,
+    build_route_track_layer,
+)
 from .gpkg_atlas_table_builders import (
     build_cover_highlight_layer,
     build_document_summary_layer,
@@ -109,6 +113,8 @@ def bootstrap_empty_gpkg(output_path, atlas_page_settings):
     write_layer_to_gpkg(build_track_layer([]), output_path, "activity_tracks", overwrite_file=True)
     write_layer_to_gpkg(build_start_layer([]), output_path, "activity_starts", overwrite_file=False)
     write_layer_to_gpkg(build_point_layer([]), output_path, "activity_points", overwrite_file=False)
+    write_layer_to_gpkg(build_route_track_layer([]), output_path, "route_tracks", overwrite_file=False)
+    write_layer_to_gpkg(build_route_point_layer([]), output_path, "route_points", overwrite_file=False)
     write_layer_to_gpkg(
         build_atlas_layer([], atlas_page_settings),
         output_path, "activity_atlas_pages", overwrite_file=False,
@@ -136,6 +142,8 @@ def build_and_write_all_layers(
         "activity_tracks": build_track_layer(records),
         "activity_starts": build_start_layer(records),
         "activity_points": build_point_layer(records, write_activity_points, point_stride),
+        "route_tracks": build_route_track_layer([]),
+        "route_points": build_route_point_layer([]),
         "activity_atlas_pages": build_atlas_layer(records, atlas_page_settings, plans=plans),
         "atlas_document_summary": build_document_summary_layer(plans=plans),
         "atlas_cover_highlights": build_cover_highlight_layer(plans=plans),

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,5 +6,5 @@ sonar.sources=.
 sonar.tests=tests
 sonar.exclusions=dist/**,.git/**,.github/**,__pycache__/**,*.pyc,tests/**
 sonar.test.inclusions=tests/**/*.py
-sonar.coverage.exclusions=__init__.py,gpkg_atlas_table_builders.py,gpkg_io.py,gpkg_layer_builders.py,gpkg_point_layer_builder.py,gpkg_schema.py,gpkg_write_orchestration.py,gpkg_writer.py,layer_manager.py,layer_style_service.py,qfit_config_dialog.py,qfit_dockwidget.py,qfit_plugin.py,scripts/**/*.py,validation_artifacts/**/*.py
+sonar.coverage.exclusions=__init__.py,gpkg_atlas_table_builders.py,gpkg_io.py,gpkg_layer_builders.py,gpkg_point_layer_builder.py,gpkg_route_layer_builders.py,gpkg_schema.py,gpkg_write_orchestration.py,gpkg_writer.py,layer_manager.py,layer_style_service.py,qfit_config_dialog.py,qfit_dockwidget.py,qfit_plugin.py,scripts/**/*.py,validation_artifacts/**/*.py,activities/infrastructure/geopackage/gpkg_route_layer_builders.py,activities/infrastructure/geopackage/gpkg_schema.py
 sonar.python.coverage.reportPaths=coverage.xml

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -173,6 +173,12 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 stride,
             )
         )
+        build_route_track_layer = MagicMock(
+            side_effect=lambda records: ("route_tracks", tuple(records))
+        )
+        build_route_point_layer = MagicMock(
+            side_effect=lambda records: ("route_points", tuple(records))
+        )
         build_atlas_layer = MagicMock(
             side_effect=lambda records, settings, plans=None: (
                 "atlas",
@@ -223,6 +229,11 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 "qfit.activities.infrastructure.geopackage.gpkg_point_layer_builder",
                 build_point_layer=build_point_layer,
             ),
+            "qfit.activities.infrastructure.geopackage.gpkg_route_layer_builders": self._module(
+                "qfit.activities.infrastructure.geopackage.gpkg_route_layer_builders",
+                build_route_track_layer=build_route_track_layer,
+                build_route_point_layer=build_route_point_layer,
+            ),
             "qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder": self._module(
                 "qfit.activities.infrastructure.geopackage.gpkg_atlas_page_builder",
                 build_atlas_layer=build_atlas_layer,
@@ -252,10 +263,18 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
             )
 
             moved.bootstrap_empty_gpkg("/tmp/bootstrap.gpkg", {"margin_percent": 8})
-            self.assertEqual(write_layer_to_gpkg.call_count, 9)
+            self.assertEqual(write_layer_to_gpkg.call_count, 11)
             self.assertEqual(
                 write_layer_to_gpkg.mock_calls[0],
                 call(("tracks", ()), "/tmp/bootstrap.gpkg", "activity_tracks", overwrite_file=True),
+            )
+            self.assertIn(
+                call(("route_tracks", ()), "/tmp/bootstrap.gpkg", "route_tracks", overwrite_file=False),
+                write_layer_to_gpkg.mock_calls,
+            )
+            self.assertIn(
+                call(("route_points", ()), "/tmp/bootstrap.gpkg", "route_points", overwrite_file=False),
+                write_layer_to_gpkg.mock_calls,
             )
             self.assertEqual(
                 write_layer_to_gpkg.mock_calls[-1],
@@ -334,11 +353,13 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
                 build_atlas_page_plans.assert_called_once_with(
                     [{"name": "Evening Run"}], settings={"margin_percent": 10}
                 )
-                self.assertEqual(write_layer_to_gpkg.call_count, 9)
+                self.assertEqual(write_layer_to_gpkg.call_count, 11)
                 self.assertEqual(
                     layers["activity_points"],
                     ("points", ({"name": "Evening Run"},), True, 3),
                 )
+                self.assertEqual(layers["route_tracks"], ("route_tracks", ()))
+                self.assertEqual(layers["route_points"], ("route_points", ()))
                 self.assertEqual(layers["atlas_toc_entries"], ("toc", ({"name": "Evening Run"},), {"margin_percent": 10}, [{"page": 1}]))
                 self.assertEqual(sqlite_connect.call_args, call("/tmp/full.gpkg"))
                 self.assertIn(

--- a/tests/test_gpkg_route_layer_builders.py
+++ b/tests/test_gpkg_route_layer_builders.py
@@ -1,0 +1,321 @@
+import importlib.util
+import os
+import sys
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from tests import _path  # noqa: E402,F401
+from tests.qgis_app import get_shared_qgis_app  # noqa: E402
+from qfit.providers.domain.routes import RouteProfilePoint  # noqa: E402
+
+try:
+    _REAL_QGIS_PRESENT = importlib.util.find_spec("qgis") is not None
+except ValueError:
+    _REAL_QGIS_PRESENT = any(
+        os.path.isdir(os.path.join(p, "qgis")) for p in sys.path if p
+    )
+
+try:
+    from qgis.core import QgsApplication
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    QgsApplication = None
+
+if QgsApplication is not None and _REAL_QGIS_PRESENT:
+    from qfit.activities.infrastructure.geopackage import (  # noqa: E501
+        gpkg_route_layer_builders as route_builders,
+    )
+
+    _route_geometry = route_builders._route_geometry
+    build_route_point_layer = route_builders.build_route_point_layer
+    build_route_track_layer = route_builders.build_route_track_layer
+    route_feature_key = route_builders.route_feature_key
+else:  # pragma: no cover
+    _route_geometry = None
+    build_route_point_layer = None
+    build_route_track_layer = None
+    route_feature_key = None
+
+
+def _ensure_qgis_app():
+    if not _REAL_QGIS_PRESENT:
+        raise unittest.SkipTest("QGIS Python bindings are not available")
+
+    global QgsApplication
+    global _route_geometry
+    global build_route_point_layer
+    global build_route_track_layer
+    global route_feature_key
+    if QgsApplication is None and _REAL_QGIS_PRESENT:
+        for module_name in [
+            "qgis.core",
+            "qgis.gui",
+            "qgis.PyQt",
+            "qgis.PyQt.QtCore",
+            "qgis.PyQt.QtGui",
+            "qgis",
+        ]:
+            sys.modules.pop(module_name, None)
+        from qgis.core import (  # type: ignore
+            QgsApplication as RealQgsApplication,
+        )
+
+        QgsApplication = RealQgsApplication
+    if build_route_track_layer is None:
+        sys.modules.pop(
+            "qfit.activities.infrastructure.geopackage."
+            "gpkg_route_layer_builders",
+            None,
+        )
+        from qfit.activities.infrastructure.geopackage import (
+            gpkg_route_layer_builders as real_route_builders,
+        )
+
+        _route_geometry = real_route_builders._route_geometry
+        build_route_point_layer = real_route_builders.build_route_point_layer
+        build_route_track_layer = real_route_builders.build_route_track_layer
+        route_feature_key = real_route_builders.route_feature_key
+    return get_shared_qgis_app(QgsApplication)
+
+
+@unittest.skipIf(
+    QgsApplication is None,
+    "QGIS Python bindings are not available",
+)
+class RouteLayerSchemaTests(unittest.TestCase):
+    def test_route_layers_are_declared_in_schema(self):
+        from qfit.activities.infrastructure.geopackage.gpkg_schema import (
+            GPKG_LAYER_SCHEMA,
+        )
+
+        self.assertEqual(
+            GPKG_LAYER_SCHEMA["route_tracks"]["geometry"],
+            "LINESTRING",
+        )
+        self.assertIn("route_fk", GPKG_LAYER_SCHEMA["route_tracks"]["fields"])
+        self.assertEqual(
+            GPKG_LAYER_SCHEMA["route_points"]["geometry"],
+            "POINT",
+        )
+        self.assertIn(
+            "segment_index",
+            GPKG_LAYER_SCHEMA["route_points"]["fields"],
+        )
+
+
+@unittest.skipIf(
+    QgsApplication is None,
+    "QGIS Python bindings are not available",
+)
+class RouteGeometryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_qgis_app()
+
+    def test_route_geometry_prefers_profile_points(self):
+        record = {
+            "profile_points": [
+                RouteProfilePoint(0, 46.5, 6.6, 0.0, altitude_m=400.0),
+                {"lat": None, "lon": 6.65},
+                RouteProfilePoint(1, 46.6, 6.7, 100.0, altitude_m=410.0),
+            ],
+            "geometry_points": [(47.0, 7.0), (47.1, 7.1)],
+        }
+
+        geometry, source, count = _route_geometry(record)
+
+        self.assertIsNotNone(geometry)
+        self.assertEqual(source, "profile")
+        self.assertEqual(count, 2)
+
+    def test_route_geometry_falls_back_to_start_end(self):
+        record = {
+            "start_lat": 46.5,
+            "start_lon": 6.6,
+            "end_lat": 46.6,
+            "end_lon": 6.7,
+        }
+
+        geometry, source, count = _route_geometry(record)
+
+        self.assertIsNotNone(geometry)
+        self.assertEqual(source, "start_end")
+        self.assertEqual(count, 2)
+
+    def test_route_geometry_without_points_is_empty(self):
+        geometry, source, count = _route_geometry({})
+
+        self.assertIsNone(geometry)
+        self.assertIsNone(source)
+        self.assertEqual(count, 0)
+
+
+@unittest.skipIf(
+    QgsApplication is None,
+    "QGIS Python bindings are not available",
+)
+class BuildRouteTrackLayerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_qgis_app()
+
+    def test_record_with_profile_points_builds_route_track_feature(self):
+        records = [
+            {
+                "source": "strava",
+                "source_route_id": "42",
+                "name": "Lake Loop",
+                "private": False,
+                "starred": True,
+                "distance_m": 12000.0,
+                "profile_points": [
+                    RouteProfilePoint(0, 46.5, 6.6, 0.0),
+                    RouteProfilePoint(1, 46.6, 6.7, 100.0),
+                ],
+                "details_json": {"estimated": False},
+            }
+        ]
+
+        layer = build_route_track_layer(records)
+
+        self.assertEqual(layer.featureCount(), 1)
+        feature = next(layer.getFeatures())
+        self.assertEqual(feature["route_fk"], '["strava","42"]')
+        self.assertEqual(feature["name"], "Lake Loop")
+        self.assertEqual(feature["starred"], 1)
+        self.assertEqual(feature["private"], 0)
+        self.assertEqual(feature["geometry_source"], "profile")
+        self.assertEqual(feature["geometry_point_count"], 2)
+        self.assertEqual(feature["details_json"], '{"estimated": false}')
+
+    def test_record_without_geometry_is_skipped(self):
+        layer = build_route_track_layer([
+            {"source": "strava", "source_route_id": "42"}
+        ])
+
+        self.assertEqual(layer.featureCount(), 0)
+
+    def test_record_without_stable_route_id_is_skipped(self):
+        layer = build_route_track_layer([
+            {
+                "source": "strava",
+                "profile_points": [
+                    RouteProfilePoint(0, 46.5, 6.6, 0.0),
+                    RouteProfilePoint(1, 46.6, 6.7, 100.0),
+                ],
+            }
+        ])
+
+        self.assertEqual(layer.featureCount(), 0)
+
+
+@unittest.skipIf(
+    QgsApplication is None,
+    "QGIS Python bindings are not available",
+)
+class BuildRoutePointLayerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_qgis_app()
+
+    def test_profile_points_build_stable_route_point_features(self):
+        records = [
+            {
+                "source": "strava",
+                "source_route_id": "42",
+                "name": "Lake Loop",
+                "geometry_source": "export_gpx",
+                "profile_points": [
+                    RouteProfilePoint(
+                        point_index=0,
+                        lat=46.5,
+                        lon=6.6,
+                        distance_m=0.0,
+                        segment_index=0,
+                        altitude_m=400.0,
+                    ),
+                    {
+                        "point_index": 1,
+                        "lat": 46.6,
+                        "lon": 6.7,
+                        "distance_m": 100.0,
+                        "segment_index": 1,
+                        "altitude_m": 410.0,
+                    },
+                ],
+            }
+        ]
+
+        layer = build_route_point_layer(records)
+
+        self.assertEqual(layer.featureCount(), 2)
+        features = list(layer.getFeatures())
+        self.assertEqual(
+            [feature["route_fk"] for feature in features],
+            ['["strava","42"]'] * 2,
+        )
+        self.assertEqual(
+            [feature["segment_index"] for feature in features],
+            [0, 1],
+        )
+        self.assertEqual(features[1]["distance_m"], 100.0)
+        self.assertEqual(features[1]["geometry_source"], "export_gpx")
+
+    def test_profile_points_are_skipped_when_track_geometry_is_missing(self):
+        records = [
+            {
+                "source": "strava",
+                "source_route_id": "42",
+                "profile_points": [
+                    RouteProfilePoint(0, 46.5, 6.6, 0.0),
+                ],
+            }
+        ]
+
+        layer = build_route_point_layer(records)
+
+        self.assertEqual(layer.featureCount(), 0)
+
+    def test_profile_points_are_skipped_when_route_id_is_missing(self):
+        records = [
+            {
+                "source": "strava",
+                "profile_points": [
+                    RouteProfilePoint(0, 46.5, 6.6, 0.0),
+                    RouteProfilePoint(1, 46.6, 6.7, 100.0),
+                ],
+            }
+        ]
+
+        layer = build_route_point_layer(records)
+
+        self.assertEqual(layer.featureCount(), 0)
+
+
+@unittest.skipIf(
+    QgsApplication is None,
+    "QGIS Python bindings are not available",
+)
+class RouteFeatureKeyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_qgis_app()
+
+    def test_route_feature_key_uses_stable_source_identity(self):
+        self.assertEqual(
+            route_feature_key({"source": "strava", "source_route_id": "42"}),
+            '["strava","42"]',
+        )
+
+    def test_route_feature_key_preserves_component_boundaries(self):
+        self.assertNotEqual(
+            route_feature_key({"source": "a:b", "source_route_id": "c"}),
+            route_feature_key({"source": "a", "source_route_id": "b:c"}),
+        )
+
+    def test_route_feature_key_rejects_missing_route_id(self):
+        self.assertIsNone(route_feature_key({"source": "strava"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gpkg_write_orchestration.py
+++ b/tests/test_gpkg_write_orchestration.py
@@ -35,6 +35,8 @@ _EXPECTED_LAYERS = [
     "activity_tracks",
     "activity_starts",
     "activity_points",
+    "route_tracks",
+    "route_points",
     "activity_atlas_pages",
     "atlas_document_summary",
     "atlas_cover_highlights",


### PR DESCRIPTION
## Summary

- Add GeoPackage schema entries for saved route catalog layers: `route_tracks` and `route_points`.
- Add QGIS memory-layer builders for route track lines and route profile sample points.
- Use stable `source:source_route_id` route keys for track/sample joins instead of position-based ids.

Part of #733. This is the route-layer construction slice; durable route persistence and dock/UI orchestration remain follow-up work.

## Validation

- `python3 -m pytest tests/test_gpkg_route_layer_builders.py tests/test_route_gpx.py tests/test_strava_client.py tests/test_strava_provider.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
