### PR TITLE
Fix Map panel filter action layout

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -470,7 +470,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 sync_saved_routes=self.on_sync_routes_clicked,
                 clear_database=self.on_clear_database_clicked,
                 load_activity_layers=self.on_load_layers_clicked,
-                edit_map_filters=self._update_status_for_filter_visibility,
                 apply_map_filters=self._run_wizard_map_step,
                 run_analysis=self.on_run_analysis_clicked,
                 set_analysis_mode=self._set_wizard_analysis_mode,
@@ -512,7 +511,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 sync_saved_routes=self.on_sync_routes_clicked,
                 clear_database=self.on_clear_database_clicked,
                 load_activity_layers=self.on_load_layers_clicked,
-                edit_map_filters=self._update_status_for_filter_visibility,
                 apply_map_filters=self.on_apply_filters_clicked,
                 run_analysis=self.on_run_analysis_clicked,
                 set_analysis_mode=self._set_wizard_analysis_mode,
@@ -589,7 +587,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             filter_group.show()
         elif hasattr(filter_group, "setVisible"):
             filter_group.setVisible(True)
-        map_content.set_filter_controls_visible(False)
+        map_content.set_filter_controls_visible()
         self._wizard_filter_controls_installed = True
         self._wizard_filter_controls_installed_target = current_target
 
@@ -600,14 +598,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         parent_layout = parent_widget.layout() if parent_widget is not None else None
         if parent_layout is not None and hasattr(parent_layout, "removeWidget"):
             parent_layout.removeWidget(widget)
-
-    def _update_status_for_filter_visibility(self, visible: bool) -> None:
-        """Reflect wizard filter-panel visibility in concise dock status copy."""
-
-        if visible:
-            self._set_status("Edit map filters, then apply filters when ready.")
-        else:
-            self._set_status("Map filter controls hidden.")
 
     def _bind_wizard_analysis_mode_controls(self, composition) -> None:
         """Expose the hidden backing analysis selector in the live wizard path."""

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -90,7 +90,6 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             sync_saved_routes=lambda: calls.append("routes"),
             clear_database=lambda: calls.append("clear"),
             load_activity_layers=lambda: calls.append("layers"),
-            edit_map_filters=lambda visible: calls.append(f"filters:{visible}"),
             apply_map_filters=lambda: calls.append("apply"),
             run_analysis=lambda: calls.append("analysis"),
             set_analysis_mode=lambda mode: calls.append(f"mode:{mode}"),
@@ -107,7 +106,6 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         composition.sync_content.clearDatabaseRequested.emit()
         composition.sync_content.loadActivitiesRequested.emit()
         composition.map_content.loadLayersRequested.emit()
-        composition.map_content.editFiltersRequested.emit(True)
         composition.map_content.applyFiltersRequested.emit()
         composition.analysis_content.runAnalysisRequested.emit()
         composition.analysis_content.analysisModeChanged.emit("Heatmap")
@@ -124,7 +122,6 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
                 "clear",
                 "layers",
                 "layers",
-                "filters:True",
                 "apply",
                 "analysis",
                 "mode:Heatmap",

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -92,32 +92,13 @@ class MapPageContentTest(unittest.TestCase):
             "qfitWizardMapApplyFiltersButton",
         )
         self.assertEqual(
-            content.edit_filters_button.objectName(),
-            "qfitWizardMapEditFiltersButton",
-        )
-        self.assertEqual(content.edit_filters_button.text(), "Edit filters")
-        self.assertEqual(
-            content.edit_filters_button.property("secondaryAction"),
-            "edit_map_filters",
-        )
-        self.assertEqual(
-            content.edit_filters_button.property("wizardActionRole"),
-            "secondary",
-        )
-        self.assertFalse(content.edit_filters_button.isEnabled())
-        self.assertEqual(
-            content.edit_filters_button.property("wizardActionAvailability"),
-            "blocked",
-        )
-        self.assertIn("Sync activities", content.edit_filters_button.toolTip())
-        self.assertEqual(
             content.filter_controls_panel.objectName(),
             "qfitWizardMapFilterControlsPanel",
         )
