### PR TITLE
refactor: retire local-first dock hook wrappers

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -87,7 +87,6 @@ from .ui.application import (
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     install_local_first_audited_controls,
-    refresh_local_first_conditional_control_visibility,
     update_local_first_mapbox_custom_style_visibility,
     build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
@@ -434,41 +433,26 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 apply_map_filters=self.on_apply_filters_clicked,
                 run_analysis=self.on_run_analysis_clicked,
                 clear_analysis=self.on_clear_analysis_clicked,
-                set_analysis_mode=self._set_local_first_analysis_mode,
+                set_analysis_mode=lambda mode: set_local_first_analysis_mode(
+                    self,
+                    mode,
+                ),
                 export_atlas=self.on_generate_atlas_pdf_clicked,
-                update_atlas_document_settings=self._update_atlas_document_settings,
+                update_atlas_document_settings=(
+                    lambda title, subtitle: update_local_first_atlas_document_settings(
+                        self,
+                        title,
+                        subtitle,
+                    )
+                ),
             ),
         )
         install_local_first_audited_controls(self, self._local_first_dock_composition)
-        self._bind_local_first_analysis_mode_controls(
+        bind_local_first_analysis_mode_controls(
+            self,
             self._local_first_dock_composition
         )
         return self._local_first_dock_composition
-
-    def _update_atlas_document_settings(self, atlas_title: str, atlas_subtitle: str) -> None:
-        """Delegate local-first atlas document mirroring to application policy."""
-
-        update_local_first_atlas_document_settings(self, atlas_title, atlas_subtitle)
-
-    def _refresh_conditional_control_visibility(self) -> None:
-        """Refresh production local-first backing controls from their live state."""
-
-        refresh_local_first_conditional_control_visibility(self)
-
-    def _hide_legacy_atlas_export_button(self) -> None:
-        legacy_export_button = getattr(self, "generateAtlasPdfButton", None)
-        if legacy_export_button is not None and hasattr(legacy_export_button, "hide"):
-            legacy_export_button.hide()
-
-    def _bind_local_first_analysis_mode_controls(self, composition) -> None:
-        """Delegate local-first analysis selector binding to application policy."""
-
-        bind_local_first_analysis_mode_controls(self, composition)
-
-    def _set_local_first_analysis_mode(self, mode: str) -> None:
-        """Mirror the local-first analysis mode selector into dock backing state."""
-
-        set_local_first_analysis_mode(self, mode)
 
     def _install_live_local_first_dock(self) -> None:
         """Make the #748 local-first navigation shell the visible dock path."""

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -537,6 +537,10 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 "qfit.ui.dock_startup_coordinator."
                 "configure_local_first_analysis_mode_backing_controls"
             ) as configure_local_first_analysis_mode_backing_controls,
+            patch(
+                "qfit.ui.dock_startup_coordinator."
+                "refresh_local_first_conditional_control_visibility"
+            ) as refresh_local_first_conditional_control_visibility,
         ):
             coordinator = DockStartupCoordinator(dock)
             result = coordinator.run()
@@ -583,7 +587,6 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 call._load_settings(),
                 call._set_default_dates(),
                 call._wire_events(),
-                call._refresh_conditional_control_visibility(),
                 call._refresh_activity_preview(),
                 call._update_connection_status(),
             ],
@@ -593,3 +596,4 @@ class DockStartupCoordinatorTests(unittest.TestCase):
         configure_local_first_analysis_mode_backing_controls.assert_called_once_with(
             dock
         )
+        refresh_local_first_conditional_control_visibility.assert_called_once_with(dock)

--- a/tests/test_local_first_atlas_controls.py
+++ b/tests/test_local_first_atlas_controls.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from tests import _path  # noqa: F401
 
 from qfit.ui.application.local_first_atlas_controls import (
+    hide_legacy_atlas_export_button,
     update_local_first_atlas_document_settings,
 )
 
@@ -73,6 +74,16 @@ class LocalFirstAtlasControlsTests(unittest.TestCase):
         self.assertEqual(dock.atlasTitleLineEdit.text(), "Spring Atlas")
         dock._mark_atlas_export_stale.assert_called_once_with()
         dock._refresh_summary_status.assert_called_once_with()
