### PR TITLE
Add local-first dock composition

### DIFF
--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -1,0 +1,146 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+from qfit.ui.application.wizard_progress import WizardProgressFacts
+
+
+def _load_local_first_composition_module():
+    for name in (
+        "qfit.ui.dockwidget.local_first_composition",
+        "qfit.ui.dockwidget.local_first_shell",
+        "qfit.ui.dockwidget.wizard_composition",
+        "qfit.ui.dockwidget.analysis_page",
+        "qfit.ui.dockwidget.atlas_page",
+        "qfit.ui.dockwidget.connection_page",
+        "qfit.ui.dockwidget.map_page",
+        "qfit.ui.dockwidget.sync_page",
+        "qfit.ui.dockwidget.action_row",
+        "qfit.ui.dockwidget.footer_status_bar",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.local_first_composition")
+
+
+class LocalFirstDockCompositionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_local_first_composition_module()
+
+    def test_builds_shell_with_local_first_pages_and_reused_content(self):
+        composition = self.module.build_local_first_dock_composition(
+            progress_facts=WizardProgressFacts(activities_stored=True),
+        )
+
+        self.assertEqual(composition.shell.objectName(), "qfitLocalFirstDockShell")
+        self.assertEqual(composition.shell.page_count(), 5)
+        self.assertEqual(
+            tuple(composition.pages),
+            ("data", "map", "analysis", "atlas", "settings"),
+        )
+        self.assertEqual(
+            composition.pages["data"].objectName(),
+            "qfitLocalFirstDockPage_data",
+        )
+        self.assertEqual(
+            composition.page_content.data_content.objectName(),
+            "qfitWizardSyncPageContent",
+        )
+        self.assertEqual(
+            composition.page_content.settings_content.objectName(),
+            "qfitWizardConnectionPageContent",
+        )
+        self.assertIs(composition.sync_content, composition.page_content.data_content)
+        self.assertIs(
+            composition.connection_content,
+            composition.page_content.settings_content,
+        )
+
+    def test_data_page_is_local_first_and_navigation_is_not_step_locked(self):
+        composition = self.module.build_local_first_dock_composition(
+            progress_facts=WizardProgressFacts(
+                activities_stored=True,
+                preferred_current_key="settings",
+            ),
+        )
+
+        self.assertEqual(composition.shell.current_key(), "settings")
+        self.assertTrue(composition.shell.button_for_key("data").isEnabled())
+        self.assertTrue(composition.shell.button_for_key("atlas").isEnabled())
+        self.assertEqual(
+            composition.sync_content.detail_label.text(),
+            "Stored activities are ready to load from the existing GeoPackage.",
+        )
+
+    def test_connects_existing_page_action_callbacks(self):
+        composition = self.module.build_local_first_dock_composition()
+        calls = []
+        callbacks = self.module.WizardActionCallbacks(
+            configure_connection=lambda: calls.append("settings"),
+            sync_activities=lambda: calls.append("sync"),
+            sync_saved_routes=lambda: calls.append("routes"),
+            load_activity_layers=lambda: calls.append("layers"),
+            edit_map_filters=lambda visible: calls.append(f"filters:{visible}"),
+            apply_map_filters=lambda: calls.append("apply"),
+            run_analysis=lambda: calls.append("analysis"),
+            set_analysis_mode=lambda mode: calls.append(f"mode:{mode}"),
+            export_atlas=lambda: calls.append("atlas"),
+        )
+
+        self.module.connect_local_first_action_callbacks(composition, callbacks)
+        composition.connection_content.configureRequested.emit()
+        composition.sync_content.syncRequested.emit()
+        composition.sync_content.syncRoutesRequested.emit()
+        composition.sync_content.loadActivitiesRequested.emit()
+        composition.map_content.loadLayersRequested.emit()
+        composition.map_content.editFiltersRequested.emit(True)
+        composition.map_content.applyFiltersRequested.emit()
+        composition.analysis_content.runAnalysisRequested.emit()
+        composition.analysis_content.analysisModeChanged.emit("Heatmap")
+        composition.atlas_content.exportAtlasRequested.emit()
+
+        self.assertEqual(
+            calls,
+            [
+                "settings",
+                "sync",
+                "routes",
+                "layers",
+                "layers",
+                "filters:True",
+                "apply",
+                "analysis",
+                "mode:Heatmap",
+                "atlas",
+            ],
+        )
+
+    def test_refresh_updates_navigation_and_page_content_state(self):
+        composition = self.module.build_local_first_dock_composition()
+
+        self.module.refresh_local_first_dock_composition(
+            composition,
+            progress_facts=WizardProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                preferred_current_key="map",
+                output_name="activities.gpkg",
+            ),
+        )
+
+        self.assertEqual(composition.shell.current_key(), "map")
+        self.assertTrue(composition.shell.button_for_key("map").property("current"))
+        self.assertEqual(composition.sync_content.status_label.text(), "Activities stored")
+        self.assertEqual(composition.map_content.status_label.text(), "Activity layers loaded")
+        self.assertEqual(composition.connection_content.status_label.text(), "Strava connected")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -141,6 +141,22 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         self.assertEqual(composition.map_content.status_label.text(), "Activity layers loaded")
         self.assertEqual(composition.connection_content.status_label.text(), "Strava connected")
 