-        self.assertFalse(content.filter_controls_panel.isVisible())
+        self.assertTrue(content.filter_controls_panel.isVisible())
         self.assertEqual(
             content.filter_controls_panel.property("filterControlsState"),
-            "collapsed",
+            "expanded",
         )
         self.assertEqual(content.apply_filters_button.text(), "Apply filters")
         self.assertEqual(
@@ -136,7 +117,6 @@ class MapPageContentTest(unittest.TestCase):
             content.action_row.outer_layout().widgets,
             [
                 content.load_layers_button,
-                content.edit_filters_button,
                 content.apply_filters_button,
             ],
         )
@@ -149,8 +129,8 @@ class MapPageContentTest(unittest.TestCase):
                 content.background_summary_label,
                 content.style_summary_label,
                 content.filter_summary_label,
-                content.action_row,
                 content.filter_controls_panel,
+                content.action_row,
             ],
         )
 
@@ -165,7 +145,6 @@ class MapPageContentTest(unittest.TestCase):
             style_summary_text="Selected activity style: By activity type",
             filter_summary_text="42 activities · Ride and Run · 2026",
             load_action_label="Reload layers",
-            edit_filters_action_enabled=True,
             primary_action_label="Apply saved filters",
         )
 
@@ -202,12 +181,6 @@ class MapPageContentTest(unittest.TestCase):
             "available",
         )
         self.assertEqual(content.load_layers_button.toolTip(), "")
-        self.assertTrue(content.edit_filters_button.isEnabled())
-        self.assertEqual(
-            content.edit_filters_button.property("wizardActionAvailability"),
-            "available",
-        )
-        self.assertEqual(content.edit_filters_button.toolTip(), "")
         self.assertEqual(content.apply_filters_button.text(), "Apply saved filters")
         self.assertTrue(content.apply_filters_button.isEnabled())
         self.assertEqual(
@@ -249,94 +222,55 @@ class MapPageContentTest(unittest.TestCase):
             "Choose at least one activity layer.",
         )
 
-    def test_can_override_edit_filter_availability(self):
-        content = self.map_page.MapPageContent(
-            self.map_page.MapPageState(
-                edit_filters_action_enabled=True,
-            )
-        )
-
-        self.assertTrue(content.edit_filters_button.isEnabled())
-        self.assertEqual(
-            content.edit_filters_button.property("wizardActionAvailability"),
-            "available",
-        )
-        self.assertEqual(content.edit_filters_button.toolTip(), "")
-
-    def test_disabling_edit_filters_collapses_embedded_filter_controls(self):
-        content = self.map_page.MapPageContent(
-            self.map_page.MapPageState(edit_filters_action_enabled=True)
-        )
-        content.set_filter_controls_visible(True)
-
-        content.set_state(self.map_page.MapPageState(edit_filters_action_enabled=False))
-
-        self.assertFalse(content.filter_controls_panel.isVisible())
-        self.assertEqual(
-            content.filter_controls_panel.property("filterControlsState"),
-            "collapsed",
-        )
-        self.assertEqual(content.edit_filters_button.text(), "Edit filters")
-
-    def test_refresh_keeps_hide_filters_label_when_panel_is_logically_expanded(self):
-        content = self.map_page.MapPageContent(
-            self.map_page.MapPageState(edit_filters_action_enabled=True)
-        )
-        content.set_filter_controls_visible(True)
-        content.filter_controls_panel.isVisible = lambda: False
-
-        content.set_state(
-            self.map_page.MapPageState(
-                loaded=True,
-                edit_filters_action_enabled=True,
-                edit_filters_action_label="Edit filters",
-            )
-        )
-
-        self.assertEqual(
-            content.filter_controls_panel.property("filterControlsState"),
-            "expanded",
-        )
-        self.assertEqual(content.edit_filters_button.text(), "Hide filters")
-
-    def test_edit_filters_button_toggles_embedded_filter_controls(self):
-        content = self.map_page.MapPageContent(
-            self.map_page.MapPageState(edit_filters_action_enabled=True)
-        )
-        calls = []
-        content.editFiltersRequested.connect(lambda visible: calls.append(visible))
-
-        content.edit_filters_button.clicked.emit()
+    def test_default_state_keeps_filter_controls_visible(self):
+        content = self.map_page.MapPageContent(self.map_page.MapPageState())
 
         self.assertTrue(content.filter_controls_panel.isVisible())
         self.assertEqual(
             content.filter_controls_panel.property("filterControlsState"),
             "expanded",
         )
-        self.assertEqual(content.edit_filters_button.text(), "Hide filters")
 
