### PR TITLE
Fix wizard route sync and local GeoPackage loading

### DIFF
--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -19,7 +19,6 @@ from qgis.PyQt.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QLayout,
     QMessageBox,
     QPushButton,
     QVBoxLayout,
@@ -49,6 +48,14 @@ logger = logging.getLogger(__name__)
 
 _NOT_TESTED_LABEL = "Not tested"
 _OAUTH_NOT_STARTED_LABEL = "Not started"
+
+
+def _configure_wrapping_status_label(label: QLabel) -> QLabel:
+    """Keep long connection/test messages inside the dialog content width."""
+
+    label.setWordWrap(True)
+    label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+    return label
 
 
 class QfitConfigDialog(QDialog):
@@ -82,7 +89,6 @@ class QfitConfigDialog(QDialog):
 
     def _build_ui(self) -> None:
         layout = QVBoxLayout(self)
-        layout.setSizeConstraint(QLayout.SetFixedSize)
 
         layout.addWidget(self._build_strava_group())
         layout.addWidget(self._build_mapbox_group())
@@ -101,7 +107,7 @@ class QfitConfigDialog(QDialog):
 
         self._strava_status_label = QLabel()
         self._strava_status_label.setObjectName("stravaStatusLabel")
-        self._strava_status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        _configure_wrapping_status_label(self._strava_status_label)
         form.addRow("Status:", self._strava_status_label)
 
         self._client_id_edit = QLineEdit()
@@ -153,8 +159,7 @@ class QfitConfigDialog(QDialog):
 
         self._strava_oauth_status_label = QLabel(_OAUTH_NOT_STARTED_LABEL)
         self._strava_oauth_status_label.setObjectName("stravaOAuthStatusLabel")
