### PR TITLE
refactor: move temporal setup into local-first analysis policy

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -16,7 +16,6 @@ from qgis.PyQt.QtWidgets import (
     QComboBox,
     QFileDialog,
     QDockWidget,
-    QGridLayout,
     QMessageBox,
 )
 
@@ -106,7 +105,7 @@ from .visualization.application import (
 )
 from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_provider import StravaProvider
-from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
+from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
 from .ui.dockwidget_dependencies import DockWidgetDependencies, build_dockwidget_dependencies
 from .ui.dock_startup_coordinator import DockStartupCoordinator
 from .configuration.application.connection_status import build_strava_connection_status
@@ -738,29 +737,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.previewSortComboBox.clear()
         for label in SORT_OPTIONS:
             self.previewSortComboBox.addItem(label)
-
-    def _configure_temporal_mode_options(self):
-        outer_layout = self.temporalModeLabel.parentWidget().layout()
-        if hasattr(outer_layout, "setSpacing"):
-            outer_layout.setSpacing(6)
-        if isinstance(outer_layout, QGridLayout):
-            outer_layout.setSpacing(6)
-        self.temporalModeComboBox.setSizeAdjustPolicy(
-            QComboBox.AdjustToMinimumContentsLengthWithIcon
-        )
-        self.temporalModeComboBox.setMinimumContentsLength(10)
-        self.temporalHelpLabel.setMargin(2)
-        self.temporalModeComboBox.clear()
-        for label in temporal_mode_labels():
-            self.temporalModeComboBox.addItem(label)
-        self.temporalModeComboBox.setCurrentText(DEFAULT_TEMPORAL_MODE_LABEL)
-        self.temporalModeComboBox.setMinimumContentsLength(10)
-        self.temporalModeComboBox.hide()
-        self.temporalModeLabel.hide()
-        self.temporalHelpLabel.hide()
-        temporal_row = getattr(self, "analysisTemporalModeRow", None)
-        if temporal_row is not None:
-            temporal_row.hide()
 
     def _bind_dependencies(self, dependencies: DockWidgetDependencies) -> None:
         self.settings = dependencies.settings

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -539,6 +539,10 @@ class DockStartupCoordinatorTests(unittest.TestCase):
             ) as configure_local_first_analysis_mode_backing_controls,
             patch(
                 "qfit.ui.dock_startup_coordinator."
+                "configure_local_first_temporal_mode_backing_controls"
+            ) as configure_local_first_temporal_mode_backing_controls,
+            patch(
+                "qfit.ui.dock_startup_coordinator."
                 "configure_local_first_basemap_options"
             ) as configure_local_first_basemap_options,
             patch(
@@ -586,7 +590,6 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 call._configure_detailed_route_filter_options(),
                 call._configure_detailed_route_strategy_options(),
                 call._configure_preview_sort_options(),
-                call._configure_temporal_mode_options(),
                 call._load_settings(),
                 call._set_default_dates(),
                 call._wire_events(),
@@ -598,6 +601,9 @@ class DockStartupCoordinatorTests(unittest.TestCase):
         configure_local_first_spinbox_unit_copy.assert_called_once_with(dock)
         configure_local_first_basemap_options.assert_called_once_with(dock)
         configure_local_first_analysis_mode_backing_controls.assert_called_once_with(
+            dock
+        )
+        configure_local_first_temporal_mode_backing_controls.assert_called_once_with(
             dock
         )
         refresh_local_first_conditional_control_visibility.assert_called_once_with(dock)

--- a/tests/test_local_first_analysis_controls.py
+++ b/tests/test_local_first_analysis_controls.py
@@ -10,20 +10,29 @@ from qfit.ui.application.local_first_analysis_controls import (
     NONE_ANALYSIS_MODE_LABEL,
     bind_local_first_analysis_mode_controls,
     configure_local_first_analysis_mode_backing_controls,
+    configure_local_first_temporal_mode_backing_controls,
     local_first_analysis_mode_options,
     set_local_first_analysis_mode,
 )
 
 
 class FakeComboBox:
+    AdjustToMinimumContentsLengthWithIcon = "adjust-minimum"
+
     def __init__(self, current_text=""):
         self.items = []
         self.current_text = current_text
+        self.size_policy = None
+        self.minimum_contents_lengths = []
+        self.hidden = False
 
     def addItem(self, item):
         self.items.append(item)
         if not self.current_text:
             self.current_text = item
+
+    def clear(self):
+        self.items.clear()
 
     def count(self):
         return len(self.items)
@@ -36,6 +45,15 @@ class FakeComboBox:
 
     def setCurrentText(self, text):
         self.current_text = text
+
+    def setSizeAdjustPolicy(self, policy):
+        self.size_policy = policy
+
+    def setMinimumContentsLength(self, length):
+        self.minimum_contents_lengths.append(length)
+
+    def hide(self):
+        self.hidden = True
 
 
 class FakeLayout:
@@ -82,6 +100,9 @@ class FakeWidget:
     def layout(self):
         return self._layout
 
+    def hide(self):
+        self.hidden = True
+
 
 class FakeHBoxLayout(FakeLayout):
     def __init__(self, widget):
@@ -96,6 +117,9 @@ class FakeLabel(FakeWidget):
 
     def text(self):
         return self._text
+
+    def setMargin(self, margin):
+        self.margin = margin
 
 
 class FakeQtComboBox(FakeWidget):
@@ -151,6 +175,36 @@ class LocalFirstAnalysisControlsTests(unittest.TestCase):
         self.assertEqual(dock.analysisModeLabel.text(), "Analysis")
         self.assertEqual(dock.analysisModeComboBox.items, list(ANALYSIS_MODE_LABELS))
         self.assertEqual(dock.runAnalysisButton.text(), "Run analysis")
+
+    def test_configure_temporal_mode_backing_controls_populates_hidden_bridge(self):
+        temporal_layout = FakeLayout()
+        temporal_parent = FakeWidget()
+        temporal_parent.setLayout(temporal_layout)
+        temporal_label = FakeLabel("Temporal", temporal_parent)
+        temporal_help = FakeLabel("Help")
+        temporal_row = FakeWidget()
+        dock = SimpleNamespace(
+            temporalModeLabel=temporal_label,
+            temporalModeComboBox=FakeComboBox(),
+            temporalHelpLabel=temporal_help,
+            analysisTemporalModeRow=temporal_row,
+        )
+
+        configure_local_first_temporal_mode_backing_controls(dock)
+
+        self.assertEqual(temporal_layout.spacing, 6)
+        self.assertEqual(
+            dock.temporalModeComboBox.size_policy,
+            FakeComboBox.AdjustToMinimumContentsLengthWithIcon,
+        )
+        self.assertEqual(dock.temporalModeComboBox.minimum_contents_lengths, [10, 10])
+        self.assertEqual(dock.temporalModeComboBox.items, ["Local activity time"])
+        self.assertEqual(dock.temporalModeComboBox.currentText(), "Local activity time")
+        self.assertEqual(temporal_help.margin, 2)
+        self.assertTrue(dock.temporalModeComboBox.hidden)
+        self.assertTrue(temporal_label.hidden)
+        self.assertTrue(temporal_help.hidden)
+        self.assertTrue(temporal_row.hidden)
 
     def test_mode_options_exclude_legacy_none_sentinel(self):
         combo = FakeComboBox()

--- a/tests/test_local_first_analysis_controls.py
+++ b/tests/test_local_first_analysis_controls.py
@@ -84,6 +84,7 @@ class FakeWidget:
         self._parent = parent
         self._object_name = None
         self._layout = None
+        self.hidden = False
 
     def setObjectName(self, name):
         self._object_name = name

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -40,6 +40,7 @@ from .local_first_analysis_controls import (
     NONE_ANALYSIS_MODE_LABEL,
     bind_local_first_analysis_mode_controls,
     configure_local_first_analysis_mode_backing_controls,
+    configure_local_first_temporal_mode_backing_controls,
     local_first_analysis_mode_options,
     set_local_first_analysis_mode,
 )
@@ -215,6 +216,7 @@ __all__ = [
     "bind_local_first_basemap_preset_controls",
     "bind_local_first_conditional_visibility_controls",
     "configure_local_first_analysis_mode_backing_controls",
+    "configure_local_first_temporal_mode_backing_controls",
     "configure_local_first_basemap_options",
     "build_current_dock_workflow_label",
     "build_detailed_fetch_visibility_update",

--- a/ui/application/local_first_analysis_controls.py
+++ b/ui/application/local_first_analysis_controls.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ...visualization.application import DEFAULT_TEMPORAL_MODE_LABEL, temporal_mode_labels
+
 
 NONE_ANALYSIS_MODE_LABEL = "None"
 ANALYSIS_MODE_LABELS = (
@@ -56,6 +58,44 @@ def configure_local_first_analysis_mode_backing_controls(dock) -> None:
     dock.runAnalysisButton = button
 
 
+def configure_local_first_temporal_mode_backing_controls(dock) -> None:
+    """Prepare temporal playback backing controls for the local-first Analysis page.
+
+    The visible local-first Analysis page owns temporal playback controls, but the
+    dock still keeps the legacy combo row as the settings/workflow bridge during
+    #805 consolidation. Keep option population and hidden backing-row policy here
+    with the rest of the local-first analysis setup.
+    """
+
+    label = getattr(dock, "temporalModeLabel", None)
+    combo = getattr(dock, "temporalModeComboBox", None)
+    help_label = getattr(dock, "temporalHelpLabel", None)
+    if label is None or combo is None or help_label is None:
+        return
+
+    parent_widget = label.parentWidget()
+    outer_layout = parent_widget.layout() if parent_widget is not None else None
+    set_spacing = getattr(outer_layout, "setSpacing", None)
+    if callable(set_spacing):
+        set_spacing(6)
+
+    _set_combo_size_policy(combo)
+    combo.setMinimumContentsLength(10)
+    help_label.setMargin(2)
+    combo.clear()
+    for label_text in temporal_mode_labels():
+        combo.addItem(label_text)
+    combo.setCurrentText(DEFAULT_TEMPORAL_MODE_LABEL)
+    combo.setMinimumContentsLength(10)
+    combo.hide()
+    label.hide()
+    help_label.hide()
+
+    temporal_row = getattr(dock, "analysisTemporalModeRow", None)
+    if temporal_row is not None:
+        temporal_row.hide()
+
+
 def bind_local_first_analysis_mode_controls(dock, composition) -> None:
     """Bind the local-first analysis page mode selector to dock state.
 
@@ -102,11 +142,29 @@ def set_local_first_analysis_mode(dock, mode: str) -> None:
     mode_combo.setCurrentText(mode)
 
 
+def _set_combo_size_policy(combo) -> None:
+    set_size_policy = getattr(combo, "setSizeAdjustPolicy", None)
+    if not callable(set_size_policy):
+        return
+
+    adjust_to_minimum = getattr(
+        type(combo),
+        "AdjustToMinimumContentsLengthWithIcon",
+        None,
+    )
+    if adjust_to_minimum is None:
+        from qgis.PyQt.QtWidgets import QComboBox
+
+        adjust_to_minimum = QComboBox.AdjustToMinimumContentsLengthWithIcon
+    set_size_policy(adjust_to_minimum)
+
+
 __all__ = [
     "ANALYSIS_MODE_LABELS",
     "NONE_ANALYSIS_MODE_LABEL",
     "bind_local_first_analysis_mode_controls",
     "configure_local_first_analysis_mode_backing_controls",
+    "configure_local_first_temporal_mode_backing_controls",
     "local_first_analysis_mode_options",
     "set_local_first_analysis_mode",
 ]

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -8,6 +8,7 @@ from .application.local_first_backing_controls import (
 )
 from .application.local_first_analysis_controls import (
     configure_local_first_analysis_mode_backing_controls,
+    configure_local_first_temporal_mode_backing_controls,
 )
 from .application.local_first_basemap_controls import (
     configure_local_first_basemap_options,
@@ -65,7 +66,7 @@ class DockStartupCoordinator:
         dock._configure_preview_sort_options()
         performed_steps.append("configure_preview_sort_options")
 
-        dock._configure_temporal_mode_options()
+        configure_local_first_temporal_mode_backing_controls(dock)
         performed_steps.append("configure_temporal_mode_options")
 
         configure_local_first_analysis_mode_backing_controls(dock)


### PR DESCRIPTION
## Summary

Move temporal playback backing-control setup out of `QfitDockWidget` and into the local-first analysis application policy.

## Changes

- Added `configure_local_first_temporal_mode_backing_controls` beside the analysis-mode local-first setup.
- Routed `DockStartupCoordinator` through the application helper instead of a dock method.
- Removed the dock-level temporal option setup wrapper and covered the migrated policy with focused unit tests.

## Testing

- `python3 -m unittest tests.test_local_first_analysis_controls tests.test_dockwidget_dependencies tests.test_qfit_dockwidget_analysis_pure -v`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
