### PR TITLE
fix: preserve elevation z for route tracks

### DIFF
--- a/activities/infrastructure/geopackage/gpkg_route_layer_builders.py
+++ b/activities/infrastructure/geopackage/gpkg_route_layer_builders.py
@@ -15,6 +15,7 @@ from qgis.core import (
     QgsPoint,
     QgsPointXY,
     QgsVectorLayer,
+    QgsWkbTypes,
 )
 
 from .gpkg_schema import (
@@ -38,7 +39,14 @@ __all__ = [
 
 def build_route_track_layer(records):
     """Build the saved-route track layer."""
-    layer = QgsVectorLayer("LineString?crs=EPSG:4326", "route_tracks", "memory")
+    records = list(records or [])
+    has_z = route_tracks_have_elevation(records)
+    layer_uri = (
+        "LineStringZ?crs=EPSG:4326"
+        if has_z
+        else "LineString?crs=EPSG:4326"
+    )
+    layer = QgsVectorLayer(layer_uri, "route_tracks", "memory")
     provider = layer.dataProvider()
     provider.addAttributes(make_qgs_fields(ROUTE_TRACK_FIELDS))
     layer.updateFields()
@@ -55,7 +63,7 @@ def build_route_track_layer(records):
             point_count,
             profile_point_count,
             route_has_z,
-        ) = _route_geometry(record)
+        ) = _route_geometry(record, force_z=has_z)
         if geometry is None:
             continue
 
@@ -186,7 +194,7 @@ def route_feature_key(record):
 
 
 def route_tracks_have_elevation(records):
-    return any(_record_has_elevation(record) for record in records)
+    return any(_record_has_elevation(record) for record in records or [])
 
 
 def _route_geometry(record, force_z=False):
@@ -208,6 +216,7 @@ def _route_geometry(record, force_z=False):
         record.get("geometry_source") or "geometry_points",
         profile_point_count,
         route_has_z,
+        force_z,
     )
     if result[0] is not None:
         return result
@@ -217,13 +226,20 @@ def _route_geometry(record, force_z=False):
         record.get("geometry_source") or "summary_polyline",
         profile_point_count,
         route_has_z,
+        force_z,
     )
     if result[0] is not None:
         return result
 
-    geometry = _fallback_route_geometry(record)
+    geometry = _fallback_route_geometry(record, force_z)
     if geometry is not None:
-        return geometry, record.get("geometry_source") or "start_end", 2, 0, False
+        return (
+            geometry,
+            record.get("geometry_source") or "start_end",
+            2,
+            0,
+            False,
+        )
 
     return None, None, 0, profile_point_count, route_has_z
 
@@ -236,12 +252,11 @@ def _geometry_from_profile_points(record, points, route_has_z, force_z):
     if len(valid_points) < 2:
         return None, None, len(valid_points), len(points), route_has_z
 
