### PR TITLE
Refactor local-first basemap policy out of dock

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -77,6 +77,7 @@ from .ui.application import (
     DockVisualWorkflowCoordinator,
     DockVisualWorkflowRequest,
     bind_local_first_analysis_mode_controls,
+    bind_local_first_basemap_preset_controls,
     bind_local_first_conditional_visibility_controls,
     RunAnalysisAction,
     build_dock_summary_status,
@@ -87,7 +88,7 @@ from .ui.application import (
     build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     install_local_first_audited_controls,
-    update_local_first_mapbox_custom_style_visibility,
+    sync_local_first_basemap_style_fields,
     build_visual_workflow_background_inputs,
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
@@ -97,11 +98,7 @@ from .detailed_route_strategy import (
     DETAILED_ROUTE_STRATEGY_MISSING,
     detailed_route_strategy_labels,
 )
-from .mapbox_config import (
-    TILE_MODES,
-    MapboxConfigError,
-    background_preset_names,
-)
+from .mapbox_config import MapboxConfigError
 from .visualization.application import (
     LayerRefs,
     build_background_map_failure_status,
@@ -689,7 +686,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.applyFiltersButton.clicked.connect(self.on_apply_filters_clicked)
         self.runAnalysisButton.clicked.connect(self.on_run_analysis_clicked)
         self.loadBackgroundButton.clicked.connect(self.on_load_background_clicked)
-        self.backgroundPresetComboBox.currentTextChanged.connect(self.on_background_preset_changed)
+        bind_local_first_basemap_preset_controls(self)
         bind_local_first_conditional_visibility_controls(self)
         self.atlasPdfBrowseButton.clicked.connect(self.on_atlas_pdf_browse_clicked)
         self.atlasPdfPathLineEdit.textChanged.connect(self._on_atlas_pdf_path_changed)
@@ -712,11 +709,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         for signal in preview_inputs:
             signal.connect(self._refresh_activity_preview)
 
-    def _configure_background_preset_options(self):
-        self.backgroundPresetComboBox.clear()
-        for preset_name in background_preset_names():
-            self.backgroundPresetComboBox.addItem(preset_name)
-
     def _configure_detailed_route_filter_options(self):
         legacy_checkbox = getattr(self, "detailedOnlyCheckBox", None)
         combo = getattr(self, "detailedRouteStatusComboBox", None)
@@ -733,9 +725,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         combo.addItem("Detailed routes only", DETAILED_ROUTE_FILTER_PRESENT)
         combo.addItem("Missing detailed routes", DETAILED_ROUTE_FILTER_MISSING)
         combo.setToolTip("Filter activities by detailed-route availability")
-        self.tileModeComboBox.clear()
-        for mode in TILE_MODES:
-            self.tileModeComboBox.addItem(mode)
 
     def _configure_detailed_route_strategy_options(self):
         combo = getattr(self, "detailedRouteStrategyComboBox", None)
@@ -869,7 +858,11 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _load_settings(self):
         load_bindings(build_dock_settings_bindings(self), self.settings)
         self.authCodeLineEdit.setText("")
-        self._sync_background_style_fields(self.backgroundPresetComboBox.currentText(), force=False)
+        sync_local_first_basemap_style_fields(
+            self,
+            self.backgroundPresetComboBox.currentText(),
+            force=False,
+        )
 
         self._update_last_sync_summary()
 
@@ -881,10 +874,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         today = QDate.currentDate()
         self.dateFromEdit.setDate(today.addYears(-1))
         self.dateToEdit.setDate(today)
-
-    def on_background_preset_changed(self, preset_name):
-        self._sync_background_style_fields(preset_name, force=True)
-        update_local_first_mapbox_custom_style_visibility(self, preset_name)
 
     def on_load_background_clicked(self):
         self._save_settings()
@@ -905,18 +894,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
 
         self._set_status(result.status)
-
-    def _sync_background_style_fields(self, preset_name, force=False):
-        result = self.background_controller.resolve_style_defaults(
-            preset_name,
-            current_owner=self.mapboxStyleOwnerLineEdit.text().strip(),
-            current_style_id=self.mapboxStyleIdLineEdit.text().strip(),
-            force=force,
-        )
-        if result is not None:
-            style_owner, style_id = result
-            self.mapboxStyleOwnerLineEdit.setText(style_owner)
-            self.mapboxStyleIdLineEdit.setText(style_id)
 
     def on_open_authorize_clicked(self):
         self._save_settings()

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -539,6 +539,10 @@ class DockStartupCoordinatorTests(unittest.TestCase):
             ) as configure_local_first_analysis_mode_backing_controls,
             patch(
                 "qfit.ui.dock_startup_coordinator."
+                "configure_local_first_basemap_options"
+            ) as configure_local_first_basemap_options,
+            patch(
+                "qfit.ui.dock_startup_coordinator."
                 "refresh_local_first_conditional_control_visibility"
             ) as refresh_local_first_conditional_control_visibility,
         ):
@@ -556,7 +560,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                     "remove_stale_qfit_layers",
                     "apply_contextual_help",
                     "configure_local_first_spinbox_unit_copy",
-                    "configure_background_preset_options",
+                    "configure_local_first_basemap_options",
                     "configure_detailed_route_filter_options",
                     "configure_detailed_route_strategy_options",
                     "configure_preview_sort_options",
@@ -579,7 +583,6 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 call._ensure_wizard_settings(),
                 call._remove_stale_qfit_layers(),
                 call._apply_contextual_help(),
-                call._configure_background_preset_options(),
                 call._configure_detailed_route_filter_options(),
                 call._configure_detailed_route_strategy_options(),
                 call._configure_preview_sort_options(),
@@ -593,6 +596,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
         )
         configure_local_first_backing_controls.assert_called_once_with(dock)
         configure_local_first_spinbox_unit_copy.assert_called_once_with(dock)
