### PR TITLE
Expose backfill action in local-first Data tab

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -526,6 +526,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._install_local_first_advanced_fetch_controls(
             self._local_first_dock_composition
         )
+        self._install_local_first_backfill_controls(self._local_first_dock_composition)
         self._install_local_first_atlas_pdf_controls(self._local_first_dock_composition)
         self._install_local_first_basemap_controls(self._local_first_dock_composition)
         self._install_local_first_storage_controls(self._local_first_dock_composition)
@@ -658,6 +659,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         installed_attr: str,
         installed_target_attr: str,
         title: str | None = None,
+        show_after_move: bool = True,
     ) -> bool:
         content = getattr(composition, content_attr, None)
         group = getattr(self, group_attr, None)
@@ -680,10 +682,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if title is not None and hasattr(group, "setTitle"):
             group.setTitle(title)
         layout.addWidget(group)
-        if hasattr(group, "show"):
-            group.show()
-        elif hasattr(group, "setVisible"):
-            group.setVisible(True)
+        if show_after_move:
+            if hasattr(group, "show"):
+                group.show()
+            elif hasattr(group, "setVisible"):
+                group.setVisible(True)
 
         setattr(self, installed_attr, True)
         setattr(self, installed_target_attr, current_target)
@@ -699,6 +702,23 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             installed_attr="_local_first_advanced_fetch_controls_installed",
             installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
         )
+
+    def _install_local_first_backfill_controls(self, composition) -> None:
+        """Expose the detailed-route backfill action in the Data tab."""
+
+        installed = self._install_local_first_group_controls(
+            composition,
+            content_attr="sync_content",
+            group_attr="backfillMissingDetailedRoutesButton",
+            installed_attr="_local_first_backfill_controls_installed",
+            installed_target_attr="_local_first_backfill_controls_installed_target",
+            show_after_move=False,
+        )
+        detailed_streams_checkbox = getattr(self, "detailedStreamsCheckBox", None)
+        if installed and hasattr(detailed_streams_checkbox, "isChecked"):
+            self._workflow_section_coordinator.update_detailed_fetch_visibility(
+                detailed_streams_checkbox.isChecked()
+            )
 
     def _install_local_first_atlas_pdf_controls(self, composition) -> None:
         """Expose backing PDF output controls in the Atlas tab."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -935,6 +935,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._install_wizard_filter_controls = MagicMock()
         dock._install_wizard_style_controls = MagicMock()
         dock._install_local_first_advanced_fetch_controls = MagicMock()
+        dock._install_local_first_backfill_controls = MagicMock()
         dock._install_local_first_atlas_pdf_controls = MagicMock()
         dock._install_local_first_basemap_controls = MagicMock()
         dock._install_local_first_storage_controls = MagicMock()
@@ -1011,6 +1012,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "connected-composition"
         )
         dock._install_local_first_advanced_fetch_controls.assert_called_once_with(
+            "connected-composition"
+        )
+        dock._install_local_first_backfill_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._install_local_first_atlas_pdf_controls.assert_called_once_with(
@@ -1538,6 +1542,64 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(advanced_fetch_group.shown)
         self.assertEqual(data_layout.added, [advanced_fetch_group])
         self.assertTrue(dock._local_first_advanced_fetch_controls_installed)
+
+    def test_local_first_backfill_action_moves_to_data_page_with_existing_visibility_rule(self):
+        class _SourceLayout:
+            def __init__(self):
+                self.removed = []
+
+            def removeWidget(self, widget):
+                self.removed.append(widget)
+
+        class _SourceParent:
+            def __init__(self, layout):
+                self._layout = layout
+
+            def layout(self):
+                return self._layout
+
+        class _BackfillButton:
+            def __init__(self, parent):
+                self._parent = parent
+                self.shown = False
+
+            def parentWidget(self):
+                return self._parent
+
+            def setParent(self, parent):
+                self._parent = parent
+
+            def show(self):
+                self.shown = True
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        source_layout = _SourceLayout()
+        source_parent = _SourceParent(source_layout)
+        backfill_button = _BackfillButton(source_parent)
+        data_layout = _FakeLayout()
+        data_content = SimpleNamespace(outer_layout=lambda: data_layout)
+        composition = SimpleNamespace(sync_content=data_content)
+        dock.backfillMissingDetailedRoutesButton = backfill_button
+        dock.detailedStreamsCheckBox = SimpleNamespace(isChecked=lambda: False)
+        dock._workflow_section_coordinator = MagicMock()
+
+        self.module.QfitDockWidget._install_local_first_backfill_controls(
+            dock,
+            composition,
+        )
+        self.module.QfitDockWidget._install_local_first_backfill_controls(
+            dock,
+            composition,
+        )
+
+        self.assertEqual(source_layout.removed, [backfill_button])
+        self.assertIs(backfill_button.parentWidget(), data_content)
+        self.assertFalse(backfill_button.shown)
+        self.assertEqual(data_layout.added, [backfill_button])
+        self.assertTrue(dock._local_first_backfill_controls_installed)
+        dock._workflow_section_coordinator.update_detailed_fetch_visibility.assert_has_calls(
+            [call(False), call(False)]
+        )
 
     def test_local_first_atlas_pdf_controls_move_to_atlas_page(self):
         class _SourceLayout:

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -353,6 +353,16 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.atlasTitleLineEdit.text(), "qfit Activity Atlas")
             self.assertEqual(dock.atlasSubtitleLineEdit.text(), "")
             self.assertEqual(dock.detailedRouteStrategyComboBox.currentText(), "Missing routes only")
+            self.assertEqual(
+                dock.backfillMissingDetailedRoutesButton.parentWidget(),
+                dock._local_first_dock_composition.sync_content,
+            )
+            self.assertGreaterEqual(
+                dock._local_first_dock_composition.sync_content.outer_layout().indexOf(
+                    dock.backfillMissingDetailedRoutesButton,
+                ),
+                0,
+            )
             self.assertIsNotNone(dock.findChild(QLabel, "detailedRouteStrategyComboBoxContextHelpLabel"))
             self.assertIsNotNone(dock.findChild(QWidget, "detailedRouteStrategyComboBoxHelpField"))
             self.assertIsNotNone(dock.findChild(QLabel, "maxDetailedActivitiesSpinBoxContextHelpLabel"))


### PR DESCRIPTION
## Summary

- Move the existing detailed-route backfill action into the visible local-first Data tab.
- Preserve the current detailed-streams visibility rule so the backfill action still appears only when detailed route fetching is enabled.
- Cover the local-first placement in pure dock tests and the QGIS smoke path.

Refs #805.

## Tests

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_defaults_to_local_first_live_path tests/test_qgis_smoke.py::QgisSmokeTests::test_workflow_section_coordinator_updates_visibility_rules -q`
- `python3 -m pytest tests/ -x -q --tb=short`
