### PR TITLE
refactor: remove deprecated local-first install wrappers

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -871,56 +871,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             ):
                 legacy_export_button.hide()
 
-    def _install_local_first_activity_style_controls(self, composition) -> None:
-        """Deprecated wrapper for activity visualization local-first controls."""
-
-        self._install_local_first_widget_move(composition, "activity_style")
-
-    def _install_local_first_filter_controls(self, composition) -> None:
-        """Deprecated wrapper for map-filter local-first controls."""
-
-        self._install_local_first_control_move(composition, "map_filters")
-
-    def _install_local_first_advanced_fetch_controls(self, composition) -> None:
-        """Deprecated wrapper for Strava fetch-limit local-first controls."""
-
-        self._install_local_first_control_move(composition, "advanced_fetch")
-
-    def _install_local_first_activity_preview_controls(self, composition) -> None:
-        """Deprecated wrapper for activity-preview local-first controls."""
-
-        self._install_local_first_control_move(composition, "activity_preview")
-
-    def _install_local_first_backfill_controls(self, composition) -> None:
-        """Deprecated wrapper for detailed-route backfill local-first controls."""
-
-        installed = self._install_local_first_control_move(composition, "backfill_routes")
-        self._after_local_first_control_move_installed(
-            "backfill_routes",
-            installed=installed,
-        )
-
-    def _install_local_first_atlas_pdf_controls(self, composition) -> None:
-        """Deprecated wrapper for PDF output local-first controls."""
-
-        installed = self._install_local_first_control_move(composition, "atlas_pdf")
-        self._after_local_first_control_move_installed("atlas_pdf", installed=installed)
-
-    def _install_local_first_strava_credentials_controls(self, composition) -> None:
-        """Deprecated wrapper for Strava OAuth local-first controls."""
-
-        self._install_local_first_control_move(composition, "strava_credentials")
-
-    def _install_local_first_basemap_controls(self, composition) -> None:
-        """Deprecated wrapper for Mapbox basemap local-first controls."""
-
-        self._install_local_first_control_move(composition, "basemap")
-
-    def _install_local_first_storage_controls(self, composition) -> None:
-        """Deprecated wrapper for GeoPackage storage local-first controls."""
-
-        self._install_local_first_control_move(composition, "storage")
-
     def _bind_wizard_analysis_mode_controls(self, composition) -> None:
         """Expose the hidden backing analysis selector in the live wizard path."""
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1149,7 +1149,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertTrue(dock._wizard_filter_controls_installed)
         self.assertEqual(dock._wizard_filter_controls_installed_target, id(map_content))
 
-    def test_install_local_first_filter_controls_uses_audited_map_filter_move(self):
+    def test_install_local_first_control_move_handles_map_filters(self):
         dock = object.__new__(self.module.QfitDockWidget)
         parent_layout = MagicMock()
         parent_widget = SimpleNamespace(layout=lambda: parent_layout)
@@ -1165,9 +1165,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             set_filter_controls_visible=MagicMock(),
         )
 
-        self.module.QfitDockWidget._install_local_first_filter_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             SimpleNamespace(map_content=map_content),
+            "map_filters",
         )
 
         parent_layout.removeWidget.assert_called_once_with(filter_group)
@@ -1337,7 +1338,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         map_content.style_controls_layout.assert_not_called()
 
-    def test_install_local_first_activity_style_controls_uses_audited_widget_move(self):
+    def test_install_local_first_widget_move_handles_activity_style_controls(self):
         dock = object.__new__(self.module.QfitDockWidget)
         parent_layout = MagicMock()
         parent_widget = SimpleNamespace(layout=lambda: parent_layout)
@@ -1374,9 +1375,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             set_style_controls_visible=MagicMock(),
         )
 
-        self.module.QfitDockWidget._install_local_first_activity_style_controls(
+        self.module.QfitDockWidget._install_local_first_widget_move(
             dock,
             SimpleNamespace(map_content=map_content),
+            "activity_style",
         )
 
         self.assertEqual(
@@ -1419,7 +1421,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             id(map_content),
         )
 
-    def test_install_local_first_activity_style_controls_requires_style_pair(self):
+    def test_install_local_first_widget_move_requires_activity_style_pair(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.stylePresetLabel = MagicMock()
         style_layout = MagicMock()
@@ -1427,9 +1429,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             style_controls_layout=MagicMock(return_value=style_layout),
         )
 
-        self.module.QfitDockWidget._install_local_first_activity_style_controls(
+        self.module.QfitDockWidget._install_local_first_widget_move(
             dock,
             SimpleNamespace(map_content=map_content),
+            "activity_style",
         )
 
         self.assertEqual(style_layout.addWidget.call_args_list, [])
@@ -1630,13 +1633,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "strava_credentials",
         )
 
-        self.module.QfitDockWidget._install_local_first_strava_credentials_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "strava_credentials",
         )
