### PR TITLE
Clarify GeoPackage sync persistence actions

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -499,7 +499,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             composition,
             WizardActionCallbacks(
                 configure_connection=self._show_connection_configuration_hint,
-                sync_activities=self.on_refresh_clicked,
+                sync_activities=self._run_wizard_sync_step,
                 sync_saved_routes=self.on_sync_routes_clicked,
                 clear_database=self.on_clear_database_clicked,
                 load_activity_layers=self.on_load_layers_clicked,
@@ -1472,7 +1472,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         button = getattr(self, "syncRoutesButton", None)
         if button is None:
             return
-        button.setText("Cancel route sync" if running else "Sync saved routes")
+        button.setText(
+            "Cancel route sync" if running else "Sync saved routes to GeoPackage"
+        )
         button.setEnabled(True)
         self.exchangeCodeButton.setEnabled(not running)
         self.openAuthorizeButton.setEnabled(not running)

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -411,7 +411,7 @@
            <item>
             <widget class="QPushButton" name="syncRoutesButton">
              <property name="text">
-              <string>Sync saved routes</string>
+              <string>Sync saved routes to GeoPackage</string>
              </property>
              <property name="toolTip">
               <string>Fetch saved/planned Strava routes, write route_catalog layers to the GeoPackage, and load them as dedicated route layers.</string>

--- a/tests/test_dock_runtime_state.py
+++ b/tests/test_dock_runtime_state.py
@@ -51,6 +51,15 @@ class TestDockRuntimeStore(unittest.TestCase):
         self.assertIs(store.state.atlas_layer, atlas_layer)
         self.assertEqual(store.state.stored_activity_count, 9)
 
+    def test_store_lifecycle_clears_pending_fetched_activities(self):
+        store = DockRuntimeStore()
+        store.finish_fetch(activities=["run", "ride"], metadata={"provider": "strava"})
+
+        store.finish_store(output_path="/tmp/qfit.gpkg", stored_activity_count=2)
+
+        self.assertEqual(store.state.activities, ())
+        self.assertEqual(store.state.stored_activity_count, 2)
+
     def test_store_and_load_lifecycle_clamps_negative_activity_counts(self):
         store = DockRuntimeStore()
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -647,6 +647,23 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.on_load_clicked.assert_called_once_with()
         dock.on_refresh_clicked.assert_not_called()
 
+    def test_run_wizard_sync_step_fetches_after_fetched_activities_are_stored(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().set_activities([object()])
+        dock._runtime_store().finish_store(
+            output_path="/tmp/qfit.gpkg",
+            stored_activity_count=1,
+        )
+        self.assertEqual(dock.runtime_state.activities, ())
+        dock.on_refresh_clicked = MagicMock()
+        dock.on_load_clicked = MagicMock()
+
+        self.module.QfitDockWidget._run_wizard_sync_step(dock)
+
+        dock.on_refresh_clicked.assert_called_once_with()
+        dock.on_load_clicked.assert_not_called()
+
     def test_run_wizard_map_step_loads_layers_before_filters_are_available(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()
@@ -947,7 +964,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         callbacks = connect_args[1]
         expected_callbacks = {
             "configure_connection": "_show_connection_configuration_hint",
-            "sync_activities": "on_refresh_clicked",
+            "sync_activities": "_run_wizard_sync_step",
             "sync_saved_routes": "on_sync_routes_clicked",
             "clear_database": "on_clear_database_clicked",
             "load_activity_layers": "on_load_layers_clicked",
@@ -2004,7 +2021,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.perPageSpinBox = _FakeSpinBox(100)
         dock.maxPagesSpinBox = _FakeSpinBox(0)
         dock.cache = "cache"
-        dock.syncRoutesButton = _FakeButton("Sync saved routes")
+        dock.syncRoutesButton = _FakeButton("Sync saved routes to GeoPackage")
         dock.exchangeCodeButton = _FakeButton("Exchange")
         dock.openAuthorizeButton = _FakeButton("Authorize")
         dock._set_status = MagicMock()
@@ -2095,7 +2112,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.runtime_state.route_tracks_layer, route_layers[0])
         self.assertEqual(dock.runtime_state.route_points_layer, route_layers[1])
         self.assertEqual(dock.runtime_state.route_profile_samples_layer, route_layers[2])
-        self.assertEqual(dock.syncRoutesButton.text(), "Sync saved routes")
+        self.assertEqual(
+            dock.syncRoutesButton.text(), "Sync saved routes to GeoPackage"
+        )
         self.assertTrue(dock.exchangeCodeButton.isEnabled())
         self.assertTrue(dock.openAuthorizeButton.isEnabled())
         dock.layer_gateway.load_route_layers.assert_called_once_with("/tmp/qfit.gpkg")

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -80,7 +80,9 @@ class SyncPageContentTest(unittest.TestCase):
             content.routes_button.objectName(),
             "qfitWizardSyncRoutesButton",
         )
-        self.assertEqual(content.routes_button.text(), "Sync saved routes")
+        self.assertEqual(
+            content.routes_button.text(), "Sync saved routes to GeoPackage"
+        )
         self.assertEqual(
             content.routes_button.property("secondaryAction"),
             "sync_saved_routes",

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -665,6 +665,23 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.shell.footer_bar.text(),
         )
 
+    def test_sync_page_prioritizes_pending_fetch_over_existing_stored_dataset(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_fetched=True,
+            activities_stored=True,
+            fetched_activity_count=2,
+            activity_count=10,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(assembled.sync_content.status_label.text(), "Activities fetched")
+        self.assertEqual(
+            assembled.sync_content.sync_button.text(),
+            "Store fetched activities",
+        )
+
     def test_map_page_summary_names_stored_output_before_layers_load(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,

--- a/ui/application/dock_runtime_state.py
+++ b/ui/application/dock_runtime_state.py
@@ -300,7 +300,11 @@ class DockRuntimeStore:
         output_path: str | None = None,
         stored_activity_count: int | None = None,
     ) -> DockRuntimeState:
-        next_state = replace(self._state, tasks=self._state.tasks.clear_store())
+        next_state = replace(
+            self._state,
+            activities=(),
+            tasks=self._state.tasks.clear_store(),
+        )
         if output_path is not None:
             next_state = replace(next_state, output_path=output_path)
         if stored_activity_count is not None:

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -48,7 +48,7 @@ class SyncPageState:
     local_action_label: str = "Load GeoPackage"
     local_action_enabled: bool = False
     local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading local data."
-    routes_action_label: str = "Sync saved routes"
+    routes_action_label: str = "Sync saved routes to GeoPackage"
     routes_action_enabled: bool = True
     routes_action_blocked_tooltip: str = (
         "Configure the Strava connection before syncing saved routes."

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -573,7 +573,12 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
     status_text = default.status_text
     detail_text = default.detail_text
     sync_blocked_tooltip = default.primary_action_blocked_tooltip
-    if facts.activities_stored:
+    if facts.activities_fetched:
+        status_text = "Activities fetched"
+        detail_text = (
+            "Store fetched activities in the GeoPackage to complete synchronization."
+        )
+    elif facts.activities_stored:
         status_text = "Activities stored"
         detail_text = (
             "Stored activities are ready to load from the existing GeoPackage."
@@ -581,14 +586,9 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
     elif not facts.connection_configured:
         status_text = "Connection required before sync"
         detail_text = "Configure Strava credentials before syncing activities."
-    elif facts.activities_fetched:
-        status_text = "Activities fetched"
-        detail_text = (
-            "Store fetched activities in the GeoPackage to complete synchronization."
-        )
     primary_action_label = default.primary_action_label
     routes_action_label = default.routes_action_label
-    if facts.activities_fetched and not facts.activities_stored:
+    if facts.activities_fetched:
         primary_action_label = "Store fetched activities"
     if facts.route_sync_in_progress:
         routes_action_label = "Cancel route sync"


### PR DESCRIPTION
## Summary

- route the local-first Data page primary sync action through the same next-step handler as the wizard, so after activities are fetched the button stores them into the GeoPackage instead of starting another fetch
- make saved-route sync copy explicit that routes are written to the GeoPackage
- update UI and pure tests for the clearer GeoPackage persistence actions

Fixes #762.

## Tests

- `python3 -m pytest tests/test_sync_page.py tests/test_wizard_shell_composition.py tests/test_local_first_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short --ignore=tests/test_qgis_smoke.py`

## Known local smoke note

- `python3 -m pytest tests/test_qgis_smoke.py -k 'dock_widget_contextual_help_smoke or local_first' -q --tb=short` currently has the pre-existing local `test_dock_widget_contextual_help_smoke` failure where `analysisModeComboBox.currentText()` is `Most frequent starting points` instead of `None`; the selected local-first smoke slice passed.
