### PR TITLE
Align Atlas page action ordering

### DIFF
--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -110,8 +110,8 @@ class AtlasPageContentTest(unittest.TestCase):
                 content.subtitle_label,
                 content.subtitle_line_edit,
                 content.input_summary_label,
-                content.output_summary_label,
                 content.action_row,
+                content.output_summary_label,
             ],
         )
 

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -175,8 +175,8 @@ class AtlasPageContent(QWidget):
             self.subtitle_label,
             self.subtitle_line_edit,
             self.input_summary_label,
-            self.output_summary_label,
             self.action_row,
+            self.output_summary_label,
         ):
             layout.addWidget(widget)
         return layout


### PR DESCRIPTION
## Summary

- moves the Atlas output summary below the `Export atlas PDF` action
- keeps document settings and export prerequisites before the primary action, matching `docs/design-system.md`
- updates the reusable Atlas page layout test for the new ordering

Refs #776.

## Tests

- `python3 -m pytest tests/test_atlas_page.py tests/test_wizard_shell_composition.py tests/test_local_first_composition.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
