### PR TITLE
Model activity sync strategy plans

### DIFF
--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -37,6 +37,8 @@ class BuildFetchTaskRequest:
     max_detailed_activities: int = 25
     detailed_route_strategy: str = DEFAULT_DETAILED_ROUTE_STRATEGY
     on_finished: object = None
+    before: int | None = None
+    after: int | None = None
 
 
 @dataclass
@@ -134,6 +136,8 @@ class SyncController:
         max_detailed_activities,
         on_finished=None,
         detailed_route_strategy=DEFAULT_DETAILED_ROUTE_STRATEGY,
+        before=None,
+        after=None,
     ) -> BuildFetchTaskRequest:
         """Build a structured request for creating a fetch task."""
         return BuildFetchTaskRequest(
@@ -147,6 +151,8 @@ class SyncController:
             max_detailed_activities=max_detailed_activities,
             detailed_route_strategy=detailed_route_strategy,
             on_finished=on_finished,
+            before=before,
+            after=after,
         )
 
     def build_fetch_task(
@@ -171,8 +177,8 @@ class SyncController:
             provider=provider,
             per_page=request.per_page,
             max_pages=request.max_pages,
-            before=None,
-            after=None,
+            before=request.before,
+            after=request.after,
             use_detailed_streams=request.use_detailed_streams,
             max_detailed_activities=request.max_detailed_activities,
             detailed_route_strategy=request.detailed_route_strategy,

--- a/activities/application/sync_strategy.py
+++ b/activities/application/sync_strategy.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+
+from ...sync_repository import ActivitySyncState
+
+DEFAULT_INCREMENTAL_OVERLAP_SECONDS = 3 * 24 * 60 * 60
+
+
+class ActivitySyncMode(str, Enum):
+    """User-visible reasons for fetching activity summaries."""
+
+    INITIAL_IMPORT = "initial_import"
+    INCREMENTAL_UPDATE = "incremental_update"
+    HISTORICAL_BACKFILL = "historical_backfill"
+
+
+@dataclass(frozen=True)
+class ActivitySyncPlan:
+    """Fetch bounds selected for one activity-sync run."""
+
+    mode: ActivitySyncMode
+    before_epoch: int | None = None
+    after_epoch: int | None = None
+    overlap_seconds: int = 0
+
+    @property
+    def is_bounded(self) -> bool:
+        return self.before_epoch is not None or self.after_epoch is not None
+
+
+def plan_activity_sync(
+    sync_state: ActivitySyncState | None,
+    *,
+    requested_mode: ActivitySyncMode | str | None = None,
+    incremental_overlap_seconds: int = DEFAULT_INCREMENTAL_OVERLAP_SECONDS,
+    backfill_before_epoch: int | None = None,
+    backfill_after_epoch: int | None = None,
+) -> ActivitySyncPlan:
+    """Choose the fetch mode and provider bounds for an activity-sync run."""
+
+    mode = _normalize_mode(requested_mode) or _default_mode(sync_state)
+    if mode == ActivitySyncMode.INCREMENTAL_UPDATE:
+        return ActivitySyncPlan(
+            mode=mode,
+            after_epoch=_incremental_after_epoch(
+                sync_state,
+                overlap_seconds=incremental_overlap_seconds,
+            ),
+            overlap_seconds=max(int(incremental_overlap_seconds), 0),
+        )
+    if mode == ActivitySyncMode.HISTORICAL_BACKFILL:
+        return ActivitySyncPlan(
+            mode=mode,
+            before_epoch=backfill_before_epoch,
+            after_epoch=backfill_after_epoch,
+        )
+    return ActivitySyncPlan(mode=ActivitySyncMode.INITIAL_IMPORT)
+
+
+def _default_mode(sync_state: ActivitySyncState | None) -> ActivitySyncMode:
+    if sync_state and sync_state.has_completed_sync and sync_state.latest_activity_start_date:
+        return ActivitySyncMode.INCREMENTAL_UPDATE
+    return ActivitySyncMode.INITIAL_IMPORT
+
+
+def _incremental_after_epoch(
+    sync_state: ActivitySyncState | None,
+    *,
+    overlap_seconds: int,
+) -> int | None:
+    if sync_state is None or not sync_state.latest_activity_start_date:
+        return None
+    start_epoch = _parse_activity_start_epoch(sync_state.latest_activity_start_date)
+    if start_epoch is None:
+        return None
+    return max(start_epoch - max(int(overlap_seconds), 0), 0)
+
+
+def _parse_activity_start_epoch(value: str) -> int | None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return int(parsed.timestamp())
+
+
+def _normalize_mode(mode: ActivitySyncMode | str | None) -> ActivitySyncMode | None:
+    if mode is None:
+        return None
+    if isinstance(mode, ActivitySyncMode):
+        return mode
+    try:
+        return ActivitySyncMode(str(mode))
+    except ValueError:
+        return None

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -103,6 +103,8 @@ class BuildFetchTaskTests(unittest.TestCase):
             max_detailed_activities=9,
             detailed_route_strategy="Recent fetch only",
             on_finished="callback",
+            before=200,
+            after=100,
         )
 
         self.assertIsInstance(request, BuildFetchTaskRequest)
@@ -110,6 +112,8 @@ class BuildFetchTaskTests(unittest.TestCase):
         self.assertEqual(request.per_page, 123)
         self.assertTrue(request.use_detailed_streams)
         self.assertEqual(request.detailed_route_strategy, "Recent fetch only")