-        content.edit_filters_button.clicked.emit()
+    def test_set_filter_controls_visible_keeps_filters_expanded(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState()
+        )
 
-        self.assertFalse(content.filter_controls_panel.isVisible())
+        content.set_filter_controls_visible()
+
+        self.assertTrue(content.filter_controls_panel.isVisible())
         self.assertEqual(
             content.filter_controls_panel.property("filterControlsState"),
-            "collapsed",
+            "expanded",
         )
-        self.assertEqual(content.edit_filters_button.text(), "Edit filters")
-        self.assertEqual(calls, [True, False])
+
+    def test_refresh_keeps_filter_controls_expanded(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState()
+        )
+
+        content.set_state(
+            self.map_page.MapPageState(
+                loaded=True,
+            )
+        )
+
+        self.assertEqual(
+            content.filter_controls_panel.property("filterControlsState"),
+            "expanded",
+        )
+        self.assertTrue(content.filter_controls_panel.isVisible())
 
     def test_buttons_emit_reusable_page_signals(self):
         content = self.map_page.MapPageContent()
         calls = []
         content.loadLayersRequested.connect(lambda: calls.append("load"))
-        content.editFiltersRequested.connect(lambda _visible: calls.append("edit"))
         content.applyFiltersRequested.connect(lambda: calls.append("filter"))
 
         content.load_layers_button.clicked.emit()
-        content.edit_filters_button.clicked.emit()
         content.apply_filters_button.clicked.emit()
 
-        self.assertEqual(calls, ["load", "edit", "filter"])
+        self.assertEqual(calls, ["load", "filter"])
 
     def test_installs_only_on_map_wizard_page_body(self):
         map_spec = next(spec for spec in build_default_wizard_page_specs() if spec.key == "map")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -815,7 +815,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "sync_saved_routes": "on_sync_routes_clicked",
             "clear_database": "on_clear_database_clicked",
             "load_activity_layers": "on_load_layers_clicked",
-            "edit_map_filters": "_update_status_for_filter_visibility",
             "apply_map_filters": "_run_wizard_map_step",
             "run_analysis": "on_run_analysis_clicked",
             "set_analysis_mode": "_set_wizard_analysis_mode",
@@ -970,7 +969,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "sync_saved_routes": "on_sync_routes_clicked",
             "clear_database": "on_clear_database_clicked",
             "load_activity_layers": "on_load_layers_clicked",
-            "edit_map_filters": "_update_status_for_filter_visibility",
             "apply_map_filters": "on_apply_filters_clicked",
             "run_analysis": "on_run_analysis_clicked",
             "set_analysis_mode": "_set_wizard_analysis_mode",
@@ -1049,7 +1047,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         filter_group.setParent.assert_called_once_with(panel)
         filter_layout.addWidget.assert_called_once_with(filter_group)
         filter_group.show.assert_called_once_with()
-        map_content.set_filter_controls_visible.assert_called_once_with(False)
+        map_content.set_filter_controls_visible.assert_called_once_with()
         self.assertTrue(dock._wizard_filter_controls_installed)
         self.assertEqual(dock._wizard_filter_controls_installed_target, id(map_content))
 
@@ -1090,19 +1088,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         parent_layout.removeWidget.assert_called_once_with(filter_group)
         filter_layout.addWidget.assert_called_once_with(filter_group)
         self.assertEqual(dock._wizard_filter_controls_installed_target, id(map_content))
