### PR TITLE
Add Atlas title fields to local-first dock

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -511,7 +511,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 update_atlas_document_settings=self._update_atlas_document_settings,
             ),
         )
-        self._sync_atlas_document_settings_controls(self._local_first_dock_composition)
         self._install_wizard_filter_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
         return self._local_first_dock_composition

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -466,8 +466,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 run_analysis=self.on_run_analysis_clicked,
                 set_analysis_mode=self._set_wizard_analysis_mode,
                 export_atlas=self.on_generate_atlas_pdf_clicked,
+                update_atlas_document_settings=self._update_atlas_document_settings,
             ),
         )
+        self._sync_atlas_document_settings_controls(self._wizard_shell_composition)
         self._install_wizard_filter_controls(self._wizard_shell_composition)
         self._bind_wizard_analysis_mode_controls(self._wizard_shell_composition)
         return self._wizard_shell_composition
@@ -490,6 +492,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         composition = build_local_first_dock_composition(
             parent=self if parent is None else parent,
             progress_facts=self._current_wizard_progress_facts(),
+            atlas_title=self.atlasTitleLineEdit.text(),
+            atlas_subtitle=self.atlasSubtitleLineEdit.text(),
         )
         self._local_first_dock_composition = connect_local_first_action_callbacks(
             composition,
@@ -504,11 +508,40 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 run_analysis=self.on_run_analysis_clicked,
                 set_analysis_mode=self._set_wizard_analysis_mode,
                 export_atlas=self.on_generate_atlas_pdf_clicked,
+                update_atlas_document_settings=self._update_atlas_document_settings,
             ),
         )
+        self._sync_atlas_document_settings_controls(self._local_first_dock_composition)
         self._install_wizard_filter_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
         return self._local_first_dock_composition
