### PR TITLE
Retire hidden local-first dock collapsibles

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -890,10 +890,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         layout.addWidget(button)
         layout.addStretch(1)
 
-        if content_layout is not None:
-            content_layout.insertWidget(0, row)
-        else:
-            self.analysisWorkflowLayout.insertWidget(0, row)
+        content_layout.insertWidget(0, row)
         self.analysisModeLabel = label
         self.analysisModeComboBox = combo
         self.runAnalysisButton = button

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -865,10 +865,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             temporal_row.hide()
 
     def _configure_analysis_mode_options(self):
-        content_widget = getattr(self, "analysisSectionContentWidget", self.analysisWorkflowGroupBox)
-        content_layout = content_widget.layout() if content_widget is not None else None
+        content_widget = self.analysisWorkflowGroupBox
+        content_layout = content_widget.layout()
 
-        row = QWidget(content_widget or self.analysisWorkflowGroupBox)
+        row = QWidget(content_widget)
         row.setObjectName("analysisModeRow")
         layout = QHBoxLayout(row)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -391,7 +391,7 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         dock.statusLabel = _FakeWidget()
         return dock
 
-    def test_configure_starting_sections_moves_widgets_and_installs_collapsibles(self):
+    def test_configure_starting_sections_prepares_local_first_backing_controls(self):
         import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
 
         class _FakeSignal:
@@ -423,9 +423,6 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         class _FakeToolButton(_FakeWidget):
             def __init__(self, _parent=None):
                 super().__init__()
-                self.toggled = _FakeSignal()
-                self.arrow_type = None
-                self.checked = None
                 self.object_name = None
                 self.text = None
                 self.menu = None
@@ -440,55 +437,29 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
             def setToolButtonStyle(self, _style):
                 pass
 
-            def setArrowType(self, arrow_type):
-                self.arrow_type = arrow_type
-
-            def setChecked(self, checked):
-                self.checked = checked
-
             def setPopupMode(self, mode):
                 self.popup_mode = mode
 
             def setMenu(self, menu):
                 self.menu = menu
 
-            def setStyleSheet(self, _style):
-                pass
-
-        class _FakeVBoxLayout:
-            def __init__(self, _parent=None):
-                self.items = []
-                self._spacing = 0
-
-            def setContentsMargins(self, *_args):
-                pass
-
-            def setSpacing(self, spacing):
-                self._spacing = spacing
-
-            def addWidget(self, widget):
-                self.items.append(("widget", widget))
-
-            def addLayout(self, layout):
-                self.items.append(("layout", layout))
-
-            def addItem(self, item):
-                self.items.append(("item", item))
-
         _FakeToolButton.InstantPopup = "instant-popup"
 
         qtwidgets = ModuleType("qgis.PyQt.QtWidgets")
         qtwidgets.QMenu = _FakeMenu
         qtwidgets.QToolButton = _FakeToolButton
-        qtwidgets.QVBoxLayout = _FakeVBoxLayout
-        qtwidgets.QWidget = _FakeWidget
 
-        coordinator = workflow_section_coordinator.WorkflowSectionCoordinator(self._make_section_dock())
+        coordinator = workflow_section_coordinator.WorkflowSectionCoordinator(
+            self._make_section_dock()
+        )
         with patch.dict(sys.modules, {"qgis.PyQt.QtWidgets": qtwidgets}):
             coordinator.configure_starting_sections()
         dock = coordinator.dock_widget
 
-        self.assertEqual(dock.workflowLabel.text, "Sections: Fetch & store · Visualize · Analyze · Publish")
+        self.assertEqual(
+            dock.workflowLabel.text,
+            "Sections: Fetch & store · Visualize · Analyze · Publish",
+        )
         self.assertFalse(dock.credentialsGroupBox.visible)
         self.assertEqual(dock.outputGroupBox.parent(), dock.activitiesGroupBox)
         self.assertEqual(dock.loadLayersButton.parent(), dock.styleGroupBox)
@@ -508,12 +479,11 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertFalse(dock.countLabel.visible)
         self.assertFalse(dock.statusLabel.visible)
         self.assertEqual(dock.outputGroupBox.visible, None)
