### PR TITLE
Expose atlas PDF controls in local-first Atlas tab

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -526,6 +526,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._install_local_first_advanced_fetch_controls(
             self._local_first_dock_composition
         )
+        self._install_local_first_atlas_pdf_controls(self._local_first_dock_composition)
         self._install_local_first_basemap_controls(self._local_first_dock_composition)
         self._install_local_first_storage_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
@@ -652,21 +653,21 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         installed_attr: str,
         installed_target_attr: str,
         title: str | None = None,
-    ) -> None:
+    ) -> bool:
         content = getattr(composition, content_attr, None)
         group = getattr(self, group_attr, None)
         if content is None or group is None:
-            return
+            return False
         current_target = id(content)
         if getattr(self, installed_attr, False) and (
             getattr(self, installed_target_attr, None) == current_target
         ):
-            return
+            return True
 
         layout_getter = getattr(content, "outer_layout", None)
         layout = layout_getter() if callable(layout_getter) else None
         if layout is None or not hasattr(layout, "addWidget"):
-            return
+            return False
 
         self._remove_widget_from_current_layout(group)
         if hasattr(group, "setParent"):
@@ -681,6 +682,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         setattr(self, installed_attr, True)
         setattr(self, installed_target_attr, current_target)
+        return True
 
     def _install_local_first_advanced_fetch_controls(self, composition) -> None:
         """Expose backing Strava fetch limits in the Data tab."""
@@ -692,6 +694,25 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             installed_attr="_local_first_advanced_fetch_controls_installed",
             installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
         )
+
+    def _install_local_first_atlas_pdf_controls(self, composition) -> None:
+        """Expose backing PDF output controls in the Atlas tab."""
+
+        installed = self._install_local_first_group_controls(
+            composition,
+            content_attr="atlas_content",
+            group_attr="atlasPdfGroupBox",
+            installed_attr="_local_first_atlas_pdf_controls_installed",
+            installed_target_attr="_local_first_atlas_pdf_controls_installed_target",
+            title="PDF output",
+        )
+        legacy_export_button = getattr(self, "generateAtlasPdfButton", None)
+        if (
+            installed
+            and legacy_export_button is not None
+            and hasattr(legacy_export_button, "hide")
+        ):
+            legacy_export_button.hide()
 
     def _install_local_first_basemap_controls(self, composition) -> None:
         """Expose the backing Mapbox basemap controls in the Settings tab."""
@@ -1045,6 +1066,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.writeActivityPointsCheckBox.toggled.connect(self._workflow_section_coordinator.update_point_sampling_visibility)
         self.advancedFetchGroupBox.toggled.connect(self._workflow_section_coordinator.update_advanced_fetch_visibility)
         self.atlasPdfBrowseButton.clicked.connect(self.on_atlas_pdf_browse_clicked)
+        self.atlasPdfPathLineEdit.textChanged.connect(self._on_atlas_pdf_path_changed)
         self.generateAtlasPdfButton.clicked.connect(self.on_generate_atlas_pdf_clicked)
         self.clientIdLineEdit.textChanged.connect(self._update_connection_status)
         self.clientSecretLineEdit.textChanged.connect(self._update_connection_status)
@@ -2082,6 +2104,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._mark_atlas_export_stale()
             self._refresh_summary_status()
 
+    def _on_atlas_pdf_path_changed(self) -> None:
+        """Refresh atlas export state when the visible PDF destination changes."""
+
+        self._mark_atlas_export_stale()
+        self._refresh_summary_status()
+
     def on_generate_atlas_pdf_clicked(self):
         # Cancel any running export
         if self._atlas_export_task is not None:
@@ -2165,12 +2193,37 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._set_atlas_export_running(False)
 
         result = self.atlas_export_use_case.finish_export(output_path, error, cancelled, page_count)
