### PR TITLE
Audit local-first activity style controls

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -83,6 +83,7 @@ from .ui.application import (
     DockVisualWorkflowCoordinator,
     DockVisualWorkflowRequest,
     LocalFirstControlMove,
+    LocalFirstWidgetMove,
     RunAnalysisAction,
     build_dock_summary_status,
     build_startup_wizard_progress_facts,
@@ -92,6 +93,7 @@ from .ui.application import (
     ensure_wizard_settings,
     load_wizard_settings,
     local_first_control_move_for_key,
+    local_first_widget_move_for_key,
     save_last_step_index,
     step_index_for_key,
     build_visual_workflow_background_inputs,
@@ -538,7 +540,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 update_atlas_document_settings=self._update_atlas_document_settings,
             ),
         )
-        self._install_wizard_style_controls(self._local_first_dock_composition)
+        self._install_local_first_activity_style_controls(
+            self._local_first_dock_composition
+        )
         self._install_local_first_filter_controls(self._local_first_dock_composition)
         self._install_local_first_advanced_fetch_controls(
             self._local_first_dock_composition
@@ -755,6 +759,71 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         move = local_first_control_move_for_key(key)
         return self._install_local_first_group_controls(composition, move=move)
+
+    def _install_local_first_widget_controls(
+        self,
+        composition,
+        move: LocalFirstWidgetMove,
+    ) -> bool:
+        content = getattr(composition, move.content_attr, None)
+        if content is None:
+            return False
+        current_target = id(content)
+        if getattr(self, move.installed_attr, False) and (
+            getattr(self, move.installed_target_attr, None) == current_target
+        ):
+            return True
+
+        layout = self._local_first_control_move_layout(content, move)
+        if layout is None or not hasattr(layout, "addWidget"):
+            return False
+
+        widgets = self._local_first_widget_move_widgets(move)
+        if widgets is None:
+            return False
+
+        parent_panel = self._local_first_control_move_parent_panel(content, move)
+        for widget in widgets:
+            self._remove_widget_from_current_layout(widget)
+            if hasattr(widget, "setParent"):
+                widget.setParent(parent_panel)
+            layout.addWidget(widget)
+            self._show_widget(widget)
+        for attr in move.show_widget_attrs_after_move:
+            widget = getattr(self, attr, None)
+            if widget is not None:
+                self._show_widget(widget)
+        self._refresh_local_first_control_visibility(content, move)
+
+        setattr(self, move.installed_attr, True)
+        setattr(self, move.installed_target_attr, current_target)
+        return True
+
+    def _local_first_widget_move_widgets(
+        self,
+        move: LocalFirstWidgetMove,
+    ):
+        widgets = []
+        for attr in move.required_widget_attrs:
+            widget = getattr(self, attr, None)
+            if widget is None:
+                return None
+            widgets.append(widget)
+        for group in move.optional_widget_groups:
+            group_widgets = [getattr(self, attr, None) for attr in group]
+            if all(widget is not None for widget in group_widgets):
+                widgets.extend(group_widgets)
+        for attr in move.optional_widget_attrs:
+            widget = getattr(self, attr, None)
+            if widget is not None:
+                widgets.append(widget)
+        return widgets
+
+    def _install_local_first_activity_style_controls(self, composition) -> None:
+        """Expose activity visualization controls in the local-first Map tab."""
+
+        move = local_first_widget_move_for_key("activity_style")
+        self._install_local_first_widget_controls(composition, move=move)
 
     def _install_local_first_filter_controls(self, composition) -> None:
         """Expose the backing map filters in the local-first Map tab."""

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -730,11 +730,19 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         setattr(self, move.installed_target_attr, current_target)
         return True
 
-    def _local_first_control_move_layout(self, content, move: LocalFirstControlMove):
+    def _local_first_control_move_layout(
+        self,
+        content,
+        move: LocalFirstControlMove | LocalFirstWidgetMove,
+    ):
         layout_getter = getattr(content, move.layout_getter_attr, None)
         return layout_getter() if callable(layout_getter) else None
 
-    def _local_first_control_move_parent_panel(self, content, move: LocalFirstControlMove):
+    def _local_first_control_move_parent_panel(
+        self,
+        content,
+        move: LocalFirstControlMove | LocalFirstWidgetMove,
+    ):
         if move.parent_panel_attr is None:
             return content
         return getattr(content, move.parent_panel_attr, content)
@@ -747,7 +755,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         elif hasattr(group, "setVisible"):
             group.setVisible(True)
 
-    def _refresh_local_first_control_visibility(self, content, move: LocalFirstControlMove) -> None:
+    def _refresh_local_first_control_visibility(
+        self,
+        content,
+        move: LocalFirstControlMove | LocalFirstWidgetMove,
+    ) -> None:
         if move.post_install_visible_attr is None:
             return
         set_visible = getattr(content, move.post_install_visible_attr, None)

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -4,8 +4,11 @@ from tests import _path  # noqa: F401
 
 from qfit.ui.application.local_first_control_moves import (
     LOCAL_FIRST_CONTROL_MOVES,
+    LOCAL_FIRST_WIDGET_MOVES,
     local_first_control_move_for_key,
     local_first_control_move_keys,
+    local_first_widget_move_for_key,
+    local_first_widget_move_keys,
 )
 
 
@@ -78,9 +81,48 @@ class LocalFirstControlMoveTests(unittest.TestCase):
         self.assertEqual(credentials.group_attr, "credentialsGroupBox")
         self.assertEqual(credentials.title, "Strava connection")
 
+    def test_widget_move_inventory_covers_loose_visualization_controls(self):
+        self.assertEqual(local_first_widget_move_keys(), ("activity_style",))
+
+        move = LOCAL_FIRST_WIDGET_MOVES[0]
+        self.assertEqual(move.content_attr, "map_content")
+        self.assertEqual(
+            move.required_widget_attrs,
+            ("stylePresetLabel", "stylePresetComboBox"),
+        )
+        self.assertEqual(
+            move.optional_widget_groups,
+            (("previewSortLabel", "previewSortComboBox"),),
+        )
+        self.assertEqual(
+            move.optional_widget_attrs,
+            ("analysisTemporalModeRow", "temporalHelpLabel"),
+        )
+        self.assertEqual(move.layout_getter_attr, "style_controls_layout")
+        self.assertEqual(move.parent_panel_attr, "style_controls_panel")
+        self.assertEqual(move.post_install_visible_attr, "set_style_controls_visible")
+
+    def test_widget_move_lookup_returns_full_install_metadata(self):
+        move = local_first_widget_move_for_key("activity_style")
+
+        self.assertEqual(
+            move.installed_attr,
+            "_local_first_activity_style_controls_installed",
+        )
+        self.assertEqual(
+            move.installed_target_attr,
+            "_local_first_activity_style_controls_installed_target",
+        )
+        self.assertEqual(
+            move.show_widget_attrs_after_move,
+            ("temporalModeLabel", "temporalModeComboBox"),
+        )
+
     def test_lookup_rejects_unknown_control_area(self):
         with self.assertRaises(KeyError):
             local_first_control_move_for_key("credentials")
+        with self.assertRaises(KeyError):
+            local_first_widget_move_for_key("credentials")
 
 
 if __name__ == "__main__":

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -932,7 +932,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._atlas_export_completed = False
         dock.settings = _FakeSettings()
-        dock._install_wizard_style_controls = MagicMock()
+        dock._install_local_first_activity_style_controls = MagicMock()
         dock._install_local_first_filter_controls = MagicMock()
         dock._install_local_first_advanced_fetch_controls = MagicMock()
         dock._install_local_first_activity_preview_controls = MagicMock()
@@ -1007,7 +1007,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 callback.__func__,
                 getattr(self.module.QfitDockWidget, method_name),
             )