-        self.assertTrue(hasattr(dock, "activitiesSectionToggleButton"))
-        self.assertTrue(hasattr(dock, "activitiesSectionContentWidget"))
-        self.assertTrue(hasattr(dock, "styleSectionToggleButton"))
+        self.assertFalse(hasattr(dock, "activitiesSectionToggleButton"))
+        self.assertFalse(hasattr(dock, "activitiesSectionContentWidget"))
+        self.assertFalse(hasattr(dock, "styleSectionToggleButton"))
         self.assertFalse(dock.activitiesIntroLabel.visible)
-        self.assertIn("saved in qfit → Configuration", dock.activitiesSectionToggleButton.tooltip)
-        self.assertEqual(dock.activitiesGroupBox.tooltip, dock.activitiesSectionToggleButton.tooltip)
+        self.assertIn("saved in qfit → Configuration", dock.activitiesGroupBox.tooltip)
         self.assertFalse(dock.outputIntroLabel.visible)
         self.assertEqual(dock.outputGroupBox.tooltip, dock.outputIntroLabel.text)
         self.assertFalse(dock.atlasPdfHelpLabel.visible)
@@ -541,21 +511,21 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertEqual(dock.pointSamplingStrideLabel.text, "Keep every Nth point")
         self.assertEqual(dock.pointSamplingStrideSpinBox.suffix, " points")
 
-    def test_set_section_expanded_updates_toggle_arrow_and_content_visibility(self):
+    def test_no_hidden_collapsible_section_api_remains(self):
         import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
 