+    def test_refresh_preserves_current_page_without_explicit_preference(self):
+        composition = self.module.build_local_first_dock_composition(
+            progress_facts=WizardProgressFacts(preferred_current_key="atlas"),
+        )
+
+        self.module.refresh_local_first_dock_composition(
+            composition,
+            progress_facts=WizardProgressFacts(activities_stored=True),
+        )
+
+        self.assertEqual(composition.shell.current_key(), "atlas")
+        self.assertTrue(composition.shell.button_for_key("atlas").property("current"))
+
+    def test_public_exports_include_action_callbacks(self):
+        self.assertIn("WizardActionCallbacks", self.module.__all__)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from qfit.ui.application.local_first_navigation import (
+    build_local_first_dock_navigation_state,
+)
+from qfit.ui.application.wizard_progress import WizardProgressFacts
+
+from ._qt_compat import import_qt_module
+from .analysis_page import AnalysisPageContent, build_analysis_page_content
+from .atlas_page import AtlasPageContent, build_atlas_page_content
+from .connection_page import ConnectionPageContent, build_connection_page_content
+from .local_first_shell import LocalFirstDockShell
+from .map_page import MapPageContent, build_map_page_content
+from .sync_page import SyncPageContent, build_sync_page_content
+from .wizard_composition import WizardActionCallbacks, build_wizard_page_states_from_facts
+
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    ("QVBoxLayout", "QWidget"),
+)
+
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+
+@dataclass(frozen=True)
+class LocalFirstDockPageContent:
+    """Installed reusable content widgets for the local-first dock pages."""
+
+    data_content: SyncPageContent
+    map_content: MapPageContent
+    analysis_content: AnalysisPageContent
+    atlas_content: AtlasPageContent
+    settings_content: ConnectionPageContent
+
+
+@dataclass
+class LocalFirstDockComposition:
+    """Assembled #748 local-first shell with reusable page content installed."""
+
+    shell: LocalFirstDockShell
+    pages: dict[str, QWidget]
+    page_content: LocalFirstDockPageContent
+    action_callbacks: WizardActionCallbacks | None = None
+
+    @property
+    def sync_content(self) -> SyncPageContent:
+        """Compatibility alias for existing synchronization callback wiring."""
+
+        return self.page_content.data_content
+
+    @property
+    def map_content(self) -> MapPageContent:
+        return self.page_content.map_content
+
+    @property
+    def analysis_content(self) -> AnalysisPageContent:
+        return self.page_content.analysis_content
+
+    @property
+    def atlas_content(self) -> AtlasPageContent:
+        return self.page_content.atlas_content
+
+    @property
+    def connection_content(self) -> ConnectionPageContent:
+        """Settings page uses the existing connection/configuration content."""
+
+        return self.page_content.settings_content
+
+
+def build_local_first_dock_composition(
+    *,
+    parent=None,
+    footer_text: str = "",
+    progress_facts: WizardProgressFacts | None = None,
+) -> LocalFirstDockComposition:
+    """Build the reusable local-first dock shell without swapping production UI."""
+
+    facts = progress_facts or WizardProgressFacts()
+    shell = LocalFirstDockShell(
+        parent=parent,
+        navigation_state=build_local_first_dock_navigation_state(facts),
+        footer_text=footer_text,
+    )
+    pages = _install_local_first_pages(shell)
+    page_content = _install_local_first_page_content(pages, facts=facts)
+    return LocalFirstDockComposition(
+        shell=shell,
+        pages=pages,
+        page_content=page_content,
+    )
+
+
+def connect_local_first_action_callbacks(
+    composition: LocalFirstDockComposition,
+    callbacks: WizardActionCallbacks,
+) -> LocalFirstDockComposition:
+    """Connect concrete dock callbacks to local-first page content actions."""
+
+    if composition.action_callbacks is not None:
+        return composition
+    _connect_optional_signal(
+        composition.connection_content,
+        "configureRequested",
+        callbacks.configure_connection,
+    )
+    _connect_optional_signal(composition.sync_content, "syncRequested", callbacks.sync_activities)
+    _connect_optional_signal(
+        composition.sync_content,
+        "syncRoutesRequested",
+        callbacks.sync_saved_routes,
+    )
+    _connect_optional_signal(
+        composition.sync_content,
+        "loadActivitiesRequested",
+        callbacks.load_activity_layers,
+    )
+    _connect_optional_signal(
+        composition.map_content,
+        "loadLayersRequested",
+        callbacks.load_activity_layers,
+    )
+    _connect_optional_signal(
+        composition.map_content,
+        "editFiltersRequested",
+        callbacks.edit_map_filters,
+    )
+    _connect_optional_signal(
+        composition.map_content,
+        "applyFiltersRequested",
+        callbacks.apply_map_filters,
+    )
+    _connect_optional_signal(
+        composition.analysis_content,
+        "runAnalysisRequested",
+        callbacks.run_analysis,
+    )
+    _connect_optional_signal(
+        composition.analysis_content,
+        "analysisModeChanged",
+        callbacks.set_analysis_mode,
+    )
+    _connect_optional_signal(
+        composition.atlas_content,
+        "exportAtlasRequested",
+        callbacks.export_atlas,
+    )
+    composition.action_callbacks = callbacks
+    return composition
+
+
+def refresh_local_first_dock_composition(
+    composition: LocalFirstDockComposition,
+    *,
+    progress_facts: WizardProgressFacts | None = None,
+) -> LocalFirstDockComposition:
+    """Refresh navigation and page status from render-neutral workflow facts."""
+
+    facts = progress_facts or WizardProgressFacts()
+    page_states = build_wizard_page_states_from_facts(_content_facts(facts))
+    composition.shell.set_navigation_state(build_local_first_dock_navigation_state(facts))
+    composition.sync_content.set_state(page_states.sync_state)
+    composition.map_content.set_state(page_states.map_state)
+    composition.analysis_content.set_state(page_states.analysis_state)
+    composition.atlas_content.set_state(page_states.atlas_state)
+    composition.connection_content.set_state(page_states.connection_state)
+    return composition
+
+
+def _content_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
+    """Adapt local-first page facts to legacy wizard content state helpers."""
+
+    return replace(facts, preferred_current_key=None)
+
+
+def _connect_optional_signal(content, signal_name: str, callback) -> None:
+    if content is None or callback is None:
+        return
+    getattr(content, signal_name).connect(callback)
+
+
+def _install_local_first_pages(shell: LocalFirstDockShell) -> dict[str, QWidget]:
+    pages = {
+        key: _LocalFirstDockPage(key=key, parent=shell)
+        for key in ("data", "map", "analysis", "atlas", "settings")
+    }
+    for key, page in pages.items():
+        shell.add_page(key, page)
+    return pages
+
+
+def _install_local_first_page_content(
+    pages: dict[str, QWidget],
+    *,
+    facts: WizardProgressFacts,
+) -> LocalFirstDockPageContent:
+    page_states = build_wizard_page_states_from_facts(_content_facts(facts))
+    data_content = build_sync_page_content(
+        parent=pages["data"],
+        state=page_states.sync_state,
+    )
+    map_content = build_map_page_content(
+        parent=pages["map"],
+        state=page_states.map_state,
+    )
+    analysis_content = build_analysis_page_content(
+        parent=pages["analysis"],
+        state=page_states.analysis_state,
+    )
+    atlas_content = build_atlas_page_content(
+        parent=pages["atlas"],
+        state=page_states.atlas_state,
+    )
+    settings_content = build_connection_page_content(
+        parent=pages["settings"],
+        state=page_states.connection_state,
+    )
+    _page_layout(pages["data"]).addWidget(data_content)
+    _page_layout(pages["map"]).addWidget(map_content)
+    _page_layout(pages["analysis"]).addWidget(analysis_content)
+    _page_layout(pages["atlas"]).addWidget(atlas_content)
+    _page_layout(pages["settings"]).addWidget(settings_content)
+    return LocalFirstDockPageContent(
+        data_content=data_content,
+        map_content=map_content,
+        analysis_content=analysis_content,
+        atlas_content=atlas_content,
+        settings_content=settings_content,
+    )
+
+
+def _page_layout(page: QWidget):
+    layout_getter = getattr(page, "body_layout", None)
+    if not callable(layout_getter):
+        raise TypeError("Local-first pages must expose body_layout()")
+    return layout_getter()
+
+
+class _LocalFirstDockPage(QWidget):
+    def __init__(self, *, key: str, parent=None) -> None:
+        super().__init__(parent)
+        self.key = key
+        self.setObjectName(f"qfitLocalFirstDockPage_{key}")
+        self._layout = QVBoxLayout(self)
+        if hasattr(self._layout, "setObjectName"):
+            self._layout.setObjectName(f"qfitLocalFirstDockPageLayout_{key}")
+        self._layout.setContentsMargins(12, 8, 12, 8)
+        self._layout.setSpacing(8)
+
+    def body_layout(self):
+        return self._layout
+
+
+__all__ = [
+    "LocalFirstDockComposition",
+    "LocalFirstDockPageContent",
+    "build_local_first_dock_composition",
+    "connect_local_first_action_callbacks",
+    "refresh_local_first_dock_composition",
+]

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -14,7 +14,11 @@ from .connection_page import ConnectionPageContent, build_connection_page_conten
 from .local_first_shell import LocalFirstDockShell
 from .map_page import MapPageContent, build_map_page_content
 from .sync_page import SyncPageContent, build_sync_page_content
