### PR TITLE
Standardize local-first panel spacing

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -37,6 +37,8 @@ Rules:
 - Section internal spacing = M.
 - Section spacing = L or XL.
 - Avoid arbitrary spacing values unless a native Qt/QGIS control requires a specific margin.
+- Local-first right-panel pages use M page margins, M spacing between top-level page content blocks, and S spacing inside each page-content layout.
+- Local-first right-panel content is top-aligned. Do not distribute controls vertically to fill the available dock height; leaving empty space at the bottom is preferred to tab-to-tab spacing drift.
 
 ### Typography
 

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 
 from tests import _path  # noqa: F401
-from tests.test_wizard_shell import _fake_qt_modules
+from tests.test_wizard_shell import _FakeQt, _fake_qt_modules
 
 from qfit.ui.application.wizard_progress import WizardProgressFacts
 
@@ -86,6 +86,30 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             composition.sync_content.detail_label.text(),
             "Stored activities are ready to load from the existing GeoPackage.",
         )
+
+    def test_local_first_pages_use_fixed_top_aligned_spacing(self):
+        composition = self.module.build_local_first_dock_composition()
+
+        for page in composition.pages.values():
+            layout = page.body_layout()
+            self.assertEqual(layout.contents_margins, (12, 12, 12, 12))
+            self.assertEqual(layout.spacing, 12)
+            self.assertEqual(layout.alignment, _FakeQt.AlignTop)
+
+        for content in (
+            composition.sync_content,
+            composition.map_content,
+            composition.analysis_content,
+            composition.atlas_content,
+            composition.connection_content,
+        ):
+            layout = content.outer_layout()
+            self.assertEqual(layout.contents_margins, (0, 0, 0, 0))
+            self.assertEqual(layout.spacing, 8)
+            self.assertEqual(layout.alignment, _FakeQt.AlignTop)
+
+        self.assertEqual(composition.map_content.filter_controls_layout().spacing, 8)
+        self.assertEqual(composition.map_content.style_controls_layout().spacing, 8)
 
     def test_connects_existing_page_action_callbacks(self):
         composition = self.module.build_local_first_dock_composition(

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -47,6 +47,7 @@ class _FakeCursor:
 
 
 class _FakeQt:
+    AlignTop = 8
     AlignCenter = 9
     ForbiddenCursor = 10
     Horizontal = 13
@@ -325,6 +326,7 @@ class _FakeVBoxLayout:
         self.object_name = ""
         self.contents_margins = None
         self.spacing = None
+        self.alignment = None
         self.direction = None
         self.widgets = []
         self.stretches = []
@@ -337,6 +339,9 @@ class _FakeVBoxLayout:
 
     def setSpacing(self, value):  # noqa: N802
         self.spacing = value
+
+    def setAlignment(self, value):  # noqa: N802
+        self.alignment = value
 
     def setDirection(self, value):  # noqa: N802
         self.direction = value

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -11,6 +11,7 @@ from .action_row import (
 )
 from .page_content_style import (
     configure_fluid_text_label,
+    configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -170,8 +171,7 @@ class AnalysisPageContent(QWidget):
         layout = QVBoxLayout(self)
         if hasattr(layout, "setObjectName"):
             layout.setObjectName("qfitWizardAnalysisPageContentLayout")
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(8)
+        configure_top_aligned_panel_layout(layout)
         for widget in (
             self.status_label,
             self.detail_label,

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -10,6 +10,7 @@ from .action_row import (
 )
 from .page_content_style import (
     configure_fluid_text_label,
+    configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -167,8 +168,7 @@ class AtlasPageContent(QWidget):
         layout = QVBoxLayout(self)
         if hasattr(layout, "setObjectName"):
             layout.setObjectName("qfitWizardAtlasPageContentLayout")
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(8)
+        configure_top_aligned_panel_layout(layout)
         for widget in (
             self.status_label,
             self.detail_label,

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -10,6 +10,7 @@ from .action_row import (
 )
 from .page_content_style import (
     configure_fluid_text_label,
+    configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -119,8 +120,7 @@ class ConnectionPageContent(QWidget):
         layout = QVBoxLayout(self)
         if hasattr(layout, "setObjectName"):
             layout.setObjectName("qfitWizardConnectionPageContentLayout")
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(8)
+        configure_top_aligned_panel_layout(layout)
         layout.addWidget(self.status_label)
         layout.addWidget(self.detail_label)
         layout.addWidget(self.credential_summary_label)

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -17,6 +17,11 @@ from .connection_page import (
 )
 from .local_first_shell import LocalFirstDockShell
 from .map_page import MapPageContent, build_map_page_content
+from .page_content_style import (
+    LOCAL_FIRST_PAGE_MARGINS,
+    LOCAL_FIRST_PAGE_SPACING,
+    configure_top_aligned_panel_layout,
+)
 from .sync_page import SyncPageContent, build_sync_page_content
 from .wizard_composition import (
     WizardActionCallbacks,
@@ -303,8 +308,11 @@ class _LocalFirstDockPage(QWidget):
         self._layout = QVBoxLayout(self)
         if hasattr(self._layout, "setObjectName"):
             self._layout.setObjectName(f"qfitLocalFirstDockPageLayout_{key}")
-        self._layout.setContentsMargins(12, 8, 12, 8)
-        self._layout.setSpacing(8)
+        configure_top_aligned_panel_layout(
+            self._layout,
+            margins=LOCAL_FIRST_PAGE_MARGINS,
+            spacing=LOCAL_FIRST_PAGE_SPACING,
+        )
 
     def body_layout(self):
         return self._layout

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -11,6 +11,7 @@ from .action_row import (
 )
 from .page_content_style import (
     configure_fluid_text_label,
+    configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -185,24 +186,21 @@ class MapPageContent(QWidget):
         layout = QVBoxLayout(self.filter_controls_panel)
         if hasattr(layout, "setObjectName"):
             layout.setObjectName("qfitWizardMapFilterControlsLayout")
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(6)
+        configure_top_aligned_panel_layout(layout)
         return layout
 
     def _build_style_controls_layout(self):
         layout = QVBoxLayout(self.style_controls_panel)
         if hasattr(layout, "setObjectName"):
             layout.setObjectName("qfitWizardMapStyleControlsLayout")
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(6)
+        configure_top_aligned_panel_layout(layout)
         return layout
 
     def _build_layout(self):
         layout = QVBoxLayout(self)
         if hasattr(layout, "setObjectName"):
             layout.setObjectName("qfitWizardMapPageContentLayout")
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(8)
+        configure_top_aligned_panel_layout(layout)
         layout.addWidget(self.status_label)
         layout.addWidget(self.detail_label)
         layout.addWidget(self.layer_summary_label)

--- a/ui/dockwidget/page_content_style.py
+++ b/ui/dockwidget/page_content_style.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from qfit.ui.tokens import COLOR_MUTED, pill_tone_palette
+from qfit.ui.tokens import (
+    COLOR_MUTED,
+    SPACING_M,
+    SPACING_S,
+    pill_tone_palette,
+)
 
 from ._qt_compat import import_qt_module
 
@@ -9,8 +14,19 @@ _qtwidgets = import_qt_module(
     "PyQt5.QtWidgets",
     ("QSizePolicy",),
 )
+_qtcore = import_qt_module(
+    "qgis.PyQt.QtCore",
+    "PyQt5.QtCore",
+    ("Qt",),
+)
 
 QSizePolicy = _qtwidgets.QSizePolicy
+Qt = _qtcore.Qt
+
+PAGE_CONTENT_MARGINS = (0, 0, 0, 0)
+LOCAL_FIRST_PAGE_MARGINS = (SPACING_M, SPACING_M, SPACING_M, SPACING_M)
+LOCAL_FIRST_PAGE_SPACING = SPACING_M
+PANEL_CONTENT_SPACING = SPACING_S
 
 _DETAIL_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 _SUMMARY_LABEL_QSS = (
@@ -44,6 +60,23 @@ def configure_fluid_text_label(label) -> None:
         label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
 
 
+def configure_top_aligned_panel_layout(
+    layout,
+    *,
+    margins: tuple[int, int, int, int] = PAGE_CONTENT_MARGINS,
+    spacing: int = PANEL_CONTENT_SPACING,
+) -> None:
+    """Apply qfit panel spacing and top anchoring to a vertical layout."""
+
+    if hasattr(layout, "setContentsMargins"):
+        layout.setContentsMargins(*margins)
+    if hasattr(layout, "setSpacing"):
+        layout.setSpacing(spacing)
+    align_top = getattr(Qt, "AlignTop", None)
+    if align_top is not None and hasattr(layout, "setAlignment"):
+        layout.setAlignment(align_top)
+
+
 def style_status_pill(label, *, active: bool) -> None:
     """Render a wizard page status label as an ok/warn token pill."""
 
@@ -68,7 +101,12 @@ def _status_pill_stylesheet(tone: str, *, object_name: str) -> str:
 
 __all__ = [
     "style_detail_label",
+    "configure_top_aligned_panel_layout",
     "configure_fluid_text_label",
+    "LOCAL_FIRST_PAGE_MARGINS",
+    "LOCAL_FIRST_PAGE_SPACING",
+    "PAGE_CONTENT_MARGINS",
+    "PANEL_CONTENT_SPACING",
     "style_status_pill",
     "style_summary_label",
 ]

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -12,6 +12,7 @@ from .action_row import (
 )
 from .page_content_style import (
     configure_fluid_text_label,
+    configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
     style_summary_label,
@@ -168,8 +169,7 @@ class SyncPageContent(QWidget):
         layout = QVBoxLayout(self)
         if hasattr(layout, "setObjectName"):
             layout.setObjectName("qfitWizardSyncPageContentLayout")
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(8)
+        configure_top_aligned_panel_layout(layout)
         layout.addWidget(self.status_label)
         layout.addWidget(self.detail_label)
         layout.addWidget(self.action_row)

--- a/ui/tokens.py
+++ b/ui/tokens.py
@@ -16,6 +16,12 @@ COLOR_SEPARATOR = "#dcdcdc"
 COLOR_HOVER = "#e8e8e8"
 COLOR_TITLE_BAR = "#e4e4e7"
 
+SPACING_XS = 4
+SPACING_S = 8
+SPACING_M = 12
+SPACING_L = 16
+SPACING_XL = 24
+
 PILL_TONES: dict[str, tuple[str, str]] = {
     "ok": ("#dcefd0", "#2e6318"),
     "info": ("#d6e7f7", "#124c8c"),
@@ -67,5 +73,10 @@ __all__ = [
     "COLOR_WARN",
     "PILL_TONES",
     "PRIMARY_BTN_QSS",
+    "SPACING_L",
+    "SPACING_M",
+    "SPACING_S",
+    "SPACING_XL",
+    "SPACING_XS",
     "pill_tone_palette",
 ]


### PR DESCRIPTION
## Summary
- Add explicit qfit spacing tokens and a shared top-aligned panel-layout helper.
- Apply fixed local-first right-panel margins/spacing and top anchoring across Data, Map, Analysis, Atlas, and Settings content.
- Document the local-first right-panel spacing rule in the design system.

Refs #805.

## Tests
- `python3 -m pytest tests/test_local_first_composition.py tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
