### PR TITLE
Apply text feedback styling convention

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -46,8 +46,24 @@ Rules:
 - Title text: bold.
 - Section heading: bold.
 - Field label: default weight.
-- Helper and status text: default or slightly smaller, with muted color only as supporting emphasis.
+- Instruction/helper text: regular style, default or slightly smaller, with muted color only as supporting emphasis.
+- Tool feedback text: italic and muted when it reports generated facts, workflow results, empty states, or non-blocking status detail.
+- Semantic badges/pills may remain regular/bold because their component shape and text already communicate status.
+- Warnings and errors should stay regular by default for readability and urgency; use semantic color, status copy, a pill/badge, or a dialog/message bar depending on severity.
 - No all-caps labels.
+
+Instruction text tells the user what to do next; keep it visually stable and regular. Tool feedback tells the user what qfit observed, computed, loaded, cleared, or exported; render it quieter in italic. Do not rely on italic alone for meaning: pair feedback with placement, copy, color, or a status component.
+
+Use this text-voice split for normal inline copy:
+
+| Voice | Example use | Treatment |
+| --- | --- | --- |
+| Instruction/helper | What to do next, field guidance, prerequisites | Regular, muted if secondary |
+| Informational feedback | Loaded counts, active filters, empty states, export summaries | Italic, muted |
+| Warning | Recoverable problem or degraded output | Regular, warning token/pill and explicit warning copy |
+| Error | Blocking failure or action that could not complete | Regular, danger token or blocking dialog/message bar |
+
+So regular text is not the only distinction between information and errors: warnings/errors must carry semantic warning/error treatment in addition to position and wording.
 
 ### Status categories
 
@@ -155,6 +171,8 @@ Usage rules:
 
 - Keep it close to the UI it describes.
 - Use concrete copy: what happened, what is missing, or what to do next.
+- Render status detail and generated-result feedback in muted italic text unless the text is inside a semantic pill/badge.
+- Do not italicize warning or error messages by default; preserve a direct regular style and pair it with warning/error semantics.
 - Do not use color or icon alone as the status.
 
 ### Presentation/free-text labels

--- a/tests/test_page_content_style.py
+++ b/tests/test_page_content_style.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
-from qfit.ui.tokens import COLOR_MUTED
+from qfit.ui.tokens import COLOR_DANGER, COLOR_MUTED, COLOR_WARN
 
 
 def _load_page_content_style_module():
@@ -25,16 +25,38 @@ class PageContentStyleTest(unittest.TestCase):
     def setUpClass(cls):
         cls.page_content_style = _load_page_content_style_module()
 
-    def test_styles_detail_and_summary_labels_with_muted_tokens(self):
+    def test_styles_instruction_and_feedback_labels_by_voice(self):
         detail = _FakeLabel(object_name="detailLabel")
-        summary = _FakeLabel(object_name="summaryLabel")
+        feedback = _FakeLabel(object_name="feedbackLabel")
 
         self.page_content_style.style_detail_label(detail)
-        self.page_content_style.style_summary_label(summary)
+        self.page_content_style.style_feedback_label(feedback)
 
         self.assertIn(COLOR_MUTED, detail.styleSheet())
+        self.assertNotIn("font-style: italic", detail.styleSheet())
+        self.assertIn(COLOR_MUTED, feedback.styleSheet())
+        self.assertIn("font-style: italic", feedback.styleSheet())
+        self.assertIn("padding: 1px 0", feedback.styleSheet())
+
+    def test_summary_label_style_remains_feedback_compatible(self):
+        summary = _FakeLabel(object_name="summaryLabel")
+
+        self.page_content_style.style_summary_label(summary)
+
         self.assertIn(COLOR_MUTED, summary.styleSheet())
