### PR TITLE
Fold activity storage into sync flow

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1392,12 +1392,23 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if result.preview_result is not None:
             self.querySummaryLabel.setText(result.preview_result.query_summary_text)
             self.activityPreviewPlainTextEdit.setPlainText(result.preview_result.preview_text)
+        if result.activities:
+            store_started = self._start_store_activities(
+                status_text="Storing fetched activities…"
+            )
+            if store_started:
+                return
+            if store_started is None:
+                return
         self._set_status(result.status_text)
 
     def on_load_clicked(self):
+        self._start_store_activities(status_text="Store started...")
+
+    def _start_store_activities(self, *, status_text):
         if self._store_task is not None:
             self._set_status("Store already in progress...")
-            return
+            return None
 
         self._save_settings()
         workflow = self._store_activities_workflow()
@@ -1412,13 +1423,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
         except LoadWorkflowError as exc:
             self._show_error("Missing input", str(exc))
-            return
+            return False
         except (RuntimeError, OSError, ValueError) as exc:
             _msg = "GeoPackage export failed"
             logger.exception(_msg)
             self._show_error(_msg, str(exc))
             self._set_status(_msg)
-            return
+            return None
 
         store_task = build_store_task(
             workflow,
@@ -1428,8 +1439,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._runtime_store().begin_store(store_task)
         self.loadButton.setEnabled(False)
         self.loadButton.setText("Store in progress...")
-        self._set_status("Store started...")
+        self._set_status(status_text)
         QgsApplication.taskManager().addTask(store_task)
+        return True
 
     def _handle_store_task_finished(self, result, error_message, cancelled):
         self._runtime_store().clear_store()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2245,6 +2245,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.querySummaryLabel = SimpleNamespace(setText=MagicMock())
         dock.activityPreviewPlainTextEdit = SimpleNamespace(setPlainText=MagicMock())
         dock._set_status = MagicMock()
+        dock._start_store_activities = MagicMock(return_value=True)
         result = SimpleNamespace(
             cancelled=False,
             error_message=None,
@@ -2272,7 +2273,174 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.countLabel.text(), "Activities fetched: 1")
         dock.querySummaryLabel.setText.assert_called_once_with("1 activity")
         dock.activityPreviewPlainTextEdit.setPlainText.assert_called_once_with("Morning Run")
+        dock._start_store_activities.assert_called_once_with(
+            status_text="Storing fetched activities…"
+        )
+        dock._set_status.assert_not_called()
+
+    def test_on_fetch_finished_reports_status_without_auto_store_when_no_activities(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._fetch_task = object()
+        dock._set_fetch_running = MagicMock()
+        dock.activityTypeComboBox = _FakeComboBox(current_text="All")
+        dock._current_activity_preview_request = MagicMock(return_value=None)
+        dock.activity_workflow = MagicMock()
+        dock.settings = _FakeSettings()
+        dock._apply_activity_type_options = MagicMock()
+        dock.countLabel = _FakeLabel("")
+        dock.querySummaryLabel = SimpleNamespace(setText=MagicMock())
+        dock.activityPreviewPlainTextEdit = SimpleNamespace(setPlainText=MagicMock())
+        dock._set_status = MagicMock()
+        dock._start_store_activities = MagicMock(return_value=True)
+        result = SimpleNamespace(
+            cancelled=False,
+            error_message=None,
+            activities=[],
+            metadata={"provider": "strava"},
+            today_str="2026-04-16",
+            activity_type_options=None,
+            count_label_text="Activities fetched: 0",
+            preview_result=None,
+            status_text="Fetched 0 activities",
+        )
+        dock.activity_workflow.build_fetch_completion_result.return_value = result
+
+        self.module.QfitDockWidget._on_fetch_finished(dock, [], None, False, object())
+
+        dock._start_store_activities.assert_not_called()
+        dock._set_status.assert_called_once_with("Fetched 0 activities")
+
+    def test_on_fetch_finished_reports_fetch_status_when_auto_store_cannot_start(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._fetch_task = object()
+        dock._set_fetch_running = MagicMock()
+        dock.activityTypeComboBox = _FakeComboBox(current_text="All")
+        dock._current_activity_preview_request = MagicMock(return_value=None)
+        dock.activity_workflow = MagicMock()
+        dock.settings = _FakeSettings()
+        dock._apply_activity_type_options = MagicMock()
+        dock.countLabel = _FakeLabel("")
+        dock.querySummaryLabel = SimpleNamespace(setText=MagicMock())
+        dock.activityPreviewPlainTextEdit = SimpleNamespace(setPlainText=MagicMock())
+        dock._set_status = MagicMock()
+        dock._start_store_activities = MagicMock(return_value=False)
+        result = SimpleNamespace(
+            cancelled=False,
+            error_message=None,
+            activities=[{"id": 1}],
+            metadata={"provider": "strava"},
+            today_str="2026-04-16",
+            activity_type_options=None,
+            count_label_text="Activities fetched: 1",
+            preview_result=None,
+            status_text="Fetched 1 activity",
+        )
+        dock.activity_workflow.build_fetch_completion_result.return_value = result
+
+        self.module.QfitDockWidget._on_fetch_finished(dock, [{"id": 1}], None, False, object())
+
+        dock._start_store_activities.assert_called_once_with(
+            status_text="Storing fetched activities…"
+        )
         dock._set_status.assert_called_once_with("Fetched 1 activity")
+
+    def test_on_fetch_finished_keeps_store_failure_status_when_auto_store_handles_error(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._fetch_task = object()
+        dock._set_fetch_running = MagicMock()
+        dock.activityTypeComboBox = _FakeComboBox(current_text="All")
+        dock._current_activity_preview_request = MagicMock(return_value=None)
+        dock.activity_workflow = MagicMock()
+        dock.settings = _FakeSettings()
+        dock._apply_activity_type_options = MagicMock()
+        dock.countLabel = _FakeLabel("")
+        dock.querySummaryLabel = SimpleNamespace(setText=MagicMock())
+        dock.activityPreviewPlainTextEdit = SimpleNamespace(setPlainText=MagicMock())
+        dock._set_status = MagicMock()
+        dock._start_store_activities = MagicMock(return_value=None)
+        result = SimpleNamespace(
+            cancelled=False,
+            error_message=None,
+            activities=[{"id": 1}],
+            metadata={"provider": "strava"},
+            today_str="2026-04-16",
+            activity_type_options=None,
+            count_label_text="Activities fetched: 1",
+            preview_result=None,
+            status_text="Fetched 1 activity",
+        )
+        dock.activity_workflow.build_fetch_completion_result.return_value = result
+
+        self.module.QfitDockWidget._on_fetch_finished(dock, [{"id": 1}], None, False, object())
+
+        dock._start_store_activities.assert_called_once_with(
+            status_text="Storing fetched activities…"
+        )
+        dock._set_status.assert_not_called()
+
+    def test_start_store_activities_reports_already_running_task(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._store_task = object()
+        dock._set_status = MagicMock()
+
+        started = self.module.QfitDockWidget._start_store_activities(
+            dock,
+            status_text="Storing fetched activities…",
+        )
+
+        self.assertIsNone(started)
+        dock._set_status.assert_called_once_with("Store already in progress...")
+
+    def test_start_store_activities_returns_false_for_missing_input(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._store_task = None
+        dock._save_settings = MagicMock()
+        dock.activities = []
+        dock.outputPathLineEdit = _FakeLineEdit("")
+        dock.writeActivityPointsCheckBox = _FakeCheckBox(True)
+        dock.pointSamplingStrideSpinBox = _FakeSpinBox(2)
+        dock.last_fetch_context = {"provider": "strava"}
+        dock.settings = _FakeSettings()
+        dock.load_workflow = MagicMock()
+        dock.load_workflow.build_write_request.side_effect = self.module.LoadWorkflowError(
+            "Choose a GeoPackage output path first."
+        )
+        dock._show_error = MagicMock()
+
+        started = self.module.QfitDockWidget._start_store_activities(
+            dock,
+            status_text="Storing fetched activities…",
+        )
+
+        self.assertFalse(started)
+        dock._show_error.assert_called_once_with(
+            "Missing input",
+            "Choose a GeoPackage output path first.",
+        )
+
+    def test_start_store_activities_returns_false_for_write_request_error(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._store_task = None
+        dock._save_settings = MagicMock()
+        dock.activities = [{"id": 1}]
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock.writeActivityPointsCheckBox = _FakeCheckBox(True)
+        dock.pointSamplingStrideSpinBox = _FakeSpinBox(2)
+        dock.last_fetch_context = {"provider": "strava"}
+        dock.settings = _FakeSettings()
+        dock.load_workflow = MagicMock()
+        dock.load_workflow.build_write_request.side_effect = RuntimeError("database locked")
+        dock._show_error = MagicMock()
+        dock._set_status = MagicMock()
+
+        started = self.module.QfitDockWidget._start_store_activities(
+            dock,
+            status_text="Storing fetched activities…",
+        )
+
+        self.assertIsNone(started)
+        dock._show_error.assert_called_once_with("GeoPackage export failed", "database locked")
+        dock._set_status.assert_called_once_with("GeoPackage export failed")
 
     def test_on_load_layers_clicked_updates_runtime_state_from_result(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -633,7 +633,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             "Wait for the current synchronization to finish.",
         )
 
-    def test_sync_page_shows_fetched_activities_ready_to_store(self):
+    def test_sync_page_shows_fetched_activities_ready_to_finish_sync(self):
         facts = self.composition.WizardProgressFacts(
             connection_configured=True,
             activities_fetched=True,
@@ -646,20 +646,48 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities fetched")
         self.assertEqual(
             assembled.sync_content.detail_label.text(),
-            "Store fetched activities in the GeoPackage to complete synchronization.",
+            "Finish synchronization to persist fetched activities in the GeoPackage.",
         )
         self.assertEqual(
             assembled.sync_content.activity_summary_label.text(),
-            "3 fetched activities ready to store",
+            "3 fetched activities ready to finish sync",
         )
         self.assertEqual(
             assembled.sync_content.sync_button.text(),
-            "Store fetched activities",
+            "Finish activity sync",
         )
         self.assertTrue(assembled.sync_content.sync_button.isEnabled())
         self.assertIn(
-            "3 fetched activities ready to store",
+            "3 fetched activities ready to finish sync",
             assembled.shell.footer_bar.text(),
+        )
+
+    def test_sync_page_describes_unknown_fetched_activity_count(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_fetched=True,
+            fetched_activity_count=None,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "Fetched activities ready to finish sync",
+        )
+
+    def test_sync_page_uses_singular_fetched_activity_summary(self):
+        facts = self.composition.WizardProgressFacts(
+            connection_configured=True,
+            activities_fetched=True,
+            fetched_activity_count=1,
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "1 fetched activity ready to finish sync",
         )
 
     def test_sync_page_prioritizes_pending_fetch_over_existing_stored_dataset(self):
@@ -676,7 +704,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities fetched")
         self.assertEqual(
             assembled.sync_content.sync_button.text(),
-            "Store fetched activities",
+            "Finish activity sync",
         )
 
     def test_map_page_summary_names_stored_output_before_layers_load(self):

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -571,7 +571,7 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
     if facts.activities_fetched:
         status_text = "Activities fetched"
         detail_text = (
-            "Store fetched activities in the GeoPackage to complete synchronization."
+            "Finish synchronization to persist fetched activities in the GeoPackage."
         )
     elif facts.activities_stored:
         status_text = "Activities stored"
@@ -584,7 +584,7 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
     primary_action_label = default.primary_action_label
     routes_action_label = default.routes_action_label
     if facts.activities_fetched:
-        primary_action_label = "Store fetched activities"
+        primary_action_label = "Finish activity sync"
     if facts.route_sync_in_progress:
         routes_action_label = "Cancel route sync"
     if facts.sync_in_progress:
@@ -691,9 +691,9 @@ def _stored_activity_summary(facts: WizardProgressFacts) -> str:
 
 def _fetched_activity_summary(facts: WizardProgressFacts) -> str:
     if facts.fetched_activity_count is None:
-        return "Fetched activities ready to store"
+        return "Fetched activities ready to finish sync"
     noun = "activity" if facts.fetched_activity_count == 1 else "activities"
-    return f"{max(facts.fetched_activity_count, 0)} fetched {noun} ready to store"
+    return f"{max(facts.fetched_activity_count, 0)} fetched {noun} ready to finish sync"
 
 
 def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:


### PR DESCRIPTION
## Summary

- automatically start the GeoPackage store task after a successful activity fetch
- keep fetched activity state as a recovery path with `Finish activity sync` copy instead of `Store fetched activities`
- preserve the existing manual store task path while normal `Sync activities` now fetches and persists in one flow

Closes #783.

## Tests

- `python3 -m pytest tests/ -x -q --tb=short`
