### PR TITLE
Expose style controls in local-first Map page

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -479,6 +479,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             ),
         )
         self._sync_atlas_document_settings_controls(self._wizard_shell_composition)
+        self._install_wizard_style_controls(self._wizard_shell_composition)
         self._install_wizard_filter_controls(self._wizard_shell_composition)
         self._bind_wizard_analysis_mode_controls(self._wizard_shell_composition)
         return self._wizard_shell_composition
@@ -520,6 +521,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 update_atlas_document_settings=self._update_atlas_document_settings,
             ),
         )
+        self._install_wizard_style_controls(self._local_first_dock_composition)
         self._install_wizard_filter_controls(self._local_first_dock_composition)
         self._install_local_first_basemap_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
@@ -593,6 +595,41 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         map_content.set_filter_controls_visible()
         self._wizard_filter_controls_installed = True
         self._wizard_filter_controls_installed_target = current_target
+
+    def _install_wizard_style_controls(self, composition) -> None:
+        """Move the live activity-style selector into the wizard map page."""
+
+        map_content = getattr(composition, "map_content", None)
+        style_label = getattr(self, "stylePresetLabel", None)
+        style_combo = getattr(self, "stylePresetComboBox", None)
+        if map_content is None or style_label is None or style_combo is None:
+            return
+        installed_target = getattr(self, "_wizard_style_controls_installed_target", None)
+        current_target = id(map_content)
+        if getattr(self, "_wizard_style_controls_installed", False) and (
+            installed_target == current_target
+        ):
+            return
+        style_controls_layout = getattr(map_content, "style_controls_layout", None)
+        if not callable(style_controls_layout):
+            return
+
+        target_layout = style_controls_layout()
+        parent_panel = getattr(map_content, "style_controls_panel", map_content)
+        for widget in (style_label, style_combo):
+            self._remove_widget_from_current_layout(widget)
+            if hasattr(widget, "setParent"):
+                widget.setParent(parent_panel)
+            target_layout.addWidget(widget)
+            if hasattr(widget, "show"):
+                widget.show()
+            elif hasattr(widget, "setVisible"):
+                widget.setVisible(True)
+        set_visible = getattr(map_content, "set_style_controls_visible", None)
+        if callable(set_visible):
+            set_visible()
+        self._wizard_style_controls_installed = True
+        self._wizard_style_controls_installed_target = current_target
 
     def _remove_widget_from_current_layout(self, widget) -> None:
         parent_widget = (

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -63,6 +63,15 @@ class MapPageContentTest(unittest.TestCase):
         self.assertEqual(content.style_summary_label.text(), "Default activity styling")
         self.assertIn(COLOR_MUTED, content.style_summary_label.styleSheet())
         self.assertEqual(
+            content.style_controls_panel.objectName(),
+            "qfitWizardMapStyleControlsPanel",
+        )
+        self.assertTrue(content.style_controls_panel.isVisible())
+        self.assertEqual(
+            content.style_controls_panel.property("styleControlsState"),
+            "expanded",
+        )
+        self.assertEqual(
             content.filter_summary_label.objectName(),
             "qfitWizardMapFilterSummary",
         )
@@ -128,6 +137,7 @@ class MapPageContentTest(unittest.TestCase):
                 content.layer_summary_label,
                 content.background_summary_label,
                 content.style_summary_label,
+                content.style_controls_panel,
                 content.filter_summary_label,
                 content.filter_controls_panel,
                 content.action_row,
@@ -245,6 +255,15 @@ class MapPageContentTest(unittest.TestCase):
             "expanded",
         )
 
