### PR TITLE
chore: move temporal controls to analysis page

### DIFF
--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -74,6 +74,19 @@ class AnalysisPageContentTest(unittest.TestCase):
         )
         self.assertEqual(content.current_analysis_mode(), "Heatmap")
         self.assertEqual(
+            content.temporal_controls_panel.objectName(),
+            "qfitWizardAnalysisTemporalControlsPanel",
+        )
+        self.assertTrue(content.temporal_controls_panel.isVisible())
+        self.assertEqual(
+            content.temporal_controls_panel.property("temporalControlsState"),
+            "expanded",
+        )
+        self.assertEqual(
+            content.temporal_controls_layout().object_name,
+            "qfitWizardAnalysisTemporalControlsLayout",
+        )
+        self.assertEqual(
             content.run_analysis_button.objectName(),
             "qfitWizardAnalysisRunButton",
         )
@@ -119,6 +132,7 @@ class AnalysisPageContentTest(unittest.TestCase):
                 content.input_summary_label,
                 content.analysis_mode_label,
                 content.analysis_mode_combo,
+                content.temporal_controls_panel,
                 content.action_row,
                 content.result_summary_label,
             ],

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -143,25 +143,45 @@ class LocalFirstControlMoveTests(unittest.TestCase):
         self.assertEqual(credentials.title, "Strava connection")
 
     def test_widget_move_inventory_covers_loose_visualization_controls(self):
-        self.assertEqual(local_first_widget_move_keys(), ("activity_style",))
-
-        move = LOCAL_FIRST_WIDGET_MOVES[0]
-        self.assertEqual(move.content_attr, "map_content")
         self.assertEqual(
-            move.required_widget_attrs,
+            local_first_widget_move_keys(),
+            ("activity_style", "analysis_temporal"),
+        )
+
+        activity_style = LOCAL_FIRST_WIDGET_MOVES[0]
+        self.assertEqual(activity_style.content_attr, "map_content")
+        self.assertEqual(
+            activity_style.required_widget_attrs,
             ("stylePresetLabel", "stylePresetComboBox"),
         )
         self.assertEqual(
-            move.optional_widget_groups,
+            activity_style.optional_widget_groups,
             (("previewSortLabel", "previewSortComboBox"),),
         )
+        self.assertEqual(activity_style.optional_widget_attrs, ())
+        self.assertEqual(activity_style.layout_getter_attr, "style_controls_layout")
+        self.assertEqual(activity_style.parent_panel_attr, "style_controls_panel")
         self.assertEqual(
-            move.optional_widget_attrs,
+            activity_style.post_install_visible_attr,
+            "set_style_controls_visible",
+        )
+
+        analysis_temporal = LOCAL_FIRST_WIDGET_MOVES[1]
+        self.assertEqual(analysis_temporal.content_attr, "analysis_content")
+        self.assertEqual(
+            analysis_temporal.required_widget_attrs,
             ("analysisTemporalModeRow", "temporalHelpLabel"),
         )
-        self.assertEqual(move.layout_getter_attr, "style_controls_layout")
-        self.assertEqual(move.parent_panel_attr, "style_controls_panel")
-        self.assertEqual(move.post_install_visible_attr, "set_style_controls_visible")
+        self.assertEqual(
+            analysis_temporal.show_widget_attrs_after_move,
+            ("temporalModeLabel", "temporalModeComboBox"),
+        )
+        self.assertEqual(analysis_temporal.layout_getter_attr, "temporal_controls_layout")
+        self.assertEqual(analysis_temporal.parent_panel_attr, "temporal_controls_panel")
+        self.assertEqual(
+            analysis_temporal.post_install_visible_attr,
+            "set_temporal_controls_visible",
+        )
 
     def test_widget_move_lookup_returns_full_install_metadata(self):
         move = local_first_widget_move_for_key("activity_style")
@@ -174,9 +194,15 @@ class LocalFirstControlMoveTests(unittest.TestCase):
             move.installed_target_attr,
             "_local_first_activity_style_controls_installed_target",
         )
+
+        temporal_move = local_first_widget_move_for_key("analysis_temporal")
         self.assertEqual(
-            move.show_widget_attrs_after_move,
-            ("temporalModeLabel", "temporalModeComboBox"),
+            temporal_move.installed_attr,
+            "_local_first_analysis_temporal_controls_installed",
+        )
+        self.assertEqual(
+            temporal_move.installed_target_attr,
+            "_local_first_analysis_temporal_controls_installed_target",
         )
 
     def test_lookup_rejects_unknown_control_area(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1057,9 +1057,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             composition,
         )
 
