### PR TITLE
Refactor local-first atlas settings policy

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -88,6 +88,7 @@ from .ui.application import (
     build_visual_layer_refs,
     build_wizard_filter_description,
     set_local_first_analysis_mode,
+    update_local_first_atlas_document_settings,
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     install_local_first_audited_controls,
@@ -449,22 +450,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         return self._local_first_dock_composition
 
     def _update_atlas_document_settings(self, atlas_title: str, atlas_subtitle: str) -> None:
-        """Mirror visible atlas-page title fields into the export settings widgets."""
+        """Delegate local-first atlas document mirroring to application policy."""
 
-        title_line_edit = getattr(self, "atlasTitleLineEdit", None)
-        subtitle_line_edit = getattr(self, "atlasSubtitleLineEdit", None)
-        title_changed = title_line_edit is not None and title_line_edit.text() != atlas_title
-        subtitle_changed = (
-            subtitle_line_edit is not None
-            and subtitle_line_edit.text() != atlas_subtitle
-        )
-        if title_line_edit is not None:
-            title_line_edit.setText(atlas_title)
-        if subtitle_line_edit is not None:
-            subtitle_line_edit.setText(atlas_subtitle)
-        if title_changed or subtitle_changed:
-            self._mark_atlas_export_stale()
-            self._refresh_summary_status()
+        update_local_first_atlas_document_settings(self, atlas_title, atlas_subtitle)
 
     def _refresh_conditional_control_visibility(self) -> None:
         """Refresh production local-first backing controls from their live state."""

--- a/tests/test_local_first_atlas_controls.py
+++ b/tests/test_local_first_atlas_controls.py
@@ -1,0 +1,79 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.local_first_atlas_controls import (
+    update_local_first_atlas_document_settings,
+)
+
+
+class _FakeLineEdit:
+    def __init__(self, text=""):
+        self._text = text
+
+    def text(self):
+        return self._text
+
+    def setText(self, text):
+        self._text = text
+
+
+class LocalFirstAtlasControlsTests(unittest.TestCase):
+    def test_updates_backing_fields_and_marks_export_stale_when_changed(self):
+        dock = SimpleNamespace(
+            atlasTitleLineEdit=_FakeLineEdit("Old title"),
+            atlasSubtitleLineEdit=_FakeLineEdit("Old subtitle"),
+            _mark_atlas_export_stale=MagicMock(),
+            _refresh_summary_status=MagicMock(),
+        )
+
+        update_local_first_atlas_document_settings(
+            dock,
+            "Spring Atlas",
+            "Road and trail",
+        )
+
+        self.assertEqual(dock.atlasTitleLineEdit.text(), "Spring Atlas")
+        self.assertEqual(dock.atlasSubtitleLineEdit.text(), "Road and trail")
+        dock._mark_atlas_export_stale.assert_called_once_with()
+        dock._refresh_summary_status.assert_called_once_with()
+
+    def test_keeps_export_current_when_fields_are_unchanged(self):
+        dock = SimpleNamespace(
+            atlasTitleLineEdit=_FakeLineEdit("Spring Atlas"),
+            atlasSubtitleLineEdit=_FakeLineEdit("Road and trail"),
+            _mark_atlas_export_stale=MagicMock(),
+            _refresh_summary_status=MagicMock(),
+        )
+
+        update_local_first_atlas_document_settings(
+            dock,
+            "Spring Atlas",
+            "Road and trail",
+        )
+
+        dock._mark_atlas_export_stale.assert_not_called()
+        dock._refresh_summary_status.assert_not_called()
+
+    def test_missing_backing_field_does_not_block_available_field_update(self):
+        dock = SimpleNamespace(
+            atlasTitleLineEdit=_FakeLineEdit("Old title"),
+            _mark_atlas_export_stale=MagicMock(),
+            _refresh_summary_status=MagicMock(),
+        )
+
+        update_local_first_atlas_document_settings(
+            dock,
+            "Spring Atlas",
+            "Road and trail",
+        )
+
+        self.assertEqual(dock.atlasTitleLineEdit.text(), "Spring Atlas")
+        dock._mark_atlas_export_stale.assert_called_once_with()
+        dock._refresh_summary_status.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -43,6 +43,7 @@ from .local_first_analysis_controls import (
     local_first_analysis_mode_options,
     set_local_first_analysis_mode,
 )
+from .local_first_atlas_controls import update_local_first_atlas_document_settings
 from .local_first_control_moves import (
     LOCAL_FIRST_CONTROL_MOVES,
     LOCAL_FIRST_WIDGET_MOVES,
@@ -256,6 +257,7 @@ __all__ = [
     "save_last_step_index",
     "set_local_first_analysis_mode",
     "show_local_first_control_group",
+    "update_local_first_atlas_document_settings",
     "show_widget",
     "step_index_for_key",
     "step_key_for_index",

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -257,9 +257,9 @@ __all__ = [
     "save_last_step_index",
     "set_local_first_analysis_mode",
     "show_local_first_control_group",
-    "update_local_first_atlas_document_settings",
     "show_widget",
     "step_index_for_key",
     "step_key_for_index",
+    "update_local_first_atlas_document_settings",
     "wizard_step_key_for_index",
 ]

--- a/ui/application/local_first_atlas_controls.py
+++ b/ui/application/local_first_atlas_controls.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+def update_local_first_atlas_document_settings(
+    dock,
+    atlas_title: str,
+    atlas_subtitle: str,
+) -> None:
+    """Mirror local-first atlas document fields into export backing widgets.
+
+    The visible local-first Atlas page owns the user-facing title and subtitle
+    fields. During dock consolidation, the legacy export widgets remain the
+    persistence/export backing controls, so keep this mirroring policy in the
+    local-first application layer instead of embedding it in QfitDockWidget.
+    """
+
+    title_line_edit = getattr(dock, "atlasTitleLineEdit", None)
+    subtitle_line_edit = getattr(dock, "atlasSubtitleLineEdit", None)
+    title_changed = (
+        title_line_edit is not None and title_line_edit.text() != atlas_title
+    )
+    subtitle_changed = (
+        subtitle_line_edit is not None
+        and subtitle_line_edit.text() != atlas_subtitle
+    )
+    if title_line_edit is not None:
+        title_line_edit.setText(atlas_title)
+    if subtitle_line_edit is not None:
+        subtitle_line_edit.setText(atlas_subtitle)
+    if title_changed or subtitle_changed:
+        dock._mark_atlas_export_stale()
+        dock._refresh_summary_status()
+
+
+__all__ = ["update_local_first_atlas_document_settings"]


### PR DESCRIPTION
## Summary

- Move local-first Atlas title/subtitle mirroring into `ui.application.local_first_atlas_controls`.
- Keep `QfitDockWidget` as a thin callback delegate for the local-first Atlas page.
- Add focused tests for changed, unchanged, and partially available backing field paths.

Refs #805

## Tests

- `python3 -m pytest tests/test_local_first_atlas_controls.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
