### PR TITLE
Refactor local-first progress facts out of dock

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -87,6 +87,11 @@ from .ui.application import (
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
 )
+from .ui.application.local_first_progress_facts import (
+    current_local_first_activity_style_preset,
+    current_local_first_background_facts,
+    current_local_first_visual_temporal_mode,
+)
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import DETAILED_ROUTE_STRATEGY_MISSING
 from .mapbox_config import MapboxConfigError
@@ -97,7 +102,6 @@ from .visualization.application import (
 )
 from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_provider import StravaProvider
-from .visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
 from .ui.dockwidget_dependencies import DockWidgetDependencies, build_dockwidget_dependencies
 from .ui.dock_startup_coordinator import DockStartupCoordinator
 from .configuration.application.connection_status import build_strava_connection_status
@@ -198,7 +202,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             background_enabled,
             background_layer_loaded,
             background_name,
-        ) = self._current_wizard_background_facts(runtime_state)
+        ) = current_local_first_background_facts(self, runtime_state)
         (
             filters_active,
             filtered_activity_count,
@@ -215,7 +219,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             filters_active=filters_active,
             filtered_activity_count=filtered_activity_count,
             filter_description=filter_description,
-            activity_style_preset=self._current_wizard_activity_style_preset(),
+            activity_style_preset=current_local_first_activity_style_preset(self),
             last_sync_date=self._current_wizard_last_sync_date(),
         )
 
@@ -245,87 +249,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._runtime_store().select_output_path((value or "").strip() or None)
         self._refresh_live_dock_navigation_from_runtime()
-
-    def _current_wizard_activity_style_preset(self) -> str | None:
-        """Return current activity style copy for the optional wizard map page."""
-
-        preset_combo = getattr(self, "stylePresetComboBox", None)
-        if preset_combo is None or not hasattr(preset_combo, "currentText"):
-            return None
-        try:
-            preset_name = preset_combo.currentText()
-        except RuntimeError:
-            logger.debug("Failed to read wizard activity style preset", exc_info=True)
-            return None
-        if not isinstance(preset_name, str):
-            return None
-        stripped = preset_name.strip()
-        return stripped or None
-
-    def _current_visual_temporal_mode(self) -> str:
-        """Return the visible temporal playback setting for visual workflow actions."""
-
-        combo = getattr(self, "temporalModeComboBox", None)
-        if combo is None or not hasattr(combo, "currentText"):
-            return DEFAULT_TEMPORAL_MODE_LABEL
-        try:
-            mode_label = combo.currentText()
-        except RuntimeError:
-            logger.debug("Failed to read temporal playback mode", exc_info=True)
-            return DEFAULT_TEMPORAL_MODE_LABEL
-        if not isinstance(mode_label, str):
-            return DEFAULT_TEMPORAL_MODE_LABEL
-        return mode_label.strip() or DEFAULT_TEMPORAL_MODE_LABEL
-
-    def _current_wizard_background_facts(self, runtime_state) -> tuple[bool, bool, str | None]:
-        """Return current basemap facts for the optional wizard map page."""
-
-        background_layer_loaded = runtime_state.background_layer is not None
-        if background_layer_loaded:
-            return True, True, self._current_wizard_layer_name(
-                runtime_state.background_layer,
-                log_message="Failed to read wizard background layer name",
-            )
-
-        checkbox = getattr(self, "backgroundMapCheckBox", None)
-        background_enabled = bool(
-            checkbox is not None
-            and hasattr(checkbox, "isChecked")
-            and checkbox.isChecked()
-        )
-        if not background_enabled:
-            return False, False, None
-        return True, False, self._current_wizard_background_name()
-
-    def _current_wizard_layer_name(self, layer, *, log_message: str) -> str | None:
-        if layer is None:
-            return None
-        name_method = getattr(layer, "name", None)
-        if not callable(name_method):
-            return None
-        try:
-            layer_name = name_method()
-        except RuntimeError:
-            logger.debug(log_message, exc_info=True)
-            return None
-        if not isinstance(layer_name, str):
-            return None
-        stripped = layer_name.strip()
-        return stripped or None
-
-    def _current_wizard_background_name(self) -> str | None:
-        preset_combo = getattr(self, "backgroundPresetComboBox", None)
-        if preset_combo is None or not hasattr(preset_combo, "currentText"):
-            return None
-        try:
-            preset_name = preset_combo.currentText()
-        except RuntimeError:
-            logger.debug("Failed to read wizard background preset", exc_info=True)
-            return None
-        if not isinstance(preset_name, str):
-            return None
-        stripped = preset_name.strip()
-        return stripped or None
 
     def _current_wizard_filter_facts(self) -> tuple[bool, int | None, str | None]:
         """Return the current map-filter facts the optional wizard can summarize."""
