### PR TITLE
Clarify Settings page copy

### DIFF
--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -61,6 +61,15 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             composition.connection_content,
             composition.page_content.settings_content,
         )
+        self.assertEqual(
+            composition.connection_content.detail_label.text(),
+            "Review provider credentials and durable qfit preferences away from "
+            "daily workflow panels.",
+        )
+        self.assertEqual(
+            composition.connection_content.configure_button.text(),
+            "Configure settings",
+        )
 
     def test_data_page_is_local_first_and_navigation_is_not_step_locked(self):
         composition = self.module.build_local_first_dock_composition(
@@ -162,6 +171,15 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         self.assertEqual(composition.sync_content.status_label.text(), "Activities stored")
         self.assertEqual(composition.map_content.status_label.text(), "Activity layers loaded")
         self.assertEqual(composition.connection_content.status_label.text(), "Strava connected")
+        self.assertEqual(
+            composition.connection_content.detail_label.text(),
+            "Review provider credentials and durable qfit preferences away from "
+            "daily workflow panels.",
+        )
+        self.assertEqual(
+            composition.connection_content.configure_button.text(),
+            "Review settings",
+        )
 
     def test_refresh_preserves_current_page_without_explicit_preference(self):
         composition = self.module.build_local_first_dock_composition(

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -43,6 +43,7 @@ class ConnectionPageState:
     """
 
     connected: bool = False
+    connection_configured: bool = False
     status_text: str = "Strava not connected"
     detail_text: str = "Configure qfit once, then continue to synchronization."
     credential_summary_text: str = "No Strava credentials configured"

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -10,7 +10,11 @@ from qfit.ui.application.wizard_progress import WizardProgressFacts
 from ._qt_compat import import_qt_module
 from .analysis_page import AnalysisPageContent, build_analysis_page_content
 from .atlas_page import AtlasPageContent, build_atlas_page_content
-from .connection_page import ConnectionPageContent, build_connection_page_content
+from .connection_page import (
+    ConnectionPageContent,
+    ConnectionPageState,
+    build_connection_page_content,
+)
 from .local_first_shell import LocalFirstDockShell
 from .map_page import MapPageContent, build_map_page_content
 from .sync_page import SyncPageContent, build_sync_page_content
@@ -188,7 +192,9 @@ def refresh_local_first_dock_composition(
     composition.map_content.set_state(page_states.map_state)
     composition.analysis_content.set_state(page_states.analysis_state)
     composition.atlas_content.set_state(page_states.atlas_state)
-    composition.connection_content.set_state(page_states.connection_state)
+    composition.connection_content.set_state(
+        _settings_state_from_connection_state(page_states.connection_state)
+    )
     return composition
 
 
@@ -236,7 +242,7 @@ def _install_local_first_page_content(
     )
     settings_content = build_connection_page_content(
         parent=pages["settings"],
-        state=page_states.connection_state,
+        state=_settings_state_from_connection_state(page_states.connection_state),
     )
     _page_layout(pages["data"]).addWidget(data_content)
     _page_layout(pages["map"]).addWidget(map_content)
@@ -249,6 +255,31 @@ def _install_local_first_page_content(
         analysis_content=analysis_content,
         atlas_content=atlas_content,
         settings_content=settings_content,
+    )
+
+
+def _settings_state_from_connection_state(
+    state: ConnectionPageState,
+) -> ConnectionPageState:
+    """Adapt reusable connection controls for the local-first Settings page."""
+
+    settings_action_label = (
+        "Review settings"
+        if state.connection_configured
+        else "Configure settings"
+    )
+    return ConnectionPageState(
+        connected=state.connected,
+        connection_configured=state.connection_configured,
+        status_text=state.status_text,
+        detail_text=(
+            "Review provider credentials and durable qfit preferences away from "
+            "daily workflow panels."
+        ),
+        credential_summary_text=state.credential_summary_text,
+        primary_action_label=settings_action_label,
+        primary_action_enabled=state.primary_action_enabled,
+        primary_action_blocked_tooltip=state.primary_action_blocked_tooltip,
     )
 
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -540,6 +540,7 @@ def _connection_state_from_facts(facts: WizardProgressFacts) -> ConnectionPageSt
     if facts.connection_configured:
         return ConnectionPageState(
             connected=True,
+            connection_configured=True,
             status_text="Strava connected",
             detail_text="Connection is configured; continue to synchronization.",
             credential_summary_text="Strava OAuth credentials are stored in qfit settings",


### PR DESCRIPTION
## Summary

- adapts the reused connection content for the local-first Settings page with Settings-specific helper copy
- tracks provider-connection readiness explicitly instead of coupling Settings labels to status text
- updates local-first composition tests for initial and refreshed Settings states

Refs #776.

## Tests

- `python3 -m pytest tests/test_connection_page.py tests/test_local_first_composition.py tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