-
-    def test_update_status_for_filter_visibility_updates_status_copy(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._set_status = MagicMock()
-
-        self.module.QfitDockWidget._update_status_for_filter_visibility(dock, True)
-        self.module.QfitDockWidget._update_status_for_filter_visibility(dock, False)
-
-        dock._set_status.assert_any_call(
-            "Edit map filters, then apply filters when ready."
-        )
-        dock._set_status.assert_any_call("Map filter controls hidden.")
-
 
     def test_bind_wizard_analysis_mode_controls_exposes_non_none_modes(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -332,7 +332,6 @@ class WizardShellCompositionTest(unittest.TestCase):
             sync_saved_routes=lambda: calls.append("routes"),
             clear_database=lambda: calls.append("clear"),
             load_activity_layers=lambda: calls.append("load"),
-            edit_map_filters=lambda visible: calls.append(f"edit:{visible}"),
             apply_map_filters=lambda: calls.append("filter"),
             run_analysis=lambda: calls.append("analysis"),
             set_analysis_mode=lambda mode: calls.append(f"mode:{mode}"),
@@ -353,7 +352,6 @@ class WizardShellCompositionTest(unittest.TestCase):
         assembled.sync_content.clear_button.clicked.emit()
         assembled.sync_content.load_button.clicked.emit()
         assembled.map_content.load_layers_button.clicked.emit()
-        assembled.map_content.edit_filters_button.clicked.emit()
         assembled.map_content.apply_filters_button.clicked.emit()
         assembled.analysis_content.run_analysis_button.clicked.emit()
         assembled.analysis_content.analysis_mode_combo.setCurrentText("Heatmap")
@@ -370,7 +368,6 @@ class WizardShellCompositionTest(unittest.TestCase):
                 "clear",
                 "load",
                 "load",
-                "edit:True",
                 "filter",
                 "analysis",
                 "mode:Heatmap",
@@ -474,7 +471,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Use the primary action to load activity layers.",
         )
         self.assertEqual(assembled.map_content.apply_filters_button.text(), "Load activity layers")
-        self.assertTrue(assembled.map_content.edit_filters_button.isEnabled())
+        self.assertTrue(assembled.map_content.filter_controls_panel.isVisible())
         self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
         self.assertEqual(
             assembled.map_content.apply_filters_button.property("wizardActionAvailability"),
@@ -1328,7 +1325,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.sync_content.sync_button.isEnabled())
         self.assertFalse(assembled.map_state.loaded)
         self.assertFalse(assembled.map_content.load_layers_button.isEnabled())
-        self.assertFalse(assembled.map_content.edit_filters_button.isEnabled())
+        self.assertTrue(assembled.map_content.filter_controls_panel.isVisible())
         self.assertFalse(assembled.map_content.apply_filters_button.isEnabled())
         self.assertEqual(assembled.shell.footer_bar.activity_pill.text(), "— activities")
         self.assertEqual(assembled.shell.footer_bar.layer_pill.text(), "0 layers")

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -141,11 +141,6 @@ def connect_local_first_action_callbacks(
     )
     _connect_optional_signal(
         composition.map_content,
-        "editFiltersRequested",
-        callbacks.edit_map_filters,
-    )
-    _connect_optional_signal(
-        composition.map_content,
         "applyFiltersRequested",
         callbacks.apply_map_filters,
     )

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -48,11 +48,6 @@ class MapPageState:
     load_action_label: str = "Load activity layers"
     load_action_enabled: bool = True
     load_action_blocked_tooltip: str = "Sync activities before loading map layers."
-    edit_filters_action_label: str = "Edit filters"
-    edit_filters_action_enabled: bool = False
-    edit_filters_action_blocked_tooltip: str = (
-        "Sync activities before editing map filters."
-    )
     primary_action_label: str = "Apply filters"
     apply_action_enabled: bool | None = None
     apply_action_blocked_tooltip: str = "Load activity layers before applying filters."
@@ -62,7 +57,6 @@ class MapPageContent(QWidget):
     """Reusable third-page content for the wizard map-and-filters step."""
 
     loadLayersRequested = pyqtSignal()
-    editFiltersRequested = pyqtSignal(bool)
     applyFiltersRequested = pyqtSignal()
 
     def __init__(self, state: MapPageState | None = None, parent=None) -> None:
@@ -94,13 +88,6 @@ class MapPageContent(QWidget):
             action_name="load_activity_layers",
         )
         self.load_layers_button.clicked.connect(self.loadLayersRequested.emit)
-        self.edit_filters_button = QToolButton(self)
-        self.edit_filters_button.setObjectName("qfitWizardMapEditFiltersButton")
-        style_secondary_action_button(
-            self.edit_filters_button,
-            action_name="edit_map_filters",
-        )
-        self.edit_filters_button.clicked.connect(self._toggle_filter_controls)
         self.apply_filters_button = QToolButton(self)
         self.apply_filters_button.setObjectName("qfitWizardMapApplyFiltersButton")
         style_primary_action_button(
@@ -110,15 +97,14 @@ class MapPageContent(QWidget):
         self.apply_filters_button.clicked.connect(self.applyFiltersRequested.emit)
         self.action_row = build_wizard_action_row(
             self.load_layers_button,
-            self.edit_filters_button,
             self.apply_filters_button,
             parent=self,
             object_name="qfitWizardMapActionRow",
         )
         self.filter_controls_panel = QWidget(self)
         self.filter_controls_panel.setObjectName("qfitWizardMapFilterControlsPanel")
-        self.filter_controls_panel.setVisible(False)
-        self.filter_controls_panel.setProperty("filterControlsState", "collapsed")
+        self.filter_controls_panel.setVisible(True)
+        self.filter_controls_panel.setProperty("filterControlsState", "expanded")
         self._filter_controls_layout = self._build_filter_controls_layout()
         self._layout = self._build_layout()
         self.set_state(state or MapPageState())
@@ -145,16 +131,7 @@ class MapPageContent(QWidget):
             enabled=state.load_action_enabled,
             tooltip=state.load_action_blocked_tooltip,
         )