+        configure_local_first_basemap_options.assert_called_once_with(dock)
         configure_local_first_analysis_mode_backing_controls.assert_called_once_with(
             dock
         )

--- a/tests/test_local_first_basemap_controls.py
+++ b/tests/test_local_first_basemap_controls.py
@@ -1,0 +1,130 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.local_first_basemap_controls import (
+    bind_local_first_basemap_preset_controls,
+    configure_local_first_basemap_options,
+    sync_local_first_basemap_style_fields,
+    update_local_first_basemap_preset,
+)
+
+
+class FakeCombo:
+    def __init__(self):
+        self.items = ["stale"]
+
+    def clear(self):
+        self.items.clear()
+
+    def addItem(self, value):
+        self.items.append(value)
+
+
+class FakeSignal:
+    def __init__(self):
+        self.connected = []
+
+    def connect(self, callback):
+        self.connected.append(callback)
+
+
+class FakeLineEdit:
+    def __init__(self, value=""):
+        self.value = value
+
+    def text(self):
+        return self.value
+
+    def setText(self, value):
+        self.value = value
+
+
+class LocalFirstBasemapControlsTests(unittest.TestCase):
+    def test_configure_options_populates_preset_and_tile_combos(self):
+        dock = SimpleNamespace(
+            backgroundPresetComboBox=FakeCombo(),
+            tileModeComboBox=FakeCombo(),
+        )
+
+        with (
+            patch(
+                "qfit.ui.application.local_first_basemap_controls."
+                "background_preset_names",
+                return_value=("Outdoor", "Custom"),
+            ),
+            patch(
+                "qfit.ui.application.local_first_basemap_controls.TILE_MODES",
+                ("raster", "vector"),
+            ),
+        ):
+            configure_local_first_basemap_options(dock)
+
+        self.assertEqual(dock.backgroundPresetComboBox.items, ["Outdoor", "Custom"])
+        self.assertEqual(dock.tileModeComboBox.items, ["raster", "vector"])
+
+    def test_sync_style_fields_uses_controller_defaults(self):
+        controller = MagicMock()
+        controller.resolve_style_defaults.return_value = ("mapbox", "outdoors-v12")
+        dock = SimpleNamespace(
+            background_controller=controller,
+            mapboxStyleOwnerLineEdit=FakeLineEdit(" existing-owner "),
+            mapboxStyleIdLineEdit=FakeLineEdit(" existing-style "),
+        )
+
+        sync_local_first_basemap_style_fields(dock, "Outdoor", force=False)
+
+        controller.resolve_style_defaults.assert_called_once_with(
+            "Outdoor",
+            current_owner="existing-owner",
+            current_style_id="existing-style",
+            force=False,
+        )
+        self.assertEqual(dock.mapboxStyleOwnerLineEdit.value, "mapbox")
+        self.assertEqual(dock.mapboxStyleIdLineEdit.value, "outdoors-v12")
+
+    def test_update_preset_syncs_fields_and_visibility(self):
+        dock = SimpleNamespace(
+            background_controller=MagicMock(),
+            mapboxStyleOwnerLineEdit=FakeLineEdit(),
+            mapboxStyleIdLineEdit=FakeLineEdit(),
+        )
+        dock.background_controller.resolve_style_defaults.return_value = (
+            "owner",
+            "style",
+        )
+
+        with patch(
+            "qfit.ui.application.local_first_basemap_controls."
+            "update_local_first_mapbox_custom_style_visibility"
+        ) as update_visibility:
+            update_local_first_basemap_preset(dock, "Custom")
+
+        dock.background_controller.resolve_style_defaults.assert_called_once_with(
+            "Custom",
+            current_owner="",
+            current_style_id="",
+            force=True,
+        )
+        update_visibility.assert_called_once_with(dock, "Custom")
+
+    def test_bind_preset_controls_routes_signal_to_policy(self):
+        signal = FakeSignal()
+        dock = SimpleNamespace(
+            backgroundPresetComboBox=SimpleNamespace(currentTextChanged=signal),
+        )
+
+        with patch(
+            "qfit.ui.application.local_first_basemap_controls."
+            "update_local_first_basemap_preset"
+        ) as update_preset:
+            bind_local_first_basemap_preset_controls(dock)
+            signal.connected[0]("Satellite")
+
+        update_preset.assert_called_once_with(dock, "Satellite")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -973,7 +973,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "on_apply_filters_clicked",
             "on_run_analysis_clicked",
             "on_load_background_clicked",
