### PR TITLE
fix: reapply local-first visibility hooks

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -857,19 +857,52 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         if not installed:
             return
-        if key == "backfill_routes":
-            detailed_streams_checkbox = getattr(self, "detailedStreamsCheckBox", None)
-            if hasattr(detailed_streams_checkbox, "isChecked"):
-                self._workflow_section_coordinator.update_detailed_fetch_visibility(
-                    detailed_streams_checkbox.isChecked()
-                )
-        elif key == "atlas_pdf":
-            legacy_export_button = getattr(self, "generateAtlasPdfButton", None)
-            if legacy_export_button is not None and hasattr(
-                legacy_export_button,
-                "hide",
-            ):
-                legacy_export_button.hide()
+        hook = {
+            "advanced_fetch": self._refresh_local_first_advanced_fetch_visibility,
+            "backfill_routes": self._refresh_local_first_detailed_fetch_visibility,
+            "basemap": self._refresh_local_first_mapbox_visibility,
+            "storage": self._refresh_local_first_point_sampling_visibility,
+            "atlas_pdf": self._hide_legacy_atlas_export_button,
+        }.get(key)
+        if hook is not None:
+            hook()
+
+    def _refresh_local_first_advanced_fetch_visibility(self) -> None:
+        advanced_fetch_group = getattr(self, "advancedFetchGroupBox", None)
+        if hasattr(advanced_fetch_group, "isChecked"):
+            self._workflow_section_coordinator.update_advanced_fetch_visibility(
+                advanced_fetch_group.isChecked()
+            )
+
+    def _refresh_local_first_detailed_fetch_visibility(self) -> None:
+        detailed_streams_checkbox = getattr(self, "detailedStreamsCheckBox", None)
+        if hasattr(detailed_streams_checkbox, "isChecked"):
+            self._workflow_section_coordinator.update_detailed_fetch_visibility(
+                detailed_streams_checkbox.isChecked()
+            )
+
+    def _refresh_local_first_mapbox_visibility(self) -> None:
+        background_preset_combo = getattr(self, "backgroundPresetComboBox", None)
+        if hasattr(background_preset_combo, "currentText"):
+            self._workflow_section_coordinator.update_mapbox_advanced_visibility(
+                background_preset_combo.currentText()
+            )
+
+    def _refresh_local_first_point_sampling_visibility(self) -> None:
+        write_activity_points_checkbox = getattr(
+            self,
+            "writeActivityPointsCheckBox",
+            None,
+        )
+        if hasattr(write_activity_points_checkbox, "isChecked"):
+            self._workflow_section_coordinator.update_point_sampling_visibility(
+                write_activity_points_checkbox.isChecked()
+            )
+
+    def _hide_legacy_atlas_export_button(self) -> None:
+        legacy_export_button = getattr(self, "generateAtlasPdfButton", None)
+        if legacy_export_button is not None and hasattr(legacy_export_button, "hide"):
+            legacy_export_button.hide()
 
     def _bind_wizard_analysis_mode_controls(self, composition) -> None:
         """Expose the hidden backing analysis selector in the live wizard path."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1090,35 +1090,36 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
     def test_after_local_first_control_move_installed_applies_required_hooks(self):
         dock = object.__new__(self.module.QfitDockWidget)
+        dock.advancedFetchGroupBox = SimpleNamespace(isChecked=lambda: False)
         dock.detailedStreamsCheckBox = SimpleNamespace(isChecked=lambda: True)
+        dock.backgroundPresetComboBox = SimpleNamespace(currentText=lambda: "Custom")
+        dock.writeActivityPointsCheckBox = SimpleNamespace(isChecked=lambda: True)
         dock._workflow_section_coordinator = MagicMock()
         dock.generateAtlasPdfButton = MagicMock()
 
-        self.module.QfitDockWidget._after_local_first_control_move_installed(
-            dock,
+        for key in (
+            "advanced_fetch",
             "backfill_routes",
-            installed=True,
-        )
-        self.module.QfitDockWidget._after_local_first_control_move_installed(
-            dock,
-            "atlas_pdf",
-            installed=True,
-        )
-        self.module.QfitDockWidget._after_local_first_control_move_installed(
-            dock,
+            "basemap",
             "storage",
-            installed=True,
-        )
+            "atlas_pdf",
+        ):
+            self.module.QfitDockWidget._after_local_first_control_move_installed(
+                dock,
+                key,
+                installed=True,
+            )
         self.module.QfitDockWidget._after_local_first_control_move_installed(
             dock,
             "atlas_pdf",
             installed=False,
         )
 
-        update_visibility = (
-            dock._workflow_section_coordinator.update_detailed_fetch_visibility
-        )
-        update_visibility.assert_called_once_with(True)
+        coordinator = dock._workflow_section_coordinator
+        coordinator.update_advanced_fetch_visibility.assert_called_once_with(False)
+        coordinator.update_detailed_fetch_visibility.assert_called_once_with(True)
+        coordinator.update_mapbox_advanced_visibility.assert_called_once_with("Custom")
+        coordinator.update_point_sampling_visibility.assert_called_once_with(True)
         dock.generateAtlasPdfButton.hide.assert_called_once_with()
 
     def test_install_wizard_filter_controls_moves_live_filter_group_into_map_panel(self):


### PR DESCRIPTION
## Summary

Reapplies visibility rules immediately after local-first audited controls are moved into their visible pages.

## Changes

- Refresh advanced fetch expansion state after the advanced fetch controls are surfaced in Data.
- Refresh Mapbox custom-style visibility after basemap controls are surfaced in Settings.
- Refresh point-sampling stride visibility after storage controls are surfaced in Settings.
- Extend pure dock tests for these local-first post-install hooks.

## Testing

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_after_local_first_control_move_installed_applies_required_hooks -q --tb=short`
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py tests/test_local_first_control_moves.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805

