### PR TITLE
Move Strava connection into local-first settings

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -548,6 +548,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self._install_local_first_backfill_controls(self._local_first_dock_composition)
         self._install_local_first_atlas_pdf_controls(self._local_first_dock_composition)
+        self._install_local_first_strava_credentials_controls(
+            self._local_first_dock_composition
+        )
         self._install_local_first_basemap_controls(self._local_first_dock_composition)
         self._install_local_first_storage_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
@@ -789,6 +792,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             and hasattr(legacy_export_button, "hide")
         ):
             legacy_export_button.hide()
+
+    def _install_local_first_strava_credentials_controls(self, composition) -> None:
+        """Expose the backing Strava OAuth controls in the Settings tab."""
+
+        self._install_local_first_control_move(composition, "strava_credentials")
 
     def _install_local_first_basemap_controls(self, composition) -> None:
         """Expose the backing Mapbox basemap controls in the Settings tab."""

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -19,6 +19,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "backfill_routes",
                 "map_filters",
                 "atlas_pdf",
+                "strava_credentials",
                 "basemap",
                 "storage",
             ),
@@ -31,6 +32,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "backfillMissingDetailedRoutesButton",
                 "filterGroupBox",
                 "atlasPdfGroupBox",
+                "credentialsGroupBox",
                 "backgroundGroupBox",
                 "outputGroupBox",
             ],
@@ -49,6 +51,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "backfill_routes": "sync_content",
                 "map_filters": "map_content",
                 "atlas_pdf": "atlas_content",
+                "strava_credentials": "connection_content",
                 "basemap": "connection_content",
                 "storage": "connection_content",
             },
@@ -69,6 +72,11 @@ class LocalFirstControlMoveTests(unittest.TestCase):
         self.assertEqual(filters.layout_getter_attr, "filter_controls_layout")
         self.assertEqual(filters.parent_panel_attr, "filter_controls_panel")
         self.assertEqual(filters.post_install_visible_attr, "set_filter_controls_visible")
+
+        credentials = local_first_control_move_for_key("strava_credentials")
+        self.assertEqual(credentials.content_attr, "connection_content")
+        self.assertEqual(credentials.group_attr, "credentialsGroupBox")
+        self.assertEqual(credentials.title, "Strava connection")
 
     def test_lookup_rejects_unknown_control_area(self):
         with self.assertRaises(KeyError):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -938,6 +938,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._install_local_first_activity_preview_controls = MagicMock()
         dock._install_local_first_backfill_controls = MagicMock()
         dock._install_local_first_atlas_pdf_controls = MagicMock()
+        dock._install_local_first_strava_credentials_controls = MagicMock()
         dock._install_local_first_basemap_controls = MagicMock()
         dock._install_local_first_storage_controls = MagicMock()
         dock._bind_wizard_analysis_mode_controls = MagicMock()
@@ -1022,6 +1023,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "connected-composition"
         )
         dock._install_local_first_atlas_pdf_controls.assert_called_once_with(
+            "connected-composition"
+        )
+        dock._install_local_first_strava_credentials_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._install_local_first_basemap_controls.assert_called_once_with(
@@ -1429,6 +1433,64 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         dock.scrollArea.hide.assert_not_called()
         dock.summaryStatusLabel.hide.assert_not_called()
+
+    def test_local_first_strava_credentials_controls_move_to_settings_page(self):
+        class _SourceLayout:
+            def __init__(self):
+                self.removed = []
+
+            def removeWidget(self, widget):
+                self.removed.append(widget)
+
+        class _SourceParent:
+            def __init__(self, layout):
+                self._layout = layout
+
+            def layout(self):
+                return self._layout
+
+        class _CredentialsGroup:
+            def __init__(self, parent):
+                self._parent = parent
+                self.title = None
+                self.shown = False
+
+            def parentWidget(self):
+                return self._parent
+
+            def setParent(self, parent):
+                self._parent = parent
+
+            def setTitle(self, title):
+                self.title = title
+
+            def show(self):
+                self.shown = True
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        source_layout = _SourceLayout()
+        source_parent = _SourceParent(source_layout)
+        credentials_group = _CredentialsGroup(source_parent)
+        settings_layout = _FakeLayout()
+        settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
+        composition = SimpleNamespace(connection_content=settings_content)
+        dock.credentialsGroupBox = credentials_group
+
+        self.module.QfitDockWidget._install_local_first_strava_credentials_controls(
+            dock,
+            composition,
+        )
+        self.module.QfitDockWidget._install_local_first_strava_credentials_controls(
+            dock,
+            composition,
+        )
+
+        self.assertEqual(source_layout.removed, [credentials_group])
+        self.assertIs(credentials_group.parentWidget(), settings_content)
+        self.assertEqual(credentials_group.title, "Strava connection")
+        self.assertTrue(credentials_group.shown)
+        self.assertEqual(settings_layout.added, [credentials_group])
+        self.assertTrue(dock._local_first_strava_credentials_controls_installed)
 
     def test_local_first_basemap_controls_move_to_settings_page(self):
         class _SourceLayout:

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -270,7 +270,17 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.maxDetailedActivitiesLabel.text(), "Max new detailed routes this run")
             self.assertEqual(dock.pointSamplingStrideLabel.text(), "Keep every Nth point")
             self.assertEqual(dock.workflowLabel.text(), "Sections: Fetch & store · Visualize · Analyze · Publish")
-            self.assertFalse(dock.credentialsGroupBox.isVisible())
+            self.assertEqual(dock.credentialsGroupBox.title(), "Strava connection")
+            self.assertEqual(
+                dock.credentialsGroupBox.parentWidget(),
+                dock._local_first_dock_composition.connection_content,
+            )
+            self.assertGreaterEqual(
+                dock._local_first_dock_composition.connection_content.outer_layout().indexOf(
+                    dock.credentialsGroupBox,
+                ),
+                0,
+            )
             self.assertTrue(bool(dock.features() & dock.DockWidgetMovable))
             self.assertTrue(bool(dock.features() & dock.DockWidgetFloatable))
             self.assertEqual(dock.activitiesGroupBox.title(), "")

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -69,6 +69,14 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         title="PDF output",
     ),
     LocalFirstControlMove(
+        key="strava_credentials",
+        content_attr="connection_content",
+        group_attr="credentialsGroupBox",
+        installed_attr="_local_first_strava_credentials_controls_installed",
+        installed_target_attr="_local_first_strava_credentials_controls_installed_target",
+        title="Strava connection",
+    ),
+    LocalFirstControlMove(
         key="basemap",
         content_attr="connection_content",
         group_attr="backgroundGroupBox",


### PR DESCRIPTION
## Summary
- move the legacy Strava connection/OAuth group into the local-first Settings tab
- add the Strava connection group to the local-first control-move inventory
- cover the new move path in pure dock/widget inventory tests and update the QGIS smoke expectation

## Tests
- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #805.
