### PR TITLE
refactor: split local-first sync store action

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -487,7 +487,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             composition,
             WizardActionCallbacks(
                 configure_connection=self._show_connection_configuration_hint,
-                sync_activities=self._run_wizard_sync_step,
+                sync_activities=self.on_refresh_clicked,
+                store_activities=self.on_load_clicked,
                 sync_saved_routes=self.on_sync_routes_clicked,
                 clear_database=self.on_clear_database_clicked,
                 load_activity_layers=self.on_load_layers_clicked,
@@ -530,7 +531,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             composition,
             WizardActionCallbacks(
                 configure_connection=self._show_connection_configuration_hint,
-                sync_activities=self._run_wizard_sync_step,
+                sync_activities=self.on_refresh_clicked,
+                store_activities=self.on_load_clicked,
                 sync_saved_routes=self.on_sync_routes_clicked,
                 clear_database=self.on_clear_database_clicked,
                 load_activity_layers=self.on_load_layers_clicked,

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -232,14 +232,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._update_connection_status()
         self._set_status("Configuration saved; qfit dock connection state refreshed.")
 
-    def _run_wizard_sync_step(self) -> None:
-        """Run the next concrete action for the wizard synchronization step."""
-
-        if self.runtime_state.activities:
-            self.on_load_clicked()
-            return
-        self.on_refresh_clicked()
-
     def _run_wizard_map_step(self) -> None:
         """Run the next concrete action for the wizard map-and-filters step."""
 

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -124,6 +124,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         callbacks = self.module.WizardActionCallbacks(
             configure_connection=lambda: calls.append("settings"),
             sync_activities=lambda: calls.append("sync"),
+            store_activities=lambda: calls.append("store"),
             sync_saved_routes=lambda: calls.append("routes"),
             clear_database=lambda: calls.append("clear"),
             load_activity_layers=lambda: calls.append("layers"),
@@ -140,6 +141,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         self.module.connect_local_first_action_callbacks(composition, callbacks)
         composition.settings_content.configureRequested.emit()
         composition.sync_content.syncRequested.emit()
+        composition.sync_content.storeRequested.emit()
         composition.sync_content.syncRoutesRequested.emit()
         composition.sync_content.clearDatabaseRequested.emit()
         composition.sync_content.loadActivitiesRequested.emit()
@@ -157,6 +159,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             [
                 "settings",
                 "sync",
+                "store",
                 "routes",
                 "clear",
                 "layers",

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -831,7 +831,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         callbacks = connect_args[1]
         expected_callbacks = {
             "configure_connection": "_show_connection_configuration_hint",
-            "sync_activities": "_run_wizard_sync_step",
+            "sync_activities": "on_refresh_clicked",
+            "store_activities": "on_load_clicked",
             "sync_saved_routes": "on_sync_routes_clicked",
             "clear_database": "on_clear_database_clicked",
             "load_activity_layers": "on_load_layers_clicked",
@@ -986,7 +987,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         callbacks = connect_args[1]
         expected_callbacks = {
             "configure_connection": "_show_connection_configuration_hint",
-            "sync_activities": "_run_wizard_sync_step",
+            "sync_activities": "on_refresh_clicked",
+            "store_activities": "on_load_clicked",
             "sync_saved_routes": "on_sync_routes_clicked",
             "clear_database": "on_clear_database_clicked",
             "load_activity_layers": "on_load_layers_clicked",

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -646,46 +646,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "Configuration saved; qfit dock connection state refreshed."
         )
 
-    def test_run_wizard_sync_step_fetches_when_no_activities_are_ready(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._runtime_state_store = self.module.DockRuntimeStore()
-        dock.on_refresh_clicked = MagicMock()
-        dock.on_load_clicked = MagicMock()
-
-        self.module.QfitDockWidget._run_wizard_sync_step(dock)
-
-        dock.on_refresh_clicked.assert_called_once_with()
-        dock.on_load_clicked.assert_not_called()
-
-    def test_run_wizard_sync_step_stores_fetched_activities(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._runtime_state_store = self.module.DockRuntimeStore()
-        dock._runtime_store().set_activities([object()])
-        dock.on_refresh_clicked = MagicMock()
-        dock.on_load_clicked = MagicMock()
-
-        self.module.QfitDockWidget._run_wizard_sync_step(dock)
-
-        dock.on_load_clicked.assert_called_once_with()
-        dock.on_refresh_clicked.assert_not_called()
-
-    def test_run_wizard_sync_step_fetches_after_fetched_activities_are_stored(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._runtime_state_store = self.module.DockRuntimeStore()
-        dock._runtime_store().set_activities([object()])
-        dock._runtime_store().finish_store(
-            output_path="/tmp/qfit.gpkg",
-            stored_activity_count=1,
-        )
-        self.assertEqual(dock.runtime_state.activities, ())
-        dock.on_refresh_clicked = MagicMock()
-        dock.on_load_clicked = MagicMock()
-
-        self.module.QfitDockWidget._run_wizard_sync_step(dock)
-
-        dock.on_refresh_clicked.assert_called_once_with()
-        dock.on_load_clicked.assert_not_called()
-
     def test_run_wizard_map_step_loads_layers_before_filters_are_available(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -329,6 +329,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         callbacks = self.composition.WizardActionCallbacks(
             configure_connection=lambda: calls.append("configure"),
             sync_activities=lambda: calls.append("sync"),
+            store_activities=lambda: calls.append("store"),
             sync_saved_routes=lambda: calls.append("routes"),
             clear_database=lambda: calls.append("clear"),
             load_activity_layers=lambda: calls.append("load"),
@@ -377,6 +378,25 @@ class WizardShellCompositionTest(unittest.TestCase):
                 "atlas",
             ],
         )
+
+    def test_sync_primary_action_stores_when_activities_are_fetched(self):
+        calls = []
+        callbacks = self.composition.WizardActionCallbacks(
+            sync_activities=lambda: calls.append("sync"),
+            store_activities=lambda: calls.append("store"),
+        )
+        assembled = self.composition.build_placeholder_wizard_shell(
+            progress_facts=self.composition.WizardProgressFacts(
+                connection_configured=True,
+                activities_fetched=True,
+            ),
+        )
+
+        self.composition.connect_wizard_action_callbacks(assembled, callbacks)
+        assembled.sync_content.sync_button.clicked.emit()
+
+        self.assertEqual(assembled.sync_content.sync_button.text(), "Finish activity sync")
+        self.assertEqual(calls, ["store"])
 
     def test_action_callbacks_are_only_wired_once_per_composition(self):
         calls = []

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -136,6 +136,11 @@ def connect_local_first_action_callbacks(
     _connect_optional_signal(composition.sync_content, "syncRequested", callbacks.sync_activities)
     _connect_optional_signal(
         composition.sync_content,
+        "storeRequested",
+        callbacks.store_activities,
+    )
+    _connect_optional_signal(
+        composition.sync_content,
         "syncRoutesRequested",
         callbacks.sync_saved_routes,
     )

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -46,6 +46,7 @@ class SyncPageState:
     detail_text: str = "Sync Strava activities or load stored map layers from an existing GeoPackage."
     activity_summary_text: str = "No activities stored"
     primary_action_label: str = "Sync activities"
+    primary_action_kind: str = "sync"
     primary_action_enabled: bool = True
     primary_action_blocked_tooltip: str = "Configure the Strava connection before syncing activities."
     local_action_label: str = "Load stored map layers"
@@ -65,6 +66,7 @@ class SyncPageContent(QWidget):
     """Reusable second-page content for the wizard synchronization step."""
 
     syncRequested = pyqtSignal()
+    storeRequested = pyqtSignal()
     loadActivitiesRequested = pyqtSignal()
     syncRoutesRequested = pyqtSignal()
     clearDatabaseRequested = pyqtSignal()
@@ -88,7 +90,8 @@ class SyncPageContent(QWidget):
             self.sync_button,
             action_name="sync_activities",
         )
-        self.sync_button.clicked.connect(self.syncRequested.emit)
+        self._primary_action_kind = "sync"
+        self.sync_button.clicked.connect(self._emit_primary_action_requested)
         self.load_button = QToolButton(self)
         self.load_button.setObjectName("qfitWizardSyncLoadButton")
         style_secondary_action_button(
@@ -135,6 +138,7 @@ class SyncPageContent(QWidget):
         self.detail_label.setText(state.detail_text)
         self.activity_summary_label.setText(state.activity_summary_text)
         self.activity_summary_label.setProperty("syncState", sync_state)
+        self._primary_action_kind = state.primary_action_kind
         self.sync_button.setText(state.primary_action_label)
         set_wizard_action_availability(
             self.sync_button,
@@ -164,6 +168,12 @@ class SyncPageContent(QWidget):
         """Expose the layout for adapter wiring and pure tests."""
 
         return self._layout
+
+    def _emit_primary_action_requested(self) -> None:
+        if self._primary_action_kind == "store":
+            self.storeRequested.emit()
+            return
+        self.syncRequested.emit()
 
     def _build_layout(self):
         layout = QVBoxLayout(self)

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -68,6 +68,7 @@ class WizardActionCallbacks:
 
     configure_connection: Callable[[], None] | None = None
     sync_activities: Callable[[], None] | None = None
+    store_activities: Callable[[], None] | None = None
     sync_saved_routes: Callable[[], None] | None = None
     clear_database: Callable[[], None] | None = None
     load_activity_layers: Callable[[], None] | None = None
@@ -413,6 +414,7 @@ def _connect_action_callbacks(
         callbacks.configure_connection,
     )
     _connect_optional_signal(sync_content, "syncRequested", callbacks.sync_activities)
+    _connect_optional_signal(sync_content, "storeRequested", callbacks.store_activities)
     _connect_optional_signal(
         sync_content,
         "syncRoutesRequested",
@@ -588,9 +590,12 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
         status_text = "Connection required before sync"
         detail_text = "Configure Strava credentials before syncing activities."
     primary_action_label = default.primary_action_label
+    primary_action_kind = default.primary_action_kind
     routes_action_label = default.routes_action_label
     if facts.activities_fetched:
         primary_action_label = "Finish activity sync"
+        primary_action_kind = "store"
+        sync_blocked_tooltip = ""
     if facts.route_sync_in_progress:
         routes_action_label = "Cancel route sync"
     if facts.sync_in_progress:
@@ -599,6 +604,7 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
             "Wait for the current synchronization to finish before starting another sync."
         )
         primary_action_label = "Sync in progress…"
+        primary_action_kind = "sync"
         sync_blocked_tooltip = _SYNC_IN_PROGRESS_TOOLTIP
     return SyncPageState(
         ready=facts.activities_stored,
@@ -606,7 +612,10 @@ def _sync_state_from_facts(facts: WizardProgressFacts) -> SyncPageState:
         detail_text=detail_text,
         activity_summary_text=_sync_activity_summary(facts, default),
         primary_action_label=primary_action_label,
-        primary_action_enabled=facts.connection_configured and not facts.sync_in_progress,
+        primary_action_kind=primary_action_kind,
+        primary_action_enabled=(
+            facts.activities_fetched or facts.connection_configured
+        ) and not facts.sync_in_progress,
         primary_action_blocked_tooltip=sync_blocked_tooltip,
         local_action_enabled=facts.activities_stored and not facts.sync_in_progress,
         local_action_blocked_tooltip=_sync_local_action_blocked_tooltip(facts, default),


### PR DESCRIPTION
## Summary

Split the Data page's primary synchronization CTA so fetched activities emit a direct store action instead of routing through the wizard-era compound sync helper.

## Changes

- Add a `storeRequested` signal for the sync/Data page primary CTA when the page state is `Finish activity sync`.
- Wire wizard and local-first compositions to explicit fetch and store callbacks.
- Update focused composition and dock callback tests for the separated local-first action path.

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py tests/test_local_first_composition.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
