### PR TITLE
Add Qt UI enforcement skill

### DIFF
--- a/skills/qt-ui-enforcement/SKILL.md
+++ b/skills/qt-ui-enforcement/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: qt-ui-enforcement
+description: Use as a strict PR review or audit gate for Qt, PyQt, or QGIS UI changes. Prefer this over qt-workflow-ux when deciding whether to approve, request changes, or reject UI work involving layout, panels, buttons, navigation, or workflow behavior.
+---
+
+# Qt UI Enforcement
+
+Use this skill as a review gate for Qt/PyQt/QGIS UI changes. Be strict: reject or request redesign when the interface becomes ambiguous, inconsistent, or hard to scale for expert workflows.
+
+## Core classification rule
+
+Every UI element must be exactly one of:
+
+1. **Navigation** — where the user is or which workflow is selected.
+2. **Action** — what the user can do now.
+3. **Status** — what happened, what is running, or what is missing.
+4. **Input** — what the user configures before acting.
+
+If an element mixes roles, request a structural redesign before accepting styling tweaks.
+
+## Mandatory checks
+
+### 1. Navigation
+
+Reject if navigation:
+
+- uses `QPushButton`, `QToolButton`, or button-like chrome
+- looks like an action row
+- uses primary/accent color, filled green, or danger styling for selected state
+- depends on color alone to communicate selected/current state
+
+Expected patterns:
+
+- `QListWidget`, `QTreeWidget`, tabs, or an equivalent selection-list pattern
+- neutral selected background
+- bold selected label
+- status exposed in text or tooltip, not only color
+
+### 2. Button hierarchy
+
+Reject if:
+
+- more than one primary button is visible in one section
+- the primary button is not the obvious recommended action
+- primary styling is used for navigation, selection, status, or destructive actions
+- destructive action looks like primary
+- button meaning depends on border color, outline style, or shade of grey
+
+Required action roles:
+
+| Type | Meaning |
+| --- | --- |
+| Primary | Main recommended action |
+| Secondary | Normal supporting action |
+| Tertiary | Low-priority supplemental action |
+| Destructive | Risky or data-loss action |
+
+### 3. Action ordering
+
+Within a section, actions must be ordered:
+
+```text
+secondary actions
+primary action last/rightmost
+destructive action separated
+```
+
+Reject action rows that mix unrelated workflows or place destructive actions beside normal actions without separation.
+
+### 4. Input-before-action flow
+
+Reject if:
+
+- users are asked to run an action before seeing the inputs that determine it
+- essential inputs are hidden in advanced sections
+- advanced options materially change output but are not summarized
+- disabled actions lack nearby prerequisite copy or tooltip guidance
+
+### 5. Status and feedback
+
+Reject if:
+
+- result/status text is far from the action or workflow it describes
+- normal success/progress feedback is only modal
+- errors are vague, color-only, or do not name a recovery step
+- status is styled like navigation or an action
+
+Expected inline feedback examples:
+
+- `No data loaded. Load data before running analysis.`
+- `Exporting atlas PDF…`
+- `Export completed: 42 pages written.`
+- `Missing input: choose an output folder before exporting.`
+
+## Review procedure
+
+1. Inventory changed widgets as navigation, actions, status, and inputs.
+2. Count primary actions per visible section.
+3. Check action order and destructive-action separation.
+4. Verify navigation cannot be mistaken for actions.
+5. Verify the UI remains understandable without color or border semantics.
+6. Confirm tests or screenshots cover visible behavior changes when practical.
+
+## Decision language
+
+Use clear review outcomes:
+
+- **Approve** when the UI satisfies the classification, hierarchy, ordering, and feedback checks.
+- **Request changes** when a mandatory check fails.
+- **Comment** when the issue is a non-blocking consistency improvement.
+
+When requesting changes, name the failed rule and propose the smallest structural fix, not just a color change.

--- a/tests/test_project_skills.py
+++ b/tests/test_project_skills.py
@@ -9,13 +9,19 @@ def _skill_text(skill_name: str) -> str:
     return (REPO_ROOT / "skills" / skill_name / "SKILL.md").read_text(encoding="utf-8")
 
 
+def _assert_skill_frontmatter(text: str, skill_name: str) -> None:
+    lines = text.splitlines()
+
+    assert lines[0] == "---"
+    assert lines[1] == f"name: {skill_name}"
+    assert lines[2].startswith("description: ")
+    assert lines[3] == "---"
+
+
 def test_qt_workflow_ux_skill_has_required_metadata():
     text = _skill_text("qt-workflow-ux")
 
-    assert text.startswith("---\n")
-    assert "\n---\n" in text
-    assert "name: qt-workflow-ux" in text
-    assert "description:" in text
+    _assert_skill_frontmatter(text, "qt-workflow-ux")
 
 
 def test_qt_workflow_ux_skill_keeps_core_contract():
@@ -26,3 +32,23 @@ def test_qt_workflow_ux_skill_keeps_core_contract():
     assert "Status" in text
     assert "At most one primary action per section" in text
     assert "Do not use `QPushButton`, `QToolButton`, or button-like chrome" in text
+
+
+def test_qt_ui_enforcement_skill_has_required_metadata():
+    text = _skill_text("qt-ui-enforcement")
+
+    _assert_skill_frontmatter(text, "qt-ui-enforcement")
+    assert "strict PR review or audit gate" in text.splitlines()[2]
+
+
+def test_qt_ui_enforcement_skill_keeps_review_gates():
+    text = _skill_text("qt-ui-enforcement")
+
+    assert "Core classification rule" in text
+    assert "Navigation" in text
+    assert "Action" in text
+    assert "Status" in text
+    assert "Input" in text
+    assert "more than one primary button" in text
+    assert "destructive action separated" in text
+    assert "Request changes" in text


### PR DESCRIPTION
## Summary

- Add the `qt-ui-enforcement` project skill under `skills/qt-ui-enforcement/SKILL.md`.
- Capture review gates for UI role classification, navigation, button hierarchy, action ordering, input-before-action flow, and status feedback.
- Extend the project skill regression tests to cover the new skill metadata and mandatory review gates.

Closes #795.

## Validation

- `python3 -m pytest tests/test_project_skills.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
