### PR TITLE
Expose storage controls in local-first Settings

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -524,6 +524,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._install_wizard_style_controls(self._local_first_dock_composition)
         self._install_wizard_filter_controls(self._local_first_dock_composition)
         self._install_local_first_basemap_controls(self._local_first_dock_composition)
+        self._install_local_first_storage_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
         return self._local_first_dock_composition
 
@@ -671,6 +672,43 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._local_first_basemap_controls_installed = True
         self._local_first_basemap_controls_installed_target = current_target
+
+    def _install_local_first_storage_controls(self, composition) -> None:
+        """Expose the backing GeoPackage storage controls in the Settings tab."""
+
+        settings_content = getattr(composition, "connection_content", None)
+        storage_group = getattr(self, "outputGroupBox", None)
+        if settings_content is None or storage_group is None:
+            return
+        installed_target = getattr(
+            self,
+            "_local_first_storage_controls_installed_target",
+            None,
+        )
+        current_target = id(settings_content)
+        if getattr(self, "_local_first_storage_controls_installed", False) and (
+            installed_target == current_target
+        ):
+            return
+
+        layout_getter = getattr(settings_content, "outer_layout", None)
+        layout = layout_getter() if callable(layout_getter) else None
+        if layout is None or not hasattr(layout, "addWidget"):
+            return
+
+        self._remove_widget_from_current_layout(storage_group)
+        if hasattr(storage_group, "setParent"):
+            storage_group.setParent(settings_content)
+        if hasattr(storage_group, "setTitle"):
+            storage_group.setTitle("Data storage")
+        layout.addWidget(storage_group)
+        if hasattr(storage_group, "show"):
+            storage_group.show()
+        elif hasattr(storage_group, "setVisible"):
+            storage_group.setVisible(True)
+
+        self._local_first_storage_controls_installed = True
+        self._local_first_storage_controls_installed_target = current_target
 
     def _bind_wizard_analysis_mode_controls(self, composition) -> None:
         """Expose the hidden backing analysis selector in the live wizard path."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -919,6 +919,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.settings = _FakeSettings()
         dock._install_wizard_filter_controls = MagicMock()
         dock._install_wizard_style_controls = MagicMock()
+        dock._install_local_first_basemap_controls = MagicMock()
+        dock._install_local_first_storage_controls = MagicMock()
         dock._bind_wizard_analysis_mode_controls = MagicMock()
         parent = object()
 
@@ -989,6 +991,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "connected-composition"
         )
         dock._install_wizard_filter_controls.assert_called_once_with(
+            "connected-composition"
+        )
+        dock._install_local_first_basemap_controls.assert_called_once_with(
+            "connected-composition"
+        )
+        dock._install_local_first_storage_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._bind_wizard_analysis_mode_controls.assert_called_once_with(
@@ -1353,6 +1361,64 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(basemap_group.shown)
         self.assertEqual(settings_layout.added, [basemap_group])
         self.assertTrue(dock._local_first_basemap_controls_installed)
+
+    def test_local_first_storage_controls_move_to_settings_page(self):
+        class _SourceLayout:
+            def __init__(self):
+                self.removed = []
+
+            def removeWidget(self, widget):
+                self.removed.append(widget)
+
+        class _SourceParent:
+            def __init__(self, layout):
+                self._layout = layout
+
+            def layout(self):
+                return self._layout
+
+        class _StorageGroup:
+            def __init__(self, parent):
+                self._parent = parent
+                self.title = None
+                self.shown = False
+
+            def parentWidget(self):
+                return self._parent
+
+            def setParent(self, parent):
+                self._parent = parent
+
+            def setTitle(self, title):
+                self.title = title
+
+            def show(self):
+                self.shown = True
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        source_layout = _SourceLayout()
+        source_parent = _SourceParent(source_layout)
+        storage_group = _StorageGroup(source_parent)
+        settings_layout = _FakeLayout()
+        settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
+        composition = SimpleNamespace(connection_content=settings_content)
+        dock.outputGroupBox = storage_group
+
+        self.module.QfitDockWidget._install_local_first_storage_controls(
+            dock,
+            composition,
+        )
+        self.module.QfitDockWidget._install_local_first_storage_controls(
+            dock,
+            composition,
+        )
+
+        self.assertEqual(source_layout.removed, [storage_group])
+        self.assertIs(storage_group.parentWidget(), settings_content)
+        self.assertEqual(storage_group.title, "Data storage")
+        self.assertTrue(storage_group.shown)
+        self.assertEqual(settings_layout.added, [storage_group])
+        self.assertTrue(dock._local_first_storage_controls_installed)
 
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary
- Move the existing GeoPackage data-storage controls into the visible local-first Settings tab.
- Preserve the existing output-path, browse, sampled-point, and point-stride settings bindings/callbacks for this small consolidation slice.
- Cover the move with pure dock tests, including idempotency and local-first composition wiring.

Refs #805.

## Tests
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
