### PR TITLE
Explain missing saved route layers on load

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -159,6 +159,42 @@ def _build_write_and_load_status(result: StoreActivitiesResult) -> str:
     )
 
 
+def _route_layer_load_status(
+    route_tracks_layer,
+    route_points_layer,
+    route_profile_samples_layer,
+) -> str:
+    if all(
+        layer is None
+        for layer in (
+            route_tracks_layer,
+            route_points_layer,
+            route_profile_samples_layer,
+        )
+    ):
+        return (
+            "No saved route layers found; use Data → Sync saved routes to GeoPackage "
+            "before loading planned routes."
+        )
+    tracks = _safe_feature_count(route_tracks_layer)
+    points = _safe_feature_count(route_points_layer)
+    samples = _safe_feature_count(route_profile_samples_layer)
+    return (
+        "Loaded saved route layers: {tracks} route tracks, {points} route points, "
+        "and {samples} profile samples."
+    ).format(tracks=tracks, points=points, samples=samples)
+
+
+def _safe_feature_count(layer) -> int:
+    if layer is None or not hasattr(layer, "featureCount"):
+        return 0
+    try:
+        return max(int(layer.featureCount()), 0)
+    except (TypeError, ValueError, RuntimeError):
+        logger.debug("Failed to read route layer feature count", exc_info=True)
+        return 0
+
+
 class StoreActivitiesWorkflow:
     """Write fetched activities into qfit's GeoPackage dataset."""
 
@@ -301,7 +337,14 @@ class LoadDatasetWorkflow:
             route_points_layer=route_points_layer,
             route_profile_samples_layer=route_profile_samples_layer,
             total_stored=total,
-            status="Layers loaded from {path}.".format(path=request.output_path),
+            status="Layers loaded from {path}. {route_status}".format(
+                path=request.output_path,
+                route_status=_route_layer_load_status(
+                    route_tracks_layer,
+                    route_points_layer,
+                    route_profile_samples_layer,
+                ),
+            ),
         )
 
     def load_existing_request(self, request: LoadDatasetRequest) -> LoadDatasetResult:

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -80,6 +80,9 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
             MagicMock(name="route_points"),
             MagicMock(name="route_profile_samples"),
         )
+        route_layers[0].featureCount.return_value = 3
+        route_layers[1].featureCount.return_value = 24
+        route_layers[2].featureCount.return_value = 16
         layer_gateway.load_output_layers.return_value = (
             activities_layer,
             MagicMock(name="starts"),
@@ -99,6 +102,58 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
         self.assertEqual(result.route_points_layer, route_layers[1])
         self.assertEqual(result.route_profile_samples_layer, route_layers[2])
         self.assertIn("/tmp/existing.gpkg", result.status)
+        self.assertIn(
+            "3 route tracks, 24 route points, and 16 profile samples",
+            result.status,
+        )
+
+    def test_load_existing_status_explains_when_route_layers_are_missing(self):
+        layer_gateway = MagicMock()
+        activities_layer = MagicMock()
+        activities_layer.featureCount.return_value = 42
+        layer_gateway.load_output_layers.return_value = (
+            activities_layer,
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+        layer_gateway.load_route_layers.return_value = (None, None, None)
+        workflow = LoadDatasetWorkflow(layer_gateway, path_exists=lambda _path: True)
+
+        result = workflow.load_existing_request(
+            workflow.build_load_existing_request("/tmp/existing.gpkg")
+        )
+
+        self.assertIn("No saved route layers found", result.status)
+        self.assertIn("Sync saved routes to GeoPackage", result.status)
+
+    def test_load_existing_route_status_tolerates_uncountable_route_layers(self):
+        class BrokenFeatureCountLayer:
+            def featureCount(self):  # noqa: N802
+                raise RuntimeError("provider unavailable")
+
+        layer_gateway = MagicMock()
+        activities_layer = MagicMock()
+        activities_layer.featureCount.return_value = 42
+        layer_gateway.load_output_layers.return_value = (
+            activities_layer,
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+        layer_gateway.load_route_layers.return_value = (
+            object(),
+            BrokenFeatureCountLayer(),
+            None,
+        )
+        workflow = LoadDatasetWorkflow(layer_gateway, path_exists=lambda _path: True)
+
+        result = workflow.load_existing_request(
+            workflow.build_load_existing_request("/tmp/existing.gpkg")
+        )
+
+        self.assertIn("Loaded saved route layers: 0 route tracks", result.status)
+        self.assertIn("0 route points", result.status)
 
 
 class ClearDatabaseWorkflowTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add explicit route-layer load feedback when an existing GeoPackage is loaded
- tell the user when no saved route layers are present and point them to `Data → Sync saved routes to GeoPackage`
- include route layer feature counts in the load status when saved route layers are present

Refs #759.

## Tests

- `python3 -m pytest tests/test_load_workflow.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short --ignore=tests/test_qgis_smoke.py`
