### PR TITLE
Refactor local-first control installs through audit inventory

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -837,6 +837,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _install_local_first_audited_controls(self, composition) -> None:
         """Install all audited legacy-backed controls into local-first pages."""
 
+        # The audited inventories define the production install order.  This does
+        # not preserve the older hand-written call sequence when targets are
+        # independent; it keeps the local-first composition aligned with the
+        # audit metadata instead.
         for key in local_first_widget_move_keys():
             self._install_local_first_widget_move(composition, key)
         for key in local_first_control_move_keys():
@@ -868,27 +872,27 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 legacy_export_button.hide()
 
     def _install_local_first_activity_style_controls(self, composition) -> None:
-        """Expose activity visualization controls in the local-first Map tab."""
+        """Deprecated wrapper for activity visualization local-first controls."""
 
         self._install_local_first_widget_move(composition, "activity_style")
 
     def _install_local_first_filter_controls(self, composition) -> None:
-        """Expose the backing map filters in the local-first Map tab."""
+        """Deprecated wrapper for map-filter local-first controls."""
 
         self._install_local_first_control_move(composition, "map_filters")
 
     def _install_local_first_advanced_fetch_controls(self, composition) -> None:
-        """Expose backing Strava fetch limits in the Data tab."""
+        """Deprecated wrapper for Strava fetch-limit local-first controls."""
 
         self._install_local_first_control_move(composition, "advanced_fetch")
 
     def _install_local_first_activity_preview_controls(self, composition) -> None:
-        """Expose fetched activity query details in the Data tab."""
+        """Deprecated wrapper for activity-preview local-first controls."""
 
         self._install_local_first_control_move(composition, "activity_preview")
 
     def _install_local_first_backfill_controls(self, composition) -> None:
-        """Expose the detailed-route backfill action in the Data tab."""
+        """Deprecated wrapper for detailed-route backfill local-first controls."""
 
         installed = self._install_local_first_control_move(composition, "backfill_routes")
         self._after_local_first_control_move_installed(
@@ -897,23 +901,23 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
 
     def _install_local_first_atlas_pdf_controls(self, composition) -> None:
-        """Expose backing PDF output controls in the Atlas tab."""
+        """Deprecated wrapper for PDF output local-first controls."""
 
         installed = self._install_local_first_control_move(composition, "atlas_pdf")
         self._after_local_first_control_move_installed("atlas_pdf", installed=installed)
 
     def _install_local_first_strava_credentials_controls(self, composition) -> None:
-        """Expose the backing Strava OAuth controls in the Settings tab."""
+        """Deprecated wrapper for Strava OAuth local-first controls."""
 
         self._install_local_first_control_move(composition, "strava_credentials")
 
     def _install_local_first_basemap_controls(self, composition) -> None:
-        """Expose the backing Mapbox basemap controls in the Settings tab."""
+        """Deprecated wrapper for Mapbox basemap local-first controls."""
 
         self._install_local_first_control_move(composition, "basemap")
 
     def _install_local_first_storage_controls(self, composition) -> None:
-        """Expose the backing GeoPackage storage controls in the Settings tab."""
+        """Deprecated wrapper for GeoPackage storage local-first controls."""
 
         self._install_local_first_control_move(composition, "storage")
 

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -93,7 +93,9 @@ from .ui.application import (
     ensure_wizard_settings,
     load_wizard_settings,
     local_first_control_move_for_key,
+    local_first_control_move_keys,
     local_first_widget_move_for_key,
+    local_first_widget_move_keys,
     save_last_step_index,
     step_index_for_key,
     build_visual_workflow_background_inputs,
@@ -540,23 +542,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 update_atlas_document_settings=self._update_atlas_document_settings,
             ),
         )
