### PR TITLE
Apply activity sync plans to fetch bounds

### DIFF
--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -329,8 +329,8 @@ class SyncController:
         is_full_sync = is_unbounded_fetch and uses_default_bounds and not getattr(provider, "last_fetch_notice", None)
         return {
             "provider": provider.source_name,
-            "before_epoch": None,
-            "after_epoch": None,
+            "before_epoch": fetch_context.get("before"),
+            "after_epoch": fetch_context.get("after"),
             "fetched_count": len(activities),
             "detailed_count": detailed_count,
             "stream_stats": provider.last_stream_enrichment_stats,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sqlite3
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import date
@@ -55,6 +56,7 @@ from .activities.application.layer_summary import (
     build_stored_activities_summary,
 )
 from .activities.application.load_workflow import LoadWorkflowError
+from .activities.application.sync_strategy import ActivitySyncMode, plan_activity_sync
 from .activities.application.store_task import build_store_task
 from .analysis.infrastructure.activity_heatmap_layer import (
     ACTIVITY_HEATMAP_LAYER_NAME,
@@ -119,10 +121,17 @@ from .ui.workflow_section_coordinator import WorkflowSectionCoordinator
 from .configuration.application.connection_status import build_strava_connection_status
 from .configuration.application.dock_settings_bindings import build_dock_settings_bindings
 from .configuration.application.ui_settings_binding import load_bindings, save_bindings
+from .sync_repository import SyncRepository
 
 FORM_CLASS, _ = uic.loadUiType(
     __import__("os").path.join(__import__("os").path.dirname(__file__), "qfit_dockwidget_base.ui")
 )
+
+
+def _fetch_status_for_sync_plan(status_text, sync_plan):
+    if sync_plan.mode != ActivitySyncMode.INCREMENTAL_UPDATE or sync_plan.after_epoch is None:
+        return status_text
+    return "Fetching recent activities from Strava with GeoPackage sync overlap…"
 
 
 class QfitDockWidget(QDockWidget, FORM_CLASS):
@@ -1291,10 +1300,22 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             use_detailed_streams=True,
             detailed_route_strategy=DETAILED_ROUTE_STRATEGY_MISSING,
             status_text="Backfilling missing detailed routes from Strava…",
+            use_activity_sync_plan=False,
         )
 
-    def _start_fetch(self, detailed_route_strategy, status_text, use_detailed_streams=None):
+    def _start_fetch(
+        self,
+        detailed_route_strategy,
+        status_text,
+        use_detailed_streams=None,
+        use_activity_sync_plan=True,
+    ):
         self._save_settings()
+        sync_plan = (
+            self._current_activity_sync_plan()
+            if use_activity_sync_plan
+            else plan_activity_sync(None)
+        )
         try:
             fetch_task = self.activity_workflow.build_fetch_task(
                 DockFetchRequest(
@@ -1310,6 +1331,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                     max_pages_value=self.maxPagesSpinBox.value(),
                     max_detailed_activities_value=self.maxDetailedActivitiesSpinBox.value(),
                     use_detailed_streams_override=use_detailed_streams,
+                    before_epoch=sync_plan.before_epoch,
+                    after_epoch=sync_plan.after_epoch,
                 )
             )
         except ProviderError as exc:
@@ -1319,8 +1342,21 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._runtime_store().begin_fetch(fetch_task)
         self._set_fetch_running(True)
-        self._set_status(status_text)
+        self._set_status(_fetch_status_for_sync_plan(status_text, sync_plan))
         QgsApplication.taskManager().addTask(fetch_task)
+
+    def _current_activity_sync_plan(self):
+        output_path = self.outputPathLineEdit.text().strip()
+        sync_state = None
+        if output_path:
+            try:
+                sync_state = SyncRepository(output_path).load_activity_sync_state(provider="strava")
+            except (OSError, RuntimeError, sqlite3.Error):
+                logger.warning(
+                    "Could not read GeoPackage activity sync state; using unbounded fetch plan",
+                    exc_info=True,
+                )
+        return plan_activity_sync(sync_state)
 
     def _set_fetch_running(self, running):
         """Toggle UI state while a background fetch is in progress."""

--- a/tests/test_dock_activity_workflow.py
+++ b/tests/test_dock_activity_workflow.py
@@ -50,6 +50,8 @@ class DockActivityWorkflowCoordinatorTests(unittest.TestCase):
         self.assertEqual(kwargs["max_pages"], 0)
         self.assertFalse(kwargs["use_detailed_streams"])
         self.assertEqual(kwargs["max_detailed_activities"], 25)
+        self.assertIsNone(kwargs["before"])
+        self.assertIsNone(kwargs["after"])
         self.sync_controller.build_fetch_task.assert_called_once_with("fetch-request")
 
     def test_build_fetch_task_respects_advanced_fetch_values(self):
@@ -69,6 +71,8 @@ class DockActivityWorkflowCoordinatorTests(unittest.TestCase):
                 per_page_value=75,
                 max_pages_value=4,
                 max_detailed_activities_value=30,
+                before_epoch=200,
+                after_epoch=100,
             )
         )
 
