### PR TITLE
Move temporal playback controls into local-first map tab

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -319,6 +319,21 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         stripped = preset_name.strip()
         return stripped or None
 
+    def _current_visual_temporal_mode(self) -> str:
+        """Return the visible temporal playback setting for visual workflow actions."""
+
+        combo = getattr(self, "temporalModeComboBox", None)
+        if combo is None or not hasattr(combo, "currentText"):
+            return DEFAULT_TEMPORAL_MODE_LABEL
+        try:
+            mode_label = combo.currentText()
+        except RuntimeError:
+            logger.debug("Failed to read temporal playback mode", exc_info=True)
+            return DEFAULT_TEMPORAL_MODE_LABEL
+        if not isinstance(mode_label, str):
+            return DEFAULT_TEMPORAL_MODE_LABEL
+        return mode_label.strip() or DEFAULT_TEMPORAL_MODE_LABEL
+
     def _current_wizard_background_facts(self, runtime_state) -> tuple[bool, bool, str | None]:
         """Return current basemap facts for the optional wizard map page."""
 
@@ -623,24 +638,44 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         target_layout = style_controls_layout()
         parent_panel = getattr(map_content, "style_controls_panel", map_content)
         controls = [style_label, style_combo]
+        show_after_move = []
         preview_sort_label = getattr(self, "previewSortLabel", None)
         preview_sort_combo = getattr(self, "previewSortComboBox", None)
         if preview_sort_label is not None and preview_sort_combo is not None:
             controls.extend((preview_sort_label, preview_sort_combo))
+        temporal_row = getattr(self, "analysisTemporalModeRow", None)
+        if temporal_row is not None:
+            controls.append(temporal_row)
+            temporal_help = getattr(self, "temporalHelpLabel", None)
+            if temporal_help is not None:
+                controls.append(temporal_help)
+            show_after_move.extend(
+                widget
+                for widget in (
+                    getattr(self, "temporalModeLabel", None),
+                    getattr(self, "temporalModeComboBox", None),
+                )
+                if widget is not None
+            )
         for widget in controls:
             self._remove_widget_from_current_layout(widget)
             if hasattr(widget, "setParent"):
                 widget.setParent(parent_panel)
             target_layout.addWidget(widget)
-            if hasattr(widget, "show"):
-                widget.show()
-            elif hasattr(widget, "setVisible"):
-                widget.setVisible(True)
+            self._show_widget(widget)
+        for widget in show_after_move:
+            self._show_widget(widget)
         set_visible = getattr(map_content, "set_style_controls_visible", None)
         if callable(set_visible):
             set_visible()
         self._wizard_style_controls_installed = True
         self._wizard_style_controls_installed_target = current_target
+
+    def _show_widget(self, widget) -> None:
+        if hasattr(widget, "show"):
+            widget.show()
+        elif hasattr(widget, "setVisible"):
+            widget.setVisible(True)
 
     def _remove_widget_from_current_layout(self, widget) -> None:
         parent_widget = (
@@ -1894,7 +1929,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             ),
             settings=build_visual_workflow_settings_snapshot(
                 style_preset=self.stylePresetComboBox.currentText(),
-                temporal_mode=DEFAULT_TEMPORAL_MODE_LABEL,
+                temporal_mode=self._current_visual_temporal_mode(),
                 analysis_mode=self.analysisModeComboBox.currentText(),
             ),
             background=build_visual_workflow_background_inputs(

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1138,14 +1138,24 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         style_combo = MagicMock()
         preview_sort_label = MagicMock()
         preview_sort_combo = MagicMock()
+        temporal_row = MagicMock()
+        temporal_label = MagicMock()
+        temporal_combo = MagicMock()
+        temporal_help = MagicMock()
         style_label.parentWidget.return_value = parent_widget
         style_combo.parentWidget.return_value = parent_widget
         preview_sort_label.parentWidget.return_value = parent_widget
         preview_sort_combo.parentWidget.return_value = parent_widget
+        temporal_row.parentWidget.return_value = parent_widget
+        temporal_help.parentWidget.return_value = parent_widget
         dock.stylePresetLabel = style_label
         dock.stylePresetComboBox = style_combo
         dock.previewSortLabel = preview_sort_label
         dock.previewSortComboBox = preview_sort_combo
+        dock.analysisTemporalModeRow = temporal_row
+        dock.temporalModeLabel = temporal_label
+        dock.temporalModeComboBox = temporal_combo
+        dock.temporalHelpLabel = temporal_help
         panel = object()
         style_layout = MagicMock()
         map_content = SimpleNamespace(
@@ -1166,12 +1176,16 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 call(style_combo),
                 call(preview_sort_label),
                 call(preview_sort_combo),
+                call(temporal_row),
+                call(temporal_help),
             ],
         )
         style_label.setParent.assert_called_once_with(panel)
         style_combo.setParent.assert_called_once_with(panel)
         preview_sort_label.setParent.assert_called_once_with(panel)
         preview_sort_combo.setParent.assert_called_once_with(panel)