-        self.assertIn("padding: 1px 0", summary.styleSheet())
+        self.assertIn("font-style: italic", summary.styleSheet())
+
+    def test_styles_problem_labels_with_semantic_color_without_italic(self):
+        warning = _FakeLabel(object_name="warningLabel")
+        error = _FakeLabel(object_name="errorLabel")
+
+        self.page_content_style.style_warning_label(warning)
+        self.page_content_style.style_error_label(error)
+
+        self.assertIn(COLOR_WARN, warning.styleSheet())
+        self.assertNotIn("font-style: italic", warning.styleSheet())
+        self.assertIn(COLOR_DANGER, error.styleSheet())
+        self.assertNotIn("font-style: italic", error.styleSheet())
 
     def test_styles_status_labels_as_scoped_token_pills(self):
         label = _FakeLabel(object_name="statusLabel")

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -71,7 +71,7 @@ class WizardPageTest(unittest.TestCase):
         self.assertIn("background map", page.summary_label.text())
         self.assertIn(COLOR_MUTED, page.summary_label.styleSheet())
         self.assertIn(COLOR_MUTED, page.primary_hint_label.styleSheet())
-        self.assertIn("font-style: italic", page.primary_hint_label.styleSheet())
+        self.assertNotIn("font-style: italic", page.primary_hint_label.styleSheet())
         for label in (page.title_label, page.summary_label, page.primary_hint_label):
             self.assertTrue(label.word_wrap)
             self.assertEqual(label.minimumWidth(), 0)

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -14,7 +14,7 @@ from .page_content_style import (
     configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
-    style_summary_label,
+    style_feedback_label,
 )
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -75,11 +75,11 @@ class AnalysisPageContent(QWidget):
         self.input_summary_label = QLabel("", self)
         self.input_summary_label.setObjectName("qfitWizardAnalysisInputSummary")
         configure_fluid_text_label(self.input_summary_label)
-        style_summary_label(self.input_summary_label)
+        style_feedback_label(self.input_summary_label)
         self.result_summary_label = QLabel("", self)
         self.result_summary_label.setObjectName("qfitWizardAnalysisResultSummary")
         configure_fluid_text_label(self.result_summary_label)
-        style_summary_label(self.result_summary_label)
+        style_feedback_label(self.result_summary_label)
         self.analysis_mode_label = QLabel("Analysis mode", self)
         self.analysis_mode_label.setObjectName("qfitWizardAnalysisModeLabel")
         style_detail_label(self.analysis_mode_label)

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -13,7 +13,7 @@ from .page_content_style import (
     configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
-    style_summary_label,
+    style_feedback_label,
 )
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -79,11 +79,11 @@ class AtlasPageContent(QWidget):
         self.input_summary_label = QLabel("", self)
         self.input_summary_label.setObjectName("qfitWizardAtlasInputSummary")
         configure_fluid_text_label(self.input_summary_label)
-        style_summary_label(self.input_summary_label)
+        style_feedback_label(self.input_summary_label)
         self.output_summary_label = QLabel("", self)
         self.output_summary_label.setObjectName("qfitWizardAtlasOutputSummary")
         configure_fluid_text_label(self.output_summary_label)
-        style_summary_label(self.output_summary_label)
+        style_feedback_label(self.output_summary_label)
         self.title_label = QLabel("Atlas title", self)
         self.title_label.setObjectName("qfitWizardAtlasTitleLabel")
         style_detail_label(self.title_label)

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -13,7 +13,7 @@ from .page_content_style import (
     configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
-    style_summary_label,
+    style_feedback_label,
 )
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -73,7 +73,7 @@ class ConnectionPageContent(QWidget):
         self.credential_summary_label = QLabel("", self)
         self.credential_summary_label.setObjectName("qfitWizardConnectionCredentialSummary")
         configure_fluid_text_label(self.credential_summary_label)