-            "on_background_preset_changed",
             "on_atlas_pdf_browse_clicked",
             "_on_atlas_pdf_path_changed",
             "on_generate_atlas_pdf_clicked",
@@ -996,6 +995,13 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         self.assertFalse(
             hasattr(self.module.QfitDockWidget, "_update_advanced_fetch_visibility")
+        )
+        self.assertFalse(
+            hasattr(self.module.QfitDockWidget, "on_background_preset_changed")
+        )
+        self.assertEqual(
+            len(dock.backgroundPresetComboBox.currentTextChanged.connected),
+            1,
         )
 
     def test_install_local_first_control_move_handles_map_filters(self):

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -44,6 +44,11 @@ from .local_first_analysis_controls import (
     set_local_first_analysis_mode,
 )
 from .local_first_atlas_controls import update_local_first_atlas_document_settings
+from .local_first_basemap_controls import (
+    bind_local_first_basemap_preset_controls,
+    configure_local_first_basemap_options,
+    sync_local_first_basemap_style_fields,
+)
 from .local_first_control_moves import (
     LOCAL_FIRST_CONTROL_MOVES,
     LOCAL_FIRST_WIDGET_MOVES,
@@ -207,8 +212,10 @@ __all__ = [
     "build_advanced_fetch_visibility_update",
     "apply_local_first_visibility_update",
     "bind_local_first_analysis_mode_controls",
+    "bind_local_first_basemap_preset_controls",
     "bind_local_first_conditional_visibility_controls",
     "configure_local_first_analysis_mode_backing_controls",
+    "configure_local_first_basemap_options",
     "build_current_dock_workflow_label",
     "build_detailed_fetch_visibility_update",
     "build_dock_summary_status",
@@ -260,6 +267,7 @@ __all__ = [
     "save_last_step_index",
     "set_local_first_analysis_mode",
     "show_local_first_control_group",
+    "sync_local_first_basemap_style_fields",
     "update_local_first_mapbox_custom_style_visibility",
     "show_widget",
     "step_index_for_key",

--- a/ui/application/local_first_basemap_controls.py
+++ b/ui/application/local_first_basemap_controls.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from ...mapbox_config import TILE_MODES, background_preset_names
+from .local_first_control_visibility import update_local_first_mapbox_custom_style_visibility
+
+
+def configure_local_first_basemap_options(dock) -> None:
+    """Populate basemap backing controls used by the local-first Settings page."""
+
+    preset_combo = getattr(dock, "backgroundPresetComboBox", None)
+    if preset_combo is not None:
+        _replace_combo_items(preset_combo, background_preset_names())
+
+    tile_mode_combo = getattr(dock, "tileModeComboBox", None)
+    if tile_mode_combo is not None:
+        _replace_combo_items(tile_mode_combo, TILE_MODES)
+
+
+def bind_local_first_basemap_preset_controls(dock) -> None:
+    """Bind local-first basemap preset changes to backing field policy."""
+
+    preset_combo = getattr(dock, "backgroundPresetComboBox", None)
+    signal = getattr(preset_combo, "currentTextChanged", None)
+    connect = getattr(signal, "connect", None)
+    if callable(connect):
+        connect(
+            lambda preset_name: update_local_first_basemap_preset(dock, preset_name)
+        )
+
+
+def update_local_first_basemap_preset(dock, preset_name: str) -> None:
+    """Apply a user-selected basemap preset to local-first backing controls."""
+
+    sync_local_first_basemap_style_fields(dock, preset_name, force=True)
+    update_local_first_mapbox_custom_style_visibility(dock, preset_name)
+
+
+def sync_local_first_basemap_style_fields(
+    dock,
+    preset_name: str | None,
+    *,
+    force: bool = False,
+) -> None:
+    """Sync Mapbox owner/style fields from the selected basemap preset."""
+
+    controller = getattr(dock, "background_controller", None)
+    resolve_style_defaults = getattr(controller, "resolve_style_defaults", None)
+    if not callable(resolve_style_defaults):
+        return
+
+    result = resolve_style_defaults(
+        preset_name,
+        current_owner=_line_edit_text(getattr(dock, "mapboxStyleOwnerLineEdit", None)),
+        current_style_id=_line_edit_text(getattr(dock, "mapboxStyleIdLineEdit", None)),
+        force=force,
+    )
+    if result is None:
+        return
+
+    style_owner, style_id = result
+    _set_line_edit_text(getattr(dock, "mapboxStyleOwnerLineEdit", None), style_owner)
+    _set_line_edit_text(getattr(dock, "mapboxStyleIdLineEdit", None), style_id)
+
+
+def _replace_combo_items(combo, values) -> None:
+    clear = getattr(combo, "clear", None)
+    if callable(clear):
+        clear()
+    add_item = getattr(combo, "addItem", None)
+    if callable(add_item):
+        for value in values:
+            add_item(value)
+
+
+def _line_edit_text(line_edit) -> str:
+    text = getattr(line_edit, "text", None)
+    if not callable(text):
+        return ""
+    return str(text()).strip()
+
+
+def _set_line_edit_text(line_edit, text: str) -> None:
+    set_text = getattr(line_edit, "setText", None)
+    if callable(set_text):
+        set_text(text)
+
+
+__all__ = [
+    "bind_local_first_basemap_preset_controls",
+    "configure_local_first_basemap_options",
+    "sync_local_first_basemap_style_fields",
+    "update_local_first_basemap_preset",
+]

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -9,6 +9,9 @@ from .application.local_first_backing_controls import (
 from .application.local_first_analysis_controls import (
     configure_local_first_analysis_mode_backing_controls,
 )
+from .application.local_first_basemap_controls import (
+    configure_local_first_basemap_options,
+)
 from .application.local_first_control_visibility import (
     refresh_local_first_conditional_control_visibility,
 )
@@ -50,8 +53,8 @@ class DockStartupCoordinator:
         configure_local_first_spinbox_unit_copy(dock)
         performed_steps.append("configure_local_first_spinbox_unit_copy")
 
-        dock._configure_background_preset_options()
-        performed_steps.append("configure_background_preset_options")
+        configure_local_first_basemap_options(dock)
+        performed_steps.append("configure_local_first_basemap_options")
 
         dock._configure_detailed_route_filter_options()
         performed_steps.append("configure_detailed_route_filter_options")


### PR DESCRIPTION
## Summary

- Move local-first basemap option population, preset-change binding, and style-field syncing into `ui.application.local_first_basemap_controls`.
- Stop `QfitDockWidget` from owning the basemap preset wrapper and Mapbox owner/style mirroring policy.
- Keep startup ordering explicit through `DockStartupCoordinator` and cover the migrated policy with focused tests.

## Testing

- `python3 -m unittest tests.test_local_first_basemap_controls -v`
- `python3 -m pytest tests/test_local_first_basemap_controls.py tests/test_dockwidget_dependencies.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `coverage erase && coverage run -m unittest tests.test_local_first_basemap_controls -v && coverage report -m ui/application/local_first_basemap_controls.py`

Refs #805
