### PR TITLE
Refactor local-first analysis mode binding

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -84,6 +84,7 @@ from .ui.application import (
     DockVisualWorkflowRequest,
     LocalFirstControlVisibilityUpdate,
     apply_local_first_visibility_update,
+    bind_local_first_analysis_mode_controls,
     RunAnalysisAction,
     build_advanced_fetch_visibility_update,
     build_detailed_fetch_visibility_update,
@@ -92,6 +93,7 @@ from .ui.application import (
     build_point_sampling_visibility_update,
     build_visual_layer_refs,
     build_wizard_filter_description,
+    set_local_first_analysis_mode,
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     install_local_first_audited_controls,
@@ -441,13 +443,15 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 apply_map_filters=self.on_apply_filters_clicked,
                 run_analysis=self.on_run_analysis_clicked,
                 clear_analysis=self.on_clear_analysis_clicked,
-                set_analysis_mode=self._set_wizard_analysis_mode,
+                set_analysis_mode=self._set_local_first_analysis_mode,
                 export_atlas=self.on_generate_atlas_pdf_clicked,
                 update_atlas_document_settings=self._update_atlas_document_settings,
             ),
         )
         install_local_first_audited_controls(self, self._local_first_dock_composition)
-        self._bind_wizard_analysis_mode_controls(self._local_first_dock_composition)
+        self._bind_local_first_analysis_mode_controls(
+            self._local_first_dock_composition
+        )
         return self._local_first_dock_composition
 
     def _update_atlas_document_settings(self, atlas_title: str, atlas_subtitle: str) -> None:
@@ -504,33 +508,15 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if legacy_export_button is not None and hasattr(legacy_export_button, "hide"):
             legacy_export_button.hide()
 
-    def _bind_wizard_analysis_mode_controls(self, composition) -> None:
-        """Expose the hidden backing analysis selector in the live wizard path."""
+    def _bind_local_first_analysis_mode_controls(self, composition) -> None:
+        """Delegate local-first analysis selector binding to application policy."""
 
-        analysis_content = getattr(composition, "analysis_content", None)
-        mode_combo = getattr(self, "analysisModeComboBox", None)
-        if analysis_content is None or mode_combo is None:
-            return
-        options = tuple(
-            mode_combo.itemText(index)
-            for index in range(mode_combo.count())
-            if mode_combo.itemText(index) != "None"
-        )
-        if not options:
-            return
-        selected_mode = mode_combo.currentText()
-        if selected_mode == "None" or selected_mode not in options:
-            selected_mode = options[0]
-        analysis_content.set_analysis_mode_options(options, selected=selected_mode)
-        self._set_wizard_analysis_mode(selected_mode)
+        bind_local_first_analysis_mode_controls(self, composition)
 
-    def _set_wizard_analysis_mode(self, mode: str) -> None:
-        """Mirror the wizard analysis mode selector into the backing dock combo."""
+    def _set_local_first_analysis_mode(self, mode: str) -> None:
+        """Mirror the local-first analysis mode selector into dock backing state."""
 
-        mode_combo = getattr(self, "analysisModeComboBox", None)
-        if mode_combo is None or not mode:
-            return
-        mode_combo.setCurrentText(mode)
+        set_local_first_analysis_mode(self, mode)
 
     def _install_live_local_first_dock(self) -> None:
         """Make the #748 local-first navigation shell the visible dock path."""

