### PR TITLE
refactor: move local-first progress policies

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sqlite3
 from collections.abc import Callable
-from dataclasses import replace
 from datetime import date
 
 logger = logging.getLogger(__name__)
@@ -91,7 +90,9 @@ from .ui.application.local_first_progress_facts import (
     current_local_first_atlas_output_path,
     current_local_first_background_facts,
     current_local_first_filter_facts,
+    current_local_first_last_sync_date,
     current_local_first_visual_temporal_mode,
+    runtime_state_with_local_first_output_path,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import DETAILED_ROUTE_STRATEGY_MISSING
@@ -193,7 +194,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _current_wizard_progress_facts(self):
         """Return render-neutral #609 wizard facts from the live dock state."""
 
-        runtime_state = self._wizard_runtime_state_with_selected_output_path()
+        runtime_state = runtime_state_with_local_first_output_path(
+            self.runtime_state,
+            self._widget_text("outputPathLineEdit"),
+        )
         atlas_exported = bool(getattr(self, "_atlas_export_completed", False))
         atlas_export_output_path = current_local_first_atlas_output_path(
             runtime_state=runtime_state,
@@ -224,29 +228,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             filtered_activity_count=filtered_activity_count,
             filter_description=filter_description,
             activity_style_preset=current_local_first_activity_style_preset(self),
-            last_sync_date=self._current_wizard_last_sync_date(),
+            last_sync_date=current_local_first_last_sync_date(
+                getattr(self, "settings", None)
+            ),
         )
-
-    def _current_wizard_last_sync_date(self) -> str | None:
-        """Return the persisted last sync date for wizard status summaries."""
-
-        settings = getattr(self, "settings", None)
-        get_value = getattr(settings, "get", None)
-        if not callable(get_value):
-            return None
-        value = get_value("last_sync_date", None)
-        if not isinstance(value, str):
-            return None
-        return value.strip() or None
-
-    def _wizard_runtime_state_with_selected_output_path(self):
-        """Reflect the visible GeoPackage path in wizard availability facts."""
-
-        runtime_state = self.runtime_state
-        selected_output_path = self._widget_text("outputPathLineEdit").strip()
-        if not selected_output_path or selected_output_path == runtime_state.output_path:
-            return runtime_state
-        return replace(runtime_state, output_path=selected_output_path)
 
     def _on_output_path_changed(self, value: str) -> None:
         """Keep live local-load actions in sync with the selected GeoPackage path."""

--- a/tests/test_local_first_progress_facts.py
+++ b/tests/test_local_first_progress_facts.py
@@ -1,4 +1,5 @@
 import unittest
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 from tests import _path  # noqa: F401
@@ -7,7 +8,9 @@ from qfit.ui.application.local_first_progress_facts import (
     current_local_first_activity_style_preset,
     current_local_first_atlas_output_path,
     current_local_first_background_facts,
+    current_local_first_last_sync_date,
     current_local_first_visual_temporal_mode,
+    runtime_state_with_local_first_output_path,
 )
 from qfit.visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
 
@@ -39,6 +42,11 @@ class _FakeLayer:
 
     def name(self):
         return self._name
+
+
+@dataclass(frozen=True)
+class _FakeRuntimeState:
+    output_path: str | None = None
 
 
 class TestLocalFirstProgressFacts(unittest.TestCase):
@@ -146,6 +154,40 @@ class TestLocalFirstProgressFacts(unittest.TestCase):
             ),
             "changed.pdf",
         )
