### PR TITLE
refactor: audit local-first install hooks

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -858,9 +858,8 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         hook_attr = move.after_install_hook_attr
         if hook_attr is None:
             return
-        hook = getattr(self, hook_attr, None)
-        if callable(hook):
-            hook()
+        hook = getattr(self, hook_attr)
+        hook()
 
     def _refresh_local_first_advanced_fetch_visibility(self) -> None:
         advanced_fetch_group = getattr(self, "advancedFetchGroupBox", None)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -851,14 +851,15 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         if not installed:
             return
-        hook = {
-            "advanced_fetch": self._refresh_local_first_advanced_fetch_visibility,
-            "backfill_routes": self._refresh_local_first_detailed_fetch_visibility,
-            "basemap": self._refresh_local_first_mapbox_visibility,
-            "storage": self._refresh_local_first_point_sampling_visibility,
-            "atlas_pdf": self._hide_legacy_atlas_export_button,
-        }.get(key)
-        if hook is not None:
+        try:
+            move = local_first_control_move_for_key(key)
+        except KeyError:
+            return
+        hook_attr = move.after_install_hook_attr
+        if hook_attr is None:
+            return
+        hook = getattr(self, hook_attr, None)
+        if callable(hook):
             hook()
 
     def _refresh_local_first_advanced_fetch_visibility(self) -> None:

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -128,19 +128,47 @@ class LocalFirstControlMoveTests(unittest.TestCase):
         )
         self.assertEqual(move.title, "PDF output")
         self.assertTrue(move.show_after_move)
+        self.assertEqual(
+            move.after_install_hook_attr,
+            "_hide_legacy_atlas_export_button",
+        )
 
         backfill = local_first_control_move_for_key("backfill_routes")
         self.assertFalse(backfill.show_after_move)
+        self.assertEqual(
+            backfill.after_install_hook_attr,
+            "_refresh_local_first_detailed_fetch_visibility",
+        )
 
         filters = local_first_control_move_for_key("map_filters")
         self.assertEqual(filters.layout_getter_attr, "filter_controls_layout")
         self.assertEqual(filters.parent_panel_attr, "filter_controls_panel")
         self.assertEqual(filters.post_install_visible_attr, "set_filter_controls_visible")
+        self.assertIsNone(filters.after_install_hook_attr)
 
         credentials = local_first_control_move_for_key("strava_credentials")
         self.assertEqual(credentials.content_attr, "settings_content")
         self.assertEqual(credentials.group_attr, "credentialsGroupBox")
         self.assertEqual(credentials.title, "Strava connection")
+
+    def test_control_moves_document_post_install_hooks(self):
+        hooks = {
+            move.key: move.after_install_hook_attr for move in LOCAL_FIRST_CONTROL_MOVES
+        }
+
+        self.assertEqual(
+            hooks,
+            {
+                "advanced_fetch": "_refresh_local_first_advanced_fetch_visibility",
+                "activity_preview": None,
+                "backfill_routes": "_refresh_local_first_detailed_fetch_visibility",
+                "map_filters": None,
+                "atlas_pdf": "_hide_legacy_atlas_export_button",
+                "strava_credentials": None,
+                "basemap": "_refresh_local_first_mapbox_visibility",
+                "storage": "_refresh_local_first_point_sampling_visibility",
+            },
+        )
 
     def test_widget_move_inventory_covers_loose_visualization_controls(self):
         self.assertEqual(

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1089,6 +1089,22 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._update_point_sampling_visibility.assert_called_once_with(True)
         dock.generateAtlasPdfButton.hide.assert_called_once_with()
 
+    def test_after_local_first_control_move_installed_raises_for_missing_hook(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        move = SimpleNamespace(after_install_hook_attr="_missing_local_first_hook")
+
+        with patch.object(
+            self.module,
+            "local_first_control_move_for_key",
+            return_value=move,
+        ):
+            with self.assertRaises(AttributeError):
+                self.module.QfitDockWidget._after_local_first_control_move_installed(
+                    dock,
+                    "advanced_fetch",
+                    installed=True,
+                )
+
     def test_local_first_visibility_updates_do_not_use_workflow_sections(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._workflow_section_coordinator = MagicMock()

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -24,6 +24,7 @@ class LocalFirstControlMove:
     layout_getter_attr: str = "outer_layout"
     parent_panel_attr: str | None = None
     post_install_visible_attr: str | None = None
+    after_install_hook_attr: str | None = None
 
 
 @dataclass(frozen=True)
@@ -89,6 +90,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         ),
         installed_attr="_local_first_advanced_fetch_controls_installed",
         installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
+        after_install_hook_attr="_refresh_local_first_advanced_fetch_visibility",
     ),
     LocalFirstControlMove(
         key="activity_preview",
@@ -106,6 +108,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_backfill_controls_installed",
         installed_target_attr="_local_first_backfill_controls_installed_target",
         show_after_move=False,
+        after_install_hook_attr="_refresh_local_first_detailed_fetch_visibility",
     ),
     LocalFirstControlMove(
         key="map_filters",
@@ -135,6 +138,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_atlas_pdf_controls_installed",
         installed_target_attr="_local_first_atlas_pdf_controls_installed_target",
         title="PDF output",
+        after_install_hook_attr="_hide_legacy_atlas_export_button",
     ),
     LocalFirstControlMove(
         key="strava_credentials",
@@ -168,6 +172,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_basemap_controls_installed",
         installed_target_attr="_local_first_basemap_controls_installed_target",
         title="Mapbox basemap",
+        after_install_hook_attr="_refresh_local_first_mapbox_visibility",
     ),
     LocalFirstControlMove(
         key="storage",
@@ -182,6 +187,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_storage_controls_installed",
         installed_target_attr="_local_first_storage_controls_installed_target",
         title="Data storage",
+        after_install_hook_attr="_refresh_local_first_point_sampling_visibility",
     ),
 )
 


### PR DESCRIPTION
## Summary
- move local-first control post-install hook ownership into the audited control-move inventory
- keep `QfitDockWidget` dispatching through that metadata instead of a hard-coded key map
- add regression coverage for the audited hook contracts

Refs ebelo/qfit#805

## Tests
- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof
- Not rendering-sensitive; this only refactors local-first control-install metadata and dispatch.