-        style_summary_label(self.credential_summary_label)
+        style_feedback_label(self.credential_summary_label)
         self.configure_button = QToolButton(self)
         self.configure_button.setObjectName("qfitWizardConnectionConfigureButton")
         style_primary_action_button(

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -14,7 +14,7 @@ from .page_content_style import (
     configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
-    style_summary_label,
+    style_feedback_label,
 )
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -73,15 +73,15 @@ class MapPageContent(QWidget):
         self.layer_summary_label = QLabel("", self)
         self.layer_summary_label.setObjectName("qfitWizardMapLayerSummary")
         configure_fluid_text_label(self.layer_summary_label)
-        style_summary_label(self.layer_summary_label)
+        style_feedback_label(self.layer_summary_label)
         self.background_summary_label = QLabel("", self)
         self.background_summary_label.setObjectName("qfitWizardMapBackgroundSummary")
         configure_fluid_text_label(self.background_summary_label)
-        style_summary_label(self.background_summary_label)
+        style_feedback_label(self.background_summary_label)
         self.style_summary_label = QLabel("", self)
         self.style_summary_label.setObjectName("qfitWizardMapStyleSummary")
         configure_fluid_text_label(self.style_summary_label)
-        style_summary_label(self.style_summary_label)
+        style_feedback_label(self.style_summary_label)
         self.style_controls_panel = QWidget(self)
         self.style_controls_panel.setObjectName("qfitWizardMapStyleControlsPanel")
         self.style_controls_panel.setVisible(True)
@@ -90,7 +90,7 @@ class MapPageContent(QWidget):
         self.filter_summary_label = QLabel("", self)
         self.filter_summary_label.setObjectName("qfitWizardMapFilterSummary")
         configure_fluid_text_label(self.filter_summary_label)
-        style_summary_label(self.filter_summary_label)
+        style_feedback_label(self.filter_summary_label)
         self.load_layers_button = QToolButton(self)
         self.load_layers_button.setObjectName("qfitWizardMapLoadLayersButton")
         style_secondary_action_button(

--- a/ui/dockwidget/page_content_style.py
+++ b/ui/dockwidget/page_content_style.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from qfit.ui.tokens import (
+    COLOR_DANGER,
     COLOR_MUTED,
+    COLOR_WARN,
     SPACING_M,
     SPACING_S,
     pill_tone_palette,
@@ -28,25 +30,49 @@ LOCAL_FIRST_PAGE_MARGINS = (SPACING_M, SPACING_M, SPACING_M, SPACING_M)
 LOCAL_FIRST_PAGE_SPACING = SPACING_M
 PANEL_CONTENT_SPACING = SPACING_S
 
-_DETAIL_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
-_SUMMARY_LABEL_QSS = (
+_INSTRUCTION_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
+_FEEDBACK_LABEL_QSS = (
     "QLabel { "
     f"color: {COLOR_MUTED}; "
+    "font-style: italic; "
     "padding: 1px 0; "
     "}"
 )
+_WARNING_LABEL_QSS = f"QLabel {{ color: {COLOR_WARN}; }}"
+_ERROR_LABEL_QSS = f"QLabel {{ color: {COLOR_DANGER}; }}"
 
 
 def style_detail_label(label) -> None:
-    """Apply muted explanatory text styling to a wizard page detail label."""
+    """Apply muted regular styling to instruction or helper text."""
 
-    label.setStyleSheet(_DETAIL_LABEL_QSS)
+    label.setStyleSheet(_INSTRUCTION_LABEL_QSS)
+
+
+def style_feedback_label(label) -> None:
+    """Apply muted italic styling to generated tool feedback text."""
+
+    label.setStyleSheet(_FEEDBACK_LABEL_QSS)
+
+
+def style_warning_label(label) -> None:
+    """Apply regular warning styling to inline non-blocking problem text."""
+
+    label.setStyleSheet(_WARNING_LABEL_QSS)
+
+
+def style_error_label(label) -> None:
+    """Apply regular error styling to inline blocking problem text."""
+
+    label.setStyleSheet(_ERROR_LABEL_QSS)
 
 
 def style_summary_label(label) -> None:
-    """Apply consistent compact summary styling for wizard page status facts."""
+    """Compatibility wrapper for existing summary labels that are feedback.
 
-    label.setStyleSheet(_SUMMARY_LABEL_QSS)
+    Deprecated: prefer ``style_feedback_label`` for new code.
+    """
+
+    style_feedback_label(label)
 
 
 def configure_fluid_text_label(label) -> None:
@@ -101,6 +127,9 @@ def _status_pill_stylesheet(tone: str, *, object_name: str) -> str:
 
 __all__ = [
     "style_detail_label",
+    "style_feedback_label",
+    "style_warning_label",
+    "style_error_label",
     "configure_top_aligned_panel_layout",
     "configure_fluid_text_label",
     "LOCAL_FIRST_PAGE_MARGINS",

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -15,7 +15,7 @@ from .page_content_style import (
     configure_top_aligned_panel_layout,
     style_detail_label,
     style_status_pill,
-    style_summary_label,
+    style_feedback_label,
 )
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("pyqtSignal",))
@@ -81,7 +81,7 @@ class SyncPageContent(QWidget):
         self.activity_summary_label = QLabel("", self)
         self.activity_summary_label.setObjectName("qfitWizardSyncActivitySummary")
         configure_fluid_text_label(self.activity_summary_label)
-        style_summary_label(self.activity_summary_label)
+        style_feedback_label(self.activity_summary_label)
         self.sync_button = QToolButton(self)
         self.sync_button.setObjectName("qfitWizardSyncButton")
         style_primary_action_button(

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -33,12 +33,7 @@ _TITLE_LABEL_QSS = (
     "}"
 )
 _SUMMARY_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
-_PRIMARY_HINT_LABEL_QSS = (
-    "QLabel { "
-    f"color: {COLOR_MUTED}; "
-    "font-style: italic; "
-    "}"
-)
+_PRIMARY_HINT_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 
 
 class WizardPage(QWidget):

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from qgis.PyQt.QtCore import Qt
 
+from qfit.ui.tokens import COLOR_MUTED
+
 from ..mapbox_config import preset_requires_custom_style
 from .application.dock_workflow_sections import (
     CURRENT_DOCK_SECTIONS,
@@ -37,6 +39,7 @@ class WorkflowSectionCoordinator:
         dock.publishSettingsWidget.setVisible(True)
         self._pin_summary_status_footer()
         self._hide_redundant_status_labels()
+        self._style_legacy_feedback_labels()
         section_widgets = {
             "sync": (dock.activitiesGroupBox, "activitiesGroupLayout", "activities"),
             "map": (dock.styleGroupBox, "styleGroupLayout", "style"),
@@ -93,6 +96,7 @@ class WorkflowSectionCoordinator:
             label.setStyleSheet(
                 "QLabel#summaryStatusLabel { "
                 "border-top: 1px solid palette(mid); "
+                "font-style: italic; "
                 "padding: 4px 8px; "
                 "}"
             )
@@ -105,6 +109,23 @@ class WorkflowSectionCoordinator:
             label = getattr(self.dock_widget, name, None)
             if label is not None and hasattr(label, "hide"):
                 label.hide()
+
+    def _style_legacy_feedback_labels(self) -> None:
+        for name in (
+            "connectionStatusLabel",
+            "querySummaryLabel",
+            "atlasPdfStatusLabel",
+        ):
+            label = getattr(self.dock_widget, name, None)
+            if label is None or not hasattr(label, "setStyleSheet"):
+                continue
+            label.setStyleSheet(
+                f"QLabel#{name} {{ "
+                f"color: {COLOR_MUTED}; "
+                "font-style: italic; "
+                "padding: 1px 0; "
+                "}"
+            )
 
     def configure_spinbox_unit_copy(self) -> None:
         """Keep units in spin boxes instead of repeating them in form labels."""


### PR DESCRIPTION
## Summary
- Document the design-system convention: instruction/helper copy stays regular, generated qfit feedback is muted italic.
- Add a shared `style_feedback_label` helper and apply it to local-first generated summary/result labels.
- Keep placeholder instruction hints regular and align legacy feedback labels with the same convention.

## Tests
- `python3 -m pytest tests/test_page_content_style.py tests/test_wizard_pages.py tests/test_map_page.py tests/test_local_first_composition.py tests/test_dockwidget_dependencies.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

## Notes
- No QGIS screenshot captured in this headless run; validation is through shared-style tests and pure UI composition tests.