-from .wizard_composition import WizardActionCallbacks, build_wizard_page_states_from_facts
+from .wizard_composition import (
+    WizardActionCallbacks,
+    _connect_optional_signal,
+    build_wizard_page_states_from_facts,
+)
 
 _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
@@ -161,7 +165,13 @@ def refresh_local_first_dock_composition(
 
     facts = progress_facts or WizardProgressFacts()
     page_states = build_wizard_page_states_from_facts(_content_facts(facts))
-    composition.shell.set_navigation_state(build_local_first_dock_navigation_state(facts))
+    current_key = facts.preferred_current_key or composition.shell.current_key()
+    composition.shell.set_navigation_state(
+        build_local_first_dock_navigation_state(
+            facts,
+            preferred_current_key=current_key,
+        )
+    )
     composition.sync_content.set_state(page_states.sync_state)
     composition.map_content.set_state(page_states.map_state)
     composition.analysis_content.set_state(page_states.analysis_state)
@@ -174,12 +184,6 @@ def _content_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
     """Adapt local-first page facts to legacy wizard content state helpers."""
 
     return replace(facts, preferred_current_key=None)
-
-
-def _connect_optional_signal(content, signal_name: str, callback) -> None:
-    if content is None or callback is None:
-        return
-    getattr(content, signal_name).connect(callback)
 
 
 def _install_local_first_pages(shell: LocalFirstDockShell) -> dict[str, QWidget]:
@@ -257,6 +261,7 @@ class _LocalFirstDockPage(QWidget):
 __all__ = [
     "LocalFirstDockComposition",
     "LocalFirstDockPageContent",
+    "WizardActionCallbacks",
     "build_local_first_dock_composition",
     "connect_local_first_action_callbacks",
     "refresh_local_first_dock_composition",


### PR DESCRIPTION
## Summary

- add a reusable `LocalFirstDockComposition` for issue #748 groundwork
- assemble the local-first shell with Data, Map, Analysis, Atlas, and Settings pages
- reuse existing page content/actions while placing sync/local-load controls on Data and connection settings on Settings
- add refresh and callback wiring seams without swapping the production dock yet
- address review feedback by preserving the selected page on refresh and exporting the callback dataclass

Refs #748.

## Tests

- `python3 -m pytest tests/test_local_first_composition.py -q --tb=short`
- `python3 -m pytest tests/test_local_first_composition.py tests/test_local_first_shell.py tests/test_local_first_navigation.py tests/test_architecture_boundaries.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof

Not rendering-sensitive yet. This PR assembles reusable Qt widgets behind a new composition seam only; it does not swap the production dock, alter QGIS layer rendering, or change atlas export output.
