### PR TITLE
Refresh canvas after clearing analysis layers

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1934,7 +1934,22 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 logger.debug("Failed to remove stale analysis layer", exc_info=True)
         if analysis_removed:
             self._mark_atlas_export_stale()
+            self._refresh_map_canvas()
         return analysis_removed
+
+    def _refresh_map_canvas(self) -> None:
+        """Force QGIS to repaint the map canvas after direct layer mutations."""
+
+        iface = getattr(self, "iface", None)
+        canvas_getter = getattr(iface, "mapCanvas", None)
+        canvas = canvas_getter() if callable(canvas_getter) else None
+        refresh = getattr(canvas, "refresh", None)
+        if not callable(refresh):
+            return
+        try:
+            refresh()
+        except RuntimeError:
+            logger.debug("Failed to refresh map canvas", exc_info=True)
 
     def _current_activity_preview_request(self):
         return build_activity_preview_request(

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2116,12 +2116,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         dock.analysis_layer = current_layer
         dock._atlas_export_completed = True
+        canvas = SimpleNamespace(refresh=MagicMock())
+        dock.iface = SimpleNamespace(mapCanvas=lambda: canvas)
 
         with patch.object(self.module.QgsProject, "instance", return_value=project):
             self.module.QfitDockWidget._clear_analysis_layer(dock)
 
         self.assertIsNone(dock.analysis_layer)
         self.assertFalse(dock._atlas_export_completed)
+        canvas.refresh.assert_called_once_with()
         self.assertEqual(
             project.removed,
             [current_layer.id(), stale_layer.id(), stale_heatmap_layer.id()],
@@ -2131,12 +2134,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock = object.__new__(self.module.QfitDockWidget)
         project = _FakeProject({"other": _FakeLayer("other")})
         dock._atlas_export_completed = True
+        canvas = SimpleNamespace(refresh=MagicMock())
+        dock.iface = SimpleNamespace(mapCanvas=lambda: canvas)
 
         with patch.object(self.module.QgsProject, "instance", return_value=project):
             removed = self.module.QfitDockWidget._clear_analysis_layer(dock)
 
         self.assertFalse(removed)
         self.assertTrue(dock._atlas_export_completed)
+        canvas.refresh.assert_not_called()
         self.assertEqual(project.removed, [])
 
     def test_on_load_clicked_starts_background_store_task(self):


### PR DESCRIPTION
## Summary
- Force the QGIS map canvas to refresh after qfit removes analysis layers.
- Keep clear-analysis as a no-op for canvas repainting when no analysis layer was removed.
- Add a regression test for the stale proportional-symbol repaint case.

## Tests
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
