### PR TITLE
Tighten Data page action copy

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -173,7 +173,7 @@ def _route_layer_load_status(
         )
     ):
         return (
-            "No saved route layers found; use Data → Sync saved routes to GeoPackage "
+            "No saved route layers found; use Data → Sync saved routes "
             "before loading planned routes."
         )
     tracks = _safe_feature_count(route_tracks_layer)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1499,7 +1499,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if button is None:
             return
         button.setText(
-            "Cancel route sync" if running else "Sync saved routes to GeoPackage"
+            "Cancel route sync" if running else "Sync saved routes"
         )
         button.setEnabled(True)
         self.exchangeCodeButton.setEnabled(not running)

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -411,7 +411,7 @@
            <item>
             <widget class="QPushButton" name="syncRoutesButton">
              <property name="text">
-              <string>Sync saved routes to GeoPackage</string>
+              <string>Sync saved routes</string>
              </property>
              <property name="toolTip">
               <string>Fetch saved/planned Strava routes, write route_catalog layers to the GeoPackage, and load them as dedicated route layers.</string>

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -125,7 +125,7 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
         )
 
         self.assertIn("No saved route layers found", result.status)
-        self.assertIn("Sync saved routes to GeoPackage", result.status)
+        self.assertIn("Sync saved routes", result.status)
 
     def test_load_existing_route_status_tolerates_uncountable_route_layers(self):
         class BrokenFeatureCountLayer:

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2008,7 +2008,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.perPageSpinBox = _FakeSpinBox(100)
         dock.maxPagesSpinBox = _FakeSpinBox(0)
         dock.cache = "cache"
-        dock.syncRoutesButton = _FakeButton("Sync saved routes to GeoPackage")
+        dock.syncRoutesButton = _FakeButton("Sync saved routes")
         dock.exchangeCodeButton = _FakeButton("Exchange")
         dock.openAuthorizeButton = _FakeButton("Authorize")
         dock._set_status = MagicMock()
@@ -2101,7 +2101,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.runtime_state.route_points_layer, route_layers[1])
         self.assertEqual(dock.runtime_state.route_profile_samples_layer, route_layers[2])
         self.assertEqual(
-            dock.syncRoutesButton.text(), "Sync saved routes to GeoPackage"
+            dock.syncRoutesButton.text(), "Sync saved routes"
         )
         self.assertTrue(dock.exchangeCodeButton.isEnabled())
         self.assertTrue(dock.openAuthorizeButton.isEnabled())

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -243,7 +243,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock._local_first_live_shell.current_key(), "data")
             self.assertEqual(
                 dock._local_first_dock_composition.sync_content.clear_button.text(),
-                "Clear database…",
+                "Clear local database…",
             )
             self.assertTrue(dock.scrollArea.isHidden())
             self.assertTrue(dock.summaryStatusLabel.isHidden())

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -61,7 +61,7 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.sync_button.toolTip(), "")
         self.assertEqual(content.load_button.objectName(), "qfitWizardSyncLoadButton")
-        self.assertEqual(content.load_button.text(), "Load GeoPackage")
+        self.assertEqual(content.load_button.text(), "Load activity layers")
         self.assertEqual(
             content.load_button.property("secondaryAction"),
             "load_activities",
@@ -74,14 +74,14 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertEqual(
             content.load_button.toolTip(),
-            "Select an existing GeoPackage before loading local data.",
+            "Select an existing GeoPackage before loading activity layers.",
         )
         self.assertEqual(
             content.routes_button.objectName(),
             "qfitWizardSyncRoutesButton",
         )
         self.assertEqual(
-            content.routes_button.text(), "Sync saved routes to GeoPackage"
+            content.routes_button.text(), "Sync saved routes"
         )
         self.assertEqual(
             content.routes_button.property("secondaryAction"),
@@ -97,7 +97,7 @@ class SyncPageContentTest(unittest.TestCase):
             content.clear_button.objectName(),
             "qfitWizardSyncClearDatabaseButton",
         )
-        self.assertEqual(content.clear_button.text(), "Clear database…")
+        self.assertEqual(content.clear_button.text(), "Clear local database…")
         self.assertEqual(
             content.clear_button.property("secondaryAction"),
             "clear_database",

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -460,7 +460,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
         self.assertTrue(assembled.sync_content.sync_button.isEnabled())
         self.assertTrue(assembled.sync_content.load_button.isEnabled())
-        self.assertEqual(assembled.sync_content.load_button.text(), "Load GeoPackage")
+        self.assertEqual(assembled.sync_content.load_button.text(), "Load activity layers")
         self.assertEqual(
             assembled.map_content.status_label.text(),
             "Stored activities ready to load",

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -40,20 +40,20 @@ class SyncPageState:
 
     ready: bool = False
     status_text: str = "Activities not synced yet"
-    detail_text: str = "Sync Strava activities or load an existing GeoPackage."
+    detail_text: str = "Sync Strava activities or load activity layers from an existing GeoPackage."
     activity_summary_text: str = "No activities stored"
     primary_action_label: str = "Sync activities"
     primary_action_enabled: bool = True
-    primary_action_blocked_tooltip: str = "Configure the Strava connection before syncing."
-    local_action_label: str = "Load GeoPackage"
+    primary_action_blocked_tooltip: str = "Configure the Strava connection before syncing activities."
+    local_action_label: str = "Load activity layers"
     local_action_enabled: bool = False
-    local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading local data."
-    routes_action_label: str = "Sync saved routes to GeoPackage"
+    local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading activity layers."
+    routes_action_label: str = "Sync saved routes"
     routes_action_enabled: bool = True
     routes_action_blocked_tooltip: str = (
         "Configure the Strava connection before syncing saved routes."
     )
-    clear_action_label: str = "Clear database…"
+    clear_action_label: str = "Clear local database…"
     clear_action_enabled: bool = False
     clear_action_blocked_tooltip: str = "Select a GeoPackage before clearing local data."
 


### PR DESCRIPTION
## Summary

- tightens Data page action labels to match `docs/design-system.md` verb/object guidance
- keeps GeoPackage-specific details in helper copy/tooltips instead of overloading button labels
- updates reusable Sync page, dockwidget, and load-workflow tests for the new action copy

Refs #776.

## Tests

- `python3 -m pytest tests/test_sync_page.py tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_load_workflow.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