+    def test_default_state_keeps_style_controls_visible(self):
+        content = self.map_page.MapPageContent(self.map_page.MapPageState())
+
+        self.assertTrue(content.style_controls_panel.isVisible())
+        self.assertEqual(
+            content.style_controls_panel.property("styleControlsState"),
+            "expanded",
+        )
+
     def test_set_filter_controls_visible_keeps_filters_expanded(self):
         content = self.map_page.MapPageContent(
             self.map_page.MapPageState()
@@ -255,6 +274,19 @@ class MapPageContentTest(unittest.TestCase):
         self.assertTrue(content.filter_controls_panel.isVisible())
         self.assertEqual(
             content.filter_controls_panel.property("filterControlsState"),
+            "expanded",
+        )
+
+    def test_set_style_controls_visible_keeps_style_controls_expanded(self):
+        content = self.map_page.MapPageContent(
+            self.map_page.MapPageState()
+        )
+
+        content.set_style_controls_visible()
+
+        self.assertTrue(content.style_controls_panel.isVisible())
+        self.assertEqual(
+            content.style_controls_panel.property("styleControlsState"),
             "expanded",
         )
 
@@ -274,6 +306,11 @@ class MapPageContentTest(unittest.TestCase):
             "expanded",
         )
         self.assertTrue(content.filter_controls_panel.isVisible())
+        self.assertEqual(
+            content.style_controls_panel.property("styleControlsState"),
+            "expanded",
+        )
+        self.assertTrue(content.style_controls_panel.isVisible())
 
     def test_buttons_emit_reusable_page_signals(self):
         content = self.map_page.MapPageContent()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 import unittest
 from types import ModuleType, SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from tests import _path  # noqa: F401
 from qfit.activities.domain.activity_query import DETAILED_ROUTE_FILTER_MISSING
@@ -918,6 +918,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._atlas_export_completed = False
         dock.settings = _FakeSettings()
         dock._install_wizard_filter_controls = MagicMock()
+        dock._install_wizard_style_controls = MagicMock()
         dock._bind_wizard_analysis_mode_controls = MagicMock()
         parent = object()
 
@@ -984,6 +985,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 callback.__func__,
                 getattr(self.module.QfitDockWidget, method_name),
             )
+        dock._install_wizard_style_controls.assert_called_once_with(
+            "connected-composition"
+        )
         dock._install_wizard_filter_controls.assert_called_once_with(
             "connected-composition"
         )
@@ -1090,6 +1094,60 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         parent_layout.removeWidget.assert_called_once_with(filter_group)
         filter_layout.addWidget.assert_called_once_with(filter_group)
         self.assertEqual(dock._wizard_filter_controls_installed_target, id(map_content))
