### PR TITLE
feat: style route catalog layers

### DIFF
--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -89,8 +89,10 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
             gateway._project_layer_loader = MagicMock(name="project_layer_loader")
             gateway._project_layer_loader.load_route_layers.return_value = (
                 MagicMock(name="routes"),
+                MagicMock(name="route_points"),
                 MagicMock(name="profile_samples"),
             )
+            gateway._style_service = MagicMock(name="style_service")
             gateway._move_background_layers_to_bottom = MagicMock(name="move_background_layers_to_bottom")
             result = gateway.load_route_layers("/tmp/out.gpkg")
 
@@ -99,6 +101,7 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         loader = gateway._project_layer_loader
         canvas.ensure_working_crs.assert_called_once_with(gateway.iface, preserve_extent=False)
         loader.load_route_layers.assert_called_once_with("/tmp/out.gpkg")
+        gateway._style_service.apply_route_style.assert_called_once_with(*result)
         canvas.zoom_to_layers.assert_called_once_with(gateway.iface, result)
         gateway._move_background_layers_to_bottom.assert_called_once_with()
 

--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -194,6 +194,25 @@ class LayerStyleServiceTests(unittest.TestCase):
         self.assertIsInstance(self.style_service, LayerStyleService)
         self.assertIsNot(self.style_service, self.layer_manager)
 
+    def test_route_style_sets_dedicated_route_renderers(self):
+        route_tracks = MagicMock()
+        route_points = MagicMock()
+        profile_samples = MagicMock()
+
+        self.style_service.apply_route_style(
+            route_tracks,
+            route_points,
+            profile_samples,
+        )
+
+        route_tracks.setRenderer.assert_called_once()
+        route_tracks.setOpacity.assert_called_once_with(0.85)
+        route_tracks.triggerRepaint.assert_called_once()
+        route_points.setRenderer.assert_called_once()
+        route_points.setOpacity.assert_called_once_with(0.45)
+        route_points.triggerRepaint.assert_called_once()
+        profile_samples.setRenderer.assert_not_called()
+
     def test_simple_lines_applies_single_symbol_renderer(self):
         with tempfile.TemporaryDirectory() as tmp:
             activities_layer, starts_layer, points_layer, atlas_layer = self._write_and_load(tmp)
@@ -369,6 +388,23 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         self.service.apply_style(acts, starts, points, None, "Simple lines")
         acts.setRenderer.assert_called_once()
         acts.triggerRepaint.assert_called()
+
+    def test_route_style_sets_dedicated_route_renderers(self):
+        route_tracks = self._make_layer()
+        route_points = self._make_layer()
+        profile_samples = self._make_layer()
+
+        self.service.apply_route_style(
+            route_tracks,
+            route_points,
+            profile_samples,
+        )
+
+        route_tracks.setRenderer.assert_called_once()
+        route_tracks.setOpacity.assert_called_once_with(0.85)
+        route_points.setRenderer.assert_called_once()
+        route_points.setOpacity.assert_called_once_with(0.45)
+        profile_samples.setRenderer.assert_not_called()
 
     def test_by_activity_type_sets_renderer_on_tracks(self):
         acts = self._make_layer()

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -45,6 +45,8 @@ OTHER_ACTIVITY_LABEL = "Other"
 HEATMAP_ANALYSIS_RADIUS_M = 750
 HEATMAP_VISUALIZE_RADIUS_M = 250
 HEATMAP_VISUALIZE_MAXIMUM = 25
+ROUTE_LINE_HEX = "#8e44ad"
+ROUTE_POINT_RGBA = "142,68,173,150"
 
 
 def _fixed_visualize_heatmap_maximum(layer):
@@ -140,6 +142,18 @@ class LayerStyleService:
 
         if atlas_layer is not None:
             self._apply_layer_render_plan(atlas_layer, render_plan.atlas, basemap_preset_name)
+
+    def apply_route_style(
+        self,
+        route_tracks_layer,
+        route_points_layer=None,
+        _route_profile_samples_layer=None,
+    ):
+        """Style saved-route catalog layers so they differ from activities."""
+        if route_tracks_layer is not None:
+            self._apply_route_track_style(route_tracks_layer)
+        if route_points_layer is not None:
+            self._apply_route_point_style(route_points_layer)
 
     def _apply_layer_render_plan(self, layer, layer_plan, basemap_preset_name):
         if layer is None or layer_plan is None:
@@ -341,4 +355,33 @@ class LayerStyleService:
         )
         layer.setRenderer(QgsSingleSymbolRenderer(symbol))
         layer.setOpacity(1.0)
+        layer.triggerRepaint()
+
+    def _apply_route_track_style(self, layer):
+        symbol = QgsLineSymbol()
+        symbol.deleteSymbolLayer(0)
+
+        line_layer = QgsSimpleLineSymbolLayer()
+        line_layer.setColor(QColor(ROUTE_LINE_HEX))
+        line_layer.setWidth(0.65)
+        line_layer.setPenCapStyle(Qt.RoundCap)
+        line_layer.setPenJoinStyle(Qt.RoundJoin)
+        line_layer.setPenStyle(Qt.DashLine)
+        symbol.appendSymbolLayer(line_layer)
+
+        layer.setRenderer(QgsSingleSymbolRenderer(symbol))
+        layer.setOpacity(0.85)
+        layer.triggerRepaint()
+
+    def _apply_route_point_style(self, layer):
+        symbol = QgsMarkerSymbol.createSimple(
+            {
+                "name": "circle",
+                "color": ROUTE_POINT_RGBA,
+                "size": "1.1",
+                "outline_style": "no",
+            }
+        )
+        layer.setRenderer(QgsSingleSymbolRenderer(symbol))
+        layer.setOpacity(0.45)
         layer.triggerRepaint()

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -106,6 +106,7 @@ class QgisLayerGateway:
         project_layer_loader = self._get_project_layer_loader()
         canvas_service.ensure_working_crs(self.iface, preserve_extent=False)
         route_layers = project_layer_loader.load_route_layers(gpkg_path)
+        self._get_style_service().apply_route_style(*route_layers)
         self._move_background_layers_to_bottom()
         canvas_service.zoom_to_layers(self.iface, route_layers)
         return route_layers


### PR DESCRIPTION
Refs #733

## Summary
- Applies a dedicated dashed purple renderer to saved-route track layers when route layers are loaded.
- Applies a subtle point style to route sample points while leaving the profile sample table unstyled.
- Adds gateway/style-service coverage so route layer loading verifies styling is applied separately from activity styling.

## Tests
- `python3 -m pytest tests/test_layer_gateway.py tests/test_layer_style_service.py tests/test_project_layer_loader.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
