### PR TITLE
refactor: move local-first audited install loop

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -91,11 +91,11 @@ from .ui.application import (
     build_wizard_filter_description,
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
+    after_local_first_control_move_installed,
+    install_local_first_audited_controls,
     load_wizard_settings,
     local_first_control_move_for_key,
-    local_first_control_move_keys,
     local_first_widget_move_for_key,
-    local_first_widget_move_keys,
     install_local_first_group_controls,
     install_local_first_widget_controls,
     local_first_control_move_layout,
@@ -546,7 +546,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 update_atlas_document_settings=self._update_atlas_document_settings,
             ),
         )
-        self._install_local_first_audited_controls(self._local_first_dock_composition)
+        install_local_first_audited_controls(self, self._local_first_dock_composition)
         self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
         return self._local_first_dock_composition
 
@@ -741,38 +741,13 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         move = local_first_widget_move_for_key(key)
         return self._install_local_first_widget_controls(composition, move=move)
 
-    def _install_local_first_audited_controls(self, composition) -> None:
-        """Install all audited legacy-backed controls into local-first pages."""
-
-        # The audited inventories define the production install order.  This does
-        # not preserve the older hand-written call sequence when targets are
-        # independent; it keeps the local-first composition aligned with the
-        # audit metadata instead.
-        for key in local_first_widget_move_keys():
-            self._install_local_first_widget_move(composition, key)
-        for key in local_first_control_move_keys():
-            installed = self._install_local_first_control_move(composition, key)
-            self._after_local_first_control_move_installed(key, installed=installed)
-
     def _after_local_first_control_move_installed(
         self,
         key: str,
         *,
         installed: bool,
     ) -> None:
-        """Apply per-control side effects after an audited local-first move."""
-
-        if not installed:
-            return
-        try:
-            move = local_first_control_move_for_key(key)
-        except KeyError:
-            return
-        hook_attr = move.after_install_hook_attr
-        if hook_attr is None:
-            return
-        hook = getattr(self, hook_attr)
-        hook()
+        after_local_first_control_move_installed(self, key, installed=installed)
 
     def _refresh_local_first_advanced_fetch_visibility(self) -> None:
         advanced_fetch_group = getattr(self, "advancedFetchGroupBox", None)

--- a/tests/test_local_first_control_installer.py
+++ b/tests/test_local_first_control_installer.py
@@ -1,12 +1,16 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 from tests import _path  # noqa: F401
 
 from qfit.ui.application.local_first_control_installer import (
+    after_local_first_control_move_installed,
+    install_local_first_audited_controls,
     install_local_first_group_controls,
+    install_local_first_control_move,
     install_local_first_widget_controls,
+    install_local_first_widget_move,
 )
 from qfit.ui.application.local_first_control_moves import (
     local_first_control_move_for_key,
@@ -15,6 +19,120 @@ from qfit.ui.application.local_first_control_moves import (
 
 
 class LocalFirstControlInstallerTests(unittest.TestCase):
+    def test_installs_audited_controls_in_inventory_order(self):
+        dock = object()
+        composition = object()
+
+        with patch(
+            "qfit.ui.application.local_first_control_installer.install_local_first_widget_move",
+            return_value=True,
+        ) as install_widget_move, patch(
+            "qfit.ui.application.local_first_control_installer.install_local_first_control_move",
+            return_value=True,
+        ) as install_control_move, patch(
+            "qfit.ui.application.local_first_control_installer.after_local_first_control_move_installed",
+        ) as after_control_move:
+            install_local_first_audited_controls(dock, composition)
+
+        self.assertEqual(
+            install_widget_move.call_args_list,
+            [
+                call(dock, composition, "activity_style"),
+                call(dock, composition, "analysis_temporal"),
+            ],
+        )
+        self.assertEqual(
+            install_control_move.call_args_list,
+            [
+                call(dock, composition, "advanced_fetch"),
+                call(dock, composition, "activity_preview"),
+                call(dock, composition, "backfill_routes"),
+                call(dock, composition, "map_filters"),
+                call(dock, composition, "atlas_pdf"),
+                call(dock, composition, "strava_credentials"),
+                call(dock, composition, "basemap"),
+                call(dock, composition, "storage"),
+            ],
+        )
+        self.assertEqual(
+            after_control_move.call_args_list,
+            [
+                call(dock, "advanced_fetch", installed=True),
+                call(dock, "activity_preview", installed=True),
+                call(dock, "backfill_routes", installed=True),
+                call(dock, "map_filters", installed=True),
+                call(dock, "atlas_pdf", installed=True),
+                call(dock, "strava_credentials", installed=True),
+                call(dock, "basemap", installed=True),
+                call(dock, "storage", installed=True),
+            ],
+        )
+
+    def test_control_move_lookup_installs_matching_group(self):
+        source_layout = MagicMock()
+        source_parent = SimpleNamespace(layout=lambda: source_layout)
+        group = MagicMock()
+        group.parentWidget.return_value = source_parent
+        dock = SimpleNamespace(
+            filterGroupBox=group,
+            activityTypeComboBox=object(),
+            activitySearchLineEdit=object(),
+            dateFromEdit=object(),
+            dateToEdit=object(),
+            minDistanceSpinBox=object(),
+            maxDistanceSpinBox=object(),
+            detailedRouteStatusComboBox=object(),
+        )
+        target_layout = MagicMock()
+        map_content = SimpleNamespace(
+            filter_controls_layout=MagicMock(return_value=target_layout),
+            set_filter_controls_visible=MagicMock(),
+        )
+
+        installed = install_local_first_control_move(
+            dock,
+            SimpleNamespace(map_content=map_content),
+            "map_filters",
+        )
+
+        self.assertTrue(installed)
+        target_layout.addWidget.assert_called_once_with(group)
+        self.assertTrue(dock._local_first_filter_controls_installed)
+
+    def test_widget_move_lookup_installs_matching_widgets(self):
+        style_label = MagicMock()
+        style_combo = MagicMock()
+        dock = SimpleNamespace(
+            stylePresetLabel=style_label,
+            stylePresetComboBox=style_combo,
+        )
+        target_layout = MagicMock()
+        map_content = SimpleNamespace(
+            style_controls_layout=MagicMock(return_value=target_layout),
+            set_style_controls_visible=MagicMock(),
+        )
+
+        installed = install_local_first_widget_move(
+            dock,
+            SimpleNamespace(map_content=map_content),
+            "activity_style",
+        )
+
+        self.assertTrue(installed)
+        self.assertEqual(
+            target_layout.addWidget.call_args_list,
+            [call(style_label), call(style_combo)],
+        )
+        self.assertTrue(dock._local_first_activity_style_controls_installed)
+
+    def test_after_control_move_installed_runs_hook_only_after_successful_move(self):
+        dock = SimpleNamespace(_refresh_local_first_mapbox_visibility=MagicMock())
+
+        after_local_first_control_move_installed(dock, "basemap", installed=False)
+        after_local_first_control_move_installed(dock, "basemap", installed=True)
+
+        dock._refresh_local_first_mapbox_visibility.assert_called_once_with()
+
     def test_installs_group_move_from_audited_inventory(self):
         source_layout = MagicMock()
         source_parent = SimpleNamespace(layout=lambda: source_layout)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -898,7 +898,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._atlas_export_completed = False
         dock.settings = _FakeSettings()
-        dock._install_local_first_audited_controls = MagicMock()
         dock._bind_wizard_analysis_mode_controls = MagicMock()
         parent = object()
 
@@ -923,7 +922,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                     fake_local_first_composition
                 )
             },
