### PR TITLE
refactor: move local-first backing startup helpers

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -120,7 +120,6 @@ from .providers.infrastructure.strava_provider import StravaProvider
 from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
 from .ui.dockwidget_dependencies import DockWidgetDependencies, build_dockwidget_dependencies
 from .ui.dock_startup_coordinator import DockStartupCoordinator
-from .ui.workflow_section_coordinator import WorkflowSectionCoordinator
 from .configuration.application.connection_status import build_strava_connection_status
 from .configuration.application.dock_settings_bindings import build_dock_settings_bindings
 from .configuration.application.ui_settings_binding import load_bindings, save_bindings
@@ -166,11 +165,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._dependencies = dependencies or build_dockwidget_dependencies(iface)
         self._bind_dependencies(self._dependencies)
         self.setupUi(self)
-        self._workflow_section_coordinator = WorkflowSectionCoordinator(self)
-        self._dock_startup_coordinator = DockStartupCoordinator(
-            self,
-            workflow_section_coordinator=self._workflow_section_coordinator,
-        )
+        self._dock_startup_coordinator = DockStartupCoordinator(self)
         self._startup_result = self._dock_startup_coordinator.run()
         self._dock_action_dispatcher = DockActionDispatcher(
             visual_apply=self.visual_apply,

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -348,7 +348,7 @@ class _FakeGroupBox:
         self.tooltip = text
 
 
-class WorkflowSectionCoordinatorTests(unittest.TestCase):
+class LocalFirstBackingControlsTests(unittest.TestCase):
     def _make_section_dock(self):
         dock = type("Dock", (), {})()
         dock.activitiesGroupLayout = _FakeLayoutContainer([_FakeItem(widget=object())])
@@ -392,7 +392,9 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         return dock
 
     def test_configure_starting_sections_prepares_local_first_backing_controls(self):
-        import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
+        from qfit.ui.application.local_first_backing_controls import (
+            configure_local_first_backing_controls,
+        )
 
         class _FakeSignal:
             def __init__(self):
@@ -449,12 +451,9 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         qtwidgets.QMenu = _FakeMenu
         qtwidgets.QToolButton = _FakeToolButton
 
-        coordinator = workflow_section_coordinator.WorkflowSectionCoordinator(
-            self._make_section_dock()
-        )
+        dock = self._make_section_dock()
         with patch.dict(sys.modules, {"qgis.PyQt.QtWidgets": qtwidgets}):
-            coordinator.configure_starting_sections()
-        dock = coordinator.dock_widget
+            configure_local_first_backing_controls(dock)
 
         self.assertEqual(
             dock.workflowLabel.text,
@@ -493,11 +492,12 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
         self.assertFalse(dock.mapboxAccessTokenLineEdit.visible)
 
     def test_configure_spinbox_unit_copy_moves_units_to_spinbox_suffixes(self):
-        import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
+        from qfit.ui.application.local_first_backing_controls import (
+            configure_local_first_spinbox_unit_copy,
+        )
 
-        coordinator = workflow_section_coordinator.WorkflowSectionCoordinator(self._make_section_dock())
-        coordinator.configure_spinbox_unit_copy()
-        dock = coordinator.dock_widget
+        dock = self._make_section_dock()
+        configure_local_first_spinbox_unit_copy(dock)
 
         self.assertEqual(dock.perPageLabel.text, "Page size")
         self.assertEqual(dock.perPageSpinBox.suffix, " activities")
@@ -527,19 +527,46 @@ class WorkflowSectionCoordinatorTests(unittest.TestCase):
             )
         )
 
+    def test_workflow_section_coordinator_is_only_compatibility_shim(self):
+        import qfit.ui.workflow_section_coordinator as workflow_section_coordinator
+
+        dock = object()
+        coordinator = workflow_section_coordinator.WorkflowSectionCoordinator(dock)
+
+        with (
+            patch.object(
+                workflow_section_coordinator,
+                "configure_local_first_backing_controls",
+            ) as configure_local_first_backing_controls,
+            patch.object(
+                workflow_section_coordinator,
+                "configure_local_first_spinbox_unit_copy",
+            ) as configure_local_first_spinbox_unit_copy,
+        ):
+            coordinator.configure_starting_sections()
+            coordinator.configure_spinbox_unit_copy()
+
+        configure_local_first_backing_controls.assert_called_once_with(dock)
+        configure_local_first_spinbox_unit_copy.assert_called_once_with(dock)
+
+
 class DockStartupCoordinatorTests(unittest.TestCase):
     def test_run_orchestrates_startup_in_constructor_order(self):
         dock = MagicMock()
         dock.DEFAULT_DOCK_FEATURES = sentinel.features
         dock.STARTUP_ALLOWED_AREAS = sentinel.allowed_areas