+        temporal_row.setParent.assert_called_once_with(panel)
+        temporal_help.setParent.assert_called_once_with(panel)
         self.assertEqual(
             style_layout.addWidget.call_args_list,
             [
@@ -1179,12 +1193,18 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 call(style_combo),
                 call(preview_sort_label),
                 call(preview_sort_combo),
+                call(temporal_row),
+                call(temporal_help),
             ],
         )
         style_label.show.assert_called_once_with()
         style_combo.show.assert_called_once_with()
         preview_sort_label.show.assert_called_once_with()
         preview_sort_combo.show.assert_called_once_with()
+        temporal_row.show.assert_called_once_with()
+        temporal_label.show.assert_called_once_with()
+        temporal_combo.show.assert_called_once_with()
+        temporal_help.show.assert_called_once_with()
         map_content.set_style_controls_visible.assert_called_once_with()
         self.assertTrue(dock._wizard_style_controls_installed)
         self.assertEqual(dock._wizard_style_controls_installed_target, id(map_content))
@@ -1964,7 +1984,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         build_selection_handoff.assert_called_once_with(selection_state)
         build_settings.assert_called_once_with(
             style_preset="By activity type",
-            temporal_mode=self.module.DEFAULT_TEMPORAL_MODE_LABEL,
+            temporal_mode="By month",
             analysis_mode="Most frequent starting points",
         )
         build_background.assert_called_once_with(

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -334,14 +334,23 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
             self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
             self.assertEqual(dock.analysisModeLabel.parentWidget().parentWidget(), dock.analysisSectionContentWidget)
-            self.assertEqual(dock.temporalModeLabel.parentWidget().parentWidget(), dock.styleSectionContentWidget)
+            self.assertEqual(
+                dock.temporalModeLabel.parentWidget().parentWidget(),
+                dock._local_first_dock_composition.map_content.style_controls_panel,
+            )
+            self.assertGreaterEqual(
+                dock._local_first_dock_composition.map_content.style_controls_layout().indexOf(
+                    dock.analysisTemporalModeRow,
+                ),
+                0,
+            )
             temporal_mode_layout = dock.temporalModeLabel.parentWidget().layout()
             self.assertEqual(temporal_mode_layout.spacing(), 6)
             self.assertGreaterEqual(dock.temporalModeComboBox.minimumContentsLength(), 10)
             self.assertGreaterEqual(dock.temporalHelpLabel.margin(), 2)
-            self.assertTrue(dock.temporalModeLabel.isHidden())
-            self.assertTrue(dock.temporalModeComboBox.isHidden())
-            self.assertTrue(dock.temporalHelpLabel.isHidden())
+            self.assertFalse(dock.temporalModeLabel.isHidden())
+            self.assertFalse(dock.temporalModeComboBox.isHidden())
+            self.assertFalse(dock.temporalHelpLabel.isHidden())
             self.assertEqual(dock.publishGroupBox.title(), "")
             self.assertEqual(dock.publishSectionToggleButton.text(), "Publish / atlas")
             self.assertFalse(dock.publishSectionContentWidget.isHidden())


### PR DESCRIPTION
## Summary

- move the existing temporal playback controls into the local-first Visualize map controls panel
- keep the visible visual workflow request in sync with the selected temporal mode instead of hardcoding the default
- cover the reparenting and request handoff with pure widget tests, plus update the QGIS smoke expectations

## Tests

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #805.