+
+    def test_install_wizard_style_controls_moves_live_style_selector_into_map_panel(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        parent_layout = MagicMock()
+        parent_widget = SimpleNamespace(layout=lambda: parent_layout)
+        style_label = MagicMock()
+        style_combo = MagicMock()
+        style_label.parentWidget.return_value = parent_widget
+        style_combo.parentWidget.return_value = parent_widget
+        dock.stylePresetLabel = style_label
+        dock.stylePresetComboBox = style_combo
+        panel = object()
+        style_layout = MagicMock()
+        map_content = SimpleNamespace(
+            style_controls_panel=panel,
+            style_controls_layout=MagicMock(return_value=style_layout),
+            set_style_controls_visible=MagicMock(),
+        )
+
+        self.module.QfitDockWidget._install_wizard_style_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
+        self.assertEqual(
+            parent_layout.removeWidget.call_args_list,
+            [call(style_label), call(style_combo)],
+        )
+        style_label.setParent.assert_called_once_with(panel)
+        style_combo.setParent.assert_called_once_with(panel)
+        self.assertEqual(
+            style_layout.addWidget.call_args_list,
+            [call(style_label), call(style_combo)],
+        )
+        style_label.show.assert_called_once_with()
+        style_combo.show.assert_called_once_with()
+        map_content.set_style_controls_visible.assert_called_once_with()
+        self.assertTrue(dock._wizard_style_controls_installed)
+        self.assertEqual(dock._wizard_style_controls_installed_target, id(map_content))
+
+    def test_install_wizard_style_controls_is_idempotent(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._wizard_style_controls_installed = True
+        dock.stylePresetLabel = MagicMock()
+        dock.stylePresetComboBox = MagicMock()
+        map_content = SimpleNamespace(style_controls_layout=MagicMock())
+        dock._wizard_style_controls_installed_target = id(map_content)
+
+        self.module.QfitDockWidget._install_wizard_style_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
+        map_content.style_controls_layout.assert_not_called()
 
     def test_bind_wizard_analysis_mode_controls_exposes_non_none_modes(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -303,6 +303,16 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.outputGroupBox.parent(), dock.activitiesSectionContentWidget)
             self.assertGreater(dock.activitiesSectionContentWidget.layout().indexOf(dock.outputGroupBox), dock.activitiesSectionContentWidget.layout().indexOf(dock.previewGroupBox))
             self.assertEqual(dock.styleGroupBox.title(), "")
+            self.assertEqual(
+                dock.stylePresetComboBox.parentWidget(),
+                dock._local_first_dock_composition.map_content.style_controls_panel,
+            )
+            self.assertGreaterEqual(
+                dock._local_first_dock_composition.map_content.style_controls_layout().indexOf(
+                    dock.stylePresetComboBox,
+                ),
+                0,
+            )
             self.assertEqual(dock.styleSectionToggleButton.text(), "Visualize")
             self.assertEqual(dock.styleSectionToggleButton.arrowType(), Qt.DownArrow)
             self.assertFalse(dock.styleSectionContentWidget.isHidden())

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -81,6 +81,11 @@ class MapPageContent(QWidget):
         self.style_summary_label.setObjectName("qfitWizardMapStyleSummary")
         configure_fluid_text_label(self.style_summary_label)
         style_summary_label(self.style_summary_label)
+        self.style_controls_panel = QWidget(self)
+        self.style_controls_panel.setObjectName("qfitWizardMapStyleControlsPanel")
+        self.style_controls_panel.setVisible(True)
+        self.style_controls_panel.setProperty("styleControlsState", "expanded")
+        self._style_controls_layout = self._build_style_controls_layout()
         self.filter_summary_label = QLabel("", self)
         self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
         configure_fluid_text_label(self.filter_summary_label)
@@ -127,6 +132,7 @@ class MapPageContent(QWidget):
         self.background_summary_label.setProperty("mapState", map_state)
         self.style_summary_label.setText(state.style_summary_text)
         self.style_summary_label.setProperty("mapState", map_state)
+        self.set_style_controls_visible()
         self.filter_summary_label.setText(state.filter_summary_text)
         self.filter_summary_label.setProperty("mapState", map_state)
         self.load_layers_button.setText(state.load_action_label)
@@ -153,6 +159,17 @@ class MapPageContent(QWidget):
 
         return self._filter_controls_layout
 
+    def style_controls_layout(self):
+        """Expose the wizard panel slot for live style controls."""
+
+        return self._style_controls_layout
+
+    def set_style_controls_visible(self) -> None:
+        """Keep embedded style controls visible without rebuilding the page."""
+
+        self.style_controls_panel.setVisible(True)
+        self.style_controls_panel.setProperty("styleControlsState", "expanded")
+
     def set_filter_controls_visible(self) -> None:
         """Keep embedded filter controls visible without rebuilding the page."""
 
@@ -172,6 +189,14 @@ class MapPageContent(QWidget):
         layout.setSpacing(6)
         return layout
 
+    def _build_style_controls_layout(self):
+        layout = QVBoxLayout(self.style_controls_panel)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardMapStyleControlsLayout")
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        return layout
+
     def _build_layout(self):
         layout = QVBoxLayout(self)
         if hasattr(layout, "setObjectName"):
@@ -183,6 +208,7 @@ class MapPageContent(QWidget):
         layout.addWidget(self.layer_summary_label)
         layout.addWidget(self.background_summary_label)
         layout.addWidget(self.style_summary_label)
+        layout.addWidget(self.style_controls_panel)
         layout.addWidget(self.filter_summary_label)
         layout.addWidget(self.filter_controls_panel)
         layout.addWidget(self.action_row)


### PR DESCRIPTION
## Summary
- Add a local-first Map-page slot for activity style controls.
- Move the existing style preset label/combo into that visible Map-page slot for both wizard and local-first compositions.
- Cover the migrated control placement in pure page/dock tests and QGIS smoke coverage.

Refs #805.

## Tests
- `python3 -m pytest tests/test_map_page.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_defaults_to_local_first_live_path -q`
- `python3 -m pytest tests/ -x -q --tb=short`
