### PR TITLE
Keep map filter button label in sync

### DIFF
--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -278,6 +278,27 @@ class MapPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.edit_filters_button.text(), "Edit filters")
 
+    def test_refresh_keeps_hide_filters_label_when_panel_is_logically_expanded(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState(edit_filters_action_enabled=True)
+        )
+        content.set_filter_controls_visible(True)
+        content.filter_controls_panel.isVisible = lambda: False
+
+        content.set_state(
+            self.map_page.MapPageState(
+                loaded=True,
+                edit_filters_action_enabled=True,
+                edit_filters_action_label="Edit filters",
+            )
+        )
+
+        self.assertEqual(
+            content.filter_controls_panel.property("filterControlsState"),
+            "expanded",
+        )
+        self.assertEqual(content.edit_filters_button.text(), "Hide filters")
+
     def test_edit_filters_button_toggles_embedded_filter_controls(self):
         content = self.map_page.MapPageContent(
             self.map_page.MapPageState(edit_filters_action_enabled=True)

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -151,9 +151,9 @@ class MapPageContent(QWidget):
             enabled=state.edit_filters_action_enabled,
             tooltip=state.edit_filters_action_blocked_tooltip,
         )
-        if not state.edit_filters_action_enabled and self.filter_controls_panel.isVisible():
+        if not state.edit_filters_action_enabled and self._filter_controls_are_expanded():
             self.set_filter_controls_visible(False)
-        elif self.filter_controls_panel.isVisible():
+        elif self._filter_controls_are_expanded():
             self.edit_filters_button.setText("Hide filters")
         self.apply_filters_button.setText(state.primary_action_label)
         apply_action_enabled = (
@@ -183,9 +183,12 @@ class MapPageContent(QWidget):
         self.edit_filters_button.setText("Hide filters" if visible else "Edit filters")
 
     def _toggle_filter_controls(self) -> None:
-        next_visible = not self.filter_controls_panel.isVisible()
+        next_visible = not self._filter_controls_are_expanded()
         self.set_filter_controls_visible(next_visible)
         self.editFiltersRequested.emit(next_visible)
+
+    def _filter_controls_are_expanded(self) -> bool:
+        return self.filter_controls_panel.property("filterControlsState") == "expanded"
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""


### PR DESCRIPTION
## Summary

- track the map filter panel's logical expanded/collapsed state instead of relying on Qt effective visibility during refreshes
- keep the edit-filters button labelled `Hide filters` whenever the panel is logically expanded
- use the same logical state for toggling so hidden ancestors do not desynchronize the next button state

Fixes #758.

## Tests

- `python3 -m pytest tests/test_map_page.py tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short --ignore=tests/test_qgis_smoke.py`
