### PR TITLE
Clarify local-first navigation state

### DIFF
--- a/tests/test_local_first_shell.py
+++ b/tests/test_local_first_shell.py
@@ -41,6 +41,13 @@ class LocalFirstDockShellTests(unittest.TestCase):
         )
         self.assertFalse(any("..." in button.text() for button in shell.navigation_buttons()))
         self.assertTrue(all(button.isEnabled() for button in shell.navigation_buttons()))
+        self.assertTrue(all(button.minimumWidth() == 88 for button in shell.navigation_buttons()))
+        self.assertTrue(
+            all(
+                button.tool_button_style == self.shell_module.Qt.ToolButtonTextOnly
+                for button in shell.navigation_buttons()
+            )
+        )
 
     def test_outer_layout_keeps_navigation_content_and_footer_separate(self):
         shell = self.shell_module.LocalFirstDockShell()
@@ -67,6 +74,11 @@ class LocalFirstDockShellTests(unittest.TestCase):
         self.assertEqual(data_button.property("navTone"), "ready")
         self.assertTrue(map_button.property("current"))
         self.assertEqual(map_button.property("navTone"), "current")
+        self.assertTrue(map_button.isCheckable())
+        self.assertTrue(map_button.isChecked())
+        self.assertFalse(data_button.isChecked())
+        self.assertIn("background: #589632", map_button.styleSheet())
+        self.assertIn("QToolButton:checked:hover", map_button.styleSheet())
         self.assertFalse(analysis_button.property("ready"))
         self.assertEqual(analysis_button.property("navTone"), "available")
         self.assertTrue(analysis_button.isEnabled())

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -53,6 +53,7 @@ class _FakeQt:
     Orientation = int
     PointingHandCursor = 11
     ToolButtonTextBesideIcon = 12
+    ToolButtonTextOnly = 15
     Vertical = 14
 
 
@@ -143,8 +144,22 @@ class _FakeToolButton(_FakeWidget):
         super().__init__(parent)
         self.clicked = _FakeSignal()
         self._text = ""
+        self._checkable = False
+        self._checked = False
         self.tool_button_style = None
         self.size_policy = None
+
+    def setCheckable(self, value):  # noqa: N802
+        self._checkable = value
+
+    def isCheckable(self):  # noqa: N802
+        return self._checkable
+
+    def setChecked(self, value):  # noqa: N802
+        self._checked = value
+
+    def isChecked(self):  # noqa: N802
+        return self._checked
 
     def setToolButtonStyle(self, value):  # noqa: N802
         self.tool_button_style = value

--- a/ui/dockwidget/local_first_shell.py
+++ b/ui/dockwidget/local_first_shell.py
@@ -5,6 +5,14 @@ from qfit.ui.application.local_first_navigation import (
     LocalFirstDockPageState,
     build_local_first_dock_navigation_state,
 )
+from qfit.ui.tokens import (
+    COLOR_ACCENT,
+    COLOR_ACCENT_DARK,
+    COLOR_HOVER,
+    COLOR_MUTED,
+    COLOR_SEPARATOR,
+    COLOR_TEXT,
+)
 
 from ._qt_compat import import_qt_module
 from .footer_status_bar import FooterStatusBar
@@ -150,14 +158,19 @@ class LocalFirstDockShell(QWidget):
         return self._main_layout
 
     def _apply_button_state(self, button: QToolButton, page_state: LocalFirstDockPageState) -> None:
+        tone = _nav_tone(page_state)
         button.setText(page_state.title)
         button.setEnabled(page_state.enabled)
+        if hasattr(button, "setChecked"):
+            button.setChecked(page_state.current)
         button.setProperty("pageKey", page_state.key)
         button.setProperty("current", page_state.current)
         button.setProperty("ready", page_state.ready)
-        button.setProperty("navTone", _nav_tone(page_state))
+        button.setProperty("navTone", tone)
         button.setToolTip(f"{page_state.title}: {page_state.status_text}")
         button.setCursor(Qt.PointingHandCursor if page_state.enabled else Qt.ForbiddenCursor)
+        if hasattr(button, "setStyleSheet"):
+            button.setStyleSheet(_navigation_button_stylesheet(tone))
         _refresh_dynamic_qss(button)
 
     def _build_footer_bar(self, footer_text: str):
@@ -216,8 +229,14 @@ class LocalFirstDockShell(QWidget):
     def _new_navigation_button(self, page_state: LocalFirstDockPageState):
         button = QToolButton(self.navigation_container)
         button.setObjectName(f"qfitLocalFirstDockNav_{page_state.key}")
-        button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        button.setToolButtonStyle(
+            getattr(Qt, "ToolButtonTextOnly", Qt.ToolButtonTextBesideIcon)
+        )
         button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        if hasattr(button, "setCheckable"):
+            button.setCheckable(True)
+        if hasattr(button, "setMinimumWidth"):
+            button.setMinimumWidth(88)
         button.clicked.connect(lambda _checked=False, key=page_state.key: self.show_page_key(key))
         return button
 
@@ -248,6 +267,39 @@ def _nav_tone(page_state: LocalFirstDockPageState) -> str:
     if page_state.ready:
         return "ready"
     return "available"
+
+
+def _navigation_button_stylesheet(tone: str) -> str:
+    if tone == "current":
+        background = COLOR_ACCENT
+        border = COLOR_ACCENT_DARK
+        color = "white"
+        font_weight = "700"
+    elif tone == "ready":
+        background = "transparent"
+        border = COLOR_ACCENT
+        color = COLOR_TEXT
+        font_weight = "600"
+    else:
+        background = "transparent"
+        border = COLOR_SEPARATOR
+        color = COLOR_MUTED
+        font_weight = "500"
+    return (
+        "QToolButton { "
+        f"background: {background}; "
+        f"border: 1px solid {border}; "
+        "border-radius: 8px; "
+        "padding: 4px 8px; "
+        f"color: {color}; "
+        f"font-weight: {font_weight}; "
+        "text-align: left; "
+        "} "
+        f"QToolButton:hover:enabled {{ background: {COLOR_HOVER}; color: {COLOR_TEXT}; }} "
+        f"QToolButton:checked {{ background: {COLOR_ACCENT}; color: white; }} "
+        f"QToolButton:checked:hover {{ background: {COLOR_ACCENT_DARK}; color: white; }} "
+        f"QToolButton:disabled {{ color: {COLOR_MUTED}; }}"
+    )
 
 
 __all__ = ["LocalFirstDockShell"]


### PR DESCRIPTION
## Summary

- make local-first right-panel navigation buttons checkable and checked for the current page
- apply explicit current/ready/available button styling so the selected page is visible at a glance
- switch navigation buttons to text-only mode with a stable minimum width and full tooltips to keep labels usable in narrow dock layouts

Fixes #757.

## Tests

- `python3 -m pytest tests/test_local_first_shell.py tests/test_local_first_navigation.py -q --tb=short`
- `python3 -m pytest tests/test_local_first_shell.py tests/test_local_first_navigation.py tests/test_local_first_composition.py tests/test_wizard_shell.py tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short --ignore=tests/test_qgis_smoke.py`