+
+    def _sync_atlas_document_settings_controls(self, composition) -> None:
+        atlas_content = getattr(composition, "atlas_content", None)
+        set_document_settings = getattr(atlas_content, "set_document_settings", None)
+        if not callable(set_document_settings):
+            return
+        set_document_settings(
+            atlas_title=self.atlasTitleLineEdit.text(),
+            atlas_subtitle=self.atlasSubtitleLineEdit.text(),
+        )
+
+    def _update_atlas_document_settings(self, atlas_title: str, atlas_subtitle: str) -> None:
+        """Mirror visible atlas-page title fields into the export settings widgets."""
+
+        title_line_edit = getattr(self, "atlasTitleLineEdit", None)
+        subtitle_line_edit = getattr(self, "atlasSubtitleLineEdit", None)
+        title_changed = title_line_edit is not None and title_line_edit.text() != atlas_title
+        subtitle_changed = (
+            subtitle_line_edit is not None
+            and subtitle_line_edit.text() != atlas_subtitle
+        )
+        if title_line_edit is not None:
+            title_line_edit.setText(atlas_title)
+        if subtitle_line_edit is not None:
+            subtitle_line_edit.setText(atlas_subtitle)
+        if title_changed or subtitle_changed:
+            self._mark_atlas_export_stale()
 
     def _persist_startup_wizard_step_if_needed(
         self,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -541,6 +541,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             subtitle_line_edit.setText(atlas_subtitle)
         if title_changed or subtitle_changed:
             self._mark_atlas_export_stale()
+            self._refresh_summary_status()
 
     def _persist_startup_wizard_step_if_needed(
         self,

--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -236,6 +236,21 @@ class AtlasPageContentTest(unittest.TestCase):
 
         self.assertIs(atlas_page.body_layout().widgets[-1], content)
 
+    def test_install_forwards_seeded_document_settings(self):
+        atlas_spec = next(
+            spec for spec in build_default_wizard_page_specs() if spec.key == "atlas"
+        )
+        atlas_page = self.wizard_page.WizardPage(atlas_spec)
+
+        content = self.atlas_page.install_atlas_page_content(
+            atlas_page,
+            atlas_title="Spring Atlas",
+            atlas_subtitle="Road and trail",
+        )
+
+        self.assertEqual(content.title_line_edit.text(), "Spring Atlas")
+        self.assertEqual(content.subtitle_line_edit.text(), "Road and trail")
+
     def test_rejects_installing_on_other_wizard_page(self):
         analysis_spec = next(
             spec for spec in build_default_wizard_page_specs() if spec.key == "analysis"

--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -59,6 +59,23 @@ class AtlasPageContentTest(unittest.TestCase):
             "PDF output path will be chosen before generation",
         )
         self.assertIn(COLOR_MUTED, content.output_summary_label.styleSheet())
+        self.assertEqual(content.title_label.objectName(), "qfitWizardAtlasTitleLabel")
+        self.assertEqual(content.title_label.text(), "Atlas title")
+        self.assertEqual(
+            content.title_line_edit.objectName(),
+            "qfitWizardAtlasTitleLineEdit",
+        )
+        self.assertEqual(content.title_line_edit.text(), "qfit Activity Atlas")
+        self.assertEqual(
+            content.subtitle_label.objectName(),
+            "qfitWizardAtlasSubtitleLabel",
+        )
+        self.assertEqual(content.subtitle_label.text(), "Atlas subtitle")
+        self.assertEqual(
+            content.subtitle_line_edit.objectName(),
+            "qfitWizardAtlasSubtitleLineEdit",
+        )
+        self.assertEqual(content.subtitle_line_edit.placeholderText(), "Optional subtitle…")
         self.assertEqual(
             content.export_atlas_button.objectName(),
             "qfitWizardAtlasExportButton",
@@ -88,11 +105,64 @@ class AtlasPageContentTest(unittest.TestCase):
             [
                 content.status_label,
                 content.detail_label,
+                content.title_label,
+                content.title_line_edit,
+                content.subtitle_label,
+                content.subtitle_line_edit,
                 content.input_summary_label,
                 content.output_summary_label,
                 content.action_row,
             ],
         )
+
+    def test_can_seed_and_update_visible_document_settings(self):
+        content = self.atlas_page.AtlasPageContent(
+            atlas_title="Spring Atlas",
+            atlas_subtitle="Road and trail",
+        )
+
+        self.assertEqual(content.title_line_edit.text(), "Spring Atlas")
+        self.assertEqual(content.subtitle_line_edit.text(), "Road and trail")
+
+        content.set_document_settings(
+            atlas_title="Summer Atlas",
+            atlas_subtitle="Gravel rides",
+        )
+
+        self.assertEqual(content.title_line_edit.text(), "Summer Atlas")
+        self.assertEqual(content.subtitle_line_edit.text(), "Gravel rides")
+
+    def test_document_settings_emit_when_user_edits_fields(self):
+        content = self.atlas_page.AtlasPageContent()
+        calls = []
+        content.atlasDocumentSettingsChanged.connect(
+            lambda title, subtitle: calls.append((title, subtitle))
+        )
+
+        content.title_line_edit.setText("Custom Atlas")
+        content.subtitle_line_edit.setText("April 2026")
+
+        self.assertEqual(
+            calls,
+            [
+                ("Custom Atlas", ""),
+                ("Custom Atlas", "April 2026"),
+            ],
+        )
+
+    def test_programmatic_document_settings_update_does_not_emit_user_change(self):
+        content = self.atlas_page.AtlasPageContent()
+        calls = []
+        content.atlasDocumentSettingsChanged.connect(
+            lambda title, subtitle: calls.append((title, subtitle))
+        )
+
+        content.set_document_settings(
+            atlas_title="Saved Atlas",
+            atlas_subtitle="Saved subtitle",
+        )
+
+        self.assertEqual(calls, [])
 
     def test_refreshes_ready_state_without_rebuilding(self):
         content = self.atlas_page.AtlasPageContent()

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -79,7 +79,10 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         )
 
     def test_connects_existing_page_action_callbacks(self):
-        composition = self.module.build_local_first_dock_composition()
+        composition = self.module.build_local_first_dock_composition(
+            atlas_title="Spring Atlas",
+            atlas_subtitle="Road and trail",
+        )
         calls = []
         callbacks = self.module.WizardActionCallbacks(
             configure_connection=lambda: calls.append("settings"),
@@ -92,6 +95,9 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             run_analysis=lambda: calls.append("analysis"),
             set_analysis_mode=lambda mode: calls.append(f"mode:{mode}"),
             export_atlas=lambda: calls.append("atlas"),
+            update_atlas_document_settings=lambda title, subtitle: calls.append(
+                f"atlas-settings:{title}:{subtitle}"
+            ),
         )
 
         self.module.connect_local_first_action_callbacks(composition, callbacks)
@@ -106,6 +112,8 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         composition.analysis_content.runAnalysisRequested.emit()
         composition.analysis_content.analysisModeChanged.emit("Heatmap")
         composition.atlas_content.exportAtlasRequested.emit()
+        composition.atlas_content.title_line_edit.setText("Summer Atlas")
+        composition.atlas_content.subtitle_line_edit.setText("April 2026")
 
         self.assertEqual(
             calls,
@@ -121,7 +129,21 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
                 "analysis",
                 "mode:Heatmap",
                 "atlas",
+                "atlas-settings:Summer Atlas:Road and trail",
+                "atlas-settings:Summer Atlas:April 2026",
             ],
+        )
+
+    def test_seeds_atlas_document_settings_controls(self):
+        composition = self.module.build_local_first_dock_composition(
+            atlas_title="Spring Atlas",
+            atlas_subtitle="Road and trail",
+        )
+
+        self.assertEqual(composition.atlas_content.title_line_edit.text(), "Spring Atlas")
+        self.assertEqual(
+            composition.atlas_content.subtitle_line_edit.text(),
+            "Road and trail",
         )
 
     def test_refresh_updates_navigation_and_page_content_state(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -977,6 +977,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasTitleLineEdit = _FakeLineEdit("Old Atlas")
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Old subtitle")
         dock._mark_atlas_export_stale = MagicMock()
+        dock._refresh_summary_status = MagicMock()
 
         self.module.QfitDockWidget._update_atlas_document_settings(
             dock,
@@ -987,12 +988,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.atlasTitleLineEdit.text(), "Spring Atlas")
         self.assertEqual(dock.atlasSubtitleLineEdit.text(), "Road and trail")
         dock._mark_atlas_export_stale.assert_called_once_with()
+        dock._refresh_summary_status.assert_called_once_with()
 
     def test_update_atlas_document_settings_keeps_current_export_when_unchanged(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.atlasTitleLineEdit = _FakeLineEdit("Spring Atlas")
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._mark_atlas_export_stale = MagicMock()
+        dock._refresh_summary_status = MagicMock()
 
         self.module.QfitDockWidget._update_atlas_document_settings(
             dock,
@@ -1001,6 +1004,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
 
         dock._mark_atlas_export_stale.assert_not_called()
+        dock._refresh_summary_status.assert_not_called()
 
     def test_install_wizard_filter_controls_moves_live_filter_group_into_map_panel(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -894,6 +894,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.clientIdLineEdit = _FakeLineEdit("client-id")
         dock.clientSecretLineEdit = _FakeLineEdit("client-secret")
         dock.refreshTokenLineEdit = _FakeLineEdit("refresh-token")
+        dock.atlasTitleLineEdit = _FakeLineEdit("Spring Atlas")
+        dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._atlas_export_completed = False
         dock.settings = _FakeSettings()
         dock._install_wizard_filter_controls = MagicMock()
@@ -935,6 +937,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         self.assertEqual(kwargs["parent"], parent)
         self.assertTrue(kwargs["progress_facts"].connection_configured)
+        self.assertEqual(kwargs["atlas_title"], "Spring Atlas")
+        self.assertEqual(kwargs["atlas_subtitle"], "Road and trail")
         fake_local_first_composition.connect_local_first_action_callbacks.assert_called_once()
         connect_args = (
             fake_local_first_composition.connect_local_first_action_callbacks.call_args.args
@@ -952,6 +956,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "run_analysis": "on_run_analysis_clicked",
             "set_analysis_mode": "_set_wizard_analysis_mode",
             "export_atlas": "on_generate_atlas_pdf_clicked",
+            "update_atlas_document_settings": "_update_atlas_document_settings",
         }
         for callback_name, method_name in expected_callbacks.items():
             callback = getattr(callbacks, callback_name)
@@ -966,6 +971,36 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._bind_wizard_analysis_mode_controls.assert_called_once_with(
             "connected-composition"
         )
+
+    def test_update_atlas_document_settings_mirrors_visible_fields(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.atlasTitleLineEdit = _FakeLineEdit("Old Atlas")
+        dock.atlasSubtitleLineEdit = _FakeLineEdit("Old subtitle")
+        dock._mark_atlas_export_stale = MagicMock()
+
+        self.module.QfitDockWidget._update_atlas_document_settings(
+            dock,
+            "Spring Atlas",
+            "Road and trail",
+        )
+
+        self.assertEqual(dock.atlasTitleLineEdit.text(), "Spring Atlas")
+        self.assertEqual(dock.atlasSubtitleLineEdit.text(), "Road and trail")
+        dock._mark_atlas_export_stale.assert_called_once_with()
+
+    def test_update_atlas_document_settings_keeps_current_export_when_unchanged(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.atlasTitleLineEdit = _FakeLineEdit("Spring Atlas")
+        dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
+        dock._mark_atlas_export_stale = MagicMock()
+
+        self.module.QfitDockWidget._update_atlas_document_settings(
+            dock,
+            "Spring Atlas",
+            "Road and trail",
+        )
+
+        dock._mark_atlas_export_stale.assert_not_called()
 
     def test_install_wizard_filter_controls_moves_live_filter_group_into_map_panel(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -226,6 +226,27 @@ class _FakeLabel(_FakeWidget):
         self.word_wrap = value
 
 
+class _FakeLineEdit(_FakeWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.textChanged = _FakeSignal()
+        self._text = ""
+        self._placeholder_text = ""
+
+    def setText(self, value):  # noqa: N802
+        self._text = value
+        self.textChanged.emit(value)
+
+    def text(self):
+        return self._text
+
+    def setPlaceholderText(self, value):  # noqa: N802
+        self._placeholder_text = value
+
+    def placeholderText(self):  # noqa: N802
+        return self._placeholder_text
+
+
 class _FakeScrollArea(_FakeWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -326,6 +347,7 @@ def _fake_qt_modules():
     qtwidgets.QFrame = _FakeFrame
     qtwidgets.QHBoxLayout = _FakeHBoxLayout
     qtwidgets.QLabel = _FakeLabel
+    qtwidgets.QLineEdit = _FakeLineEdit
     qtwidgets.QScrollArea = _FakeScrollArea
     qtwidgets.QSizePolicy = _FakeSizePolicy
     qtwidgets.QStackedWidget = _FakeStackedWidget

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -34,6 +34,8 @@ QToolButton = _qtwidgets.QToolButton
 QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
 
+_DEFAULT_ATLAS_TITLE = "qfit Activity Atlas"
+
 
 @dataclass(frozen=True)
 class AtlasPageState:
@@ -60,7 +62,7 @@ class AtlasPageContent(QWidget):
         state: AtlasPageState | None = None,
         parent=None,
         *,
-        atlas_title: str = "qfit Activity Atlas",
+        atlas_title: str = _DEFAULT_ATLAS_TITLE,
         atlas_subtitle: str = "",
     ) -> None:
         super().__init__(parent)
@@ -184,7 +186,7 @@ def build_atlas_page_content(
     *,
     parent=None,
     state: AtlasPageState | None = None,
-    atlas_title: str = "qfit Activity Atlas",
+    atlas_title: str = _DEFAULT_ATLAS_TITLE,
     atlas_subtitle: str = "",
 ) -> AtlasPageContent:
     """Build the reusable atlas-export-step content widget."""
@@ -201,7 +203,7 @@ def install_atlas_page_content(
     page,
     *,
     state: AtlasPageState | None = None,
-    atlas_title: str = "qfit Activity Atlas",
+    atlas_title: str = _DEFAULT_ATLAS_TITLE,
     atlas_subtitle: str = "",
 ) -> AtlasPageContent:
     """Append atlas-export content to the matching wizard page body layout."""

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -201,6 +201,8 @@ def install_atlas_page_content(
     page,
     *,
     state: AtlasPageState | None = None,
+    atlas_title: str = "qfit Activity Atlas",
+    atlas_subtitle: str = "",
 ) -> AtlasPageContent:
     """Append atlas-export content to the matching wizard page body layout."""
 
@@ -208,7 +210,12 @@ def install_atlas_page_content(
         raise ValueError(
             "Atlas page content can only be installed on the atlas wizard page"
         )
-    content = build_atlas_page_content(parent=page, state=state)
+    content = build_atlas_page_content(
+        parent=page,
+        state=state,
+        atlas_title=atlas_title,
+        atlas_subtitle=atlas_subtitle,
+    )
     page.body_layout().addWidget(content)
     page.retire_primary_action_hint()
     return content

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -20,6 +20,7 @@ _qtwidgets = import_qt_module(
     "PyQt5.QtWidgets",
     (
         "QLabel",
+        "QLineEdit",
         "QToolButton",
         "QVBoxLayout",
         "QWidget",
@@ -28,6 +29,7 @@ _qtwidgets = import_qt_module(
 
 pyqtSignal = _qtcore.pyqtSignal
 QLabel = _qtwidgets.QLabel
+QLineEdit = _qtwidgets.QLineEdit
 QToolButton = _qtwidgets.QToolButton
 QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
@@ -51,9 +53,18 @@ class AtlasPageContent(QWidget):
     """Reusable fifth-page content for the wizard atlas-export step."""
 
     exportAtlasRequested = pyqtSignal()
+    atlasDocumentSettingsChanged = pyqtSignal(str, str)
 
-    def __init__(self, state: AtlasPageState | None = None, parent=None) -> None:
+    def __init__(
+        self,
+        state: AtlasPageState | None = None,
+        parent=None,
+        *,
+        atlas_title: str = "qfit Activity Atlas",
+        atlas_subtitle: str = "",
+    ) -> None:
         super().__init__(parent)
+        self._updating_document_settings = False
         self.setObjectName("qfitWizardAtlasPageContent")
         self.status_label = QLabel("", self)
         self.status_label.setObjectName("qfitWizardAtlasStatus")
@@ -68,6 +79,22 @@ class AtlasPageContent(QWidget):
         self.output_summary_label = QLabel("", self)
         self.output_summary_label.setObjectName("qfitWizardAtlasOutputSummary")
         style_summary_label(self.output_summary_label)
+        self.title_label = QLabel("Atlas title", self)
+        self.title_label.setObjectName("qfitWizardAtlasTitleLabel")
+        style_detail_label(self.title_label)
+        self.title_line_edit = QLineEdit(self)
+        self.title_line_edit.setObjectName("qfitWizardAtlasTitleLineEdit")
+        self.title_line_edit.setText(atlas_title)
+        self.subtitle_label = QLabel("Atlas subtitle", self)
+        self.subtitle_label.setObjectName("qfitWizardAtlasSubtitleLabel")
+        style_detail_label(self.subtitle_label)
+        self.subtitle_line_edit = QLineEdit(self)
+        self.subtitle_line_edit.setObjectName("qfitWizardAtlasSubtitleLineEdit")
+        if hasattr(self.subtitle_line_edit, "setPlaceholderText"):
+            self.subtitle_line_edit.setPlaceholderText("Optional subtitle…")
+        self.subtitle_line_edit.setText(atlas_subtitle)
+        self.title_line_edit.textChanged.connect(self._emit_document_settings_changed)
+        self.subtitle_line_edit.textChanged.connect(self._emit_document_settings_changed)
         self.export_atlas_button = QToolButton(self)
         self.export_atlas_button.setObjectName("qfitWizardAtlasExportButton")
         style_primary_action_button(
@@ -82,6 +109,26 @@ class AtlasPageContent(QWidget):
         )
         self._layout = self._build_layout()
         self.set_state(state or AtlasPageState())
+
+    def set_document_settings(self, *, atlas_title: str, atlas_subtitle: str) -> None:
+        """Refresh visible cover settings without emitting a user-change signal."""
+
+        self._updating_document_settings = True
+        try:
+            if self.title_line_edit.text() != atlas_title:
+                self.title_line_edit.setText(atlas_title)
+            if self.subtitle_line_edit.text() != atlas_subtitle:
+                self.subtitle_line_edit.setText(atlas_subtitle)
+        finally:
+            self._updating_document_settings = False
+
+    def _emit_document_settings_changed(self, *_args) -> None:
+        if self._updating_document_settings:
+            return
+        self.atlasDocumentSettingsChanged.emit(
+            self.title_line_edit.text(),
+            self.subtitle_line_edit.text(),
+        )
 
     def set_state(self, state: AtlasPageState) -> None:
         """Refresh copy and state properties without rebuilding the page."""
@@ -121,6 +168,10 @@ class AtlasPageContent(QWidget):
         for widget in (
             self.status_label,
             self.detail_label,
+            self.title_label,
+            self.title_line_edit,
+            self.subtitle_label,
+            self.subtitle_line_edit,
             self.input_summary_label,
             self.output_summary_label,
             self.action_row,
@@ -133,10 +184,17 @@ def build_atlas_page_content(
     *,
     parent=None,
     state: AtlasPageState | None = None,
+    atlas_title: str = "qfit Activity Atlas",
+    atlas_subtitle: str = "",
 ) -> AtlasPageContent:
     """Build the reusable atlas-export-step content widget."""
 
-    return AtlasPageContent(state=state, parent=parent)
+    return AtlasPageContent(
+        state=state,
+        parent=parent,
+        atlas_title=atlas_title,
+        atlas_subtitle=atlas_subtitle,
+    )
 
 
 def install_atlas_page_content(

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -80,6 +80,8 @@ def build_local_first_dock_composition(
     parent=None,
     footer_text: str = "",
     progress_facts: WizardProgressFacts | None = None,
+    atlas_title: str = "qfit Activity Atlas",
+    atlas_subtitle: str = "",
 ) -> LocalFirstDockComposition:
     """Build the reusable local-first dock shell without swapping production UI."""
 
@@ -90,7 +92,12 @@ def build_local_first_dock_composition(
         footer_text=footer_text,
     )
     pages = _install_local_first_pages(shell)
-    page_content = _install_local_first_page_content(pages, facts=facts)
+    page_content = _install_local_first_page_content(
+        pages,
+        facts=facts,
+        atlas_title=atlas_title,
+        atlas_subtitle=atlas_subtitle,
+    )
     return LocalFirstDockComposition(
         shell=shell,
         pages=pages,
@@ -157,6 +164,11 @@ def connect_local_first_action_callbacks(
         "exportAtlasRequested",
         callbacks.export_atlas,
     )
+    _connect_optional_signal(
+        composition.atlas_content,
+        "atlasDocumentSettingsChanged",
+        callbacks.update_atlas_document_settings,
+    )
     composition.action_callbacks = callbacks
     return composition
 
@@ -205,6 +217,8 @@ def _install_local_first_page_content(
     pages: dict[str, QWidget],
     *,
     facts: WizardProgressFacts,
+    atlas_title: str,
+    atlas_subtitle: str,
 ) -> LocalFirstDockPageContent:
     page_states = build_wizard_page_states_from_facts(_content_facts(facts))
     data_content = build_sync_page_content(
@@ -222,6 +236,8 @@ def _install_local_first_page_content(
     atlas_content = build_atlas_page_content(
         parent=pages["atlas"],
         state=page_states.atlas_state,
+        atlas_title=atlas_title,
+        atlas_subtitle=atlas_subtitle,
     )
     settings_content = build_connection_page_content(
         parent=pages["settings"],

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -76,6 +76,7 @@ class WizardActionCallbacks:
     run_analysis: Callable[[], None] | None = None
     set_analysis_mode: Callable[[str], None] | None = None
     export_atlas: Callable[[], None] | None = None
+    update_atlas_document_settings: Callable[[str, str], None] | None = None
 
 
 @dataclass(frozen=True)
@@ -453,6 +454,11 @@ def _connect_action_callbacks(
         callbacks.set_analysis_mode,
     )
     _connect_optional_signal(atlas_content, "exportAtlasRequested", callbacks.export_atlas)
+    _connect_optional_signal(
+        atlas_content,
+        "atlasDocumentSettingsChanged",
+        callbacks.update_atlas_document_settings,
+    )
 
 
 def _connect_optional_signal(content, signal_name: str, callback) -> None:


### PR DESCRIPTION
## Summary

- Add visible Atlas title and subtitle fields to the local-first Atlas page.
- Seed those fields from the persisted export settings and mirror edits into the existing export command path.
- Mark prior Atlas exports stale when document title/subtitle settings change.

## Validation

- `python3 -m pytest tests/test_atlas_page.py tests/test_local_first_composition.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_wizard_shell_composition.py tests/test_dock_settings_bindings.py tests/test_contextual_help.py tests/test_dock_atlas_workflow.py tests/test_atlas_export_use_case.py tests/test_atlas_export_service.py tests/test_qgis_smoke.py -q -k 'not test_dock_widget_contextual_help_smoke' --tb=short` *(stopped by unrelated QGIS smoke rendering/settings failures; focused Atlas smoke tests pass separately)*
- `python3 -m pytest tests/test_qgis_smoke.py -q -k 'atlas or local_first' --tb=short`
- `python3 -m pytest tests/ -q --tb=short --ignore=tests/test_qgis_smoke.py`
- `python3 scripts/install_plugin.py --plugins-dir /mnt/c/Users/emman/AppData/Roaming/QGIS/QGIS3/profiles/default/python/plugins --mode copy`

## Notes

The full non-smoke test suite passed locally. The broader QGIS smoke suite is currently not fully stable in this environment: one test reads the existing QGIS analysis-mode setting instead of `None`, and heatmap rendering produced an empty image. The Atlas/local-first smoke subset passed.
