### PR TITLE
Audit local-first control child widgets

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -711,6 +711,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             getattr(self, move.installed_target_attr, None) == current_target
         ):
             return True
+        if not self._local_first_control_move_required_widgets_available(move):
+            return False
 
         layout = self._local_first_control_move_layout(content, move)
         if layout is None or not hasattr(layout, "addWidget"):
@@ -729,6 +731,15 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         setattr(self, move.installed_attr, True)
         setattr(self, move.installed_target_attr, current_target)
         return True
+
+    def _local_first_control_move_required_widgets_available(
+        self,
+        move: LocalFirstControlMove,
+    ) -> bool:
+        return all(
+            getattr(self, attr, None) is not None
+            for attr in move.required_widget_attrs
+        )
 
     def _local_first_control_move_layout(
         self,

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -60,11 +60,72 @@ class LocalFirstControlMoveTests(unittest.TestCase):
             },
         )
 
+    def test_control_moves_document_required_supported_controls(self):
+        required_widgets = {
+            move.key: move.required_widget_attrs for move in LOCAL_FIRST_CONTROL_MOVES
+        }
+
+        self.assertEqual(
+            required_widgets,
+            {
+                "advanced_fetch": (
+                    "advancedFetchSettingsWidget",
+                    "perPageSpinBox",
+                    "maxPagesSpinBox",
+                    "detailedStreamsCheckBox",
+                    "detailedRouteStrategyComboBox",
+                    "maxDetailedActivitiesSpinBox",
+                ),
+                "activity_preview": (
+                    "querySummaryLabel",
+                    "activityPreviewPlainTextEdit",
+                ),
+                "backfill_routes": (),
+                "map_filters": (
+                    "activityTypeComboBox",
+                    "activitySearchLineEdit",
+                    "dateFromEdit",
+                    "dateToEdit",
+                    "minDistanceSpinBox",
+                    "maxDistanceSpinBox",
+                    "detailedRouteStatusComboBox",
+                ),
+                "atlas_pdf": ("atlasPdfPathLineEdit", "atlasPdfBrowseButton"),
+                "strava_credentials": (
+                    "clientIdLineEdit",
+                    "clientSecretLineEdit",
+                    "redirectUriLineEdit",
+                    "authCodeLineEdit",
+                    "refreshTokenLineEdit",
+                    "openAuthorizeButton",
+                    "exchangeCodeButton",
+                ),
+                "basemap": (
+                    "backgroundMapCheckBox",
+                    "backgroundPresetComboBox",
+                    "mapboxStyleOwnerLineEdit",
+                    "mapboxStyleIdLineEdit",
+                    "tileModeComboBox",
+                    "loadBackgroundButton",
+                ),
+                "storage": (
+                    "outputPathLineEdit",
+                    "browseButton",
+                    "writeActivityPointsCheckBox",
+                    "pointSamplingStrideSpinBox",
+                ),
+            },
+        )
+
     def test_lookup_returns_full_install_metadata(self):
         move = local_first_control_move_for_key("atlas_pdf")
 
         self.assertEqual(move.content_attr, "atlas_content")
         self.assertEqual(move.group_attr, "atlasPdfGroupBox")
+        self.assertEqual(
+            move.required_widget_attrs,
+            ("atlasPdfPathLineEdit", "atlasPdfBrowseButton"),
+        )
         self.assertEqual(move.title, "PDF output")
         self.assertTrue(move.show_after_move)
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -280,6 +280,11 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
     def setUpClass(cls):
         cls.module = cls._import_module_with_stubs()
 
+    def _install_required_local_first_group_widgets(self, dock, key):
+        move = self.module.local_first_control_move_for_key(key)
+        for attr in move.required_widget_attrs:
+            setattr(dock, attr, MagicMock(name=attr))
+
     @staticmethod
     def _import_module_with_stubs():
         qgis_mod = ModuleType("qgis")
@@ -1107,6 +1112,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         filter_group = MagicMock()
         filter_group.parentWidget.return_value = parent_widget
         dock.filterGroupBox = filter_group
