### PR TITLE
Expose advanced fetch controls in local-first Data tab

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -523,6 +523,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self._install_wizard_style_controls(self._local_first_dock_composition)
         self._install_wizard_filter_controls(self._local_first_dock_composition)
+        self._install_local_first_advanced_fetch_controls(
+            self._local_first_dock_composition
+        )
         self._install_local_first_basemap_controls(self._local_first_dock_composition)
         self._install_local_first_storage_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
@@ -640,75 +643,79 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if parent_layout is not None and hasattr(parent_layout, "removeWidget"):
             parent_layout.removeWidget(widget)
 
-    def _install_local_first_basemap_controls(self, composition) -> None:
-        """Expose the backing Mapbox basemap controls in the Settings tab."""
-
-        settings_content = getattr(composition, "connection_content", None)
-        background_group = getattr(self, "backgroundGroupBox", None)
-        if settings_content is None or background_group is None:
+    def _install_local_first_group_controls(
+        self,
+        composition,
+        *,
+        content_attr: str,
+        group_attr: str,
+        installed_attr: str,
+        installed_target_attr: str,
+        title: str | None = None,
+    ) -> None:
+        content = getattr(composition, content_attr, None)
+        group = getattr(self, group_attr, None)
+        if content is None or group is None:
             return
-        installed_target = getattr(self, "_local_first_basemap_controls_installed_target", None)
-        current_target = id(settings_content)
-        if getattr(self, "_local_first_basemap_controls_installed", False) and (
-            installed_target == current_target
+        current_target = id(content)
+        if getattr(self, installed_attr, False) and (
+            getattr(self, installed_target_attr, None) == current_target
         ):
             return
 
-        layout_getter = getattr(settings_content, "outer_layout", None)
+        layout_getter = getattr(content, "outer_layout", None)
         layout = layout_getter() if callable(layout_getter) else None
         if layout is None or not hasattr(layout, "addWidget"):
             return
 
-        self._remove_widget_from_current_layout(background_group)
-        if hasattr(background_group, "setParent"):
-            background_group.setParent(settings_content)
-        if hasattr(background_group, "setTitle"):
-            background_group.setTitle("Mapbox basemap")
-        layout.addWidget(background_group)
-        if hasattr(background_group, "show"):
-            background_group.show()
-        elif hasattr(background_group, "setVisible"):
-            background_group.setVisible(True)
+        self._remove_widget_from_current_layout(group)
+        if hasattr(group, "setParent"):
+            group.setParent(content)
+        if title is not None and hasattr(group, "setTitle"):
+            group.setTitle(title)
+        layout.addWidget(group)
+        if hasattr(group, "show"):
+            group.show()
+        elif hasattr(group, "setVisible"):
+            group.setVisible(True)
 
-        self._local_first_basemap_controls_installed = True
-        self._local_first_basemap_controls_installed_target = current_target
+        setattr(self, installed_attr, True)
+        setattr(self, installed_target_attr, current_target)
+
+    def _install_local_first_advanced_fetch_controls(self, composition) -> None:
+        """Expose backing Strava fetch limits in the Data tab."""
+
+        self._install_local_first_group_controls(
+            composition,
+            content_attr="sync_content",
+            group_attr="advancedFetchGroupBox",
+            installed_attr="_local_first_advanced_fetch_controls_installed",
+            installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
+        )
+
+    def _install_local_first_basemap_controls(self, composition) -> None:
+        """Expose the backing Mapbox basemap controls in the Settings tab."""
+
+        self._install_local_first_group_controls(
+            composition,
+            content_attr="connection_content",
+            group_attr="backgroundGroupBox",
+            installed_attr="_local_first_basemap_controls_installed",
+            installed_target_attr="_local_first_basemap_controls_installed_target",
+            title="Mapbox basemap",
+        )
 
     def _install_local_first_storage_controls(self, composition) -> None:
         """Expose the backing GeoPackage storage controls in the Settings tab."""
 
-        settings_content = getattr(composition, "connection_content", None)
-        storage_group = getattr(self, "outputGroupBox", None)
-        if settings_content is None or storage_group is None:
-            return
-        installed_target = getattr(
-            self,
-            "_local_first_storage_controls_installed_target",
-            None,
+        self._install_local_first_group_controls(
+            composition,
+            content_attr="connection_content",
+            group_attr="outputGroupBox",
+            installed_attr="_local_first_storage_controls_installed",
+            installed_target_attr="_local_first_storage_controls_installed_target",
+            title="Data storage",
         )
-        current_target = id(settings_content)
-        if getattr(self, "_local_first_storage_controls_installed", False) and (
-            installed_target == current_target
-        ):
-            return
-
-        layout_getter = getattr(settings_content, "outer_layout", None)
-        layout = layout_getter() if callable(layout_getter) else None
-        if layout is None or not hasattr(layout, "addWidget"):
-            return
-
-        self._remove_widget_from_current_layout(storage_group)
-        if hasattr(storage_group, "setParent"):
-            storage_group.setParent(settings_content)
-        if hasattr(storage_group, "setTitle"):
-            storage_group.setTitle("Data storage")
-        layout.addWidget(storage_group)
-        if hasattr(storage_group, "show"):
-            storage_group.show()
-        elif hasattr(storage_group, "setVisible"):
-            storage_group.setVisible(True)
-
-        self._local_first_storage_controls_installed = True
-        self._local_first_storage_controls_installed_target = current_target
 
     def _bind_wizard_analysis_mode_controls(self, composition) -> None:
         """Expose the hidden backing analysis selector in the live wizard path."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -919,6 +919,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.settings = _FakeSettings()
         dock._install_wizard_filter_controls = MagicMock()
         dock._install_wizard_style_controls = MagicMock()
+        dock._install_local_first_advanced_fetch_controls = MagicMock()
         dock._install_local_first_basemap_controls = MagicMock()
         dock._install_local_first_storage_controls = MagicMock()
         dock._bind_wizard_analysis_mode_controls = MagicMock()
@@ -991,6 +992,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "connected-composition"
         )
         dock._install_wizard_filter_controls.assert_called_once_with(
+            "connected-composition"
+        )
+        dock._install_local_first_advanced_fetch_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._install_local_first_basemap_controls.assert_called_once_with(
@@ -1419,6 +1423,59 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(storage_group.shown)
         self.assertEqual(settings_layout.added, [storage_group])
         self.assertTrue(dock._local_first_storage_controls_installed)
+
+    def test_local_first_advanced_fetch_controls_move_to_data_page(self):
+        class _SourceLayout:
+            def __init__(self):
+                self.removed = []
+
+            def removeWidget(self, widget):
+                self.removed.append(widget)
+
+        class _SourceParent:
+            def __init__(self, layout):
+                self._layout = layout
+
+            def layout(self):
+                return self._layout
+
+        class _AdvancedFetchGroup:
+            def __init__(self, parent):
+                self._parent = parent
+                self.shown = False
+
+            def parentWidget(self):
+                return self._parent
+
+            def setParent(self, parent):
+                self._parent = parent
+
+            def show(self):
+                self.shown = True
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        source_layout = _SourceLayout()
+        source_parent = _SourceParent(source_layout)
+        advanced_fetch_group = _AdvancedFetchGroup(source_parent)
+        data_layout = _FakeLayout()
+        data_content = SimpleNamespace(outer_layout=lambda: data_layout)
+        composition = SimpleNamespace(sync_content=data_content)
+        dock.advancedFetchGroupBox = advanced_fetch_group
+
+        self.module.QfitDockWidget._install_local_first_advanced_fetch_controls(
+            dock,
+            composition,
+        )
+        self.module.QfitDockWidget._install_local_first_advanced_fetch_controls(
+            dock,
+            composition,
+        )
+
+        self.assertEqual(source_layout.removed, [advanced_fetch_group])
+        self.assertIs(advanced_fetch_group.parentWidget(), data_content)
+        self.assertTrue(advanced_fetch_group.shown)
+        self.assertEqual(data_layout.added, [advanced_fetch_group])
+        self.assertTrue(dock._local_first_advanced_fetch_controls_installed)
 
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary

- expose the existing advanced Strava fetch settings in the local-first Data tab
- reuse one shared local-first group-control installer for advanced fetch, basemap, and storage groups
- add regression coverage for the advanced fetch control move

## Tests

- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
