### PR TITLE
Refactor local-first atlas progress path out of dock

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -88,6 +88,7 @@ from .ui.application import (
 )
 from .ui.application.local_first_progress_facts import (
     current_local_first_activity_style_preset,
+    current_local_first_atlas_output_path,
     current_local_first_background_facts,
     current_local_first_filter_facts,
     current_local_first_visual_temporal_mode,
@@ -194,9 +195,12 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         runtime_state = self._wizard_runtime_state_with_selected_output_path()
         atlas_exported = bool(getattr(self, "_atlas_export_completed", False))
-        atlas_export_output_path = self._current_wizard_atlas_output_path(
+        atlas_export_output_path = current_local_first_atlas_output_path(
             runtime_state=runtime_state,
+            atlas_pdf_path=self._widget_text("atlasPdfPathLineEdit"),
             atlas_exported=atlas_exported,
+            completed_output_path=getattr(self, "_atlas_export_output_path", None),
+            task_output_path=getattr(self, "_atlas_export_task_output_path", None),
         )
         (
             background_enabled,
@@ -249,19 +253,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._runtime_store().select_output_path((value or "").strip() or None)
         self._refresh_live_dock_navigation_from_runtime()
-
-    def _current_wizard_atlas_output_path(self, *, runtime_state, atlas_exported: bool):
-        """Return the atlas output path the optional wizard should describe."""
-
-        if runtime_state.atlas_export_task is not None:
-            return (
-                getattr(self, "_atlas_export_task_output_path", None)
-                or self._widget_text("atlasPdfPathLineEdit")
-            )
-        completed_output_path = getattr(self, "_atlas_export_output_path", None)
-        if atlas_exported and completed_output_path:
-            return completed_output_path
-        return self._widget_text("atlasPdfPathLineEdit")
 
     def _build_local_first_dock_from_runtime(self, *, parent=None):
         """Build the #748 local-first dock composition from live runtime facts.

--- a/tests/test_local_first_progress_facts.py
+++ b/tests/test_local_first_progress_facts.py
@@ -5,6 +5,7 @@ from tests import _path  # noqa: F401
 
 from qfit.ui.application.local_first_progress_facts import (
     current_local_first_activity_style_preset,
+    current_local_first_atlas_output_path,
     current_local_first_background_facts,
     current_local_first_visual_temporal_mode,
 )
@@ -91,6 +92,59 @@ class TestLocalFirstProgressFacts(unittest.TestCase):
         self.assertEqual(
             current_local_first_background_facts(dock, runtime_state),
             (True, False, "Satellite"),
+        )
+
+    def test_atlas_output_path_uses_visible_path_before_export(self):
+        runtime_state = SimpleNamespace(atlas_export_task=None)
+
+        self.assertEqual(
+            current_local_first_atlas_output_path(
+                runtime_state=runtime_state,
+                atlas_pdf_path="draft.pdf",
+                atlas_exported=False,
+                completed_output_path="completed.pdf",
+            ),
+            "draft.pdf",
+        )
+
+    def test_atlas_output_path_prefers_completed_path_after_export(self):
+        runtime_state = SimpleNamespace(atlas_export_task=None)
+
+        self.assertEqual(
+            current_local_first_atlas_output_path(
+                runtime_state=runtime_state,
+                atlas_pdf_path="draft.pdf",
+                atlas_exported=True,
+                completed_output_path="completed.pdf",
+            ),
+            "completed.pdf",
+        )
+
+    def test_atlas_output_path_freezes_task_path_during_export(self):
+        runtime_state = SimpleNamespace(atlas_export_task=object())
+
+        self.assertEqual(
+            current_local_first_atlas_output_path(
+                runtime_state=runtime_state,
+                atlas_pdf_path="changed.pdf",
+                atlas_exported=True,
+                completed_output_path="completed.pdf",
+                task_output_path="running.pdf",
+            ),
+            "running.pdf",
+        )
+
+    def test_atlas_output_path_falls_back_to_visible_path_for_running_legacy_task(self):
+        runtime_state = SimpleNamespace(atlas_export_task=object())
+
+        self.assertEqual(
+            current_local_first_atlas_output_path(
+                runtime_state=runtime_state,
+                atlas_pdf_path="changed.pdf",
+                atlas_exported=True,
+                completed_output_path="completed.pdf",
+            ),
+            "changed.pdf",
         )
 
     def test_visual_temporal_mode_reads_trimmed_combo_text(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -952,6 +952,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "_configure_detailed_route_filter_options",
             "_configure_detailed_route_strategy_options",
             "_configure_preview_sort_options",
+            "_current_wizard_atlas_output_path",
             "_current_wizard_filter_facts",
             "_current_wizard_layer_feature_count",
             "_current_wizard_layer_filter_facts",

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -63,6 +63,23 @@ def current_local_first_background_facts(dock, runtime_state) -> tuple[bool, boo
     return True, False, _current_local_first_background_name(dock)
 
 
+def current_local_first_atlas_output_path(
+    *,
+    runtime_state,
+    atlas_pdf_path: str,
+    atlas_exported: bool,
+    completed_output_path: str | None = None,
+    task_output_path: str | None = None,
+) -> str:
+    """Return the atlas output path local-first progress should describe."""
+
+    if runtime_state.atlas_export_task is not None:
+        return task_output_path or atlas_pdf_path
+    if atlas_exported and completed_output_path:
+        return completed_output_path
+    return atlas_pdf_path
+
+
 def current_local_first_filter_facts(dock, runtime_state) -> tuple[bool, int | None, str | None]:
     """Return current map-filter facts for local-first progress summaries."""
 
@@ -148,6 +165,7 @@ def _current_local_first_background_name(dock) -> str | None:
 
 __all__ = [
     "current_local_first_activity_style_preset",
+    "current_local_first_atlas_output_path",
     "current_local_first_background_facts",
     "current_local_first_filter_facts",
     "current_local_first_visual_temporal_mode",


### PR DESCRIPTION
## Summary

- Move local-first atlas output path progress selection out of `QfitDockWidget` into `ui.application.local_first_progress_facts`.
- Keep the dock responsible for supplying live widget/task state while retiring the dock helper method.
- Add unittest-discoverable coverage for in-progress, completed, and visible-path fallback cases plus the dock reintroduction guard.

## Tests

- `python3 -m unittest tests.test_local_first_progress_facts tests.test_qfit_dockwidget_analysis_pure -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