-        workflow_section_coordinator = MagicMock()
-
-        coordinator = DockStartupCoordinator(
-            dock,
-            workflow_section_coordinator=workflow_section_coordinator,
-        )
-
-        result = coordinator.run()
+        with (
+            patch(
+                "qfit.ui.dock_startup_coordinator."
+                "configure_local_first_backing_controls"
+            ) as configure_local_first_backing_controls,
+            patch(
+                "qfit.ui.dock_startup_coordinator."
+                "configure_local_first_spinbox_unit_copy"
+            ) as configure_local_first_spinbox_unit_copy,
+        ):
+            coordinator = DockStartupCoordinator(dock)
+            result = coordinator.run()
 
         self.assertEqual(
             result,
@@ -548,10 +575,10 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                     "set_features",
                     "set_allowed_areas",
                     "ensure_wizard_settings",
-                    "configure_starting_sections",
+                    "configure_local_first_backing_controls",
                     "remove_stale_qfit_layers",
                     "apply_contextual_help",
-                    "configure_spinbox_unit_copy",
+                    "configure_local_first_spinbox_unit_copy",
                     "configure_background_preset_options",
                     "configure_detailed_route_filter_options",
                     "configure_detailed_route_strategy_options",
@@ -589,10 +616,5 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 call._update_connection_status(),
             ],
         )
-        self.assertEqual(
-            workflow_section_coordinator.mock_calls,
-            [
-                call.configure_starting_sections(),
-                call.configure_spinbox_unit_copy(),
-            ],
-        )
+        configure_local_first_backing_controls.assert_called_once_with(dock)
+        configure_local_first_spinbox_unit_copy.assert_called_once_with(dock)

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -215,11 +215,9 @@ class QgisSmokeTests(unittest.TestCase):
             startup_coordinator.return_value.run.return_value = MagicMock()
             dock = QfitDockWidget(self.iface, dependencies=dependencies)
         try:
-            startup_coordinator.assert_called_once_with(
-                dock,
-                workflow_section_coordinator=dock._workflow_section_coordinator,
-            )
+            startup_coordinator.assert_called_once_with(dock)
             startup_coordinator.return_value.run.assert_called_once_with()
+            self.assertFalse(hasattr(dock, "_workflow_section_coordinator"))
             self.assertIs(dock._dock_startup_coordinator, startup_coordinator.return_value)
             self.assertIs(dock._startup_result, startup_coordinator.return_value.run.return_value)
         finally:

