### PR TITLE
Add local-first dock runtime adapter

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -471,6 +471,43 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._bind_wizard_analysis_mode_controls(self._wizard_shell_composition)
         return self._wizard_shell_composition
 
+    def _build_local_first_dock_from_runtime(self, *, parent=None):
+        """Build the #748 local-first dock composition from live runtime facts.
+
+        This keeps the production swap small: the reusable local-first shell can
+        now be assembled with the same mature workflow callbacks as the wizard,
+        while keeping each action independent instead of routing through a
+        linear next-step helper.
+        """
+
+        from .ui.dockwidget.local_first_composition import (
+            WizardActionCallbacks,
+            build_local_first_dock_composition,
+            connect_local_first_action_callbacks,
+        )
+
+        composition = build_local_first_dock_composition(
+            parent=self if parent is None else parent,
+            progress_facts=self._current_wizard_progress_facts(),
+        )
+        self._local_first_dock_composition = connect_local_first_action_callbacks(
+            composition,
+            WizardActionCallbacks(
+                configure_connection=self._show_connection_configuration_hint,
+                sync_activities=self.on_refresh_clicked,
+                sync_saved_routes=self.on_sync_routes_clicked,
+                load_activity_layers=self.on_load_layers_clicked,
+                edit_map_filters=self._update_status_for_filter_visibility,
+                apply_map_filters=self.on_apply_filters_clicked,
+                run_analysis=self.on_run_analysis_clicked,
+                set_analysis_mode=self._set_wizard_analysis_mode,
+                export_atlas=self.on_generate_atlas_pdf_clicked,
+            ),
+        )
+        self._install_wizard_filter_controls(self._local_first_dock_composition)
+        self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
+        return self._local_first_dock_composition
+
     def _persist_startup_wizard_step_if_needed(
         self,
         *,
@@ -619,6 +656,29 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             wizard_settings=load_wizard_settings(self.settings),
         )
         return self._wizard_shell_composition
+
+    def _refresh_local_first_dock_from_runtime(self):
+        """Refresh an optional #748 local-first dock composition from runtime facts."""
+
+        composition = getattr(self, "_local_first_dock_composition", None)
+        if composition is None:
+            return None
+
+        from .ui.dockwidget.local_first_composition import (
+            refresh_local_first_dock_composition,
+        )
+
+        self._local_first_dock_composition = refresh_local_first_dock_composition(
+            composition,
+            progress_facts=self._current_wizard_progress_facts(),
+        )
+        return self._local_first_dock_composition
+
+    def _refresh_live_dock_navigation_from_runtime(self) -> None:
+        """Refresh whichever dock navigation composition is installed."""
+
+        self._refresh_wizard_shell_from_runtime()
+        self._refresh_local_first_dock_from_runtime()
 
     def _has_configured_strava_connection(self) -> bool:
         return all(
@@ -1885,7 +1945,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     workflow_status=self._label_text("statusLabel"),
                 )
             )
-        self._refresh_wizard_shell_from_runtime()
+        self._refresh_live_dock_navigation_from_runtime()
 
     def _label_text(self, name: str) -> str:
         return self._widget_text(name)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -522,12 +522,15 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _install_wizard_filter_controls(self, composition) -> None:
         """Move the live map-filter controls into the wizard map page."""
 
-        if getattr(self, "_wizard_filter_controls_installed", False):
-            return
-
         map_content = getattr(composition, "map_content", None)
         filter_group = getattr(self, "filterGroupBox", None)
         if map_content is None or filter_group is None:
+            return
+        installed_target = getattr(self, "_wizard_filter_controls_installed_target", None)
+        current_target = id(map_content)
+        if getattr(self, "_wizard_filter_controls_installed", False) and (
+            installed_target == current_target
+        ):
             return
         filter_controls_layout = getattr(map_content, "filter_controls_layout", None)
         if not callable(filter_controls_layout):
@@ -544,6 +547,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             filter_group.setVisible(True)
         map_content.set_filter_controls_visible(False)
         self._wizard_filter_controls_installed = True
+        self._wizard_filter_controls_installed_target = current_target
 
     def _remove_widget_from_current_layout(self, widget) -> None:
         parent_widget = (

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -965,7 +965,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "connected-composition"
         )
 
-
     def test_install_wizard_filter_controls_moves_live_filter_group_into_map_panel(self):
         dock = object.__new__(self.module.QfitDockWidget)
         parent_layout = MagicMock()
