### PR TITLE
Fix atlas summary wrapping

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -11,6 +11,7 @@ Any qfit UI change must:
 
 - follow the button system defined below, with at most one primary action per section
 - clearly separate navigation, actions, and status/result feedback
+- keep presentation/free text fluid at narrow dock widths instead of widening the panel
 - be understandable without relying on color alone
 - pass the mandatory review checklist in this document before merge
 
@@ -154,6 +155,18 @@ Usage rules:
 - Use concrete copy: what happened, what is missing, or what to do next.
 - Do not use color or icon alone as the status.
 
+### Presentation/free-text labels
+
+Presentation text includes helper copy, summaries, inline status detail, and generated facts such as atlas selection/page-count text.
+
+Usage rules:
+
+- Treat presentation text as fluid copy, not as a fixed-width control.
+- Enable word wrapping for labels whose content can vary or become long.
+- Allow the label to shrink with the dock by clearing artificial minimum widths; in Qt this usually means `setMinimumWidth(0)` plus a horizontal size policy that does not force the `sizeHint()` width.
+- Prefer wrapping over truncation when the full sentence explains state, prerequisites, or export consequences.
+- Keep compact single-line text only for stable labels, short field names, buttons, and intentionally terse badges/pills.
+
 ### Advanced section
 
 Structure:
@@ -210,7 +223,8 @@ Best practices:
 - Use form layouts for label-field pairs.
 - Use horizontal layouts only for short, related action rows or compact paired controls.
 - Avoid fixed widths except where a widget truly needs a stable minimum.
-- Let labels wrap when helper text can become long.
+- Let labels wrap when helper, summary, status, or other presentation text can become long.
+- Do not let long free-text labels dictate the dock width; make them shrinkable and wrap within the available layout width.
 - Keep margins and spacing consistent inside a section; use larger separation between sections than between fields in the same section.
 - Keep tab order aligned with visual reading order.
 

--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -148,6 +148,18 @@ class AnalysisPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.run_analysis_button.toolTip(), "")
 
+    def test_presentation_copy_wraps_without_forcing_panel_width(self):
+        content = self.analysis_page.AnalysisPageContent()
+
+        for label in (
+            content.detail_label,
+            content.input_summary_label,
+            content.result_summary_label,
+        ):
+            self.assertTrue(label.word_wrap)
+            self.assertEqual(label.minimumWidth(), 0)
+            self.assertEqual(label.size_policy, (3, 4))
+
     def test_can_refresh_selectable_analysis_modes(self):
         content = self.analysis_page.AnalysisPageContent()
         calls = []

--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -120,10 +120,13 @@ class AtlasPageContentTest(unittest.TestCase):
 
         self.assertTrue(content.detail_label.word_wrap)
         self.assertEqual(content.detail_label.minimumWidth(), 0)
+        self.assertEqual(content.detail_label.size_policy, (3, 4))
         self.assertTrue(content.input_summary_label.word_wrap)
         self.assertEqual(content.input_summary_label.minimumWidth(), 0)
+        self.assertEqual(content.input_summary_label.size_policy, (3, 4))
         self.assertTrue(content.output_summary_label.word_wrap)
         self.assertEqual(content.output_summary_label.minimumWidth(), 0)
+        self.assertEqual(content.output_summary_label.size_policy, (3, 4))
 
     def test_can_seed_and_update_visible_document_settings(self):
         content = self.atlas_page.AtlasPageContent(

--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -115,6 +115,16 @@ class AtlasPageContentTest(unittest.TestCase):
             ],
         )
 
+    def test_summary_copy_wraps_without_forcing_panel_width(self):
+        content = self.atlas_page.AtlasPageContent()
+
+        self.assertTrue(content.detail_label.word_wrap)
+        self.assertEqual(content.detail_label.minimumWidth(), 0)
+        self.assertTrue(content.input_summary_label.word_wrap)
+        self.assertEqual(content.input_summary_label.minimumWidth(), 0)
+        self.assertTrue(content.output_summary_label.word_wrap)
+        self.assertEqual(content.output_summary_label.minimumWidth(), 0)
+
     def test_can_seed_and_update_visible_document_settings(self):
         content = self.atlas_page.AtlasPageContent(
             atlas_title="Spring Atlas",

--- a/tests/test_connection_page.py
+++ b/tests/test_connection_page.py
@@ -115,6 +115,16 @@ class ConnectionPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.configure_button.text(), "Review connection")
 