-        self._install_local_first_activity_style_controls(
-            self._local_first_dock_composition
-        )
-        self._install_local_first_filter_controls(self._local_first_dock_composition)
-        self._install_local_first_advanced_fetch_controls(
-            self._local_first_dock_composition
-        )
-        self._install_local_first_activity_preview_controls(
-            self._local_first_dock_composition
-        )
-        self._install_local_first_backfill_controls(self._local_first_dock_composition)
-        self._install_local_first_atlas_pdf_controls(self._local_first_dock_composition)
-        self._install_local_first_strava_credentials_controls(
-            self._local_first_dock_composition
-        )
-        self._install_local_first_basemap_controls(self._local_first_dock_composition)
-        self._install_local_first_storage_controls(self._local_first_dock_composition)
+        self._install_local_first_audited_controls(self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
         return self._local_first_dock_composition
 
@@ -842,11 +828,49 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 widgets.append(widget)
         return widgets
 
+    def _install_local_first_widget_move(self, composition, key: str) -> bool:
+        """Install one audited loose-widget area into local-first UI."""
+
+        move = local_first_widget_move_for_key(key)
+        return self._install_local_first_widget_controls(composition, move=move)
+
+    def _install_local_first_audited_controls(self, composition) -> None:
+        """Install all audited legacy-backed controls into local-first pages."""
+
+        for key in local_first_widget_move_keys():
+            self._install_local_first_widget_move(composition, key)
+        for key in local_first_control_move_keys():
+            installed = self._install_local_first_control_move(composition, key)
+            self._after_local_first_control_move_installed(key, installed=installed)
+
+    def _after_local_first_control_move_installed(
+        self,
+        key: str,
+        *,
+        installed: bool,
+    ) -> None:
+        """Apply per-control side effects after an audited local-first move."""
+
+        if not installed:
+            return
+        if key == "backfill_routes":
+            detailed_streams_checkbox = getattr(self, "detailedStreamsCheckBox", None)
+            if hasattr(detailed_streams_checkbox, "isChecked"):
+                self._workflow_section_coordinator.update_detailed_fetch_visibility(
+                    detailed_streams_checkbox.isChecked()
+                )
+        elif key == "atlas_pdf":
+            legacy_export_button = getattr(self, "generateAtlasPdfButton", None)
+            if legacy_export_button is not None and hasattr(
+                legacy_export_button,
+                "hide",
+            ):
+                legacy_export_button.hide()
+
     def _install_local_first_activity_style_controls(self, composition) -> None:
         """Expose activity visualization controls in the local-first Map tab."""
 
-        move = local_first_widget_move_for_key("activity_style")
-        self._install_local_first_widget_controls(composition, move=move)
+        self._install_local_first_widget_move(composition, "activity_style")
 
     def _install_local_first_filter_controls(self, composition) -> None:
         """Expose the backing map filters in the local-first Map tab."""
@@ -867,23 +891,16 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         """Expose the detailed-route backfill action in the Data tab."""
 
         installed = self._install_local_first_control_move(composition, "backfill_routes")
-        detailed_streams_checkbox = getattr(self, "detailedStreamsCheckBox", None)
-        if installed and hasattr(detailed_streams_checkbox, "isChecked"):
-            self._workflow_section_coordinator.update_detailed_fetch_visibility(
-                detailed_streams_checkbox.isChecked()
-            )
+        self._after_local_first_control_move_installed(
+            "backfill_routes",
+            installed=installed,
+        )
 
     def _install_local_first_atlas_pdf_controls(self, composition) -> None:
         """Expose backing PDF output controls in the Atlas tab."""
 
         installed = self._install_local_first_control_move(composition, "atlas_pdf")
-        legacy_export_button = getattr(self, "generateAtlasPdfButton", None)
-        if (
-            installed
-            and legacy_export_button is not None
-            and hasattr(legacy_export_button, "hide")
-        ):
-            legacy_export_button.hide()
+        self._after_local_first_control_move_installed("atlas_pdf", installed=installed)
 
     def _install_local_first_strava_credentials_controls(self, composition) -> None:
         """Expose the backing Strava OAuth controls in the Settings tab."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -937,15 +937,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._atlas_export_completed = False
         dock.settings = _FakeSettings()
-        dock._install_local_first_activity_style_controls = MagicMock()
-        dock._install_local_first_filter_controls = MagicMock()
-        dock._install_local_first_advanced_fetch_controls = MagicMock()
-        dock._install_local_first_activity_preview_controls = MagicMock()
-        dock._install_local_first_backfill_controls = MagicMock()
-        dock._install_local_first_atlas_pdf_controls = MagicMock()
-        dock._install_local_first_strava_credentials_controls = MagicMock()
-        dock._install_local_first_basemap_controls = MagicMock()
-        dock._install_local_first_storage_controls = MagicMock()
+        dock._install_local_first_audited_controls = MagicMock()
         dock._bind_wizard_analysis_mode_controls = MagicMock()
         parent = object()
 
@@ -1012,31 +1004,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 callback.__func__,
                 getattr(self.module.QfitDockWidget, method_name),
             )
-        dock._install_local_first_activity_style_controls.assert_called_once_with(
-            "connected-composition"
-        )
-        dock._install_local_first_filter_controls.assert_called_once_with(
-            "connected-composition"
-        )
-        dock._install_local_first_advanced_fetch_controls.assert_called_once_with(
-            "connected-composition"
-        )
-        dock._install_local_first_activity_preview_controls.assert_called_once_with(
-            "connected-composition"
-        )
-        dock._install_local_first_backfill_controls.assert_called_once_with(
-            "connected-composition"
-        )
-        dock._install_local_first_atlas_pdf_controls.assert_called_once_with(
-            "connected-composition"
-        )
-        dock._install_local_first_strava_credentials_controls.assert_called_once_with(
-            "connected-composition"
-        )
-        dock._install_local_first_basemap_controls.assert_called_once_with(
-            "connected-composition"
-        )
-        dock._install_local_first_storage_controls.assert_called_once_with(
+        dock._install_local_first_audited_controls.assert_called_once_with(
             "connected-composition"
         )
         dock._bind_wizard_analysis_mode_controls.assert_called_once_with(
@@ -1076,6 +1044,82 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         dock._mark_atlas_export_stale.assert_not_called()
         dock._refresh_summary_status.assert_not_called()
+
+    def test_install_local_first_audited_controls_uses_inventory_order(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._install_local_first_widget_move = MagicMock(return_value=True)
+        dock._install_local_first_control_move = MagicMock(return_value=True)
+        dock._after_local_first_control_move_installed = MagicMock()
+        composition = object()
+
+        self.module.QfitDockWidget._install_local_first_audited_controls(
+            dock,
+            composition,
+        )
+
+        dock._install_local_first_widget_move.assert_called_once_with(
+            composition,
+            "activity_style",
+        )
+        self.assertEqual(
+            dock._install_local_first_control_move.call_args_list,
+            [
+                call(composition, "advanced_fetch"),
+                call(composition, "activity_preview"),
+                call(composition, "backfill_routes"),
+                call(composition, "map_filters"),
+                call(composition, "atlas_pdf"),
+                call(composition, "strava_credentials"),
+                call(composition, "basemap"),
+                call(composition, "storage"),
+            ],
+        )
+        self.assertEqual(
+            dock._after_local_first_control_move_installed.call_args_list,
+            [
+                call("advanced_fetch", installed=True),
+                call("activity_preview", installed=True),
+                call("backfill_routes", installed=True),
+                call("map_filters", installed=True),
+                call("atlas_pdf", installed=True),
+                call("strava_credentials", installed=True),
+                call("basemap", installed=True),
+                call("storage", installed=True),
+            ],
+        )
+
+    def test_after_local_first_control_move_installed_applies_required_hooks(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.detailedStreamsCheckBox = SimpleNamespace(isChecked=lambda: True)
+        dock._workflow_section_coordinator = MagicMock()
+        dock.generateAtlasPdfButton = MagicMock()
+
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "backfill_routes",
+            installed=True,
+        )
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "atlas_pdf",
+            installed=True,
+        )
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "storage",
+            installed=True,
+        )
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "atlas_pdf",
+            installed=False,
+        )
+
+        update_visibility = (
+            dock._workflow_section_coordinator.update_detailed_fetch_visibility
+        )
+        update_visibility.assert_called_once_with(True)
+        dock.generateAtlasPdfButton.hide.assert_called_once_with()
 
     def test_install_wizard_filter_controls_moves_live_filter_group_into_map_panel(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary

- Drive live local-first legacy-backed control installation from the audited control/widget move inventories.
- Keep required per-control side effects for route-backfill visibility and hiding the replaced atlas export button behind one post-install hook.
- Add regression coverage that the production local-first dock builder uses the audited installer path and that inventory order/hook behavior stays explicit.

Refs #805.

## Tests

- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