-        if not result.cancelled and result.error is None and result.output_path:
+        output_path_widget = getattr(self, "atlasPdfPathLineEdit", None)
+        current_output_path = self._widget_text("atlasPdfPathLineEdit").strip()
+        output_matches_current_path = (
+            output_path_widget is None or result.output_path == current_output_path
+        )
+        completed_export_is_current = (
+            not result.cancelled
+            and result.error is None
+            and result.output_path
+            and output_matches_current_path
+        )
+        stale_successful_export = (
+            not result.cancelled
+            and result.error is None
+            and result.output_path
+            and not output_matches_current_path
+        )
+        if completed_export_is_current:
             self._atlas_export_completed = True
             self._atlas_export_output_path = result.output_path
         self._atlas_export_task_output_path = None
-        self._set_atlas_pdf_status(result.pdf_status)
-        self._set_status(result.main_status)
+        if stale_successful_export:
+            stale_pdf_status = (
+                "Atlas PDF export finished for a previous destination. "
+                "Generate again for the current path."
+            )
+            self._set_atlas_pdf_status(stale_pdf_status)
+            self._set_status("Atlas PDF export finished for a previous destination")
+        else:
+            self._set_atlas_pdf_status(result.pdf_status)
+            self._set_status(result.main_status)
         if result.error is not None and not result.cancelled:
             self._show_error("Atlas PDF export failed", result.error)
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -504,6 +504,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(facts.atlas_export_in_progress)
         self.assertEqual(facts.atlas_output_name, "running-atlas.pdf")
 