+        self.assertEqual(request.before, 200)
+        self.assertEqual(request.after, 100)
 
     def test_build_fetch_task_request_preserves_legacy_positional_callback_slot(self):
         ctrl = SyncController()
@@ -149,6 +153,8 @@ class BuildFetchTaskTests(unittest.TestCase):
                 max_detailed_activities=7,
                 detailed_route_strategy="Recent fetch only",
                 on_finished="callback",
+                before=200,
+                after=100,
             )
 
         build_provider.assert_called_once()
@@ -156,8 +162,8 @@ class BuildFetchTaskTests(unittest.TestCase):
             provider=provider,
             per_page=50,
             max_pages=2,
-            before=None,
-            after=None,
+            before=200,
+            after=100,
             use_detailed_streams=True,
             max_detailed_activities=7,
             detailed_route_strategy="Recent fetch only",

--- a/tests/test_sync_strategy.py
+++ b/tests/test_sync_strategy.py
@@ -1,0 +1,94 @@
+import unittest
+
+from tests import _path  # noqa: F401
+from qfit.activities.application.sync_strategy import (
+    ActivitySyncMode,
+    DEFAULT_INCREMENTAL_OVERLAP_SECONDS,
+    plan_activity_sync,
+)
+from qfit.sync_repository import ActivitySyncState
+
+
+class ActivitySyncStrategyTests(unittest.TestCase):
+    def test_defaults_to_initial_import_without_completed_sync_state(self):
+        plan = plan_activity_sync(None)
+
+        self.assertEqual(plan.mode, ActivitySyncMode.INITIAL_IMPORT)
+        self.assertFalse(plan.is_bounded)
+
+    def test_defaults_to_incremental_update_with_completed_sync_state(self):
+        state = ActivitySyncState(
+            provider="strava",
+            last_success_status="ok",
+            updated_at="2026-05-03T20:00:00+00:00",
+            latest_activity_start_date="2026-05-03T12:00:00Z",
+        )
+
+        plan = plan_activity_sync(state)
+
+        self.assertEqual(plan.mode, ActivitySyncMode.INCREMENTAL_UPDATE)
+        self.assertEqual(plan.overlap_seconds, DEFAULT_INCREMENTAL_OVERLAP_SECONDS)
+        self.assertEqual(plan.after_epoch, 1777550400)
+        self.assertIsNone(plan.before_epoch)
+
+    def test_incremental_overlap_can_be_overridden(self):
+        state = ActivitySyncState(
+            provider="strava",
+            last_success_status="ok",
+            updated_at="2026-05-03T20:00:00+00:00",
+            latest_activity_start_date="2026-05-03T12:00:00+00:00",
+        )
+
+        plan = plan_activity_sync(state, incremental_overlap_seconds=3600)
+
+        self.assertEqual(plan.after_epoch, 1777806000)
+        self.assertEqual(plan.overlap_seconds, 3600)
+
+    def test_explicit_historical_backfill_preserves_requested_bounds(self):
+        state = ActivitySyncState(
+            provider="strava",
+            last_success_status="ok",
+            updated_at="2026-05-03T20:00:00+00:00",
+            latest_activity_start_date="2026-05-03T12:00:00Z",
+        )
+
+        plan = plan_activity_sync(
+            state,
+            requested_mode="historical_backfill",
+            backfill_before_epoch=200,
+            backfill_after_epoch=100,
+        )
+
+        self.assertEqual(plan.mode, ActivitySyncMode.HISTORICAL_BACKFILL)
+        self.assertEqual(plan.before_epoch, 200)
+        self.assertEqual(plan.after_epoch, 100)
+
+    def test_invalid_latest_start_date_keeps_incremental_unbounded_for_caller_safety(self):
+        state = ActivitySyncState(
+            provider="strava",
+            last_success_status="ok",
+            updated_at="2026-05-03T20:00:00+00:00",
+            latest_activity_start_date="not-a-date",
+        )
+
+        plan = plan_activity_sync(state)
+
+        self.assertEqual(plan.mode, ActivitySyncMode.INCREMENTAL_UPDATE)
+        self.assertIsNone(plan.after_epoch)
+
+    def test_unrecognized_requested_mode_falls_back_to_state_default(self):
+        state = ActivitySyncState(
+            provider="strava",
+            last_success_status="ok",
+            updated_at="2026-05-03T20:00:00+00:00",
+            latest_activity_start_date="2026-05-03T12:00:00Z",
+        )
+
+        plan = plan_activity_sync(state, requested_mode="future_mode")
+
+        self.assertEqual(plan.mode, ActivitySyncMode.INCREMENTAL_UPDATE)
+        self.assertIsNotNone(plan.after_epoch)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add explicit `ActivitySyncMode` / `ActivitySyncPlan` modeling for initial import, incremental update, and historical backfill
- default completed GeoPackages to incremental update plans using the latest stored activity start date minus a three-day overlap window
- carry optional `before` / `after` bounds through `BuildFetchTaskRequest` into `FetchTask`

Refs #761.

## Tests

- `python3 -m pytest tests/test_sync_strategy.py tests/test_sync_controller.py tests/test_sync_repository.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short --ignore=tests/test_qgis_smoke.py`