-        self.module.QfitDockWidget._install_local_first_strava_credentials_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "strava_credentials",
         )
 
         self.assertEqual(source_layout.removed, [credentials_group])
@@ -1689,13 +1694,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.backgroundGroupBox = basemap_group
         self._install_required_local_first_group_widgets(dock, "basemap")
 
-        self.module.QfitDockWidget._install_local_first_basemap_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "basemap",
         )
-        self.module.QfitDockWidget._install_local_first_basemap_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "basemap",
         )
 
         self.assertEqual(source_layout.removed, [basemap_group])
@@ -1748,13 +1755,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.outputGroupBox = storage_group
         self._install_required_local_first_group_widgets(dock, "storage")
 
-        self.module.QfitDockWidget._install_local_first_storage_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "storage",
         )
-        self.module.QfitDockWidget._install_local_first_storage_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "storage",
         )
 
         self.assertEqual(source_layout.removed, [storage_group])
@@ -1803,13 +1812,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.advancedFetchGroupBox = advanced_fetch_group
         self._install_required_local_first_group_widgets(dock, "advanced_fetch")
 
-        self.module.QfitDockWidget._install_local_first_advanced_fetch_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "advanced_fetch",
         )
-        self.module.QfitDockWidget._install_local_first_advanced_fetch_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "advanced_fetch",
         )
 
         self.assertEqual(source_layout.removed, [advanced_fetch_group])
@@ -1861,13 +1872,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.previewGroupBox = preview_group
         self._install_required_local_first_group_widgets(dock, "activity_preview")
 
-        self.module.QfitDockWidget._install_local_first_activity_preview_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "activity_preview",
         )
-        self.module.QfitDockWidget._install_local_first_activity_preview_controls(
+        self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "activity_preview",
         )
 
         self.assertEqual(source_layout.removed, [preview_group])
@@ -1917,13 +1930,25 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.detailedStreamsCheckBox = SimpleNamespace(isChecked=lambda: False)
         dock._workflow_section_coordinator = MagicMock()
 
-        self.module.QfitDockWidget._install_local_first_backfill_controls(
+        installed = self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "backfill_routes",
         )
-        self.module.QfitDockWidget._install_local_first_backfill_controls(
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "backfill_routes",
+            installed=installed,
+        )
+        installed = self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "backfill_routes",
+        )
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "backfill_routes",
+            installed=installed,
         )
 
         self.assertEqual(source_layout.removed, [backfill_button])
@@ -1979,13 +2004,25 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.generateAtlasPdfButton = MagicMock()
         self._install_required_local_first_group_widgets(dock, "atlas_pdf")
 
-        self.module.QfitDockWidget._install_local_first_atlas_pdf_controls(
+        installed = self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "atlas_pdf",
         )
-        self.module.QfitDockWidget._install_local_first_atlas_pdf_controls(
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "atlas_pdf",
+            installed=installed,
+        )
+        installed = self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "atlas_pdf",
+        )
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "atlas_pdf",
+            installed=installed,
         )
 
         self.assertEqual(source_layout.removed, [atlas_pdf_group])
@@ -2003,9 +2040,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         composition = SimpleNamespace(atlas_content=atlas_content)
         dock.generateAtlasPdfButton = MagicMock()
 
-        self.module.QfitDockWidget._install_local_first_atlas_pdf_controls(
+        installed = self.module.QfitDockWidget._install_local_first_control_move(
             dock,
             composition,
+            "atlas_pdf",
+        )
+        self.module.QfitDockWidget._after_local_first_control_move_installed(
+            dock,
+            "atlas_pdf",
+            installed=installed,
         )
 
         self.assertEqual(atlas_layout.added, [])


### PR DESCRIPTION
## Summary

Removes the deprecated per-section local-first installer wrappers now that the audited local-first control inventory is the single production installation path.

## Changes

- Delete obsolete `_install_local_first_*_controls` wrapper methods from `QfitDockWidget`
- Point existing move coverage directly at `_install_local_first_control_move` / `_install_local_first_widget_move`
- Keep the audited move hooks covered for backfill visibility and atlas PDF legacy-button hiding

## Testing

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_local_first_control_moves.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Relates to #805.