+        self._install_required_local_first_group_widgets(dock, "map_filters")
         panel = object()
         filter_layout = MagicMock()
         map_content = SimpleNamespace(
@@ -1575,6 +1581,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
         composition = SimpleNamespace(connection_content=settings_content)
         dock.credentialsGroupBox = credentials_group
+        self._install_required_local_first_group_widgets(
+            dock,
+            "strava_credentials",
+        )
 
         self.module.QfitDockWidget._install_local_first_strava_credentials_controls(
             dock,
@@ -1633,6 +1643,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
         composition = SimpleNamespace(connection_content=settings_content)
         dock.backgroundGroupBox = basemap_group
+        self._install_required_local_first_group_widgets(dock, "basemap")
 
         self.module.QfitDockWidget._install_local_first_basemap_controls(
             dock,
@@ -1691,6 +1702,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
         composition = SimpleNamespace(connection_content=settings_content)
         dock.outputGroupBox = storage_group
+        self._install_required_local_first_group_widgets(dock, "storage")
 
         self.module.QfitDockWidget._install_local_first_storage_controls(
             dock,
@@ -1745,6 +1757,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         data_content = SimpleNamespace(outer_layout=lambda: data_layout)
         composition = SimpleNamespace(sync_content=data_content)
         dock.advancedFetchGroupBox = advanced_fetch_group
+        self._install_required_local_first_group_widgets(dock, "advanced_fetch")
 
         self.module.QfitDockWidget._install_local_first_advanced_fetch_controls(
             dock,
@@ -1802,6 +1815,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         data_content = SimpleNamespace(outer_layout=lambda: data_layout)
         composition = SimpleNamespace(sync_content=data_content)
         dock.previewGroupBox = preview_group
+        self._install_required_local_first_group_widgets(dock, "activity_preview")
 
         self.module.QfitDockWidget._install_local_first_activity_preview_controls(
             dock,
@@ -1919,6 +1933,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         composition = SimpleNamespace(atlas_content=atlas_content)
         dock.atlasPdfGroupBox = atlas_pdf_group
         dock.generateAtlasPdfButton = MagicMock()
+        self._install_required_local_first_group_widgets(dock, "atlas_pdf")
 
         self.module.QfitDockWidget._install_local_first_atlas_pdf_controls(
             dock,
@@ -1954,6 +1969,44 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertFalse(
             getattr(dock, "_local_first_atlas_pdf_controls_installed", False)
         )
+
+    def test_local_first_group_move_requires_audited_supported_controls(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.atlasPdfGroupBox = MagicMock()
+        dock.atlasPdfPathLineEdit = MagicMock()
+        atlas_layout = _FakeLayout()
+        atlas_content = SimpleNamespace(outer_layout=lambda: atlas_layout)
+        composition = SimpleNamespace(atlas_content=atlas_content)
+
+        installed = self.module.QfitDockWidget._install_local_first_control_move(
+            dock,
+            composition,
+            "atlas_pdf",
+        )
+
+        self.assertFalse(installed)
+        self.assertEqual(atlas_layout.added, [])
+        self.assertFalse(
+            getattr(dock, "_local_first_atlas_pdf_controls_installed", False)
+        )
+
+    def test_local_first_group_move_keeps_idempotent_result_before_required_guard(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.atlasPdfGroupBox = MagicMock()
+        dock.atlasPdfPathLineEdit = MagicMock()
+        atlas_layout = _FakeLayout()
+        atlas_content = SimpleNamespace(outer_layout=lambda: atlas_layout)
+        dock._local_first_atlas_pdf_controls_installed = True
+        dock._local_first_atlas_pdf_controls_installed_target = id(atlas_content)
+
+        installed = self.module.QfitDockWidget._install_local_first_control_move(
+            dock,
+            SimpleNamespace(atlas_content=atlas_content),
+            "atlas_pdf",
+        )
+
+        self.assertTrue(installed)
+        self.assertEqual(atlas_layout.added, [])
 
     def test_refresh_wizard_shell_from_runtime_updates_optional_composition(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -18,6 +18,7 @@ class LocalFirstControlMove:
     group_attr: str
     installed_attr: str
     installed_target_attr: str
+    required_widget_attrs: tuple[str, ...] = ()
     title: str | None = None
     show_after_move: bool = True
     layout_getter_attr: str = "outer_layout"
@@ -69,6 +70,14 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         key="advanced_fetch",
         content_attr="sync_content",
         group_attr="advancedFetchGroupBox",
+        required_widget_attrs=(
+            "advancedFetchSettingsWidget",
+            "perPageSpinBox",
+            "maxPagesSpinBox",
+            "detailedStreamsCheckBox",
+            "detailedRouteStrategyComboBox",
+            "maxDetailedActivitiesSpinBox",
+        ),
         installed_attr="_local_first_advanced_fetch_controls_installed",
         installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
     ),
@@ -76,6 +85,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         key="activity_preview",
         content_attr="sync_content",
         group_attr="previewGroupBox",
+        required_widget_attrs=("querySummaryLabel", "activityPreviewPlainTextEdit"),
         installed_attr="_local_first_activity_preview_controls_installed",
         installed_target_attr="_local_first_activity_preview_controls_installed_target",
         title="Fetched activity preview",
@@ -92,6 +102,15 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         key="map_filters",
         content_attr="map_content",
         group_attr="filterGroupBox",
+        required_widget_attrs=(
+            "activityTypeComboBox",
+            "activitySearchLineEdit",
+            "dateFromEdit",
+            "dateToEdit",
+            "minDistanceSpinBox",
+            "maxDistanceSpinBox",
+            "detailedRouteStatusComboBox",
+        ),
         installed_attr="_local_first_filter_controls_installed",
         installed_target_attr="_local_first_filter_controls_installed_target",
         title="Map filters",
@@ -103,6 +122,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         key="atlas_pdf",
         content_attr="atlas_content",
         group_attr="atlasPdfGroupBox",
+        required_widget_attrs=("atlasPdfPathLineEdit", "atlasPdfBrowseButton"),
         installed_attr="_local_first_atlas_pdf_controls_installed",
         installed_target_attr="_local_first_atlas_pdf_controls_installed_target",
         title="PDF output",
@@ -111,6 +131,15 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         key="strava_credentials",
         content_attr="connection_content",
         group_attr="credentialsGroupBox",
+        required_widget_attrs=(
+            "clientIdLineEdit",
+            "clientSecretLineEdit",
+            "redirectUriLineEdit",
+            "authCodeLineEdit",
+            "refreshTokenLineEdit",
+            "openAuthorizeButton",
+            "exchangeCodeButton",
+        ),
         installed_attr="_local_first_strava_credentials_controls_installed",
         installed_target_attr="_local_first_strava_credentials_controls_installed_target",
         title="Strava connection",
@@ -119,6 +148,14 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         key="basemap",
         content_attr="connection_content",
         group_attr="backgroundGroupBox",
+        required_widget_attrs=(
+            "backgroundMapCheckBox",
+            "backgroundPresetComboBox",
+            "mapboxStyleOwnerLineEdit",
+            "mapboxStyleIdLineEdit",
+            "tileModeComboBox",
+            "loadBackgroundButton",
+        ),
         installed_attr="_local_first_basemap_controls_installed",
         installed_target_attr="_local_first_basemap_controls_installed_target",
         title="Mapbox basemap",
@@ -127,6 +164,12 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         key="storage",
         content_attr="connection_content",
         group_attr="outputGroupBox",
+        required_widget_attrs=(
+            "outputPathLineEdit",
+            "browseButton",
+            "writeActivityPointsCheckBox",
+            "pointSamplingStrideSpinBox",
+        ),
         installed_attr="_local_first_storage_controls_installed",
         installed_target_attr="_local_first_storage_controls_installed_target",
         title="Data storage",


### PR DESCRIPTION
## Summary

- add required child-widget contracts to the local-first legacy-backed control move inventory
- prevent group moves from installing when a supported backing control is missing
- cover the new audit metadata and install guard with focused tests

## Tests

- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805.
