### PR TITLE
Align Analysis page action ordering

### DIFF
--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -103,10 +103,10 @@ class AnalysisPageContentTest(unittest.TestCase):
                 content.status_label,
                 content.detail_label,
                 content.input_summary_label,
-                content.result_summary_label,
                 content.analysis_mode_label,
                 content.analysis_mode_combo,
                 content.action_row,
+                content.result_summary_label,
             ],
         )
 

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -157,10 +157,10 @@ class AnalysisPageContent(QWidget):
             self.status_label,
             self.detail_label,
             self.input_summary_label,
-            self.result_summary_label,
             self.analysis_mode_label,
             self.analysis_mode_combo,
             self.action_row,
+            self.result_summary_label,
         ):
             layout.addWidget(widget)
         return layout


### PR DESCRIPTION
## Summary

- moves the Analysis result summary below the mode selector and `Run analysis` action
- keeps analysis prerequisites/parameters before the primary action, matching `docs/design-system.md`
- updates the reusable Analysis page layout test for the new ordering

Refs #776.

## Tests

- `python3 -m pytest tests/test_analysis_page.py tests/test_wizard_shell_composition.py tests/test_local_first_composition.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
