### PR TITLE
refactor: move local-first connection facts

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -298,16 +298,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         self._refresh_local_first_dock_from_runtime()
 
-    def _has_configured_strava_connection(self) -> bool:
-        return all(
-            self._widget_text(name).strip()
-            for name in (
-                "clientIdLineEdit",
-                "clientSecretLineEdit",
-                "refreshTokenLineEdit",
-            )
-        )
-
     def _mark_atlas_export_stale(self) -> None:
         self._atlas_export_completed = False
         self._atlas_export_output_path = None

--- a/tests/test_local_first_progress_facts.py
+++ b/tests/test_local_first_progress_facts.py
@@ -10,6 +10,7 @@ from qfit.ui.application.local_first_progress_facts import (
     current_local_first_activity_style_preset,
     current_local_first_atlas_output_path,
     current_local_first_background_facts,
+    current_local_first_connection_configured,
     current_local_first_last_sync_date,
     current_local_first_visual_temporal_mode,
     runtime_state_with_local_first_output_path,
@@ -46,6 +47,11 @@ class _FailingComboBox:
         raise RuntimeError("deleted widget")
 
 
+class _FailingLineEdit:
+    def text(self):
+        raise RuntimeError("deleted widget")
+
+
 class _FakeLayer:
     def __init__(self, name):
         self._name = name
@@ -69,11 +75,13 @@ class TestLocalFirstProgressFacts(unittest.TestCase):
             backgroundPresetComboBox=_FakeComboBox("Outdoors"),
             stylePresetComboBox=_FakeComboBox(" Simple lines "),
             settings={"last_sync_date": " 2026-05-09 "},
+            clientIdLineEdit=_FakeLineEdit("client-id"),
+            clientSecretLineEdit=_FakeLineEdit("client-secret"),
+            refreshTokenLineEdit=_FakeLineEdit("refresh-token"),
             _atlas_export_completed=True,
             _atlas_export_output_path="exported.pdf",
             _atlas_export_task_output_path=None,
             _widget_text=lambda name: getattr(dock, name).text(),
-            _has_configured_strava_connection=lambda: True,
         )
 
         facts = build_current_local_first_progress_facts(dock)
@@ -85,6 +93,30 @@ class TestLocalFirstProgressFacts(unittest.TestCase):
         self.assertFalse(facts.background_enabled)
         self.assertEqual(facts.activity_style_preset, "Simple lines")
         self.assertEqual(facts.last_sync_date, "2026-05-09")
+
+    def test_connection_configured_requires_visible_credential_text(self):
+        configured_dock = SimpleNamespace(
+            clientIdLineEdit=_FakeLineEdit(" client-id "),
+            clientSecretLineEdit=_FakeLineEdit(" client-secret "),
+            refreshTokenLineEdit=_FakeLineEdit(" refresh-token "),
+        )
+        missing_token_dock = SimpleNamespace(
+            clientIdLineEdit=_FakeLineEdit("client-id"),
+            clientSecretLineEdit=_FakeLineEdit("client-secret"),
+            refreshTokenLineEdit=_FakeLineEdit("   "),
+        )
+
+        self.assertTrue(current_local_first_connection_configured(configured_dock))
+        self.assertFalse(current_local_first_connection_configured(missing_token_dock))
+
+    def test_connection_configured_handles_deleted_backing_widgets(self):
+        dock = SimpleNamespace(
+            clientIdLineEdit=_FakeLineEdit("client-id"),
+            clientSecretLineEdit=_FailingLineEdit(),
+            refreshTokenLineEdit=_FakeLineEdit("refresh-token"),
+        )
+
+        self.assertFalse(current_local_first_connection_configured(dock))
 
     def test_activity_style_preset_reads_trimmed_combo_text(self):
         dock = SimpleNamespace(stylePresetComboBox=_FakeComboBox(" Simple lines "))

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -38,7 +38,7 @@ def build_current_local_first_progress_facts(dock):
     ) = current_local_first_filter_facts(dock, runtime_state)
     return build_wizard_progress_facts_from_runtime_state(
         runtime_state,
-        connection_configured=dock._has_configured_strava_connection(),
+        connection_configured=current_local_first_connection_configured(dock),
         atlas_exported=atlas_exported,
         atlas_output_path=atlas_export_output_path,
         background_enabled=background_enabled,
@@ -51,6 +51,19 @@ def build_current_local_first_progress_facts(dock):
         last_sync_date=current_local_first_last_sync_date(
             getattr(dock, "settings", None)
         ),
+    )
+
+
+def current_local_first_connection_configured(dock) -> bool:
+    """Return whether local-first progress can treat Strava as configured."""
+
+    return all(
+        _safe_local_first_widget_text(dock, name)
+        for name in (
+            "clientIdLineEdit",
+            "clientSecretLineEdit",
+            "refreshTokenLineEdit",
+        )
     )
 
 
@@ -170,6 +183,28 @@ def current_local_first_filter_facts(dock, runtime_state) -> tuple[bool, int | N
     )
 
 
+def _safe_local_first_widget_text(dock, widget_name: str) -> str:
+    widget_text = getattr(dock, "_widget_text", None)
+    if callable(widget_text):
+        try:
+            value = widget_text(widget_name)
+        except RuntimeError:
+            logger.debug("Failed to read local-first widget text", exc_info=True)
+            return ""
+        return value.strip() if isinstance(value, str) else ""
+
+    widget = getattr(dock, widget_name, None)
+    text = getattr(widget, "text", None)
+    if not callable(text):
+        return ""
+    try:
+        value = text()
+    except RuntimeError:
+        logger.debug("Failed to read local-first widget text", exc_info=True)
+        return ""
+    return value.strip() if isinstance(value, str) else ""
+
+
 def _current_local_first_layer_filter_facts(runtime_state) -> tuple[bool, int | None] | None:
     layer = runtime_state.activities_layer
     if layer is None or not hasattr(layer, "subsetString"):
@@ -234,6 +269,7 @@ __all__ = [
     "current_local_first_activity_style_preset",
     "current_local_first_atlas_output_path",
     "current_local_first_background_facts",
+    "current_local_first_connection_configured",
     "current_local_first_filter_facts",
     "current_local_first_last_sync_date",
     "current_local_first_visual_temporal_mode",


### PR DESCRIPTION
## Summary

- move the local-first Strava connection configured check out of `QfitDockWidget`
- read credential text through a safe application-layer helper for progress facts
- add unittest-discoverable coverage for configured, missing, and deleted backing widgets

## Tests

- `python3 -m unittest tests.test_local_first_progress_facts -v`
- `python3 -m pytest tests/test_local_first_progress_facts.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