-        dock._install_wizard_style_controls.assert_called_once_with(
+        dock._install_local_first_activity_style_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._install_local_first_filter_controls.assert_called_once_with(
@@ -1286,6 +1286,106 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
 
         map_content.style_controls_layout.assert_not_called()
+
+    def test_install_local_first_activity_style_controls_uses_audited_widget_move(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        parent_layout = MagicMock()
+        parent_widget = SimpleNamespace(layout=lambda: parent_layout)
+        style_label = MagicMock()
+        style_combo = MagicMock()
+        preview_sort_label = MagicMock()
+        preview_sort_combo = MagicMock()
+        temporal_row = MagicMock()
+        temporal_label = MagicMock()
+        temporal_combo = MagicMock()
+        temporal_help = MagicMock()
+        for widget in (
+            style_label,
+            style_combo,
+            preview_sort_label,
+            preview_sort_combo,
+            temporal_row,
+            temporal_help,
+        ):
+            widget.parentWidget.return_value = parent_widget
+        dock.stylePresetLabel = style_label
+        dock.stylePresetComboBox = style_combo
+        dock.previewSortLabel = preview_sort_label
+        dock.previewSortComboBox = preview_sort_combo
+        dock.analysisTemporalModeRow = temporal_row
+        dock.temporalModeLabel = temporal_label
+        dock.temporalModeComboBox = temporal_combo
+        dock.temporalHelpLabel = temporal_help
+        panel = object()
+        style_layout = MagicMock()
+        map_content = SimpleNamespace(
+            style_controls_panel=panel,
+            style_controls_layout=MagicMock(return_value=style_layout),
+            set_style_controls_visible=MagicMock(),
+        )
+
+        self.module.QfitDockWidget._install_local_first_activity_style_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
+        self.assertEqual(
+            parent_layout.removeWidget.call_args_list,
+            [
+                call(style_label),
+                call(style_combo),
+                call(preview_sort_label),
+                call(preview_sort_combo),
+                call(temporal_row),
+                call(temporal_help),
+            ],
+        )
+        self.assertEqual(
+            style_layout.addWidget.call_args_list,
+            [
+                call(style_label),
+                call(style_combo),
+                call(preview_sort_label),
+                call(preview_sort_combo),
+                call(temporal_row),
+                call(temporal_help),
+            ],
+        )
+        for widget in (
+            style_label,
+            style_combo,
+            preview_sort_label,
+            preview_sort_combo,
+            temporal_row,
+            temporal_label,
+            temporal_combo,
+            temporal_help,
+        ):
+            widget.show.assert_called_once_with()
+        map_content.set_style_controls_visible.assert_called_once_with()
+        self.assertTrue(dock._local_first_activity_style_controls_installed)
+        self.assertEqual(
+            dock._local_first_activity_style_controls_installed_target,
+            id(map_content),
+        )
+
+    def test_install_local_first_activity_style_controls_requires_style_pair(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.stylePresetLabel = MagicMock()
+        style_layout = MagicMock()
+        map_content = SimpleNamespace(
+            style_controls_layout=MagicMock(return_value=style_layout),
+        )
+
+        self.module.QfitDockWidget._install_local_first_activity_style_controls(
+            dock,
+            SimpleNamespace(map_content=map_content),
+        )
+
+        self.assertEqual(style_layout.addWidget.call_args_list, [])
+        self.assertFalse(
+            getattr(dock, "_local_first_activity_style_controls_installed", False)
+        )
 
     def test_bind_wizard_analysis_mode_controls_exposes_non_none_modes(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -37,9 +37,13 @@ from .local_first_navigation import (
 )
 from .local_first_control_moves import (
     LOCAL_FIRST_CONTROL_MOVES,
+    LOCAL_FIRST_WIDGET_MOVES,
     LocalFirstControlMove,
+    LocalFirstWidgetMove,
     local_first_control_move_for_key,
     local_first_control_move_keys,
+    local_first_widget_move_for_key,
+    local_first_widget_move_keys,
 )
 from .dock_workflow_sections import (
     CURRENT_DOCK_SECTIONS,
@@ -129,10 +133,12 @@ __all__ = [
     "LAST_STEP_INDEX_USER_SELECTED_KEY",
     "LOCAL_FIRST_CONTROL_MOVES",
     "LOCAL_FIRST_DOCK_PAGE_DEFINITIONS",
+    "LOCAL_FIRST_WIDGET_MOVES",
     "LocalFirstControlMove",
     "LocalFirstDockNavigationState",
     "LocalFirstDockPageDefinition",
     "LocalFirstDockPageState",
+    "LocalFirstWidgetMove",
     "WIZARD_WORKFLOW_STEPS",
     "WIZARD_STEP_COUNT",
     "WIZARD_VERSION",
@@ -176,6 +182,8 @@ __all__ = [
     "local_first_control_move_for_key",
     "local_first_control_move_keys",
     "local_first_dock_page_keys",
+    "local_first_widget_move_for_key",
+    "local_first_widget_move_keys",
     "preferred_current_key_from_settings",
     "save_collapsed_groups",
     "save_last_step_index",

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -25,6 +25,45 @@ class LocalFirstControlMove:
     post_install_visible_attr: str | None = None
 
 
+@dataclass(frozen=True)
+class LocalFirstWidgetMove:
+    """Legacy-backed loose widgets that are surfaced in local-first UI.
+
+    Some remaining controls were not wrapped in a single group box in the old
+    dock. Keep their widget contracts audited here so local-first parity does
+    not depend on ad-hoc installer methods with wizard-era naming.
+    """
+
+    key: str
+    content_attr: str
+    required_widget_attrs: tuple[str, ...]
+    installed_attr: str
+    installed_target_attr: str
+    optional_widget_groups: tuple[tuple[str, ...], ...] = ()
+    optional_widget_attrs: tuple[str, ...] = ()
+    show_widget_attrs_after_move: tuple[str, ...] = ()
+    layout_getter_attr: str = "outer_layout"
+    parent_panel_attr: str | None = None
+    post_install_visible_attr: str | None = None
+
+
+LOCAL_FIRST_WIDGET_MOVES: tuple[LocalFirstWidgetMove, ...] = (
+    LocalFirstWidgetMove(
+        key="activity_style",
+        content_attr="map_content",
+        required_widget_attrs=("stylePresetLabel", "stylePresetComboBox"),
+        installed_attr="_local_first_activity_style_controls_installed",
+        installed_target_attr="_local_first_activity_style_controls_installed_target",
+        optional_widget_groups=(("previewSortLabel", "previewSortComboBox"),),
+        optional_widget_attrs=("analysisTemporalModeRow", "temporalHelpLabel"),
+        show_widget_attrs_after_move=("temporalModeLabel", "temporalModeComboBox"),
+        layout_getter_attr="style_controls_layout",
+        parent_panel_attr="style_controls_panel",
+        post_install_visible_attr="set_style_controls_visible",
+    ),
+)
+
+
 LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
     LocalFirstControlMove(
         key="advanced_fetch",
@@ -110,9 +149,28 @@ def local_first_control_move_keys() -> tuple[str, ...]:
     return tuple(move.key for move in LOCAL_FIRST_CONTROL_MOVES)
 
 
+def local_first_widget_move_for_key(key: str) -> LocalFirstWidgetMove:
+    """Return the local-first loose-widget move spec for a supported area."""
+
+    for move in LOCAL_FIRST_WIDGET_MOVES:
+        if move.key == key:
+            return move
+    raise KeyError(key)
+
+
+def local_first_widget_move_keys() -> tuple[str, ...]:
+    """Return stable audit keys for loose local-first widget moves."""
+
+    return tuple(move.key for move in LOCAL_FIRST_WIDGET_MOVES)
+
+
 __all__ = [
     "LOCAL_FIRST_CONTROL_MOVES",
+    "LOCAL_FIRST_WIDGET_MOVES",
     "LocalFirstControlMove",
+    "LocalFirstWidgetMove",
     "local_first_control_move_for_key",
     "local_first_control_move_keys",
+    "local_first_widget_move_for_key",
+    "local_first_widget_move_keys",
 ]


### PR DESCRIPTION
## Summary

- add an audited local-first widget-move inventory for loose activity styling controls
- wire the local-first dock builder through a local-first activity style installer instead of the wizard-style installer
- cover the new inventory and installer behavior with pure unit tests

## Tests

- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Closes part of #805.
