### PR TITLE
Thin workflow-section visibility routing

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -495,6 +495,14 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 write_activity_points_checkbox.isChecked()
             )
 
+    def _refresh_conditional_control_visibility(self) -> None:
+        """Refresh production local-first backing controls from their live state."""
+
+        self._refresh_local_first_advanced_fetch_visibility()
+        self._refresh_local_first_detailed_fetch_visibility()
+        self._refresh_local_first_mapbox_visibility()
+        self._refresh_local_first_point_sampling_visibility()
+
     def _update_advanced_fetch_visibility(self, expanded: bool) -> None:
         self._set_named_widgets_visible(
             ("advancedFetchSettingsWidget",),

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -557,74 +557,6 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertEqual(dock.activitiesSectionToggleButton.arrow, workflow_section_coordinator.Qt.DownArrow)
         self.assertTrue(dock.activitiesSectionContentWidget.visible)
 
-class WorkflowSectionCoordinatorVisibilityTests(unittest.TestCase):
-    def _make_dock(self):
-        dock = sentinel.dock
-        attrs = {
-            "backfillMissingDetailedRoutesButton": _VisibilityTarget(),
-            "detailedRouteStrategyLabel": _VisibilityTarget(),
-            "detailedRouteStrategyComboBox": _VisibilityTarget(),
-            "maxDetailedActivitiesLabel": _VisibilityTarget(),
-            "maxDetailedActivitiesSpinBox": _VisibilityTarget(),
-            "pointSamplingStrideLabel": _VisibilityTarget(),
-            "pointSamplingStrideSpinBox": _VisibilityTarget(),
-            "advancedFetchSettingsWidget": _VisibilityTarget(),
-            "mapboxStyleOwnerLabel": _VisibilityTarget(),
-            "mapboxStyleOwnerLineEdit": _VisibilityTarget(),
-            "mapboxStyleIdLabel": _VisibilityTarget(),
-            "mapboxStyleIdLineEdit": _VisibilityTarget(),
-            "detailedRouteStrategyComboBoxContextHelpLabel": _VisibilityTarget(),
-            "detailedRouteStrategyComboBoxHelpField": _VisibilityTarget(),
-            "maxDetailedActivitiesSpinBoxContextHelpLabel": _VisibilityTarget(),
-            "maxDetailedActivitiesSpinBoxHelpField": _VisibilityTarget(),
-            "pointSamplingStrideSpinBoxContextHelpLabel": _VisibilityTarget(),
-            "pointSamplingStrideSpinBoxHelpField": _VisibilityTarget(),
-            "mapboxStyleOwnerLineEditContextHelpLabel": _VisibilityTarget(),
-            "mapboxStyleIdLineEditContextHelpLabel": _VisibilityTarget(),
-            "mapboxStyleIdLineEditHelpField": _VisibilityTarget(),
-            "detailedStreamsCheckBox": sentinel.detailedStreamsCheckBox,
-            "writeActivityPointsCheckBox": sentinel.writeActivityPointsCheckBox,
-            "advancedFetchGroupBox": sentinel.advancedFetchGroupBox,
-            "backgroundPresetComboBox": sentinel.backgroundPresetComboBox,
-        }
-        dock = type("Dock", (), attrs)()
-        dock.detailedStreamsCheckBox = sentinel.detailedStreamsCheckBox
-        dock.writeActivityPointsCheckBox = sentinel.writeActivityPointsCheckBox
-        dock.advancedFetchGroupBox = sentinel.advancedFetchGroupBox
-        dock.backgroundPresetComboBox = sentinel.backgroundPresetComboBox
-        return dock
-
-    def test_workflow_section_coordinator_applies_visibility_rules(self):
-        import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
-
-        with patch.object(
-            workflow_section_coordinator,
-            "preset_requires_custom_style",
-            side_effect=lambda name: name == "Custom",
-        ):
-            WorkflowSectionCoordinator = workflow_section_coordinator.WorkflowSectionCoordinator
-
-            detailed_streams = sentinel.detailedStreamsCheckBox
-            detailed_streams.isChecked = lambda: True
-            write_points = sentinel.writeActivityPointsCheckBox
-            write_points.isChecked = lambda: False
-            advanced_group = sentinel.advancedFetchGroupBox
-            advanced_group.isChecked = lambda: True
-            preset_combo = sentinel.backgroundPresetComboBox
-            preset_combo.currentText = lambda: "Custom"
-
-            dock = self._make_dock()
-            coordinator = WorkflowSectionCoordinator(dock)
-            coordinator.configure_workflow_sections()
-
-        self.assertTrue(dock.backfillMissingDetailedRoutesButton.visible)
-        self.assertTrue(dock.detailedRouteStrategyLabel.visible)
-        self.assertFalse(dock.pointSamplingStrideSpinBox.visible)
-        self.assertTrue(dock.advancedFetchSettingsWidget.visible)
-        self.assertTrue(dock.mapboxStyleOwnerLineEdit.visible)
-        self.assertTrue(dock.mapboxStyleIdLineEdit.visible)
-
-
 class DockStartupCoordinatorTests(unittest.TestCase):
     def test_run_orchestrates_startup_in_constructor_order(self):
         dock = MagicMock()
@@ -659,7 +591,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                     "load_settings",
                     "set_default_dates",
                     "wire_events",
-                    "configure_workflow_sections",
+                    "refresh_conditional_control_visibility",
                     "refresh_activity_preview",
                     "update_connection_status",
                 ),
