### PR TITLE
Respect Strava rate-limit headroom during route sync

### DIFF
--- a/activities/application/route_sync_task.py
+++ b/activities/application/route_sync_task.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from copy import copy
+from dataclasses import replace
 from datetime import UTC, date, datetime
 from typing import Callable
 
@@ -13,6 +15,11 @@ from ...providers.domain.provider import ProviderError
 logger = logging.getLogger(__name__)
 
 RouteSyncTaskFinishedCallback = Callable[[dict | None, str | None, bool, object], None]
+ROUTE_DETAIL_REQUESTS_PER_ROUTE = 2
+ROUTE_SYNC_MIN_SHORT_REMAINING = 10
+ROUTE_SYNC_MIN_LONG_REMAINING = 50
+ROUTE_SYNC_SHORT_WINDOW_RESERVE_FRACTION = 0.5
+ROUTE_SYNC_LONG_WINDOW_RESERVE_FRACTION = 0.05
 
 
 def _default_writer_factory(**kwargs):
@@ -45,6 +52,7 @@ class RouteSyncTask(QgsTask):
         self._on_finished = on_finished
         self._result: dict | None = None
         self._error: str | None = None
+        self._fetch_notice: str | None = None
 
     def run(self) -> bool:
         """Run the route sync in a QGIS worker thread."""
@@ -59,6 +67,9 @@ class RouteSyncTask(QgsTask):
                 routes,
                 sync_metadata=self._build_sync_metadata(routes),
             )
+            fetch_notice = self._current_fetch_notice()
+            if fetch_notice and isinstance(self._result, dict):
+                self._result["fetch_notice"] = fetch_notice
             return True
         except ProviderError as exc:
             self._error = str(exc)
@@ -96,39 +107,175 @@ class RouteSyncTask(QgsTask):
             return routes
 
         enriched_routes = []
-        for route in routes:
+        for index, route in enumerate(routes):
             if self.isCanceled():
+                break
+            if self._should_pause_route_enrichment_for_rate_limit():
+                skipped_routes = self._mark_routes_skipped_for_rate_limit(routes[index:])
+                enriched_routes.extend(skipped_routes)
+                self._fetch_notice = self._route_rate_limit_pause_notice(len(skipped_routes))
                 break
             route_id = getattr(route, "source_route_id", None)
             if route_id in (None, ""):
                 enriched_routes.append(route)
                 continue
