### PR TITLE
Expose activity preview in local-first Data tab

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -541,6 +541,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._install_local_first_advanced_fetch_controls(
             self._local_first_dock_composition
         )
+        self._install_local_first_activity_preview_controls(
+            self._local_first_dock_composition
+        )
         self._install_local_first_backfill_controls(self._local_first_dock_composition)
         self._install_local_first_atlas_pdf_controls(self._local_first_dock_composition)
         self._install_local_first_basemap_controls(self._local_first_dock_composition)
@@ -736,6 +739,18 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             group_attr="advancedFetchGroupBox",
             installed_attr="_local_first_advanced_fetch_controls_installed",
             installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
+        )
+
+    def _install_local_first_activity_preview_controls(self, composition) -> None:
+        """Expose fetched activity query details in the Data tab."""
+
+        self._install_local_first_group_controls(
+            composition,
+            content_attr="sync_content",
+            group_attr="previewGroupBox",
+            installed_attr="_local_first_activity_preview_controls_installed",
+            installed_target_attr="_local_first_activity_preview_controls_installed_target",
+            title="Fetched activity preview",
         )
 
     def _install_local_first_backfill_controls(self, composition) -> None:

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -935,6 +935,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._install_wizard_filter_controls = MagicMock()
         dock._install_wizard_style_controls = MagicMock()
         dock._install_local_first_advanced_fetch_controls = MagicMock()
+        dock._install_local_first_activity_preview_controls = MagicMock()
         dock._install_local_first_backfill_controls = MagicMock()
         dock._install_local_first_atlas_pdf_controls = MagicMock()
         dock._install_local_first_basemap_controls = MagicMock()
@@ -1012,6 +1013,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "connected-composition"
         )
         dock._install_local_first_advanced_fetch_controls.assert_called_once_with(
+            "connected-composition"
+        )
+        dock._install_local_first_activity_preview_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._install_local_first_backfill_controls.assert_called_once_with(
@@ -1562,6 +1566,64 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(advanced_fetch_group.shown)
         self.assertEqual(data_layout.added, [advanced_fetch_group])
         self.assertTrue(dock._local_first_advanced_fetch_controls_installed)
+
+    def test_local_first_activity_preview_controls_move_to_data_page(self):
+        class _SourceLayout:
+            def __init__(self):
+                self.removed = []
+
+            def removeWidget(self, widget):
+                self.removed.append(widget)
+
+        class _SourceParent:
+            def __init__(self, layout):
+                self._layout = layout
+
+            def layout(self):
+                return self._layout
+
+        class _ActivityPreviewGroup:
+            def __init__(self, parent):
+                self._parent = parent
+                self.title = None
+                self.shown = False
+
+            def parentWidget(self):
+                return self._parent
+
+            def setParent(self, parent):
+                self._parent = parent
+
+            def setTitle(self, title):
+                self.title = title
+
+            def show(self):
+                self.shown = True
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        source_layout = _SourceLayout()
+        source_parent = _SourceParent(source_layout)
+        preview_group = _ActivityPreviewGroup(source_parent)
+        data_layout = _FakeLayout()
+        data_content = SimpleNamespace(outer_layout=lambda: data_layout)
+        composition = SimpleNamespace(sync_content=data_content)
+        dock.previewGroupBox = preview_group
+
+        self.module.QfitDockWidget._install_local_first_activity_preview_controls(
+            dock,
+            composition,
+        )
+        self.module.QfitDockWidget._install_local_first_activity_preview_controls(
+            dock,
+            composition,
+        )
+
+        self.assertEqual(source_layout.removed, [preview_group])
+        self.assertIs(preview_group.parentWidget(), data_content)
+        self.assertEqual(preview_group.title, "Fetched activity preview")
+        self.assertTrue(preview_group.shown)
+        self.assertEqual(data_layout.added, [preview_group])
+        self.assertTrue(dock._local_first_activity_preview_controls_installed)
 
     def test_local_first_backfill_action_moves_to_data_page_with_existing_visibility_rule(self):
         class _SourceLayout:

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -299,9 +299,28 @@ class QgisSmokeTests(unittest.TestCase):
                 dock.outputGroupBox.toolTip(),
                 "Pick where qfit should store the synced GeoPackage. Tracks and start points are always written; sampled point analysis is optional.",
             )
-            self.assertEqual(dock.outputGroupBox.title(), "Store / database")
-            self.assertEqual(dock.outputGroupBox.parent(), dock.activitiesSectionContentWidget)
-            self.assertGreater(dock.activitiesSectionContentWidget.layout().indexOf(dock.outputGroupBox), dock.activitiesSectionContentWidget.layout().indexOf(dock.previewGroupBox))
+            self.assertEqual(dock.outputGroupBox.title(), "Data storage")
+            self.assertEqual(
+                dock.outputGroupBox.parentWidget(),
+                dock._local_first_dock_composition.connection_content,
+            )
+            self.assertGreaterEqual(
+                dock._local_first_dock_composition.connection_content.outer_layout().indexOf(
+                    dock.outputGroupBox,
+                ),
+                0,
+            )
+            self.assertEqual(dock.previewGroupBox.title(), "Fetched activity preview")
+            self.assertEqual(
+                dock.previewGroupBox.parentWidget(),
+                dock._local_first_dock_composition.sync_content,
+            )
+            self.assertGreaterEqual(
+                dock._local_first_dock_composition.sync_content.outer_layout().indexOf(
+                    dock.previewGroupBox,
+                ),
+                0,
+            )
             self.assertEqual(dock.styleGroupBox.title(), "")
             self.assertEqual(
                 dock.stylePresetComboBox.parentWidget(),


### PR DESCRIPTION
## Summary

Expose the existing fetched activity preview panel in the local-first Data tab so query details and the recent-activity preview are no longer only available through the hidden long-scroll dock.

## Changes

- Move `previewGroupBox` into the local-first Data page during dock composition.
- Keep the move idempotent through the existing local-first group-control helper.
- Add pure regression coverage for the preview-panel migration and build wiring.

## Testing

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/test_local_first_composition.py tests/test_local_first_shell.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