-        dock._install_local_first_widget_move.assert_called_once_with(
-            composition,
-            "activity_style",
+        self.assertEqual(
+            dock._install_local_first_widget_move.call_args_list,
+            [
+                call(composition, "activity_style"),
+                call(composition, "analysis_temporal"),
+            ],
         )
         self.assertEqual(
             dock._install_local_first_control_move.call_args_list,
@@ -1489,27 +1492,17 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         style_combo = MagicMock()
         preview_sort_label = MagicMock()
         preview_sort_combo = MagicMock()
-        temporal_row = MagicMock()
-        temporal_label = MagicMock()
-        temporal_combo = MagicMock()
-        temporal_help = MagicMock()
         for widget in (
             style_label,
             style_combo,
             preview_sort_label,
             preview_sort_combo,
-            temporal_row,
-            temporal_help,
         ):
             widget.parentWidget.return_value = parent_widget
         dock.stylePresetLabel = style_label
         dock.stylePresetComboBox = style_combo
         dock.previewSortLabel = preview_sort_label
         dock.previewSortComboBox = preview_sort_combo
-        dock.analysisTemporalModeRow = temporal_row
-        dock.temporalModeLabel = temporal_label
-        dock.temporalModeComboBox = temporal_combo
-        dock.temporalHelpLabel = temporal_help
         panel = object()
         style_layout = MagicMock()
         map_content = SimpleNamespace(
@@ -1531,8 +1524,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 call(style_combo),
                 call(preview_sort_label),
                 call(preview_sort_combo),
-                call(temporal_row),
-                call(temporal_help),
             ],
         )
         self.assertEqual(
@@ -1542,8 +1533,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 call(style_combo),
                 call(preview_sort_label),
                 call(preview_sort_combo),
-                call(temporal_row),
-                call(temporal_help),
             ],
         )
         for widget in (
@@ -1551,10 +1540,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             style_combo,
             preview_sort_label,
             preview_sort_combo,
-            temporal_row,
-            temporal_label,
-            temporal_combo,
-            temporal_help,
         ):
             widget.show.assert_called_once_with()
         map_content.set_style_controls_visible.assert_called_once_with()