@@ -1376,7 +1299,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             ),
             settings=build_visual_workflow_settings_snapshot(
                 style_preset=self.stylePresetComboBox.currentText(),
-                temporal_mode=self._current_visual_temporal_mode(),
+                temporal_mode=current_local_first_visual_temporal_mode(self),
                 analysis_mode=self.analysisModeComboBox.currentText(),
             ),
             background=build_visual_workflow_background_inputs(

--- a/tests/test_local_first_progress_facts.py
+++ b/tests/test_local_first_progress_facts.py
@@ -1,0 +1,124 @@
+import unittest
+from types import SimpleNamespace
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.local_first_progress_facts import (
+    current_local_first_activity_style_preset,
+    current_local_first_background_facts,
+    current_local_first_visual_temporal_mode,
+)
+from qfit.visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
+
+
+class _FakeCheckBox:
+    def __init__(self, checked):
+        self._checked = checked
+
+    def isChecked(self):
+        return self._checked
+
+
+class _FakeComboBox:
+    def __init__(self, text):
+        self._text = text
+
+    def currentText(self):
+        return self._text
+
+
+class _FailingComboBox:
+    def currentText(self):
+        raise RuntimeError("deleted widget")
+
+
+class _FakeLayer:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class TestLocalFirstProgressFacts(unittest.TestCase):
+    def test_activity_style_preset_reads_trimmed_combo_text(self):
+        dock = SimpleNamespace(stylePresetComboBox=_FakeComboBox(" Simple lines "))
+
+        self.assertEqual(
+            current_local_first_activity_style_preset(dock),
+            "Simple lines",
+        )
+
+    def test_activity_style_preset_handles_missing_or_deleted_combo(self):
+        self.assertIsNone(current_local_first_activity_style_preset(SimpleNamespace()))
+        self.assertIsNone(
+            current_local_first_activity_style_preset(
+                SimpleNamespace(stylePresetComboBox=_FailingComboBox())
+            )
+        )
+
+    def test_background_facts_report_disabled_basemap(self):
+        dock = SimpleNamespace(
+            backgroundMapCheckBox=_FakeCheckBox(False),
+            backgroundPresetComboBox=_FakeComboBox("Outdoors"),
+        )
+        runtime_state = SimpleNamespace(background_layer=None)
+
+        self.assertEqual(
+            current_local_first_background_facts(dock, runtime_state),
+            (False, False, None),
+        )
+
+    def test_background_facts_prefer_loaded_layer_over_pending_ui(self):
+        dock = SimpleNamespace(
+            backgroundMapCheckBox=_FakeCheckBox(False),
+            backgroundPresetComboBox=_FakeComboBox("Outdoors"),
+        )
+        runtime_state = SimpleNamespace(background_layer=_FakeLayer("Satellite"))
+
+        self.assertEqual(
+            current_local_first_background_facts(dock, runtime_state),
+            (True, True, "Satellite"),
+        )
+
+    def test_background_facts_report_enabled_basemap_name(self):
+        dock = SimpleNamespace(
+            backgroundMapCheckBox=_FakeCheckBox(True),
+            backgroundPresetComboBox=_FakeComboBox(" Satellite "),
+        )
+        runtime_state = SimpleNamespace(background_layer=None)
+
+        self.assertEqual(
+            current_local_first_background_facts(dock, runtime_state),
+            (True, False, "Satellite"),
+        )
+
+    def test_visual_temporal_mode_reads_trimmed_combo_text(self):
+        dock = SimpleNamespace(temporalModeComboBox=_FakeComboBox(" Activity time "))
+
+        self.assertEqual(
+            current_local_first_visual_temporal_mode(dock),
+            "Activity time",
+        )
+
+    def test_visual_temporal_mode_falls_back_to_default_for_missing_blank_or_deleted_combo(self):
+        self.assertEqual(
+            current_local_first_visual_temporal_mode(SimpleNamespace()),
+            DEFAULT_TEMPORAL_MODE_LABEL,
+        )
+        self.assertEqual(
+            current_local_first_visual_temporal_mode(
+                SimpleNamespace(temporalModeComboBox=_FakeComboBox("   "))
+            ),
+            DEFAULT_TEMPORAL_MODE_LABEL,
+        )
+        self.assertEqual(
+            current_local_first_visual_temporal_mode(
+                SimpleNamespace(temporalModeComboBox=_FailingComboBox())
+            ),
+            DEFAULT_TEMPORAL_MODE_LABEL,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -22,6 +22,10 @@ from qfit.ui.application.local_first_control_visibility import (
     update_local_first_mapbox_custom_style_visibility,
     update_local_first_point_sampling_visibility,
 )
+from qfit.ui.application.local_first_progress_facts import (
+    current_local_first_activity_style_preset,
+    current_local_first_background_facts,
+)
 from qfit.activities.domain.activity_query import DETAILED_ROUTE_FILTER_MISSING
 from qfit.sync_repository import ActivitySyncState
 
@@ -416,9 +420,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.stylePresetComboBox = _FakeComboBox(current_text=" Simple lines ")
 
-        style_preset = (
-            self.module.QfitDockWidget._current_wizard_activity_style_preset(dock)
-        )
+        style_preset = current_local_first_activity_style_preset(dock)
 
         self.assertEqual(style_preset, "Simple lines")
 
@@ -428,7 +430,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.backgroundMapCheckBox = _FakeCheckBox(False)
         dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
 
-        facts = self.module.QfitDockWidget._current_wizard_background_facts(
+        facts = current_local_first_background_facts(
             dock,
             dock.runtime_state,
         )
@@ -442,7 +444,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
         dock._runtime_store().set_background_layer(_FakeLayer("Satellite"))
 
-        facts = self.module.QfitDockWidget._current_wizard_background_facts(
+        facts = current_local_first_background_facts(
             dock,
             dock.runtime_state,
         )
@@ -456,7 +458,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.backgroundPresetComboBox = _FakeComboBox(current_text="Outdoors")
         dock._runtime_store().set_background_layer(_FakeLayer("   "))
 
-        facts = self.module.QfitDockWidget._current_wizard_background_facts(
+        facts = current_local_first_background_facts(
             dock,
             dock.runtime_state,
         )
@@ -469,7 +471,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.backgroundMapCheckBox = _FakeCheckBox(True)
         dock.backgroundPresetComboBox = _FakeComboBox(current_text=" Satellite ")
 
-        facts = self.module.QfitDockWidget._current_wizard_background_facts(
+        facts = current_local_first_background_facts(
             dock,
             dock.runtime_state,
         )

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+
+from ...visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
+
+logger = logging.getLogger(__name__)
+
+
+def current_local_first_activity_style_preset(dock) -> str | None:
+    """Return current activity style copy for local-first progress summaries."""
+
+    preset_combo = getattr(dock, "stylePresetComboBox", None)
+    if preset_combo is None or not hasattr(preset_combo, "currentText"):
+        return None
+    try:
+        preset_name = preset_combo.currentText()
+    except RuntimeError:
+        logger.debug("Failed to read local-first activity style preset", exc_info=True)
+        return None
+    if not isinstance(preset_name, str):
+        return None
+    stripped = preset_name.strip()
+    return stripped or None
+
+
+def current_local_first_visual_temporal_mode(dock) -> str:
+    """Return the visible temporal playback setting for visual workflow actions."""
+
+    combo = getattr(dock, "temporalModeComboBox", None)
+    if combo is None or not hasattr(combo, "currentText"):
+        return DEFAULT_TEMPORAL_MODE_LABEL
+    try:
+        mode_label = combo.currentText()
+    except RuntimeError:
+        logger.debug("Failed to read local-first temporal playback mode", exc_info=True)
+        return DEFAULT_TEMPORAL_MODE_LABEL
+    if not isinstance(mode_label, str):
+        return DEFAULT_TEMPORAL_MODE_LABEL
+    return mode_label.strip() or DEFAULT_TEMPORAL_MODE_LABEL
+
+
+def current_local_first_background_facts(dock, runtime_state) -> tuple[bool, bool, str | None]:
+    """Return current basemap facts for local-first progress summaries."""
+
+    background_layer_loaded = runtime_state.background_layer is not None
+    if background_layer_loaded:
+        return True, True, _current_local_first_layer_name(
+            runtime_state.background_layer,
+            log_message="Failed to read local-first background layer name",
+        )
+
+    checkbox = getattr(dock, "backgroundMapCheckBox", None)
+    background_enabled = bool(
+        checkbox is not None
+        and hasattr(checkbox, "isChecked")
+        and checkbox.isChecked()
+    )
+    if not background_enabled:
+        return False, False, None
+    return True, False, _current_local_first_background_name(dock)
+
+
+def _current_local_first_layer_name(layer, *, log_message: str) -> str | None:
+    if layer is None:
+        return None
+    name_method = getattr(layer, "name", None)
+    if not callable(name_method):
+        return None
+    try:
+        layer_name = name_method()
+    except RuntimeError:
+        logger.debug(log_message, exc_info=True)
+        return None
+    if not isinstance(layer_name, str):
+        return None
+    stripped = layer_name.strip()
+    return stripped or None
+
+
+def _current_local_first_background_name(dock) -> str | None:
+    preset_combo = getattr(dock, "backgroundPresetComboBox", None)
+    if preset_combo is None or not hasattr(preset_combo, "currentText"):
+        return None
+    try:
+        preset_name = preset_combo.currentText()
+    except RuntimeError:
+        logger.debug("Failed to read local-first background preset", exc_info=True)
+        return None
+    if not isinstance(preset_name, str):
+        return None
+    stripped = preset_name.strip()
+    return stripped or None
+
+
+__all__ = [
+    "current_local_first_activity_style_preset",
+    "current_local_first_background_facts",
+    "current_local_first_visual_temporal_mode",
+]


### PR DESCRIPTION
## Summary

Move local-first progress/readback policy for activity styling, basemap status, and visual temporal mode out of `QfitDockWidget` into an application helper module.

## Changes

- Added `ui/application/local_first_progress_facts.py` for local-first progress and visual workflow readbacks.
- Updated `QfitDockWidget` to call the application helper instead of carrying these private methods directly.
- Added unittest-discoverable focused coverage for the extracted helper and kept existing dock progress tests aligned.

## Testing

- `python3 -m unittest tests.test_local_first_progress_facts tests.test_qfit_dockwidget_analysis_pure -q`
- `python3 -m pytest tests/test_local_first_progress_facts.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