+    def test_atlas_pdf_path_change_marks_export_stale(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._atlas_export_completed = True
+        dock._atlas_export_output_path = "/tmp/old-atlas.pdf"
+        dock._atlas_export_task_output_path = "/tmp/old-atlas.pdf"
+        dock._refresh_summary_status = MagicMock()
+
+        self.module.QfitDockWidget._on_atlas_pdf_path_changed(dock)
+
+        self.assertFalse(dock._atlas_export_completed)
+        self.assertIsNone(dock._atlas_export_output_path)
+        self.assertIsNone(dock._atlas_export_task_output_path)
+        dock._refresh_summary_status.assert_called_once_with()
+
     def test_current_wizard_filter_facts_prefers_loaded_layer_subset(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()
@@ -920,6 +935,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._install_wizard_filter_controls = MagicMock()
         dock._install_wizard_style_controls = MagicMock()
         dock._install_local_first_advanced_fetch_controls = MagicMock()
+        dock._install_local_first_atlas_pdf_controls = MagicMock()
         dock._install_local_first_basemap_controls = MagicMock()
         dock._install_local_first_storage_controls = MagicMock()
         dock._bind_wizard_analysis_mode_controls = MagicMock()
@@ -995,6 +1011,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "connected-composition"
         )
         dock._install_local_first_advanced_fetch_controls.assert_called_once_with(
+            "connected-composition"
+        )
+        dock._install_local_first_atlas_pdf_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._install_local_first_basemap_controls.assert_called_once_with(
@@ -1476,6 +1495,84 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(advanced_fetch_group.shown)
         self.assertEqual(data_layout.added, [advanced_fetch_group])
         self.assertTrue(dock._local_first_advanced_fetch_controls_installed)
+
+    def test_local_first_atlas_pdf_controls_move_to_atlas_page(self):
+        class _SourceLayout:
+            def __init__(self):
+                self.removed = []
+
+            def removeWidget(self, widget):
+                self.removed.append(widget)
+
+        class _SourceParent:
+            def __init__(self, layout):
+                self._layout = layout
+
+            def layout(self):
+                return self._layout
+
+        class _AtlasPdfGroup:
+            def __init__(self, parent):
+                self._parent = parent
+                self.title = None
+                self.shown = False
+
+            def parentWidget(self):
+                return self._parent
+
+            def setParent(self, parent):
+                self._parent = parent
+
+            def setTitle(self, title):
+                self.title = title
+
+            def show(self):
+                self.shown = True
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        source_layout = _SourceLayout()
+        source_parent = _SourceParent(source_layout)
+        atlas_pdf_group = _AtlasPdfGroup(source_parent)
+        atlas_layout = _FakeLayout()
+        atlas_content = SimpleNamespace(outer_layout=lambda: atlas_layout)
+        composition = SimpleNamespace(atlas_content=atlas_content)
+        dock.atlasPdfGroupBox = atlas_pdf_group
+        dock.generateAtlasPdfButton = MagicMock()
+
+        self.module.QfitDockWidget._install_local_first_atlas_pdf_controls(
+            dock,
+            composition,
+        )
+        self.module.QfitDockWidget._install_local_first_atlas_pdf_controls(
+            dock,
+            composition,
+        )
+
+        self.assertEqual(source_layout.removed, [atlas_pdf_group])
+        self.assertIs(atlas_pdf_group.parentWidget(), atlas_content)
+        self.assertEqual(atlas_pdf_group.title, "PDF output")
+        self.assertTrue(atlas_pdf_group.shown)
+        self.assertEqual(atlas_layout.added, [atlas_pdf_group])
+        self.assertEqual(dock.generateAtlasPdfButton.hide.call_count, 2)
+        self.assertTrue(dock._local_first_atlas_pdf_controls_installed)
+
+    def test_local_first_atlas_pdf_controls_keep_export_button_when_move_fails(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        atlas_layout = _FakeLayout()
+        atlas_content = SimpleNamespace(outer_layout=lambda: atlas_layout)
+        composition = SimpleNamespace(atlas_content=atlas_content)
+        dock.generateAtlasPdfButton = MagicMock()
+
+        self.module.QfitDockWidget._install_local_first_atlas_pdf_controls(
+            dock,
+            composition,
+        )
+
+        self.assertEqual(atlas_layout.added, [])
+        dock.generateAtlasPdfButton.hide.assert_not_called()
+        self.assertFalse(
+            getattr(dock, "_local_first_atlas_pdf_controls_installed", False)
+        )
 
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -2908,6 +3005,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._set_atlas_pdf_status = MagicMock()
         dock._set_status = MagicMock()
         dock._show_error = MagicMock()
+        dock.atlasPdfPathLineEdit = _FakeLineEdit("/tmp/qfit-atlas.pdf")
         dock.atlas_export_use_case = MagicMock()
         dock.atlas_export_use_case.finish_export.return_value = SimpleNamespace(
             output_path="/tmp/qfit-atlas.pdf",
@@ -2932,6 +3030,90 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._set_atlas_export_running.assert_called_once_with(False)
         dock._set_atlas_pdf_status.assert_called_once_with("Atlas PDF ready")
         dock._set_status.assert_called_once_with("Atlas created")
+        dock._show_error.assert_not_called()
+
+    def test_on_atlas_export_finished_keeps_path_edit_during_export_stale(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._atlas_export_task = object()
+        dock._atlas_export_completed = False
+        dock._atlas_export_output_path = None
+        dock._atlas_export_task_output_path = "/tmp/old-atlas.pdf"
+        dock.atlasPdfPathLineEdit = _FakeLineEdit("/tmp/new-atlas.pdf")
+        dock._set_atlas_export_running = MagicMock()
+        dock._set_atlas_pdf_status = MagicMock()
+        dock._set_status = MagicMock()
+        dock._show_error = MagicMock()
+        dock.atlas_export_use_case = MagicMock()
+        dock.atlas_export_use_case.finish_export.return_value = SimpleNamespace(
+            output_path="/tmp/old-atlas.pdf",
+            pdf_status="Atlas PDF ready",
+            main_status="Atlas created",
+            error=None,
+            cancelled=False,
+        )
+
+        self.module.QfitDockWidget._on_atlas_export_finished(
+            dock,
+            "/tmp/old-atlas.pdf",
+            None,
+            False,
+            3,
+        )
+
+        self.assertIsNone(dock._atlas_export_task)
+        self.assertFalse(dock._atlas_export_completed)
+        self.assertIsNone(dock._atlas_export_output_path)
+        self.assertIsNone(dock._atlas_export_task_output_path)
+        dock._set_atlas_export_running.assert_called_once_with(False)
+        dock._set_atlas_pdf_status.assert_called_once_with(
+            "Atlas PDF export finished for a previous destination. "
+            "Generate again for the current path."
+        )
+        dock._set_status.assert_called_once_with(
+            "Atlas PDF export finished for a previous destination"
+        )
+        dock._show_error.assert_not_called()
+
+    def test_on_atlas_export_finished_keeps_cleared_path_during_export_stale(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._atlas_export_task = object()
+        dock._atlas_export_completed = False
+        dock._atlas_export_output_path = None
+        dock._atlas_export_task_output_path = "/tmp/old-atlas.pdf"
+        dock.atlasPdfPathLineEdit = _FakeLineEdit("")
+        dock._set_atlas_export_running = MagicMock()
+        dock._set_atlas_pdf_status = MagicMock()
+        dock._set_status = MagicMock()
+        dock._show_error = MagicMock()
+        dock.atlas_export_use_case = MagicMock()
+        dock.atlas_export_use_case.finish_export.return_value = SimpleNamespace(
+            output_path="/tmp/old-atlas.pdf",
+            pdf_status="Atlas PDF ready",
+            main_status="Atlas created",
+            error=None,
+            cancelled=False,
+        )
+
+        self.module.QfitDockWidget._on_atlas_export_finished(
+            dock,
+            "/tmp/old-atlas.pdf",
+            None,
+            False,
+            3,
+        )
+
+        self.assertIsNone(dock._atlas_export_task)
+        self.assertFalse(dock._atlas_export_completed)
+        self.assertIsNone(dock._atlas_export_output_path)
+        self.assertIsNone(dock._atlas_export_task_output_path)
+        dock._set_atlas_export_running.assert_called_once_with(False)
+        dock._set_atlas_pdf_status.assert_called_once_with(
+            "Atlas PDF export finished for a previous destination. "
+            "Generate again for the current path."
+        )
+        dock._set_status.assert_called_once_with(
+            "Atlas PDF export finished for a previous destination"
+        )
         dock._show_error.assert_not_called()
 
     def test_on_atlas_pdf_browse_marks_export_stale_and_refreshes_wizard(self):

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -1098,13 +1098,13 @@ class WizardShellCompositionTest(unittest.TestCase):
             assembled.atlas_content.status_label.text(),
             "Atlas export in progress",
         )
-        self.assertFalse(assembled.atlas_content.export_atlas_button.isEnabled())
+        self.assertTrue(assembled.atlas_content.export_atlas_button.isEnabled())
         self.assertEqual(
-            assembled.atlas_content.export_atlas_button.text(), "Export in progress…"
+            assembled.atlas_content.export_atlas_button.text(), "Cancel export"
         )
         self.assertEqual(
             assembled.atlas_content.export_atlas_button.toolTip(),
-            "Wait for the current atlas export to finish.",
+            "",
         )
 
     def test_busy_sync_summary_uses_output_name_when_available(self):

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -895,19 +895,19 @@ def _atlas_state_from_facts(facts: WizardProgressFacts) -> AtlasPageState:
     primary_action_label = (
         "Refresh atlas PDF" if facts.atlas_exported else default.primary_action_label
     )
+    primary_action_enabled = facts.activity_layers_loaded
     if facts.atlas_export_in_progress:
         status_text = "Atlas export in progress"
-        primary_action_label = "Export in progress…"
-        atlas_blocked_tooltip = "Wait for the current atlas export to finish."
+        primary_action_label = "Cancel export"
+        primary_action_enabled = True
+        atlas_blocked_tooltip = "Cancel the current atlas PDF export."
     return AtlasPageState(
         ready=facts.atlas_exported,
         status_text=status_text,
         input_summary_text=_atlas_input_summary(facts),
         output_summary_text=output_summary_text,
         primary_action_label=primary_action_label,
-        primary_action_enabled=(
-            facts.activity_layers_loaded and not facts.atlas_export_in_progress
-        ),
+        primary_action_enabled=primary_action_enabled,
         primary_action_blocked_tooltip=atlas_blocked_tooltip,
     )
 


### PR DESCRIPTION
## Summary

- expose the existing atlas PDF output path/browse/status controls in the local-first Atlas tab
- retitle the moved backing group as PDF output so the local-first export button remains the single visible export CTA
- add regression coverage for the atlas PDF control move

## Tests

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