--- a/ui/application/local_first_backing_controls.py
+++ b/ui/application/local_first_backing_controls.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from qfit.ui.tokens import COLOR_MUTED
+
+from .dock_workflow_sections import build_current_dock_workflow_label
+
+
+def configure_local_first_backing_controls(dock) -> None:
+    """Prepare legacy widgets that still back the local-first dock pages."""
+
+    dock.workflowLabel.setText(build_current_dock_workflow_label())
+    dock.credentialsGroupBox.hide()
+    for group_box in (
+        dock.activitiesGroupBox,
+        dock.styleGroupBox,
+        dock.analysisWorkflowGroupBox,
+        dock.publishGroupBox,
+    ):
+        group_box.setTitle("")
+    dock.activitiesIntroLabel.setText(
+        "Fetch your activities from Strava using the credentials saved in qfit → "
+        "Configuration. Store or clear the local GeoPackage here too. Filters "
+        "are applied later in the Visualize step — no re-fetch needed."
+    )
+    _move_store_section_under_fetch(dock)
+    _move_load_layers_to_visualize(dock)
+    _move_temporal_controls_to_visualize(dock)
+    _move_clear_database_to_actions_menu(dock)
+    dock.outputGroupBox.setTitle("Store / database")
+    dock.publishGroupBox.setCheckable(False)
+    dock.publishSettingsWidget.setVisible(True)
+    _pin_summary_status_footer(dock)
+    _hide_redundant_status_labels(dock)
+    _style_legacy_feedback_labels(dock)
+    _move_help_label_to_tooltip(
+        dock.activitiesIntroLabel,
+        dock.activitiesGroupBox,
+    )
+    _move_help_label_to_tooltip(dock.outputIntroLabel, dock.outputGroupBox)
+    _move_help_label_to_tooltip(
+        dock.atlasPdfHelpLabel,
+        dock.atlasPdfGroupBox,
+        dock.generateAtlasPdfButton,
+    )
+    dock.mapboxAccessTokenLabel.hide()
+    dock.mapboxAccessTokenLineEdit.hide()
+
+
+def configure_local_first_spinbox_unit_copy(dock) -> None:
+    """Keep units in spin boxes instead of repeating them in form labels."""
+
+    for label_name, label_text, spinbox_name, suffix in (
+        ("perPageLabel", "Page size", "perPageSpinBox", " activities"),
+        ("maxPagesLabel", "Pages to fetch", "maxPagesSpinBox", " pages"),
+        (
+            "maxDetailedActivitiesLabel",
+            "Max new detailed routes this run",
+            "maxDetailedActivitiesSpinBox",
+            " routes",
+        ),
+        (
+            "pointSamplingStrideLabel",
+            "Keep every Nth point",
+            "pointSamplingStrideSpinBox",
+            " points",
+        ),
+    ):
+        _set_label_text(dock, label_name, label_text)
+        _set_spinbox_suffix(dock, spinbox_name, suffix)
+
+
+def _pin_summary_status_footer(dock) -> None:
+    if getattr(dock, "_summary_status_footer_pinned", False):
+        return
+
+    label = getattr(dock, "summaryStatusLabel", None)
+    outer_layout = getattr(dock, "outerLayout", None)
+    if label is None or outer_layout is None:
+        return
+
+    scroll_layout = getattr(dock, "verticalLayout", None)
+    if scroll_layout is not None and hasattr(scroll_layout, "removeWidget"):
+        scroll_layout.removeWidget(label)
+
+    parent = getattr(dock, "dockWidgetContents", None)
+    if parent is not None and hasattr(label, "setParent"):
+        label.setParent(parent)
+
+    if hasattr(label, "setMinimumHeight"):
+        label.setMinimumHeight(28)
+    if hasattr(label, "setStyleSheet"):
+        label.setStyleSheet(
+            "QLabel#summaryStatusLabel { "
+            "border-top: 1px solid palette(mid); "
+            "font-style: italic; "
+            "padding: 4px 8px; "
+            "}"
+        )
+
+    outer_layout.addWidget(label)
+    dock._summary_status_footer_pinned = True
+
+
+def _hide_redundant_status_labels(dock) -> None:
+    for name in ("countLabel", "statusLabel"):
+        label = getattr(dock, name, None)
+        if label is not None and hasattr(label, "hide"):
+            label.hide()
+
+
+def _style_legacy_feedback_labels(dock) -> None:
+    for name in (
+        "connectionStatusLabel",
+        "querySummaryLabel",
+        "atlasPdfStatusLabel",
+    ):
+        label = getattr(dock, name, None)
+        if label is None or not hasattr(label, "setStyleSheet"):
+            continue
+        label.setStyleSheet(
+            f"QLabel#{name} {{ "
+            f"color: {COLOR_MUTED}; "
+            "font-style: italic; "
+            "padding: 1px 0; "
+            "}"
+        )
+
+
+def _set_label_text(dock, name: str, text: str) -> None:
+    label = getattr(dock, name, None)
+    if label is not None and hasattr(label, "setText"):
+        label.setText(text)
+
+
+def _set_spinbox_suffix(dock, name: str, suffix: str) -> None:
+    spinbox = getattr(dock, name, None)
+    if spinbox is not None and hasattr(spinbox, "setSuffix"):
+        spinbox.setSuffix(suffix)
+
+
+def _move_clear_database_to_actions_menu(dock) -> None:
+    if hasattr(dock, "databaseActionsButton"):
+        return
+
+    clear_button = getattr(dock, "clearDatabaseButton", None)
+    output_layout = getattr(dock, "outputGroupLayout", None)
+    if clear_button is None or output_layout is None:
+        return
+
+    from qgis.PyQt.QtCore import Qt
+    from qgis.PyQt.QtWidgets import QMenu, QToolButton
+
+    menu = QMenu(getattr(dock, "outputGroupBox", None))
+    if hasattr(menu, "setObjectName"):
+        menu.setObjectName("databaseActionsMenu")
+    clear_action = menu.addAction("Clear database…")
+    clear_action.setToolTip(
+        "Delete qfit's stored activities and derived layers after confirmation."
+    )
+    clear_action.triggered.connect(clear_button.click)
+
+    menu_button = QToolButton(getattr(dock, "outputGroupBox", None))
+    menu_button.setObjectName("databaseActionsButton")
+    menu_button.setText("Database actions")
+    menu_button.setToolTip(
+        "Less common database operations; destructive actions ask for confirmation."
+    )
+    menu_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+    menu_button.setPopupMode(QToolButton.InstantPopup)
+    menu_button.setMenu(menu)
+
+    output_layout.removeWidget(clear_button)
+    clear_button.hide()
+    output_layout.addWidget(menu_button)
+
+    dock.databaseActionsMenu = menu
+    dock.databaseActionsButton = menu_button
+    dock.clearDatabaseAction = clear_action
+
+
+def _move_help_label_to_tooltip(label, *widgets) -> None:
+    if label is None:
+        return
+
+    text = getattr(label, "text", None)
+    if callable(text):
+        text = text()
+    if not text:
+        return
+
+    for widget in widgets:
+        if widget is not None and hasattr(widget, "setToolTip"):
+            widget.setToolTip(text)
+
+    if hasattr(label, "hide"):
+        label.hide()
+
+
+def _move_store_section_under_fetch(dock) -> None:
+    outer_layout = getattr(dock, "verticalLayout", None)
+    activities_layout = getattr(dock, "activitiesGroupLayout", None)
+    if outer_layout is None or activities_layout is None:
+        return
+    if dock.outputGroupBox.parent() is dock.activitiesGroupBox:
+        return
+    outer_layout.removeWidget(dock.outputGroupBox)
+    dock.outputGroupBox.setParent(dock.activitiesGroupBox)
+    activities_layout.addWidget(dock.outputGroupBox)
+
+
+def _move_load_layers_to_visualize(dock) -> None:
+    output_layout = getattr(dock, "outputGroupLayout", None)
+    style_layout = getattr(dock, "styleGroupLayout", None)
+    if output_layout is None or style_layout is None:
+        return
+    if dock.loadLayersButton.parent() is dock.styleGroupBox:
+        return
+    output_layout.removeWidget(dock.loadLayersButton)
+    dock.loadLayersButton.setParent(dock.styleGroupBox)
+    style_layout.insertWidget(0, dock.loadLayersButton)
+
+
+def _move_temporal_controls_to_visualize(dock) -> None:
+    analysis_layout = getattr(dock, "analysisWorkflowLayout", None)
+    style_layout = getattr(dock, "styleGroupLayout", None)
+    temporal_row = getattr(dock, "analysisTemporalModeRow", None)
+    temporal_help = getattr(dock, "temporalHelpLabel", None)
+    if (
+        analysis_layout is None
+        or style_layout is None
+        or temporal_row is None
+        or temporal_help is None
+    ):
+        return
+    if temporal_row.parent() is dock.styleGroupBox:
+        return
+    analysis_layout.removeWidget(temporal_row)
+    analysis_layout.removeWidget(temporal_help)
+    temporal_row.setParent(dock.styleGroupBox)
+    temporal_help.setParent(dock.styleGroupBox)
+    style_layout.addWidget(temporal_row)
+    style_layout.addWidget(temporal_help)
+
+
+__all__ = [
+    "configure_local_first_backing_controls",
+    "configure_local_first_spinbox_unit_copy",
+]

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .application.local_first_backing_controls import (
+    configure_local_first_backing_controls,
+    configure_local_first_spinbox_unit_copy,
+)
+
 
 @dataclass(frozen=True)
 class DockStartupResult:
