### PR TITLE
Expose preview sort in local-first Map tab

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -602,7 +602,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._wizard_filter_controls_installed_target = current_target
 
     def _install_wizard_style_controls(self, composition) -> None:
-        """Move the live activity-style selector into the wizard map page."""
+        """Move live activity visualization controls into the wizard map page."""
 
         map_content = getattr(composition, "map_content", None)
         style_label = getattr(self, "stylePresetLabel", None)
@@ -621,7 +621,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         target_layout = style_controls_layout()
         parent_panel = getattr(map_content, "style_controls_panel", map_content)
-        for widget in (style_label, style_combo):
+        controls = [style_label, style_combo]
+        preview_sort_label = getattr(self, "previewSortLabel", None)
+        preview_sort_combo = getattr(self, "previewSortComboBox", None)
+        if preview_sort_label is not None and preview_sort_combo is not None:
+            controls.extend((preview_sort_label, preview_sort_combo))
+        for widget in controls:
             self._remove_widget_from_current_layout(widget)
             if hasattr(widget, "setParent"):
                 widget.setParent(parent_panel)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1126,16 +1126,22 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         filter_layout.addWidget.assert_called_once_with(filter_group)
         self.assertEqual(dock._wizard_filter_controls_installed_target, id(map_content))
 
-    def test_install_wizard_style_controls_moves_live_style_selector_into_map_panel(self):
+    def test_install_wizard_style_controls_moves_live_visualization_controls_into_map_panel(self):
         dock = object.__new__(self.module.QfitDockWidget)
         parent_layout = MagicMock()
         parent_widget = SimpleNamespace(layout=lambda: parent_layout)
         style_label = MagicMock()
         style_combo = MagicMock()
+        preview_sort_label = MagicMock()
+        preview_sort_combo = MagicMock()
         style_label.parentWidget.return_value = parent_widget
         style_combo.parentWidget.return_value = parent_widget
+        preview_sort_label.parentWidget.return_value = parent_widget
+        preview_sort_combo.parentWidget.return_value = parent_widget
         dock.stylePresetLabel = style_label
         dock.stylePresetComboBox = style_combo
+        dock.previewSortLabel = preview_sort_label
+        dock.previewSortComboBox = preview_sort_combo
         panel = object()
         style_layout = MagicMock()
         map_content = SimpleNamespace(
@@ -1151,19 +1157,56 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         self.assertEqual(
             parent_layout.removeWidget.call_args_list,
-            [call(style_label), call(style_combo)],
+            [
+                call(style_label),
+                call(style_combo),
+                call(preview_sort_label),
+                call(preview_sort_combo),
+            ],
         )
         style_label.setParent.assert_called_once_with(panel)
         style_combo.setParent.assert_called_once_with(panel)
+        preview_sort_label.setParent.assert_called_once_with(panel)
+        preview_sort_combo.setParent.assert_called_once_with(panel)
+        self.assertEqual(
+            style_layout.addWidget.call_args_list,
+            [
+                call(style_label),
+                call(style_combo),
+                call(preview_sort_label),
+                call(preview_sort_combo),
+            ],
+        )
+        style_label.show.assert_called_once_with()
+        style_combo.show.assert_called_once_with()
+        preview_sort_label.show.assert_called_once_with()
+        preview_sort_combo.show.assert_called_once_with()
+        map_content.set_style_controls_visible.assert_called_once_with()
+        self.assertTrue(dock._wizard_style_controls_installed)
+        self.assertEqual(dock._wizard_style_controls_installed_target, id(map_content))
+
+    def test_install_wizard_style_controls_keeps_preview_sort_optional(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        style_label = MagicMock()
+        style_combo = MagicMock()
+        dock.stylePresetLabel = style_label
+        dock.stylePresetComboBox = style_combo
+        style_layout = MagicMock()
+        map_content = SimpleNamespace(
+            style_controls_layout=MagicMock(return_value=style_layout),
+            set_style_controls_visible=MagicMock(),
+        )
+
+        self.module.QfitDockWidget._install_wizard_style_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
         self.assertEqual(
             style_layout.addWidget.call_args_list,
             [call(style_label), call(style_combo)],
         )
-        style_label.show.assert_called_once_with()
-        style_combo.show.assert_called_once_with()
         map_content.set_style_controls_visible.assert_called_once_with()
-        self.assertTrue(dock._wizard_style_controls_installed)
-        self.assertEqual(dock._wizard_style_controls_installed_target, id(map_content))
 
     def test_install_wizard_style_controls_is_idempotent(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary

- move the existing preview-sort label and combo into the local-first Map tab visualization controls alongside the style preset
- keep preview-sort migration optional so older/partial forms still expose the style preset controls
- update pure dock-widget coverage for the expanded control move

## Tests

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #805.
