### PR TITLE
Complete Strava saved route sync workflow

### DIFF
--- a/activities/application/__init__.py
+++ b/activities/application/__init__.py
@@ -16,11 +16,13 @@ __all__ = [
     "ActivitySelectionState",
     "ActivityTypeOptionsResult",
     "BuildStravaProviderRequest",
+    "BuildRouteSyncTaskRequest",
     "ClearDatabaseWorkflow",
     "FetchActivitiesRequest",
     "FetchResult",
     "FetchResultService",
     "FetchTask",
+    "RouteSyncTask",
     "LoadDatabaseRequest",
     "LoadDatasetRequest",
     "LoadDatasetResult",
@@ -44,6 +46,7 @@ __all__ = [
     "build_activity_type_options",
     "build_activity_type_options_from_activities",
     "build_activity_type_options_from_records",
+    "build_route_sync_task",
 ]
 
 _ACTIVITY_TYPE_OPTIONS_MODULE = ".activity_type_options"
@@ -56,11 +59,13 @@ _EXPORTS = {
     "ActivitySelectionState": (".activity_selection_state", "ActivitySelectionState"),
     "ActivityTypeOptionsResult": (_ACTIVITY_TYPE_OPTIONS_MODULE, "ActivityTypeOptionsResult"),
     "BuildStravaProviderRequest": (".sync_controller", "BuildStravaProviderRequest"),
+    "BuildRouteSyncTaskRequest": (".sync_controller", "BuildRouteSyncTaskRequest"),
     "ClearDatabaseWorkflow": (".load_workflow", "ClearDatabaseWorkflow"),
     "FetchActivitiesRequest": (".fetch_result_service", "FetchActivitiesRequest"),
     "FetchResult": (".fetch_result_service", "FetchResult"),
     "FetchResultService": (".fetch_result_service", "FetchResultService"),
     "FetchTask": (".fetch_task", "FetchTask"),
+    "RouteSyncTask": (".route_sync_task", "RouteSyncTask"),
     "LoadDatabaseRequest": (".load_workflow", "LoadDatabaseRequest"),
     "LoadDatasetRequest": (".load_workflow", "LoadDatasetRequest"),
     "LoadDatasetResult": (".load_workflow", "LoadDatasetResult"),
@@ -84,6 +89,7 @@ _EXPORTS = {
     "build_activity_type_options": (_ACTIVITY_TYPE_OPTIONS_MODULE, "build_activity_type_options"),
     "build_activity_type_options_from_activities": (_ACTIVITY_TYPE_OPTIONS_MODULE, "build_activity_type_options_from_activities"),
     "build_activity_type_options_from_records": (_ACTIVITY_TYPE_OPTIONS_MODULE, "build_activity_type_options_from_records"),
+    "build_route_sync_task": (".route_sync_task", "build_route_sync_task"),
 }
 
 

--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -73,6 +73,9 @@ class LoadDatasetResult:
     starts_layer: object = None
     points_layer: object = None
     atlas_layer: object = None
+    route_tracks_layer: object = None
+    route_points_layer: object = None
+    route_profile_samples_layer: object = None
     total_stored: int = 0
     status: str = ""
 
@@ -86,6 +89,9 @@ class LoadResult:
     starts_layer: object = None
     points_layer: object = None
     atlas_layer: object = None
+    route_tracks_layer: object = None
+    route_points_layer: object = None
+    route_profile_samples_layer: object = None
     total_stored: int = 0
     status: str = ""
     sync: SyncStats | None = None
@@ -280,6 +286,9 @@ class LoadDatasetWorkflow:
         activities_layer, starts_layer, points_layer, atlas_layer = (
             self.layer_gateway.load_output_layers(request.output_path)
         )
+        route_tracks_layer, route_points_layer, route_profile_samples_layer = (
+            self.layer_gateway.load_route_layers(request.output_path)
+        )
         total = activities_layer.featureCount() if activities_layer else 0
 
         return LoadDatasetResult(
@@ -288,6 +297,9 @@ class LoadDatasetWorkflow:
             starts_layer=starts_layer,
             points_layer=points_layer,
             atlas_layer=atlas_layer,
+            route_tracks_layer=route_tracks_layer,
+            route_points_layer=route_points_layer,
+            route_profile_samples_layer=route_profile_samples_layer,
             total_stored=total,
             status="Layers loaded from {path}.".format(path=request.output_path),
         )
@@ -413,6 +425,9 @@ class LoadWorkflowService:
             starts_layer=result.starts_layer,
             points_layer=result.points_layer,
             atlas_layer=result.atlas_layer,
+            route_tracks_layer=result.route_tracks_layer,
+            route_points_layer=result.route_points_layer,
+            route_profile_samples_layer=result.route_profile_samples_layer,
             total_stored=result.total_stored,
             status=result.status,
         )

--- a/activities/application/route_sync_task.py
+++ b/activities/application/route_sync_task.py
@@ -1,0 +1,159 @@
+"""Background task for syncing saved Strava routes into the GeoPackage."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime
+from typing import Callable
+
+from qgis.core import QgsTask
+
+from ...providers.domain.provider import ProviderError
+
+logger = logging.getLogger(__name__)
+
+RouteSyncTaskFinishedCallback = Callable[[dict | None, str | None, bool, object], None]
+
+
+def _default_writer_factory(**kwargs):
+    from ..infrastructure.geopackage.gpkg_writer import GeoPackageWriter
+
+    return GeoPackageWriter(**kwargs)
+
+
+class RouteSyncTask(QgsTask):
+    """Fetch saved routes, enrich them with GPX geometry, and persist route layers."""
+
+    def __init__(
+        self,
+        *,
+        provider,
+        output_path: str,
+        per_page: int = 200,
+        max_pages: int = 0,
+        use_gpx_geometry: bool = True,
+        writer_factory=None,
+        on_finished: RouteSyncTaskFinishedCallback | None = None,
+    ):
+        super().__init__("Sync saved Strava routes", QgsTask.CanCancel)
+        self._provider = provider
+        self._output_path = output_path
+        self._per_page = max(1, int(per_page or 1))
+        self._max_pages = max(0, int(max_pages or 0))
+        self._use_gpx_geometry = bool(use_gpx_geometry)
+        self._writer_factory = writer_factory or _default_writer_factory
+        self._on_finished = on_finished
+        self._result: dict | None = None
+        self._error: str | None = None
+
+    def run(self) -> bool:
+        """Run the route sync in a QGIS worker thread."""
+
+        try:
+            routes = self._fetch_routes()
+            if self.isCanceled():
+                return False
+
+            writer = self._writer_factory(output_path=self._output_path)
+            self._result = writer.write_routes(
+                routes,
+                sync_metadata=self._build_sync_metadata(routes),
+            )
+            return not self.isCanceled()
+        except ProviderError as exc:
+            self._error = str(exc)
+            return False
+        except Exception as exc:  # noqa: BLE001 – worker-thread safety net
+            logger.exception("Route sync task failed")
+            self._error = str(exc)
+            return False
+
+    def finished(self, result: bool) -> None:  # pragma: no cover - Qt callback shape
+        cancelled = self.isCanceled() and not result and self._error is None
+        if self._on_finished is not None:
+            self._on_finished(
+                self._result if result else None,
+                self._error,
+                cancelled,
+                self._provider,
+            )
+
+    def _fetch_routes(self):
+        if not hasattr(self._provider, "fetch_routes"):
+            raise ProviderError("The configured provider does not support saved routes")
+
+        self._provider.last_fetch_context = {
+            "route_max_pages": self._max_pages,
+            "route_per_page": self._per_page,
+        }
+        routes = list(
+            self._provider.fetch_routes(
+                per_page=self._per_page,
+                max_pages=self._max_pages,
+            )
+        )
+        if not self._use_gpx_geometry or not hasattr(self._provider, "fetch_route_detail"):
+            return routes
+
+        enriched_routes = []
+        for route in routes:
+            if self.isCanceled():
+                break
+            route_id = getattr(route, "source_route_id", None)
+            if route_id in (None, ""):
+                enriched_routes.append(route)
+                continue
+            enriched_routes.append(
+                self._provider.fetch_route_detail(
+                    route_id,
+                    use_gpx_geometry=True,
+                )
+            )
+        return enriched_routes
+
+    def _build_sync_metadata(self, routes):
+        provider_name = getattr(self._provider, "source_name", "strava")
+        fetch_notice = getattr(self._provider, "last_fetch_notice", None)
+        is_full_sync = self._max_pages == 0 and not fetch_notice
+        return {
+            "provider": provider_name,
+            "fetched_count": len(routes),
+            "detailed_count": sum(1 for route in routes if _route_has_gpx_geometry(route)),
+            "rate_limit": getattr(self._provider, "last_rate_limit", None),
+            "is_full_sync": is_full_sync,
+            "today_str": date.today().isoformat(),
+            "synced_at": datetime.now(UTC).isoformat(),
+        }
+
+
+def _route_has_gpx_geometry(route) -> bool:
+    details = getattr(route, "details_json", None) or {}
+    return details.get("gpx_geometry_status") == "downloaded"
+
+
+def build_route_sync_task(
+    *,
+    provider,
+    output_path: str,
+    per_page: int = 200,
+    max_pages: int = 0,
+    use_gpx_geometry: bool = True,
+    writer_factory=None,
+    on_finished: RouteSyncTaskFinishedCallback | None = None,
+) -> RouteSyncTask:
+    return RouteSyncTask(
+        provider=provider,
+        output_path=output_path,
+        per_page=per_page,
+        max_pages=max_pages,
+        use_gpx_geometry=use_gpx_geometry,
+        writer_factory=writer_factory,
+        on_finished=on_finished,
+    )
+
+
+__all__ = [
+    "RouteSyncTask",
+    "RouteSyncTaskFinishedCallback",
+    "build_route_sync_task",
+]

--- a/activities/application/route_sync_task.py
+++ b/activities/application/route_sync_task.py
@@ -59,7 +59,7 @@ class RouteSyncTask(QgsTask):
                 routes,
                 sync_metadata=self._build_sync_metadata(routes),
             )
-            return not self.isCanceled()
+            return True
         except ProviderError as exc:
             self._error = str(exc)
             return False
@@ -69,10 +69,10 @@ class RouteSyncTask(QgsTask):
             return False
 
     def finished(self, result: bool) -> None:  # pragma: no cover - Qt callback shape
-        cancelled = self.isCanceled() and not result and self._error is None
+        cancelled = self.isCanceled() and self._error is None
         if self._on_finished is not None:
             self._on_finished(
-                self._result if result else None,
+                self._result if (result or self._result is not None) else None,
                 self._error,
                 cancelled,
                 self._provider,

--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -5,6 +5,7 @@ from datetime import date
 from ...detailed_route_strategy import DEFAULT_DETAILED_ROUTE_STRATEGY
 from ...providers.application.provider_registry import build_default_provider_registry
 from .fetch_task import FetchTask
+from .route_sync_task import RouteSyncTask
 from ...providers.domain.provider import ProviderError
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,21 @@ class BuildFetchTaskRequest:
     use_detailed_streams: bool = False
     max_detailed_activities: int = 25
     detailed_route_strategy: str = DEFAULT_DETAILED_ROUTE_STRATEGY
+    on_finished: object = None
+
+
+@dataclass
+class BuildRouteSyncTaskRequest:
+    """Structured input for creating a saved-route sync task."""
+
+    client_id: str = ""
+    client_secret: str = ""
+    refresh_token: str = ""
+    cache: object = None
+    output_path: str = ""
+    per_page: int = 200
+    max_pages: int = 0
+    use_gpx_geometry: bool = True
     on_finished: object = None
 
 
@@ -160,6 +176,63 @@ class SyncController:
             use_detailed_streams=request.use_detailed_streams,
             max_detailed_activities=request.max_detailed_activities,
             detailed_route_strategy=request.detailed_route_strategy,
+            on_finished=request.on_finished,
+        )
+
+    @staticmethod
+    def build_route_sync_task_request(
+        client_id,
+        client_secret,
+        refresh_token,
+        cache,
+        output_path,
+        per_page=200,
+        max_pages=0,
+        use_gpx_geometry=True,
+        on_finished=None,
+    ) -> BuildRouteSyncTaskRequest:
+        """Build a structured request for syncing saved Strava routes."""
+
+        return BuildRouteSyncTaskRequest(
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+            cache=cache,
+            output_path=output_path,
+            per_page=per_page,
+            max_pages=max_pages,
+            use_gpx_geometry=use_gpx_geometry,
+            on_finished=on_finished,
+        )
+
+    def build_route_sync_task(
+        self,
+        request: BuildRouteSyncTaskRequest | None = None,
+        **legacy_kwargs,
+    ) -> RouteSyncTask:
+        """Create a validated :class:`RouteSyncTask` for route-catalog sync."""
+
+        if request is None:
+            request = self.build_route_sync_task_request(**legacy_kwargs)
+
+        if not request.output_path:
+            raise ProviderError("Choose a GeoPackage output path first.")
+
+        provider_request = self.build_provider_request(
+            client_id=request.client_id,
+            client_secret=request.client_secret,
+            refresh_token=request.refresh_token,
+            cache=request.cache,
+            require_refresh_token=True,
+        )
+        provider = self.build_strava_provider(provider_request)
+
+        return RouteSyncTask(
+            provider=provider,
+            output_path=request.output_path,
+            per_page=request.per_page,
+            max_pages=request.max_pages,
+            use_gpx_geometry=request.use_gpx_geometry,
             on_finished=request.on_finished,
         )
 

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -739,6 +739,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._runtime_store().set_store_task(value)
 
     @property
+    def _route_sync_task(self):
+        return self.runtime_state.tasks.route_sync
+
+    @_route_sync_task.setter
+    def _route_sync_task(self, value):
+        self._runtime_store().set_route_sync_task(value)
+
+    @property
     def _atlas_export_task(self):
         return self.runtime_state.tasks.atlas_export
 
@@ -770,6 +778,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.refreshButton.clicked.connect(self.on_refresh_clicked)
         self.backfillMissingDetailedRoutesButton.clicked.connect(self.on_backfill_missing_detailed_routes_clicked)
         self.loadButton.clicked.connect(self.on_load_clicked)
+        if getattr(self, "syncRoutesButton", None) is not None:
+            self.syncRoutesButton.clicked.connect(self.on_sync_routes_clicked)
         self.loadLayersButton.clicked.connect(self.on_load_layers_clicked)
         self.clearDatabaseButton.clicked.connect(self.on_clear_database_clicked)
         self.applyFiltersButton.clicked.connect(self.on_apply_filters_clicked)
@@ -1281,6 +1291,107 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._update_stored_activities_summary(result.total_stored)
         self._set_status(result.status)
 
+    def on_sync_routes_clicked(self):
+        """Fetch saved Strava routes, persist them, and load route layers."""
+
+        if self._route_sync_task is not None:
+            self._route_sync_task.cancel()
+            self._runtime_store().clear_route_sync()
+            self._set_route_sync_running(False)
+            self._set_status("Route sync cancelled.")
+            return
+
+        self._save_settings()
+        output_path = self.outputPathLineEdit.text().strip()
+        if not output_path:
+            self._show_error(*build_missing_output_path_error())
+            return
+
+        try:
+            route_sync_request = self.sync_controller.build_route_sync_task_request(
+                client_id=self.clientIdLineEdit.text().strip(),
+                client_secret=self.clientSecretLineEdit.text().strip(),
+                refresh_token=self.refreshTokenLineEdit.text().strip(),
+                cache=self.cache,
+                output_path=output_path,
+                per_page=self.perPageSpinBox.value(),
+                max_pages=self.maxPagesSpinBox.value(),
+                use_gpx_geometry=True,
+                on_finished=self._handle_route_sync_task_finished,
+            )
+            route_sync_task = self.sync_controller.build_route_sync_task(route_sync_request)
+        except ProviderError as exc:
+            self._show_error("Route sync failed", str(exc))
+            self._set_status("Route sync failed")
+            return
+
+        self._runtime_store().begin_route_sync(route_sync_task)
+        self._set_route_sync_running(True)
+        self._set_status("Syncing saved Strava routes…")
+        QgsApplication.taskManager().addTask(route_sync_task)
+
+    def _set_route_sync_running(self, running):
+        button = getattr(self, "syncRoutesButton", None)
+        if button is None:
+            return
+        button.setText("Cancel route sync" if running else "Sync saved routes")
+        button.setEnabled(True)
+        self.exchangeCodeButton.setEnabled(not running)
+        self.openAuthorizeButton.setEnabled(not running)
+
+    def _handle_route_sync_task_finished(self, result, error_message, cancelled, provider):
+        self._runtime_store().clear_route_sync()
+        self._set_route_sync_running(False)
+
+        if cancelled:
+            self._set_status("Route sync cancelled")
+            return
+        if error_message:
+            self._show_error("Route sync failed", error_message)
+            self._set_status("Route sync failed")
+            return
+        if result is None:
+            self._set_status("Route sync failed")
+            return
+
+        try:
+            route_tracks_layer, route_points_layer, route_profile_samples_layer = (
+                self.layer_gateway.load_route_layers(result["path"])
+            )
+        except (RuntimeError, OSError) as exc:
+            _msg = "Load route layers failed"
+            logger.exception(_msg)
+            self._show_error(_msg, str(exc))
+            self._set_status(_msg)
+            return
+
+        self._runtime_store().set_route_layers(
+            route_tracks_layer=route_tracks_layer,
+            route_points_layer=route_points_layer,
+            route_profile_samples_layer=route_profile_samples_layer,
+        )
+        self._mark_atlas_export_stale()
+
+        sync = result.get("sync")
+        rate_limit_note = self.sync_controller._rate_limit_note(
+            getattr(provider, "last_rate_limit", None)
+        )
+        status = (
+            "Synced {fetched} saved routes into GeoPackage: inserted {inserted}, "
+            "updated {updated}, unchanged {unchanged}, stored total {total}. "
+            "Loaded {tracks} route tracks, {points} route points, and {samples} profile samples."
+        ).format(
+            fetched=result.get("fetched_count", 0),
+            inserted=sync.inserted if sync else 0,
+            updated=sync.updated if sync else 0,
+            unchanged=sync.unchanged if sync else 0,
+            total=sync.total_count if sync else 0,
+            tracks=result.get("route_track_count", 0),
+            points=result.get("route_point_count", 0),
+            samples=result.get("route_profile_sample_count", 0),
+        )
+        self._set_status(status + rate_limit_note)
+
     def on_load_layers_clicked(self):
         """Load an existing GeoPackage into QGIS without fetching from Strava."""
         self._save_settings()
@@ -1307,6 +1418,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             starts_layer=result.starts_layer,
             points_layer=result.points_layer,
             atlas_layer=result.atlas_layer,
+        )
+        self._runtime_store().set_route_layers(
+            route_tracks_layer=getattr(result, "route_tracks_layer", None),
+            route_points_layer=getattr(result, "route_points_layer", None),
+            route_profile_samples_layer=getattr(result, "route_profile_samples_layer", None),
         )
         self._mark_atlas_export_stale()
 
@@ -1345,6 +1461,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     self.starts_layer,
                     self.points_layer,
                     self.atlas_layer,
+                    self.runtime_state.route_tracks_layer,
+                    self.runtime_state.route_points_layer,
+                    self.runtime_state.route_profile_samples_layer,
                 ],
             )
             result = workflow.clear_database_request(request)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1296,9 +1296,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         if self._route_sync_task is not None:
             self._route_sync_task.cancel()
-            self._runtime_store().clear_route_sync()
-            self._set_route_sync_running(False)
-            self._set_status("Route sync cancelled.")
+            self._set_route_sync_cancelling()
+            self._set_status("Route sync cancellation requested…")
             return
 
         self._save_settings()
@@ -1339,11 +1338,20 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.exchangeCodeButton.setEnabled(not running)
         self.openAuthorizeButton.setEnabled(not running)
 
+    def _set_route_sync_cancelling(self):
+        button = getattr(self, "syncRoutesButton", None)
+        if button is None:
+            return
+        button.setText("Cancelling route sync…")
+        button.setEnabled(False)
+        self.exchangeCodeButton.setEnabled(False)
+        self.openAuthorizeButton.setEnabled(False)
+
     def _handle_route_sync_task_finished(self, result, error_message, cancelled, provider):
         self._runtime_store().clear_route_sync()
         self._set_route_sync_running(False)
 
-        if cancelled:
+        if cancelled and result is None:
             self._set_status("Route sync cancelled")
             return
         if error_message:
@@ -1355,8 +1363,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         try:
+            output_path = result.get("path")
+            if not output_path:
+                raise RuntimeError("Route sync did not return a GeoPackage path.")
             route_tracks_layer, route_points_layer, route_profile_samples_layer = (
-                self.layer_gateway.load_route_layers(result["path"])
+                self.layer_gateway.load_route_layers(output_path)
             )
         except (RuntimeError, OSError) as exc:
             _msg = "Load route layers failed"
@@ -1390,6 +1401,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             points=result.get("route_point_count", 0),
             samples=result.get("route_profile_sample_count", 0),
         )
+        if cancelled:
+            status = "Route sync completed after cancellation was requested. " + status
         self._set_status(status + rate_limit_note)
 
     def on_load_layers_clicked(self):

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -409,6 +409,16 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="syncRoutesButton">
+             <property name="text">
+              <string>Sync saved routes</string>
+             </property>
+             <property name="toolTip">
+              <string>Fetch saved/planned Strava routes, write route_catalog layers to the GeoPackage, and load them as dedicated route layers.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QPushButton" name="loadLayersButton">
              <property name="text">
               <string>Load activity layers</string>

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -75,12 +75,18 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
         layer_gateway = MagicMock()
         activities_layer = MagicMock()
         activities_layer.featureCount.return_value = 42
+        route_layers = (
+            MagicMock(name="route_tracks"),
+            MagicMock(name="route_points"),
+            MagicMock(name="route_profile_samples"),
+        )
         layer_gateway.load_output_layers.return_value = (
             activities_layer,
             MagicMock(name="starts"),
             MagicMock(name="points"),
             MagicMock(name="atlas"),
         )
+        layer_gateway.load_route_layers.return_value = route_layers
         workflow = LoadDatasetWorkflow(layer_gateway, path_exists=lambda _path: True)
 
         result = workflow.load_existing_request(
@@ -89,6 +95,9 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
 
         self.assertIsInstance(result, LoadDatasetResult)
         self.assertEqual(result.total_stored, 42)
+        self.assertEqual(result.route_tracks_layer, route_layers[0])
+        self.assertEqual(result.route_points_layer, route_layers[1])
+        self.assertEqual(result.route_profile_samples_layer, route_layers[2])
         self.assertIn("/tmp/existing.gpkg", result.status)
 
 
@@ -396,7 +405,13 @@ class LoadExistingSuccessTests(unittest.TestCase):
             MagicMock(name="points"),
             MagicMock(name="atlas"),
         )
+        route_layers = (
+            MagicMock(name="route_tracks"),
+            MagicMock(name="route_points"),
+            MagicMock(name="route_profile_samples"),
+        )
         self.layer_manager.load_output_layers.return_value = mock_layers
+        self.layer_manager.load_route_layers.return_value = route_layers
 
         result = self.service.load_existing("/tmp/existing.gpkg")
 
@@ -404,12 +419,15 @@ class LoadExistingSuccessTests(unittest.TestCase):
         self.assertEqual(result.output_path, "/tmp/existing.gpkg")
         self.assertEqual(result.total_stored, 42)
         self.assertEqual(result.activities_layer, mock_activities_layer)
+        self.assertEqual(result.route_tracks_layer, route_layers[0])
         self.assertIn("/tmp/existing.gpkg", result.status)
         self.layer_manager.load_output_layers.assert_called_once_with("/tmp/existing.gpkg")
+        self.layer_manager.load_route_layers.assert_called_once_with("/tmp/existing.gpkg")
 
     @patch("qfit.activities.application.load_workflow.os.path.exists", return_value=True)
     def test_handles_none_activities_layer(self, mock_exists):
         self.layer_manager.load_output_layers.return_value = (None, None, None, None)
+        self.layer_manager.load_route_layers.return_value = (None, None, None)
 
         result = self.service.load_existing("/tmp/empty.gpkg")
 
@@ -543,6 +561,7 @@ class LoadRequestContractTests(unittest.TestCase):
     def test_load_existing_request_matches_legacy_wrapper(self, _mock_exists):
         layer_manager = MagicMock()
         layer_manager.load_output_layers.return_value = (None, None, None, None)
+        layer_manager.load_route_layers.return_value = (None, None, None)
         service = LoadWorkflowService(layer_manager)
 
         request = service.build_load_existing_request("/tmp/existing.gpkg")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1743,6 +1743,23 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._set_status.assert_called_once_with("Syncing saved Strava routes…")
         fake_task_manager.addTask.assert_called_once_with(fake_task)
 
+    def test_on_sync_routes_clicked_requests_cancel_without_clearing_running_task(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        running_task = MagicMock()
+        dock._route_sync_task = running_task
+        dock.syncRoutesButton = _FakeButton("Cancel route sync")
+        dock.exchangeCodeButton = _FakeButton("Exchange")
+        dock.openAuthorizeButton = _FakeButton("Authorize")
+        dock._set_status = MagicMock()
+
+        self.module.QfitDockWidget.on_sync_routes_clicked(dock)
+
+        running_task.cancel.assert_called_once_with()
+        self.assertIs(dock._route_sync_task, running_task)
+        self.assertEqual(dock.syncRoutesButton.text(), "Cancelling route sync…")
+        self.assertFalse(dock.syncRoutesButton.isEnabled())
+        dock._set_status.assert_called_once_with("Route sync cancellation requested…")
+
     def test_handle_route_sync_task_finished_loads_route_layers(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._route_sync_task = object()
@@ -1786,6 +1803,29 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.layer_gateway.load_route_layers.assert_called_once_with("/tmp/qfit.gpkg")
         dock._mark_atlas_export_stale.assert_called_once_with()
         dock._set_status.assert_called_once()
+
+    def test_handle_route_sync_task_finished_reports_missing_result_path(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._route_sync_task = object()
+        dock.syncRoutesButton = _FakeButton("Cancel route sync")
+        dock.exchangeCodeButton = _FakeButton("Exchange")
+        dock.openAuthorizeButton = _FakeButton("Authorize")
+        dock.layer_gateway = MagicMock()
+        dock._show_error = MagicMock()
+        dock._set_status = MagicMock()
+
+        self.module.QfitDockWidget._handle_route_sync_task_finished(
+            dock,
+            {},
+            None,
+            False,
+            SimpleNamespace(last_rate_limit=None),
+        )
+
+        self.assertIsNone(dock._route_sync_task)
+        dock.layer_gateway.load_route_layers.assert_not_called()
+        dock._show_error.assert_called_once()
+        dock._set_status.assert_called_once_with("Load route layers failed")
 
     def test_on_refresh_clicked_cancels_existing_fetch_task(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1695,6 +1695,98 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._update_stored_activities_summary.assert_called_once_with(12)
         dock._set_status.assert_called_once_with("Stored 12 activities")
 
+    def test_on_sync_routes_clicked_starts_background_route_task(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._route_sync_task = None
+        dock._save_settings = MagicMock()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock.perPageSpinBox = _FakeSpinBox(100)
+        dock.maxPagesSpinBox = _FakeSpinBox(0)
+        dock.cache = "cache"
+        dock.syncRoutesButton = _FakeButton("Sync saved routes")
+        dock.exchangeCodeButton = _FakeButton("Exchange")
+        dock.openAuthorizeButton = _FakeButton("Authorize")
+        dock._set_status = MagicMock()
+        dock.sync_controller = MagicMock()
+        dock.sync_controller.build_route_sync_task_request.return_value = "route-request"
+        fake_task = object()
+        dock.sync_controller.build_route_sync_task.return_value = fake_task
+        fake_task_manager = SimpleNamespace(addTask=MagicMock())
+
+        with patch.object(
+            self.module.QgsApplication,
+            "taskManager",
+            return_value=fake_task_manager,
+        ):
+            self.module.QfitDockWidget.on_sync_routes_clicked(dock)
+
+        dock._save_settings.assert_called_once_with()
+        dock.sync_controller.build_route_sync_task_request.assert_called_once_with(
+            client_id="client-id",
+            client_secret="client-secret",
+            refresh_token="refresh-token",
+            cache="cache",
+            output_path="/tmp/qfit.gpkg",
+            per_page=100,
+            max_pages=0,
+            use_gpx_geometry=True,
+            on_finished=dock._handle_route_sync_task_finished,
+        )
+        dock.sync_controller.build_route_sync_task.assert_called_once_with("route-request")
+        self.assertIs(dock._route_sync_task, fake_task)
+        self.assertEqual(dock.syncRoutesButton.text(), "Cancel route sync")
+        self.assertFalse(dock.exchangeCodeButton.isEnabled())
+        self.assertFalse(dock.openAuthorizeButton.isEnabled())
+        dock._set_status.assert_called_once_with("Syncing saved Strava routes…")
+        fake_task_manager.addTask.assert_called_once_with(fake_task)
+
+    def test_handle_route_sync_task_finished_loads_route_layers(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._route_sync_task = object()
+        dock.syncRoutesButton = _FakeButton("Cancel route sync")
+        dock.exchangeCodeButton = _FakeButton("Exchange")
+        dock.exchangeCodeButton.setEnabled(False)
+        dock.openAuthorizeButton = _FakeButton("Authorize")
+        dock.openAuthorizeButton.setEnabled(False)
+        dock.layer_gateway = MagicMock()
+        route_layers = ("route-tracks", "route-points", "route-profile-samples")
+        dock.layer_gateway.load_route_layers.return_value = route_layers
+        dock.sync_controller = MagicMock()
+        dock.sync_controller._rate_limit_note.return_value = ""
+        dock._mark_atlas_export_stale = MagicMock()
+        dock._set_status = MagicMock()
+        result = {
+            "path": "/tmp/qfit.gpkg",
+            "fetched_count": 2,
+            "route_track_count": 2,
+            "route_point_count": 6,
+            "route_profile_sample_count": 10,
+            "sync": SimpleNamespace(inserted=1, updated=1, unchanged=0, total_count=2),
+        }
+        provider = SimpleNamespace(last_rate_limit=None)
+
+        self.module.QfitDockWidget._handle_route_sync_task_finished(
+            dock,
+            result,
+            None,
+            False,
+            provider,
+        )
+
+        self.assertIsNone(dock._route_sync_task)
+        self.assertEqual(dock.runtime_state.route_tracks_layer, route_layers[0])
+        self.assertEqual(dock.runtime_state.route_points_layer, route_layers[1])
+        self.assertEqual(dock.runtime_state.route_profile_samples_layer, route_layers[2])
+        self.assertEqual(dock.syncRoutesButton.text(), "Sync saved routes")
+        self.assertTrue(dock.exchangeCodeButton.isEnabled())
+        self.assertTrue(dock.openAuthorizeButton.isEnabled())
+        dock.layer_gateway.load_route_layers.assert_called_once_with("/tmp/qfit.gpkg")
+        dock._mark_atlas_export_stale.assert_called_once_with()
+        dock._set_status.assert_called_once()
+
     def test_on_refresh_clicked_cancels_existing_fetch_task(self):
         dock = object.__new__(self.module.QfitDockWidget)
         running_task = MagicMock()

--- a/tests/test_route_sync_task.py
+++ b/tests/test_route_sync_task.py
@@ -1,0 +1,146 @@
+import importlib
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+
+
+class _FakeQgsTask:
+    CanCancel = 1
+
+    def __init__(self, description, flags=0):
+        self._cancelled = False
+
+    def isCanceled(self):
+        return self._cancelled
+
+    def cancel(self):
+        self._cancelled = True
+
+
+_qgis_core = ModuleType("qgis.core")
+_qgis_core.QgsTask = _FakeQgsTask
+_qgis = ModuleType("qgis")
+_qgis.core = _qgis_core
+_ORIGINAL_QGIS = sys.modules.get("qgis")
+_ORIGINAL_QGIS_CORE = sys.modules.get("qgis.core")
+sys.modules["qgis"] = _qgis
+sys.modules["qgis.core"] = _qgis_core
+
+from qfit.activities.application import route_sync_task as route_sync_task_module  # noqa: E402
+from qfit.providers.domain import ProviderError  # noqa: E402
+
+route_sync_task_module = importlib.reload(route_sync_task_module)
+RouteSyncTask = route_sync_task_module.RouteSyncTask
+
+if _ORIGINAL_QGIS is not None:
+    sys.modules["qgis"] = _ORIGINAL_QGIS
+else:
+    sys.modules.pop("qgis", None)
+if _ORIGINAL_QGIS_CORE is not None:
+    sys.modules["qgis.core"] = _ORIGINAL_QGIS_CORE
+else:
+    sys.modules.pop("qgis.core", None)
+
+
+def _run_task(task):
+    ok = task.run()
+    task.finished(ok)
+    return ok
+
+
+class RouteSyncTaskTests(unittest.TestCase):
+    def test_fetches_enriches_and_writes_routes(self):
+        received = {}
+        summary_route = SimpleNamespace(source_route_id="42", details_json={})
+        detailed_route = SimpleNamespace(
+            source_route_id="42",
+            details_json={"gpx_geometry_status": "downloaded"},
+        )
+        provider = MagicMock()
+        provider.source_name = "strava"
+        provider.last_fetch_notice = None
+        provider.last_rate_limit = {"short_remaining": 50}
+        provider.fetch_routes.return_value = [summary_route]
+        provider.fetch_route_detail.return_value = detailed_route
+        writer = MagicMock()
+        writer.write_routes.return_value = {"path": "/tmp/routes.gpkg", "sync": None}
+        writer_factory = MagicMock(return_value=writer)
+
+        task = RouteSyncTask(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            per_page=25,
+            max_pages=0,
+            writer_factory=writer_factory,
+            on_finished=lambda result, error, cancelled, provider: received.update(
+                result=result,
+                error=error,
+                cancelled=cancelled,
+                provider=provider,
+            ),
+        )
+
+        self.assertTrue(_run_task(task))
+        provider.fetch_routes.assert_called_once_with(per_page=25, max_pages=0)
+        provider.fetch_route_detail.assert_called_once_with("42", use_gpx_geometry=True)
+        writer_factory.assert_called_once_with(output_path="/tmp/routes.gpkg")
+        written_routes = writer.write_routes.call_args.args[0]
+        metadata = writer.write_routes.call_args.kwargs["sync_metadata"]
+        self.assertEqual(written_routes, [detailed_route])
+        self.assertEqual(metadata["provider"], "strava")
+        self.assertEqual(metadata["fetched_count"], 1)
+        self.assertEqual(metadata["detailed_count"], 1)
+        self.assertTrue(metadata["is_full_sync"])
+        self.assertEqual(received["result"], {"path": "/tmp/routes.gpkg", "sync": None})
+        self.assertIsNone(received["error"])
+        self.assertFalse(received["cancelled"])
+        self.assertIs(received["provider"], provider)
+
+    def test_returns_error_when_provider_fails(self):
+        received = {}
+        provider = MagicMock()
+        provider.fetch_routes.side_effect = ProviderError("route scope missing")
+
+        task = RouteSyncTask(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            writer_factory=MagicMock(),
+            on_finished=lambda result, error, cancelled, provider: received.update(
+                result=result,
+                error=error,
+                cancelled=cancelled,
+            ),
+        )
+
+        self.assertFalse(_run_task(task))
+        self.assertIsNone(received["result"])
+        self.assertEqual(received["error"], "route scope missing")
+        self.assertFalse(received["cancelled"])
+
+    def test_can_skip_gpx_detail_fetch(self):
+        route = SimpleNamespace(source_route_id="42", details_json={})
+        provider = MagicMock()
+        provider.source_name = "strava"
+        provider.last_fetch_notice = None
+        provider.last_rate_limit = None
+        provider.fetch_routes.return_value = [route]
+        writer = MagicMock()
+        writer.write_routes.return_value = {}
+
+        task = RouteSyncTask(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            use_gpx_geometry=False,
+            writer_factory=MagicMock(return_value=writer),
+        )
+
+        self.assertTrue(task.run())
+        provider.fetch_route_detail.assert_not_called()
+        self.assertEqual(writer.write_routes.call_args.args[0], [route])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_route_sync_task.py
+++ b/tests/test_route_sync_task.py
@@ -120,6 +120,41 @@ class RouteSyncTaskTests(unittest.TestCase):
         self.assertEqual(received["error"], "route scope missing")
         self.assertFalse(received["cancelled"])
 
+    def test_preserves_write_result_when_cancelled_after_persisting(self):
+        received = {}
+        route = SimpleNamespace(source_route_id="42", details_json={})
+        provider = MagicMock()
+        provider.source_name = "strava"
+        provider.last_fetch_notice = None
+        provider.last_rate_limit = None
+        provider.fetch_routes.return_value = [route]
+        writer = MagicMock()
+
+        task = RouteSyncTask(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            use_gpx_geometry=False,
+            writer_factory=MagicMock(return_value=writer),
+            on_finished=lambda result, error, cancelled, provider: received.update(
+                result=result,
+                error=error,
+                cancelled=cancelled,
+            ),
+        )
+
+        write_result = {"path": "/tmp/routes.gpkg", "sync": None}
+
+        def _write_routes(_routes, sync_metadata=None):
+            task.cancel()
+            return write_result
+
+        writer.write_routes.side_effect = _write_routes
+
+        self.assertTrue(_run_task(task))
+        self.assertEqual(received["result"], write_result)
+        self.assertIsNone(received["error"])
+        self.assertTrue(received["cancelled"])
+
     def test_can_skip_gpx_detail_fetch(self):
         route = SimpleNamespace(source_route_id="42", details_json={})
         provider = MagicMock()

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -7,6 +7,7 @@ from qfit.providers.domain import ProviderError
 from qfit.providers.infrastructure import StravaProvider
 from qfit.activities.application.sync_controller import (
     BuildFetchTaskRequest,
+    BuildRouteSyncTaskRequest,
     BuildStravaProviderRequest,
     ExchangeStravaCodeRequest,
     StravaAuthorizeRequest,
@@ -162,7 +163,71 @@ class BuildFetchTaskTests(unittest.TestCase):
             detailed_route_strategy="Recent fetch only",
             on_finished="callback",
         )
-        self.assertIs(task, fetch_task_class.return_value)
+
+
+class BuildRouteSyncTaskTests(unittest.TestCase):
+    def test_build_route_sync_task_request_returns_structured_request(self):
+        ctrl = SyncController()
+
+        request = ctrl.build_route_sync_task_request(
+            client_id="id",
+            client_secret="secret",
+            refresh_token="token",
+            cache="cache",
+            output_path="/tmp/routes.gpkg",
+            per_page=50,
+            max_pages=2,
+            use_gpx_geometry=False,
+            on_finished="callback",
+        )
+
+        self.assertIsInstance(request, BuildRouteSyncTaskRequest)
+        self.assertEqual(request.output_path, "/tmp/routes.gpkg")
+        self.assertEqual(request.per_page, 50)
+        self.assertFalse(request.use_gpx_geometry)
+
+    def test_build_route_sync_task_validates_provider_and_constructs_task(self):
+        ctrl = SyncController()
+        provider = MagicMock(name="provider")
+
+        with (
+            patch.object(ctrl, "build_strava_provider", return_value=provider) as build_provider,
+            patch("qfit.activities.application.sync_controller.RouteSyncTask") as task_class,
+        ):
+            task = ctrl.build_route_sync_task(
+                client_id="id",
+                client_secret="secret",
+                refresh_token="token",
+                cache="cache",
+                output_path="/tmp/routes.gpkg",
+                per_page=25,
+                max_pages=1,
+                use_gpx_geometry=True,
+                on_finished="callback",
+            )
+
+        build_provider.assert_called_once()
+        task_class.assert_called_once_with(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            per_page=25,
+            max_pages=1,
+            use_gpx_geometry=True,
+            on_finished="callback",
+        )
+        self.assertIs(task, task_class.return_value)
+
+    def test_build_route_sync_task_requires_output_path(self):
+        ctrl = SyncController()
+
+        with self.assertRaisesRegex(ProviderError, "GeoPackage output path"):
+            ctrl.build_route_sync_task(
+                client_id="id",
+                client_secret="secret",
+                refresh_token="token",
+                cache="cache",
+                output_path="",
+            )
 
     def test_build_fetch_task_supports_legacy_kwargs_without_strategy(self):
         ctrl = SyncController()

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -163,6 +163,7 @@ class BuildFetchTaskTests(unittest.TestCase):
             detailed_route_strategy="Recent fetch only",
             on_finished="callback",
         )
+        self.assertIs(task, fetch_task_class.return_value)
 
 
 class BuildRouteSyncTaskTests(unittest.TestCase):

--- a/ui/application/dock_runtime_state.py
+++ b/ui/application/dock_runtime_state.py
@@ -12,6 +12,9 @@ class DockRuntimeLayers:
     starts: object = None
     points: object = None
     atlas: object = None
+    route_tracks: object = None
+    route_points: object = None
+    route_profile_samples: object = None
     background: object = None
     analysis: object = None
 
@@ -33,6 +36,23 @@ class DockRuntimeLayers:
 
     def clear_dataset(self) -> "DockRuntimeLayers":
         return self.with_dataset()
+
+    def with_routes(
+        self,
+        *,
+        route_tracks_layer=None,
+        route_points_layer=None,
+        route_profile_samples_layer=None,
+    ) -> "DockRuntimeLayers":
+        return replace(
+            self,
+            route_tracks=route_tracks_layer,
+            route_points=route_points_layer,
+            route_profile_samples=route_profile_samples_layer,
+        )
+
+    def clear_routes(self) -> "DockRuntimeLayers":
+        return self.with_routes()
 
     def with_background(self, layer) -> "DockRuntimeLayers":
         return replace(self, background=layer)
@@ -56,6 +76,7 @@ class DockRuntimeLayers:
 class DockRuntimeTasks:
     fetch: object = None
     store: object = None
+    route_sync: object = None
     atlas_export: object = None
 
     def with_fetch(self, task) -> "DockRuntimeTasks":
@@ -63,6 +84,9 @@ class DockRuntimeTasks:
 
     def with_store(self, task) -> "DockRuntimeTasks":
         return replace(self, store=task)
+
+    def with_route_sync(self, task) -> "DockRuntimeTasks":
+        return replace(self, route_sync=task)
 
     def with_atlas_export(self, task) -> "DockRuntimeTasks":
         return replace(self, atlas_export=task)
@@ -72,6 +96,9 @@ class DockRuntimeTasks:
 
     def clear_store(self) -> "DockRuntimeTasks":
         return self.with_store(None)
+
+    def clear_route_sync(self) -> "DockRuntimeTasks":
+        return self.with_route_sync(None)
 
     def clear_atlas_export(self) -> "DockRuntimeTasks":
         return self.with_atlas_export(None)
@@ -103,6 +130,18 @@ class DockRuntimeState:
         return self.layers.atlas
 
     @property
+    def route_tracks_layer(self):
+        return self.layers.route_tracks
+
+    @property
+    def route_points_layer(self):
+        return self.layers.route_points
+
+    @property
+    def route_profile_samples_layer(self):
+        return self.layers.route_profile_samples
+
+    @property
     def background_layer(self):
         return self.layers.background
 
@@ -117,6 +156,10 @@ class DockRuntimeState:
     @property
     def store_task(self):
         return self.tasks.store
+
+    @property
+    def route_sync_task(self):
+        return self.tasks.route_sync
 
     @property
     def atlas_export_task(self):
@@ -166,6 +209,21 @@ class DockRuntimeStore:
             )
         )
 
+    def set_route_layers(
+        self,
+        *,
+        route_tracks_layer=None,
+        route_points_layer=None,
+        route_profile_samples_layer=None,
+    ) -> DockRuntimeState:
+        return self._replace_state(
+            layers=self._state.layers.with_routes(
+                route_tracks_layer=route_tracks_layer,
+                route_points_layer=route_points_layer,
+                route_profile_samples_layer=route_profile_samples_layer,
+            )
+        )
+
     def set_background_layer(self, layer) -> DockRuntimeState:
         return self._replace_state(layers=self._state.layers.with_background(layer))
 
@@ -184,8 +242,14 @@ class DockRuntimeStore:
     def set_store_task(self, task) -> DockRuntimeState:
         return self._replace_state(tasks=self._state.tasks.with_store(task))
 
+    def set_route_sync_task(self, task) -> DockRuntimeState:
+        return self._replace_state(tasks=self._state.tasks.with_route_sync(task))
+
     def clear_store(self) -> DockRuntimeState:
         return self._replace_state(tasks=self._state.tasks.clear_store())
+
+    def clear_route_sync(self) -> DockRuntimeState:
+        return self._replace_state(tasks=self._state.tasks.clear_route_sync())
 
     def set_atlas_export_task(self, task) -> DockRuntimeState:
         return self._replace_state(tasks=self._state.tasks.with_atlas_export(task))
@@ -214,6 +278,9 @@ class DockRuntimeStore:
 
     def begin_store(self, task) -> DockRuntimeState:
         return self.set_store_task(task)
+
+    def begin_route_sync(self, task) -> DockRuntimeState:
+        return self.set_route_sync_task(task)
 
     def finish_store(
         self,
@@ -282,7 +349,7 @@ class DockRuntimeStore:
             output_path=None,
             stored_activity_count=None,
             last_fetch_context={},
-            layers=self._state.layers.clear_dataset(),
+            layers=self._state.layers.clear_dataset().clear_routes(),
         )
 
     def clear_loaded_dataset(self) -> DockRuntimeState:


### PR DESCRIPTION
## Summary
- add a background saved-route sync task that fetches Strava saved routes, enriches route detail with GPX geometry, writes route_catalog data to the GeoPackage, and preserves full-sync prune metadata
- wire a dock button to run/cancel route sync and load dedicated route layers when it completes
- load route layers when reopening an existing GeoPackage and clear them with the database reset flow

Closes #733

## Tests
- python3 -m pytest -q (via /tmp copy named qfit because this worktree name is not import-compatible with tests/_path.py): 1530 passed, 177 skipped, 9 subtests passed