@@ -9,11 +14,10 @@ class DockStartupResult:
 
 
 class DockStartupCoordinator:
-    """Coordinate top-level dock-widget startup without moving lower-level UI methods."""
+    """Coordinate top-level dock-widget startup without owning page policy."""
 
-    def __init__(self, dock_widget, *, workflow_section_coordinator):
+    def __init__(self, dock_widget):
         self.dock_widget = dock_widget
-        self.workflow_section_coordinator = workflow_section_coordinator
 
     def run(self) -> DockStartupResult:
         dock = self.dock_widget
@@ -28,8 +32,8 @@ class DockStartupCoordinator:
         dock._ensure_wizard_settings()
         performed_steps.append("ensure_wizard_settings")
 
-        self.workflow_section_coordinator.configure_starting_sections()
-        performed_steps.append("configure_starting_sections")
+        configure_local_first_backing_controls(dock)
+        performed_steps.append("configure_local_first_backing_controls")
 
         dock._remove_stale_qfit_layers()
         performed_steps.append("remove_stale_qfit_layers")
@@ -37,8 +41,8 @@ class DockStartupCoordinator:
         dock._apply_contextual_help()
         performed_steps.append("apply_contextual_help")
 
-        self.workflow_section_coordinator.configure_spinbox_unit_copy()
-        performed_steps.append("configure_spinbox_unit_copy")
+        configure_local_first_spinbox_unit_copy(dock)
+        performed_steps.append("configure_local_first_spinbox_unit_copy")
 
         dock._configure_background_preset_options()
         performed_steps.append("configure_background_preset_options")