@@ -1562,6 +1547,51 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(
             dock._local_first_activity_style_controls_installed_target,
             id(map_content),
+        )
+
+    def test_install_local_first_widget_move_handles_analysis_temporal_controls(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        parent_layout = MagicMock()
+        parent_widget = SimpleNamespace(layout=lambda: parent_layout)
+        temporal_row = MagicMock()
+        temporal_label = MagicMock()
+        temporal_combo = MagicMock()
+        temporal_help = MagicMock()
+        for widget in (temporal_row, temporal_help):
+            widget.parentWidget.return_value = parent_widget
+        dock.analysisTemporalModeRow = temporal_row
+        dock.temporalModeLabel = temporal_label
+        dock.temporalModeComboBox = temporal_combo
+        dock.temporalHelpLabel = temporal_help
+        panel = object()
+        temporal_layout = MagicMock()
+        analysis_content = SimpleNamespace(
+            temporal_controls_panel=panel,
+            temporal_controls_layout=MagicMock(return_value=temporal_layout),
+            set_temporal_controls_visible=MagicMock(),
+        )
+
+        self.module.QfitDockWidget._install_local_first_widget_move(
+            dock,
+            SimpleNamespace(analysis_content=analysis_content),
+            "analysis_temporal",
+        )
+
+        self.assertEqual(
+            parent_layout.removeWidget.call_args_list,
+            [call(temporal_row), call(temporal_help)],
+        )
+        self.assertEqual(
+            temporal_layout.addWidget.call_args_list,
+            [call(temporal_row), call(temporal_help)],
+        )
+        for widget in (temporal_row, temporal_label, temporal_combo, temporal_help):
+            widget.show.assert_called_once_with()
+        analysis_content.set_temporal_controls_visible.assert_called_once_with()
+        self.assertTrue(dock._local_first_analysis_temporal_controls_installed)
+        self.assertEqual(
+            dock._local_first_analysis_temporal_controls_installed_target,
+            id(analysis_content),
         )
 
     def test_install_local_first_widget_move_requires_activity_style_pair(self):

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -365,10 +365,10 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock.analysisModeLabel.parentWidget().parentWidget(), dock.analysisSectionContentWidget)
             self.assertEqual(
                 dock.temporalModeLabel.parentWidget().parentWidget(),
-                dock._local_first_dock_composition.map_content.style_controls_panel,
+                dock._local_first_dock_composition.analysis_content.temporal_controls_panel,
             )
             self.assertGreaterEqual(
-                dock._local_first_dock_composition.map_content.style_controls_layout().indexOf(
+                dock._local_first_dock_composition.analysis_content.temporal_controls_layout().indexOf(
                     dock.analysisTemporalModeRow,
                 ),
                 0,

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -56,11 +56,20 @@ LOCAL_FIRST_WIDGET_MOVES: tuple[LocalFirstWidgetMove, ...] = (
         installed_attr="_local_first_activity_style_controls_installed",
         installed_target_attr="_local_first_activity_style_controls_installed_target",
         optional_widget_groups=(("previewSortLabel", "previewSortComboBox"),),
-        optional_widget_attrs=("analysisTemporalModeRow", "temporalHelpLabel"),
-        show_widget_attrs_after_move=("temporalModeLabel", "temporalModeComboBox"),
         layout_getter_attr="style_controls_layout",
         parent_panel_attr="style_controls_panel",
         post_install_visible_attr="set_style_controls_visible",
+    ),
+    LocalFirstWidgetMove(
+        key="analysis_temporal",
+        content_attr="analysis_content",
+        required_widget_attrs=("analysisTemporalModeRow", "temporalHelpLabel"),
+        installed_attr="_local_first_analysis_temporal_controls_installed",
+        installed_target_attr="_local_first_analysis_temporal_controls_installed_target",
+        show_widget_attrs_after_move=("temporalModeLabel", "temporalModeComboBox"),
+        layout_getter_attr="temporal_controls_layout",
+        parent_panel_attr="temporal_controls_panel",
+        post_install_visible_attr="set_temporal_controls_visible",
     ),
 )
 

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -90,6 +90,13 @@ class AnalysisPageContent(QWidget):
             self.analysis_mode_combo.currentTextChanged.connect(
                 self.analysisModeChanged.emit
             )
+        self.temporal_controls_panel = QWidget(self)
+        self.temporal_controls_panel.setObjectName(
+            "qfitWizardAnalysisTemporalControlsPanel"
+        )
+        self.temporal_controls_panel.setVisible(True)
+        self.temporal_controls_panel.setProperty("temporalControlsState", "expanded")
+        self._temporal_controls_layout = self._build_temporal_controls_layout()
         self.run_analysis_button = QToolButton(self)
         self.run_analysis_button.setObjectName("qfitWizardAnalysisRunButton")
         style_primary_action_button(
@@ -143,6 +150,7 @@ class AnalysisPageContent(QWidget):
         self.detail_label.setText(state.detail_text)
         self.input_summary_label.setText(state.input_summary_text)
         self.input_summary_label.setProperty("analysisState", analysis_state)
+        self.set_temporal_controls_visible()
         self.result_summary_label.setText(state.result_summary_text)
         self.result_summary_label.setProperty("analysisState", analysis_state)
         self.run_analysis_button.setText(state.primary_action_label)
@@ -162,10 +170,28 @@ class AnalysisPageContent(QWidget):
             enabled=state.clear_action_enabled,
         )
 
+    def temporal_controls_layout(self):
+        """Expose the panel slot for temporal playback controls."""
+
+        return self._temporal_controls_layout
+
+    def set_temporal_controls_visible(self) -> None:
+        """Keep embedded temporal playback controls visible after state refreshes."""
+
+        self.temporal_controls_panel.setVisible(True)
+        self.temporal_controls_panel.setProperty("temporalControlsState", "expanded")
+
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""
 
         return self._layout
+
+    def _build_temporal_controls_layout(self):
+        layout = QVBoxLayout(self.temporal_controls_panel)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName("qfitWizardAnalysisTemporalControlsLayout")
+        configure_top_aligned_panel_layout(layout)
+        return layout
 
     def _build_layout(self):
         layout = QVBoxLayout(self)
@@ -178,6 +204,7 @@ class AnalysisPageContent(QWidget):
             self.input_summary_label,
             self.analysis_mode_label,
             self.analysis_mode_combo,
+            self.temporal_controls_panel,
             self.action_row,
             self.result_summary_label,
         ):


### PR DESCRIPTION
## Summary

Move the legacy-backed temporal playback controls into the local-first Analysis page instead of keeping them inside the Map styling panel.

## Changes

- adds a dedicated temporal controls slot to the local-first Analysis page content
- splits the audited loose-widget move inventory into activity styling and analysis temporal controls
- updates pure, page-content, and QGIS smoke coverage for the new local-first destination

## Testing

- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_analysis_page.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_contextual_help_smoke -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
