### PR TITLE
Refactor local-first progress facts assembly

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -77,7 +77,6 @@ from .ui.application import (
     build_visual_layer_refs,
     set_local_first_analysis_mode,
     update_local_first_atlas_document_settings,
-    build_wizard_progress_facts_from_runtime_state,
     ensure_wizard_settings,
     install_local_first_audited_controls,
     sync_local_first_basemap_style_fields,
@@ -86,13 +85,8 @@ from .ui.application import (
     build_visual_workflow_settings_snapshot,
 )
 from .ui.application.local_first_progress_facts import (
-    current_local_first_activity_style_preset,
-    current_local_first_atlas_output_path,
-    current_local_first_background_facts,
-    current_local_first_filter_facts,
-    current_local_first_last_sync_date,
+    build_current_local_first_progress_facts,
     current_local_first_visual_temporal_mode,
-    runtime_state_with_local_first_output_path,
 )
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import DETAILED_ROUTE_STRATEGY_MISSING
@@ -194,44 +188,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def _current_wizard_progress_facts(self):
         """Return render-neutral #609 wizard facts from the live dock state."""
 
-        runtime_state = runtime_state_with_local_first_output_path(
-            self.runtime_state,
-            self._widget_text("outputPathLineEdit"),
-        )
-        atlas_exported = bool(getattr(self, "_atlas_export_completed", False))
-        atlas_export_output_path = current_local_first_atlas_output_path(
-            runtime_state=runtime_state,
-            atlas_pdf_path=self._widget_text("atlasPdfPathLineEdit"),
-            atlas_exported=atlas_exported,
-            completed_output_path=getattr(self, "_atlas_export_output_path", None),
-            task_output_path=getattr(self, "_atlas_export_task_output_path", None),
-        )
-        (
-            background_enabled,
-            background_layer_loaded,
-            background_name,
-        ) = current_local_first_background_facts(self, runtime_state)
-        (
-            filters_active,
-            filtered_activity_count,
-            filter_description,
-        ) = current_local_first_filter_facts(self, runtime_state)
-        return build_wizard_progress_facts_from_runtime_state(
-            runtime_state,
-            connection_configured=self._has_configured_strava_connection(),
-            atlas_exported=atlas_exported,
-            atlas_output_path=atlas_export_output_path,
-            background_enabled=background_enabled,
-            background_layer_loaded=background_layer_loaded,
-            background_name=background_name,
-            filters_active=filters_active,
-            filtered_activity_count=filtered_activity_count,
-            filter_description=filter_description,
-            activity_style_preset=current_local_first_activity_style_preset(self),
-            last_sync_date=current_local_first_last_sync_date(
-                getattr(self, "settings", None)
-            ),
-        )
+        return build_current_local_first_progress_facts(self)
 
     def _on_output_path_changed(self, value: str) -> None:
         """Keep live local-load actions in sync with the selected GeoPackage path."""

--- a/tests/test_local_first_progress_facts.py
+++ b/tests/test_local_first_progress_facts.py
@@ -4,7 +4,9 @@ from types import SimpleNamespace
 
 from tests import _path  # noqa: F401
 
+from qfit.ui.application.dock_runtime_state import DockRuntimeState
 from qfit.ui.application.local_first_progress_facts import (
+    build_current_local_first_progress_facts,
     current_local_first_activity_style_preset,
     current_local_first_atlas_output_path,
     current_local_first_background_facts,
@@ -31,6 +33,14 @@ class _FakeComboBox:
         return self._text
 
 
+class _FakeLineEdit:
+    def __init__(self, text):
+        self._text = text
+
+    def text(self):
+        return self._text
+
+
 class _FailingComboBox:
     def currentText(self):
         raise RuntimeError("deleted widget")
@@ -50,6 +60,32 @@ class _FakeRuntimeState:
 
 
 class TestLocalFirstProgressFacts(unittest.TestCase):
+    def test_current_progress_facts_assemble_live_local_first_state(self):
+        dock = SimpleNamespace(
+            runtime_state=DockRuntimeState(output_path="stored.gpkg"),
+            outputPathLineEdit=_FakeLineEdit(" selected.gpkg "),
+            atlasPdfPathLineEdit=_FakeLineEdit("draft.pdf"),
+            backgroundMapCheckBox=_FakeCheckBox(False),
+            backgroundPresetComboBox=_FakeComboBox("Outdoors"),
+            stylePresetComboBox=_FakeComboBox(" Simple lines "),
+            settings={"last_sync_date": " 2026-05-09 "},
+            _atlas_export_completed=True,
+            _atlas_export_output_path="exported.pdf",
+            _atlas_export_task_output_path=None,
+            _widget_text=lambda name: getattr(dock, name).text(),
+            _has_configured_strava_connection=lambda: True,
+        )
+
+        facts = build_current_local_first_progress_facts(dock)
+
+        self.assertTrue(facts.connection_configured)
+        self.assertEqual(facts.output_name, "selected.gpkg")
+        self.assertTrue(facts.atlas_exported)
+        self.assertEqual(facts.atlas_output_name, "exported.pdf")
+        self.assertFalse(facts.background_enabled)
+        self.assertEqual(facts.activity_style_preset, "Simple lines")
+        self.assertEqual(facts.last_sync_date, "2026-05-09")
+
     def test_activity_style_preset_reads_trimmed_combo_text(self):
         dock = SimpleNamespace(stylePresetComboBox=_FakeComboBox(" Simple lines "))
 

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -6,8 +6,52 @@ from dataclasses import replace
 from ...activities.application import build_activity_preview_selection_state
 from ...visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
 from .wizard_filter_summary import build_wizard_filter_description
+from .wizard_progress import build_wizard_progress_facts_from_runtime_state
 
 logger = logging.getLogger(__name__)
+
+
+def build_current_local_first_progress_facts(dock):
+    """Return render-neutral local-first progress facts from the live dock state."""
+
+    runtime_state = runtime_state_with_local_first_output_path(
+        dock.runtime_state,
+        dock._widget_text("outputPathLineEdit"),
+    )
+    atlas_exported = bool(getattr(dock, "_atlas_export_completed", False))
+    atlas_export_output_path = current_local_first_atlas_output_path(
+        runtime_state=runtime_state,
+        atlas_pdf_path=dock._widget_text("atlasPdfPathLineEdit"),
+        atlas_exported=atlas_exported,
+        completed_output_path=getattr(dock, "_atlas_export_output_path", None),
+        task_output_path=getattr(dock, "_atlas_export_task_output_path", None),
+    )
+    (
+        background_enabled,
+        background_layer_loaded,
+        background_name,
+    ) = current_local_first_background_facts(dock, runtime_state)
+    (
+        filters_active,
+        filtered_activity_count,
+        filter_description,
+    ) = current_local_first_filter_facts(dock, runtime_state)
+    return build_wizard_progress_facts_from_runtime_state(
+        runtime_state,
+        connection_configured=dock._has_configured_strava_connection(),
+        atlas_exported=atlas_exported,
+        atlas_output_path=atlas_export_output_path,
+        background_enabled=background_enabled,
+        background_layer_loaded=background_layer_loaded,
+        background_name=background_name,
+        filters_active=filters_active,
+        filtered_activity_count=filtered_activity_count,
+        filter_description=filter_description,
+        activity_style_preset=current_local_first_activity_style_preset(dock),
+        last_sync_date=current_local_first_last_sync_date(
+            getattr(dock, "settings", None)
+        ),
+    )
 
 
 def current_local_first_activity_style_preset(dock) -> str | None:
@@ -186,6 +230,7 @@ def _current_local_first_background_name(dock) -> str | None:
 
 
 __all__ = [
+    "build_current_local_first_progress_facts",
     "current_local_first_activity_style_preset",
     "current_local_first_atlas_output_path",
     "current_local_first_background_facts",


### PR DESCRIPTION
## Summary

Move the local-first wizard progress-facts assembly out of `QfitDockWidget` and into the local-first progress policy module.

## Changes

- Added `build_current_local_first_progress_facts` to centralize live local-first progress fact assembly.
- Reduced `QfitDockWidget._current_wizard_progress_facts` to a compatibility entry point that delegates to the policy helper.
- Covered the extracted helper with a focused unittest-discoverable test.

## Testing

- `python3 -m unittest tests.test_local_first_progress_facts tests.test_qfit_dockwidget_analysis_pure -q`
- `python3 -m pytest tests/test_local_first_progress_facts.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
