### PR TITLE
Add clear analysis action

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1835,9 +1835,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
 
     def _clear_analysis_layer(self):
-        self._mark_atlas_export_stale()
         project = QgsProject.instance()
+        analysis_removed = False
         if self.analysis_layer is not None:
+            analysis_removed = True
             try:
                 project.removeMapLayer(self.analysis_layer.id())
             except RuntimeError:
@@ -1851,10 +1852,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         for layer in tuple(project.mapLayers().values()):
             if layer.name() not in analysis_layer_names:
                 continue
+            analysis_removed = True
             try:
                 project.removeMapLayer(layer.id())
             except RuntimeError:
                 logger.debug("Failed to remove stale analysis layer", exc_info=True)
+        if analysis_removed:
+            self._mark_atlas_export_stale()
+        return analysis_removed
 
     def _current_activity_preview_request(self):
         return build_activity_preview_request(

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -472,6 +472,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 load_activity_layers=self.on_load_layers_clicked,
                 apply_map_filters=self._run_wizard_map_step,
                 run_analysis=self.on_run_analysis_clicked,
+                clear_analysis=self.on_clear_analysis_clicked,
                 set_analysis_mode=self._set_wizard_analysis_mode,
                 export_atlas=self.on_generate_atlas_pdf_clicked,
                 update_atlas_document_settings=self._update_atlas_document_settings,
@@ -513,6 +514,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 load_activity_layers=self.on_load_layers_clicked,
                 apply_map_filters=self.on_apply_filters_clicked,
                 run_analysis=self.on_run_analysis_clicked,
+                clear_analysis=self.on_clear_analysis_clicked,
                 set_analysis_mode=self._set_wizard_analysis_mode,
                 export_atlas=self.on_generate_atlas_pdf_clicked,
                 update_atlas_document_settings=self._update_atlas_document_settings,
@@ -1715,6 +1717,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def on_run_analysis_clicked(self):
         self._dispatch_dock_action(RunAnalysisAction)
+
+    def on_clear_analysis_clicked(self):
+        self._clear_analysis_layer()
+        self._set_status("No analysis displayed")
+        self._refresh_live_dock_navigation_from_runtime()
 
     def _dispatch_dock_action(self, action_type):
         result = self._dock_visual_workflow.dispatch_action(

--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -56,7 +56,7 @@ class AnalysisPageContentTest(unittest.TestCase):
         )
         self.assertEqual(
             content.result_summary_label.text(),
-            "Analysis outputs will appear in the project once generated",
+            "No analysis displayed",
         )
         self.assertIn(COLOR_MUTED, content.result_summary_label.styleSheet())
         self.assertEqual(
@@ -92,10 +92,24 @@ class AnalysisPageContentTest(unittest.TestCase):
             "blocked",
         )
         self.assertIn("Load activity layers", content.run_analysis_button.toolTip())
+        self.assertEqual(
+            content.clear_analysis_button.objectName(),
+            "qfitWizardAnalysisClearButton",
+        )
+        self.assertEqual(content.clear_analysis_button.text(), "Clear analysis")
+        self.assertEqual(
+            content.clear_analysis_button.property("secondaryAction"),
+            "clear_analysis",
+        )
+        self.assertEqual(
+            content.clear_analysis_button.property("wizardActionRole"),
+            "secondary",
+        )
+        self.assertTrue(content.clear_analysis_button.isEnabled())
         self.assertEqual(content.action_row.objectName(), "qfitWizardAnalysisActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,
-            [content.run_analysis_button],
+            [content.run_analysis_button, content.clear_analysis_button],
         )
         self.assertEqual(
             content.outer_layout().widgets,
@@ -195,14 +209,16 @@ class AnalysisPageContentTest(unittest.TestCase):
             "Choose an analysis input layer.",
         )
 
-    def test_button_emits_reusable_page_signal(self):
+    def test_buttons_emit_reusable_page_signals(self):
         content = self.analysis_page.AnalysisPageContent()
         calls = []
         content.runAnalysisRequested.connect(lambda: calls.append("run"))
+        content.clearAnalysisRequested.connect(lambda: calls.append("clear"))
 
         content.run_analysis_button.clicked.emit()
+        content.clear_analysis_button.clicked.emit()
 
-        self.assertEqual(calls, ["run"])
+        self.assertEqual(calls, ["run", "clear"])
 
     def test_installs_only_on_analysis_wizard_page_body(self):
         analysis_spec = next(

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -101,6 +101,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             load_activity_layers=lambda: calls.append("layers"),
             apply_map_filters=lambda: calls.append("apply"),
             run_analysis=lambda: calls.append("analysis"),
+            clear_analysis=lambda: calls.append("clear-analysis"),
             set_analysis_mode=lambda mode: calls.append(f"mode:{mode}"),
             export_atlas=lambda: calls.append("atlas"),
             update_atlas_document_settings=lambda title, subtitle: calls.append(
@@ -117,6 +118,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         composition.map_content.loadLayersRequested.emit()
         composition.map_content.applyFiltersRequested.emit()
         composition.analysis_content.runAnalysisRequested.emit()
+        composition.analysis_content.clearAnalysisRequested.emit()
         composition.analysis_content.analysisModeChanged.emit("Heatmap")
         composition.atlas_content.exportAtlasRequested.emit()
         composition.atlas_content.title_line_edit.setText("Summer Atlas")
@@ -133,6 +135,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
                 "layers",
                 "apply",
                 "analysis",
+                "clear-analysis",
                 "mode:Heatmap",
                 "atlas",
                 "atlas-settings:Summer Atlas:Road and trail",

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -817,6 +817,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "load_activity_layers": "on_load_layers_clicked",
             "apply_map_filters": "_run_wizard_map_step",
             "run_analysis": "on_run_analysis_clicked",
+            "clear_analysis": "on_clear_analysis_clicked",
             "set_analysis_mode": "_set_wizard_analysis_mode",
             "export_atlas": "on_generate_atlas_pdf_clicked",
         }
@@ -971,6 +972,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "load_activity_layers": "on_load_layers_clicked",
             "apply_map_filters": "on_apply_filters_clicked",
             "run_analysis": "on_run_analysis_clicked",
+            "clear_analysis": "on_clear_analysis_clicked",
             "set_analysis_mode": "_set_wizard_analysis_mode",
             "export_atlas": "on_generate_atlas_pdf_clicked",
             "update_atlas_document_settings": "_update_atlas_document_settings",
@@ -1407,6 +1409,18 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._dispatch_dock_action.assert_called_once_with(
             self.module.RunAnalysisAction
         )
+
+    def test_on_clear_analysis_clicked_removes_analysis_and_refreshes_state(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._clear_analysis_layer = MagicMock()
+        dock._set_status = MagicMock()
+        dock._refresh_live_dock_navigation_from_runtime = MagicMock()
+
+        self.module.QfitDockWidget.on_clear_analysis_clicked(dock)
+
+        dock._clear_analysis_layer.assert_called_once_with()
+        dock._set_status.assert_called_once_with("No analysis displayed")
+        dock._refresh_live_dock_navigation_from_runtime.assert_called_once_with()
 
     def test_dispatch_dock_action_returns_early_without_layers(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2003,6 +2003,18 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             [current_layer.id(), stale_layer.id(), stale_heatmap_layer.id()],
         )
 
+    def test_clear_analysis_layer_is_noop_when_no_analysis_is_displayed(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        project = _FakeProject({"other": _FakeLayer("other")})
+        dock._atlas_export_completed = True
+
+        with patch.object(self.module.QgsProject, "instance", return_value=project):
+            removed = self.module.QfitDockWidget._clear_analysis_layer(dock)
+
+        self.assertFalse(removed)
+        self.assertTrue(dock._atlas_export_completed)
+        self.assertEqual(project.removed, [])
+
     def test_on_load_clicked_starts_background_store_task(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._store_task = None

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -334,6 +334,7 @@ class WizardShellCompositionTest(unittest.TestCase):
             load_activity_layers=lambda: calls.append("load"),
             apply_map_filters=lambda: calls.append("filter"),
             run_analysis=lambda: calls.append("analysis"),
+            clear_analysis=lambda: calls.append("clear-analysis"),
             set_analysis_mode=lambda mode: calls.append(f"mode:{mode}"),
             export_atlas=lambda: calls.append("atlas"),
         )
@@ -354,6 +355,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         assembled.map_content.load_layers_button.clicked.emit()
         assembled.map_content.apply_filters_button.clicked.emit()
         assembled.analysis_content.run_analysis_button.clicked.emit()
+        assembled.analysis_content.clear_analysis_button.clicked.emit()
         assembled.analysis_content.analysis_mode_combo.setCurrentText("Heatmap")
         assembled.atlas_content.export_atlas_button.clicked.emit()
 
@@ -370,6 +372,7 @@ class WizardShellCompositionTest(unittest.TestCase):
                 "load",
                 "filter",
                 "analysis",
+                "clear-analysis",
                 "mode:Heatmap",
                 "atlas",
             ],

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -7,6 +7,7 @@ from .action_row import (
     build_wizard_action_row,
     set_wizard_action_availability,
     style_primary_action_button,
+    style_secondary_action_button,
 )
 from .page_content_style import (
     configure_fluid_text_label,
@@ -46,16 +47,19 @@ class AnalysisPageState:
         "Optional: calculate heatmaps, corridors, and start points from loaded data."
     )
     input_summary_text: str = "No loaded activity layers available for analysis"
-    result_summary_text: str = "Analysis outputs will appear in the project once generated"
+    result_summary_text: str = "No analysis displayed"
     primary_action_label: str = "Run analysis"
     primary_action_enabled: bool | None = None
     primary_action_blocked_tooltip: str = "Load activity layers before running analysis."
+    clear_action_label: str = "Clear analysis"
+    clear_action_enabled: bool = True
 
 
 class AnalysisPageContent(QWidget):
     """Reusable fourth-page content for the wizard spatial-analysis step."""
 
     runAnalysisRequested = pyqtSignal()
+    clearAnalysisRequested = pyqtSignal()
     analysisModeChanged = pyqtSignal(str)
 
     def __init__(self, state: AnalysisPageState | None = None, parent=None) -> None:
@@ -92,8 +96,16 @@ class AnalysisPageContent(QWidget):
             action_name="run_analysis",
         )
         self.run_analysis_button.clicked.connect(self.runAnalysisRequested.emit)
+        self.clear_analysis_button = QToolButton(self)
+        self.clear_analysis_button.setObjectName("qfitWizardAnalysisClearButton")
+        style_secondary_action_button(
+            self.clear_analysis_button,
+            action_name="clear_analysis",
+        )
+        self.clear_analysis_button.clicked.connect(self.clearAnalysisRequested.emit)
         self.action_row = build_wizard_action_row(
             self.run_analysis_button,
+            self.clear_analysis_button,
             parent=self,
             object_name="qfitWizardAnalysisActionRow",
         )
@@ -142,6 +154,11 @@ class AnalysisPageContent(QWidget):
             self.run_analysis_button,
             enabled=primary_action_enabled,
             tooltip=state.primary_action_blocked_tooltip,
+        )
+        self.clear_analysis_button.setText(state.clear_action_label)
+        set_wizard_action_availability(
+            self.clear_analysis_button,
+            enabled=state.clear_action_enabled,
         )
 
     def outer_layout(self):

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -155,6 +155,11 @@ def connect_local_first_action_callbacks(
     )
     _connect_optional_signal(
         composition.analysis_content,
+        "clearAnalysisRequested",
+        callbacks.clear_analysis,
+    )
+    _connect_optional_signal(
+        composition.analysis_content,
         "analysisModeChanged",
         callbacks.set_analysis_mode,
     )

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -73,6 +73,7 @@ class WizardActionCallbacks:
     load_activity_layers: Callable[[], None] | None = None
     apply_map_filters: Callable[[], None] | None = None
     run_analysis: Callable[[], None] | None = None
+    clear_analysis: Callable[[], None] | None = None
     set_analysis_mode: Callable[[str], None] | None = None
     export_atlas: Callable[[], None] | None = None
     update_atlas_document_settings: Callable[[str, str], None] | None = None
@@ -441,6 +442,11 @@ def _connect_action_callbacks(
         analysis_content,
         "runAnalysisRequested",
         callbacks.run_analysis,
+    )
+    _connect_optional_signal(
+        analysis_content,
+        "clearAnalysisRequested",
+        callbacks.clear_analysis,
     )
     _connect_optional_signal(
         analysis_content,


### PR DESCRIPTION
## Summary
- Add a visible **Clear analysis** action to the Analysis tab content.
- Wire the action through the wizard/local-first callback adapters to remove qfit analysis overlays.
- Refresh the dock state after clearing and show neutral “No analysis displayed” copy.

Closes #804.

## Tests
- `python3 -m pytest tests/test_analysis_page.py tests/test_local_first_composition.py tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
