### PR TITLE
Rename stored map layer load action

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -129,7 +129,7 @@ def _build_store_database_status(result: StoreActivitiesResult) -> str:
         "Synced {fetched} fetched activities into GeoPackage: "
         "inserted {inserted}, updated {updated}, unchanged {unchanged}, "
         "stored total {total}. GeoPackage updated at {path}. "
-        "Use Load activity layers in Visualize when you want the stored data in QGIS."
+        "Use Load stored map layers in Visualize when you want the stored data in QGIS."
     ).format(
         fetched=result.fetched_count,
         inserted=result.sync.inserted if result.sync else 0,

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -53,7 +53,7 @@ Best practices:
 - Each page or section should have at most one primary action.
 - Secondary actions should support the primary flow without competing with it.
 - Destructive actions must be visually and textually distinct, and should require confirmation when data loss is possible.
-- Button labels should be verbs plus objects: `Load activity layers`, `Apply filters`, `Export atlas PDF`.
+- Button labels should be verbs plus objects: `Load stored map layers`, `Apply filters`, `Export atlas PDF`.
 - Avoid vague labels such as `Run`, `OK`, `Process`, or `Submit` unless the surrounding context makes the action unambiguous.
 
 ### 1.5 Prefer explicit state over surprise behavior
@@ -156,7 +156,7 @@ Button rules:
 - Use one primary action per workflow section.
 - Use specific action labels:
   - `Sync activities`
-  - `Load activity layers`
+  - `Load stored map layers`
   - `Apply filters`
   - `Run analysis`
   - `Export atlas PDF`
@@ -173,7 +173,7 @@ Rules:
 - Do not add a show/hide filters control.
 - Filter fields appear before filter actions.
 - The Map panel action row appears below the filter fields.
-- `Load activity layers` is a preparation action.
+- `Load stored map layers` is a preparation action.
 - `Apply filters` is the primary filter action.
 - Basemap and style configuration should stay visually distinct from activity filters.
 - Filter summaries should describe the active subset, not replace the fields.
@@ -184,7 +184,7 @@ Recommended Map panel order:
 2. Basemap configuration.
 3. Style configuration.
 4. Filter configuration.
-5. `Load activity layers` / `Apply filters` actions.
+5. `Load stored map layers` / `Apply filters` actions.
 6. Filter or layer result status.
 
 ### 2.6 Data panel rules
@@ -259,7 +259,7 @@ Examples:
 
 - No credentials: prompt users to configure Strava in Settings.
 - No stored activities: prompt users to sync or import data.
-- No loaded layers: prompt users to load activity layers before filtering.
+- No loaded layers: prompt users to load stored map layers before filtering.
 - No atlas pages: explain which data or configuration is required before export.
 
 Disabled actions should not feel broken. Pair disabled state with tooltip or nearby helper text that names the prerequisite.

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1599,7 +1599,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._show_error("GeoPackage not found", str(exc))
             return
         except (RuntimeError, OSError) as exc:
-            _msg = "Load activity layers failed"
+            _msg = "Load stored map layers failed"
             logger.exception(_msg)
             self._show_error(_msg, str(exc))
             self._set_status(_msg)

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -67,7 +67,7 @@ class StoreActivitiesWorkflowTests(unittest.TestCase):
         self.assertIsInstance(result, StoreActivitiesResult)
         self.assertEqual(result.output_path, "/tmp/out.gpkg")
         self.assertEqual(result.total_stored, 7)
-        self.assertIn("Use Load activity layers in Visualize", result.status)
+        self.assertIn("Use Load stored map layers in Visualize", result.status)
 
 
 class LoadDatasetWorkflowTests(unittest.TestCase):
@@ -419,7 +419,7 @@ class WriteDatabaseSuccessTests(unittest.TestCase):
         self.assertEqual(result.output_path, "/tmp/out.gpkg")
         self.assertEqual(result.total_stored, 8)
         self.assertIsNone(result.activities_layer)
-        self.assertIn("Use Load activity layers in Visualize", result.status)
+        self.assertIn("Use Load stored map layers in Visualize", result.status)
 
 
 class LoadExistingValidationTests(unittest.TestCase):

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -169,7 +169,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         self.assertEqual(composition.shell.current_key(), "map")
         self.assertTrue(composition.shell.button_for_key("map").property("current"))
         self.assertEqual(composition.sync_content.status_label.text(), "Activities stored")
-        self.assertEqual(composition.map_content.status_label.text(), "Activity layers loaded")
+        self.assertEqual(composition.map_content.status_label.text(), "Stored map layers loaded")
         self.assertEqual(composition.connection_content.status_label.text(), "Strava connected")
         self.assertEqual(
             composition.connection_content.detail_label.text(),

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -35,7 +35,7 @@ class MapPageContentTest(unittest.TestCase):
 
         self.assertEqual(content.objectName(), "qfitWizardMapPageContent")
         self.assertEqual(content.status_label.objectName(), "qfitWizardMapStatus")
-        self.assertEqual(content.status_label.text(), "Activity layers not loaded")
+        self.assertEqual(content.status_label.text(), "Stored map layers not loaded")
         self.assertEqual(content.status_label.property("mapState"), "not_loaded")
         self.assertEqual(content.status_label.property("tone"), "warn")
         self.assertEqual(content.detail_label.objectName(), "qfitWizardMapDetail")
@@ -47,7 +47,7 @@ class MapPageContentTest(unittest.TestCase):
         )
         self.assertEqual(
             content.layer_summary_label.text(),
-            "No activity layers on the map",
+            "No stored map layers on the map",
         )
         self.assertIn(COLOR_MUTED, content.layer_summary_label.styleSheet())
         self.assertEqual(
@@ -75,7 +75,7 @@ class MapPageContentTest(unittest.TestCase):
             content.load_layers_button.objectName(),
             "qfitWizardMapLoadLayersButton",
         )
-        self.assertEqual(content.load_layers_button.text(), "Load activity layers")
+        self.assertEqual(content.load_layers_button.text(), "Load stored map layers")
         self.assertEqual(
             content.load_layers_button.property("secondaryAction"),
             "load_activity_layers",
@@ -111,7 +111,7 @@ class MapPageContentTest(unittest.TestCase):
             content.apply_filters_button.property("wizardActionAvailability"),
             "blocked",
         )
-        self.assertIn("Load activity layers", content.apply_filters_button.toolTip())
+        self.assertIn("Load stored map layers", content.apply_filters_button.toolTip())
         self.assertEqual(content.action_row.objectName(), "qfitWizardMapActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2603,7 +2603,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.generateAtlasPdfButton = _FakeButton("Generate atlas PDF")
         dock.loadButton = _FakeButton("Store activities")
-        dock.loadLayersButton = _FakeButton("Load activity layers")
+        dock.loadLayersButton = _FakeButton("Load stored map layers")
         dock.refreshButton = _FakeButton("Fetch activities")
 
         self.module.QfitDockWidget._set_atlas_export_running(dock, True)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -285,7 +285,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertFalse(dock.mapboxAccessTokenLineEdit.isVisible())
             self.assertEqual(dock.refreshButton.text(), "Fetch activities")
             self.assertEqual(dock.loadButton.text(), "Store activities")
-            self.assertEqual(dock.loadLayersButton.text(), "Load activity layers")
+            self.assertEqual(dock.loadLayersButton.text(), "Load stored map layers")
             self.assertEqual(dock.clearDatabaseButton.text(), "Clear database…")
             self.assertEqual(dock.applyFiltersButton.text(), "Apply filters")
             self.assertTrue(dock.writeActivityPointsCheckBox.isChecked())

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -61,7 +61,7 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.sync_button.toolTip(), "")
         self.assertEqual(content.load_button.objectName(), "qfitWizardSyncLoadButton")
-        self.assertEqual(content.load_button.text(), "Load activity layers")
+        self.assertEqual(content.load_button.text(), "Load stored map layers")
         self.assertEqual(
             content.load_button.property("secondaryAction"),
             "load_activities",
@@ -74,7 +74,7 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertEqual(
             content.load_button.toolTip(),
-            "Select an existing GeoPackage before loading activity layers.",
+            "Select an existing GeoPackage before loading stored map layers.",
         )
         self.assertEqual(
             content.routes_button.objectName(),

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -88,7 +88,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertEqual(
             assembled.map_content.status_label.text(),
-            "Activity layers not loaded",
+            "Stored map layers not loaded",
         )
         self.assertIsNotNone(assembled.analysis_content)
         self.assertIs(
@@ -460,17 +460,17 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
         self.assertTrue(assembled.sync_content.sync_button.isEnabled())
         self.assertTrue(assembled.sync_content.load_button.isEnabled())
-        self.assertEqual(assembled.sync_content.load_button.text(), "Load activity layers")
+        self.assertEqual(assembled.sync_content.load_button.text(), "Load stored map layers")
         self.assertEqual(
             assembled.map_content.status_label.text(),
-            "Stored activities ready to load",
+            "Stored map layers ready to load",
         )
         self.assertFalse(assembled.map_content.load_layers_button.isEnabled())
         self.assertEqual(
             assembled.map_content.load_layers_button.toolTip(),
-            "Use the primary action to load activity layers.",
+            "Use the primary action to load stored map layers.",
         )
-        self.assertEqual(assembled.map_content.apply_filters_button.text(), "Load activity layers")
+        self.assertEqual(assembled.map_content.apply_filters_button.text(), "Load stored map layers")
         self.assertTrue(assembled.map_content.filter_controls_panel.isVisible())
         self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
         self.assertEqual(
@@ -503,7 +503,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertTrue(assembled.sync_content.clear_button.isEnabled())
         self.assertEqual(
             assembled.map_content.status_label.text(),
-            "Stored activities ready to load",
+            "Stored map layers ready to load",
         )
         self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
 
@@ -718,14 +718,14 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(
             assembled.map_content.status_label.text(),
-            "Stored activities ready to load",
+            "Stored map layers ready to load",
         )
         self.assertEqual(
             assembled.map_content.layer_summary_label.text(),
-            "Stored activities in qfit.gpkg are ready to load",
+            "Stored map layers in qfit.gpkg are ready to load",
         )
         self.assertIn(
-            "Stored activities in qfit.gpkg are ready to load",
+            "Stored map layers in qfit.gpkg are ready to load",
             assembled.shell.footer_bar.text(),
         )
 
@@ -741,10 +741,10 @@ class WizardShellCompositionTest(unittest.TestCase):
 
         self.assertEqual(
             assembled.map_content.layer_summary_label.text(),
-            "Activity layers from qfit.gpkg are loaded on the map",
+            "Stored map layers from qfit.gpkg are loaded on the map",
         )
         self.assertIn(
-            "Activity layers from qfit.gpkg are loaded on the map",
+            "Stored map layers from qfit.gpkg are loaded on the map",
             assembled.shell.footer_bar.text(),
         )
 
@@ -1009,7 +1009,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.map_content.load_layers_button.isEnabled())
         self.assertEqual(
             assembled.map_content.load_layers_button.toolTip(),
-            "Sync activities before loading map layers.",
+            "Sync activities before loading stored map layers.",
         )
         self.assertFalse(assembled.analysis_content.run_analysis_button.isEnabled())
         self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
@@ -1041,7 +1041,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertEqual(
             assembled.map_content.layer_summary_label.text(),
-            "Sync activities before loading map layers",
+            "Sync activities before loading stored map layers",
         )
         self.assertEqual(
             assembled.analysis_content.status_label.text(),
@@ -1375,7 +1375,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(
             assembled.shell.footer_bar.text(),
             "Strava not connected · No activities stored · "
-            "No activity layers on the map · Analysis not run yet · "
+            "No stored map layers on the map · Analysis not run yet · "
             "Atlas PDF not exported yet",
         )
 
@@ -1537,7 +1537,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(
             assembled.shell.footer_bar.text(),
             "Strava connected · 12 activities stored · "
-            "No activity layers on the map · Analysis not run yet · "
+            "No stored map layers on the map · Analysis not run yet · "
             "Atlas PDF not exported yet",
         )
 
@@ -1628,8 +1628,8 @@ class WizardShellCompositionTest(unittest.TestCase):
         )
         self.assertEqual(assembled.connection_content.status_label.text(), "Strava connected")
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
-        self.assertEqual(assembled.map_content.status_label.text(), "Activity layers loaded")
-        self.assertEqual(assembled.map_content.load_layers_button.text(), "Reload activity layers")
+        self.assertEqual(assembled.map_content.status_label.text(), "Stored map layers loaded")
+        self.assertEqual(assembled.map_content.load_layers_button.text(), "Reload stored map layers")
         self.assertTrue(assembled.map_content.load_layers_button.isEnabled())
         self.assertEqual(assembled.map_content.apply_filters_button.text(), "Apply filters")
         self.assertTrue(assembled.map_content.apply_filters_button.isEnabled())
@@ -1746,7 +1746,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(
             assembled.shell.footer_bar.text(),
             "Strava not connected · No activities stored · "
-            "No activity layers on the map · Analysis not run yet · "
+            "No stored map layers on the map · Analysis not run yet · "
             "Atlas PDF not exported yet",
         )
         self.assertEqual(assembled.presenter.progress.current_key, "connection")

--- a/ui/application/wizard_page_specs.py
+++ b/ui/application/wizard_page_specs.py
@@ -51,7 +51,7 @@ _PAGE_COPY_BY_KEY = {
         "Primary action: sync activities; secondary action: load activities",
     ),
     "map": (
-        "Load activity layers, choose a background map, and refine filters.",
+        "Load stored map layers, choose a background map, and refine filters.",
         "Primary action: apply map filters",
     ),
     "analysis": (

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -202,7 +202,7 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
         anchor_name="loadButton",
         target_text="Store activities",
         tooltip=(
-            "Writes the full fetched result to the GeoPackage only. Use Load activity layers in Visualize when you want to "
+            "Writes the full fetched result to the GeoPackage only. Use Load stored map layers in Visualize when you want to "
             "bring the stored qfit layers into QGIS."
         ),
     ),
@@ -216,10 +216,10 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
     ),
     HelpEntry(
         anchor_name="loadLayersButton",
-        target_text="Load activity layers",
+        target_text="Load stored map layers",
         tooltip=(
-            "Loads the stored qfit layers from the GeoPackage into QGIS. Use this after storing activities or when "
-            "reopening an existing qfit database."
+            "Loads the stored qfit layers from the selected GeoPackage into QGIS. Use this after syncing activities or routes, "
+            "or when reopening an existing qfit database."
         ),
     ),
     HelpEntry(
@@ -233,7 +233,7 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
     HelpEntry(
         anchor_name="buttonLayout",
         helper_text=(
-            "Use Store activities to update the GeoPackage database. Then use Load activity layers in Visualize when you want "
+            "Use Store activities to update the GeoPackage database. Then use Load stored map layers in Visualize when you want "
             "the stored dataset in QGIS. Use Apply filters only when you want loaded layers and tables to match "
             "the current dock query."
         ),

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -39,18 +39,18 @@ class MapPageState:
     """Render facts for the #609 map-and-filters wizard page."""
 
     loaded: bool = False
-    status_text: str = "Activity layers not loaded"
-    detail_text: str = "Load stored activities, choose map context, then apply filters."
-    layer_summary_text: str = "No activity layers on the map"
+    status_text: str = "Stored map layers not loaded"
+    detail_text: str = "Load stored map layers, choose map context, then apply filters."
+    layer_summary_text: str = "No stored map layers on the map"
     background_summary_text: str = "Basemap disabled"
     style_summary_text: str = "Default activity styling"
     filter_summary_text: str = "All stored activities visible once layers are loaded"
-    load_action_label: str = "Load activity layers"
+    load_action_label: str = "Load stored map layers"
     load_action_enabled: bool = True
-    load_action_blocked_tooltip: str = "Sync activities before loading map layers."
+    load_action_blocked_tooltip: str = "Sync activities before loading stored map layers."
     primary_action_label: str = "Apply filters"
     apply_action_enabled: bool | None = None
-    apply_action_blocked_tooltip: str = "Load activity layers before applying filters."
+    apply_action_blocked_tooltip: str = "Load stored map layers before applying filters."
 
 
 class MapPageContent(QWidget):

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -40,14 +40,14 @@ class SyncPageState:
 
     ready: bool = False
     status_text: str = "Activities not synced yet"
-    detail_text: str = "Sync Strava activities or load activity layers from an existing GeoPackage."
+    detail_text: str = "Sync Strava activities or load stored map layers from an existing GeoPackage."
     activity_summary_text: str = "No activities stored"
     primary_action_label: str = "Sync activities"
     primary_action_enabled: bool = True
     primary_action_blocked_tooltip: str = "Configure the Strava connection before syncing activities."
-    local_action_label: str = "Load activity layers"
+    local_action_label: str = "Load stored map layers"
     local_action_enabled: bool = False
-    local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading activity layers."
+    local_action_blocked_tooltip: str = "Select an existing GeoPackage before loading stored map layers."
     routes_action_label: str = "Sync saved routes"
     routes_action_enabled: bool = True
     routes_action_blocked_tooltip: str = (

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -708,22 +708,22 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
         style_summary_text=_map_style_summary(facts, default),
         filter_summary_text=_map_filter_summary(facts, default),
         load_action_label=(
-            "Reload activity layers" if activity_layers_loaded else default.load_action_label
+            "Reload stored map layers" if activity_layers_loaded else default.load_action_label
         ),
         load_action_enabled=activity_layers_loaded,
         load_action_blocked_tooltip=(
-            "Use the primary action to load activity layers."
+            "Use the primary action to load stored map layers."
             if stored_without_loaded_layers
             else default.load_action_blocked_tooltip
         ),
         primary_action_label=(
-            "Load activity layers"
+            "Load stored map layers"
             if stored_without_loaded_layers
             else default.primary_action_label
         ),
         apply_action_enabled=facts.activities_stored,
         apply_action_blocked_tooltip=(
-            "Sync activities before loading map layers."
+            "Sync activities before loading stored map layers."
             if not facts.activities_stored
             else default.apply_action_blocked_tooltip
         ),
@@ -732,22 +732,22 @@ def _map_state_from_facts(facts: WizardProgressFacts) -> MapPageState:
 
 def _map_status_text(facts: WizardProgressFacts) -> str:
     if facts.activity_layers_loaded:
-        return "Activity layers loaded"
+        return "Stored map layers loaded"
     if facts.activities_stored:
-        return "Stored activities ready to load"
+        return "Stored map layers ready to load"
     return "Sync required before map loading"
 
 
 def _map_layer_summary(facts: WizardProgressFacts) -> str:
     if facts.activity_layers_loaded:
         if facts.output_name is not None:
-            return f"Activity layers from {facts.output_name} are loaded on the map"
-        return "Activity layers are loaded on the map"
+            return f"Stored map layers from {facts.output_name} are loaded on the map"
+        return "Stored map layers are loaded on the map"
     if facts.activities_stored:
         if facts.output_name is not None:
-            return f"Stored activities in {facts.output_name} are ready to load"
-        return "Stored activities are ready to load"
-    return "Sync activities before loading map layers"
+            return f"Stored map layers in {facts.output_name} are ready to load"
+        return "Stored map layers are ready to load"
+    return "Sync activities before loading stored map layers"
 
 
 def _map_background_summary(facts: WizardProgressFacts, default: MapPageState) -> str:


### PR DESCRIPTION
## Summary

- rename the Data/Map load action to `Load stored map layers`
- update Data/Map helper, tooltip, status, footer, and contextual help copy to avoid activity-only wording
- refresh design-system wording and tests for the stored-map-layer action

Closes #784.

## Tests

- `python3 -m pytest tests/ -x -q --tb=short`
