### PR TITLE
fix: keep route points visible

### DIFF
--- a/tests/test_layer_style_service.py
+++ b/tests/test_layer_style_service.py
@@ -209,7 +209,7 @@ class LayerStyleServiceTests(unittest.TestCase):
         route_tracks.setOpacity.assert_called_once_with(0.85)
         route_tracks.triggerRepaint.assert_called_once()
         route_points.setRenderer.assert_called_once()
-        route_points.setOpacity.assert_called_once_with(0.45)
+        route_points.setOpacity.assert_called_once_with(0.65)
         route_points.triggerRepaint.assert_called_once()
         profile_samples.setRenderer.assert_not_called()
 
@@ -403,7 +403,7 @@ class LayerStyleServiceUnitTests(unittest.TestCase):
         route_tracks.setRenderer.assert_called_once()
         route_tracks.setOpacity.assert_called_once_with(0.85)
         route_points.setRenderer.assert_called_once()
-        route_points.setOpacity.assert_called_once_with(0.45)
+        route_points.setOpacity.assert_called_once_with(0.65)
         profile_samples.setRenderer.assert_not_called()
 
     def test_by_activity_type_sets_renderer_on_tracks(self):

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -46,7 +46,7 @@ HEATMAP_ANALYSIS_RADIUS_M = 750
 HEATMAP_VISUALIZE_RADIUS_M = 250
 HEATMAP_VISUALIZE_MAXIMUM = 25
 ROUTE_LINE_HEX = "#8e44ad"
-ROUTE_POINT_RGBA = "142,68,173,150"
+ROUTE_POINT_RGB = "142,68,173"
 
 
 def _fixed_visualize_heatmap_maximum(layer):
@@ -377,11 +377,11 @@ class LayerStyleService:
         symbol = QgsMarkerSymbol.createSimple(
             {
                 "name": "circle",
-                "color": ROUTE_POINT_RGBA,
+                "color": ROUTE_POINT_RGB,
                 "size": "1.1",
                 "outline_style": "no",
             }
         )
         layer.setRenderer(QgsSingleSymbolRenderer(symbol))
-        layer.setOpacity(0.45)
+        layer.setOpacity(0.65)
         layer.triggerRepaint()


### PR DESCRIPTION
Refs #733
Follow-up to Greptile feedback on #741.

## Summary
- Removes the baked-in alpha from the route point marker color.
- Raises the route point layer opacity to 0.65 so sample points stay subtle but readable on basemaps.
- Updates style-service expectations for the adjusted point opacity.

## Tests
- `python3 -m pytest tests/test_layer_style_service.py tests/test_layer_gateway.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