+
+    def test_hides_legacy_export_button_when_present(self):
+        dock = SimpleNamespace(generateAtlasPdfButton=MagicMock())
+
+        hide_legacy_atlas_export_button(dock)
+
+        dock.generateAtlasPdfButton.hide.assert_called_once_with()
+
+    def test_hiding_legacy_export_button_tolerates_missing_button(self):
+        hide_legacy_atlas_export_button(SimpleNamespace())
 
 
 if __name__ == "__main__":

--- a/tests/test_local_first_control_installer.py
+++ b/tests/test_local_first_control_installer.py
@@ -11,8 +11,11 @@ from qfit.ui.application.local_first_control_installer import (
     install_local_first_control_move,
     install_local_first_widget_controls,
     install_local_first_widget_move,
+    local_first_after_install_hook_for_key,
 )
 from qfit.ui.application.local_first_control_moves import (
+    HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
+    REFRESH_CONDITIONAL_VISIBILITY_HOOK,
     local_first_control_move_for_key,
     local_first_widget_move_for_key,
 )
@@ -126,12 +129,31 @@ class LocalFirstControlInstallerTests(unittest.TestCase):
         self.assertTrue(dock._local_first_activity_style_controls_installed)
 
     def test_after_control_move_installed_runs_hook_only_after_successful_move(self):
-        dock = SimpleNamespace(_refresh_conditional_control_visibility=MagicMock())
+        hook = MagicMock()
+        dock = SimpleNamespace()
 
-        after_local_first_control_move_installed(dock, "basemap", installed=False)
-        after_local_first_control_move_installed(dock, "basemap", installed=True)
+        with patch(
+            "qfit.ui.application.local_first_control_installer."
+            "local_first_after_install_hook_for_key",
+            return_value=hook,
+        ) as hook_for_key:
+            after_local_first_control_move_installed(dock, "basemap", installed=False)
+            after_local_first_control_move_installed(dock, "basemap", installed=True)
 
