### PR TITLE
Install local-first dock as live path

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -289,10 +289,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return replace(runtime_state, output_path=selected_output_path)
 
     def _on_output_path_changed(self, value: str) -> None:
-        """Keep wizard local-load actions in sync with the selected GeoPackage path."""
+        """Keep live local-load actions in sync with the selected GeoPackage path."""
 
         self._runtime_store().select_output_path((value or "").strip() or None)
-        self._refresh_wizard_shell_from_runtime()
+        self._refresh_live_dock_navigation_from_runtime()
 
     def _current_wizard_activity_style_preset(self) -> str | None:
         """Return current activity style copy for the optional wizard map page."""

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -168,7 +168,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._dock_visual_workflow = DockVisualWorkflowCoordinator(
             dispatcher=self._dock_action_dispatcher,
         )
-        self._install_live_wizard_shell()
+        self._install_live_local_first_dock()
 
     def _ensure_wizard_settings(self):
         """Persist first-launch wizard defaults for the #609 dock migration."""
@@ -635,6 +635,28 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._wizard_live_shell = shell
         self._wizard_live_path_installed = True
+
+    def _install_live_local_first_dock(self) -> None:
+        """Make the #748 local-first navigation shell the visible dock path."""
+
+        if getattr(self, "_local_first_live_path_installed", False):
+            return
+
+        parent = getattr(self, "dockWidgetContents", self)
+        composition = self._build_local_first_dock_from_runtime(parent=parent)
+        shell = getattr(composition, "shell", None)
+        if shell is None:
+            raise RuntimeError("Local-first dock composition must expose a shell widget")
+
+        outer_layout = getattr(self, "outerLayout", None)
+        if outer_layout is None:
+            raise RuntimeError("Local-first dock requires the base outer layout")
+
+        self._hide_legacy_scroll_dock_content()
+        outer_layout.addWidget(shell)
+
+        self._local_first_live_shell = shell
+        self._local_first_live_path_installed = True
 
     def _hide_legacy_scroll_dock_content(self) -> None:
         """Hide the replaced long-scroll dock widgets without deleting them."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1146,6 +1146,50 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.scrollArea.hide.assert_not_called()
         dock.summaryStatusLabel.hide.assert_not_called()
 
+    def test_install_live_local_first_dock_hides_long_scroll_path(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        shell = object()
+        composition = SimpleNamespace(shell=shell)
+        dock.dockWidgetContents = object()
+        dock.outerLayout = _FakeLayout()
+        dock.scrollArea = MagicMock()
+        dock.summaryStatusLabel = MagicMock()
+        dock._build_local_first_dock_from_runtime = MagicMock(return_value=composition)
+
+        self.module.QfitDockWidget._install_live_local_first_dock(dock)
+
+        dock._build_local_first_dock_from_runtime.assert_called_once_with(
+            parent=dock.dockWidgetContents,
+        )
+        dock.scrollArea.hide.assert_called_once_with()
+        dock.summaryStatusLabel.hide.assert_called_once_with()
+        self.assertEqual(dock.outerLayout.added, [shell])
+        self.assertIs(dock._local_first_live_shell, shell)
+        self.assertTrue(dock._local_first_live_path_installed)
+
+    def test_install_live_local_first_dock_is_idempotent(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._local_first_live_path_installed = True
+        dock._build_local_first_dock_from_runtime = MagicMock()
+
+        self.module.QfitDockWidget._install_live_local_first_dock(dock)
+
+        dock._build_local_first_dock_from_runtime.assert_not_called()
+
+    def test_install_live_local_first_dock_requires_base_outer_layout(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.dockWidgetContents = object()
+        dock.scrollArea = MagicMock()
+        dock.summaryStatusLabel = MagicMock()
+        dock._build_local_first_dock_from_runtime = MagicMock(
+            return_value=SimpleNamespace(shell=object()),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "base outer layout"):
+            self.module.QfitDockWidget._install_live_local_first_dock(dock)
+
+        dock.scrollArea.hide.assert_not_called()
+        dock.summaryStatusLabel.hide.assert_not_called()
 
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -670,10 +670,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.on_apply_filters_clicked.assert_called_once_with()
         dock.on_load_layers_clicked.assert_not_called()
 
-    def test_output_path_change_updates_wizard_runtime_state(self):
+    def test_output_path_change_updates_runtime_state_and_live_navigation(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()
-        dock._refresh_wizard_shell_from_runtime = MagicMock()
+        dock._refresh_live_dock_navigation_from_runtime = MagicMock()
 
         self.module.QfitDockWidget._on_output_path_changed(
             dock,
@@ -681,7 +681,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
 
         self.assertEqual(dock.runtime_state.output_path, "/tmp/local-qfit.gpkg")
-        dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
+        dock._refresh_live_dock_navigation_from_runtime.assert_called_once_with()
 
     def test_output_path_change_clears_stale_loaded_dataset_state(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -691,7 +691,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             stored_activity_count=3,
             activities_layer=object(),
         )
-        dock._refresh_wizard_shell_from_runtime = MagicMock()
+        dock._refresh_live_dock_navigation_from_runtime = MagicMock()
 
         self.module.QfitDockWidget._on_output_path_changed(
             dock,
@@ -701,7 +701,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.runtime_state.output_path, "/tmp/new-qfit.gpkg")
         self.assertIsNone(dock.runtime_state.stored_activity_count)
         self.assertIsNone(dock.runtime_state.activities_layer)
-        dock._refresh_wizard_shell_from_runtime.assert_called_once_with()
+        dock._refresh_live_dock_navigation_from_runtime.assert_called_once_with()
 
     def test_wizard_progress_facts_reflect_existing_visible_geopackage_path(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -227,16 +227,26 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
-    def test_dock_widget_defaults_to_wizard_shell_live_path(self):
+    def test_dock_widget_defaults_to_local_first_live_path(self):
         dock = QfitDockWidget(self.iface)
         try:
-            self.assertTrue(dock._wizard_live_path_installed)
-            self.assertEqual(dock._wizard_live_shell.objectName(), "qfitWizardShell")
-            self.assertIs(dock._wizard_shell_composition.shell, dock._wizard_live_shell)
-            self.assertEqual(dock._wizard_live_shell.page_count(), 5)
+            self.assertTrue(dock._local_first_live_path_installed)
+            self.assertEqual(
+                dock._local_first_live_shell.objectName(),
+                "qfitLocalFirstDockShell",
+            )
+            self.assertIs(
+                dock._local_first_dock_composition.shell,
+                dock._local_first_live_shell,
+            )
+            self.assertEqual(dock._local_first_live_shell.page_count(), 5)
+            self.assertEqual(dock._local_first_live_shell.current_key(), "data")
             self.assertTrue(dock.scrollArea.isHidden())
             self.assertTrue(dock.summaryStatusLabel.isHidden())
-            self.assertGreaterEqual(dock.outerLayout.indexOf(dock._wizard_live_shell), 0)
+            self.assertGreaterEqual(
+                dock.outerLayout.indexOf(dock._local_first_live_shell),
+                0,
+            )
         finally:
             dock.close()
             dock.deleteLater()


### PR DESCRIPTION
## Summary

- make the #748 local-first shell the live production dock path
- keep the legacy long-scroll controls hidden as backing widgets for existing workflows
- retain the wizard live-path helper as a compatibility/backout seam
- update pure and QGIS smoke tests to expect the local-first dock shell
- address review feedback by refreshing live dock navigation after GeoPackage output-path edits

Refs #748.

## Tests

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_local_first_composition.py tests/test_local_first_shell.py tests/test_local_first_navigation.py tests/test_architecture_boundaries.py -q --tb=short`
- `python3 -m pytest tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_defaults_to_local_first_live_path -q --tb=short`
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_defaults_to_local_first_live_path -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof

This swaps the visible dock shell but does not alter QGIS layer rendering or atlas export output. A QGIS smoke test instantiates the dock and verifies the local-first shell is installed, the legacy long-scroll widgets are hidden, and the shell has five pages with Data selected as the landing page.
