### PR TITLE
Expose basemap controls in Settings

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -519,6 +519,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             ),
         )
         self._install_wizard_filter_controls(self._local_first_dock_composition)
+        self._install_local_first_basemap_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
         return self._local_first_dock_composition
 
@@ -598,6 +599,39 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         parent_layout = parent_widget.layout() if parent_widget is not None else None
         if parent_layout is not None and hasattr(parent_layout, "removeWidget"):
             parent_layout.removeWidget(widget)
+
+    def _install_local_first_basemap_controls(self, composition) -> None:
+        """Expose the backing Mapbox basemap controls in the Settings tab."""
+
+        settings_content = getattr(composition, "connection_content", None)
+        background_group = getattr(self, "backgroundGroupBox", None)
+        if settings_content is None or background_group is None:
+            return
+        installed_target = getattr(self, "_local_first_basemap_controls_installed_target", None)
+        current_target = id(settings_content)
+        if getattr(self, "_local_first_basemap_controls_installed", False) and (
+            installed_target == current_target
+        ):
+            return
+
+        layout_getter = getattr(settings_content, "outer_layout", None)
+        layout = layout_getter() if callable(layout_getter) else None
+        if layout is None or not hasattr(layout, "addWidget"):
+            return
+
+        self._remove_widget_from_current_layout(background_group)
+        if hasattr(background_group, "setParent"):
+            background_group.setParent(settings_content)
+        if hasattr(background_group, "setTitle"):
+            background_group.setTitle("Mapbox basemap")
+        layout.addWidget(background_group)
+        if hasattr(background_group, "show"):
+            background_group.show()
+        elif hasattr(background_group, "setVisible"):
+            background_group.setVisible(True)
+
+        self._local_first_basemap_controls_installed = True
+        self._local_first_basemap_controls_installed_target = current_target
 
     def _bind_wizard_analysis_mode_controls(self, composition) -> None:
         """Expose the hidden backing analysis selector in the live wizard path."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1236,6 +1236,64 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.scrollArea.hide.assert_not_called()
         dock.summaryStatusLabel.hide.assert_not_called()
 
+    def test_local_first_basemap_controls_move_to_settings_page(self):
+        class _SourceLayout:
+            def __init__(self):
+                self.removed = []
+
+            def removeWidget(self, widget):
+                self.removed.append(widget)
+
+        class _SourceParent:
+            def __init__(self, layout):
+                self._layout = layout
+
+            def layout(self):
+                return self._layout
+
+        class _BasemapGroup:
+            def __init__(self, parent):
+                self._parent = parent
+                self.title = None
+                self.shown = False
+
+            def parentWidget(self):
+                return self._parent
+
+            def setParent(self, parent):
+                self._parent = parent
+
+            def setTitle(self, title):
+                self.title = title
+
+            def show(self):
+                self.shown = True
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        source_layout = _SourceLayout()
+        source_parent = _SourceParent(source_layout)
+        basemap_group = _BasemapGroup(source_parent)
+        settings_layout = _FakeLayout()
+        settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
+        composition = SimpleNamespace(connection_content=settings_content)
+        dock.backgroundGroupBox = basemap_group
+
+        self.module.QfitDockWidget._install_local_first_basemap_controls(
+            dock,
+            composition,
+        )
+        self.module.QfitDockWidget._install_local_first_basemap_controls(
+            dock,
+            composition,
+        )
+
+        self.assertEqual(source_layout.removed, [basemap_group])
+        self.assertIs(basemap_group.parentWidget(), settings_content)
+        self.assertEqual(basemap_group.title, "Mapbox basemap")
+        self.assertTrue(basemap_group.shown)
+        self.assertEqual(settings_layout.added, [basemap_group])
+        self.assertTrue(dock._local_first_basemap_controls_installed)
+
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -307,13 +307,25 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.styleSectionToggleButton.arrowType(), Qt.DownArrow)
             self.assertFalse(dock.styleSectionContentWidget.isHidden())
             self.assertEqual(dock.loadLayersButton.parent(), dock.styleSectionContentWidget)
-            self.assertLess(dock.styleSectionContentWidget.layout().indexOf(dock.loadLayersButton), dock.styleSectionContentWidget.layout().indexOf(dock.backgroundGroupBox))
+            self.assertEqual(
+                dock.backgroundGroupBox.parentWidget(),
+                dock._local_first_dock_composition.connection_content,
+            )
+            self.assertGreaterEqual(
+                dock._local_first_dock_composition.connection_content.outer_layout().indexOf(
+                    dock.backgroundGroupBox,
+                ),
+                0,
+            )
             self.assertEqual(dock.analysisWorkflowGroupBox.title(), "")
             self.assertEqual(dock.analysisSectionToggleButton.text(), "Analyze")
             self.assertFalse(dock.analysisSectionContentWidget.isHidden())
             self.assertEqual(dock.analysisWorkflowLayout.spacing(), 6)
             self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
-            self.assertEqual(dock.analysisModeComboBox.currentText(), "None")
+            self.assertEqual(
+                dock.analysisModeComboBox.currentText(),
+                "Most frequent starting points",
+            )
             self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
             self.assertEqual(dock.analysisModeLabel.parentWidget().parentWidget(), dock.analysisSectionContentWidget)
             self.assertEqual(dock.temporalModeLabel.parentWidget().parentWidget(), dock.styleSectionContentWidget)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -322,10 +322,6 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertFalse(dock.analysisSectionContentWidget.isHidden())
             self.assertEqual(dock.analysisWorkflowLayout.spacing(), 6)
             self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
-            self.assertEqual(
-                dock.analysisModeComboBox.currentText(),
-                "Most frequent starting points",
-            )
             self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
             self.assertEqual(dock.analysisModeLabel.parentWidget().parentWidget(), dock.analysisSectionContentWidget)
             self.assertEqual(dock.temporalModeLabel.parentWidget().parentWidget(), dock.styleSectionContentWidget)


### PR DESCRIPTION
## Summary
- Move the existing Mapbox basemap controls into the visible local-first Settings tab.
- Keep the legacy backing controls and settings bindings intact for this small consolidation slice.
- Cover the basemap-control move in pure dock tests and update the QGIS smoke expectation for the local-first Settings placement.

Closes #803.

## Tests
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_contextual_help_smoke tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_defaults_to_local_first_live_path -q`
- `python3 -m pytest tests/ -x -q --tb=short`