-        ):
+        ), patch.object(
+            self.module,
+            "install_local_first_audited_controls",
+        ) as install_local_first_audited_controls:
             composition = self.module.QfitDockWidget._build_local_first_dock_from_runtime(
                 dock,
                 parent=parent,
@@ -966,7 +968,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 callback.__func__,
                 getattr(self.module.QfitDockWidget, method_name),
             )
-        dock._install_local_first_audited_controls.assert_called_once_with(
+        install_local_first_audited_controls.assert_called_once_with(
+            dock,
             "connected-composition"
         )
         dock._bind_wizard_analysis_mode_controls.assert_called_once_with(
@@ -1006,52 +1009,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         dock._mark_atlas_export_stale.assert_not_called()
         dock._refresh_summary_status.assert_not_called()
-
-    def test_install_local_first_audited_controls_uses_inventory_order(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._install_local_first_widget_move = MagicMock(return_value=True)
-        dock._install_local_first_control_move = MagicMock(return_value=True)
-        dock._after_local_first_control_move_installed = MagicMock()
-        composition = object()
-
-        self.module.QfitDockWidget._install_local_first_audited_controls(
-            dock,
-            composition,
-        )
-
-        self.assertEqual(
-            dock._install_local_first_widget_move.call_args_list,
-            [
-                call(composition, "activity_style"),
-                call(composition, "analysis_temporal"),
-            ],
-        )
-        self.assertEqual(
-            dock._install_local_first_control_move.call_args_list,
-            [
-                call(composition, "advanced_fetch"),
-                call(composition, "activity_preview"),
-                call(composition, "backfill_routes"),
-                call(composition, "map_filters"),
-                call(composition, "atlas_pdf"),
-                call(composition, "strava_credentials"),
-                call(composition, "basemap"),
-                call(composition, "storage"),
-            ],
-        )
-        self.assertEqual(
-            dock._after_local_first_control_move_installed.call_args_list,
-            [
-                call("advanced_fetch", installed=True),
-                call("activity_preview", installed=True),
-                call("backfill_routes", installed=True),
-                call("map_filters", installed=True),
-                call("atlas_pdf", installed=True),
-                call("strava_credentials", installed=True),
-                call("basemap", installed=True),
-                call("storage", installed=True),
-            ],
-        )
 
     def test_after_local_first_control_move_installed_applies_required_hooks(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -1093,9 +1050,8 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock = object.__new__(self.module.QfitDockWidget)
         move = SimpleNamespace(after_install_hook_attr="_missing_local_first_hook")
 
-        with patch.object(
-            self.module,
-            "local_first_control_move_for_key",
+        with patch(
+            "qfit.ui.application.local_first_control_installer.local_first_control_move_for_key",
             return_value=move,
         ):
             with self.assertRaises(AttributeError):

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -46,7 +46,11 @@ from .local_first_control_moves import (
     local_first_widget_move_keys,
 )
 from .local_first_control_installer import (
+    after_local_first_control_move_installed,
+    install_local_first_audited_controls,
+    install_local_first_control_move,
     install_local_first_group_controls,
+    install_local_first_widget_move,
     install_local_first_widget_controls,
     local_first_control_move_layout,
     local_first_control_move_parent_panel,
@@ -120,6 +124,7 @@ from .visual_workflow_action_builder import build_visual_workflow_settings_snaps
 
 __all__ = [
     "ApplyVisualizationAction",
+    "after_local_first_control_move_installed",
     "COLLAPSED_GROUPS_KEY",
     "DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES",
     "DockActionDispatcher",
@@ -190,7 +195,10 @@ __all__ = [
     "clamp_wizard_step_index",
     "ensure_wizard_settings",
     "get_workflow_section",
+    "install_local_first_audited_controls",
+    "install_local_first_control_move",
     "install_local_first_group_controls",
+    "install_local_first_widget_move",
     "install_local_first_widget_controls",
     "load_wizard_settings",
     "local_first_control_move_layout",

--- a/ui/application/local_first_control_installer.py
+++ b/ui/application/local_first_control_installer.py
@@ -1,6 +1,62 @@
 from __future__ import annotations
 
-from .local_first_control_moves import LocalFirstControlMove, LocalFirstWidgetMove
+from .local_first_control_moves import (
+    LocalFirstControlMove,
+    LocalFirstWidgetMove,
+    local_first_control_move_for_key,
+    local_first_control_move_keys,
+    local_first_widget_move_for_key,
+    local_first_widget_move_keys,
+)
+
+
+def install_local_first_audited_controls(dock, composition) -> None:
+    """Install all audited legacy-backed controls into local-first pages."""
+
+    # The audited inventories define the production install order.  This does
+    # not preserve the older hand-written call sequence when targets are
+    # independent; it keeps the local-first composition aligned with the audit
+    # metadata instead.
+    for key in local_first_widget_move_keys():
+        install_local_first_widget_move(dock, composition, key)
+    for key in local_first_control_move_keys():
+        installed = install_local_first_control_move(dock, composition, key)
+        after_local_first_control_move_installed(dock, key, installed=installed)
+
+
+def install_local_first_control_move(dock, composition, key: str) -> bool:
+    """Install one audited legacy-backed control area into local-first UI."""
+
+    move = local_first_control_move_for_key(key)
+    return install_local_first_group_controls(dock, composition, move)
+
+
+def install_local_first_widget_move(dock, composition, key: str) -> bool:
+    """Install one audited loose-widget area into local-first UI."""
+
+    move = local_first_widget_move_for_key(key)
+    return install_local_first_widget_controls(dock, composition, move)
+
+
+def after_local_first_control_move_installed(
+    dock,
+    key: str,
+    *,
+    installed: bool,
+) -> None:
+    """Apply per-control side effects after an audited local-first move."""
+
+    if not installed:
+        return
+    try:
+        move = local_first_control_move_for_key(key)
+    except KeyError:
+        return
+    hook_attr = move.after_install_hook_attr
+    if hook_attr is None:
+        return
+    hook = getattr(dock, hook_attr)
+    hook()
 
 
 def install_local_first_group_controls(
@@ -176,7 +232,11 @@ def show_widget(widget) -> None:
 
 
 __all__ = [
+    "after_local_first_control_move_installed",
+    "install_local_first_audited_controls",
+    "install_local_first_control_move",
     "install_local_first_group_controls",
+    "install_local_first_widget_move",
     "install_local_first_widget_controls",
     "local_first_control_move_layout",
     "local_first_control_move_parent_panel",


### PR DESCRIPTION
## Summary

Move the audited local-first control installation loop out of `QfitDockWidget` and into the local-first application installer module.

## Changes

- Added application-level helpers for installing all audited local-first control/widget moves.
- Routed local-first composition setup through the application installer instead of a dock-owned loop.
- Kept dock-side visibility hooks available while delegating hook dispatch to the installer.
- Moved the inventory-order test coverage to the installer tests and updated the dock wiring test.

## Testing

- `python3 -m pytest tests/test_local_first_control_installer.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof

Not rendering-sensitive: this is a UI wiring/refactor slice and does not alter atlas/export rendering output.

Refs ebelo/qfit#805