@@ -682,6 +614,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 call._load_settings(),
                 call._set_default_dates(),
                 call._wire_events(),
+                call._refresh_conditional_control_visibility(),
                 call._refresh_activity_preview(),
                 call._update_connection_status(),
             ],
@@ -691,6 +624,5 @@ class DockStartupCoordinatorTests(unittest.TestCase):
             [
                 call.configure_starting_sections(),
                 call.configure_spinbox_unit_copy(),
-                call.configure_workflow_sections(),
             ],
         )

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -883,6 +883,20 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                     installed=True,
                 )
 
+    def test_refresh_conditional_control_visibility_uses_local_first_handlers(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._refresh_local_first_advanced_fetch_visibility = MagicMock()
+        dock._refresh_local_first_detailed_fetch_visibility = MagicMock()
+        dock._refresh_local_first_mapbox_visibility = MagicMock()
+        dock._refresh_local_first_point_sampling_visibility = MagicMock()
+
+        self.module.QfitDockWidget._refresh_conditional_control_visibility(dock)
+
+        dock._refresh_local_first_advanced_fetch_visibility.assert_called_once_with()
+        dock._refresh_local_first_detailed_fetch_visibility.assert_called_once_with()
+        dock._refresh_local_first_mapbox_visibility.assert_called_once_with()
+        dock._refresh_local_first_point_sampling_visibility.assert_called_once_with()
+
     def test_dock_widget_does_not_reintroduce_per_move_local_first_installers(self):
         self.assertFalse(
             hasattr(self.module.QfitDockWidget, "_install_local_first_control_move")

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -60,7 +60,6 @@ try:
     from qfit.qfit_dockwidget import ApplyVisualizationAction, QfitDockWidget
     from qfit.configuration.application.settings_service import SettingsService
     from qfit.ui.dockwidget_dependencies import build_dockwidget_dependencies
-    from qfit.ui.workflow_section_coordinator import WorkflowSectionCoordinator
     from qfit.visualization.application.visual_apply import VisualApplyService
     from qfit.visualization.application.temporal_config import DEFAULT_TEMPORAL_MODE_LABEL
 
@@ -422,34 +421,32 @@ class QgisSmokeTests(unittest.TestCase):
             dock.close()
             dock.deleteLater()
 
-    def test_workflow_section_coordinator_updates_visibility_rules(self):
+    def test_dock_widget_updates_local_first_visibility_rules(self):
         dock = QfitDockWidget(self.iface)
         try:
-            coordinator = WorkflowSectionCoordinator(dock)
-
-            coordinator.update_detailed_fetch_visibility(False)
+            dock._update_detailed_fetch_visibility(False)
             self.assertTrue(dock.backfillMissingDetailedRoutesButton.isHidden())
             self.assertTrue(dock.detailedRouteStrategyLabel.isHidden())
             self.assertTrue(dock.maxDetailedActivitiesSpinBox.isHidden())
 
-            coordinator.update_detailed_fetch_visibility(True)
+            dock._update_detailed_fetch_visibility(True)
             self.assertFalse(dock.backfillMissingDetailedRoutesButton.isHidden())
             self.assertFalse(dock.detailedRouteStrategyLabel.isHidden())
             self.assertFalse(dock.maxDetailedActivitiesSpinBox.isHidden())
 
-            coordinator.update_point_sampling_visibility(False)
+            dock._update_point_sampling_visibility(False)
             self.assertTrue(dock.pointSamplingStrideSpinBox.isHidden())
-            coordinator.update_point_sampling_visibility(True)
+            dock._update_point_sampling_visibility(True)
             self.assertFalse(dock.pointSamplingStrideSpinBox.isHidden())
 
-            coordinator.update_advanced_fetch_visibility(False)
+            dock._update_advanced_fetch_visibility(False)
             self.assertTrue(dock.advancedFetchSettingsWidget.isHidden())
-            coordinator.update_advanced_fetch_visibility(True)
+            dock._update_advanced_fetch_visibility(True)
             self.assertFalse(dock.advancedFetchSettingsWidget.isHidden())
 
-            coordinator.update_mapbox_advanced_visibility("Outdoor")
+            dock._update_mapbox_advanced_visibility("Outdoor")
             self.assertTrue(dock.mapboxStyleOwnerLineEdit.isHidden())
-            coordinator.update_mapbox_advanced_visibility("Custom")
+            dock._update_mapbox_advanced_visibility("Custom")
             self.assertFalse(dock.mapboxStyleOwnerLineEdit.isHidden())
             self.assertFalse(dock.mapboxStyleIdLineEdit.isHidden())
         finally:

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -67,8 +67,8 @@ class DockStartupCoordinator:
         dock._wire_events()
         performed_steps.append("wire_events")
 
-        self.workflow_section_coordinator.configure_workflow_sections()
-        performed_steps.append("configure_workflow_sections")
+        dock._refresh_conditional_control_visibility()
+        performed_steps.append("refresh_conditional_control_visibility")
 
         dock._refresh_activity_preview()
         performed_steps.append("refresh_activity_preview")

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -4,7 +4,6 @@ from qgis.PyQt.QtCore import Qt
 
 from qfit.ui.tokens import COLOR_MUTED
 
-from ..mapbox_config import preset_requires_custom_style
 from .application.dock_workflow_sections import (
     CURRENT_DOCK_SECTIONS,
     build_current_dock_workflow_label,
@@ -268,68 +267,6 @@ class WorkflowSectionCoordinator:
 
         if hasattr(label, "hide"):
             label.hide()
-
-    def configure_workflow_sections(self) -> None:
-        dock = self.dock_widget
-        self.update_detailed_fetch_visibility(dock.detailedStreamsCheckBox.isChecked())
-        self.update_point_sampling_visibility(dock.writeActivityPointsCheckBox.isChecked())
-        self.update_advanced_fetch_visibility(dock.advancedFetchGroupBox.isChecked())
-        self.update_mapbox_advanced_visibility(dock.backgroundPresetComboBox.currentText())
-
-    def update_detailed_fetch_visibility(self, enabled: bool) -> None:
-        dock = self.dock_widget
-        backfill_button = getattr(dock, "backfillMissingDetailedRoutesButton", None)
-        if backfill_button is not None:
-            backfill_button.setVisible(enabled)
-        dock.detailedRouteStrategyLabel.setVisible(enabled)
-        dock.detailedRouteStrategyComboBox.setVisible(enabled)
-        strategy_helper = getattr(dock, "detailedRouteStrategyComboBoxContextHelpLabel", None)
-        if strategy_helper is not None:
-            strategy_helper.setVisible(enabled)
-        strategy_wrapper = getattr(dock, "detailedRouteStrategyComboBoxHelpField", None)
-        if strategy_wrapper is not None:
-            strategy_wrapper.setVisible(enabled)
-        dock.maxDetailedActivitiesLabel.setVisible(enabled)
-        dock.maxDetailedActivitiesSpinBox.setVisible(enabled)
-        helper = getattr(dock, "maxDetailedActivitiesSpinBoxContextHelpLabel", None)
-        if helper is not None:
-            helper.setVisible(enabled)
-        wrapper = getattr(dock, "maxDetailedActivitiesSpinBoxHelpField", None)
-        if wrapper is not None:
-            wrapper.setVisible(enabled)
-
-    def update_point_sampling_visibility(self, enabled: bool) -> None:
-        dock = self.dock_widget
-        dock.pointSamplingStrideLabel.setVisible(enabled)
-        dock.pointSamplingStrideSpinBox.setVisible(enabled)
-        helper = getattr(dock, "pointSamplingStrideSpinBoxContextHelpLabel", None)
-        if helper is not None:
-            helper.setVisible(enabled)
-        wrapper = getattr(dock, "pointSamplingStrideSpinBoxHelpField", None)
-        if wrapper is not None:
-            wrapper.setVisible(enabled)
-
-    def update_advanced_fetch_visibility(self, expanded: bool) -> None:
-        widget = getattr(self.dock_widget, "advancedFetchSettingsWidget", None)
-        if widget is not None:
-            widget.setVisible(expanded)
-
-    def update_mapbox_advanced_visibility(self, preset_name: str) -> None:
-        dock = self.dock_widget
-        show_advanced = preset_requires_custom_style(preset_name)
-        dock.mapboxStyleOwnerLabel.setVisible(show_advanced)
-        dock.mapboxStyleOwnerLineEdit.setVisible(show_advanced)
-        dock.mapboxStyleIdLabel.setVisible(show_advanced)
-        dock.mapboxStyleIdLineEdit.setVisible(show_advanced)
-        owner_helper = getattr(dock, "mapboxStyleOwnerLineEditContextHelpLabel", None)
-        if owner_helper is not None:
-            owner_helper.setVisible(show_advanced)
-        style_helper = getattr(dock, "mapboxStyleIdLineEditContextHelpLabel", None)
-        if style_helper is not None:
-            style_helper.setVisible(show_advanced)
-        style_wrapper = getattr(dock, "mapboxStyleIdLineEditHelpField", None)
-        if style_wrapper is not None:
-            style_wrapper.setVisible(show_advanced)
 
     def _move_store_section_under_fetch(self) -> None:
         dock = self.dock_widget


### PR DESCRIPTION
## Summary

- route startup conditional visibility refreshes through the production local-first dock handlers
- remove the intermediate workflow-section coordinator's duplicate visibility policy
- update pure and QGIS smoke coverage so the local-first dock remains the tested owner of those visibility rules

Refs #805

## Testing

- `python3 -m pytest tests/test_dockwidget_dependencies.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_updates_local_first_visibility_rules -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof

Not rendering-sensitive; this only changes dock startup/control visibility routing and removes duplicate intermediate-section policy.
