### PR TITLE
Fix atlas export cancellation flow

### DIFF
--- a/atlas/export_coordinator.py
+++ b/atlas/export_coordinator.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Callable
+
+from .infrastructure.pdf_assembly import AtlasPdfAssemblyCancelled
 
 
 @dataclass(frozen=True)
@@ -63,6 +66,14 @@ class AtlasExportCoordinator:
             error=f"{user_label or stage.capitalize()} failed: {detail}",
         )
 
+    @staticmethod
+    def _discard_pdf_parts(page_paths: list[str], *front_paths: str | None) -> None:
+        for path in [path for path in front_paths if path] + page_paths:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
     def execute(self) -> AtlasExportExecutionResult:
         try:
             feature_count = self.atlas_layer.featureCount() if self.atlas_layer else 0
@@ -78,6 +89,9 @@ class AtlasExportCoordinator:
                 success=False,
                 error="No atlas pages found. Store and load activity layers first.",
             )
+
+        if self.is_canceled():
+            return AtlasExportExecutionResult(success=False, page_count=feature_count)
 
         try:
             layout = self.build_layout(
@@ -114,6 +128,7 @@ class AtlasExportCoordinator:
         if page_error is not None:
             return AtlasExportExecutionResult(success=False, page_count=page_count, error=page_error)
         if self.is_canceled():
+            self._discard_pdf_parts(page_paths)
             return AtlasExportExecutionResult(success=False, page_count=page_count)
         if not page_paths:
             return AtlasExportExecutionResult(
@@ -128,12 +143,21 @@ class AtlasExportCoordinator:
                 self.output_path,
                 project=self.project,
             )
+            if self.is_canceled():
+                self._discard_pdf_parts(page_paths, cover_path)
+                return AtlasExportExecutionResult(success=False, page_count=page_count)
             toc_path = self.export_toc_page(
                 self.atlas_layer,
                 self.output_path,
                 project=self.project,
             )
+            if self.is_canceled():
+                self._discard_pdf_parts(page_paths, cover_path, toc_path)
+                return AtlasExportExecutionResult(success=False, page_count=page_count)
             self.assemble_output_pdf(page_paths, cover_path=cover_path, toc_path=toc_path)
+        except AtlasPdfAssemblyCancelled:
+            self._discard_pdf_parts(page_paths, cover_path, toc_path)
+            return AtlasExportExecutionResult(success=False, page_count=page_count)
         except (RuntimeError, OSError) as exc:
             return self._stage_failure(
                 "final PDF assembly",

--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -1234,6 +1234,7 @@ class AtlasExportTask(QgsTask):
 
     def _build_pdf_assembler(self) -> AtlasPdfAssembler:
         return AtlasPdfAssembler(
+            is_canceled=self.isCanceled,
             warn=logger.warning,
         )
 

--- a/atlas/infrastructure/__init__.py
+++ b/atlas/infrastructure/__init__.py
@@ -1,3 +1,3 @@
-from .pdf_assembly import AtlasPdfAssembler, load_pdf_writer
+from .pdf_assembly import AtlasPdfAssembler, AtlasPdfAssemblyCancelled, load_pdf_writer
 
-__all__ = ["AtlasPdfAssembler", "load_pdf_writer"]
+__all__ = ["AtlasPdfAssembler", "AtlasPdfAssemblyCancelled", "load_pdf_writer"]

--- a/atlas/infrastructure/pdf_assembly.py
+++ b/atlas/infrastructure/pdf_assembly.py
@@ -8,6 +8,10 @@ from typing import Callable
 logger = logging.getLogger(__name__)
 
 
+class AtlasPdfAssemblyCancelled(Exception):
+    """Raised when cooperative cancellation interrupts PDF assembly."""
+
+
 def load_pdf_writer():
     """Return :class:`pypdf.PdfWriter`, preferring bundled plugin vendoring.
 
@@ -56,12 +60,18 @@ class AtlasPdfAssembler:
         replace_file: Callable[[str, str], None] | None = None,
         remove_file: Callable[[str], None] | None = None,
         open_file: Callable[..., object] | None = None,
+        is_canceled: Callable[[], bool] | None = None,
     ):
         self._load_pdf_writer = load_pdf_writer_fn
         self._warn = warn or logger.warning
         self._replace_file = replace_file or os.replace
         self._remove_file = remove_file or os.remove
         self._open_file = open_file or open
+        self._is_canceled = is_canceled or (lambda: False)
+
+    def _check_canceled(self) -> None:
+        if self._is_canceled():
+            raise AtlasPdfAssemblyCancelled()
 
     def assemble(
         self,
@@ -75,16 +85,19 @@ class AtlasPdfAssembler:
 
         front_pages = [path for path in (cover_path, toc_path) if path]
         all_paths = front_pages + page_paths
-        if len(all_paths) == 1:
-            self._replace_file(all_paths[0], output_path)
-            return
+        try:
+            self._check_canceled()
+            if len(all_paths) == 1:
+                self._replace_file(all_paths[0], output_path)
+                return
 
-        self.merge(all_paths, output_path)
-        for path in all_paths:
-            try:
-                self._remove_file(path)
-            except OSError:
-                pass
+            self.merge(all_paths, output_path)
+        finally:
+            for path in all_paths:
+                try:
+                    self._remove_file(path)
+                except OSError:
+                    pass
 
     def merge(self, page_paths: list[str], output_path: str) -> None:
         """Merge per-page PDF files into a single multi-page PDF."""
@@ -98,10 +111,13 @@ class AtlasPdfAssembler:
         if pdf_writer_cls is not None:
             writer = pdf_writer_cls()
             for path in page_paths:
+                self._check_canceled()
                 writer.append(path)
+            self._check_canceled()
             with self._open_file(output_path, "wb") as fout:
                 writer.write(fout)
             return
 
         if page_paths:
+            self._check_canceled()
             self._replace_file(page_paths[0], output_path)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1901,11 +1901,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         # Cancel any running export
         if self._atlas_export_task is not None:
             self._atlas_export_task.cancel()
-            self._set_atlas_pdf_status("Atlas PDF export cancelled.")
-            self._set_atlas_export_running(False)
-            self._runtime_store().clear_atlas_export()
-            self._atlas_export_task_output_path = None
-            self._refresh_summary_status()
+            self._set_atlas_export_cancelling()
+            self._set_atlas_pdf_status("Atlas PDF export cancellation requested…")
+            self._set_status("Atlas PDF export cancellation requested…")
             return
 
         export_command = self._atlas_workflow_service().build_export_command(
@@ -1961,9 +1959,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.generateAtlasPdfButton.setText(
             "Cancel export" if running else "Generate atlas PDF"
         )
+        self.generateAtlasPdfButton.setEnabled(True)
         self.loadButton.setEnabled(not running)
         self.loadLayersButton.setEnabled(not running)
         self.refreshButton.setEnabled(not running)
+
+    def _set_atlas_export_cancelling(self) -> None:
+        self.generateAtlasPdfButton.setText("Cancelling…")
+        self.generateAtlasPdfButton.setEnabled(False)
 
     def _on_atlas_export_finished(
         self,

--- a/tests/test_atlas_export_coordinator.py
+++ b/tests/test_atlas_export_coordinator.py
@@ -1,9 +1,10 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 
 from qfit.atlas.export_coordinator import AtlasExportCoordinator, AtlasExportExecutionResult
+from qfit.atlas.infrastructure import AtlasPdfAssemblyCancelled
 
 
 class AtlasExportCoordinatorTests(unittest.TestCase):
@@ -106,6 +107,56 @@ class AtlasExportCoordinatorTests(unittest.TestCase):
             ["/tmp/page-0.pdf"],
             cover_path="/tmp/cover.pdf",
             toc_path="/tmp/toc.pdf",
+        )
+
+    def test_execute_stops_before_layout_when_cancellation_is_already_requested(self):
+        parts = self._make_coordinator(canceled=True)
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(result, AtlasExportExecutionResult(success=False, page_count=2))
+        parts["build_layout"].assert_not_called()
+
+    def test_execute_stops_between_front_matter_stages_when_cancelled(self):
+        parts = self._make_coordinator()
+        parts["coordinator"].is_canceled.side_effect = [False, False, False, True]
+
+        with patch("qfit.atlas.export_coordinator.os.remove") as remove:
+            result = parts["coordinator"].execute()
+
+        self.assertEqual(result, AtlasExportExecutionResult(success=False, page_count=2))
+        parts["export_cover_page"].assert_called_once()
+        parts["export_toc_page"].assert_not_called()
+        parts["assemble_output_pdf"].assert_not_called()
+        self.assertEqual(
+            [call.args[0] for call in remove.call_args_list],
+            ["/tmp/cover.pdf", "/tmp/page-0.pdf"],
+        )
+
+    def test_execute_discards_page_parts_when_cancelled_after_page_export(self):
+        parts = self._make_coordinator()
+        parts["coordinator"].is_canceled.side_effect = [False, False, True]
+
+        with patch("qfit.atlas.export_coordinator.os.remove") as remove:
+            result = parts["coordinator"].execute()
+
+        self.assertEqual(result, AtlasExportExecutionResult(success=False, page_count=2))
+        parts["export_cover_page"].assert_not_called()
+        parts["assemble_output_pdf"].assert_not_called()
+        remove.assert_called_once_with("/tmp/page-0.pdf")
+
+    def test_execute_treats_pdf_assembly_cancellation_as_cancelled(self):
+        parts = self._make_coordinator()
+        parts["assemble_output_pdf"].side_effect = AtlasPdfAssemblyCancelled()
+
+        with patch("qfit.atlas.export_coordinator.os.remove") as remove:
+            result = parts["coordinator"].execute()
+
+        self.assertEqual(result, AtlasExportExecutionResult(success=False, page_count=2))
+        parts["logger"].exception.assert_not_called()
+        self.assertEqual(
+            [call.args[0] for call in remove.call_args_list],
+            ["/tmp/cover.pdf", "/tmp/toc.pdf", "/tmp/page-0.pdf"],
         )
 
     def test_execute_returns_page_runner_error(self):

--- a/tests/test_atlas_pdf_assembly.py
+++ b/tests/test_atlas_pdf_assembly.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, mock_open, patch
 from tests import _path  # noqa: F401
 
 from qfit.atlas.infrastructure import pdf_assembly
-from qfit.atlas.infrastructure.pdf_assembly import AtlasPdfAssembler
+from qfit.atlas.infrastructure.pdf_assembly import (
+    AtlasPdfAssembler,
+    AtlasPdfAssemblyCancelled,
+)
 
 
 class AtlasPdfAssemblerTests(unittest.TestCase):
@@ -45,6 +48,21 @@ class AtlasPdfAssemblerTests(unittest.TestCase):
 
         assembler.merge.assert_not_called()
         self.assertEqual(replace_calls, [("/tmp/page-1.pdf", "/tmp/out.pdf")])
+
+    def test_assemble_stops_before_writing_when_cancelled(self):
+        remove_calls = []
+        replace_file = MagicMock()
+        assembler = AtlasPdfAssembler(
+            is_canceled=MagicMock(return_value=True),
+            replace_file=replace_file,
+            remove_file=lambda path: remove_calls.append(path),
+        )
+
+        with self.assertRaises(AtlasPdfAssemblyCancelled):
+            assembler.assemble(["/tmp/page-1.pdf"], "/tmp/out.pdf")
+
+        replace_file.assert_not_called()
+        self.assertEqual(remove_calls, ["/tmp/page-1.pdf"])
 
     def test_merge_uses_vendored_qfit_pypdf_when_top_level_module_missing(self):
         import builtins
@@ -145,6 +163,26 @@ class AtlasPdfAssemblerTests(unittest.TestCase):
 
         warn.assert_called_once()
         self.assertEqual(replace_calls, [("/tmp/one.pdf", "/tmp/out.pdf")])
+
+    def test_merge_checks_cancellation_between_appended_pages(self):
+        calls = []
+
+        class FakeWriter:
+            def append(self, path):
+                calls.append(("append", path))
+
+            def write(self, handle):
+                calls.append(("write", handle))
+
+        assembler = AtlasPdfAssembler(
+            load_pdf_writer_fn=MagicMock(return_value=FakeWriter),
+            is_canceled=MagicMock(side_effect=[False, True]),
+        )
+
+        with self.assertRaises(AtlasPdfAssemblyCancelled), patch("builtins.open", mock_open()):
+            assembler.merge(["/tmp/one.pdf", "/tmp/two.pdf"], "/tmp/out.pdf")
+
+        self.assertEqual(calls, [("append", "/tmp/one.pdf")])
 
 
 if __name__ == "__main__":

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2223,17 +2223,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._atlas_export_task = running_task
         dock._atlas_export_task_output_path = "/tmp/running-atlas.pdf"
         dock._set_atlas_pdf_status = MagicMock()
-        dock._set_atlas_export_running = MagicMock()
-        dock._refresh_summary_status = MagicMock()
+        dock._set_atlas_export_cancelling = MagicMock()
+        dock._set_status = MagicMock()
 
         self.module.QfitDockWidget.on_generate_atlas_pdf_clicked(dock)
 
         running_task.cancel.assert_called_once_with()
-        self.assertIsNone(dock._atlas_export_task)
-        self.assertIsNone(dock._atlas_export_task_output_path)
-        dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF export cancelled.")
-        dock._set_atlas_export_running.assert_called_once_with(False)
-        dock._refresh_summary_status.assert_called_once_with()
+        self.assertIs(dock._atlas_export_task, running_task)
+        self.assertEqual(dock._atlas_export_task_output_path, "/tmp/running-atlas.pdf")
+        dock._set_atlas_export_cancelling.assert_called_once_with()
+        dock._set_atlas_pdf_status.assert_called_once_with(
+            "Atlas PDF export cancellation requested…"
+        )
+        dock._set_status.assert_called_once_with(
+            "Atlas PDF export cancellation requested…"
+        )
 
     def test_current_atlas_export_request_uses_current_ui_state(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -2344,6 +2348,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.module.QfitDockWidget._set_atlas_export_running(dock, True)
 
         self.assertEqual(dock.generateAtlasPdfButton.text(), "Cancel export")
+        self.assertTrue(dock.generateAtlasPdfButton.isEnabled())
         self.assertFalse(dock.loadButton.isEnabled())
         self.assertFalse(dock.loadLayersButton.isEnabled())
         self.assertFalse(dock.refreshButton.isEnabled())
@@ -2354,6 +2359,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(dock.loadButton.isEnabled())
         self.assertTrue(dock.loadLayersButton.isEnabled())
         self.assertTrue(dock.refreshButton.isEnabled())
+
+    def test_set_atlas_export_cancelling_disables_cancel_button(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.generateAtlasPdfButton = _FakeButton("Cancel export")
+
+        self.module.QfitDockWidget._set_atlas_export_cancelling(dock)
+
+        self.assertEqual(dock.generateAtlasPdfButton.text(), "Cancelling…")
+        self.assertFalse(dock.generateAtlasPdfButton.isEnabled())
 
     def test_on_atlas_export_finished_clears_task_and_updates_status(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary

- keep the running atlas export task attached after the user requests cancellation, so completion still flows through the normal finished callback
- show a distinct cancellation-requested UI state instead of immediately reporting completion
- add cooperative cancellation checks before layout setup, between front-matter stages, and during final PDF assembly

Fixes #756.

## Tests

- `python3 -m pytest tests/test_atlas_pdf_assembly.py tests/test_atlas_export_coordinator.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/test_atlas_export_task.py tests/test_atlas_export_service.py tests/test_atlas_export_use_case.py tests/test_dock_atlas_workflow.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short --ignore=tests/test_qgis_smoke.py`
- `python3 -m pytest tests/test_qgis_smoke.py -k 'atlas' -q --tb=short`
