### PR TITLE
Add local-first control move inventory

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -90,6 +90,7 @@ from .ui.application import (
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     load_wizard_settings,
+    local_first_control_move_for_key,
     save_last_step_index,
     step_index_for_key,
     build_visual_workflow_background_inputs,
@@ -730,40 +731,34 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         setattr(self, installed_target_attr, current_target)
         return True
 
+    def _install_local_first_control_move(self, composition, key: str) -> bool:
+        """Install one audited legacy-backed control area into local-first UI."""
+
+        move = local_first_control_move_for_key(key)
+        return self._install_local_first_group_controls(
+            composition,
+            content_attr=move.content_attr,
+            group_attr=move.group_attr,
+            installed_attr=move.installed_attr,
+            installed_target_attr=move.installed_target_attr,
+            title=move.title,
+            show_after_move=move.show_after_move,
+        )
+
     def _install_local_first_advanced_fetch_controls(self, composition) -> None:
         """Expose backing Strava fetch limits in the Data tab."""
 
-        self._install_local_first_group_controls(
-            composition,
-            content_attr="sync_content",
-            group_attr="advancedFetchGroupBox",
-            installed_attr="_local_first_advanced_fetch_controls_installed",
-            installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
-        )
+        self._install_local_first_control_move(composition, "advanced_fetch")
 
     def _install_local_first_activity_preview_controls(self, composition) -> None:
         """Expose fetched activity query details in the Data tab."""
 
-        self._install_local_first_group_controls(
-            composition,
-            content_attr="sync_content",
-            group_attr="previewGroupBox",
-            installed_attr="_local_first_activity_preview_controls_installed",
-            installed_target_attr="_local_first_activity_preview_controls_installed_target",
-            title="Fetched activity preview",
-        )
+        self._install_local_first_control_move(composition, "activity_preview")
 
     def _install_local_first_backfill_controls(self, composition) -> None:
         """Expose the detailed-route backfill action in the Data tab."""
 
-        installed = self._install_local_first_group_controls(
-            composition,
-            content_attr="sync_content",
-            group_attr="backfillMissingDetailedRoutesButton",
-            installed_attr="_local_first_backfill_controls_installed",
-            installed_target_attr="_local_first_backfill_controls_installed_target",
-            show_after_move=False,
-        )
+        installed = self._install_local_first_control_move(composition, "backfill_routes")
         detailed_streams_checkbox = getattr(self, "detailedStreamsCheckBox", None)
         if installed and hasattr(detailed_streams_checkbox, "isChecked"):
             self._workflow_section_coordinator.update_detailed_fetch_visibility(
@@ -773,14 +768,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _install_local_first_atlas_pdf_controls(self, composition) -> None:
         """Expose backing PDF output controls in the Atlas tab."""
 
-        installed = self._install_local_first_group_controls(
-            composition,
-            content_attr="atlas_content",
-            group_attr="atlasPdfGroupBox",
-            installed_attr="_local_first_atlas_pdf_controls_installed",
-            installed_target_attr="_local_first_atlas_pdf_controls_installed_target",
-            title="PDF output",
-        )
+        installed = self._install_local_first_control_move(composition, "atlas_pdf")
         legacy_export_button = getattr(self, "generateAtlasPdfButton", None)
         if (
             installed
@@ -792,26 +780,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _install_local_first_basemap_controls(self, composition) -> None:
         """Expose the backing Mapbox basemap controls in the Settings tab."""
 
-        self._install_local_first_group_controls(
-            composition,
-            content_attr="connection_content",
-            group_attr="backgroundGroupBox",
-            installed_attr="_local_first_basemap_controls_installed",
-            installed_target_attr="_local_first_basemap_controls_installed_target",
-            title="Mapbox basemap",
-        )
+        self._install_local_first_control_move(composition, "basemap")
 
     def _install_local_first_storage_controls(self, composition) -> None:
         """Expose the backing GeoPackage storage controls in the Settings tab."""
 
-        self._install_local_first_group_controls(
-            composition,
-            content_attr="connection_content",
-            group_attr="outputGroupBox",
-            installed_attr="_local_first_storage_controls_installed",
-            installed_target_attr="_local_first_storage_controls_installed_target",
-            title="Data storage",
-        )
+        self._install_local_first_control_move(composition, "storage")
 
     def _bind_wizard_analysis_mode_controls(self, composition) -> None:
         """Expose the hidden backing analysis selector in the live wizard path."""

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -1,0 +1,71 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.local_first_control_moves import (
+    LOCAL_FIRST_CONTROL_MOVES,
+    local_first_control_move_for_key,
+    local_first_control_move_keys,
+)
+
+
+class LocalFirstControlMoveTests(unittest.TestCase):
+    def test_control_move_inventory_covers_current_legacy_backed_surfaces(self):
+        self.assertEqual(
+            local_first_control_move_keys(),
+            (
+                "advanced_fetch",
+                "activity_preview",
+                "backfill_routes",
+                "atlas_pdf",
+                "basemap",
+                "storage",
+            ),
+        )
+        self.assertEqual(
+            [move.group_attr for move in LOCAL_FIRST_CONTROL_MOVES],
+            [
+                "advancedFetchGroupBox",
+                "previewGroupBox",
+                "backfillMissingDetailedRoutesButton",
+                "atlasPdfGroupBox",
+                "backgroundGroupBox",
+                "outputGroupBox",
+            ],
+        )
+
+    def test_control_moves_document_local_first_destination_pages(self):
+        destinations = {
+            move.key: move.content_attr for move in LOCAL_FIRST_CONTROL_MOVES
+        }
+
+        self.assertEqual(
+            destinations,
+            {
+                "advanced_fetch": "sync_content",
+                "activity_preview": "sync_content",
+                "backfill_routes": "sync_content",
+                "atlas_pdf": "atlas_content",
+                "basemap": "connection_content",
+                "storage": "connection_content",
+            },
+        )
+
+    def test_lookup_returns_full_install_metadata(self):
+        move = local_first_control_move_for_key("atlas_pdf")
+
+        self.assertEqual(move.content_attr, "atlas_content")
+        self.assertEqual(move.group_attr, "atlasPdfGroupBox")
+        self.assertEqual(move.title, "PDF output")
+        self.assertTrue(move.show_after_move)
+
+        backfill = local_first_control_move_for_key("backfill_routes")
+        self.assertFalse(backfill.show_after_move)
+
+    def test_lookup_rejects_unknown_control_area(self):
+        with self.assertRaises(KeyError):
+            local_first_control_move_for_key("credentials")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -35,6 +35,12 @@ from .local_first_navigation import (
     build_local_first_dock_navigation_state,
     local_first_dock_page_keys,
 )
+from .local_first_control_moves import (
+    LOCAL_FIRST_CONTROL_MOVES,
+    LocalFirstControlMove,
+    local_first_control_move_for_key,
+    local_first_control_move_keys,
+)
 from .dock_workflow_sections import (
     CURRENT_DOCK_SECTIONS,
     WIZARD_WORKFLOW_STEPS,
@@ -121,7 +127,9 @@ __all__ = [
     "CURRENT_DOCK_SECTIONS",
     "LAST_STEP_INDEX_KEY",
     "LAST_STEP_INDEX_USER_SELECTED_KEY",
+    "LOCAL_FIRST_CONTROL_MOVES",
     "LOCAL_FIRST_DOCK_PAGE_DEFINITIONS",
+    "LocalFirstControlMove",
     "LocalFirstDockNavigationState",
     "LocalFirstDockPageDefinition",
     "LocalFirstDockPageState",
@@ -165,6 +173,8 @@ __all__ = [
     "ensure_wizard_settings",
     "get_workflow_section",
     "load_wizard_settings",
+    "local_first_control_move_for_key",
+    "local_first_control_move_keys",
     "local_first_dock_page_keys",
     "preferred_current_key_from_settings",
     "save_collapsed_groups",

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LocalFirstControlMove:
+    """Legacy-backed control group that is explicitly surfaced in local-first UI."""
+
+    key: str
+    content_attr: str
+    group_attr: str
+    installed_attr: str
+    installed_target_attr: str
+    title: str | None = None
+    show_after_move: bool = True
+
+
+LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
+    LocalFirstControlMove(
+        key="advanced_fetch",
+        content_attr="sync_content",
+        group_attr="advancedFetchGroupBox",
+        installed_attr="_local_first_advanced_fetch_controls_installed",
+        installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
+    ),
+    LocalFirstControlMove(
+        key="activity_preview",
+        content_attr="sync_content",
+        group_attr="previewGroupBox",
+        installed_attr="_local_first_activity_preview_controls_installed",
+        installed_target_attr="_local_first_activity_preview_controls_installed_target",
+        title="Fetched activity preview",
+    ),
+    LocalFirstControlMove(
+        key="backfill_routes",
+        content_attr="sync_content",
+        group_attr="backfillMissingDetailedRoutesButton",
+        installed_attr="_local_first_backfill_controls_installed",
+        installed_target_attr="_local_first_backfill_controls_installed_target",
+        show_after_move=False,
+    ),
+    LocalFirstControlMove(
+        key="atlas_pdf",
+        content_attr="atlas_content",
+        group_attr="atlasPdfGroupBox",
+        installed_attr="_local_first_atlas_pdf_controls_installed",
+        installed_target_attr="_local_first_atlas_pdf_controls_installed_target",
+        title="PDF output",
+    ),
+    LocalFirstControlMove(
+        key="basemap",
+        content_attr="connection_content",
+        group_attr="backgroundGroupBox",
+        installed_attr="_local_first_basemap_controls_installed",
+        installed_target_attr="_local_first_basemap_controls_installed_target",
+        title="Mapbox basemap",
+    ),
+    LocalFirstControlMove(
+        key="storage",
+        content_attr="connection_content",
+        group_attr="outputGroupBox",
+        installed_attr="_local_first_storage_controls_installed",
+        installed_target_attr="_local_first_storage_controls_installed_target",
+        title="Data storage",
+    ),
+)
+
+
+def local_first_control_move_for_key(key: str) -> LocalFirstControlMove:
+    """Return the local-first control move spec for a supported control area."""
+
+    for move in LOCAL_FIRST_CONTROL_MOVES:
+        if move.key == key:
+            return move
+    raise KeyError(key)
+
+
+def local_first_control_move_keys() -> tuple[str, ...]:
+    """Return stable audit keys for legacy-backed local-first control moves."""
+
+    return tuple(move.key for move in LOCAL_FIRST_CONTROL_MOVES)
+
+
+__all__ = [
+    "LOCAL_FIRST_CONTROL_MOVES",
+    "LocalFirstControlMove",
+    "local_first_control_move_for_key",
+    "local_first_control_move_keys",
+]


### PR DESCRIPTION
## Summary

- add an explicit local-first control-move inventory for legacy-backed controls that are currently surfaced in the tabbed dock
- route the existing install helpers through that audited metadata instead of duplicating destination/title/install-state strings
- add focused tests covering the inventory keys, destination pages, and install metadata

Refs #805.

## Tests

- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_local_first_advanced_fetch_controls_move_to_data_page tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_local_first_activity_preview_controls_move_to_data_page tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_local_first_backfill_action_moves_to_data_page_with_existing_visibility_rule tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_local_first_atlas_pdf_controls_move_to_atlas_page tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_local_first_basemap_controls_move_to_settings_page tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_local_first_storage_controls_move_to_settings_page -q --tb=short`
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_local_first_composition.py tests/test_local_first_control_moves.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
