### PR TITLE
Refactor local-first filter facts out of dock

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -76,7 +76,6 @@ from .ui.application import (
     RunAnalysisAction,
     build_dock_summary_status,
     build_visual_layer_refs,
-    build_wizard_filter_description,
     set_local_first_analysis_mode,
     update_local_first_atlas_document_settings,
     build_wizard_progress_facts_from_runtime_state,
@@ -90,6 +89,7 @@ from .ui.application import (
 from .ui.application.local_first_progress_facts import (
     current_local_first_activity_style_preset,
     current_local_first_background_facts,
+    current_local_first_filter_facts,
     current_local_first_visual_temporal_mode,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
@@ -207,7 +207,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             filters_active,
             filtered_activity_count,
             filter_description,
-        ) = self._current_wizard_filter_facts()
+        ) = current_local_first_filter_facts(self, runtime_state)
         return build_wizard_progress_facts_from_runtime_state(
             runtime_state,
             connection_configured=self._has_configured_strava_connection(),
@@ -249,54 +249,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._runtime_store().select_output_path((value or "").strip() or None)
         self._refresh_live_dock_navigation_from_runtime()
-
-    def _current_wizard_filter_facts(self) -> tuple[bool, int | None, str | None]:
-        """Return the current map-filter facts the optional wizard can summarize."""
-
-        layer_filter_facts = self._current_wizard_layer_filter_facts()
-        if layer_filter_facts is not None:
-            filters_active, filtered_activity_count = layer_filter_facts
-            filter_description = "layer subset" if filters_active else None
-            return filters_active, filtered_activity_count, filter_description
-
-        activities = tuple(self.runtime_state.activities)
-        if not activities:
-            return False, None, None
-        preview_request = self._current_activity_preview_request()
-        selection_state = build_activity_preview_selection_state(preview_request)
-        filters_active = selection_state.filtered_count != len(activities)
-        if not filters_active:
-            return False, None, None
-        return (
-            True,
-            selection_state.filtered_count,
-            build_wizard_filter_description(preview_request),
-        )
-
-    def _current_wizard_layer_filter_facts(self) -> tuple[bool, int | None] | None:
-        layer = self.runtime_state.activities_layer
-        if layer is None or not hasattr(layer, "subsetString"):
-            return None
-        try:
-            subset = (layer.subsetString() or "").strip()
-        except RuntimeError:
-            logger.debug("Failed to read activity layer subset", exc_info=True)
-            return None
-        if not subset:
-            return False, None
-        return True, self._current_wizard_layer_feature_count(layer)
-
-    def _current_wizard_layer_feature_count(self, layer) -> int | None:
-        if not hasattr(layer, "featureCount"):
-            return None
-        try:
-            count = layer.featureCount()
-        except RuntimeError:
-            logger.debug("Failed to read activity layer feature count", exc_info=True)
-            return None
-        if not isinstance(count, int):
-            return None
-        return max(count, 0)
 
     def _current_wizard_atlas_output_path(self, *, runtime_state, atlas_exported: bool):
         """Return the atlas output path the optional wizard should describe."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -25,6 +25,7 @@ from qfit.ui.application.local_first_control_visibility import (
 from qfit.ui.application.local_first_progress_facts import (
     current_local_first_activity_style_preset,
     current_local_first_background_facts,
+    current_local_first_filter_facts,
 )
 from qfit.activities.domain.activity_query import DETAILED_ROUTE_FILTER_MISSING
 from qfit.sync_repository import ActivitySyncState
@@ -520,8 +521,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             activities_layer=_FakeSubsetLayer('"activity_type" = \'Run\'', 2),
         )
 
-        filters_active, filtered_count, filter_description = (
-            self.module.QfitDockWidget._current_wizard_filter_facts(dock)
+        filters_active, filtered_count, filter_description = current_local_first_filter_facts(
+            dock,
+            dock.runtime_state,
         )
 
         self.assertTrue(filters_active)
@@ -537,8 +539,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             activities_layer=_FakeSubsetLayer("", 3),
         )
 
-        filters_active, filtered_count, filter_description = (
-            self.module.QfitDockWidget._current_wizard_filter_facts(dock)
+        filters_active, filtered_count, filter_description = current_local_first_filter_facts(
+            dock,
+            dock.runtime_state,
         )
 
         self.assertFalse(filters_active)
@@ -560,13 +563,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         dock._current_activity_preview_request = MagicMock(return_value=preview_request)
 
-        with patch.object(
-            self.module,
+        with patch(
+            "qfit.ui.application.local_first_progress_facts."
             "build_activity_preview_selection_state",
             return_value=SimpleNamespace(filtered_count=1),
         ):
-            filters_active, filtered_count, filter_description = (
-                self.module.QfitDockWidget._current_wizard_filter_facts(dock)
+            filters_active, filtered_count, filter_description = current_local_first_filter_facts(
+                dock,
+                dock.runtime_state,
             )
 
         self.assertTrue(filters_active)
@@ -576,6 +580,94 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "type: Run · search: “alps” · dates: from 2026-04-01 · "
             "distance: ≥ 10 km · routes: missing details",
         )
+
+    def test_current_wizard_filter_facts_reports_unfiltered_preview_request(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().set_activities([object(), object(), object()])
+        preview_request = SimpleNamespace(activity_type=None)
+        dock._current_activity_preview_request = MagicMock(return_value=preview_request)
+
+        with patch(
+            "qfit.ui.application.local_first_progress_facts."
+            "build_activity_preview_selection_state",
+            return_value=SimpleNamespace(filtered_count=3),
+        ):
+            filters_active, filtered_count, filter_description = current_local_first_filter_facts(
+                dock,
+                dock.runtime_state,
+            )
+
+        self.assertFalse(filters_active)
+        self.assertIsNone(filtered_count)
+        self.assertIsNone(filter_description)
+
+    def test_current_wizard_filter_facts_ignores_unreadable_layer_subset(self):
+        class UnreadableSubsetLayer:
+            def subsetString(self):
+                raise RuntimeError("layer deleted")
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().load_dataset(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer=UnreadableSubsetLayer(),
+        )
+
+        filters_active, filtered_count, filter_description = current_local_first_filter_facts(
+            dock,
+            dock.runtime_state,
+        )
+
+        self.assertFalse(filters_active)
+        self.assertIsNone(filtered_count)
+        self.assertIsNone(filter_description)
+
+    def test_current_wizard_filter_facts_allows_unknown_layer_feature_count(self):
+        class NoFeatureCountLayer:
+            def subsetString(self):
+                return '"activity_type" = \'Ride\''
+
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._runtime_store().load_dataset(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer=NoFeatureCountLayer(),
+        )
+
+        filters_active, filtered_count, filter_description = current_local_first_filter_facts(
+            dock,
+            dock.runtime_state,
+        )
+
+        self.assertTrue(filters_active)
+        self.assertIsNone(filtered_count)
+        self.assertEqual(filter_description, "layer subset")
+
+    def test_current_wizard_filter_facts_ignores_invalid_layer_feature_count(self):
+        for feature_count in ("two", RuntimeError("layer deleted")):
+            with self.subTest(feature_count=feature_count):
+                layer = _FakeSubsetLayer('"activity_type" = \'Run\'', feature_count)
+                if isinstance(feature_count, RuntimeError):
+                    layer.featureCount = MagicMock(side_effect=feature_count)
+
+                dock = object.__new__(self.module.QfitDockWidget)
+                dock._runtime_state_store = self.module.DockRuntimeStore()
+                dock._runtime_store().load_dataset(
+                    output_path="/tmp/qfit.gpkg",
+                    activities_layer=layer,
+                )
+
+                filters_active, filtered_count, filter_description = (
+                    current_local_first_filter_facts(
+                        dock,
+                        dock.runtime_state,
+                    )
+                )
+
+                self.assertTrue(filters_active)
+                self.assertIsNone(filtered_count)
+                self.assertEqual(filter_description, "layer subset")
 
     def test_show_connection_configuration_hint_opens_config_when_available(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -860,6 +952,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "_configure_detailed_route_filter_options",
             "_configure_detailed_route_strategy_options",
             "_configure_preview_sort_options",
+            "_current_wizard_filter_facts",
+            "_current_wizard_layer_feature_count",
+            "_current_wizard_layer_filter_facts",
         )
 
         for method_name in retired_methods:

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import logging
 
+from ...activities.application import build_activity_preview_selection_state
 from ...visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
+from .wizard_filter_summary import build_wizard_filter_description
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +63,57 @@ def current_local_first_background_facts(dock, runtime_state) -> tuple[bool, boo
     return True, False, _current_local_first_background_name(dock)
 
 
+def current_local_first_filter_facts(dock, runtime_state) -> tuple[bool, int | None, str | None]:
+    """Return current map-filter facts for local-first progress summaries."""
+
+    layer_filter_facts = _current_local_first_layer_filter_facts(runtime_state)
+    if layer_filter_facts is not None:
+        filters_active, filtered_activity_count = layer_filter_facts
+        filter_description = "layer subset" if filters_active else None
+        return filters_active, filtered_activity_count, filter_description
+
+    activities = tuple(runtime_state.activities)
+    if not activities:
+        return False, None, None
+    preview_request = dock._current_activity_preview_request()
+    selection_state = build_activity_preview_selection_state(preview_request)
+    filters_active = selection_state.filtered_count != len(activities)
+    if not filters_active:
+        return False, None, None
+    return (
+        True,
+        selection_state.filtered_count,
+        build_wizard_filter_description(preview_request),
+    )
+
+
+def _current_local_first_layer_filter_facts(runtime_state) -> tuple[bool, int | None] | None:
+    layer = runtime_state.activities_layer
+    if layer is None or not hasattr(layer, "subsetString"):
+        return None
+    try:
+        subset = (layer.subsetString() or "").strip()
+    except RuntimeError:
+        logger.debug("Failed to read activity layer subset", exc_info=True)
+        return None
+    if not subset:
+        return False, None
+    return True, _current_local_first_layer_feature_count(layer)
+
+
+def _current_local_first_layer_feature_count(layer) -> int | None:
+    if not hasattr(layer, "featureCount"):
+        return None
+    try:
+        count = layer.featureCount()
+    except RuntimeError:
+        logger.debug("Failed to read activity layer feature count", exc_info=True)
+        return None
+    if not isinstance(count, int):
+        return None
+    return max(count, 0)
+
+
 def _current_local_first_layer_name(layer, *, log_message: str) -> str | None:
     if layer is None:
         return None
@@ -96,5 +149,6 @@ def _current_local_first_background_name(dock) -> str | None:
 __all__ = [
     "current_local_first_activity_style_preset",
     "current_local_first_background_facts",
+    "current_local_first_filter_facts",
     "current_local_first_visual_temporal_mode",
 ]


### PR DESCRIPTION
## Summary

- Move local-first map-filter progress facts from `QfitDockWidget` into `ui.application.local_first_progress_facts`.
- Keep the dock responsible for supplying runtime state while retiring the filter-fact helper methods from the dock class.
- Update unittest coverage to exercise the application helper and guard against reintroducing the dock methods.

## Tests

- `python3 -m unittest tests.test_qfit_dockwidget_analysis_pure.TestQfitDockWidgetAnalysisPure.test_current_wizard_filter_facts_prefers_loaded_layer_subset tests.test_qfit_dockwidget_analysis_pure.TestQfitDockWidgetAnalysisPure.test_current_wizard_filter_facts_treats_empty_loaded_subset_as_unfiltered tests.test_qfit_dockwidget_analysis_pure.TestQfitDockWidgetAnalysisPure.test_current_wizard_filter_facts_describes_preview_request_filters tests.test_qfit_dockwidget_analysis_pure.TestQfitDockWidgetAnalysisPure.test_current_wizard_progress_facts_reads_live_dock_runtime tests.test_qfit_dockwidget_analysis_pure.TestQfitDockWidgetAnalysisPure.test_dock_widget_does_not_reintroduce_per_move_local_first_installers`
- `python3 -m unittest tests.test_qfit_dockwidget_analysis_pure`
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