+
+    def test_last_sync_date_reads_trimmed_settings_value(self):
+        settings = {"last_sync_date": " 2026-05-09 "}
+
+        self.assertEqual(current_local_first_last_sync_date(settings), "2026-05-09")
+
+    def test_last_sync_date_ignores_missing_or_non_string_settings_value(self):
+        self.assertIsNone(current_local_first_last_sync_date(object()))
+        self.assertIsNone(current_local_first_last_sync_date({"last_sync_date": None}))
+        self.assertIsNone(current_local_first_last_sync_date({"last_sync_date": "   "}))
+
+    def test_runtime_state_with_output_path_preserves_matching_or_blank_path(self):
+        runtime_state = _FakeRuntimeState(output_path="stored.gpkg")
+
+        self.assertIs(
+            runtime_state_with_local_first_output_path(runtime_state, "stored.gpkg"),
+            runtime_state,
+        )
+        self.assertIs(
+            runtime_state_with_local_first_output_path(runtime_state, "   "),
+            runtime_state,
+        )
+
+    def test_runtime_state_with_output_path_reflects_visible_selection(self):
+        runtime_state = _FakeRuntimeState(output_path="stored.gpkg")
+
+        updated = runtime_state_with_local_first_output_path(
+            runtime_state,
+            " selected.gpkg ",
+        )
+
+        self.assertEqual(updated.output_path, "selected.gpkg")
+        self.assertEqual(runtime_state.output_path, "stored.gpkg")
+        self.assertIsNot(updated, runtime_state)
 
     def test_visual_temporal_mode_reads_trimmed_combo_text(self):
         dock = SimpleNamespace(temporalModeComboBox=_FakeComboBox(" Activity time "))

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -98,6 +98,10 @@ from .local_first_control_visibility import (
     refresh_local_first_conditional_control_visibility,
     update_local_first_mapbox_custom_style_visibility,
 )
+from .local_first_progress_facts import (
+    current_local_first_last_sync_date,
+    runtime_state_with_local_first_output_path,
+)
 from .dock_workflow_sections import (
     CURRENT_DOCK_SECTIONS,
     WIZARD_WORKFLOW_STEPS,
@@ -240,6 +244,7 @@ __all__ = [
     "build_stepper_items",
     "build_stepper_states",
     "build_startup_wizard_progress_facts",
+    "current_local_first_last_sync_date",
     "build_wizard_filter_description",
     "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts",
@@ -275,6 +280,7 @@ __all__ = [
     "refresh_local_first_conditional_control_visibility",
     "refresh_local_first_control_visibility",
     "remove_widget_from_current_layout",
+    "runtime_state_with_local_first_output_path",
     "save_collapsed_groups",
     "save_last_step_index",
     "set_local_first_analysis_mode",

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 
 from ...activities.application import build_activity_preview_selection_state
 from ...visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
@@ -78,6 +79,27 @@ def current_local_first_atlas_output_path(
     if atlas_exported and completed_output_path:
         return completed_output_path
     return atlas_pdf_path
+
+
+def current_local_first_last_sync_date(settings) -> str | None:
+    """Return the persisted last sync date for local-first progress summaries."""
+
+    get_value = getattr(settings, "get", None)
+    if not callable(get_value):
+        return None
+    value = get_value("last_sync_date", None)
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
+
+
+def runtime_state_with_local_first_output_path(runtime_state, selected_output_path: str):
+    """Return runtime facts that reflect the visible local-first GeoPackage path."""
+
+    selected_output_path = (selected_output_path or "").strip()
+    if not selected_output_path or selected_output_path == runtime_state.output_path:
+        return runtime_state
+    return replace(runtime_state, output_path=selected_output_path)
 
 
 def current_local_first_filter_facts(dock, runtime_state) -> tuple[bool, int | None, str | None]:
@@ -168,5 +190,7 @@ __all__ = [
     "current_local_first_atlas_output_path",
     "current_local_first_background_facts",
     "current_local_first_filter_facts",
+    "current_local_first_last_sync_date",
     "current_local_first_visual_temporal_mode",
+    "runtime_state_with_local_first_output_path",
 ]


### PR DESCRIPTION
## Summary

Moves two local-first progress policies out of `QfitDockWidget` and into the application progress-facts helper so the dock delegates visible GeoPackage path and last-sync-date handling instead of owning that policy inline.

## Changes

- Added application helpers for last sync date normalization and visible GeoPackage output-path runtime facts.
- Updated `QfitDockWidget` to call those helpers while building local-first progress facts.
- Added unittest-discoverable coverage for the new helpers.

## Testing

- `python3 -m unittest tests.test_local_first_progress_facts`
- `python3 -m pytest tests/test_local_first_progress_facts.py tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_defaults_to_local_first_live_path -q --tb=short`
- `python3 -m pytest tests/test_local_first_progress_facts.py tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_current_wizard_progress_facts_uses_frozen_atlas_path_during_export -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