-        dock._refresh_conditional_control_visibility.assert_called_once_with()
+        hook_for_key.assert_called_once_with(REFRESH_CONDITIONAL_VISIBILITY_HOOK)
+        hook.assert_called_once_with(dock)
+
+    def test_after_install_hook_lookup_resolves_application_hooks(self):
+        self.assertIsNotNone(
+            local_first_after_install_hook_for_key(
+                REFRESH_CONDITIONAL_VISIBILITY_HOOK,
+            )
+        )
+        self.assertIsNotNone(
+            local_first_after_install_hook_for_key(
+                HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
+            )
+        )
 
     def test_installs_group_move_from_audited_inventory(self):
         source_layout = MagicMock()

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -3,6 +3,7 @@ import unittest
 from tests import _path  # noqa: F401
 
 from qfit.ui.application.local_first_control_moves import (
+    HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
     LOCAL_FIRST_CONTROL_MOVES,
     LOCAL_FIRST_WIDGET_MOVES,
     REFRESH_CONDITIONAL_VISIBILITY_HOOK,
@@ -130,14 +131,14 @@ class LocalFirstControlMoveTests(unittest.TestCase):
         self.assertEqual(move.title, "PDF output")
         self.assertTrue(move.show_after_move)
         self.assertEqual(
-            move.after_install_hook_attr,
-            "_hide_legacy_atlas_export_button",
+            move.after_install_hook_key,
+            HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
         )
 
         backfill = local_first_control_move_for_key("backfill_routes")
         self.assertFalse(backfill.show_after_move)
         self.assertEqual(
-            backfill.after_install_hook_attr,
+            backfill.after_install_hook_key,
             REFRESH_CONDITIONAL_VISIBILITY_HOOK,
         )
 
@@ -145,7 +146,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
         self.assertEqual(filters.layout_getter_attr, "filter_controls_layout")
         self.assertEqual(filters.parent_panel_attr, "filter_controls_panel")
         self.assertEqual(filters.post_install_visible_attr, "set_filter_controls_visible")
-        self.assertIsNone(filters.after_install_hook_attr)
+        self.assertIsNone(filters.after_install_hook_key)
 
         credentials = local_first_control_move_for_key("strava_credentials")
         self.assertEqual(credentials.content_attr, "settings_content")
@@ -154,7 +155,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
 
     def test_control_moves_document_post_install_hooks(self):
         hooks = {
-            move.key: move.after_install_hook_attr for move in LOCAL_FIRST_CONTROL_MOVES
+            move.key: move.after_install_hook_key for move in LOCAL_FIRST_CONTROL_MOVES
         }
 
         self.assertEqual(
@@ -164,7 +165,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "activity_preview": None,
                 "backfill_routes": REFRESH_CONDITIONAL_VISIBILITY_HOOK,
                 "map_filters": None,
-                "atlas_pdf": "_hide_legacy_atlas_export_button",
+                "atlas_pdf": HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
                 "strava_credentials": None,
                 "basemap": REFRESH_CONDITIONAL_VISIBILITY_HOOK,
                 "storage": REFRESH_CONDITIONAL_VISIBILITY_HOOK,

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -696,7 +696,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._atlas_export_completed = False
         dock.settings = _FakeSettings()
-        dock._bind_local_first_analysis_mode_controls = MagicMock()
         parent = object()
 
         class FakeWizardActionCallbacks(SimpleNamespace):
@@ -723,7 +722,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         ), patch.object(
             self.module,
             "install_local_first_audited_controls",
-        ) as install_local_first_audited_controls:
+        ) as install_local_first_audited_controls, patch.object(
+            self.module,
+            "bind_local_first_analysis_mode_controls",
+        ) as bind_local_first_analysis_mode_controls:
             composition = self.module.QfitDockWidget._build_local_first_dock_from_runtime(
                 dock,
                 parent=parent,
@@ -755,9 +757,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "apply_map_filters": "on_apply_filters_clicked",
             "run_analysis": "on_run_analysis_clicked",
             "clear_analysis": "on_clear_analysis_clicked",
-            "set_analysis_mode": "_set_local_first_analysis_mode",
             "export_atlas": "on_generate_atlas_pdf_clicked",
-            "update_atlas_document_settings": "_update_atlas_document_settings",
         }
         for callback_name, method_name in expected_callbacks.items():
             callback = getattr(callbacks, callback_name)
@@ -766,51 +766,44 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 callback.__func__,
                 getattr(self.module.QfitDockWidget, method_name),
             )
+        with patch.object(
+            self.module,
+            "set_local_first_analysis_mode",
+        ) as set_local_first_analysis_mode, patch.object(
+            self.module,
+            "update_local_first_atlas_document_settings",
+        ) as update_local_first_atlas_document_settings:
+            callbacks.set_analysis_mode("Most frequent starting points")
+            callbacks.update_atlas_document_settings("Updated", "Subtitle")
+
+        set_local_first_analysis_mode.assert_called_once_with(
+            dock,
+            "Most frequent starting points",
+        )
+        update_local_first_atlas_document_settings.assert_called_once_with(
+            dock,
+            "Updated",
+            "Subtitle",
+        )
         install_local_first_audited_controls.assert_called_once_with(
             dock,
             "connected-composition"
         )
