### PR TITLE
Refactor local-first activity preview option setup

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -13,7 +13,6 @@ from qgis.PyQt.QtCore import QDate, Qt, QUrl
 from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import (
     QApplication,
-    QComboBox,
     QFileDialog,
     QDockWidget,
     QMessageBox,
@@ -21,10 +20,6 @@ from qgis.PyQt.QtWidgets import (
 
 from .activities.domain.activity_query import (
     DEFAULT_SORT_LABEL,
-    DETAILED_ROUTE_FILTER_ANY,
-    DETAILED_ROUTE_FILTER_MISSING,
-    DETAILED_ROUTE_FILTER_PRESENT,
-    SORT_OPTIONS,
 )
 from .activities.application import (
     ActivitySelectionState,
@@ -93,10 +88,7 @@ from .ui.application import (
     build_visual_workflow_settings_snapshot,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
-from .detailed_route_strategy import (
-    DETAILED_ROUTE_STRATEGY_MISSING,
-    detailed_route_strategy_labels,
-)
+from .detailed_route_strategy import DETAILED_ROUTE_STRATEGY_MISSING
 from .mapbox_config import MapboxConfigError
 from .visualization.application import (
     LayerRefs,
@@ -707,36 +699,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         ]
         for signal in preview_inputs:
             signal.connect(self._refresh_activity_preview)
-
-    def _configure_detailed_route_filter_options(self):
-        legacy_checkbox = getattr(self, "detailedOnlyCheckBox", None)
-        combo = getattr(self, "detailedRouteStatusComboBox", None)
-        if combo is None:
-            combo = QComboBox(legacy_checkbox.parentWidget())
-            combo.setObjectName("detailedRouteStatusComboBox")
-            layout = legacy_checkbox.parentWidget().layout()
-            if layout is not None and hasattr(layout, "replaceWidget"):
-                layout.replaceWidget(legacy_checkbox, combo)
-            legacy_checkbox.hide()
-            self.detailedRouteStatusComboBox = combo
-        combo.clear()
-        combo.addItem("Any routes", DETAILED_ROUTE_FILTER_ANY)
-        combo.addItem("Detailed routes only", DETAILED_ROUTE_FILTER_PRESENT)
-        combo.addItem("Missing detailed routes", DETAILED_ROUTE_FILTER_MISSING)
-        combo.setToolTip("Filter activities by detailed-route availability")
-
-    def _configure_detailed_route_strategy_options(self):
-        combo = getattr(self, "detailedRouteStrategyComboBox", None)
-        if combo is None:
-            return
-        combo.clear()
-        for label in detailed_route_strategy_labels():
-            combo.addItem(label)
-
-    def _configure_preview_sort_options(self):
-        self.previewSortComboBox.clear()
-        for label in SORT_OPTIONS:
-            self.previewSortComboBox.addItem(label)
 
     def _bind_dependencies(self, dependencies: DockWidgetDependencies) -> None:
         self.settings = dependencies.settings

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -535,6 +535,10 @@ class DockStartupCoordinatorTests(unittest.TestCase):
             ) as configure_local_first_spinbox_unit_copy,
             patch(
                 "qfit.ui.dock_startup_coordinator."
+                "configure_local_first_activity_preview_options"
+            ) as configure_local_first_activity_preview_options,
+            patch(
+                "qfit.ui.dock_startup_coordinator."
                 "configure_local_first_analysis_mode_backing_controls"
             ) as configure_local_first_analysis_mode_backing_controls,
             patch(
@@ -565,9 +569,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                     "apply_contextual_help",
                     "configure_local_first_spinbox_unit_copy",
                     "configure_local_first_basemap_options",
-                    "configure_detailed_route_filter_options",
-                    "configure_detailed_route_strategy_options",
-                    "configure_preview_sort_options",
+                    "configure_local_first_activity_preview_options",
                     "configure_temporal_mode_options",
                     "configure_analysis_mode_options",
                     "load_settings",
@@ -587,9 +589,6 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 call._ensure_wizard_settings(),
                 call._remove_stale_qfit_layers(),
                 call._apply_contextual_help(),
-                call._configure_detailed_route_filter_options(),
-                call._configure_detailed_route_strategy_options(),
-                call._configure_preview_sort_options(),
                 call._load_settings(),
                 call._set_default_dates(),
                 call._wire_events(),
@@ -600,6 +599,9 @@ class DockStartupCoordinatorTests(unittest.TestCase):
         configure_local_first_backing_controls.assert_called_once_with(dock)
         configure_local_first_spinbox_unit_copy.assert_called_once_with(dock)
         configure_local_first_basemap_options.assert_called_once_with(dock)
+        configure_local_first_activity_preview_options.assert_called_once_with(
+            dock
+        )
         configure_local_first_analysis_mode_backing_controls.assert_called_once_with(
             dock
         )

--- a/tests/test_local_first_activity_controls.py
+++ b/tests/test_local_first_activity_controls.py
@@ -1,0 +1,192 @@
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.domain.activity_query import (
+    DEFAULT_SORT_LABEL,
+    DETAILED_ROUTE_FILTER_ANY,
+    DETAILED_ROUTE_FILTER_MISSING,
+    DETAILED_ROUTE_FILTER_PRESENT,
+    SORT_OPTIONS,
+)
+from qfit.detailed_route_strategy import detailed_route_strategy_labels
+from qfit.ui.application.local_first_activity_controls import (
+    configure_detailed_route_filter_options,
+    configure_detailed_route_strategy_options,
+    configure_local_first_activity_preview_options,
+    configure_preview_sort_options,
+)
+
+
+class FakeComboBox:
+    def __init__(self, parent=None):
+        self._parent = parent
+        self.items = []
+        self.object_name = None
+        self.tooltip = None
+        self.cleared = False
+
+    def addItem(self, label, data=None):
+        self.items.append((label, data))
+
+    def clear(self):
+        self.cleared = True
+        self.items.clear()
+
+    def setObjectName(self, name):
+        self.object_name = name
+
+    def setToolTip(self, text):
+        self.tooltip = text
+
+    def parentWidget(self):
+        return self._parent
+
+
+class FakeLayout:
+    def __init__(self):
+        self.replacements = []
+
+    def replaceWidget(self, old_widget, new_widget):
+        self.replacements.append((old_widget, new_widget))
+
+
+class FakeParent:
+    def __init__(self):
+        self._layout = FakeLayout()
+
+    def layout(self):
+        return self._layout
+
+
+class FakeLegacyCheckBox:
+    def __init__(self, parent):
+        self._parent = parent
+        self.hidden = False
+
+    def parentWidget(self):
+        return self._parent
+
+    def hide(self):
+        self.hidden = True
+
+
+def install_fake_qtwidgets():
+    qgis = ModuleType("qgis")
+    pyqt = ModuleType("qgis.PyQt")
+    qtwidgets = ModuleType("qgis.PyQt.QtWidgets")
+    qtwidgets.QComboBox = FakeComboBox
+    qgis.PyQt = pyqt
+    pyqt.QtWidgets = qtwidgets
+    return {
+        "qgis": qgis,
+        "qgis.PyQt": pyqt,
+        "qgis.PyQt.QtWidgets": qtwidgets,
+    }
+
+
+class LocalFirstActivityControlsTests(unittest.TestCase):
+    def test_configure_detailed_route_filter_replaces_legacy_checkbox(self):
+        parent = FakeParent()
+        legacy_checkbox = FakeLegacyCheckBox(parent)
+        dock = SimpleNamespace(detailedOnlyCheckBox=legacy_checkbox)
+
+        with patch.dict(sys.modules, install_fake_qtwidgets()):
+            configure_detailed_route_filter_options(dock)
+
+        combo = dock.detailedRouteStatusComboBox
+        self.assertIs(combo.parentWidget(), parent)
+        self.assertEqual(combo.object_name, "detailedRouteStatusComboBox")
+        self.assertEqual(
+            parent.layout().replacements,
+            [(legacy_checkbox, combo)],
+        )
+        self.assertTrue(legacy_checkbox.hidden)
+        self.assertEqual(
+            combo.items,
+            [
+                ("Any routes", DETAILED_ROUTE_FILTER_ANY),
+                ("Detailed routes only", DETAILED_ROUTE_FILTER_PRESENT),
+                ("Missing detailed routes", DETAILED_ROUTE_FILTER_MISSING),
+            ],
+        )
+        self.assertEqual(
+            combo.tooltip,
+            "Filter activities by detailed-route availability",
+        )
+
+    def test_configure_detailed_route_filter_reuses_existing_combo(self):
+        combo = FakeComboBox()
+        combo.addItem("stale", "value")
+        dock = SimpleNamespace(detailedRouteStatusComboBox=combo)
+
+        configure_detailed_route_filter_options(dock)
+
+        self.assertTrue(combo.cleared)
+        self.assertEqual(
+            combo.items,
+            [
+                ("Any routes", DETAILED_ROUTE_FILTER_ANY),
+                ("Detailed routes only", DETAILED_ROUTE_FILTER_PRESENT),
+                ("Missing detailed routes", DETAILED_ROUTE_FILTER_MISSING),
+            ],
+        )
+
+    def test_configure_detailed_route_strategy_populates_when_present(self):
+        combo = FakeComboBox()
+        combo.addItem("stale")
+        dock = SimpleNamespace(detailedRouteStrategyComboBox=combo)
+
+        configure_detailed_route_strategy_options(dock)
+
+        self.assertTrue(combo.cleared)
+        self.assertEqual(
+            combo.items,
+            [(label, None) for label in detailed_route_strategy_labels()],
+        )
+
+    def test_configure_detailed_route_strategy_skips_missing_combo(self):
+        configure_detailed_route_strategy_options(SimpleNamespace())
+
+    def test_configure_preview_sort_populates_sort_options(self):
+        combo = FakeComboBox()
+        combo.addItem("stale")
+        dock = SimpleNamespace(previewSortComboBox=combo)
+
+        configure_preview_sort_options(dock)
+
+        self.assertTrue(combo.cleared)
+        self.assertEqual(
+            combo.items,
+            [(label, None) for label in SORT_OPTIONS],
+        )
+        self.assertEqual(combo.items[0], (DEFAULT_SORT_LABEL, None))
+
+    def test_configure_activity_preview_options_populates_backing_combos(self):
+        route_status_combo = FakeComboBox()
+        strategy_combo = FakeComboBox()
+        sort_combo = FakeComboBox()
+        dock = SimpleNamespace(
+            detailedRouteStatusComboBox=route_status_combo,
+            detailedRouteStrategyComboBox=strategy_combo,
+            previewSortComboBox=sort_combo,
+        )
+
+        configure_local_first_activity_preview_options(dock)
+
+        self.assertEqual(route_status_combo.items[0], ("Any routes", "any"))
+        self.assertEqual(
+            strategy_combo.items,
+            [(label, None) for label in detailed_route_strategy_labels()],
+        )
+        self.assertEqual(
+            sort_combo.items,
+            [(label, None) for label in SORT_OPTIONS],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -855,6 +855,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "_bind_local_first_analysis_mode_controls",
             "_set_local_first_analysis_mode",
             "_update_atlas_document_settings",
+            "_configure_detailed_route_filter_options",
+            "_configure_detailed_route_strategy_options",
+            "_configure_preview_sort_options",
         )
 
         for method_name in retired_methods:

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -35,6 +35,12 @@ from .local_first_navigation import (
     build_local_first_dock_navigation_state,
     local_first_dock_page_keys,
 )
+from .local_first_activity_controls import (
+    configure_detailed_route_filter_options,
+    configure_detailed_route_strategy_options,
+    configure_local_first_activity_preview_options,
+    configure_preview_sort_options,
+)
 from .local_first_analysis_controls import (
     ANALYSIS_MODE_LABELS,
     NONE_ANALYSIS_MODE_LABEL,
@@ -215,9 +221,13 @@ __all__ = [
     "bind_local_first_analysis_mode_controls",
     "bind_local_first_basemap_preset_controls",
     "bind_local_first_conditional_visibility_controls",
+    "configure_detailed_route_filter_options",
+    "configure_detailed_route_strategy_options",
+    "configure_local_first_activity_preview_options",
     "configure_local_first_analysis_mode_backing_controls",
     "configure_local_first_temporal_mode_backing_controls",
     "configure_local_first_basemap_options",
+    "configure_preview_sort_options",
     "build_current_dock_workflow_label",
     "build_detailed_fetch_visibility_update",
     "build_dock_summary_status",

--- a/ui/application/local_first_activity_controls.py
+++ b/ui/application/local_first_activity_controls.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from ...activities.domain.activity_query import (
+    DETAILED_ROUTE_FILTER_ANY,
+    DETAILED_ROUTE_FILTER_MISSING,
+    DETAILED_ROUTE_FILTER_PRESENT,
+    SORT_OPTIONS,
+)
+from ...detailed_route_strategy import detailed_route_strategy_labels
+
+
+def configure_local_first_activity_preview_options(dock) -> None:
+    """Prepare activity preview backing controls for the Data page."""
+
+    configure_detailed_route_filter_options(dock)
+    configure_detailed_route_strategy_options(dock)
+    configure_preview_sort_options(dock)
+
+
+def configure_detailed_route_filter_options(dock) -> None:
+    """Populate the detailed-route availability filter backing combo."""
+
+    legacy_checkbox = getattr(dock, "detailedOnlyCheckBox", None)
+    combo = getattr(dock, "detailedRouteStatusComboBox", None)
+    if combo is None:
+        from qgis.PyQt.QtWidgets import QComboBox
+
+        combo = QComboBox(legacy_checkbox.parentWidget())
+        combo.setObjectName("detailedRouteStatusComboBox")
+        layout = legacy_checkbox.parentWidget().layout()
+        if layout is not None and hasattr(layout, "replaceWidget"):
+            layout.replaceWidget(legacy_checkbox, combo)
+        legacy_checkbox.hide()
+        dock.detailedRouteStatusComboBox = combo
+    combo.clear()
+    combo.addItem("Any routes", DETAILED_ROUTE_FILTER_ANY)
+    combo.addItem("Detailed routes only", DETAILED_ROUTE_FILTER_PRESENT)
+    combo.addItem("Missing detailed routes", DETAILED_ROUTE_FILTER_MISSING)
+    combo.setToolTip("Filter activities by detailed-route availability")
+
+
+def configure_detailed_route_strategy_options(dock) -> None:
+    """Populate the detailed-route fetch strategy backing combo."""
+
+    combo = getattr(dock, "detailedRouteStrategyComboBox", None)
+    if combo is None:
+        return
+    combo.clear()
+    for label in detailed_route_strategy_labels():
+        combo.addItem(label)
+
+
+def configure_preview_sort_options(dock) -> None:
+    """Populate the activity preview sort backing combo."""
+
+    combo = getattr(dock, "previewSortComboBox", None)
+    if combo is None:
+        return
+    combo.clear()
+    for label in SORT_OPTIONS:
+        combo.addItem(label)
+
+
+__all__ = [
+    "configure_detailed_route_filter_options",
+    "configure_detailed_route_strategy_options",
+    "configure_local_first_activity_preview_options",
+    "configure_preview_sort_options",
+]

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .application.local_first_activity_controls import (
+    configure_local_first_activity_preview_options,
+)
 from .application.local_first_backing_controls import (
     configure_local_first_backing_controls,
     configure_local_first_spinbox_unit_copy,
@@ -57,14 +60,10 @@ class DockStartupCoordinator:
         configure_local_first_basemap_options(dock)
         performed_steps.append("configure_local_first_basemap_options")
 
-        dock._configure_detailed_route_filter_options()
-        performed_steps.append("configure_detailed_route_filter_options")
-
-        dock._configure_detailed_route_strategy_options()
-        performed_steps.append("configure_detailed_route_strategy_options")
-
-        dock._configure_preview_sort_options()
-        performed_steps.append("configure_preview_sort_options")
+        configure_local_first_activity_preview_options(dock)
+        performed_steps.append(
+            "configure_local_first_activity_preview_options"
+        )
 
         configure_local_first_temporal_mode_backing_controls(dock)
         performed_steps.append("configure_temporal_mode_options")


### PR DESCRIPTION
## Summary

- Move local-first activity preview option setup out of `QfitDockWidget` into an application-layer helper.
- Route dock startup through the helper for detailed-route filters, detailed-route strategy, and preview sorting.
- Add focused unittest-discoverable coverage for the helper and keep the dock method-retirement guard updated.

Refs #805

## Tests

- `python3 -m unittest tests.test_local_first_activity_controls tests.test_dockwidget_dependencies tests.test_qfit_dockwidget_analysis_pure -q`
- `python3 -m pytest tests/ -x -q --tb=short`
