### PR TITLE
Make navigation bolding current-only

### DIFF
--- a/tests/test_local_first_shell.py
+++ b/tests/test_local_first_shell.py
@@ -115,6 +115,7 @@ class LocalFirstDockShellTests(unittest.TestCase):
         self.assertIn("font-weight: 500", data_item.styleSheet())
         self.assertTrue(map_item.property("current"))
         self.assertEqual(map_item.property("navTone"), "current")
+        self.assertIn("font-weight: 700", map_item.styleSheet())
         self.assertTrue(map_item.isChecked())
         self.assertFalse(data_item.isChecked())
         self.assertIn(f"background-color: {COLOR_TITLE_BAR}", map_item.styleSheet())

--- a/tests/test_local_first_shell.py
+++ b/tests/test_local_first_shell.py
@@ -112,6 +112,7 @@ class LocalFirstDockShellTests(unittest.TestCase):
 
         self.assertTrue(data_item.property("ready"))
         self.assertEqual(data_item.property("navTone"), "ready")
+        self.assertIn("font-weight: 500", data_item.styleSheet())
         self.assertTrue(map_item.property("current"))
         self.assertEqual(map_item.property("navTone"), "current")
         self.assertTrue(map_item.isChecked())

--- a/ui/dockwidget/local_first_shell.py
+++ b/ui/dockwidget/local_first_shell.py
@@ -405,7 +405,7 @@ def _navigation_item_stylesheet(tone: str, object_name: str) -> str:
     elif tone == "ready":
         background = "transparent"
         color = COLOR_TEXT
-        font_weight = "600"
+        font_weight = "500"
     else:
         background = "transparent"
         color = COLOR_MUTED


### PR DESCRIPTION
## Summary
- align left navigation typography with the design-system rule that only the selected/current page is bold
- keep ready-but-unselected pages neutral while preserving their text color/status metadata
- add UI shell coverage for ready navigation font weight

## Tests
- `python3 -m pytest tests/test_local_first_shell.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

## Local validation
- Deployed this branch to the Windows QGIS default plugin folder for local testing.
