### PR TITLE
refactor: audit local-first map filter move

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -705,37 +705,47 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         ):
             return True
 
-        layout_getter = getattr(content, move.layout_getter_attr, None)
-        layout = layout_getter() if callable(layout_getter) else None
+        layout = self._local_first_control_move_layout(content, move)
         if layout is None or not hasattr(layout, "addWidget"):
             return False
 
         self._remove_widget_from_current_layout(group)
-        parent_panel = content
-        if move.parent_panel_attr is not None:
-            parent_panel = getattr(content, move.parent_panel_attr, content)
+        parent_panel = self._local_first_control_move_parent_panel(content, move)
         if hasattr(group, "setParent"):
             group.setParent(parent_panel)
         if move.title is not None and hasattr(group, "setTitle"):
             group.setTitle(move.title)
         layout.addWidget(group)
-        if move.show_after_move:
-            if hasattr(group, "show"):
-                group.show()
-            elif hasattr(group, "setVisible"):
-                group.setVisible(True)
-
-        set_visible = getattr(
-            content,
-            f"set_{move.layout_getter_attr.removesuffix('_layout')}_visible",
-            None,
-        )
-        if callable(set_visible):
-            set_visible()
+        self._show_local_first_control_group(group, move)
+        self._refresh_local_first_control_visibility(content, move)
 
         setattr(self, move.installed_attr, True)
         setattr(self, move.installed_target_attr, current_target)
         return True
+
+    def _local_first_control_move_layout(self, content, move: LocalFirstControlMove):
+        layout_getter = getattr(content, move.layout_getter_attr, None)
+        return layout_getter() if callable(layout_getter) else None
+
+    def _local_first_control_move_parent_panel(self, content, move: LocalFirstControlMove):
+        if move.parent_panel_attr is None:
+            return content
+        return getattr(content, move.parent_panel_attr, content)
+
+    def _show_local_first_control_group(self, group, move: LocalFirstControlMove) -> None:
+        if not move.show_after_move:
+            return
+        if hasattr(group, "show"):
+            group.show()
+        elif hasattr(group, "setVisible"):
+            group.setVisible(True)
+
+    def _refresh_local_first_control_visibility(self, content, move: LocalFirstControlMove) -> None:
+        if move.post_install_visible_attr is None:
+            return
+        set_visible = getattr(content, move.post_install_visible_attr, None)
+        if callable(set_visible):
+            set_visible()
 
     def _install_local_first_control_move(self, composition, key: str) -> bool:
         """Install one audited legacy-backed control area into local-first UI."""

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -82,6 +82,7 @@ from .ui.application import (
     DockRuntimeStore,
     DockVisualWorkflowCoordinator,
     DockVisualWorkflowRequest,
+    LocalFirstControlMove,
     RunAnalysisAction,
     build_dock_summary_status,
     build_startup_wizard_progress_facts,
@@ -538,7 +539,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             ),
         )
         self._install_wizard_style_controls(self._local_first_dock_composition)
-        self._install_wizard_filter_controls(self._local_first_dock_composition)
+        self._install_local_first_filter_controls(self._local_first_dock_composition)
         self._install_local_first_advanced_fetch_controls(
             self._local_first_dock_composition
         )
@@ -692,58 +693,60 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _install_local_first_group_controls(
         self,
         composition,
-        *,
-        content_attr: str,
-        group_attr: str,
-        installed_attr: str,
-        installed_target_attr: str,
-        title: str | None = None,
-        show_after_move: bool = True,
+        move: LocalFirstControlMove,
     ) -> bool:
-        content = getattr(composition, content_attr, None)
-        group = getattr(self, group_attr, None)
+        content = getattr(composition, move.content_attr, None)
+        group = getattr(self, move.group_attr, None)
         if content is None or group is None:
             return False
         current_target = id(content)
