### PR TITLE
Separate Data page destructive action row

### DIFF
--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -121,9 +121,16 @@ class SyncPageContentTest(unittest.TestCase):
             [
                 content.load_button,
                 content.routes_button,
-                content.clear_button,
                 content.sync_button,
             ],
+        )
+        self.assertEqual(
+            content.clear_action_row.objectName(),
+            "qfitWizardSyncDestructiveActionRow",
+        )
+        self.assertEqual(
+            content.clear_action_row.outer_layout().widgets,
+            [content.clear_button],
         )
         self.assertEqual(
             content.outer_layout().widgets,
@@ -132,6 +139,7 @@ class SyncPageContentTest(unittest.TestCase):
                 content.detail_label,
                 content.activity_summary_label,
                 content.action_row,
+                content.clear_action_row,
             ],
         )
 

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -110,10 +110,14 @@ class SyncPageContent(QWidget):
         self.action_row = build_wizard_action_row(
             self.load_button,
             self.routes_button,
-            self.clear_button,
             self.sync_button,
             parent=self,
             object_name="qfitWizardSyncActionRow",
+        )
+        self.clear_action_row = build_wizard_action_row(
+            self.clear_button,
+            parent=self,
+            object_name="qfitWizardSyncDestructiveActionRow",
         )
         self._layout = self._build_layout()
         self.set_state(state or SyncPageState())
@@ -168,6 +172,7 @@ class SyncPageContent(QWidget):
         layout.addWidget(self.detail_label)
         layout.addWidget(self.activity_summary_label)
         layout.addWidget(self.action_row)
+        layout.addWidget(self.clear_action_row)
         return layout
 
 


### PR DESCRIPTION
## Summary

- separates the Data page destructive `Clear database…` action from normal sync/load actions
- keeps the normal Data action row focused on local load, saved-route sync, and activity sync
- updates pure Sync page layout tests for the new destructive action row

Refs #776.

## Tests

- `python3 -m pytest tests/test_sync_page.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
