### PR TITLE
refactor: move analysis backing setup out of dock

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -17,13 +17,7 @@ from qgis.PyQt.QtWidgets import (
     QFileDialog,
     QDockWidget,
     QGridLayout,
-    QHBoxLayout,
-    QLabel,
     QMessageBox,
-    QPushButton,
-    QToolButton,
-    QVBoxLayout,
-    QWidget,
 )
 
 from .activities.domain.activity_query import (
@@ -844,37 +838,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         temporal_row = getattr(self, "analysisTemporalModeRow", None)
         if temporal_row is not None:
             temporal_row.hide()
-
-    def _configure_analysis_mode_options(self):
-        content_widget = self.analysisWorkflowGroupBox
-        content_layout = content_widget.layout()
-
-        row = QWidget(content_widget)
-        row.setObjectName("analysisModeRow")
-        layout = QHBoxLayout(row)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(6)
-
-        label = QLabel("Analysis", row)
-        label.setObjectName("analysisModeLabel")
-        layout.addWidget(label)
-
-        combo = QComboBox(row)
-        combo.setObjectName("analysisModeComboBox")
-        combo.addItem("None")
-        combo.addItem("Most frequent starting points")
-        combo.addItem("Heatmap")
-        layout.addWidget(combo)
-
-        button = QPushButton("Run analysis", row)
-        button.setObjectName("runAnalysisButton")
-        layout.addWidget(button)
-        layout.addStretch(1)
-
-        content_layout.insertWidget(0, row)
-        self.analysisModeLabel = label
-        self.analysisModeComboBox = combo
-        self.runAnalysisButton = button
 
     def _bind_dependencies(self, dependencies: DockWidgetDependencies) -> None:
         self.settings = dependencies.settings

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -533,6 +533,10 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 "qfit.ui.dock_startup_coordinator."
                 "configure_local_first_spinbox_unit_copy"
             ) as configure_local_first_spinbox_unit_copy,
+            patch(
+                "qfit.ui.dock_startup_coordinator."
+                "configure_local_first_analysis_mode_backing_controls"
+            ) as configure_local_first_analysis_mode_backing_controls,
         ):
             coordinator = DockStartupCoordinator(dock)
             result = coordinator.run()
@@ -576,7 +580,6 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 call._configure_detailed_route_strategy_options(),
                 call._configure_preview_sort_options(),
                 call._configure_temporal_mode_options(),
-                call._configure_analysis_mode_options(),
                 call._load_settings(),
                 call._set_default_dates(),
                 call._wire_events(),
@@ -587,3 +590,6 @@ class DockStartupCoordinatorTests(unittest.TestCase):
         )
         configure_local_first_backing_controls.assert_called_once_with(dock)
         configure_local_first_spinbox_unit_copy.assert_called_once_with(dock)
+        configure_local_first_analysis_mode_backing_controls.assert_called_once_with(
+            dock
+        )

--- a/tests/test_local_first_analysis_controls.py
+++ b/tests/test_local_first_analysis_controls.py
@@ -1,12 +1,15 @@
 import unittest
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
 from tests import _path  # noqa: F401
 
 from qfit.ui.application.local_first_analysis_controls import (
+    ANALYSIS_MODE_LABELS,
     NONE_ANALYSIS_MODE_LABEL,
     bind_local_first_analysis_mode_controls,
+    configure_local_first_analysis_mode_backing_controls,
     local_first_analysis_mode_options,
     set_local_first_analysis_mode,
 )
@@ -35,7 +38,120 @@ class FakeComboBox:
         self.current_text = text
 
 