--- a/tests/test_local_first_analysis_controls.py
+++ b/tests/test_local_first_analysis_controls.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from tests import _path  # noqa: F401
 
 from qfit.ui.application.local_first_analysis_controls import (
+    NONE_ANALYSIS_MODE_LABEL,
     bind_local_first_analysis_mode_controls,
     local_first_analysis_mode_options,
     set_local_first_analysis_mode,
@@ -90,14 +91,28 @@ class LocalFirstAnalysisControlsTests(unittest.TestCase):
         self.assertEqual(combo.currentText(), "Most frequent starting points")
 
     def test_bind_skips_missing_analysis_content(self):
-        combo = FakeComboBox(current_text="None")
-        combo.addItem("None")
+        combo = FakeComboBox(current_text=NONE_ANALYSIS_MODE_LABEL)
+        combo.addItem(NONE_ANALYSIS_MODE_LABEL)
         combo.addItem("Heatmap")
         dock = SimpleNamespace(analysisModeComboBox=combo)
 
         bind_local_first_analysis_mode_controls(dock, SimpleNamespace())
 
-        self.assertEqual(combo.currentText(), "None")
+        self.assertEqual(combo.currentText(), NONE_ANALYSIS_MODE_LABEL)
+
+    def test_bind_skips_empty_user_facing_mode_options(self):
+        combo = FakeComboBox(current_text=NONE_ANALYSIS_MODE_LABEL)
+        combo.addItem(NONE_ANALYSIS_MODE_LABEL)
+        dock = SimpleNamespace(analysisModeComboBox=combo)
+        analysis_content = SimpleNamespace(set_analysis_mode_options=MagicMock())
+
+        bind_local_first_analysis_mode_controls(
+            dock,
+            SimpleNamespace(analysis_content=analysis_content),
+        )
+
+        analysis_content.set_analysis_mode_options.assert_not_called()
+        self.assertEqual(combo.currentText(), NONE_ANALYSIS_MODE_LABEL)
 
 
 if __name__ == "__main__":

--- a/tests/test_local_first_analysis_controls.py
+++ b/tests/test_local_first_analysis_controls.py
@@ -1,0 +1,104 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.local_first_analysis_controls import (
+    bind_local_first_analysis_mode_controls,
+    local_first_analysis_mode_options,
+    set_local_first_analysis_mode,
+)
+
+
+class FakeComboBox:
+    def __init__(self, current_text=""):
+        self.items = []
+        self.current_text = current_text
+
+    def addItem(self, item):
+        self.items.append(item)
+        if not self.current_text:
+            self.current_text = item
+
+    def count(self):
+        return len(self.items)
+
+    def itemText(self, index):
+        return self.items[index]
+
+    def currentText(self):
+        return self.current_text
+
+    def setCurrentText(self, text):
+        self.current_text = text
+
+
+class LocalFirstAnalysisControlsTests(unittest.TestCase):
+    def test_mode_options_exclude_legacy_none_sentinel(self):
+        combo = FakeComboBox()
+        for mode in ("None", "Heatmap", "Most frequent starting points"):
+            combo.addItem(mode)
+
+        self.assertEqual(
+            local_first_analysis_mode_options(combo),
+            ("Heatmap", "Most frequent starting points"),
+        )
+
+    def test_bind_exposes_user_facing_modes_and_selects_first_real_mode(self):
+        combo = FakeComboBox(current_text="None")
+        for mode in ("None", "Heatmap", "Most frequent starting points"):
+            combo.addItem(mode)
+        dock = SimpleNamespace(analysisModeComboBox=combo)
+        analysis_content = SimpleNamespace(set_analysis_mode_options=MagicMock())
+
+        bind_local_first_analysis_mode_controls(
+            dock,
+            SimpleNamespace(analysis_content=analysis_content),
+        )
+
+        analysis_content.set_analysis_mode_options.assert_called_once_with(
+            ("Heatmap", "Most frequent starting points"),
+            selected="Heatmap",
+        )
+        self.assertEqual(combo.currentText(), "Heatmap")
+
+    def test_bind_preserves_supported_current_mode(self):
+        combo = FakeComboBox(current_text="Most frequent starting points")
+        for mode in ("None", "Heatmap", "Most frequent starting points"):
+            combo.addItem(mode)
+        dock = SimpleNamespace(analysisModeComboBox=combo)
+        analysis_content = SimpleNamespace(set_analysis_mode_options=MagicMock())
+
+        bind_local_first_analysis_mode_controls(
+            dock,
+            SimpleNamespace(analysis_content=analysis_content),
+        )
+
+        analysis_content.set_analysis_mode_options.assert_called_once_with(
+            ("Heatmap", "Most frequent starting points"),
+            selected="Most frequent starting points",
+        )
+        self.assertEqual(combo.currentText(), "Most frequent starting points")
+
+    def test_set_local_first_analysis_mode_updates_backing_combo(self):
+        combo = FakeComboBox(current_text="None")
+        dock = SimpleNamespace(analysisModeComboBox=combo)
+
+        set_local_first_analysis_mode(dock, "Most frequent starting points")
+
+        self.assertEqual(combo.currentText(), "Most frequent starting points")
+
+    def test_bind_skips_missing_analysis_content(self):
+        combo = FakeComboBox(current_text="None")
+        combo.addItem("None")
+        combo.addItem("Heatmap")
+        dock = SimpleNamespace(analysisModeComboBox=combo)
+
+        bind_local_first_analysis_mode_controls(dock, SimpleNamespace())
+
+        self.assertEqual(combo.currentText(), "None")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -719,7 +719,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._atlas_export_completed = False
         dock.settings = _FakeSettings()
-        dock._bind_wizard_analysis_mode_controls = MagicMock()
+        dock._bind_local_first_analysis_mode_controls = MagicMock()
         parent = object()
 
         class FakeWizardActionCallbacks(SimpleNamespace):
@@ -778,7 +778,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "apply_map_filters": "on_apply_filters_clicked",
             "run_analysis": "on_run_analysis_clicked",
             "clear_analysis": "on_clear_analysis_clicked",
-            "set_analysis_mode": "_set_wizard_analysis_mode",
+            "set_analysis_mode": "_set_local_first_analysis_mode",
             "export_atlas": "on_generate_atlas_pdf_clicked",
             "update_atlas_document_settings": "_update_atlas_document_settings",
         }
