### PR TITLE
Add local-first dock shell

### DIFF
--- a/tests/test_local_first_shell.py
+++ b/tests/test_local_first_shell.py
@@ -1,0 +1,104 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.local_first_navigation import build_local_first_dock_navigation_state
+from qfit.ui.application.wizard_progress import WizardProgressFacts
+
+
+def _load_local_first_shell_module():
+    for name in (
+        "qfit.ui.dockwidget.local_first_shell",
+        "qfit.ui.dockwidget.footer_status_bar",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.local_first_shell")
+
+
+class LocalFirstDockShellTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.shell_module = _load_local_first_shell_module()
+
+    def test_builds_standard_qt_shell_with_full_navigation_labels(self):
+        shell = self.shell_module.LocalFirstDockShell(footer_text="Ready")
+
+        self.assertEqual(shell.objectName(), "qfitLocalFirstDockShell")
+        self.assertEqual(shell.navigation_container.objectName(), "qfitLocalFirstDockNavigation")
+        self.assertEqual(shell.main_container.objectName(), "qfitLocalFirstDockMain")
+        self.assertEqual(shell.separator.objectName(), "qfitLocalFirstDockSeparator")
+        self.assertEqual(shell.pages_stack.objectName(), "qfitLocalFirstDockPagesStack")
+        self.assertEqual(shell.footer_bar.text(), "Ready")
+        self.assertEqual(
+            [button.text() for button in shell.navigation_buttons()],
+            ["Data", "Map", "Analysis", "Atlas", "Settings"],
+        )
+        self.assertFalse(any("..." in button.text() for button in shell.navigation_buttons()))
+        self.assertTrue(all(button.isEnabled() for button in shell.navigation_buttons()))
+
+    def test_outer_layout_keeps_navigation_content_and_footer_separate(self):
+        shell = self.shell_module.LocalFirstDockShell()
+
+        self.assertEqual(shell.outer_layout().object_name, "qfitLocalFirstDockOuterLayout")
+        self.assertEqual(shell.outer_layout().widgets, [shell.main_container, shell.footer_bar])
+        self.assertEqual(
+            shell.main_layout().widgets,
+            [shell.navigation_container, shell.separator, shell.pages_stack],
+        )
+
+    def test_navigation_state_sets_button_metadata_without_step_locking(self):
+        navigation = build_local_first_dock_navigation_state(
+            WizardProgressFacts(activities_stored=True, activity_layers_loaded=True),
+            preferred_current_key="map",
+        )
+        shell = self.shell_module.LocalFirstDockShell(navigation_state=navigation)
+
+        data_button = shell.button_for_key("data")
+        map_button = shell.button_for_key("map")
+        analysis_button = shell.button_for_key("analysis")
+
+        self.assertTrue(data_button.property("ready"))
+        self.assertEqual(data_button.property("navTone"), "ready")
+        self.assertTrue(map_button.property("current"))
+        self.assertEqual(map_button.property("navTone"), "current")
+        self.assertFalse(analysis_button.property("ready"))
+        self.assertEqual(analysis_button.property("navTone"), "available")
+        self.assertTrue(analysis_button.isEnabled())
+
+    def test_clicking_navigation_button_shows_matching_page_and_emits_key(self):
+        shell = self.shell_module.LocalFirstDockShell()
+        calls = []
+        data_page = self.shell_module.QWidget()
+        atlas_page = self.shell_module.QWidget()
+        shell.add_page("data", data_page)
+        shell.add_page("atlas", atlas_page)
+        shell.pageRequested.connect(lambda key: calls.append(key))
+
+        shell.button_for_key("atlas").clicked.emit()
+
+        self.assertEqual(shell.current_key(), "atlas")
+        self.assertEqual(shell.pages_stack.currentIndex(), 1)
+        self.assertEqual(calls, ["atlas"])
+        self.assertTrue(shell.button_for_key("atlas").property("current"))
+        self.assertFalse(shell.button_for_key("data").property("current"))
+
+    def test_new_current_page_selects_installed_page(self):
+        shell = self.shell_module.LocalFirstDockShell(
+            navigation_state=build_local_first_dock_navigation_state(
+                preferred_current_key="settings"
+            )
+        )
+        shell.add_page("data", self.shell_module.QWidget())
+        shell.add_page("settings", self.shell_module.QWidget())
+
+        self.assertEqual(shell.pages_stack.currentIndex(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_local_first_shell.py
+++ b/tests/test_local_first_shell.py
@@ -71,6 +71,39 @@ class LocalFirstDockShellTests(unittest.TestCase):
         self.assertEqual(analysis_button.property("navTone"), "available")
         self.assertTrue(analysis_button.isEnabled())
 
+    def test_navigation_state_refreshes_dynamic_qss_properties(self):
+        class FakeStyle:
+            def __init__(self):
+                self.calls = []
+
+            def unpolish(self, widget):
+                self.calls.append(("unpolish", widget.objectName()))
+
+            def polish(self, widget):
+                self.calls.append(("polish", widget.objectName()))
+
+        shell = self.shell_module.LocalFirstDockShell()
+        button = shell.button_for_key("atlas")
+        style = FakeStyle()
+        updates = []
+        button.style = lambda: style
+        button.update = lambda: updates.append(button.objectName())
+
+        shell.show_page_key("atlas")
+
+        self.assertIn(("unpolish", "qfitLocalFirstDockNav_atlas"), style.calls)
+        self.assertIn(("polish", "qfitLocalFirstDockNav_atlas"), style.calls)
+        self.assertIn("qfitLocalFirstDockNav_atlas", updates)
+
+    def test_unknown_navigation_key_raises_descriptive_error(self):
+        shell = self.shell_module.LocalFirstDockShell()
+
+        with self.assertRaisesRegex(
+            KeyError,
+            "No navigation button registered for key 'missing'",
+        ):
+            shell.button_for_key("missing")
+
     def test_clicking_navigation_button_shows_matching_page_and_emits_key(self):
         shell = self.shell_module.LocalFirstDockShell()
         calls = []

--- a/ui/dockwidget/local_first_shell.py
+++ b/ui/dockwidget/local_first_shell.py
@@ -77,7 +77,14 @@ class LocalFirstDockShell(QWidget):
     def button_for_key(self, key: str):
         """Return the navigation button for tests and adapter wiring."""
 
-        return self._buttons_by_key[key]
+        try:
+            return self._buttons_by_key[key]
+        except KeyError:
+            msg = (
+                f"No navigation button registered for key {key!r}. "
+                f"Available keys: {list(self._buttons_by_key)}"
+            )
+            raise KeyError(msg) from None
 
     def current_key(self) -> str:
         """Return the currently selected local-first page key."""
@@ -151,6 +158,7 @@ class LocalFirstDockShell(QWidget):
         button.setProperty("navTone", _nav_tone(page_state))
         button.setToolTip(f"{page_state.title}: {page_state.status_text}")
         button.setCursor(Qt.PointingHandCursor if page_state.enabled else Qt.ForbiddenCursor)
+        _refresh_dynamic_qss(button)
 
     def _build_footer_bar(self, footer_text: str):
         return FooterStatusBar(self, footer_text=footer_text)
@@ -220,6 +228,18 @@ class LocalFirstDockShell(QWidget):
         index = self._page_indices_by_key.get(key)
         if index is not None:
             self.pages_stack.setCurrentIndex(index)
+
+
+def _refresh_dynamic_qss(widget) -> None:
+    style_getter = getattr(widget, "style", None)
+    style = style_getter() if callable(style_getter) else None
+    if style is not None:
+        if hasattr(style, "unpolish"):
+            style.unpolish(widget)
+        if hasattr(style, "polish"):
+            style.polish(widget)
+    if hasattr(widget, "update"):
+        widget.update()
 
 
 def _nav_tone(page_state: LocalFirstDockPageState) -> str:

--- a/ui/dockwidget/local_first_shell.py
+++ b/ui/dockwidget/local_first_shell.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from qfit.ui.application.local_first_navigation import (
+    LocalFirstDockNavigationState,
+    LocalFirstDockPageState,
+    build_local_first_dock_navigation_state,
+)
+
+from ._qt_compat import import_qt_module
+from .footer_status_bar import FooterStatusBar
+
+_qtcore = import_qt_module(
+    "qgis.PyQt.QtCore",
+    "PyQt5.QtCore",
+    ("Qt", "pyqtSignal"),
+)
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QFrame",
+        "QHBoxLayout",
+        "QSizePolicy",
+        "QStackedWidget",
+        "QToolButton",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+Qt = _qtcore.Qt
+pyqtSignal = _qtcore.pyqtSignal
+QFrame = _qtwidgets.QFrame
+QHBoxLayout = _qtwidgets.QHBoxLayout
+QSizePolicy = _qtwidgets.QSizePolicy
+QStackedWidget = _qtwidgets.QStackedWidget
+QToolButton = _qtwidgets.QToolButton
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+class LocalFirstDockShell(QWidget):
+    """Standard-Qt shell for the #748 local-first dock navigation."""
+
+    pageRequested = pyqtSignal(str)
+
+    def __init__(
+        self,
+        parent=None,
+        *,
+        navigation_state: LocalFirstDockNavigationState | None = None,
+        footer_text: str = "",
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("qfitLocalFirstDockShell")
+        self._navigation_state = navigation_state or build_local_first_dock_navigation_state()
+        self._page_indices_by_key: dict[str, int] = {}
+        self._buttons_by_key: dict[str, QToolButton] = {}
+        self.navigation_container = self._build_navigation_container()
+        self.separator = self._build_separator()
+        self.pages_stack = self._build_pages_stack()
+        self.main_container = self._build_main_container()
+        self.footer_bar = self._build_footer_bar(footer_text)
+        self._outer_layout = self._build_outer_layout()
+        self._install_navigation_buttons(self._navigation_state.pages)
+        self.set_navigation_state(self._navigation_state)
+
+    def add_page(self, key: str, page: QWidget) -> int:
+        """Append a page widget for a stable local-first navigation key."""
+
+        index = self.pages_stack.addWidget(page)
+        self._page_indices_by_key[key] = index
+        if key == self.current_key():
+            self.pages_stack.setCurrentIndex(index)
+        return index
+
+    def button_for_key(self, key: str):
+        """Return the navigation button for tests and adapter wiring."""
+
+        return self._buttons_by_key[key]
+
+    def current_key(self) -> str:
+        """Return the currently selected local-first page key."""
+
+        return self._navigation_state.current_key
+
+    def navigation_buttons(self) -> tuple[QToolButton, ...]:
+        """Return navigation buttons in rendered order."""
+
+        return tuple(self._buttons_by_key[page.key] for page in self._navigation_state.pages)
+
+    def page_count(self) -> int:
+        """Return the number of page widgets currently installed."""
+
+        return self.pages_stack.count()
+
+    def set_footer_text(self, text: str) -> None:
+        """Update the compact persistent status/footer text."""
+
+        self.footer_bar.set_status_text(text)
+
+    def set_navigation_state(self, state: LocalFirstDockNavigationState) -> None:
+        """Apply render-neutral local-first navigation state to the shell."""
+
+        self._navigation_state = state
+        for page_state in state.pages:
+            button = self._buttons_by_key.get(page_state.key)
+            if button is not None:
+                self._apply_button_state(button, page_state)
+        self._show_page_for_key(state.current_key)
+
+    def show_page_key(self, key: str) -> None:
+        """Select an enabled page by stable local-first key."""
+
+        page_state = self._page_state_for_key(key)
+        if page_state is None or not page_state.enabled:
+            return
+        updated_pages = tuple(
+            LocalFirstDockPageState(
+                key=page.key,
+                title=page.title,
+                description=page.description,
+                status_text=page.status_text,
+                ready=page.ready,
+                enabled=page.enabled,
+                current=page.key == key,
+            )
+            for page in self._navigation_state.pages
+        )
+        self.set_navigation_state(
+            LocalFirstDockNavigationState(current_key=key, pages=updated_pages)
+        )
+        self.pageRequested.emit(key)
+
+    def outer_layout(self):
+        """Expose the structural layout for pure tests."""
+
+        return self._outer_layout
+
+    def main_layout(self):
+        """Expose the main navigation/content layout for pure tests."""
+
+        return self._main_layout
+
+    def _apply_button_state(self, button: QToolButton, page_state: LocalFirstDockPageState) -> None:
+        button.setText(page_state.title)
+        button.setEnabled(page_state.enabled)
+        button.setProperty("pageKey", page_state.key)
+        button.setProperty("current", page_state.current)
+        button.setProperty("ready", page_state.ready)
+        button.setProperty("navTone", _nav_tone(page_state))
+        button.setToolTip(f"{page_state.title}: {page_state.status_text}")
+        button.setCursor(Qt.PointingHandCursor if page_state.enabled else Qt.ForbiddenCursor)
+
+    def _build_footer_bar(self, footer_text: str):
+        return FooterStatusBar(self, footer_text=footer_text)
+
+    def _build_main_container(self):
+        container = QWidget(self)
+        container.setObjectName("qfitLocalFirstDockMain")
+        self._main_layout = QHBoxLayout(container)
+        self._main_layout.setContentsMargins(0, 0, 0, 0)
+        self._main_layout.setSpacing(0)
+        self._main_layout.addWidget(self.navigation_container)
+        self._main_layout.addWidget(self.separator)
+        self._main_layout.addWidget(self.pages_stack)
+        return container
+
+    def _build_navigation_container(self):
+        container = QWidget(self)
+        container.setObjectName("qfitLocalFirstDockNavigation")
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 8, 0)
+        layout.setSpacing(4)
+        self._navigation_layout = layout
+        return container
+
+    def _build_outer_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitLocalFirstDockOuterLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.main_container)
+        layout.addWidget(self.footer_bar)
+        return layout
+
+    def _build_pages_stack(self):
+        stack = QStackedWidget(self)
+        stack.setObjectName("qfitLocalFirstDockPagesStack")
+        return stack
+
+    def _build_separator(self):
+        separator = QFrame(self)
+        separator.setObjectName("qfitLocalFirstDockSeparator")
+        separator.setFrameShape(getattr(QFrame, "VLine", QFrame.HLine))
+        separator.setFrameShadow(QFrame.Plain)
+        separator.setFixedWidth(1)
+        return separator
+
+    def _install_navigation_buttons(self, pages: tuple[LocalFirstDockPageState, ...]) -> None:
+        for page_state in pages:
+            button = self._new_navigation_button(page_state)
+            self._buttons_by_key[page_state.key] = button
+            self._navigation_layout.addWidget(button)
+        self._navigation_layout.addStretch(1)
+
+    def _new_navigation_button(self, page_state: LocalFirstDockPageState):
+        button = QToolButton(self.navigation_container)
+        button.setObjectName(f"qfitLocalFirstDockNav_{page_state.key}")
+        button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        button.clicked.connect(lambda _checked=False, key=page_state.key: self.show_page_key(key))
+        return button
+
+    def _page_state_for_key(self, key: str) -> LocalFirstDockPageState | None:
+        return next((page for page in self._navigation_state.pages if page.key == key), None)
+
+    def _show_page_for_key(self, key: str) -> None:
+        index = self._page_indices_by_key.get(key)
+        if index is not None:
+            self.pages_stack.setCurrentIndex(index)
+
+
+def _nav_tone(page_state: LocalFirstDockPageState) -> str:
+    if page_state.current:
+        return "current"
+    if page_state.ready:
+        return "ready"
+    return "available"
+
+
+__all__ = ["LocalFirstDockShell"]


### PR DESCRIPTION
## Summary

- add a standard-Qt `LocalFirstDockShell` for issue #748 groundwork
- render full Data, Map, Analysis, Atlas, and Settings navigation labels without step locking
- support keyed page installation/selection and page-request signals backed by the local-first navigation state
- keep the existing footer status strip seam available for the future dock swap
- address Greptile feedback with dynamic-QSS refresh and clearer unknown-key diagnostics

Refs #748.

## Tests

- `python3 -m pytest tests/test_local_first_shell.py -q --tb=short`
- `python3 -m pytest tests/test_local_first_shell.py tests/test_local_first_navigation.py tests/test_architecture_boundaries.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof

Not rendering-sensitive yet. This PR adds a reusable shell widget and pure fake-Qt tests only; it does not swap the production dock, alter QGIS layer rendering, or change atlas export output.