-        self.edit_filters_button.setText(state.edit_filters_action_label)
-        set_wizard_action_availability(
-            self.edit_filters_button,
-            enabled=state.edit_filters_action_enabled,
-            tooltip=state.edit_filters_action_blocked_tooltip,
-        )
-        if not state.edit_filters_action_enabled and self._filter_controls_are_expanded():
-            self.set_filter_controls_visible(False)
-        elif self._filter_controls_are_expanded():
-            self.edit_filters_button.setText("Hide filters")
+        self.set_filter_controls_visible()
         self.apply_filters_button.setText(state.primary_action_label)
         apply_action_enabled = (
             state.loaded
@@ -172,23 +149,11 @@ class MapPageContent(QWidget):
 
         return self._filter_controls_layout
 
-    def set_filter_controls_visible(self, visible: bool) -> None:
-        """Show or hide the embedded filter controls without rebuilding the page."""
+    def set_filter_controls_visible(self) -> None:
+        """Keep embedded filter controls visible without rebuilding the page."""
 
-        self.filter_controls_panel.setVisible(visible)
-        self.filter_controls_panel.setProperty(
-            "filterControlsState",
-            "expanded" if visible else "collapsed",
-        )
-        self.edit_filters_button.setText("Hide filters" if visible else "Edit filters")
-
-    def _toggle_filter_controls(self) -> None:
-        next_visible = not self._filter_controls_are_expanded()
-        self.set_filter_controls_visible(next_visible)
-        self.editFiltersRequested.emit(next_visible)
-
-    def _filter_controls_are_expanded(self) -> bool:
-        return self.filter_controls_panel.property("filterControlsState") == "expanded"
+        self.filter_controls_panel.setVisible(True)
+        self.filter_controls_panel.setProperty("filterControlsState", "expanded")
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""
@@ -215,8 +180,8 @@ class MapPageContent(QWidget):
         layout.addWidget(self.background_summary_label)
         layout.addWidget(self.style_summary_label)
         layout.addWidget(self.filter_summary_label)
-        layout.addWidget(self.action_row)
         layout.addWidget(self.filter_controls_panel)
+        layout.addWidget(self.action_row)
         return layout
 
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -71,7 +71,6 @@ class WizardActionCallbacks:
     sync_saved_routes: Callable[[], None] | None = None
     clear_database: Callable[[], None] | None = None
     load_activity_layers: Callable[[], None] | None = None
-    edit_map_filters: Callable[[bool], None] | None = None
     apply_map_filters: Callable[[], None] | None = None
     run_analysis: Callable[[], None] | None = None
     set_analysis_mode: Callable[[str], None] | None = None
@@ -435,11 +434,6 @@ def _connect_action_callbacks(
     )
     _connect_optional_signal(
         map_content,
-        "editFiltersRequested",
-        callbacks.edit_map_filters,
-    )
-    _connect_optional_signal(
-        map_content,
         "applyFiltersRequested",
         callbacks.apply_map_filters,
     )
@@ -726,7 +720,6 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
             if stored_without_loaded_layers
             else default.primary_action_label
         ),
-        edit_filters_action_enabled=facts.activities_stored,
         apply_action_enabled=facts.activities_stored,
         apply_action_blocked_tooltip=(
             "Sync activities before loading map layers."


### PR DESCRIPTION
## Summary

- keep Map panel filter controls visible in the wizard UI
- remove the show/hide filters button from the Map panel action row
- move Map panel actions below the embedded filter controls

Closes #771.
Closes #772.

## Tests

- `python3 -m pytest tests/ -x -q --tb=short`