@@ -793,7 +793,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             dock,
             "connected-composition"
         )
-        dock._bind_wizard_analysis_mode_controls.assert_called_once_with(
+        dock._bind_local_first_analysis_mode_controls.assert_called_once_with(
             "connected-composition"
         )
 
@@ -1200,38 +1200,38 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             getattr(dock, "_local_first_activity_style_controls_installed", False)
         )
 
-    def test_bind_wizard_analysis_mode_controls_exposes_non_none_modes(self):
+    def test_bind_local_first_analysis_mode_controls_delegates_to_application_policy(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock.analysisModeComboBox = _FakeComboBox()
-        for mode in ("None", "Heatmap", "Most frequent starting points"):
-            dock.analysisModeComboBox.addItem(mode)
-        dock.analysisModeComboBox.setCurrentText("None")
-        analysis_content = SimpleNamespace(set_analysis_mode_options=MagicMock())
+        composition = object()
 
-        self.module.QfitDockWidget._bind_wizard_analysis_mode_controls(
+        with patch.object(
+            self.module,
+            "bind_local_first_analysis_mode_controls",
+        ) as bind_local_first_analysis_mode_controls:
+            self.module.QfitDockWidget._bind_local_first_analysis_mode_controls(
+                dock,
+                composition,
+            )
+
+        bind_local_first_analysis_mode_controls.assert_called_once_with(
             dock,
-            SimpleNamespace(analysis_content=analysis_content),
+            composition,
         )
 
-        analysis_content.set_analysis_mode_options.assert_called_once_with(
-            ("Heatmap", "Most frequent starting points"),
-            selected="Heatmap",
-        )
-        self.assertEqual(dock.analysisModeComboBox.currentText(), "Heatmap")
-
-    def test_set_wizard_analysis_mode_updates_backing_combo(self):
+    def test_set_local_first_analysis_mode_delegates_to_application_policy(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock.analysisModeComboBox = _FakeComboBox()
-        for mode in ("None", "Heatmap", "Most frequent starting points"):
-            dock.analysisModeComboBox.addItem(mode)
 
-        self.module.QfitDockWidget._set_wizard_analysis_mode(
+        with patch.object(
+            self.module,
+            "set_local_first_analysis_mode",
+        ) as set_local_first_analysis_mode:
+            self.module.QfitDockWidget._set_local_first_analysis_mode(
+                dock,
+                "Most frequent starting points",
+            )
+
+        set_local_first_analysis_mode.assert_called_once_with(
             dock,
-            "Most frequent starting points",
-        )
-
-        self.assertEqual(
-            dock.analysisModeComboBox.currentText(),
             "Most frequent starting points",
         )
 

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -35,6 +35,12 @@ from .local_first_navigation import (
     build_local_first_dock_navigation_state,
     local_first_dock_page_keys,
 )
+from .local_first_analysis_controls import (
+    NONE_ANALYSIS_MODE_LABEL,
+    bind_local_first_analysis_mode_controls,
+    local_first_analysis_mode_options,
+    set_local_first_analysis_mode,
+)
 from .local_first_control_moves import (
     LOCAL_FIRST_CONTROL_MOVES,
     LOCAL_FIRST_WIDGET_MOVES,
@@ -165,6 +171,7 @@ __all__ = [
     "LOCAL_FIRST_CONTROL_MOVES",
     "LOCAL_FIRST_DOCK_PAGE_DEFINITIONS",
     "LOCAL_FIRST_WIDGET_MOVES",
+    "NONE_ANALYSIS_MODE_LABEL",
     "ADVANCED_FETCH_VISIBILITY_WIDGETS",
     "DETAILED_FETCH_VISIBILITY_WIDGETS",
     "MAPBOX_CUSTOM_STYLE_VISIBILITY_WIDGETS",
@@ -193,6 +200,7 @@ __all__ = [
     "WizardSettingsSnapshot",
     "build_advanced_fetch_visibility_update",
     "apply_local_first_visibility_update",
+    "bind_local_first_analysis_mode_controls",
     "build_current_dock_workflow_label",
     "build_detailed_fetch_visibility_update",
     "build_dock_summary_status",
@@ -226,6 +234,7 @@ __all__ = [
     "install_local_first_widget_move",
     "install_local_first_widget_controls",
     "load_wizard_settings",
+    "local_first_analysis_mode_options",
     "local_first_control_move_layout",
     "local_first_control_move_parent_panel",
     "local_first_control_move_for_key",
@@ -241,6 +250,7 @@ __all__ = [
     "remove_widget_from_current_layout",
     "save_collapsed_groups",
     "save_last_step_index",
+    "set_local_first_analysis_mode",
     "show_local_first_control_group",
     "show_widget",
     "step_index_for_key",

--- a/ui/application/local_first_analysis_controls.py
+++ b/ui/application/local_first_analysis_controls.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+
+NONE_ANALYSIS_MODE_LABEL = "None"
+
+
+def bind_local_first_analysis_mode_controls(dock, composition) -> None:
+    """Bind the local-first analysis page mode selector to dock state.
+
+    The visible local-first analysis page owns mode selection, while the legacy
+    combo remains the settings/workflow backing control during the dock
+    consolidation. Keep that bridge in application code instead of embedding the
+    binding policy in QfitDockWidget.
+    """
+
+    analysis_content = getattr(composition, "analysis_content", None)
+    mode_combo = getattr(dock, "analysisModeComboBox", None)
+    set_options = getattr(analysis_content, "set_analysis_mode_options", None)
+    if mode_combo is None or not callable(set_options):
+        return
+
+    options = local_first_analysis_mode_options(mode_combo)
+    if not options:
+        return
+
+    selected_mode = mode_combo.currentText()
+    if selected_mode == NONE_ANALYSIS_MODE_LABEL or selected_mode not in options:
+        selected_mode = options[0]
+
+    set_options(options, selected=selected_mode)
+    set_local_first_analysis_mode(dock, selected_mode)
+
+
+def local_first_analysis_mode_options(mode_combo) -> tuple[str, ...]:
+    """Return user-facing analysis modes from the backing combo box."""
+
+    return tuple(
+        mode
+        for mode in (mode_combo.itemText(index) for index in range(mode_combo.count()))
+        if mode != NONE_ANALYSIS_MODE_LABEL
+    )
+
+
+def set_local_first_analysis_mode(dock, mode: str) -> None:
+    """Mirror the local-first analysis selection into the backing dock combo."""
+
+    mode_combo = getattr(dock, "analysisModeComboBox", None)
+    if mode_combo is None or not mode:
+        return
+    mode_combo.setCurrentText(mode)
+
+
+__all__ = [
+    "NONE_ANALYSIS_MODE_LABEL",
+    "bind_local_first_analysis_mode_controls",
+    "local_first_analysis_mode_options",
+    "set_local_first_analysis_mode",
+]


### PR DESCRIPTION
## Summary

- Move local-first analysis mode binding policy out of `QfitDockWidget` and into `ui/application/local_first_analysis_controls.py`.
- Keep `QfitDockWidget` as a thin delegate for the visible analysis page selector and backing combo synchronization.
- Add focused pure tests for the local-first analysis binding helper and update dock-widget delegation tests.

Refs #805

## Testing

- `python3 -m pytest tests/test_local_first_analysis_controls.py tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_build_local_first_dock_from_runtime_wires_independent_callbacks tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_bind_local_first_analysis_mode_controls_delegates_to_application_policy tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_set_local_first_analysis_mode_delegates_to_application_policy -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