+class FakeLayout:
+    def __init__(self):
+        self.inserted = []
+        self.children = []
+        self.contents_margins = None
+        self.spacing = None
+
+    def insertWidget(self, index, widget):
+        self.inserted.append((index, widget))
+
+    def addWidget(self, widget):
+        self.children.append(widget)
+
+    def addStretch(self, stretch):
+        self.children.append(("stretch", stretch))
+
+    def setContentsMargins(self, *margins):
+        self.contents_margins = margins
+
+    def setSpacing(self, spacing):
+        self.spacing = spacing
+
+
+class FakeWidget:
+    def __init__(self, parent=None):
+        self._parent = parent
+        self._object_name = None
+        self._layout = None
+
+    def setObjectName(self, name):
+        self._object_name = name
+
+    def objectName(self):
+        return self._object_name
+
+    def parentWidget(self):
+        return self._parent
+
+    def setLayout(self, layout):
+        self._layout = layout
+
+    def layout(self):
+        return self._layout
+
+
+class FakeHBoxLayout(FakeLayout):
+    def __init__(self, widget):
+        super().__init__()
+        widget.setLayout(self)
+
+
+class FakeLabel(FakeWidget):
+    def __init__(self, text, parent=None):
+        super().__init__(parent)
+        self._text = text
+
+    def text(self):
+        return self._text
+
+
+class FakeQtComboBox(FakeWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.items = []
+
+    def addItem(self, item):
+        self.items.append(item)
+
+
+class FakeButton(FakeWidget):
+    def __init__(self, text, parent=None):
+        super().__init__(parent)
+        self._text = text
+
+    def text(self):
+        return self._text
+
+
+def install_fake_qtwidgets():
+    qgis = ModuleType("qgis")
+    pyqt = ModuleType("qgis.PyQt")
+    qtwidgets = ModuleType("qgis.PyQt.QtWidgets")
+    qtwidgets.QWidget = FakeWidget
+    qtwidgets.QHBoxLayout = FakeHBoxLayout
+    qtwidgets.QLabel = FakeLabel
+    qtwidgets.QComboBox = FakeQtComboBox
+    qtwidgets.QPushButton = FakeButton
+    qgis.PyQt = pyqt
+    pyqt.QtWidgets = qtwidgets
+    return {
+        "qgis": qgis,
+        "qgis.PyQt": pyqt,
+        "qgis.PyQt.QtWidgets": qtwidgets,
+    }
+
+
 class LocalFirstAnalysisControlsTests(unittest.TestCase):
+    def test_configure_analysis_mode_backing_controls_inserts_hidden_row(self):
+        content_layout = FakeLayout()
+        dock = SimpleNamespace(analysisWorkflowGroupBox=FakeWidget())
+        dock.analysisWorkflowGroupBox.setLayout(content_layout)
+
+        with unittest.mock.patch.dict(sys.modules, install_fake_qtwidgets()):
+            configure_local_first_analysis_mode_backing_controls(dock)
+
+        self.assertEqual(len(content_layout.inserted), 1)
+        index, row = content_layout.inserted[0]
+        self.assertEqual(index, 0)
+        self.assertEqual(row.objectName(), "analysisModeRow")
+        self.assertIs(row.parentWidget(), dock.analysisWorkflowGroupBox)
+        self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
+        self.assertEqual(dock.analysisModeComboBox.items, list(ANALYSIS_MODE_LABELS))
+        self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
+
     def test_mode_options_exclude_legacy_none_sentinel(self):
         combo = FakeComboBox()
         for mode in ("None", "Heatmap", "Most frequent starting points"):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -343,35 +343,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             sys.modules.pop("qfit.qfit_dockwidget", None)
             return importlib.import_module("qfit.qfit_dockwidget")
 
-    def test_configure_analysis_mode_options_inserts_row_into_analysis_group(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        content_layout = _FakeLayout()
-        dock.analysisWorkflowGroupBox = _FakeWidget()
-        dock.analysisWorkflowGroupBox.setLayout(content_layout)
-        dock.analysisWorkflowLayout = _FakeLayout()
-
-        with patch.multiple(
-            self.module,
-            QWidget=_FakeWidget,
-            QHBoxLayout=_FakeHBoxLayout,
-            QLabel=_FakeLabel,
-            QComboBox=_FakeComboBox,
-            QPushButton=_FakeButton,
-        ):
-            self.module.QfitDockWidget._configure_analysis_mode_options(dock)
-
-        self.assertEqual(len(content_layout.inserted), 1)
-        index, row = content_layout.inserted[0]
-        self.assertEqual(index, 0)
-        self.assertEqual(row.objectName(), "analysisModeRow")
-        self.assertIs(row.parentWidget(), dock.analysisWorkflowGroupBox)
-        self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
-        self.assertEqual(
-            dock.analysisModeComboBox.items,
-            ["None", "Most frequent starting points", "Heatmap"],
-        )
-        self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
-
     def test_set_default_dates_uses_current_date_window(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.dateFromEdit = MagicMock()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -36,8 +36,10 @@ from .local_first_navigation import (
     local_first_dock_page_keys,
 )
 from .local_first_analysis_controls import (
+    ANALYSIS_MODE_LABELS,
     NONE_ANALYSIS_MODE_LABEL,
     bind_local_first_analysis_mode_controls,
+    configure_local_first_analysis_mode_backing_controls,
     local_first_analysis_mode_options,
     set_local_first_analysis_mode,
 )
@@ -173,6 +175,7 @@ __all__ = [
     "LOCAL_FIRST_WIDGET_MOVES",
     "NONE_ANALYSIS_MODE_LABEL",
     "ADVANCED_FETCH_VISIBILITY_WIDGETS",
+    "ANALYSIS_MODE_LABELS",
     "DETAILED_FETCH_VISIBILITY_WIDGETS",
     "MAPBOX_CUSTOM_STYLE_VISIBILITY_WIDGETS",
     "POINT_SAMPLING_VISIBILITY_WIDGETS",
@@ -201,6 +204,7 @@ __all__ = [
     "build_advanced_fetch_visibility_update",
     "apply_local_first_visibility_update",
     "bind_local_first_analysis_mode_controls",
+    "configure_local_first_analysis_mode_backing_controls",
     "build_current_dock_workflow_label",
     "build_detailed_fetch_visibility_update",
     "build_dock_summary_status",

--- a/ui/application/local_first_analysis_controls.py
+++ b/ui/application/local_first_analysis_controls.py
@@ -2,6 +2,58 @@ from __future__ import annotations
 
 
 NONE_ANALYSIS_MODE_LABEL = "None"
+ANALYSIS_MODE_LABELS = (
+    NONE_ANALYSIS_MODE_LABEL,
+    "Most frequent starting points",
+    "Heatmap",
+)
+
+
+def configure_local_first_analysis_mode_backing_controls(dock) -> None:
+    """Install the analysis-mode backing controls used by local-first pages.
+
+    The visible local-first analysis page owns the user-facing selector, but the
+    dock still keeps a hidden combo/button row as the persistence and workflow
+    bridge during consolidation. Keep that bridge setup with the rest of the
+    local-first analysis control policy instead of growing QfitDockWidget.
+    """
+
+    from qgis.PyQt.QtWidgets import (
+        QComboBox,
+        QHBoxLayout,
+        QLabel,
+        QPushButton,
+        QWidget,
+    )
+
+    content_widget = dock.analysisWorkflowGroupBox
+    content_layout = content_widget.layout()
+
+    row = QWidget(content_widget)
+    row.setObjectName("analysisModeRow")
+    layout = QHBoxLayout(row)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(6)
+
+    label = QLabel("Analysis", row)
+    label.setObjectName("analysisModeLabel")
+    layout.addWidget(label)
+
+    combo = QComboBox(row)
+    combo.setObjectName("analysisModeComboBox")
+    for mode_label in ANALYSIS_MODE_LABELS:
+        combo.addItem(mode_label)
+    layout.addWidget(combo)
+
+    button = QPushButton("Run analysis", row)
+    button.setObjectName("runAnalysisButton")
+    layout.addWidget(button)
+    layout.addStretch(1)
+
+    content_layout.insertWidget(0, row)
+    dock.analysisModeLabel = label
+    dock.analysisModeComboBox = combo
+    dock.runAnalysisButton = button
 
 
 def bind_local_first_analysis_mode_controls(dock, composition) -> None:
@@ -51,8 +103,10 @@ def set_local_first_analysis_mode(dock, mode: str) -> None:
 
 
 __all__ = [
+    "ANALYSIS_MODE_LABELS",
     "NONE_ANALYSIS_MODE_LABEL",
     "bind_local_first_analysis_mode_controls",
+    "configure_local_first_analysis_mode_backing_controls",
     "local_first_analysis_mode_options",
     "set_local_first_analysis_mode",
 ]

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -6,6 +6,9 @@ from .application.local_first_backing_controls import (
     configure_local_first_backing_controls,
     configure_local_first_spinbox_unit_copy,
 )
+from .application.local_first_analysis_controls import (
+    configure_local_first_analysis_mode_backing_controls,
+)
 
 
 @dataclass(frozen=True)
@@ -59,7 +62,7 @@ class DockStartupCoordinator:
         dock._configure_temporal_mode_options()
         performed_steps.append("configure_temporal_mode_options")
 
-        dock._configure_analysis_mode_options()
+        configure_local_first_analysis_mode_backing_controls(dock)
         performed_steps.append("configure_analysis_mode_options")
 
         dock._load_settings()


### PR DESCRIPTION
## Summary

Moves local-first analysis-mode backing-control setup out of `QfitDockWidget` and into the existing local-first analysis application helper, so startup orchestration no longer depends on a dock-private method for that bridge.

## Changes

- Added `configure_local_first_analysis_mode_backing_controls` beside the analysis-mode binding policy.
- Updated `DockStartupCoordinator` to call the application helper directly.
- Removed the dock-private `_configure_analysis_mode_options` method and moved its coverage to local-first analysis-control tests.

## Testing

- `python3 -m pytest tests/test_local_first_analysis_controls.py tests/test_dockwidget_dependencies.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