-            enriched_routes.append(
-                self._provider.fetch_route_detail(
-                    route_id,
-                    use_gpx_geometry=True,
+            try:
+                enriched_routes.append(
+                    self._provider.fetch_route_detail(
+                        route_id,
+                        use_gpx_geometry=True,
+                    )
                 )
-            )
+            except ProviderError as exc:
+                if not _is_rate_limit_error(exc):
+                    raise
+                skipped_routes = self._mark_routes_skipped_for_rate_limit(routes[index:])
+                enriched_routes.extend(skipped_routes)
+                self._fetch_notice = self._route_rate_limit_pause_notice(
+                    len(skipped_routes),
+                    error_message=str(exc),
+                )
+                break
         return enriched_routes
 
     def _build_sync_metadata(self, routes):
         provider_name = getattr(self._provider, "source_name", "strava")
-        fetch_notice = getattr(self._provider, "last_fetch_notice", None)
+        fetch_notice = self._current_fetch_notice()
         is_full_sync = self._max_pages == 0 and not fetch_notice
         return {
             "provider": provider_name,
             "fetched_count": len(routes),
             "detailed_count": sum(1 for route in routes if _route_has_gpx_geometry(route)),
             "rate_limit": getattr(self._provider, "last_rate_limit", None),
+            "fetch_notice": fetch_notice,
             "is_full_sync": is_full_sync,
             "today_str": date.today().isoformat(),
             "synced_at": datetime.now(UTC).isoformat(),
         }
 
+    def _current_fetch_notice(self) -> str | None:
+        notices = []
+        for notice in (getattr(self._provider, "last_fetch_notice", None), self._fetch_notice):
+            if notice and notice not in notices:
+                notices.append(notice)
+        if not notices:
+            return None
+        return " ".join(notices)
+
+    def _should_pause_route_enrichment_for_rate_limit(self) -> bool:
+        budget = _route_detail_enrichment_budget(getattr(self._provider, "last_rate_limit", None))
+        return budget is not None and budget <= 0
+
+    def _route_rate_limit_pause_notice(self, skipped_count: int, *, error_message: str | None = None) -> str:
+        rate_limit = getattr(self._provider, "last_rate_limit", None) or {}
+        short_remaining = rate_limit.get("short_remaining")
+        long_remaining = rate_limit.get("long_remaining")
+        detail = (
+            "Stopped route GPX enrichment early to preserve Strava API headroom. "
+            "Skipped GPX enrichment for {skipped_count} saved routes; summary route metadata was still stored. "
+            "Remaining read quota: short={short}, long={long}."
+        ).format(
+            skipped_count=skipped_count,
+            short=short_remaining if short_remaining is not None else "?",
+            long=long_remaining if long_remaining is not None else "?",
+        )
+        if error_message:
+            return "{detail} Last Strava response: {error_message}".format(
+                detail=detail,
+                error_message=error_message,
+            )
+        return detail
+
+    def _mark_routes_skipped_for_rate_limit(self, routes):
+        skipped_routes = []
+        for route in routes:
+            route, details = _route_with_mutable_details(route)
+            if details is None:
+                continue
+            details["gpx_geometry_status"] = "skipped_rate_limit"
+            details["gpx_skipped_reason"] = "rate_limit_guard"
+            skipped_routes.append(route)
+        return skipped_routes
+
 
 def _route_has_gpx_geometry(route) -> bool:
     details = getattr(route, "details_json", None) or {}
     return details.get("gpx_geometry_status") == "downloaded"
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    return bool(getattr(exc, "is_rate_limit", False))
+
+
+def _route_with_mutable_details(route):
+    details = getattr(route, "details_json", None)
+    if isinstance(details, dict):
+        return route, details
+
+    details = {}
+    try:
+        route.details_json = details
+        return route, details
+    except AttributeError:
+        pass
+
+    try:
+        replaced_route = replace(route, details_json=details)
+        return replaced_route, details
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        copied_route = copy(route)
+        copied_route.details_json = details
+        return copied_route, details
+    except AttributeError:
+        return route, None
+
+
+def _route_detail_enrichment_budget(rate_limit) -> int | None:
+    if not rate_limit:
+        return None
+    budgets = []
+    short_budget = _remaining_request_budget(
+        rate_limit,
+        remaining_key="short_remaining",
+        limit_key="short_limit",
+        minimum_reserve=ROUTE_SYNC_MIN_SHORT_REMAINING,
+        reserve_fraction=ROUTE_SYNC_SHORT_WINDOW_RESERVE_FRACTION,
+    )
+    if short_budget is not None:
+        budgets.append(short_budget // ROUTE_DETAIL_REQUESTS_PER_ROUTE)
+    long_budget = _remaining_request_budget(
+        rate_limit,
+        remaining_key="long_remaining",
+        limit_key="long_limit",
+        minimum_reserve=ROUTE_SYNC_MIN_LONG_REMAINING,
+        reserve_fraction=ROUTE_SYNC_LONG_WINDOW_RESERVE_FRACTION,
+    )
+    if long_budget is not None:
+        budgets.append(long_budget // ROUTE_DETAIL_REQUESTS_PER_ROUTE)
+    if not budgets:
+        return None
+    return min(budgets)
+
+
+def _remaining_request_budget(
+    rate_limit,
+    *,
+    remaining_key: str,
+    limit_key: str,
+    minimum_reserve: int,
+    reserve_fraction: float,
+) -> int | None:
+    remaining = rate_limit.get(remaining_key)
+    if remaining is None:
+        return None
+    reserve = minimum_reserve
+    limit = rate_limit.get(limit_key)
+    if limit is not None:
+        reserve = max(reserve, int(limit * reserve_fraction))
+    return max(0, int(remaining) - reserve)
 
 
 def build_route_sync_task(

--- a/providers/domain/provider.py
+++ b/providers/domain/provider.py
@@ -13,6 +13,10 @@ from ...detailed_route_strategy import DEFAULT_DETAILED_ROUTE_STRATEGY
 class ProviderError(RuntimeError):
     """Raised by an :class:`ActivityProvider` when a fetch or auth operation fails."""
 
+    def __init__(self, *args, is_rate_limit: bool = False):
+        super().__init__(*args)
+        self.is_rate_limit = bool(is_rate_limit)
+
 
 @runtime_checkable
 class ActivityProvider(Protocol):

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -84,7 +84,9 @@ from ..domain.routes import SavedRoute
 
 
 class StravaClientError(RuntimeError):
-    pass
+    def __init__(self, *args, is_rate_limit=False):
+        super().__init__(*args)
+        self.is_rate_limit = bool(is_rate_limit)
 
 
 class StravaClient:
@@ -891,7 +893,10 @@ class StravaClient:
                 status_code = response.status_code if response is not None else "unknown"
                 body = response.text if response is not None else str(exc)
                 if response is not None and int(status_code) == 429:
-                    raise StravaClientError(self._format_rate_limit_error(operation, response)) from exc
+                    raise StravaClientError(
+                        self._format_rate_limit_error(operation, response),
+                        is_rate_limit=True,
+                    ) from exc
                 raise StravaClientError(
                     "{operation} failed with Strava API error {code}: {body}".format(
                         operation=operation,

--- a/providers/infrastructure/strava_provider.py
+++ b/providers/infrastructure/strava_provider.py
@@ -70,7 +70,7 @@ class StravaProvider:
                 detailed_route_strategy=detailed_route_strategy,
             )
         except StravaClientError as exc:
-            raise ProviderError(str(exc)) from exc
+            raise ProviderError(str(exc), is_rate_limit=exc.is_rate_limit) from exc
 
     def fetch_routes(self, athlete_id=None, per_page=200, max_pages=0):
         """Fetch saved routes from Strava.
@@ -86,14 +86,14 @@ class StravaProvider:
                 max_pages=max_pages,
             )
         except StravaClientError as exc:
-            raise ProviderError(str(exc)) from exc
+            raise ProviderError(str(exc), is_rate_limit=exc.is_rate_limit) from exc
 
     def fetch_route_detail(self, route_id, use_gpx_geometry=False):
         """Fetch detailed metadata for one Strava route."""
         try:
             return self._client.fetch_route_detail(route_id, use_gpx_geometry=use_gpx_geometry)
         except StravaClientError as exc:
-            raise ProviderError(str(exc)) from exc
+            raise ProviderError(str(exc), is_rate_limit=exc.is_rate_limit) from exc
 
     # ------------------------------------------------------------------
     # Strava-specific: OAuth authorisation helpers
@@ -112,7 +112,7 @@ class StravaProvider:
         try:
             return self._client.build_authorize_url(redirect_uri=redirect_uri)
         except StravaClientError as exc:
-            raise ProviderError(str(exc)) from exc
+            raise ProviderError(str(exc), is_rate_limit=exc.is_rate_limit) from exc
 
     def exchange_code_for_tokens(self, authorization_code, redirect_uri=None):
         """Exchange an authorisation code for access and refresh tokens."""
@@ -122,4 +122,4 @@ class StravaProvider:
                 redirect_uri=redirect_uri,
             )
         except StravaClientError as exc:
-            raise ProviderError(str(exc)) from exc
+            raise ProviderError(str(exc), is_rate_limit=exc.is_rate_limit) from exc

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1554,6 +1554,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         rate_limit_note = self.sync_controller._rate_limit_note(
             getattr(provider, "last_rate_limit", None)
         )
+        fetch_notice = result.get("fetch_notice") or getattr(provider, "last_fetch_notice", None)
+        fetch_notice_note = " {notice}".format(notice=fetch_notice) if fetch_notice else ""
         status = (
             "Synced {fetched} saved routes into GeoPackage: inserted {inserted}, "
             "updated {updated}, unchanged {unchanged}, stored total {total}. "
@@ -1570,7 +1572,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         if cancelled:
             status = "Route sync completed after cancellation was requested. " + status
-        self._set_status(status + rate_limit_note)
+        self._set_status(status + rate_limit_note + fetch_notice_note)
 
     def on_load_layers_clicked(self):
         """Load an existing GeoPackage into QGIS without fetching from Strava."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2083,6 +2083,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "route_track_count": 2,
             "route_point_count": 6,
             "route_profile_sample_count": 10,
+            "fetch_notice": "Stopped route GPX enrichment early to preserve Strava API headroom.",
             "sync": SimpleNamespace(inserted=1, updated=1, unchanged=0, total_count=2),
         }
         provider = SimpleNamespace(last_rate_limit=None)
@@ -2107,6 +2108,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.layer_gateway.load_route_layers.assert_called_once_with("/tmp/qfit.gpkg")
         dock._mark_atlas_export_stale.assert_called_once_with()
         dock._set_status.assert_called_once()
+        self.assertIn(
+            "Stopped route GPX enrichment early",
+            dock._set_status.call_args.args[0],
+        )
 
     def test_handle_route_sync_task_finished_reports_missing_result_path(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_route_sync_task.py
+++ b/tests/test_route_sync_task.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import unittest
+from dataclasses import dataclass
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -34,6 +35,12 @@ from qfit.providers.domain import ProviderError  # noqa: E402
 
 route_sync_task_module = importlib.reload(route_sync_task_module)
 RouteSyncTask = route_sync_task_module.RouteSyncTask
+
+
+@dataclass(frozen=True)
+class _FrozenRoute:
+    source_route_id: str
+    details_json: object | None = None
 
 if _ORIGINAL_QGIS is not None:
     sys.modules["qgis"] = _ORIGINAL_QGIS
@@ -175,6 +182,138 @@ class RouteSyncTaskTests(unittest.TestCase):
         self.assertTrue(task.run())
         provider.fetch_route_detail.assert_not_called()
         self.assertEqual(writer.write_routes.call_args.args[0], [route])
+
+    def test_pauses_gpx_enrichment_when_rate_limit_headroom_is_low(self):
+        routes = [
+            SimpleNamespace(source_route_id="42", details_json={}),
+            SimpleNamespace(source_route_id="43", details_json={}),
+        ]
+        provider = MagicMock()
+        provider.source_name = "strava"
+        provider.last_fetch_notice = None
+        provider.last_rate_limit = {
+            "short_limit": 200,
+            "short_remaining": 99,
+            "long_limit": 2000,
+            "long_remaining": 1797,
+        }
+        provider.fetch_routes.return_value = routes
+        writer = MagicMock()
+        writer.write_routes.return_value = {"path": "/tmp/routes.gpkg", "sync": None}
+
+        task = RouteSyncTask(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            writer_factory=MagicMock(return_value=writer),
+        )
+
+        self.assertTrue(task.run())
+        provider.fetch_route_detail.assert_not_called()
+        written_routes = writer.write_routes.call_args.args[0]
+        metadata = writer.write_routes.call_args.kwargs["sync_metadata"]
+        self.assertEqual(written_routes, routes)
+        self.assertEqual(
+            [route.details_json["gpx_geometry_status"] for route in written_routes],
+            ["skipped_rate_limit", "skipped_rate_limit"],
+        )
+        self.assertFalse(metadata["is_full_sync"])
+        self.assertIn("preserve Strava API headroom", metadata["fetch_notice"])
+        self.assertIn("fetch_notice", task._result)
+
+    def test_combines_route_list_and_gpx_rate_limit_notices(self):
+        route = SimpleNamespace(source_route_id="42", details_json={})
+        provider = MagicMock()
+        provider.source_name = "strava"
+        provider.last_fetch_notice = "Stopped early while fetching Strava routes."
+        provider.last_rate_limit = {
+            "short_limit": 200,
+            "short_remaining": 99,
+            "long_limit": 2000,
+            "long_remaining": 1797,
+        }
+        provider.fetch_routes.return_value = [route]
+        writer = MagicMock()
+        writer.write_routes.return_value = {"path": "/tmp/routes.gpkg", "sync": None}
+
+        task = RouteSyncTask(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            writer_factory=MagicMock(return_value=writer),
+        )
+
+        self.assertTrue(task.run())
+        metadata = writer.write_routes.call_args.kwargs["sync_metadata"]
+        self.assertIn("Stopped early while fetching Strava routes", metadata["fetch_notice"])
+        self.assertIn("preserve Strava API headroom", metadata["fetch_notice"])
+
+    def test_rate_limit_during_gpx_enrichment_writes_partial_routes(self):
+        first_route = SimpleNamespace(source_route_id="42", details_json={})
+        second_route = SimpleNamespace(source_route_id="43", details_json={})
+        detailed_route = SimpleNamespace(
+            source_route_id="42",
+            details_json={"gpx_geometry_status": "downloaded"},
+        )
+        provider = MagicMock()
+        provider.source_name = "strava"
+        provider.last_fetch_notice = None
+        provider.last_rate_limit = {
+            "short_limit": 200,
+            "short_remaining": 150,
+            "long_limit": 2000,
+            "long_remaining": 1800,
+        }
+        provider.fetch_routes.return_value = [first_route, second_route]
+        provider.fetch_route_detail.side_effect = [
+            detailed_route,
+            ProviderError(
+                "Fetching Strava route 43 GPX hit the Strava rate limit",
+                is_rate_limit=True,
+            ),
+        ]
+        writer = MagicMock()
+        writer.write_routes.return_value = {"path": "/tmp/routes.gpkg", "sync": None}
+
+        task = RouteSyncTask(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            writer_factory=MagicMock(return_value=writer),
+        )
+
+        self.assertTrue(task.run())
+        self.assertEqual(provider.fetch_route_detail.call_count, 2)
+        written_routes = writer.write_routes.call_args.args[0]
+        metadata = writer.write_routes.call_args.kwargs["sync_metadata"]
+        self.assertEqual(written_routes[0], detailed_route)
+        self.assertEqual(written_routes[1], second_route)
+        self.assertEqual(second_route.details_json["gpx_geometry_status"], "skipped_rate_limit")
+        self.assertFalse(metadata["is_full_sync"])
+        self.assertIn("Last Strava response", metadata["fetch_notice"])
+
+    def test_rate_limit_skip_marks_frozen_route_replacement(self):
+        route = _FrozenRoute(source_route_id="42", details_json=None)
+        provider = MagicMock()
+        provider.source_name = "strava"
+        provider.last_fetch_notice = None
+        provider.last_rate_limit = {
+            "short_limit": 200,
+            "short_remaining": 99,
+            "long_limit": 2000,
+            "long_remaining": 1797,
+        }
+        provider.fetch_routes.return_value = [route]
+        writer = MagicMock()
+        writer.write_routes.return_value = {"path": "/tmp/routes.gpkg", "sync": None}
+
+        task = RouteSyncTask(
+            provider=provider,
+            output_path="/tmp/routes.gpkg",
+            writer_factory=MagicMock(return_value=writer),
+        )
+
+        self.assertTrue(task.run())
+        written_route = writer.write_routes.call_args.args[0][0]
+        self.assertIsNot(written_route, route)
+        self.assertEqual(written_route.details_json["gpx_geometry_status"], "skipped_rate_limit")
 
 
 if __name__ == "__main__":

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -805,8 +805,10 @@ class StravaClientTests(unittest.TestCase):
         http_error = requests.HTTPError(response=response)
 
         with patch.object(client.session, "request", side_effect=http_error):
-            with self.assertRaisesRegex(StravaClientError, "Strava rate limit"):
+            with self.assertRaisesRegex(StravaClientError, "Strava rate limit") as ctx:
                 client._request_json("https://example.test", operation="Fetching Strava activities page 62")
+
+        self.assertTrue(ctx.exception.is_rate_limit)
 
 
 if __name__ == "__main__":

--- a/tests/test_strava_provider.py
+++ b/tests/test_strava_provider.py
@@ -117,6 +117,20 @@ class TestStravaProviderFetchRoutes(unittest.TestCase):
 
         self.assertIn("bad route", str(ctx.exception))
 
+    def test_fetch_route_detail_preserves_rate_limit_error_flag(self):
+        from qfit.providers.infrastructure.strava_client import StravaClientError
+
+        provider = self._make_provider()
+        provider._client.fetch_route_detail.side_effect = StravaClientError(
+            "too many requests",
+            is_rate_limit=True,
+        )
+
+        with self.assertRaises(ProviderError) as ctx:
+            provider.fetch_route_detail(42)
+
+        self.assertTrue(ctx.exception.is_rate_limit)
+
 
 class TestStravaProviderProperties(unittest.TestCase):
     """last_stream_enrichment_stats and last_rate_limit proxy to the client."""


### PR DESCRIPTION
## Summary

- stops saved-route GPX/detail enrichment before Strava route sync spends into reserved API headroom
- treats route GPX rate-limit errors as a partial-success stop instead of failing the whole route sync
- surfaces the early-stop notice in route sync status and metadata so the user knows summary routes were stored but GPX enrichment paused

## Tests

- `python3 -m pytest tests/test_route_sync_task.py tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