-        dock = type("Dock", (), {})()
-        dock.activitiesSectionToggleButton = type("Toggle", (), {"arrow": None, "setArrowType": lambda self, val: setattr(self, "arrow", val)})()
-        dock.activitiesSectionContentWidget = _FakeWidget()
-        coordinator = workflow_section_coordinator.WorkflowSectionCoordinator(dock)
-
-        coordinator.set_section_expanded("activities", False)
-        self.assertEqual(dock.activitiesSectionToggleButton.arrow, workflow_section_coordinator.Qt.RightArrow)
-        self.assertFalse(dock.activitiesSectionContentWidget.visible)
-
-        coordinator.set_section_expanded("activities", True)
-        self.assertEqual(dock.activitiesSectionToggleButton.arrow, workflow_section_coordinator.Qt.DownArrow)
-        self.assertTrue(dock.activitiesSectionContentWidget.visible)
+        self.assertFalse(
+            hasattr(
+                workflow_section_coordinator.WorkflowSectionCoordinator,
+                "install_collapsible_section",
+            )
+        )
+        self.assertFalse(
+            hasattr(
+                workflow_section_coordinator.WorkflowSectionCoordinator,
+                "set_section_expanded",
+            )
+        )
 
 class DockStartupCoordinatorTests(unittest.TestCase):
     def test_run_orchestrates_startup_in_constructor_order(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -343,13 +343,11 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             sys.modules.pop("qfit.qfit_dockwidget", None)
             return importlib.import_module("qfit.qfit_dockwidget")
 
-    def test_configure_analysis_mode_options_inserts_row_into_section_content(self):
+    def test_configure_analysis_mode_options_inserts_row_into_analysis_group(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        section_content = _FakeWidget()
         content_layout = _FakeLayout()
-        section_content.setLayout(content_layout)
-        dock.analysisSectionContentWidget = section_content
         dock.analysisWorkflowGroupBox = _FakeWidget()
+        dock.analysisWorkflowGroupBox.setLayout(content_layout)
         dock.analysisWorkflowLayout = _FakeLayout()
 
         with patch.multiple(
@@ -366,6 +364,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         index, row = content_layout.inserted[0]
         self.assertEqual(index, 0)
         self.assertEqual(row.objectName(), "analysisModeRow")
+        self.assertIs(row.parentWidget(), dock.analysisWorkflowGroupBox)
         self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
         self.assertEqual(
             dock.analysisModeComboBox.items,

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -283,13 +283,10 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertTrue(bool(dock.features() & dock.DockWidgetMovable))
             self.assertTrue(bool(dock.features() & dock.DockWidgetFloatable))
             self.assertEqual(dock.activitiesGroupBox.title(), "")
-            self.assertEqual(dock.activitiesSectionToggleButton.text(), "Fetch and store")
-            self.assertTrue(dock.activitiesSectionToggleButton.isChecked())
-            self.assertEqual(dock.activitiesSectionToggleButton.arrowType(), Qt.DownArrow)
-            self.assertFalse(dock.activitiesSectionContentWidget.isHidden())
+            self.assertFalse(hasattr(dock, "activitiesSectionToggleButton"))
+            self.assertFalse(hasattr(dock, "activitiesSectionContentWidget"))
             self.assertTrue(dock.activitiesIntroLabel.isHidden())
-            self.assertIn("saved in qfit → Configuration", dock.activitiesSectionToggleButton.toolTip())
-            self.assertEqual(dock.activitiesGroupBox.toolTip(), dock.activitiesSectionToggleButton.toolTip())
+            self.assertIn("saved in qfit → Configuration", dock.activitiesGroupBox.toolTip())
             self.assertFalse(dock.mapboxAccessTokenLabel.isVisible())
             self.assertFalse(dock.mapboxAccessTokenLineEdit.isVisible())
             self.assertEqual(dock.refreshButton.text(), "Fetch activities")
@@ -341,10 +338,9 @@ class QgisSmokeTests(unittest.TestCase):
                 ),
                 0,
             )
-            self.assertEqual(dock.styleSectionToggleButton.text(), "Visualize")
-            self.assertEqual(dock.styleSectionToggleButton.arrowType(), Qt.DownArrow)
-            self.assertFalse(dock.styleSectionContentWidget.isHidden())
-            self.assertEqual(dock.loadLayersButton.parent(), dock.styleSectionContentWidget)
+            self.assertFalse(hasattr(dock, "styleSectionToggleButton"))
+            self.assertFalse(hasattr(dock, "styleSectionContentWidget"))
+            self.assertEqual(dock.loadLayersButton.parent(), dock.styleGroupBox)
             self.assertEqual(
                 dock.backgroundGroupBox.parentWidget(),
                 dock._local_first_dock_composition.connection_content,
@@ -356,12 +352,15 @@ class QgisSmokeTests(unittest.TestCase):
                 0,
             )
             self.assertEqual(dock.analysisWorkflowGroupBox.title(), "")
-            self.assertEqual(dock.analysisSectionToggleButton.text(), "Analyze")
-            self.assertFalse(dock.analysisSectionContentWidget.isHidden())
+            self.assertFalse(hasattr(dock, "analysisSectionToggleButton"))
+            self.assertFalse(hasattr(dock, "analysisSectionContentWidget"))
             self.assertEqual(dock.analysisWorkflowLayout.spacing(), 6)
             self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
             self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
-            self.assertEqual(dock.analysisModeLabel.parentWidget().parentWidget(), dock.analysisSectionContentWidget)
+            self.assertEqual(
+                dock.analysisModeLabel.parentWidget().parentWidget(),
+                dock.analysisWorkflowGroupBox,
+            )
             self.assertEqual(
                 dock.temporalModeLabel.parentWidget().parentWidget(),
                 dock._local_first_dock_composition.analysis_content.temporal_controls_panel,
@@ -380,9 +379,12 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertFalse(dock.temporalModeComboBox.isHidden())
             self.assertFalse(dock.temporalHelpLabel.isHidden())
             self.assertEqual(dock.publishGroupBox.title(), "")
-            self.assertEqual(dock.publishSectionToggleButton.text(), "Publish / atlas")
-            self.assertFalse(dock.publishSectionContentWidget.isHidden())
-            self.assertTrue(dock.publishSettingsWidget.parent() is dock.publishSectionContentWidget or dock.publishSettingsWidget.isVisible())
+            self.assertFalse(hasattr(dock, "publishSectionToggleButton"))
+            self.assertFalse(hasattr(dock, "publishSectionContentWidget"))
+            self.assertTrue(
+                dock.publishSettingsWidget.parent() is dock.publishGroupBox
+                or dock.publishSettingsWidget.isVisible()
+            )
             self.assertTrue(dock.atlasPdfHelpLabel.isHidden())
             self.assertIn("per-activity PDF atlas", dock.atlasPdfGroupBox.toolTip())
             self.assertEqual(dock.generateAtlasPdfButton.toolTip(), dock.atlasPdfGroupBox.toolTip())
@@ -406,17 +408,6 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertIsNotNone(dock.findChild(QWidget, "maxDetailedActivitiesSpinBoxHelpField"))
             temporal_helper = dock.findChild(QLabel, "temporalModeComboBoxContextHelpLabel")
             self.assertIsNone(temporal_helper)
-            dock.activitiesSectionToggleButton.click()
-            self.assertFalse(dock.activitiesSectionToggleButton.isChecked())
-            self.assertEqual(dock.activitiesSectionToggleButton.arrowType(), Qt.RightArrow)
-            self.assertTrue(dock.activitiesSectionContentWidget.isHidden())
-            dock.styleSectionToggleButton.click()
-            self.assertTrue(dock.styleSectionContentWidget.isHidden())
-            dock.analysisSectionToggleButton.click()
-            self.assertTrue(dock.analysisSectionContentWidget.isHidden())
-            self.assertFalse(dock.analysisModeLabel.parentWidget().isVisible())
-            dock.publishSectionToggleButton.click()
-            self.assertTrue(dock.publishSectionContentWidget.isHidden())
         finally:
             dock.close()
             dock.deleteLater()

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -4,17 +4,16 @@ from qgis.PyQt.QtCore import Qt
 
 from qfit.ui.tokens import COLOR_MUTED
 
-from .application.dock_workflow_sections import (
-    CURRENT_DOCK_SECTIONS,
-    build_current_dock_workflow_label,
-)
+from .application.dock_workflow_sections import build_current_dock_workflow_label
 
 
 class WorkflowSectionCoordinator:
-    """Coordinate dock-widget workflow sections and conditional field visibility.
+    """Prepare the legacy dock controls that still back local-first pages.
 
-    This keeps section layout/visibility rules out of ``QfitDockWidget`` so the
-    dock widget can focus more on wiring signals and rendering user feedback.
+    The live dock now uses the local-first shell, so this coordinator only keeps
+    shared copy, tooltips, and legacy backing controls coherent before audited
+    controls are moved into local-first pages. It intentionally no longer
+    installs the hidden long-scroll collapsible section surface.
     """
 
     def __init__(self, dock_widget):
@@ -39,27 +38,8 @@ class WorkflowSectionCoordinator:
         self._pin_summary_status_footer()
         self._hide_redundant_status_labels()
         self._style_legacy_feedback_labels()
-        section_widgets = {
-            "sync": (dock.activitiesGroupBox, "activitiesGroupLayout", "activities"),
-            "map": (dock.styleGroupBox, "styleGroupLayout", "style"),
-            "analysis": (dock.analysisWorkflowGroupBox, "analysisWorkflowLayout", "analysis"),
-            "atlas": (dock.publishGroupBox, "publishGroupLayout", "publish"),
-        }
-        section_keys = {section.key for section in CURRENT_DOCK_SECTIONS}
-        if set(section_widgets) != section_keys:
-            raise RuntimeError("Current dock workflow bindings must match shared section metadata")
-
-        for section in CURRENT_DOCK_SECTIONS:
-            group_box, layout_attr, toggle_key = section_widgets[section.key]
-            self.install_collapsible_section(
-                group_box,
-                layout_attr,
-                section.current_dock_title,
-                toggle_key,
-            )
         self._move_help_label_to_tooltip(
             dock.activitiesIntroLabel,
-            getattr(dock, "activitiesSectionToggleButton", None),
             dock.activitiesGroupBox,
         )
         self._move_help_label_to_tooltip(dock.outputIntroLabel, dock.outputGroupBox)
@@ -196,60 +176,6 @@ class WorkflowSectionCoordinator:
         dock.databaseActionsMenu = menu
         dock.databaseActionsButton = menu_button
         dock.clearDatabaseAction = clear_action
-
-    def install_collapsible_section(self, group_box, layout_attr: str, title: str, key: str) -> None:
-        dock = self.dock_widget
-        layout = getattr(dock, layout_attr, None)
-        toggle_attr = f"{key}SectionToggleButton"
-        content_attr = f"{key}SectionContentWidget"
-        if layout is None or hasattr(dock, toggle_attr):
-            return
-
-        group_box.setTitle("")
-
-        from qgis.PyQt.QtWidgets import QToolButton, QVBoxLayout, QWidget
-
-        content_widget = QWidget(group_box)
-        content_widget.setObjectName(f"{key}SectionContentWidget")
-        content_layout = QVBoxLayout(content_widget)
-        content_layout.setContentsMargins(0, 0, 0, 0)
-        content_layout.setSpacing(layout.spacing())
-
-        while layout.count():
-            item = layout.takeAt(0)
-            widget = item.widget()
-            child_layout = item.layout()
-            spacer = item.spacerItem()
-            if widget is not None:
-                content_layout.addWidget(widget)
-            elif child_layout is not None:
-                content_layout.addLayout(child_layout)
-            elif spacer is not None:
-                content_layout.addItem(spacer)
-
-        toggle = QToolButton(group_box)
-        toggle.setObjectName(f"{key}SectionToggleButton")
-        toggle.setText(title)
-        toggle.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        toggle.setArrowType(Qt.DownArrow)
-        toggle.setCheckable(True)
-        toggle.setChecked(True)
-        toggle.setStyleSheet("QToolButton { border: none; font-weight: bold; }")
-        toggle.toggled.connect(lambda expanded, section_key=key: self.set_section_expanded(section_key, expanded))
-
-        setattr(dock, toggle_attr, toggle)
-        setattr(dock, content_attr, content_widget)
-        layout.addWidget(toggle)
-        layout.addWidget(content_widget)
-
-    def set_section_expanded(self, key: str, expanded: bool) -> None:
-        dock = self.dock_widget
-        toggle = getattr(dock, f"{key}SectionToggleButton", None)
-        content = getattr(dock, f"{key}SectionContentWidget", None)
-        if toggle is not None:
-            toggle.setArrowType(Qt.DownArrow if expanded else Qt.RightArrow)
-        if content is not None:
-            content.setVisible(expanded)
 
     def _move_help_label_to_tooltip(self, label, *widgets) -> None:
         if label is None:

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -23,7 +23,13 @@ class WorkflowSectionCoordinator:
         dock = self.dock_widget
         dock.workflowLabel.setText(build_current_dock_workflow_label())
         dock.credentialsGroupBox.hide()
-        dock.activitiesGroupBox.setTitle("")
+        for group_box in (
+            dock.activitiesGroupBox,
+            dock.styleGroupBox,
+            dock.analysisWorkflowGroupBox,
+            dock.publishGroupBox,
+        ):
+            group_box.setTitle("")
         dock.activitiesIntroLabel.setText(
             "Fetch your activities from Strava using the credentials saved in qfit → Configuration. "
             "Store or clear the local GeoPackage here too. Filters are applied later in the Visualize step — no re-fetch needed."


### PR DESCRIPTION
## Summary
- stop installing the hidden legacy collapsible workflow sections now that the local-first shell owns the visible dock surface
- keep the remaining legacy widgets as direct backing controls for local-first page moves/tooltips
- simplify analysis mode row placement to target the analysis group directly

## Tests
- `python3 -m pytest tests/test_dockwidget_dependencies.py::WorkflowSectionCoordinatorTests tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_configure_analysis_mode_options_inserts_row_into_analysis_group tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_build_local_first_dock_from_runtime_wires_independent_callbacks tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_install_live_local_first_dock_hides_long_scroll_path -q --tb=short`
- `python3 -m pytest tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_defaults_to_local_first_live_path -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