@@ -992,12 +991,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         filter_group.show.assert_called_once_with()
         map_content.set_filter_controls_visible.assert_called_once_with(False)
         self.assertTrue(dock._wizard_filter_controls_installed)
+        self.assertEqual(dock._wizard_filter_controls_installed_target, id(map_content))
 
     def test_install_wizard_filter_controls_is_idempotent(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._wizard_filter_controls_installed = True
         dock.filterGroupBox = MagicMock()
         map_content = SimpleNamespace(filter_controls_layout=MagicMock())
+        dock._wizard_filter_controls_installed_target = id(map_content)
 
         self.module.QfitDockWidget._install_wizard_filter_controls(
             dock,
@@ -1005,6 +1006,30 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
 
         map_content.filter_controls_layout.assert_not_called()
+
+    def test_install_wizard_filter_controls_reparents_for_new_composition(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._wizard_filter_controls_installed = True
+        dock._wizard_filter_controls_installed_target = 12345
+        parent_layout = MagicMock()
+        parent_widget = SimpleNamespace(layout=lambda: parent_layout)
+        filter_group = MagicMock()
+        filter_group.parentWidget.return_value = parent_widget
+        dock.filterGroupBox = filter_group
+        filter_layout = MagicMock()
+        map_content = SimpleNamespace(
+            filter_controls_layout=MagicMock(return_value=filter_layout),
+            set_filter_controls_visible=MagicMock(),
+        )
+
+        self.module.QfitDockWidget._install_wizard_filter_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
+        parent_layout.removeWidget.assert_called_once_with(filter_group)
+        filter_layout.addWidget.assert_called_once_with(filter_group)
+        self.assertEqual(dock._wizard_filter_controls_installed_target, id(map_content))
 
     def test_update_status_for_filter_visibility_updates_status_copy(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -1199,7 +1224,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
         dock._refresh_local_first_dock_from_runtime.assert_called_once_with()
 
-    def test_refresh_summary_status_notifies_optional_wizard_shell_refresh(self):
+    def test_refresh_summary_status_notifies_live_dock_navigation_refresh(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.summaryStatusLabel = _FakeLabel("")
         dock.connectionStatusLabel = _FakeLabel("Strava connection: ready")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -887,6 +887,84 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.settings.get("ui/last_step_index"), 0)
         self.assertTrue(dock.settings.get("ui/last_step_index_user_selected"))
 
+    def test_build_local_first_dock_from_runtime_wires_independent_callbacks(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock._atlas_export_completed = False
+        dock.settings = _FakeSettings()
+        dock._install_wizard_filter_controls = MagicMock()
+        dock._bind_wizard_analysis_mode_controls = MagicMock()
+        parent = object()
+
+        class FakeWizardActionCallbacks(SimpleNamespace):
+            pass
+
+        fake_local_first_composition = ModuleType(
+            "qfit.ui.dockwidget.local_first_composition"
+        )
+        fake_local_first_composition.WizardActionCallbacks = FakeWizardActionCallbacks
+        fake_local_first_composition.build_local_first_dock_composition = MagicMock(
+            return_value="composition"
+        )
+        fake_local_first_composition.connect_local_first_action_callbacks = MagicMock(
+            return_value="connected-composition"
+        )
+
+        with patch.dict(
+            sys.modules,
+            {
+                "qfit.ui.dockwidget.local_first_composition": (
+                    fake_local_first_composition
+                )
+            },
+        ):
+            composition = self.module.QfitDockWidget._build_local_first_dock_from_runtime(
+                dock,
+                parent=parent,
+            )
+
+        self.assertEqual(composition, "connected-composition")
+        self.assertEqual(dock._local_first_dock_composition, "connected-composition")
+        fake_local_first_composition.build_local_first_dock_composition.assert_called_once()
+        _args, kwargs = (
+            fake_local_first_composition.build_local_first_dock_composition.call_args
+        )
+        self.assertEqual(kwargs["parent"], parent)
+        self.assertTrue(kwargs["progress_facts"].connection_configured)
+        fake_local_first_composition.connect_local_first_action_callbacks.assert_called_once()
+        connect_args = (
+            fake_local_first_composition.connect_local_first_action_callbacks.call_args.args
+        )
+        self.assertEqual(connect_args[0], "composition")
+        callbacks = connect_args[1]
+        expected_callbacks = {
+            "configure_connection": "_show_connection_configuration_hint",
+            "sync_activities": "on_refresh_clicked",
+            "sync_saved_routes": "on_sync_routes_clicked",
+            "load_activity_layers": "on_load_layers_clicked",
+            "edit_map_filters": "_update_status_for_filter_visibility",
+            "apply_map_filters": "on_apply_filters_clicked",
+            "run_analysis": "on_run_analysis_clicked",
+            "set_analysis_mode": "_set_wizard_analysis_mode",
+            "export_atlas": "on_generate_atlas_pdf_clicked",
+        }
+        for callback_name, method_name in expected_callbacks.items():
+            callback = getattr(callbacks, callback_name)
+            self.assertIs(callback.__self__, dock)
+            self.assertIs(
+                callback.__func__,
+                getattr(self.module.QfitDockWidget, method_name),
+            )
+        dock._install_wizard_filter_controls.assert_called_once_with(
+            "connected-composition"
+        )
+        dock._bind_wizard_analysis_mode_controls.assert_called_once_with(
+            "connected-composition"
+        )
+
 
     def test_install_wizard_filter_controls_moves_live_filter_group_into_map_panel(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -1078,6 +1156,49 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(kwargs["wizard_settings"].last_step_index, 1)
         self.assertFalse(kwargs["wizard_settings"].first_launch)
 
+    def test_refresh_local_first_dock_from_runtime_updates_optional_composition(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.clientIdLineEdit = _FakeLineEdit("client-id")
+        dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock.settings = _FakeSettings()
+        composition = object()
+        dock._local_first_dock_composition = composition
+        fake_local_first_composition = ModuleType(
+            "qfit.ui.dockwidget.local_first_composition"
+        )
+        fake_local_first_composition.refresh_local_first_dock_composition = MagicMock(
+            return_value="refreshed"
+        )
+
+        with patch.dict(
+            sys.modules,
+            {"qfit.ui.dockwidget.local_first_composition": fake_local_first_composition},
+        ):
+            refreshed = self.module.QfitDockWidget._refresh_local_first_dock_from_runtime(
+                dock
+            )
+
+        self.assertEqual(refreshed, "refreshed")
+        self.assertEqual(dock._local_first_dock_composition, "refreshed")
+        fake_local_first_composition.refresh_local_first_dock_composition.assert_called_once()
+        args, kwargs = (
+            fake_local_first_composition.refresh_local_first_dock_composition.call_args
+        )
+        self.assertEqual(args, (composition,))
+        self.assertTrue(kwargs["progress_facts"].connection_configured)
+
+    def test_refresh_live_dock_navigation_refreshes_all_optional_compositions(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._refresh_wizard_shell_from_runtime = MagicMock()
+        dock._refresh_local_first_dock_from_runtime = MagicMock()
+
+        self.module.QfitDockWidget._refresh_live_dock_navigation_from_runtime(dock)
+
+        dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
+        dock._refresh_local_first_dock_from_runtime.assert_called_once_with()
+
     def test_refresh_summary_status_notifies_optional_wizard_shell_refresh(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.summaryStatusLabel = _FakeLabel("")
@@ -1085,7 +1206,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.countLabel = _FakeLabel("12 activities")
         dock.querySummaryLabel = _FakeLabel("filtered")
         dock.statusLabel = _FakeLabel("Ready")
-        dock._refresh_wizard_shell_from_runtime = MagicMock()
+        dock._refresh_live_dock_navigation_from_runtime = MagicMock()
 
         self.module.QfitDockWidget._refresh_summary_status(dock)
 
@@ -1093,7 +1214,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             dock.summaryStatusLabel.text(),
             "Strava connection: ready · 12 activities · filtered · Ready",
         )
-        dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
+        dock._refresh_live_dock_navigation_from_runtime.assert_called_once_with()
 
     def test_on_apply_filters_clicked_dispatches_apply_visualization_action(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary

- add a `QfitDockWidget` runtime adapter for the local-first dock composition
- wire Data/Map/Analysis/Atlas/Settings actions to the existing mature dock workflows as independent page actions
- add a shared refresh seam so installed wizard/local-first compositions can refresh from runtime facts
- keep the production visible dock unchanged for this slice
- address review feedback by reparenting filter controls when a different composition becomes active

Refs #748.

## Tests

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_local_first_composition.py tests/test_local_first_shell.py tests/test_local_first_navigation.py tests/test_architecture_boundaries.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof

Not rendering-sensitive yet. This PR wires the local-first composition to runtime callbacks behind a new adapter seam, but it does not swap the visible production dock, alter QGIS layer rendering, or change atlas export output.
