### PR TITLE
Refine local-first settings content wiring

### DIFF
--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -58,16 +58,20 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         )
         self.assertIs(composition.sync_content, composition.page_content.data_content)
         self.assertIs(
-            composition.connection_content,
+            composition.settings_content,
             composition.page_content.settings_content,
         )
+        self.assertIs(
+            composition.connection_content,
+            composition.settings_content,
+        )
         self.assertEqual(
-            composition.connection_content.detail_label.text(),
+            composition.settings_content.detail_label.text(),
             "Review provider credentials and durable qfit preferences away from "
             "daily workflow panels.",
         )
         self.assertEqual(
-            composition.connection_content.configure_button.text(),
+            composition.settings_content.configure_button.text(),
             "Configure settings",
         )
 
@@ -101,7 +105,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             composition.map_content,
             composition.analysis_content,
             composition.atlas_content,
-            composition.connection_content,
+            composition.settings_content,
         ):
             layout = content.outer_layout()
             self.assertEqual(layout.contents_margins, (0, 0, 0, 0))
@@ -134,7 +138,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         )
 
         self.module.connect_local_first_action_callbacks(composition, callbacks)
-        composition.connection_content.configureRequested.emit()
+        composition.settings_content.configureRequested.emit()
         composition.sync_content.syncRequested.emit()
         composition.sync_content.syncRoutesRequested.emit()
         composition.sync_content.clearDatabaseRequested.emit()
@@ -197,14 +201,14 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         self.assertTrue(composition.shell.navigation_item_for_key("map").property("current"))
         self.assertEqual(composition.sync_content.status_label.text(), "Activities stored")
         self.assertEqual(composition.map_content.status_label.text(), "Stored map layers loaded")
-        self.assertEqual(composition.connection_content.status_label.text(), "Strava connected")
+        self.assertEqual(composition.settings_content.status_label.text(), "Strava connected")
         self.assertEqual(
-            composition.connection_content.detail_label.text(),
+            composition.settings_content.detail_label.text(),
             "Review provider credentials and durable qfit preferences away from "
             "daily workflow panels.",
         )
         self.assertEqual(
-            composition.connection_content.configure_button.text(),
+            composition.settings_content.configure_button.text(),
             "Review settings",
         )
 

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -54,9 +54,9 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "backfill_routes": "sync_content",
                 "map_filters": "map_content",
                 "atlas_pdf": "atlas_content",
-                "strava_credentials": "connection_content",
-                "basemap": "connection_content",
-                "storage": "connection_content",
+                "strava_credentials": "settings_content",
+                "basemap": "settings_content",
+                "storage": "settings_content",
             },
         )
 
@@ -138,7 +138,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
         self.assertEqual(filters.post_install_visible_attr, "set_filter_controls_visible")
 
         credentials = local_first_control_move_for_key("strava_credentials")
-        self.assertEqual(credentials.content_attr, "connection_content")
+        self.assertEqual(credentials.content_attr, "settings_content")
         self.assertEqual(credentials.group_attr, "credentialsGroupBox")
         self.assertEqual(credentials.title, "Strava connection")
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1579,7 +1579,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         credentials_group = _CredentialsGroup(source_parent)
         settings_layout = _FakeLayout()
         settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
-        composition = SimpleNamespace(connection_content=settings_content)
+        composition = SimpleNamespace(settings_content=settings_content)
         dock.credentialsGroupBox = credentials_group
         self._install_required_local_first_group_widgets(
             dock,
@@ -1641,7 +1641,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         basemap_group = _BasemapGroup(source_parent)
         settings_layout = _FakeLayout()
         settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
-        composition = SimpleNamespace(connection_content=settings_content)
+        composition = SimpleNamespace(settings_content=settings_content)
         dock.backgroundGroupBox = basemap_group
         self._install_required_local_first_group_widgets(dock, "basemap")
 
@@ -1700,7 +1700,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         storage_group = _StorageGroup(source_parent)
         settings_layout = _FakeLayout()
         settings_content = SimpleNamespace(outer_layout=lambda: settings_layout)
-        composition = SimpleNamespace(connection_content=settings_content)
+        composition = SimpleNamespace(settings_content=settings_content)
         dock.outputGroupBox = storage_group
         self._install_required_local_first_group_widgets(dock, "storage")
 

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -129,7 +129,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
     ),
     LocalFirstControlMove(
         key="strava_credentials",
-        content_attr="connection_content",
+        content_attr="settings_content",
         group_attr="credentialsGroupBox",
         required_widget_attrs=(
             "clientIdLineEdit",
@@ -146,7 +146,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
     ),
     LocalFirstControlMove(
         key="basemap",
-        content_attr="connection_content",
+        content_attr="settings_content",
         group_attr="backgroundGroupBox",
         required_widget_attrs=(
             "backgroundMapCheckBox",
@@ -162,7 +162,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
     ),
     LocalFirstControlMove(
         key="storage",
-        content_attr="connection_content",
+        content_attr="settings_content",
         group_attr="outputGroupBox",
         required_widget_attrs=(
             "outputPathLineEdit",

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -78,10 +78,16 @@ class LocalFirstDockComposition:
         return self.page_content.atlas_content
 
     @property
+    def settings_content(self) -> ConnectionPageContent:
+        """Local-first Settings page content."""
+
+        return self.page_content.settings_content
+
+    @property
     def connection_content(self) -> ConnectionPageContent:
         """Settings page uses the existing connection/configuration content."""
 
-        return self.page_content.settings_content
+        return self.settings_content
 
 
 def build_local_first_dock_composition(
@@ -123,7 +129,7 @@ def connect_local_first_action_callbacks(
     if composition.action_callbacks is not None:
         return composition
     _connect_optional_signal(
-        composition.connection_content,
+        composition.settings_content,
         "configureRequested",
         callbacks.configure_connection,
     )
@@ -202,7 +208,7 @@ def refresh_local_first_dock_composition(
     composition.map_content.set_state(page_states.map_state)
     composition.analysis_content.set_state(page_states.analysis_state)
     composition.atlas_content.set_state(page_states.atlas_state)
-    composition.connection_content.set_state(
+    composition.settings_content.set_state(
         _settings_state_from_connection_state(page_states.connection_state)
     )
     return composition


### PR DESCRIPTION
## Summary

Refine the local-first Settings tab wiring so Settings-backed control moves target the explicit `settings_content` surface instead of the compatibility `connection_content` alias.

## Changes

- Add a first-class `settings_content` accessor to the local-first dock composition while keeping the existing compatibility alias.
- Point Strava credentials, Mapbox basemap, and storage control move inventory entries at the Settings page surface.
- Update local-first composition and control-move regression coverage for the explicit Settings destination.

## Testing

- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_local_first_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