@@ -77,6 +81,8 @@ class DockActivityWorkflowCoordinatorTests(unittest.TestCase):
         self.assertEqual(kwargs["max_pages"], 4)
         self.assertTrue(kwargs["use_detailed_streams"])
         self.assertEqual(kwargs["max_detailed_activities"], 30)
+        self.assertEqual(kwargs["before"], 200)
+        self.assertEqual(kwargs["after"], 100)
 
     def test_build_fetch_completion_result_returns_cancelled_status_without_preview(self):
         fetch_result = SimpleNamespace(cancelled=True, error=None, status_text="Fetch cancelled.")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1,4 +1,5 @@
 import importlib
+import sqlite3
 import sys
 import tempfile
 import unittest
@@ -7,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 from qfit.activities.domain.activity_query import DETAILED_ROUTE_FILTER_MISSING
+from qfit.sync_repository import ActivitySyncState
 
 
 class _AutoModule(ModuleType):
@@ -2157,6 +2159,88 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIsNone(dock._fetch_task)
         dock._set_fetch_running.assert_called_once_with(False)
         dock._set_status.assert_called_once_with("Fetch cancelled.")
+
+    def test_start_fetch_uses_incremental_bounds_from_completed_geopackage_sync(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._save_settings = MagicMock()
+        dock.activity_workflow = MagicMock()
+        fetch_task = object()
+        dock.activity_workflow.build_fetch_task.return_value = fetch_task
+        dock._runtime_store = MagicMock(return_value=MagicMock())
+        dock._set_fetch_running = MagicMock()
+        dock._set_status = MagicMock()
+        dock.clientIdLineEdit = _FakeLineEdit("cid")
+        dock.clientSecretLineEdit = _FakeLineEdit("secret")
+        dock.refreshTokenLineEdit = _FakeLineEdit("token")
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock.cache = object()
+        dock.advancedFetchGroupBox = _FakeCheckBox(False)
+        dock.detailedStreamsCheckBox = _FakeCheckBox(True)
+        dock.perPageSpinBox = _FakeSpinBox(50)
+        dock.maxPagesSpinBox = _FakeSpinBox(2)
+        dock.maxDetailedActivitiesSpinBox = _FakeSpinBox(9)
+        task_manager = MagicMock()
+        sync_state = ActivitySyncState(
+            provider="strava",
+            last_success_status="ok",
+            updated_at="2026-05-03T20:00:00+00:00",
+            latest_activity_start_date="2026-05-03T12:00:00Z",
+        )
+
+        with (
+            patch.object(
+                self.module,
+                "SyncRepository",
+                return_value=SimpleNamespace(load_activity_sync_state=MagicMock(return_value=sync_state)),
+            ) as repository_cls,
+            patch.object(
+                self.module,
+                "QgsApplication",
+                SimpleNamespace(taskManager=MagicMock(return_value=task_manager)),
+            ),
+        ):
+            self.module.QfitDockWidget._start_fetch(
+                dock,
+                detailed_route_strategy="Recent fetch only",
+                status_text="Fetching activities from Strava…",
+            )
+
+        repository_cls.assert_called_once_with("/tmp/qfit.gpkg")
+        dock.activity_workflow.build_fetch_task.assert_called_once()
+        request = dock.activity_workflow.build_fetch_task.call_args.args[0]
+        self.assertEqual(request.after_epoch, 1777550400)
+        self.assertIsNone(request.before_epoch)
+        dock._set_status.assert_called_once_with(
+            "Fetching recent activities from Strava with GeoPackage sync overlap…"
+        )
+        task_manager.addTask.assert_called_once_with(fetch_task)
+
+    def test_current_activity_sync_plan_falls_back_when_geopackage_state_is_unreadable(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        repository = SimpleNamespace(
+            load_activity_sync_state=MagicMock(side_effect=sqlite3.OperationalError("database is locked"))
+        )
+
+        with patch.object(self.module, "SyncRepository", return_value=repository):
+            plan = self.module.QfitDockWidget._current_activity_sync_plan(dock)
+
+        self.assertEqual(plan.mode.value, "initial_import")
+        self.assertIsNone(plan.after_epoch)
+
+    def test_backfill_missing_detailed_routes_skips_activity_sync_bounds(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._fetch_task = None
+        dock._start_fetch = MagicMock()
+
+        self.module.QfitDockWidget.on_backfill_missing_detailed_routes_clicked(dock)
+
+        dock._start_fetch.assert_called_once_with(
+            use_detailed_streams=True,
+            detailed_route_strategy=self.module.DETAILED_ROUTE_STRATEGY_MISSING,
+            status_text="Backfilling missing detailed routes from Strava…",
+            use_activity_sync_plan=False,
+        )
 
     def test_on_fetch_finished_updates_runtime_state_on_success(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -377,6 +377,22 @@ class BuildSyncMetadataTests(unittest.TestCase):
         self.assertTrue(meta["is_full_sync"])
         self.assertIn("today_str", meta)
 
+    def test_metadata_records_fetch_bounds(self):
+        ctrl = SyncController()
+        provider = SimpleNamespace(
+            source_name="strava",
+            last_stream_enrichment_stats=None,
+            last_rate_limit=None,
+            last_fetch_notice=None,
+            last_fetch_context={"max_pages": 0, "before": 200, "after": 100},
+        )
+
+        meta = ctrl.build_sync_metadata([], provider)
+
+        self.assertEqual(meta["before_epoch"], 200)
+        self.assertEqual(meta["after_epoch"], 100)
+        self.assertFalse(meta["is_full_sync"])
+
     def test_detailed_count_excludes_non_stream(self):
         ctrl = SyncController()
         activities = [

--- a/ui/application/dock_activity_workflow.py
+++ b/ui/application/dock_activity_workflow.py
@@ -30,6 +30,8 @@ class DockFetchRequest:
     max_pages_value: int
     max_detailed_activities_value: int
     use_detailed_streams_override: bool | None = None
+    before_epoch: int | None = None
+    after_epoch: int | None = None
 
 
 @dataclass(frozen=True)
@@ -91,6 +93,8 @@ class DockActivityWorkflowCoordinator:
             ),
             detailed_route_strategy=request.detailed_route_strategy,
             on_finished=request.on_finished,
+            before=request.before_epoch,
+            after=request.after_epoch,
         )
         return self.sync_controller.build_fetch_task(fetch_request)
 


### PR DESCRIPTION
## Summary

- apply the activity sync plan when starting a Strava activity fetch from the dock
- pass planned `before` / `after` bounds through the dock activity workflow into `FetchTask`
- persist completed fetch bounds into sync metadata so later GeoPackage sync-state reads can reason from real fetch context
- show an incremental-fetch status message when qfit uses the GeoPackage overlap window

Refs #761.

## Tests

- `python3 -m pytest tests/test_dock_activity_workflow.py tests/test_sync_controller.py tests/test_sync_strategy.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short --ignore=tests/test_qgis_smoke.py`
