### PR TITLE
Expose completed activity sync state

### DIFF
--- a/sync_repository.py
+++ b/sync_repository.py
@@ -16,6 +16,36 @@ class SyncStats:
     total_count: int
 
 
+@dataclass(frozen=True)
+class ActivitySyncState:
+    """Completed activity-sync metadata persisted in the GeoPackage."""
+
+    provider: str
+    last_incremental_sync_at: str | None = None
+    last_full_sync_at: str | None = None
+    last_before_epoch: int | None = None
+    last_after_epoch: int | None = None
+    last_success_status: str | None = None
+    updated_at: str | None = None
+    stored_activity_count: int = 0
+    latest_activity_start_date: str | None = None
+
+    @property
+    def has_completed_sync(self) -> bool:
+        return self.last_success_status == "ok" and self.updated_at is not None
+
+
+SYNC_STATE_COLUMNS = [
+    "provider",
+    "last_incremental_sync_at",
+    "last_full_sync_at",
+    "last_before_epoch",
+    "last_after_epoch",
+    "last_success_status",
+    "updated_at",
+]
+
+
 REGISTRY_TABLE = "activity_registry"
 SYNC_STATE_TABLE = "sync_state"
 REGISTRY_COLUMNS = [
@@ -295,6 +325,46 @@ class SyncRepository:
             activities.append(Activity(**activity_kwargs))
         return activities
 
+    def load_activity_sync_state(self, provider="strava") -> ActivitySyncState | None:
+        """Return the latest completed sync metadata for *provider*, if present."""
+
+        if not self._database_exists():
+            return None
+        try:
+            with self._connect() as connection:
+                state_row = connection.execute(
+                    """
+                    SELECT {columns}
+                    FROM sync_state
+                    WHERE provider = ?
+                    """.format(columns=", ".join(SYNC_STATE_COLUMNS)),
+                    (provider,),
+                ).fetchone()
+                if state_row is None:
+                    return None
+                activity_row = connection.execute(
+                    """
+                    SELECT COUNT(*) AS stored_activity_count, MAX(start_date) AS latest_activity_start_date
+                    FROM activity_registry
+                    WHERE source = ?
+                    """,
+                    (provider,),
+                ).fetchone()
+        except sqlite3.OperationalError as exc:
+            if _is_missing_sync_schema_error(exc):
+                return None
+            raise
+
+        return ActivitySyncState(
+            **dict(zip(SYNC_STATE_COLUMNS, state_row)),
+            stored_activity_count=int(activity_row["stored_activity_count"]),
+            latest_activity_start_date=activity_row["latest_activity_start_date"],
+        )
+
+    def has_completed_activity_sync(self, provider="strava") -> bool:
+        state = self.load_activity_sync_state(provider=provider)
+        return bool(state and state.has_completed_sync)
+
     def _upsert_registry_row(self, cursor, record):
         placeholders = ", ".join("?" for _column in REGISTRY_COLUMNS)
         update_clause = ", ".join(
@@ -454,3 +524,14 @@ class SyncRepository:
         connection = sqlite3.connect(self.db_path)
         connection.row_factory = sqlite3.Row
         return connection
+
+    def _database_exists(self):
+        return self.db_path == ":memory:" or os.path.exists(self.db_path)
+
+
+def _is_missing_sync_schema_error(exc):
+    message = str(exc).lower()
+    return any(
+        f"no such table: {table}" in message
+        for table in (SYNC_STATE_TABLE, REGISTRY_TABLE)
+    )

--- a/tests/test_sync_repository.py
+++ b/tests/test_sync_repository.py
@@ -1,10 +1,12 @@
 import tempfile
 import unittest
+import sqlite3
 from pathlib import Path
+from unittest.mock import patch
 
 from tests import _path  # noqa: F401
 from qfit.activities.domain.models import Activity
-from qfit.sync_repository import SyncRepository
+from qfit.sync_repository import ActivitySyncState, SyncRepository
 
 
 class SyncRepositoryTests(unittest.TestCase):
@@ -87,6 +89,64 @@ class SyncRepositoryTests(unittest.TestCase):
             rows = repo._connect().execute("SELECT * FROM sync_state").fetchall()
             self.assertEqual(len(rows), 1)
             self.assertEqual(rows[0][0], "strava")
+
+    def test_load_activity_sync_state_returns_completed_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = SyncRepository(str(Path(tmpdir) / "qfit.sqlite"))
+            repo.ensure_schema()
+            repo.upsert_activities(
+                [
+                    self._activity(source_activity_id="old", start_date="2026-03-19T06:00:00Z"),
+                    self._activity(source_activity_id="new", start_date="2026-03-20T06:00:00Z"),
+                ],
+                sync_metadata={
+                    "provider": "strava",
+                    "is_full_sync": True,
+                    "before_epoch": 200,
+                    "after_epoch": 100,
+                },
+            )
+
+            state = repo.load_activity_sync_state(provider="strava")
+
+            self.assertIsInstance(state, ActivitySyncState)
+            self.assertTrue(state.has_completed_sync)
+            self.assertTrue(repo.has_completed_activity_sync(provider="strava"))
+            self.assertEqual(state.provider, "strava")
+            self.assertIsNotNone(state.last_full_sync_at)
+            self.assertEqual(state.last_before_epoch, 200)
+            self.assertEqual(state.last_after_epoch, 100)
+            self.assertEqual(state.stored_activity_count, 2)
+            self.assertEqual(state.latest_activity_start_date, "2026-03-20T06:00:00Z")
+
+    def test_load_activity_sync_state_returns_none_before_completed_sync(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = SyncRepository(str(Path(tmpdir) / "qfit.sqlite"))
+
+            self.assertIsNone(repo.load_activity_sync_state(provider="strava"))
+            self.assertFalse(repo.has_completed_activity_sync(provider="strava"))
+
+            repo.ensure_schema()
+            self.assertIsNone(repo.load_activity_sync_state(provider="strava"))
+
+    def test_load_activity_sync_state_only_suppresses_missing_schema_errors(self):
+        repo = SyncRepository(":memory:")
+
+        with patch.object(
+            repo,
+            "_connect",
+            side_effect=sqlite3.OperationalError("database is locked"),
+        ):
+            with self.assertRaises(sqlite3.OperationalError):
+                repo.load_activity_sync_state(provider="strava")
+
+    def test_load_activity_sync_state_returns_none_for_existing_uninitialized_database(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "empty.sqlite"
+            db_path.touch()
+            repo = SyncRepository(str(db_path))
+
+            self.assertIsNone(repo.load_activity_sync_state(provider="strava"))
 
     def test_ensure_schema_creates_activity_registry_indexes_idempotently(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- add an `ActivitySyncState` value object for completed GeoPackage activity-sync metadata
- expose `load_activity_sync_state()` / `has_completed_activity_sync()` on `SyncRepository`
- include stored activity count and latest stored activity start date so follow-up incremental sync planning can choose a safe watermark/overlap window

Refs #761.

## Tests

- `python3 -m pytest tests/test_sync_repository.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short --ignore=tests/test_qgis_smoke.py`