--- a/ui/workflow_section_coordinator.py
+++ b/ui/workflow_section_coordinator.py
@@ -1,242 +1,27 @@
 from __future__ import annotations
 
-from qgis.PyQt.QtCore import Qt
-
-from qfit.ui.tokens import COLOR_MUTED
-
-from .application.dock_workflow_sections import build_current_dock_workflow_label
+from .application.local_first_backing_controls import (
+    configure_local_first_backing_controls,
+    configure_local_first_spinbox_unit_copy,
+)
 
 
 class WorkflowSectionCoordinator:
-    """Prepare the legacy dock controls that still back local-first pages.
+    """Compatibility shim for the retired workflow-section startup coordinator.
 
-    The live dock now uses the local-first shell, so this coordinator only keeps
-    shared copy, tooltips, and legacy backing controls coherent before audited
-    controls are moved into local-first pages. It intentionally no longer
-    installs the hidden long-scroll collapsible section surface.
+    Production startup now calls the local-first backing-control helpers directly.
+    Keep this wrapper temporarily for older imports while #805 continues to retire
+    the intermediate workflow-section path.
     """
 
     def __init__(self, dock_widget):
         self.dock_widget = dock_widget
 
     def configure_starting_sections(self) -> None:
-        dock = self.dock_widget
-        dock.workflowLabel.setText(build_current_dock_workflow_label())
-        dock.credentialsGroupBox.hide()
-        for group_box in (
-            dock.activitiesGroupBox,
-            dock.styleGroupBox,
-            dock.analysisWorkflowGroupBox,
-            dock.publishGroupBox,
-        ):
-            group_box.setTitle("")
-        dock.activitiesIntroLabel.setText(
-            "Fetch your activities from Strava using the credentials saved in qfit → Configuration. "
-            "Store or clear the local GeoPackage here too. Filters are applied later in the Visualize step — no re-fetch needed."
-        )
-        self._move_store_section_under_fetch()
-        self._move_load_layers_to_visualize()
-        self._move_temporal_controls_to_visualize()
-        self._move_clear_database_to_actions_menu()
-        dock.outputGroupBox.setTitle("Store / database")
-        dock.publishGroupBox.setCheckable(False)
-        dock.publishSettingsWidget.setVisible(True)
-        self._pin_summary_status_footer()
-        self._hide_redundant_status_labels()
-        self._style_legacy_feedback_labels()
-        self._move_help_label_to_tooltip(
-            dock.activitiesIntroLabel,
-            dock.activitiesGroupBox,
-        )
-        self._move_help_label_to_tooltip(dock.outputIntroLabel, dock.outputGroupBox)
-        self._move_help_label_to_tooltip(
-            dock.atlasPdfHelpLabel,
-            dock.atlasPdfGroupBox,
-            dock.generateAtlasPdfButton,
-        )
-        dock.mapboxAccessTokenLabel.hide()
-        dock.mapboxAccessTokenLineEdit.hide()
-
-    def _pin_summary_status_footer(self) -> None:
-        dock = self.dock_widget
-        if getattr(dock, "_summary_status_footer_pinned", False):
-            return
-
-        label = getattr(dock, "summaryStatusLabel", None)
-        outer_layout = getattr(dock, "outerLayout", None)
-        if label is None or outer_layout is None:
-            return
-
-        scroll_layout = getattr(dock, "verticalLayout", None)
-        if scroll_layout is not None and hasattr(scroll_layout, "removeWidget"):
-            scroll_layout.removeWidget(label)
-
-        parent = getattr(dock, "dockWidgetContents", None)
-        if parent is not None and hasattr(label, "setParent"):
-            label.setParent(parent)
-
-        if hasattr(label, "setMinimumHeight"):
-            label.setMinimumHeight(28)
-        if hasattr(label, "setStyleSheet"):
-            label.setStyleSheet(
-                "QLabel#summaryStatusLabel { "
-                "border-top: 1px solid palette(mid); "
-                "font-style: italic; "
-                "padding: 4px 8px; "
-                "}"
-            )
-
-        outer_layout.addWidget(label)
-        dock._summary_status_footer_pinned = True
-
-    def _hide_redundant_status_labels(self) -> None:
-        for name in ("countLabel", "statusLabel"):
-            label = getattr(self.dock_widget, name, None)
-            if label is not None and hasattr(label, "hide"):
-                label.hide()
-
-    def _style_legacy_feedback_labels(self) -> None:
-        for name in (
-            "connectionStatusLabel",
-            "querySummaryLabel",
-            "atlasPdfStatusLabel",
-        ):
-            label = getattr(self.dock_widget, name, None)
-            if label is None or not hasattr(label, "setStyleSheet"):
-                continue
-            label.setStyleSheet(
-                f"QLabel#{name} {{ "
-                f"color: {COLOR_MUTED}; "
-                "font-style: italic; "
-                "padding: 1px 0; "
-                "}"
-            )
+        configure_local_first_backing_controls(self.dock_widget)
 
     def configure_spinbox_unit_copy(self) -> None:
-        """Keep units in spin boxes instead of repeating them in form labels."""
+        configure_local_first_spinbox_unit_copy(self.dock_widget)
 
-        for label_name, label_text, spinbox_name, suffix in (
-            ("perPageLabel", "Page size", "perPageSpinBox", " activities"),
-            ("maxPagesLabel", "Pages to fetch", "maxPagesSpinBox", " pages"),
-            (
-                "maxDetailedActivitiesLabel",
-                "Max new detailed routes this run",
-                "maxDetailedActivitiesSpinBox",
-                " routes",
-            ),
-            (
-                "pointSamplingStrideLabel",
-                "Keep every Nth point",
-                "pointSamplingStrideSpinBox",
-                " points",
-            ),
-        ):
-            self._set_label_text(label_name, label_text)
-            self._set_spinbox_suffix(spinbox_name, suffix)
 
-    def _set_label_text(self, name: str, text: str) -> None:
-        label = getattr(self.dock_widget, name, None)
-        if label is not None and hasattr(label, "setText"):
-            label.setText(text)
-
-    def _set_spinbox_suffix(self, name: str, suffix: str) -> None:
-        spinbox = getattr(self.dock_widget, name, None)
-        if spinbox is not None and hasattr(spinbox, "setSuffix"):
-            spinbox.setSuffix(suffix)
-
-    def _move_clear_database_to_actions_menu(self) -> None:
-        dock = self.dock_widget
-        if hasattr(dock, "databaseActionsButton"):
-            return
-
-        clear_button = getattr(dock, "clearDatabaseButton", None)
-        output_layout = getattr(dock, "outputGroupLayout", None)
-        if clear_button is None or output_layout is None:
-            return
-
-        from qgis.PyQt.QtWidgets import QMenu, QToolButton
-
-        menu = QMenu(getattr(dock, "outputGroupBox", None))
-        if hasattr(menu, "setObjectName"):
-            menu.setObjectName("databaseActionsMenu")
-        clear_action = menu.addAction("Clear database…")
-        clear_action.setToolTip(
-            "Delete qfit's stored activities and derived layers after confirmation."
-        )
-        clear_action.triggered.connect(clear_button.click)
-
-        menu_button = QToolButton(getattr(dock, "outputGroupBox", None))
-        menu_button.setObjectName("databaseActionsButton")
-        menu_button.setText("Database actions")
-        menu_button.setToolTip(
-            "Less common database operations; destructive actions ask for confirmation."
-        )
-        menu_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        menu_button.setPopupMode(QToolButton.InstantPopup)
-        menu_button.setMenu(menu)
-
-        output_layout.removeWidget(clear_button)
-        clear_button.hide()
-        output_layout.addWidget(menu_button)
-
-        dock.databaseActionsMenu = menu
-        dock.databaseActionsButton = menu_button
-        dock.clearDatabaseAction = clear_action
-
-    def _move_help_label_to_tooltip(self, label, *widgets) -> None:
-        if label is None:
-            return
-
-        text = getattr(label, "text", None)
-        if callable(text):
-            text = text()
-        if not text:
-            return
-
-        for widget in widgets:
-            if widget is not None and hasattr(widget, "setToolTip"):
-                widget.setToolTip(text)
-
-        if hasattr(label, "hide"):
-            label.hide()
-
-    def _move_store_section_under_fetch(self) -> None:
-        dock = self.dock_widget
-        outer_layout = getattr(dock, "verticalLayout", None)
-        activities_layout = getattr(dock, "activitiesGroupLayout", None)
-        if outer_layout is None or activities_layout is None:
-            return
-        if dock.outputGroupBox.parent() is dock.activitiesGroupBox:
-            return
-        outer_layout.removeWidget(dock.outputGroupBox)
-        dock.outputGroupBox.setParent(dock.activitiesGroupBox)
-        activities_layout.addWidget(dock.outputGroupBox)
-
-    def _move_load_layers_to_visualize(self) -> None:
-        dock = self.dock_widget
-        output_layout = getattr(dock, "outputGroupLayout", None)
-        style_layout = getattr(dock, "styleGroupLayout", None)
-        if output_layout is None or style_layout is None:
-            return
-        if dock.loadLayersButton.parent() is dock.styleGroupBox:
-            return
-        output_layout.removeWidget(dock.loadLayersButton)
-        dock.loadLayersButton.setParent(dock.styleGroupBox)
-        style_layout.insertWidget(0, dock.loadLayersButton)
-
-    def _move_temporal_controls_to_visualize(self) -> None:
-        dock = self.dock_widget
-        analysis_layout = getattr(dock, "analysisWorkflowLayout", None)
-        style_layout = getattr(dock, "styleGroupLayout", None)
-        temporal_row = getattr(dock, "analysisTemporalModeRow", None)
-        temporal_help = getattr(dock, "temporalHelpLabel", None)
-        if analysis_layout is None or style_layout is None or temporal_row is None or temporal_help is None:
-            return
-        if temporal_row.parent() is dock.styleGroupBox:
-            return
-        analysis_layout.removeWidget(temporal_row)
-        analysis_layout.removeWidget(temporal_help)
-        temporal_row.setParent(dock.styleGroupBox)
-        temporal_help.setParent(dock.styleGroupBox)
-        style_layout.addWidget(temporal_row)
-        style_layout.addWidget(temporal_help)
+__all__ = ["WorkflowSectionCoordinator"]


### PR DESCRIPTION
## Summary

Moves the remaining production startup preparation for local-first backing controls out of the intermediate `WorkflowSectionCoordinator` path and into explicit local-first application helpers.

## Changes

- Adds `ui.application.local_first_backing_controls` for local-first backing-control startup setup and spinbox copy.
- Updates `QfitDockWidget` / `DockStartupCoordinator` to call those helpers directly without constructing a workflow-section coordinator.
- Leaves `WorkflowSectionCoordinator` as a temporary compatibility shim only.
- Updates focused unit/smoke tests to cover the new production seam and shim delegation.

## Testing

- `python3 -m pytest tests/test_dockwidget_dependencies.py tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_delegates_startup_to_coordinator -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