-        self._strava_oauth_status_label.setWordWrap(True)
-        self._strava_oauth_status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        _configure_wrapping_status_label(self._strava_oauth_status_label)
         form.addRow("OAuth helper:", self._strava_oauth_status_label)
 
         self._refresh_token_edit = make_password_line_edit(
@@ -165,7 +170,7 @@ class QfitConfigDialog(QDialog):
 
         self._strava_test_status_label = QLabel(_NOT_TESTED_LABEL)
         self._strava_test_status_label.setObjectName("stravaTestStatusLabel")
-        self._strava_test_status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        _configure_wrapping_status_label(self._strava_test_status_label)
         form.addRow("Last test:", self._strava_test_status_label)
 
         self._test_strava_button = QPushButton("Test connection")
@@ -182,7 +187,7 @@ class QfitConfigDialog(QDialog):
 
         self._mapbox_status_label = QLabel()
         self._mapbox_status_label.setObjectName("mapboxStatusLabel")
-        self._mapbox_status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        _configure_wrapping_status_label(self._mapbox_status_label)
         form.addRow("Status:", self._mapbox_status_label)
 
         self._mapbox_token_edit = make_password_line_edit(
@@ -193,7 +198,7 @@ class QfitConfigDialog(QDialog):
 
         self._mapbox_test_status_label = QLabel(_NOT_TESTED_LABEL)
         self._mapbox_test_status_label.setObjectName("mapboxTestStatusLabel")
-        self._mapbox_test_status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        _configure_wrapping_status_label(self._mapbox_test_status_label)
         form.addRow("Last test:", self._mapbox_test_status_label)
 
         self._test_mapbox_button = QPushButton("Test connection")
@@ -367,3 +372,4 @@ class QfitConfigDialog(QDialog):
         """Reload settings every time the dialog becomes visible."""
         super().showEvent(event)
         self._load()
+        self.adjustSize()

--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -19,6 +19,7 @@ from qgis.PyQt.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QLayout,
     QMessageBox,
     QPushButton,
     QVBoxLayout,
@@ -81,10 +82,10 @@ class QfitConfigDialog(QDialog):
 
     def _build_ui(self) -> None:
         layout = QVBoxLayout(self)
+        layout.setSizeConstraint(QLayout.SetFixedSize)
 
         layout.addWidget(self._build_strava_group())
         layout.addWidget(self._build_mapbox_group())
-        layout.addStretch()
 
         self._button_box = QDialogButtonBox(
             QDialogButtonBox.Save | QDialogButtonBox.Close,
@@ -96,6 +97,7 @@ class QfitConfigDialog(QDialog):
     def _build_strava_group(self) -> QGroupBox:
         group = QGroupBox("Strava connection")
         form = QFormLayout(group)
+        form.setRowWrapPolicy(QFormLayout.WrapLongRows)
 
         self._strava_status_label = QLabel()
         self._strava_status_label.setObjectName("stravaStatusLabel")
@@ -123,7 +125,7 @@ class QfitConfigDialog(QDialog):
         self._oauth_help_label.setObjectName("stravaOAuthHelpLabel")
         self._oauth_help_label.setWordWrap(True)
         self._oauth_help_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        form.addRow("", self._oauth_help_label)
+        form.addRow(self._oauth_help_label)
 
         self._authorization_code_edit = QLineEdit()
         self._authorization_code_edit.setObjectName("cfgAuthorizationCodeEdit")
@@ -176,6 +178,7 @@ class QfitConfigDialog(QDialog):
     def _build_mapbox_group(self) -> QGroupBox:
         group = QGroupBox("Mapbox connection")
         form = QFormLayout(group)
+        form.setRowWrapPolicy(QFormLayout.WrapLongRows)
 
         self._mapbox_status_label = QLabel()
         self._mapbox_status_label.setObjectName("mapboxStatusLabel")

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -291,7 +291,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _on_output_path_changed(self, value: str) -> None:
         """Keep wizard local-load actions in sync with the selected GeoPackage path."""
 
-        self._runtime_store().set_output_path((value or "").strip() or None)
+        self._runtime_store().select_output_path((value or "").strip() or None)
         self._refresh_wizard_shell_from_runtime()
 
     def _current_wizard_activity_style_preset(self) -> str | None:

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -442,6 +442,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             WizardActionCallbacks(
                 configure_connection=self._show_connection_configuration_hint,
                 sync_activities=self._run_wizard_sync_step,
+                sync_saved_routes=self.on_sync_routes_clicked,
                 load_activity_layers=self.on_load_layers_clicked,
                 edit_map_filters=self._update_status_for_filter_visibility,
                 apply_map_filters=self._run_wizard_map_step,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import date
 
 logger = logging.getLogger(__name__)
@@ -235,7 +236,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _current_wizard_progress_facts(self):
         """Return render-neutral #609 wizard facts from the live dock state."""
 
-        runtime_state = self.runtime_state
+        runtime_state = self._wizard_runtime_state_with_selected_output_path()
         atlas_exported = bool(getattr(self, "_atlas_export_completed", False))
         atlas_export_output_path = self._current_wizard_atlas_output_path(
             runtime_state=runtime_state,
@@ -277,6 +278,21 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if not isinstance(value, str):
             return None
         return value.strip() or None
+
+    def _wizard_runtime_state_with_selected_output_path(self):
+        """Reflect the visible GeoPackage path in wizard availability facts."""
+
+        runtime_state = self.runtime_state
+        selected_output_path = self._widget_text("outputPathLineEdit").strip()
+        if not selected_output_path or selected_output_path == runtime_state.output_path:
+            return runtime_state
+        return replace(runtime_state, output_path=selected_output_path)
+
+    def _on_output_path_changed(self, value: str) -> None:
+        """Keep wizard local-load actions in sync with the selected GeoPackage path."""
+
+        self._runtime_store().set_output_path((value or "").strip() or None)
+        self._refresh_wizard_shell_from_runtime()
 
     def _current_wizard_activity_style_preset(self) -> str | None:
         """Return current activity style copy for the optional wizard map page."""
@@ -795,6 +811,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.clientIdLineEdit.textChanged.connect(self._update_connection_status)
         self.clientSecretLineEdit.textChanged.connect(self._update_connection_status)
         self.refreshTokenLineEdit.textChanged.connect(self._update_connection_status)
+        self.outputPathLineEdit.textChanged.connect(self._on_output_path_changed)
 
         preview_inputs = [
             self.activityTypeComboBox.currentTextChanged,

--- a/tests/test_dock_runtime_state.py
+++ b/tests/test_dock_runtime_state.py
@@ -92,6 +92,37 @@ class TestDockRuntimeStore(unittest.TestCase):
         self.assertIs(store.state.background_layer, background_layer)
         self.assertIs(store.state.analysis_layer, analysis_layer)
 
+    def test_select_output_path_clears_stale_loaded_dataset_state(self):
+        store = DockRuntimeStore()
+        store.finish_fetch(activities=["run"], metadata={"provider": "strava"})
+        store.load_dataset(
+            output_path="/tmp/old-qfit.gpkg",
+            stored_activity_count=2,
+            activities_layer=object(),
+            starts_layer=object(),
+            points_layer=object(),
+            atlas_layer=object(),
+        )
+        store.set_route_layers(
+            route_tracks_layer=object(),
+            route_points_layer=object(),
+            route_profile_samples_layer=object(),
+        )
+
+        store.select_output_path("  /tmp/new-qfit.gpkg  ")
+
+        self.assertEqual(store.state.output_path, "/tmp/new-qfit.gpkg")
+        self.assertEqual(store.state.activities, ("run",))
+        self.assertEqual(store.state.last_fetch_context, {"provider": "strava"})
+        self.assertIsNone(store.state.stored_activity_count)
+        self.assertIsNone(store.state.activities_layer)
+        self.assertIsNone(store.state.starts_layer)
+        self.assertIsNone(store.state.points_layer)
+        self.assertIsNone(store.state.atlas_layer)
+        self.assertIsNone(store.state.route_tracks_layer)
+        self.assertIsNone(store.state.route_points_layer)
+        self.assertIsNone(store.state.route_profile_samples_layer)
+
     def test_analysis_background_and_export_helpers_update_runtime(self):
         store = DockRuntimeStore()
         background_layer = object()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -727,6 +727,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         expected_callbacks = {
             "configure_connection": "_show_connection_configuration_hint",
             "sync_activities": "_run_wizard_sync_step",
+            "sync_saved_routes": "on_sync_routes_clicked",
             "load_activity_layers": "on_load_layers_clicked",
             "edit_map_filters": "_update_status_for_filter_visibility",
             "apply_map_filters": "_run_wizard_map_step",

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+import tempfile
 import unittest
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -682,10 +683,27 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.runtime_state.output_path, "/tmp/local-qfit.gpkg")
         dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
 
-    def test_wizard_progress_facts_reflect_visible_geopackage_path(self):
+    def test_wizard_progress_facts_reflect_existing_visible_geopackage_path(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()
-        dock.outputPathLineEdit = _FakeLineEdit("/tmp/local-qfit.gpkg")
+        dock.clientIdLineEdit = _FakeLineEdit("")
+        dock.clientSecretLineEdit = _FakeLineEdit("")
+        dock.refreshTokenLineEdit = _FakeLineEdit("")
+        dock._atlas_export_completed = False
+        dock.settings = _FakeSettings()
+
+        with tempfile.NamedTemporaryFile(suffix=".gpkg") as geopackage:
+            dock.outputPathLineEdit = _FakeLineEdit(geopackage.name)
+
+            facts = self.module.QfitDockWidget._current_wizard_progress_facts(dock)
+
+        self.assertTrue(facts.activities_stored)
+        self.assertEqual(facts.output_name, geopackage.name.rsplit("/", 1)[-1])
+
+    def test_wizard_progress_facts_do_not_treat_missing_visible_geopackage_as_stored(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit-definitely-missing.gpkg")
         dock.clientIdLineEdit = _FakeLineEdit("")
         dock.clientSecretLineEdit = _FakeLineEdit("")
         dock.refreshTokenLineEdit = _FakeLineEdit("")
@@ -694,8 +712,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         facts = self.module.QfitDockWidget._current_wizard_progress_facts(dock)
 
-        self.assertTrue(facts.activities_stored)
-        self.assertEqual(facts.output_name, "local-qfit.gpkg")
+        self.assertFalse(facts.activities_stored)
+        self.assertEqual(facts.output_name, "qfit-definitely-missing.gpkg")
 
     def test_build_wizard_shell_from_runtime_wires_persistence_and_callbacks(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -683,6 +683,26 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.runtime_state.output_path, "/tmp/local-qfit.gpkg")
         dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
 
+    def test_output_path_change_clears_stale_loaded_dataset_state(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_state_store.load_dataset(
+            output_path="/tmp/old-qfit.gpkg",
+            stored_activity_count=3,
+            activities_layer=object(),
+        )
+        dock._refresh_wizard_shell_from_runtime = MagicMock()
+
+        self.module.QfitDockWidget._on_output_path_changed(
+            dock,
+            "/tmp/new-qfit.gpkg",
+        )
+
+        self.assertEqual(dock.runtime_state.output_path, "/tmp/new-qfit.gpkg")
+        self.assertIsNone(dock.runtime_state.stored_activity_count)
+        self.assertIsNone(dock.runtime_state.activities_layer)
+        dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
+
     def test_wizard_progress_facts_reflect_existing_visible_geopackage_path(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -669,6 +669,34 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.on_apply_filters_clicked.assert_called_once_with()
         dock.on_load_layers_clicked.assert_not_called()
 
+    def test_output_path_change_updates_wizard_runtime_state(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._refresh_wizard_shell_from_runtime = MagicMock()
+
+        self.module.QfitDockWidget._on_output_path_changed(
+            dock,
+            "  /tmp/local-qfit.gpkg  ",
+        )
+
+        self.assertEqual(dock.runtime_state.output_path, "/tmp/local-qfit.gpkg")
+        dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
+
+    def test_wizard_progress_facts_reflect_visible_geopackage_path(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/local-qfit.gpkg")
+        dock.clientIdLineEdit = _FakeLineEdit("")
+        dock.clientSecretLineEdit = _FakeLineEdit("")
+        dock.refreshTokenLineEdit = _FakeLineEdit("")
+        dock._atlas_export_completed = False
+        dock.settings = _FakeSettings()
+
+        facts = self.module.QfitDockWidget._current_wizard_progress_facts(dock)
+
+        self.assertTrue(facts.activities_stored)
+        self.assertEqual(facts.output_name, "local-qfit.gpkg")
+
     def test_build_wizard_shell_from_runtime_wires_persistence_and_callbacks(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -28,6 +28,7 @@ try:
     )
     from qgis.PyQt.QtCore import QDate, Qt
     from qgis.PyQt.QtGui import QImage
+    from qgis.PyQt.QtWidgets import QFormLayout, QLayout
 
     from qfit.activities.domain.activity_query import ActivityQuery, build_subset_string
     from qfit.analysis.infrastructure.frequent_start_points_layer import (
@@ -74,6 +75,8 @@ except Exception as exc:  # pragma: no cover - exercised only when QGIS is unava
     QgsVectorLayer = None
     QDate = None
     QImage = None
+    QFormLayout = None
+    QLayout = None
     Qt = None
     ActivityQuery = None
     build_subset_string = None
@@ -843,6 +846,25 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dialog._exchange_code_button.objectName(), "cfgExchangeCodeButton")
             self.assertIn("Do not paste", dialog._oauth_help_label.text())
             self.assertEqual(dialog._strava_oauth_status_label.text(), "Not started")
+        finally:
+            dialog.close()
+            dialog.deleteLater()
+
+    def test_config_dialog_uses_compact_content_sized_layout(self):
+        dialog = QfitConfigDialog(
+            settings_service=SettingsService(
+                qsettings=_FakeQSettings(),
+                credential_store=InMemoryCredentialStore(),
+            )
+        )
+        try:
+            self.assertEqual(dialog.layout().sizeConstraint(), QLayout.SetFixedSize)
+            self.assertEqual(dialog.layout().count(), 3)
+
+            form = dialog._oauth_help_label.parentWidget().layout()
+            _row, role = form.getWidgetPosition(dialog._oauth_help_label)
+            self.assertEqual(role, QFormLayout.SpanningRole)
+            self.assertEqual(form.rowWrapPolicy(), QFormLayout.WrapLongRows)
         finally:
             dialog.close()
             dialog.deleteLater()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -28,7 +28,7 @@ try:
     )
     from qgis.PyQt.QtCore import QDate, Qt
     from qgis.PyQt.QtGui import QImage
-    from qgis.PyQt.QtWidgets import QFormLayout, QLayout
+    from qgis.PyQt.QtWidgets import QFormLayout
 
     from qfit.activities.domain.activity_query import ActivityQuery, build_subset_string
     from qfit.analysis.infrastructure.frequent_start_points_layer import (
@@ -76,7 +76,6 @@ except Exception as exc:  # pragma: no cover - exercised only when QGIS is unava
     QDate = None
     QImage = None
     QFormLayout = None
-    QLayout = None
     Qt = None
     ActivityQuery = None
     build_subset_string = None
@@ -858,8 +857,16 @@ class QgisSmokeTests(unittest.TestCase):
             )
         )
         try:
-            self.assertEqual(dialog.layout().sizeConstraint(), QLayout.SetFixedSize)
             self.assertEqual(dialog.layout().count(), 3)
+
+            for label in (
+                dialog._strava_status_label,
+                dialog._strava_oauth_status_label,
+                dialog._strava_test_status_label,
+                dialog._mapbox_status_label,
+                dialog._mapbox_test_status_label,
+            ):
+                self.assertTrue(label.wordWrap())
 
             form = dialog._oauth_help_label.parentWidget().layout()
             _row, role = form.getWidgetPosition(dialog._oauth_help_label)

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -76,10 +76,25 @@ class SyncPageContentTest(unittest.TestCase):
             content.load_button.toolTip(),
             "Select an existing GeoPackage before loading activities.",
         )
+        self.assertEqual(
+            content.routes_button.objectName(),
+            "qfitWizardSyncRoutesButton",
+        )
+        self.assertEqual(content.routes_button.text(), "Sync saved routes")
+        self.assertEqual(
+            content.routes_button.property("secondaryAction"),
+            "sync_saved_routes",
+        )
+        self.assertEqual(
+            content.routes_button.property("wizardActionRole"),
+            "secondary",
+        )
+        self.assertTrue(content.routes_button.isEnabled())
+        self.assertEqual(content.routes_button.toolTip(), "")
         self.assertEqual(content.action_row.objectName(), "qfitWizardSyncActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,
-            [content.load_button, content.sync_button],
+            [content.load_button, content.routes_button, content.sync_button],
         )
         self.assertEqual(
             content.outer_layout().widgets,
@@ -119,6 +134,30 @@ class SyncPageContentTest(unittest.TestCase):
         self.assertEqual(content.sync_button.text(), "Fetch latest activities")
         self.assertTrue(content.load_button.isEnabled())
         self.assertEqual(content.load_button.toolTip(), "")
+
+    def test_can_block_saved_routes_action_with_tooltip_copy(self):
+        content = self.sync_page.SyncPageContent(
+            self.sync_page.SyncPageState(
+                routes_action_enabled=False,
+                routes_action_blocked_tooltip="Configure Strava first.",
+            )
+        )
+
+        self.assertFalse(content.routes_button.isEnabled())
+        self.assertEqual(
+            content.routes_button.property("wizardActionAvailability"),
+            "blocked",
+        )
+        self.assertEqual(content.routes_button.toolTip(), "Configure Strava first.")
+
+        content.set_state(self.sync_page.SyncPageState())
+
+        self.assertTrue(content.routes_button.isEnabled())
+        self.assertEqual(
+            content.routes_button.property("wizardActionAvailability"),
+            "available",
+        )
+        self.assertEqual(content.routes_button.toolTip(), "")
 
     def test_can_block_sync_action_with_tooltip_copy(self):
         content = self.sync_page.SyncPageContent(
@@ -168,6 +207,15 @@ class SyncPageContentTest(unittest.TestCase):
         content.load_button.clicked.emit()
 
         self.assertEqual(calls, ["load"])
+
+    def test_saved_routes_button_emits_reusable_page_signal(self):
+        content = self.sync_page.SyncPageContent()
+        calls = []
+        content.syncRoutesRequested.connect(lambda: calls.append("routes"))
+
+        content.routes_button.clicked.emit()
+
+        self.assertEqual(calls, ["routes"])
 
     def test_installs_only_on_sync_wizard_page_body(self):
         sync_spec = next(

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -61,7 +61,7 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.sync_button.toolTip(), "")
         self.assertEqual(content.load_button.objectName(), "qfitWizardSyncLoadButton")
-        self.assertEqual(content.load_button.text(), "Load activities")
+        self.assertEqual(content.load_button.text(), "Load GeoPackage")
         self.assertEqual(
             content.load_button.property("secondaryAction"),
             "load_activities",
@@ -74,7 +74,7 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertEqual(
             content.load_button.toolTip(),
-            "Select an existing GeoPackage before loading activities.",
+            "Select an existing GeoPackage before loading local data.",
         )
         self.assertEqual(
             content.routes_button.objectName(),

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -102,6 +102,7 @@ class WizardProgressFactsTests(unittest.TestCase):
         cases = (
             DockRuntimeTasks(fetch="fetch"),
             DockRuntimeTasks(store="store"),
+            DockRuntimeTasks(route_sync="routes"),
             DockRuntimeTasks(fetch="fetch", store="store", atlas_export="atlas"),
         )
         for tasks in cases:

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -115,6 +115,10 @@ class WizardProgressFactsTests(unittest.TestCase):
 
                 self.assertTrue(facts.sync_in_progress)
                 self.assertEqual(
+                    facts.route_sync_in_progress,
+                    tasks.route_sync is not None,
+                )
+                self.assertEqual(
                     facts.atlas_export_in_progress,
                     tasks.atlas_export is not None,
                 )

--- a/tests/test_wizard_progress.py
+++ b/tests/test_wizard_progress.py
@@ -1,4 +1,6 @@
+import tempfile
 import unittest
+from pathlib import Path
 
 from qfit.ui.application.dock_runtime_state import (
     DockRuntimeLayers,
@@ -124,6 +126,23 @@ class WizardProgressFactsTests(unittest.TestCase):
 
         self.assertFalse(facts.activities_stored)
 
+    def test_runtime_state_adapter_does_not_mark_missing_output_path_as_stored(self):
+        facts = build_wizard_progress_facts_from_runtime_state(
+            DockRuntimeState(output_path="/tmp/qfit-definitely-missing.gpkg")
+        )
+
+        self.assertFalse(facts.activities_stored)
+        self.assertEqual(facts.output_name, "qfit-definitely-missing.gpkg")
+
+    def test_runtime_state_adapter_marks_existing_output_path_as_stored(self):
+        with tempfile.NamedTemporaryFile(suffix=".gpkg") as geopackage:
+            facts = build_wizard_progress_facts_from_runtime_state(
+                DockRuntimeState(output_path=geopackage.name)
+            )
+
+        self.assertTrue(facts.activities_stored)
+        self.assertEqual(facts.output_name, Path(geopackage.name).name)
+
     def test_runtime_state_adapter_keeps_unknown_activity_count_for_loaded_file(self):
         facts = build_wizard_progress_facts_from_runtime_state(
             DockRuntimeState(output_path="/tmp/qfit.gpkg")
@@ -140,6 +159,7 @@ class WizardProgressFactsTests(unittest.TestCase):
             )
         )
 
+        self.assertTrue(facts.activities_stored)
         self.assertEqual(facts.activity_count, 12)
 
     def test_runtime_state_adapter_does_not_treat_fetch_count_as_stored_count(self):

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -460,7 +460,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
         self.assertTrue(assembled.sync_content.sync_button.isEnabled())
         self.assertTrue(assembled.sync_content.load_button.isEnabled())
-        self.assertEqual(assembled.sync_content.load_button.text(), "Load activities")
+        self.assertEqual(assembled.sync_content.load_button.text(), "Load GeoPackage")
         self.assertEqual(
             assembled.map_content.status_label.text(),
             "Stored activities ready to load",

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -1050,6 +1050,20 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertIn("Updating activities in qfit.gpkg", assembled.shell.footer_bar.text())
 
+    def test_route_sync_in_progress_keeps_routes_action_cancellable(self):
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                sync_in_progress=True,
+                route_sync_in_progress=True,
+            )
+        )
+
+        self.assertTrue(assembled.sync_content.routes_button.isEnabled())
+        self.assertEqual(assembled.sync_content.routes_button.text(), "Cancel route sync")
+        self.assertEqual(assembled.sync_content.routes_button.toolTip(), "")
+        self.assertFalse(assembled.sync_content.sync_button.isEnabled())
+
     def test_busy_sync_without_stored_activities_replaces_empty_summary(self):
         assembled = self.composition.build_placeholder_wizard_shell(
             progress_facts=self.composition.WizardProgressFacts(

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -329,6 +329,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         callbacks = self.composition.WizardActionCallbacks(
             configure_connection=lambda: calls.append("configure"),
             sync_activities=lambda: calls.append("sync"),
+            sync_saved_routes=lambda: calls.append("routes"),
             load_activity_layers=lambda: calls.append("load"),
             edit_map_filters=lambda visible: calls.append(f"edit:{visible}"),
             apply_map_filters=lambda: calls.append("filter"),
@@ -347,6 +348,7 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         assembled.connection_content.configure_button.clicked.emit()
         assembled.sync_content.sync_button.clicked.emit()
+        assembled.sync_content.routes_button.clicked.emit()
         assembled.sync_content.load_button.clicked.emit()
         assembled.map_content.load_layers_button.clicked.emit()
         assembled.map_content.edit_filters_button.clicked.emit()
@@ -362,6 +364,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             [
                 "configure",
                 "sync",
+                "routes",
                 "load",
                 "load",
                 "edit:True",

--- a/ui/application/dock_runtime_state.py
+++ b/ui/application/dock_runtime_state.py
@@ -189,6 +189,18 @@ class DockRuntimeStore:
     def set_output_path(self, output_path: str | None) -> DockRuntimeState:
         return self._replace_state(output_path=output_path)
 
+    def select_output_path(self, output_path: str | None) -> DockRuntimeState:
+        """Select a GeoPackage path while clearing stale loaded-dataset state."""
+
+        selected_path = (output_path or "").strip() or None
+        if selected_path == self._state.output_path:
+            return self._replace_state(output_path=selected_path)
+        return self._replace_state(
+            output_path=selected_path,
+            stored_activity_count=None,
+            layers=self._state.layers.clear_dataset().clear_routes(),
+        )
+
     def set_last_fetch_context(self, last_fetch_context: dict[str, Any] | None) -> DockRuntimeState:
         return self._replace_state(last_fetch_context=dict(last_fetch_context or {}))
 

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -81,7 +81,7 @@ def build_wizard_progress_facts_from_runtime_state(
     return WizardProgressFacts(
         connection_configured=connection_configured,
         activities_fetched=bool(state.activities),
-        activities_stored=_has_output_path(state),
+        activities_stored=_has_stored_activities(state),
         activity_layers_loaded=state.activities_layer is not None,
         analysis_generated=state.analysis_layer is not None,
         atlas_exported=atlas_exported,
@@ -268,8 +268,18 @@ def _workflow_keys() -> tuple[str, ...]:
     return tuple(section.key for section in WIZARD_WORKFLOW_STEPS)
 
 
-def _has_output_path(state: DockRuntimeState) -> bool:
-    return bool((state.output_path or "").strip())
+def _has_stored_activities(state: DockRuntimeState) -> bool:
+    if state.stored_activity_count is not None:
+        return True
+    if _loaded_dataset_layer_count(state) > 0:
+        return True
+    output_path = (state.output_path or "").strip()
+    if not output_path:
+        return False
+    try:
+        return Path(output_path).exists()
+    except OSError:
+        return False
 
 
 def _has_sync_task(state: DockRuntimeState) -> bool:

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -27,6 +27,7 @@ class WizardProgressFacts:
     analysis_generated: bool = False
     atlas_exported: bool = False
     sync_in_progress: bool = False
+    route_sync_in_progress: bool = False
     atlas_export_in_progress: bool = False
     preferred_current_key: str | None = None
     fetched_activity_count: int | None = None
@@ -86,6 +87,7 @@ def build_wizard_progress_facts_from_runtime_state(
         analysis_generated=state.analysis_layer is not None,
         atlas_exported=atlas_exported,
         sync_in_progress=_has_sync_task(state),
+        route_sync_in_progress=state.route_sync_task is not None,
         atlas_export_in_progress=state.atlas_export_task is not None,
         preferred_current_key=preferred_current_key,
         fetched_activity_count=len(state.activities) if state.activities else None,
@@ -185,6 +187,7 @@ def _wizard_progress_facts_with_preferred_current_key(
         analysis_generated=facts.analysis_generated,
         atlas_exported=facts.atlas_exported,
         sync_in_progress=facts.sync_in_progress,
+        route_sync_in_progress=facts.route_sync_in_progress,
         atlas_export_in_progress=facts.atlas_export_in_progress,
         preferred_current_key=preferred_current_key,
         fetched_activity_count=facts.fetched_activity_count,

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -273,7 +273,11 @@ def _has_output_path(state: DockRuntimeState) -> bool:
 
 
 def _has_sync_task(state: DockRuntimeState) -> bool:
-    return state.fetch_task is not None or state.store_task is not None
+    return (
+        state.fetch_task is not None
+        or state.store_task is not None
+        or state.route_sync_task is not None
+    )
 
 
 def _stored_activity_count(state: DockRuntimeState) -> int | None:

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -45,9 +45,9 @@ class SyncPageState:
     primary_action_label: str = "Sync activities"
     primary_action_enabled: bool = True
     primary_action_blocked_tooltip: str = "Configure the Strava connection before syncing."
-    local_action_label: str = "Load activities"
+    local_action_label: str = "Load GeoPackage"
     local_action_enabled: bool = False
-    local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading activities."
+    local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading local data."
     routes_action_label: str = "Sync saved routes"
     routes_action_enabled: bool = True
     routes_action_blocked_tooltip: str = (

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -48,6 +48,11 @@ class SyncPageState:
     local_action_label: str = "Load activities"
     local_action_enabled: bool = False
     local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading activities."
+    routes_action_label: str = "Sync saved routes"
+    routes_action_enabled: bool = True
+    routes_action_blocked_tooltip: str = (
+        "Configure the Strava connection before syncing saved routes."
+    )
 
 
 class SyncPageContent(QWidget):
@@ -55,6 +60,7 @@ class SyncPageContent(QWidget):
 
     syncRequested = pyqtSignal()
     loadActivitiesRequested = pyqtSignal()
+    syncRoutesRequested = pyqtSignal()
 
     def __init__(self, state: SyncPageState | None = None, parent=None) -> None:
         super().__init__(parent)
@@ -83,8 +89,16 @@ class SyncPageContent(QWidget):
             action_name="load_activities",
         )
         self.load_button.clicked.connect(self.loadActivitiesRequested.emit)
+        self.routes_button = QToolButton(self)
+        self.routes_button.setObjectName("qfitWizardSyncRoutesButton")
+        style_secondary_action_button(
+            self.routes_button,
+            action_name="sync_saved_routes",
+        )
+        self.routes_button.clicked.connect(self.syncRoutesRequested.emit)
         self.action_row = build_wizard_action_row(
             self.load_button,
+            self.routes_button,
             self.sync_button,
             parent=self,
             object_name="qfitWizardSyncActionRow",
@@ -113,6 +127,12 @@ class SyncPageContent(QWidget):
             self.load_button,
             enabled=state.local_action_enabled,
             tooltip=state.local_action_blocked_tooltip,
+        )
+        self.routes_button.setText(state.routes_action_label)
+        set_wizard_action_availability(
+            self.routes_button,
+            enabled=state.routes_action_enabled,
+            tooltip=state.routes_action_blocked_tooltip,
         )
 
     def outer_layout(self):

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -67,6 +67,7 @@ class WizardActionCallbacks:
 
     configure_connection: Callable[[], None] | None = None
     sync_activities: Callable[[], None] | None = None
+    sync_saved_routes: Callable[[], None] | None = None
     load_activity_layers: Callable[[], None] | None = None
     edit_map_filters: Callable[[bool], None] | None = None
     apply_map_filters: Callable[[], None] | None = None
@@ -411,6 +412,11 @@ def _connect_action_callbacks(
     _connect_optional_signal(sync_content, "syncRequested", callbacks.sync_activities)
     _connect_optional_signal(
         sync_content,
+        "syncRoutesRequested",
+        callbacks.sync_saved_routes,
+    )
+    _connect_optional_signal(
+        sync_content,
         "loadActivitiesRequested",
         callbacks.load_activity_layers,
     )
@@ -586,6 +592,8 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
         primary_action_blocked_tooltip=sync_blocked_tooltip,
         local_action_enabled=facts.activities_stored and not facts.sync_in_progress,
         local_action_blocked_tooltip=_sync_local_action_blocked_tooltip(facts, default),
+        routes_action_enabled=facts.connection_configured and not facts.sync_in_progress,
+        routes_action_blocked_tooltip=_sync_routes_action_blocked_tooltip(facts, default),
     )
 
 
@@ -597,6 +605,17 @@ def _sync_local_action_blocked_tooltip(
         return "Wait for the current synchronization to finish."
     if not facts.activities_stored:
         return default.local_action_blocked_tooltip
+    return ""
+
+
+def _sync_routes_action_blocked_tooltip(
+    facts: WizardProgressFacts,
+    default: SyncPageState,
+) -> str:
+    if facts.sync_in_progress:
+        return "Wait for the current synchronization to finish."
+    if not facts.connection_configured:
+        return default.routes_action_blocked_tooltip
     return ""
 
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -489,6 +489,7 @@ def _completed_prefix_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
         analysis_generated="analysis" in completed,
         atlas_exported="atlas" in completed,
         sync_in_progress=facts.sync_in_progress,
+        route_sync_in_progress=facts.route_sync_in_progress,
         atlas_export_in_progress=facts.atlas_export_in_progress,
         preferred_current_key=facts.preferred_current_key,
         fetched_activity_count=facts.fetched_activity_count,
@@ -574,8 +575,11 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
             "Store fetched activities in the GeoPackage to complete synchronization."
         )
     primary_action_label = default.primary_action_label
+    routes_action_label = default.routes_action_label
     if facts.activities_fetched and not facts.activities_stored:
         primary_action_label = "Store fetched activities"
+    if facts.route_sync_in_progress:
+        routes_action_label = "Cancel route sync"
     if facts.sync_in_progress:
         status_text = "Synchronization in progress"
         detail_text = (
@@ -593,7 +597,11 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
         primary_action_blocked_tooltip=sync_blocked_tooltip,
         local_action_enabled=facts.activities_stored and not facts.sync_in_progress,
         local_action_blocked_tooltip=_sync_local_action_blocked_tooltip(facts, default),
-        routes_action_enabled=facts.connection_configured and not facts.sync_in_progress,
+        routes_action_label=routes_action_label,
+        routes_action_enabled=(
+            facts.route_sync_in_progress
+            or (facts.connection_configured and not facts.sync_in_progress)
+        ),
         routes_action_blocked_tooltip=_sync_routes_action_blocked_tooltip(facts, default),
     )
 
@@ -613,6 +621,8 @@ def _sync_routes_action_blocked_tooltip(
     facts: WizardProgressFacts,
     default: SyncPageState,
 ) -> str:
+    if facts.route_sync_in_progress:
+        return ""
     if facts.sync_in_progress:
         return _SYNC_IN_PROGRESS_TOOLTIP
     if not facts.connection_configured:

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -54,6 +54,7 @@ from .wizard_shell_presenter import WizardShellPresenter
 
 _StateT = TypeVar("_StateT")
 WizardCompositionPage = WizardPage | WizardStepPage
+_SYNC_IN_PROGRESS_TOOLTIP = "Wait for the current synchronization to finish."
 
 
 @dataclass(frozen=True)
@@ -581,7 +582,7 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
             "Wait for the current synchronization to finish before starting another sync."
         )
         primary_action_label = "Sync in progress…"
-        sync_blocked_tooltip = "Wait for the current synchronization to finish."
+        sync_blocked_tooltip = _SYNC_IN_PROGRESS_TOOLTIP
     return SyncPageState(
         ready=facts.activities_stored,
         status_text=status_text,
@@ -602,7 +603,7 @@ def _sync_local_action_blocked_tooltip(
     default: SyncPageState,
 ) -> str:
     if facts.sync_in_progress:
-        return "Wait for the current synchronization to finish."
+        return _SYNC_IN_PROGRESS_TOOLTIP
     if not facts.activities_stored:
         return default.local_action_blocked_tooltip
     return ""
@@ -613,7 +614,7 @@ def _sync_routes_action_blocked_tooltip(
     default: SyncPageState,
 ) -> str:
     if facts.sync_in_progress:
-        return "Wait for the current synchronization to finish."
+        return _SYNC_IN_PROGRESS_TOOLTIP
     if not facts.connection_configured:
         return default.routes_action_blocked_tooltip
     return ""


### PR DESCRIPTION
## Summary

- expose saved Strava route sync on the wizard synchronization page
- keep the configuration dialog compact while allowing long status/test messages to wrap instead of widening the dialog
- let the wizard load an existing GeoPackage from the selected output path, including saved route layers, without requiring a Strava sync first

Closes #744.
Closes #745.
Closes #746.

## Tests

- `python3 -m pytest tests/test_sync_page.py tests/test_wizard_shell_composition.py tests/test_wizard_progress.py tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/test_qgis_smoke.py::QgisSmokeTests::test_config_dialog_uses_compact_content_sized_layout -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