-        dock._bind_local_first_analysis_mode_controls.assert_called_once_with(
+        bind_local_first_analysis_mode_controls.assert_called_once_with(
+            dock,
             "connected-composition"
         )
 
-    def test_update_atlas_document_settings_mirrors_visible_fields(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock.atlasTitleLineEdit = _FakeLineEdit("Old Atlas")
-        dock.atlasSubtitleLineEdit = _FakeLineEdit("Old subtitle")
-        dock._mark_atlas_export_stale = MagicMock()
-        dock._refresh_summary_status = MagicMock()
-
-        self.module.QfitDockWidget._update_atlas_document_settings(
-            dock,
-            "Spring Atlas",
-            "Road and trail",
-        )
-
-        self.assertEqual(dock.atlasTitleLineEdit.text(), "Spring Atlas")
-        self.assertEqual(dock.atlasSubtitleLineEdit.text(), "Road and trail")
-        dock._mark_atlas_export_stale.assert_called_once_with()
-        dock._refresh_summary_status.assert_called_once_with()
-
-    def test_update_atlas_document_settings_keeps_current_export_when_unchanged(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock.atlasTitleLineEdit = _FakeLineEdit("Spring Atlas")
-        dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
-        dock._mark_atlas_export_stale = MagicMock()
-        dock._refresh_summary_status = MagicMock()
-
-        self.module.QfitDockWidget._update_atlas_document_settings(
-            dock,
-            "Spring Atlas",
-            "Road and trail",
-        )
-
-        dock._mark_atlas_export_stale.assert_not_called()
-        dock._refresh_summary_status.assert_not_called()
-
     def test_after_local_first_control_move_installed_applies_required_hooks(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock._refresh_conditional_control_visibility = MagicMock()
+        dock.advancedFetchGroupBox = SimpleNamespace(isChecked=lambda: True)
+        dock.detailedStreamsCheckBox = SimpleNamespace(isChecked=lambda: False)
+        dock.backgroundPresetComboBox = SimpleNamespace(currentText=lambda: "Custom")
+        dock.writeActivityPointsCheckBox = SimpleNamespace(isChecked=lambda: True)
+        dock.advancedFetchSettingsWidget = MagicMock()
+        dock.backfillMissingDetailedRoutesButton = MagicMock()
+        dock.mapboxStyleOwnerLabel = MagicMock()
+        dock.pointSamplingStrideLabel = MagicMock()
         dock.generateAtlasPdfButton = MagicMock()
 
         for key in (
@@ -831,48 +824,42 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             installed=False,
         )
 
-        self.assertEqual(dock._refresh_conditional_control_visibility.call_count, 4)
+        self.assertEqual(
+            dock.advancedFetchSettingsWidget.setVisible.call_args_list,
+            [call(True)] * 4,
+        )
         dock.generateAtlasPdfButton.hide.assert_called_once_with()
 
     def test_after_local_first_control_move_installed_raises_for_missing_hook(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        move = SimpleNamespace(after_install_hook_attr="_missing_local_first_hook")
+        move = SimpleNamespace(after_install_hook_key="missing_local_first_hook")
 
         with patch.dict(
             after_local_first_control_move_installed.__globals__,
             {"local_first_control_move_for_key": MagicMock(return_value=move)},
         ):
-            with self.assertRaises(AttributeError):
+            with self.assertRaises(KeyError):
                 after_local_first_control_move_installed(
                     dock,
                     "advanced_fetch",
                     installed=True,
                 )
 
-    def test_refresh_conditional_control_visibility_uses_application_refresh(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-
-        with patch.object(
-            self.module,
-            "refresh_local_first_conditional_control_visibility",
-        ) as refresh:
-            self.module.QfitDockWidget._refresh_conditional_control_visibility(dock)
-
-        refresh.assert_called_once_with(dock)
-
     def test_dock_widget_does_not_reintroduce_per_move_local_first_installers(self):
-        self.assertFalse(
-            hasattr(self.module.QfitDockWidget, "_install_local_first_control_move")
+        retired_methods = (
+            "_install_local_first_control_move",
+            "_install_local_first_widget_move",
+            "_after_local_first_control_move_installed",
+            "_refresh_conditional_control_visibility",
+            "_hide_legacy_atlas_export_button",
+            "_bind_local_first_analysis_mode_controls",
+            "_set_local_first_analysis_mode",
+            "_update_atlas_document_settings",
         )
-        self.assertFalse(
-            hasattr(self.module.QfitDockWidget, "_install_local_first_widget_move")
-        )
-        self.assertFalse(
-            hasattr(
-                self.module.QfitDockWidget,
-                "_after_local_first_control_move_installed",
-            )
-        )
+
+        for method_name in retired_methods:
+            with self.subTest(method_name=method_name):
+                self.assertFalse(hasattr(self.module.QfitDockWidget, method_name))
 
     def test_local_first_visibility_updates_do_not_use_workflow_sections(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -1172,41 +1159,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(style_layout.addWidget.call_args_list, [])
         self.assertFalse(
             getattr(dock, "_local_first_activity_style_controls_installed", False)
-        )
-
-    def test_bind_local_first_analysis_mode_controls_delegates_to_application_policy(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        composition = object()
-
-        with patch.object(
-            self.module,
-            "bind_local_first_analysis_mode_controls",
-        ) as bind_local_first_analysis_mode_controls:
-            self.module.QfitDockWidget._bind_local_first_analysis_mode_controls(
-                dock,
-                composition,
-            )
-
-        bind_local_first_analysis_mode_controls.assert_called_once_with(
-            dock,
-            composition,
-        )
-
-    def test_set_local_first_analysis_mode_delegates_to_application_policy(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-
-        with patch.object(
-            self.module,
-            "set_local_first_analysis_mode",
-        ) as set_local_first_analysis_mode:
-            self.module.QfitDockWidget._set_local_first_analysis_mode(
-                dock,
-                "Most frequent starting points",
-            )
-
-        set_local_first_analysis_mode.assert_called_once_with(
-            dock,
-            "Most frequent starting points",
         )
 
     def test_install_live_local_first_dock_hides_long_scroll_path(self):

--- a/ui/application/local_first_atlas_controls.py
+++ b/ui/application/local_first_atlas_controls.py
@@ -32,4 +32,15 @@ def update_local_first_atlas_document_settings(
         dock._refresh_summary_status()
 
 
-__all__ = ["update_local_first_atlas_document_settings"]
+def hide_legacy_atlas_export_button(dock) -> None:
+    """Hide the legacy export button after moving PDF controls local-first."""
+
+    legacy_export_button = getattr(dock, "generateAtlasPdfButton", None)
+    if legacy_export_button is not None and hasattr(legacy_export_button, "hide"):
+        legacy_export_button.hide()
+
+
+__all__ = [
+    "hide_legacy_atlas_export_button",
+    "update_local_first_atlas_document_settings",
+]

--- a/ui/application/local_first_control_installer.py
+++ b/ui/application/local_first_control_installer.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from .local_first_control_moves import (
+    HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
     LocalFirstControlMove,
     LocalFirstWidgetMove,
+    REFRESH_CONDITIONAL_VISIBILITY_HOOK,
     local_first_control_move_for_key,
     local_first_control_move_keys,
     local_first_widget_move_for_key,
     local_first_widget_move_keys,
 )
+from .local_first_atlas_controls import hide_legacy_atlas_export_button
+from .local_first_control_visibility import refresh_local_first_conditional_control_visibility
 
 
 def install_local_first_audited_controls(dock, composition) -> None:
@@ -52,11 +56,23 @@ def after_local_first_control_move_installed(
         move = local_first_control_move_for_key(key)
     except KeyError:
         return
-    hook_attr = move.after_install_hook_attr
-    if hook_attr is None:
+    hook_key = move.after_install_hook_key
+    if hook_key is None:
         return
-    hook = getattr(dock, hook_attr)
-    hook()
+    hook = local_first_after_install_hook_for_key(hook_key)
+    hook(dock)
+
+
+def local_first_after_install_hook_for_key(hook_key: str):
+    """Return the application-layer side effect for a local-first install hook."""
+
+    hooks = {
+        REFRESH_CONDITIONAL_VISIBILITY_HOOK: (
+            refresh_local_first_conditional_control_visibility
+        ),
+        HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK: hide_legacy_atlas_export_button,
+    }
+    return hooks[hook_key]
 
 
 def install_local_first_group_controls(
@@ -238,6 +254,7 @@ __all__ = [
     "install_local_first_group_controls",
     "install_local_first_widget_move",
     "install_local_first_widget_controls",
+    "local_first_after_install_hook_for_key",
     "local_first_control_move_layout",
     "local_first_control_move_parent_panel",
     "local_first_control_move_required_widgets_available",

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
-REFRESH_CONDITIONAL_VISIBILITY_HOOK = "_refresh_conditional_control_visibility"
+REFRESH_CONDITIONAL_VISIBILITY_HOOK = "refresh_conditional_visibility"
+HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK = "hide_legacy_atlas_export_button"
 
 
 @dataclass(frozen=True)
@@ -27,7 +28,7 @@ class LocalFirstControlMove:
     layout_getter_attr: str = "outer_layout"
     parent_panel_attr: str | None = None
     post_install_visible_attr: str | None = None
-    after_install_hook_attr: str | None = None
+    after_install_hook_key: str | None = None
 
 
 @dataclass(frozen=True)
@@ -93,7 +94,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         ),
         installed_attr="_local_first_advanced_fetch_controls_installed",
         installed_target_attr="_local_first_advanced_fetch_controls_installed_target",
-        after_install_hook_attr=REFRESH_CONDITIONAL_VISIBILITY_HOOK,
+        after_install_hook_key=REFRESH_CONDITIONAL_VISIBILITY_HOOK,
     ),
     LocalFirstControlMove(
         key="activity_preview",
@@ -111,7 +112,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_backfill_controls_installed",
         installed_target_attr="_local_first_backfill_controls_installed_target",
         show_after_move=False,
-        after_install_hook_attr=REFRESH_CONDITIONAL_VISIBILITY_HOOK,
+        after_install_hook_key=REFRESH_CONDITIONAL_VISIBILITY_HOOK,
     ),
     LocalFirstControlMove(
         key="map_filters",
@@ -141,7 +142,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_atlas_pdf_controls_installed",
         installed_target_attr="_local_first_atlas_pdf_controls_installed_target",
         title="PDF output",
-        after_install_hook_attr="_hide_legacy_atlas_export_button",
+        after_install_hook_key=HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
     ),
     LocalFirstControlMove(
         key="strava_credentials",
@@ -175,7 +176,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_basemap_controls_installed",
         installed_target_attr="_local_first_basemap_controls_installed_target",
         title="Mapbox basemap",
-        after_install_hook_attr=REFRESH_CONDITIONAL_VISIBILITY_HOOK,
+        after_install_hook_key=REFRESH_CONDITIONAL_VISIBILITY_HOOK,
     ),
     LocalFirstControlMove(
         key="storage",
@@ -190,7 +191,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_attr="_local_first_storage_controls_installed",
         installed_target_attr="_local_first_storage_controls_installed_target",
         title="Data storage",
-        after_install_hook_attr=REFRESH_CONDITIONAL_VISIBILITY_HOOK,
+        after_install_hook_key=REFRESH_CONDITIONAL_VISIBILITY_HOOK,
     ),
 )
 
@@ -228,6 +229,7 @@ def local_first_widget_move_keys() -> tuple[str, ...]:
 __all__ = [
     "LOCAL_FIRST_CONTROL_MOVES",
     "LOCAL_FIRST_WIDGET_MOVES",
+    "HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK",
     "LocalFirstControlMove",
     "LocalFirstWidgetMove",
     "REFRESH_CONDITIONAL_VISIBILITY_HOOK",

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -9,6 +9,9 @@ from .application.local_first_backing_controls import (
 from .application.local_first_analysis_controls import (
     configure_local_first_analysis_mode_backing_controls,
 )
+from .application.local_first_control_visibility import (
+    refresh_local_first_conditional_control_visibility,
+)
 
 
 @dataclass(frozen=True)
@@ -74,7 +77,7 @@ class DockStartupCoordinator:
         dock._wire_events()
         performed_steps.append("wire_events")
 
-        dock._refresh_conditional_control_visibility()
+        refresh_local_first_conditional_control_visibility(dock)
         performed_steps.append("refresh_conditional_control_visibility")
 
         dock._refresh_activity_preview()


### PR DESCRIPTION
## Summary

Retires the remaining QfitDockWidget-only local-first hook/delegation wrappers so startup, install side effects, analysis mode binding, and Atlas document mirroring route through application helpers directly.

## Changes

- Routes local-first install hooks through application-layer hook keys instead of dock method-name strings.
- Moves the legacy Atlas export button hide side effect into `ui.application.local_first_atlas_controls`.
- Calls analysis mode binding and conditional visibility refresh helpers directly from composition/startup.
- Updates tests to lock the thinner dock contract and hook routing behavior.

## Testing

- `python3 -m pytest tests/test_local_first_atlas_controls.py tests/test_local_first_control_installer.py tests/test_local_first_control_moves.py tests/test_dockwidget_dependencies.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