-    if force_z and route_has_z:
+    if force_z:
         geometry = QgsGeometry.fromPolyline([
-            QgsPoint(
-                float(point.get("lon")),
-                float(point.get("lat")),
-                float(point.get("altitude_m")),
+            _elevation_point(point) if route_has_z else _padded_z_point(
+                point.get("lon"),
+                point.get("lat"),
             )
             for point in valid_points
         ])
@@ -265,16 +280,26 @@ def _geometry_from_lat_lon_pairs(
     geometry_source,
     profile_point_count,
     route_has_z,
+    force_z=False,
 ):
-    valid_points = [
-        QgsPointXY(float(lon), float(lat))
-        for lat, lon in points
-        if lat is not None and lon is not None
-    ]
+    if force_z:
+        valid_points = [
+            _padded_z_point(lon, lat)
+            for lat, lon in points
+            if lat is not None and lon is not None
+        ]
+    else:
+        valid_points = [
+            QgsPointXY(float(lon), float(lat))
+            for lat, lon in points
+            if lat is not None and lon is not None
+        ]
     if len(valid_points) < 2:
         return None, None, len(valid_points), profile_point_count, route_has_z
     return (
-        QgsGeometry.fromPolylineXY(valid_points),
+        QgsGeometry.fromPolyline(valid_points)
+        if force_z
+        else QgsGeometry.fromPolylineXY(valid_points),
         geometry_source,
         len(valid_points),
         profile_point_count,
@@ -282,17 +307,38 @@ def _geometry_from_lat_lon_pairs(
     )
 
 
-def _fallback_route_geometry(record):
+def _fallback_route_geometry(record, force_z=False):
     start_lat = record.get("start_lat")
     start_lon = record.get("start_lon")
     end_lat = record.get("end_lat")
     end_lon = record.get("end_lon")
     if None in (start_lat, start_lon, end_lat, end_lon):
         return None
+    if force_z:
+        return QgsGeometry.fromPolyline([
+            _padded_z_point(start_lon, start_lat),
+            _padded_z_point(end_lon, end_lat),
+        ])
     return QgsGeometry.fromPolylineXY([
         QgsPointXY(start_lon, start_lat),
         QgsPointXY(end_lon, end_lat),
     ])
+
+
+def _padded_z_point(lon, lat):
+    return QgsPoint(
+        float(lon),
+        float(lat),
+        wkbType=QgsWkbTypes.PointZ,
+    )
+
+
+def _elevation_point(point):
+    return QgsPoint(
+        float(point.get("lon")),
+        float(point.get("lat")),
+        float(point.get("altitude_m")),
+    )
 
 
 def _profile_points(record):

--- a/activities/infrastructure/geopackage/gpkg_schema.py
+++ b/activities/infrastructure/geopackage/gpkg_schema.py
@@ -295,6 +295,7 @@ GPKG_LAYER_SCHEMA = {
     },
     "route_tracks": {
         "geometry": "LINESTRING",
+        "geometry_variants": ("LINESTRING", "LINESTRINGZ"),
         "kind": "layer",
         "fields": [name for name, _ in ROUTE_TRACK_FIELDS],
     },

--- a/tests/test_gpkg_route_layer_builders.py
+++ b/tests/test_gpkg_route_layer_builders.py
@@ -1,4 +1,5 @@
 import importlib.util
+import math
 import os
 import sys
 import unittest
@@ -103,6 +104,10 @@ class RouteLayerSchemaTests(unittest.TestCase):
         self.assertEqual(
             GPKG_LAYER_SCHEMA["route_tracks"]["geometry"],
             "LINESTRING",
+        )
+        self.assertIn(
+            "LINESTRINGZ",
+            GPKG_LAYER_SCHEMA["route_tracks"]["geometry_variants"],
         )
         self.assertIn("route_fk", GPKG_LAYER_SCHEMA["route_tracks"]["fields"])
         self.assertEqual(
@@ -212,6 +217,95 @@ class BuildRouteTrackLayerTests(unittest.TestCase):
         self.assertEqual(feature["geometry_point_count"], 2)
         self.assertEqual(feature["profile_point_count"], 2)
         self.assertEqual(feature["details_json"], '{"estimated": false}')
+
+    def test_route_track_layer_creates_linestring_z_when_elevation_exists(self):
+        layer = build_route_track_layer(
+            [
+                {
+                    "source": "strava",
+                    "source_route_id": "42",
+                    "name": "Swiss gravel loop",
+                    "geometry_source": "export_gpx",
+                    "profile_points": [
+                        {
+                            "point_index": 0,
+                            "lat": 46.5,
+                            "lon": 6.6,
+                            "distance_m": 0.0,
+                            "altitude_m": 500.0,
+                        },
+                        {
+                            "point_index": 1,
+                            "lat": 46.501,
+                            "lon": 6.601,
+                            "distance_m": 135.4,
+                            "altitude_m": 507.5,
+                        },
+                    ],
+                }
+            ]
+        )
+
+        self.assertTrue(layer.isValid())
+        self.assertTrue(QgsWkbTypes.hasZ(layer.wkbType()))
+        self.assertEqual(layer.featureCount(), 1)
+        feature = next(layer.getFeatures())
+        self.assertEqual(feature["source_route_id"], "42")
+        self.assertEqual(feature["geometry_point_count"], 2)
+        self.assertEqual(feature["profile_point_count"], 2)
+        self.assertEqual(feature["has_elevation"], 1)
+        self.assertTrue(QgsWkbTypes.hasZ(feature.geometry().wkbType()))
+        first_vertex = next(feature.geometry().vertices())
+        self.assertAlmostEqual(first_vertex.z(), 500.0)
+
+    def test_route_track_layer_pads_mixed_catalog_geometries_when_z_exists(self):
+        layer = build_route_track_layer(
+            [
+                {
+                    "source": "strava",
+                    "source_route_id": "z-route",
+                    "profile_points": [
+                        {
+                            "point_index": 0,
+                            "lat": 46.5,
+                            "lon": 6.6,
+                            "altitude_m": 500.0,
+                        },
+                        {
+                            "point_index": 1,
+                            "lat": 46.501,
+                            "lon": 6.601,
+                            "altitude_m": 507.5,
+                        },
+                    ],
+                },
+                {
+                    "source": "strava",
+                    "source_route_id": "polyline-only",
+                    "geometry_points": [(46.7, 6.8), (46.8, 6.9)],
+                },
+            ]
+        )
+
+        features = {
+            feature["source_route_id"]: feature
+            for feature in layer.getFeatures()
+        }
+        self.assertTrue(QgsWkbTypes.hasZ(layer.wkbType()))
+        self.assertEqual(layer.featureCount(), 2)
+        self.assertTrue(
+            QgsWkbTypes.hasZ(features["z-route"].geometry().wkbType())
+        )
+        self.assertTrue(
+            QgsWkbTypes.hasZ(features["polyline-only"].geometry().wkbType())
+        )
+        first_z_vertex = next(features["z-route"].geometry().vertices())
+        first_padded_vertex = next(
+            features["polyline-only"].geometry().vertices()
+        )
+        self.assertAlmostEqual(first_z_vertex.z(), 500.0)
+        self.assertTrue(math.isnan(first_padded_vertex.z()))
+        self.assertEqual(features["polyline-only"]["has_elevation"], 0)
 
     def test_record_without_geometry_is_skipped(self):
         layer = build_route_track_layer([

--- a/tests/test_gpkg_route_layer_builders_pure.py
+++ b/tests/test_gpkg_route_layer_builders_pure.py
@@ -1,4 +1,5 @@
 import importlib
+import math
 import sys
 import unittest
 from types import ModuleType
@@ -11,10 +12,14 @@ _BUILDER_MODULE = "qfit.activities.infrastructure.geopackage.gpkg_route_layer_bu
 
 
 class _FakePoint:
-    def __init__(self, lon, lat, z=None):
+    def __init__(self, lon, lat, z=None, **kwargs):
         self.lon = lon
         self.lat = lat
-        self.z = z
+        self.z = math.nan if z is None and kwargs.get("wkbType") else z
+
+
+class _FakeWkbTypes:
+    PointZ = 1001
 
 
 class _FakePointXY:
@@ -107,6 +112,7 @@ def _make_qgis_stubs():
     qgis_core.QgsPoint = _FakePoint
     qgis_core.QgsPointXY = _FakePointXY
     qgis_core.QgsVectorLayer = _FakeVectorLayer
+    qgis_core.QgsWkbTypes = _FakeWkbTypes
     qgis_mod.core = qgis_core
     return qgis_mod, qgis_core
 
@@ -163,7 +169,7 @@ def _load_builder_with_stubs(test_case):
 
 
 class RouteLayerBuilderPureTests(unittest.TestCase):
-    def test_route_track_layer_stays_2d_and_records_elevation_metadata(self):
+    def test_route_track_layer_uses_z_only_for_complete_altitude_samples(self):
         builders = _load_builder_with_stubs(self)
 
         layer = builders.build_route_track_layer(
@@ -188,13 +194,15 @@ class RouteLayerBuilderPureTests(unittest.TestCase):
         )
 
         features = {feature["source_route_id"]: feature for feature in layer.getFeatures()}
-        self.assertEqual(layer.uri, "LineString?crs=EPSG:4326")
-        self.assertEqual(features["complete"].geometry().kind, "xy")
+        self.assertEqual(layer.uri, "LineStringZ?crs=EPSG:4326")
+        self.assertEqual(features["complete"].geometry().kind, "z")
+        self.assertEqual(features["complete"].geometry().points[0].z, 500.0)
         self.assertEqual(features["complete"]["has_elevation"], 1)
-        self.assertEqual(features["partial"].geometry().kind, "xy")
+        self.assertEqual(features["partial"].geometry().kind, "z")
+        self.assertTrue(math.isnan(features["partial"].geometry().points[0].z))
         self.assertEqual(features["partial"]["has_elevation"], 0)
 
-    def test_geometry_point_fallback_stays_2d_when_catalog_has_elevation(self):
+    def test_geometry_point_fallback_is_padded_when_catalog_has_elevation(self):
         builders = _load_builder_with_stubs(self)
 
         layer = builders.build_route_track_layer(
@@ -216,8 +224,12 @@ class RouteLayerBuilderPureTests(unittest.TestCase):
         )
 
         features = {feature["source_route_id"]: feature for feature in layer.getFeatures()}
-        self.assertEqual(layer.uri, "LineString?crs=EPSG:4326")
-        self.assertEqual(features["polyline-only"].geometry().kind, "xy")
+        self.assertEqual(layer.uri, "LineStringZ?crs=EPSG:4326")
+        self.assertEqual(features["z-route"].geometry().kind, "z")
+        self.assertEqual(features["polyline-only"].geometry().kind, "z")
+        self.assertTrue(
+            math.isnan(features["polyline-only"].geometry().points[0].z)
+        )
         self.assertEqual(features["polyline-only"]["has_elevation"], 0)
 
     def test_route_profile_samples_use_stable_join_key_and_group_index(self):

--- a/tests/test_gpkg_route_writer.py
+++ b/tests/test_gpkg_route_writer.py
@@ -1,3 +1,4 @@
+import math
 import os
 import sqlite3
 import tempfile
@@ -5,17 +6,24 @@ import unittest
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from tests import _path  # noqa: F401
-from tests.qgis_app import get_shared_qgis_app
-from qfit.providers.domain.routes import RouteProfilePoint, SavedRoute
+from tests import _path  # noqa: E402,F401
+from tests.qgis_app import get_shared_qgis_app  # noqa: E402
+from qfit.providers.domain.routes import (  # noqa: E402
+    RouteProfilePoint,
+    SavedRoute,
+)
 
 try:
-    from qgis.core import QgsApplication
+    from qgis.core import QgsApplication, QgsVectorLayer, QgsWkbTypes
 except (ImportError, ModuleNotFoundError):  # pragma: no cover
     QgsApplication = None
+    QgsVectorLayer = None
+    QgsWkbTypes = None
 
 if QgsApplication is not None:
-    from qfit.activities.infrastructure.geopackage.gpkg_writer import GeoPackageWriter
+    from qfit.activities.infrastructure.geopackage.gpkg_writer import (  # noqa: E501
+        GeoPackageWriter,
+    )
 else:  # pragma: no cover
     GeoPackageWriter = None
 
@@ -24,13 +32,18 @@ def _ensure_qgis_app():
     return get_shared_qgis_app(QgsApplication)
 
 
-@unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
+@unittest.skipIf(
+    QgsApplication is None,
+    "QGIS Python bindings are not available",
+)
 class GeoPackageRouteWriterTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         _ensure_qgis_app()
 
-    def test_write_routes_persists_track_metadata_and_profile_samples_idempotently(self):
+    def test_write_routes_persists_metadata_and_samples_idempotently(
+        self,
+    ):
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "qfit-routes.gpkg")
             writer = GeoPackageWriter(output_path=output_path)
@@ -41,30 +54,73 @@ class GeoPackageRouteWriterTests(unittest.TestCase):
                 geometry_source="export_gpx",
                 profile_points=[
                     RouteProfilePoint(0, 46.5, 6.6, 0.0, altitude_m=500.0),
-                    RouteProfilePoint(1, 46.501, 6.601, 135.4, altitude_m=507.5),
+                    RouteProfilePoint(
+                        1,
+                        46.501,
+                        6.601,
+                        135.4,
+                        altitude_m=507.5,
+                    ),
                 ],
             )
+            route_without_elevation = SavedRoute(
+                source="strava",
+                source_route_id="43",
+                name="Polyline-only loop",
+                geometry_source="summary",
+                geometry_points=[(46.7, 6.8), (46.8, 6.9)],
+            )
 
-            first = writer.write_routes([route])
-            second = writer.write_routes([route])
+            first = writer.write_routes([route, route_without_elevation])
+            second = writer.write_routes([route, route_without_elevation])
 
             with sqlite3.connect(output_path) as connection:
-                route_count = connection.execute("SELECT COUNT(*) FROM route_registry").fetchone()[0]
-                point_count = connection.execute("SELECT COUNT(*) FROM route_points").fetchone()[0]
-                profile_count = connection.execute("SELECT COUNT(*) FROM route_profile_samples").fetchone()[0]
-                z_flag = connection.execute(
-                    "SELECT z FROM gpkg_geometry_columns WHERE table_name = 'route_tracks'"
+                route_count = connection.execute(
+                    "SELECT COUNT(*) FROM route_registry"
                 ).fetchone()[0]
+                point_count = connection.execute(
+                    "SELECT COUNT(*) FROM route_points"
+                ).fetchone()[0]
+                profile_count = connection.execute(
+                    "SELECT COUNT(*) FROM route_profile_samples"
+                ).fetchone()[0]
+                z_flag = connection.execute(
+                    "SELECT z FROM gpkg_geometry_columns "
+                    "WHERE table_name = 'route_tracks'"
+                ).fetchone()[0]
+            track_layer = QgsVectorLayer(
+                f"{output_path}|layername=route_tracks",
+                "route_tracks",
+                "ogr",
+            )
+            features = {
+                feature["source_route_id"]: feature
+                for feature in track_layer.getFeatures()
+            }
 
-        self.assertEqual(first["route_track_count"], 1)
+        self.assertEqual(first["route_track_count"], 2)
         self.assertEqual(first["route_point_count"], 2)
         self.assertEqual(first["route_profile_sample_count"], 2)
-        self.assertEqual(second["sync"].unchanged, 1)
-        self.assertEqual(second["route_track_count"], 1)
-        self.assertEqual(route_count, 1)
+        self.assertEqual(second["sync"].unchanged, 2)
+        self.assertEqual(second["route_track_count"], 2)
+        self.assertEqual(route_count, 2)
         self.assertEqual(point_count, 2)
         self.assertEqual(profile_count, 2)
-        self.assertEqual(z_flag, 0)
+        self.assertEqual(z_flag, 1)
+        self.assertTrue(QgsWkbTypes.hasZ(track_layer.wkbType()))
+        self.assertTrue(
+            QgsWkbTypes.hasZ(features["42"].geometry().wkbType())
+        )
+        self.assertTrue(
+            QgsWkbTypes.hasZ(features["43"].geometry().wkbType())
+        )
+        self.assertAlmostEqual(
+            next(features["42"].geometry().vertices()).z(),
+            500.0,
+        )
+        self.assertTrue(
+            math.isnan(next(features["43"].geometry().vertices()).z())
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #733

## Implemented
- Restores `LineStringZ` route track creation when saved route profile samples contain complete elevation.
- Keeps 2D route tracks for route sets without elevation and keeps non-elevation fallback geometries 2D.
- Documents the static schema baseline as `LINESTRING` with supported `LINESTRINGZ` variants.
- Updates route writer coverage to assert GeoPackage `gpkg_geometry_columns.z = 1` when elevation is written.

## Deferred
- Full UI route sync workflow remains deferred.

## Tests
- `python3 -m pytest tests/test_route_storage.py tests/test_gpkg_route_layer_builders.py tests/test_gpkg_route_layer_builders_pure.py tests/test_gpkg_route_writer.py tests/test_gpkg_write_orchestration.py tests/test_gpkg_writer.py tests/test_project_layer_loader.py tests/test_layer_gateway.py -q` — 54 passed, 5 skipped.
- `python3 -m py_compile activities/infrastructure/geopackage/gpkg_route_layer_builders.py activities/infrastructure/geopackage/gpkg_schema.py tests/test_gpkg_route_layer_builders.py tests/test_gpkg_route_layer_builders_pure.py tests/test_gpkg_route_writer.py`
- `git diff --check`