+    def test_presentation_copy_wraps_without_forcing_panel_width(self):
+        content = self.connection_page.ConnectionPageContent()
+
+        self.assertTrue(content.detail_label.word_wrap)
+        self.assertEqual(content.detail_label.minimumWidth(), 0)
+        self.assertEqual(content.detail_label.size_policy, (3, 4))
+        self.assertTrue(content.credential_summary_label.word_wrap)
+        self.assertEqual(content.credential_summary_label.minimumWidth(), 0)
+        self.assertEqual(content.credential_summary_label.size_policy, (3, 4))
+
     def test_can_block_configure_action_with_tooltip_copy(self):
         content = self.connection_page.ConnectionPageContent(
             self.connection_page.ConnectionPageState(

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -141,6 +141,8 @@ class _FakeWidget:
         self.visible = False
         self.cursor = None
         self.focus_policy = None
+        self._minimum_width = None
+        self.size_policy = None
         self.auto_raise = False
         self.layout_obj = None
         self._children = []
@@ -170,6 +172,15 @@ class _FakeWidget:
 
     def setWordWrap(self, value):
         self.word_wrap = value
+
+    def setMinimumWidth(self, value):
+        self._minimum_width = value
+
+    def minimumWidth(self):
+        return self._minimum_width
+
+    def setSizePolicy(self, horizontal, vertical):
+        self.size_policy = (horizontal, vertical)
 
     def setTextInteractionFlags(self, value):
         self.interaction_flags = value
@@ -235,6 +246,10 @@ class _FakeRoot(_FakeWidget):
 
 
 class _FakeQtWidgetsModule:
+    class QSizePolicy:
+        Ignored = 3
+        Preferred = 4
+
     QWidget = _FakeWidget
     QLabel = _FakeLabel
     QToolButton = _FakeQToolButton
@@ -343,6 +358,8 @@ class ContextualHelpTests(unittest.TestCase):
         helper = getattr(root, "speedSpinBoxContextHelpLabel")
         self.assertEqual(helper.text(), "Inline helper copy")
         self.assertTrue(helper.word_wrap)
+        self.assertEqual(helper.minimumWidth(), 0)
+        self.assertEqual(helper.size_policy, (3, 4))
         self.assertEqual(helper.interaction_flags, _FakeQt.TextSelectableByMouse)
         self.assertIn("palette(mid)", helper.style_sheet)
 

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -189,6 +189,20 @@ class MapPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.apply_filters_button.toolTip(), "")
 
+    def test_presentation_copy_wraps_without_forcing_panel_width(self):
+        content = self.map_page.MapPageContent()
+
+        for label in (
+            content.detail_label,
+            content.layer_summary_label,
+            content.background_summary_label,
+            content.style_summary_label,
+            content.filter_summary_label,
+        ):
+            self.assertTrue(label.word_wrap)
+            self.assertEqual(label.minimumWidth(), 0)
+            self.assertEqual(label.size_policy, (3, 4))
+
     def test_can_block_load_layers_until_sync_prerequisite_is_ready(self):
         content = self.map_page.MapPageContent(
             self.map_page.MapPageState(

--- a/tests/test_page_content_style.py
+++ b/tests/test_page_content_style.py
@@ -51,12 +51,30 @@ class PageContentStyleTest(unittest.TestCase):
         self.assertEqual(label.property("tone"), "ok")
         self.assertIn("#dcefd0", label.styleSheet())
 
+    def test_configures_fluid_text_labels_for_wrapping_and_shrink(self):
+        label = _FakeLabel(object_name="summaryLabel")
+
+        self.page_content_style.configure_fluid_text_label(label)
+
+        self.assertTrue(label.word_wrap)
+        self.assertEqual(label.minimumWidth(), 0)
+        self.assertEqual(
+            label.size_policy,
+            (
+                self.page_content_style.QSizePolicy.Ignored,
+                self.page_content_style.QSizePolicy.Preferred,
+            ),
+        )
+
 
 class _FakeLabel:
     def __init__(self, *, object_name=""):
         self._object_name = object_name
         self._properties = {}
         self._stylesheet = ""
+        self._minimum_width = None
+        self.word_wrap = False
+        self.size_policy = None
 
     def setObjectName(self, object_name):  # noqa: N802
         self._object_name = object_name
@@ -75,6 +93,18 @@ class _FakeLabel:
 
     def styleSheet(self):  # noqa: N802
         return self._stylesheet
+
+    def setWordWrap(self, value):  # noqa: N802
+        self.word_wrap = value
+
+    def setMinimumWidth(self, value):  # noqa: N802
+        self._minimum_width = value
+
+    def minimumWidth(self):  # noqa: N802
+        return self._minimum_width
+
+    def setSizePolicy(self, horizontal, vertical):  # noqa: N802
+        self.size_policy = (horizontal, vertical)
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -180,6 +180,16 @@ class SyncPageContentTest(unittest.TestCase):
         self.assertTrue(content.clear_button.isEnabled())
         self.assertEqual(content.clear_button.toolTip(), "")
 
+    def test_presentation_copy_wraps_without_forcing_panel_width(self):
+        content = self.sync_page.SyncPageContent()
+
+        self.assertTrue(content.detail_label.word_wrap)
+        self.assertEqual(content.detail_label.minimumWidth(), 0)
+        self.assertEqual(content.detail_label.size_policy, (3, 4))
+        self.assertTrue(content.activity_summary_label.word_wrap)
+        self.assertEqual(content.activity_summary_label.minimumWidth(), 0)
+        self.assertEqual(content.activity_summary_label.size_policy, (3, 4))
+
     def test_can_block_saved_routes_action_with_tooltip_copy(self):
         content = self.sync_page.SyncPageContent(
             self.sync_page.SyncPageState(

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -72,6 +72,10 @@ class WizardPageTest(unittest.TestCase):
         self.assertIn(COLOR_MUTED, page.summary_label.styleSheet())
         self.assertIn(COLOR_MUTED, page.primary_hint_label.styleSheet())
         self.assertIn("font-style: italic", page.primary_hint_label.styleSheet())
+        for label in (page.title_label, page.summary_label, page.primary_hint_label):
+            self.assertTrue(label.word_wrap)
+            self.assertEqual(label.minimumWidth(), 0)
+            self.assertEqual(label.size_policy, (3, 4))
         self.assertEqual(page.body_container.objectName(), "qfitWizardMapPageBody")
         self.assertEqual(page.body_layout().contents_margins, (0, 0, 0, 0))
         self.assertEqual(page.primary_hint_label.objectName(), "qfitWizardMapPagePrimaryHint")

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -77,6 +77,7 @@ class _FakeWidget:
         self._alignment = None
         self._focus_policy = None
         self._visible = True
+        self.size_policy = None
 
     def setVisible(self, value):  # noqa: N802
         self._visible = value
@@ -150,6 +151,9 @@ class _FakeWidget:
     def styleSheet(self):  # noqa: N802
         return self._stylesheet
 
+    def setSizePolicy(self, horizontal, vertical):  # noqa: N802
+        self.size_policy = (horizontal, vertical)
+
 
 class _FakeToolButton(_FakeWidget):
     def __init__(self, parent=None):
@@ -159,7 +163,6 @@ class _FakeToolButton(_FakeWidget):
         self._checkable = False
         self._checked = False
         self.tool_button_style = None
-        self.size_policy = None
 
     def setCheckable(self, value):  # noqa: N802
         self._checkable = value

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -301,6 +301,13 @@ class ContextualHelpBinder:
         helper = qtwidgets.QLabel(text, helper_parent)
         helper.setObjectName(helper_name)
         helper.setWordWrap(True)
+        if hasattr(helper, "setMinimumWidth"):
+            helper.setMinimumWidth(0)
+        if hasattr(helper, "setSizePolicy"):
+            helper.setSizePolicy(
+                qtwidgets.QSizePolicy.Ignored,
+                qtwidgets.QSizePolicy.Preferred,
+            )
         helper.setTextInteractionFlags(self._qtcore().Qt.TextSelectableByMouse)
         helper.setStyleSheet("color: palette(mid); margin-top: 2px; margin-bottom: 4px;")
         self._insert_after_anchor(anchor, helper)

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -9,6 +9,7 @@ from .action_row import (
     style_primary_action_button,
 )
 from .page_content_style import (
+    configure_fluid_text_label,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -64,14 +65,15 @@ class AnalysisPageContent(QWidget):
         self.status_label.setObjectName("qfitWizardAnalysisStatus")
         self.detail_label = QLabel("", self)
         self.detail_label.setObjectName("qfitWizardAnalysisDetail")
-        if hasattr(self.detail_label, "setWordWrap"):
-            self.detail_label.setWordWrap(True)
+        configure_fluid_text_label(self.detail_label)
         style_detail_label(self.detail_label)
         self.input_summary_label = QLabel("", self)
         self.input_summary_label.setObjectName("qfitWizardAnalysisInputSummary")
+        configure_fluid_text_label(self.input_summary_label)
         style_summary_label(self.input_summary_label)
         self.result_summary_label = QLabel("", self)
         self.result_summary_label.setObjectName("qfitWizardAnalysisResultSummary")
+        configure_fluid_text_label(self.result_summary_label)
         style_summary_label(self.result_summary_label)
         self.analysis_mode_label = QLabel("Analysis mode", self)
         self.analysis_mode_label.setObjectName("qfitWizardAnalysisModeLabel")

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -21,6 +21,7 @@ _qtwidgets = import_qt_module(
     (
         "QLabel",
         "QLineEdit",
+        "QSizePolicy",
         "QToolButton",
         "QVBoxLayout",
         "QWidget",
@@ -30,11 +31,23 @@ _qtwidgets = import_qt_module(
 pyqtSignal = _qtcore.pyqtSignal
 QLabel = _qtwidgets.QLabel
 QLineEdit = _qtwidgets.QLineEdit
+QSizePolicy = _qtwidgets.QSizePolicy
 QToolButton = _qtwidgets.QToolButton
 QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
 
 _DEFAULT_ATLAS_TITLE = "qfit Activity Atlas"
+
+
+def _configure_fluid_text_label(label) -> None:
+    """Allow longer free-text labels to wrap instead of widening the dock."""
+
+    if hasattr(label, "setWordWrap"):
+        label.setWordWrap(True)
+    if hasattr(label, "setMinimumWidth"):
+        label.setMinimumWidth(0)
+    if hasattr(label, "setSizePolicy"):
+        label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
 
 
 @dataclass(frozen=True)
@@ -72,14 +85,15 @@ class AtlasPageContent(QWidget):
         self.status_label.setObjectName("qfitWizardAtlasStatus")
         self.detail_label = QLabel("", self)
         self.detail_label.setObjectName("qfitWizardAtlasDetail")
-        if hasattr(self.detail_label, "setWordWrap"):
-            self.detail_label.setWordWrap(True)
+        _configure_fluid_text_label(self.detail_label)
         style_detail_label(self.detail_label)
         self.input_summary_label = QLabel("", self)
         self.input_summary_label.setObjectName("qfitWizardAtlasInputSummary")
+        _configure_fluid_text_label(self.input_summary_label)
         style_summary_label(self.input_summary_label)
         self.output_summary_label = QLabel("", self)
         self.output_summary_label.setObjectName("qfitWizardAtlasOutputSummary")
+        _configure_fluid_text_label(self.output_summary_label)
         style_summary_label(self.output_summary_label)
         self.title_label = QLabel("Atlas title", self)
         self.title_label.setObjectName("qfitWizardAtlasTitleLabel")

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -9,6 +9,7 @@ from .action_row import (
     style_primary_action_button,
 )
 from .page_content_style import (
+    configure_fluid_text_label,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -21,7 +22,6 @@ _qtwidgets = import_qt_module(
     (
         "QLabel",
         "QLineEdit",
-        "QSizePolicy",
         "QToolButton",
         "QVBoxLayout",
         "QWidget",
@@ -31,23 +31,11 @@ _qtwidgets = import_qt_module(
 pyqtSignal = _qtcore.pyqtSignal
 QLabel = _qtwidgets.QLabel
 QLineEdit = _qtwidgets.QLineEdit
-QSizePolicy = _qtwidgets.QSizePolicy
 QToolButton = _qtwidgets.QToolButton
 QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
 
 _DEFAULT_ATLAS_TITLE = "qfit Activity Atlas"
-
-
-def _configure_fluid_text_label(label) -> None:
-    """Allow longer free-text labels to wrap instead of widening the dock."""
-
-    if hasattr(label, "setWordWrap"):
-        label.setWordWrap(True)
-    if hasattr(label, "setMinimumWidth"):
-        label.setMinimumWidth(0)
-    if hasattr(label, "setSizePolicy"):
-        label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
 
 
 @dataclass(frozen=True)
@@ -85,15 +73,15 @@ class AtlasPageContent(QWidget):
         self.status_label.setObjectName("qfitWizardAtlasStatus")
         self.detail_label = QLabel("", self)
         self.detail_label.setObjectName("qfitWizardAtlasDetail")
-        _configure_fluid_text_label(self.detail_label)
+        configure_fluid_text_label(self.detail_label)
         style_detail_label(self.detail_label)
         self.input_summary_label = QLabel("", self)
         self.input_summary_label.setObjectName("qfitWizardAtlasInputSummary")
-        _configure_fluid_text_label(self.input_summary_label)
+        configure_fluid_text_label(self.input_summary_label)
         style_summary_label(self.input_summary_label)
         self.output_summary_label = QLabel("", self)
         self.output_summary_label.setObjectName("qfitWizardAtlasOutputSummary")
-        _configure_fluid_text_label(self.output_summary_label)
+        configure_fluid_text_label(self.output_summary_label)
         style_summary_label(self.output_summary_label)
         self.title_label = QLabel("Atlas title", self)
         self.title_label.setObjectName("qfitWizardAtlasTitleLabel")

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -9,6 +9,7 @@ from .action_row import (
     style_primary_action_button,
 )
 from .page_content_style import (
+    configure_fluid_text_label,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -66,11 +67,11 @@ class ConnectionPageContent(QWidget):
         self.status_label.setObjectName("qfitWizardConnectionStatus")
         self.detail_label = QLabel("", self)
         self.detail_label.setObjectName("qfitWizardConnectionDetail")
-        if hasattr(self.detail_label, "setWordWrap"):
-            self.detail_label.setWordWrap(True)
+        configure_fluid_text_label(self.detail_label)
         style_detail_label(self.detail_label)
         self.credential_summary_label = QLabel("", self)
         self.credential_summary_label.setObjectName("qfitWizardConnectionCredentialSummary")
+        configure_fluid_text_label(self.credential_summary_label)
         style_summary_label(self.credential_summary_label)
         self.configure_button = QToolButton(self)
         self.configure_button.setObjectName("qfitWizardConnectionConfigureButton")

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -10,6 +10,7 @@ from .action_row import (
     style_secondary_action_button,
 )
 from .page_content_style import (
+    configure_fluid_text_label,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -66,20 +67,23 @@ class MapPageContent(QWidget):
         self.status_label.setObjectName("qfitWizardMapStatus")
         self.detail_label = QLabel("", self)
         self.detail_label.setObjectName("qfitWizardMapDetail")
-        if hasattr(self.detail_label, "setWordWrap"):
-            self.detail_label.setWordWrap(True)
+        configure_fluid_text_label(self.detail_label)
         style_detail_label(self.detail_label)
         self.layer_summary_label = QLabel("", self)
         self.layer_summary_label.setObjectName("qfitWizardMapLayerSummary")
+        configure_fluid_text_label(self.layer_summary_label)
         style_summary_label(self.layer_summary_label)
         self.background_summary_label = QLabel("", self)
         self.background_summary_label.setObjectName("qfitWizardMapBackgroundSummary")
+        configure_fluid_text_label(self.background_summary_label)
         style_summary_label(self.background_summary_label)
         self.style_summary_label = QLabel("", self)
         self.style_summary_label.setObjectName("qfitWizardMapStyleSummary")
+        configure_fluid_text_label(self.style_summary_label)
         style_summary_label(self.style_summary_label)
         self.filter_summary_label = QLabel("", self)
         self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
+        configure_fluid_text_label(self.filter_summary_label)
         style_summary_label(self.filter_summary_label)
         self.load_layers_button = QToolButton(self)
         self.load_layers_button.setObjectName("qfitWizardMapLoadLayersButton")

--- a/ui/dockwidget/page_content_style.py
+++ b/ui/dockwidget/page_content_style.py
@@ -2,6 +2,16 @@ from __future__ import annotations
 
 from qfit.ui.tokens import COLOR_MUTED, pill_tone_palette
 
+from ._qt_compat import import_qt_module
+
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    ("QSizePolicy",),
+)
+
+QSizePolicy = _qtwidgets.QSizePolicy
+
 _DETAIL_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 _SUMMARY_LABEL_QSS = (
     "QLabel { "
@@ -21,6 +31,17 @@ def style_summary_label(label) -> None:
     """Apply consistent compact summary styling for wizard page status facts."""
 
     label.setStyleSheet(_SUMMARY_LABEL_QSS)
+
+
+def configure_fluid_text_label(label) -> None:
+    """Allow presentation text to wrap instead of widening the dock."""
+
+    if hasattr(label, "setWordWrap"):
+        label.setWordWrap(True)
+    if hasattr(label, "setMinimumWidth"):
+        label.setMinimumWidth(0)
+    if hasattr(label, "setSizePolicy"):
+        label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
 
 
 def style_status_pill(label, *, active: bool) -> None:
@@ -47,6 +68,7 @@ def _status_pill_stylesheet(tone: str, *, object_name: str) -> str:
 
 __all__ = [
     "style_detail_label",
+    "configure_fluid_text_label",
     "style_status_pill",
     "style_summary_label",
 ]

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -11,6 +11,7 @@ from .action_row import (
     style_secondary_action_button,
 )
 from .page_content_style import (
+    configure_fluid_text_label,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -74,11 +75,11 @@ class SyncPageContent(QWidget):
         self.status_label.setObjectName("qfitWizardSyncStatus")
         self.detail_label = QLabel("", self)
         self.detail_label.setObjectName("qfitWizardSyncDetail")
-        if hasattr(self.detail_label, "setWordWrap"):
-            self.detail_label.setWordWrap(True)
+        configure_fluid_text_label(self.detail_label)
         style_detail_label(self.detail_label)
         self.activity_summary_label = QLabel("", self)
         self.activity_summary_label.setObjectName("qfitWizardSyncActivitySummary")
+        configure_fluid_text_label(self.activity_summary_label)
         style_summary_label(self.activity_summary_label)
         self.sync_button = QToolButton(self)
         self.sync_button.setObjectName("qfitWizardSyncButton")

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -9,6 +9,7 @@ from qfit.ui.application.wizard_page_specs import (
 from qfit.ui.tokens import COLOR_MUTED, COLOR_TEXT
 
 from ._qt_compat import import_qt_module
+from .page_content_style import configure_fluid_text_label
 
 _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
@@ -97,8 +98,7 @@ class WizardPage(QWidget):
     def _build_label(self, text: str, object_name: str, *, style: str = ""):
         label = QLabel(text, self)
         label.setObjectName(object_name)
-        if hasattr(label, "setWordWrap"):
-            label.setWordWrap(True)
+        configure_fluid_text_label(label)
         if style:
             label.setStyleSheet(style)
         return label


### PR DESCRIPTION
## Summary
- Allow atlas free-text labels to wrap instead of forcing the dock wider.
- Move the wrapping/shrink behavior into a shared fluid presentation-text helper.
- Apply the same helper to other wizard/helper/status copy that can grow: connection, sync, map, analysis, wizard page chrome, and contextual help.
- Document the design-system rule for fluid presentation/free-text labels in narrow QGIS docks.
- Cover the wrapping and size-policy behavior in widget tests, including the Greptile-noted `setSizePolicy` branch.

## Tests
- `python3 -m pytest tests/test_atlas_page.py -q`
- `python3 -m pytest tests/test_atlas_page.py tests/test_project_skills.py -q`
- `python3 -m pytest tests/test_page_content_style.py tests/test_atlas_page.py tests/test_connection_page.py tests/test_sync_page.py tests/test_analysis_page.py tests/test_map_page.py tests/test_wizard_pages.py tests/test_contextual_help.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