-        if getattr(self, installed_attr, False) and (
-            getattr(self, installed_target_attr, None) == current_target
+        if getattr(self, move.installed_attr, False) and (
+            getattr(self, move.installed_target_attr, None) == current_target
         ):
             return True
 
-        layout_getter = getattr(content, "outer_layout", None)
+        layout_getter = getattr(content, move.layout_getter_attr, None)
         layout = layout_getter() if callable(layout_getter) else None
         if layout is None or not hasattr(layout, "addWidget"):
             return False
 
         self._remove_widget_from_current_layout(group)
+        parent_panel = content
+        if move.parent_panel_attr is not None:
+            parent_panel = getattr(content, move.parent_panel_attr, content)
         if hasattr(group, "setParent"):
-            group.setParent(content)
-        if title is not None and hasattr(group, "setTitle"):
-            group.setTitle(title)
+            group.setParent(parent_panel)
+        if move.title is not None and hasattr(group, "setTitle"):
+            group.setTitle(move.title)
         layout.addWidget(group)
-        if show_after_move:
+        if move.show_after_move:
             if hasattr(group, "show"):
                 group.show()
             elif hasattr(group, "setVisible"):
                 group.setVisible(True)
 
-        setattr(self, installed_attr, True)
-        setattr(self, installed_target_attr, current_target)
+        set_visible = getattr(
+            content,
+            f"set_{move.layout_getter_attr.removesuffix('_layout')}_visible",
+            None,
+        )
+        if callable(set_visible):
+            set_visible()
+
+        setattr(self, move.installed_attr, True)
+        setattr(self, move.installed_target_attr, current_target)
         return True
 
     def _install_local_first_control_move(self, composition, key: str) -> bool:
         """Install one audited legacy-backed control area into local-first UI."""
 
         move = local_first_control_move_for_key(key)
-        return self._install_local_first_group_controls(
-            composition,
-            content_attr=move.content_attr,
-            group_attr=move.group_attr,
-            installed_attr=move.installed_attr,
-            installed_target_attr=move.installed_target_attr,
-            title=move.title,
-            show_after_move=move.show_after_move,
-        )
+        return self._install_local_first_group_controls(composition, move=move)
+
+    def _install_local_first_filter_controls(self, composition) -> None:
+        """Expose the backing map filters in the local-first Map tab."""
+
+        self._install_local_first_control_move(composition, "map_filters")
 
     def _install_local_first_advanced_fetch_controls(self, composition) -> None:
         """Expose backing Strava fetch limits in the Data tab."""

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -17,6 +17,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "advanced_fetch",
                 "activity_preview",
                 "backfill_routes",
+                "map_filters",
                 "atlas_pdf",
                 "basemap",
                 "storage",
@@ -28,6 +29,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "advancedFetchGroupBox",
                 "previewGroupBox",
                 "backfillMissingDetailedRoutesButton",
+                "filterGroupBox",
                 "atlasPdfGroupBox",
                 "backgroundGroupBox",
                 "outputGroupBox",
@@ -45,6 +47,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "advanced_fetch": "sync_content",
                 "activity_preview": "sync_content",
                 "backfill_routes": "sync_content",
+                "map_filters": "map_content",
                 "atlas_pdf": "atlas_content",
                 "basemap": "connection_content",
                 "storage": "connection_content",
@@ -61,6 +64,10 @@ class LocalFirstControlMoveTests(unittest.TestCase):
 
         backfill = local_first_control_move_for_key("backfill_routes")
         self.assertFalse(backfill.show_after_move)
+
+        filters = local_first_control_move_for_key("map_filters")
+        self.assertEqual(filters.layout_getter_attr, "filter_controls_layout")
+        self.assertEqual(filters.parent_panel_attr, "filter_controls_panel")
 
     def test_lookup_rejects_unknown_control_area(self):
         with self.assertRaises(KeyError):

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -68,6 +68,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
         filters = local_first_control_move_for_key("map_filters")
         self.assertEqual(filters.layout_getter_attr, "filter_controls_layout")
         self.assertEqual(filters.parent_panel_attr, "filter_controls_panel")
+        self.assertEqual(filters.post_install_visible_attr, "set_filter_controls_visible")
 
     def test_lookup_rejects_unknown_control_area(self):
         with self.assertRaises(KeyError):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -932,8 +932,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._atlas_export_completed = False
         dock.settings = _FakeSettings()
-        dock._install_wizard_filter_controls = MagicMock()
         dock._install_wizard_style_controls = MagicMock()
+        dock._install_local_first_filter_controls = MagicMock()
         dock._install_local_first_advanced_fetch_controls = MagicMock()
         dock._install_local_first_activity_preview_controls = MagicMock()
         dock._install_local_first_backfill_controls = MagicMock()
@@ -1009,7 +1009,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._install_wizard_style_controls.assert_called_once_with(
             "connected-composition"
         )
-        dock._install_wizard_filter_controls.assert_called_once_with(
+        dock._install_local_first_filter_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._install_local_first_advanced_fetch_controls.assert_called_once_with(
@@ -1095,6 +1095,38 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         map_content.set_filter_controls_visible.assert_called_once_with()
         self.assertTrue(dock._wizard_filter_controls_installed)
         self.assertEqual(dock._wizard_filter_controls_installed_target, id(map_content))
+
+    def test_install_local_first_filter_controls_uses_audited_map_filter_move(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        parent_layout = MagicMock()
+        parent_widget = SimpleNamespace(layout=lambda: parent_layout)
+        filter_group = MagicMock()
+        filter_group.parentWidget.return_value = parent_widget
+        dock.filterGroupBox = filter_group
+        panel = object()
+        filter_layout = MagicMock()
+        map_content = SimpleNamespace(
+            filter_controls_panel=panel,
+            filter_controls_layout=MagicMock(return_value=filter_layout),
+            set_filter_controls_visible=MagicMock(),
+        )
+
+        self.module.QfitDockWidget._install_local_first_filter_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
+        parent_layout.removeWidget.assert_called_once_with(filter_group)
+        filter_group.setParent.assert_called_once_with(panel)
+        filter_group.setTitle.assert_called_once_with("Map filters")
+        filter_layout.addWidget.assert_called_once_with(filter_group)
+        filter_group.show.assert_called_once_with()
+        map_content.set_filter_controls_visible.assert_called_once_with()
+        self.assertTrue(dock._local_first_filter_controls_installed)
+        self.assertEqual(
+            dock._local_first_filter_controls_installed_target,
+            id(map_content),
+        )
 
     def test_install_wizard_filter_controls_is_idempotent(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class LocalFirstControlMove:
-    """Legacy-backed control group that is explicitly surfaced in local-first UI."""
+    """Legacy-backed control group that is explicitly surfaced in local-first UI.
+
+    ``post_install_visible_attr`` names an optional content method that refreshes
+    local-first visibility after a move. Keep it explicit instead of deriving it
+    from the layout name so inventory entries fail review when their contracts
+    drift.
+    """
 
     key: str
     content_attr: str
@@ -16,6 +22,7 @@ class LocalFirstControlMove:
     show_after_move: bool = True
     layout_getter_attr: str = "outer_layout"
     parent_panel_attr: str | None = None
+    post_install_visible_attr: str | None = None
 
 
 LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
@@ -51,6 +58,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         title="Map filters",
         layout_getter_attr="filter_controls_layout",
         parent_panel_attr="filter_controls_panel",
+        post_install_visible_attr="set_filter_controls_visible",
     ),
     LocalFirstControlMove(
         key="atlas_pdf",

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -14,6 +14,8 @@ class LocalFirstControlMove:
     installed_target_attr: str
     title: str | None = None
     show_after_move: bool = True
+    layout_getter_attr: str = "outer_layout"
+    parent_panel_attr: str | None = None
 
 
 LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
@@ -39,6 +41,16 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_backfill_controls_installed",
         installed_target_attr="_local_first_backfill_controls_installed_target",
         show_after_move=False,
+    ),
+    LocalFirstControlMove(
+        key="map_filters",
+        content_attr="map_content",
+        group_attr="filterGroupBox",
+        installed_attr="_local_first_filter_controls_installed",
+        installed_target_attr="_local_first_filter_controls_installed_target",
+        title="Map filters",
+        layout_getter_attr="filter_controls_layout",
+        parent_panel_attr="filter_controls_panel",
     ),
     LocalFirstControlMove(
         key="atlas_pdf",


### PR DESCRIPTION
## Summary

Moves the live local-first Map tab filter installation onto the audited control-move inventory added for issue #805, so map filters are tracked alongside the other legacy-backed local-first surfaces.

## Changes

- Extend `LocalFirstControlMove` metadata with optional target layout and parent panel fields.
- Add the `map_filters` move to the local-first control inventory.
- Route the production local-first dock through `_install_local_first_filter_controls` instead of the older wizard-named filter installer.
- Cover the inventory metadata and audited map-filter installation path with tests.

## Testing

- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
