### PR TITLE
Refactor local-first connection configure policy

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -78,6 +78,7 @@ from .ui.application import (
     set_local_first_analysis_mode,
     update_local_first_atlas_document_settings,
     ensure_wizard_settings,
+    request_local_first_connection_configuration,
     install_local_first_audited_controls,
     sync_local_first_basemap_style_fields,
     build_visual_workflow_background_inputs,
@@ -162,22 +163,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         return ensure_wizard_settings(self.settings)
 
-    def _show_connection_configuration_hint(self) -> None:
-        """Open or describe the dedicated qfit configuration dialog for wizard users."""
-
-        open_configuration = getattr(self, "_open_configuration", None)
-        if open_configuration is not None:
-            open_configuration()
-            self._set_status("qfit configuration opened; save credentials to continue.")
-            return
-
-        self._show_info(
-            "Configure qfit connection",
-            "Open qfit → Configuration from the QGIS plugin menu to edit Strava "
-            "credentials, then return to the dock to continue the workflow.",
-        )
-        self._set_status("Open qfit → Configuration to edit Strava credentials.")
-
     def refresh_configuration_from_settings(self) -> None:
         """Reload saved configuration and refresh live wizard connection state."""
 
@@ -215,7 +200,17 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._local_first_dock_composition = connect_local_first_action_callbacks(
             composition,
             WizardActionCallbacks(
-                configure_connection=self._show_connection_configuration_hint,
+                configure_connection=(
+                    lambda: request_local_first_connection_configuration(
+                        open_configuration=getattr(
+                            self,
+                            "_open_configuration",
+                            None,
+                        ),
+                        set_status=self._set_status,
+                        show_info=self._show_info,
+                    )
+                ),
                 sync_activities=self.on_refresh_clicked,
                 store_activities=self.on_load_clicked,
                 sync_saved_routes=self.on_sync_routes_clicked,

--- a/tests/test_local_first_connection_controls.py
+++ b/tests/test_local_first_connection_controls.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import MagicMock
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.local_first_connection_controls import (
+    CONFIGURATION_MENU_STATUS,
+    CONFIGURATION_OPENED_STATUS,
+    CONFIGURE_CONNECTION_BODY,
+    CONFIGURE_CONNECTION_TITLE,
+    request_local_first_connection_configuration,
+)
+
+
+class LocalFirstConnectionControlsTests(unittest.TestCase):
+    def test_request_opens_configuration_when_callback_is_available(self):
+        open_configuration = MagicMock()
+        set_status = MagicMock()
+        show_info = MagicMock()
+
+        request_local_first_connection_configuration(
+            open_configuration=open_configuration,
+            set_status=set_status,
+            show_info=show_info,
+        )
+
+        open_configuration.assert_called_once_with()
+        show_info.assert_not_called()
+        set_status.assert_called_once_with(CONFIGURATION_OPENED_STATUS)
+
+    def test_request_reports_menu_path_when_callback_is_unavailable(self):
+        set_status = MagicMock()
+        show_info = MagicMock()
+
+        request_local_first_connection_configuration(
+            open_configuration=None,
+            set_status=set_status,
+            show_info=show_info,
+        )
+
+        show_info.assert_called_once_with(
+            CONFIGURE_CONNECTION_TITLE,
+            CONFIGURE_CONNECTION_BODY,
+        )
+        set_status.assert_called_once_with(CONFIGURATION_MENU_STATUS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -670,36 +670,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 self.assertIsNone(filtered_count)
                 self.assertEqual(filter_description, "layer subset")
 
-    def test_show_connection_configuration_hint_opens_config_when_available(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._open_configuration = MagicMock()
-        dock._show_info = MagicMock()
-        dock._set_status = MagicMock()
-
-        self.module.QfitDockWidget._show_connection_configuration_hint(dock)
-
-        dock._open_configuration.assert_called_once_with()
-        dock._show_info.assert_not_called()
-        dock._set_status.assert_called_once_with(
-            "qfit configuration opened; save credentials to continue."
-        )
-
-    def test_show_connection_configuration_hint_reports_menu_path_without_opener(self):
-        dock = object.__new__(self.module.QfitDockWidget)
-        dock._show_info = MagicMock()
-        dock._set_status = MagicMock()
-
-        self.module.QfitDockWidget._show_connection_configuration_hint(dock)
-
-        dock._show_info.assert_called_once_with(
-            "Configure qfit connection",
-            "Open qfit → Configuration from the QGIS plugin menu to edit Strava "
-            "credentials, then return to the dock to continue the workflow.",
-        )
-        dock._set_status.assert_called_once_with(
-            "Open qfit → Configuration to edit Strava credentials."
-        )
-
     def test_refresh_configuration_from_settings_updates_live_connection_state(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._load_settings = MagicMock()
@@ -790,6 +760,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasTitleLineEdit = _FakeLineEdit("Spring Atlas")
         dock.atlasSubtitleLineEdit = _FakeLineEdit("Road and trail")
         dock._atlas_export_completed = False
+        dock._open_configuration = MagicMock()
+        dock._set_status = MagicMock()
+        dock._show_info = MagicMock()
         dock.settings = _FakeSettings()
         parent = object()
 
@@ -843,7 +816,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(connect_args[0], "composition")
         callbacks = connect_args[1]
         expected_callbacks = {
-            "configure_connection": "_show_connection_configuration_hint",
             "sync_activities": "on_refresh_clicked",
             "store_activities": "on_load_clicked",
             "sync_saved_routes": "on_sync_routes_clicked",
@@ -861,6 +833,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
                 callback.__func__,
                 getattr(self.module.QfitDockWidget, method_name),
             )
+        callbacks.configure_connection()
+        dock._open_configuration.assert_called_once_with()
+        dock._show_info.assert_not_called()
+        dock._set_status.assert_called_once_with(
+            "qfit configuration opened; save credentials to continue."
+        )
         with patch.object(
             self.module,
             "set_local_first_analysis_mode",
@@ -950,6 +928,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "_bind_local_first_analysis_mode_controls",
             "_set_local_first_analysis_mode",
             "_update_atlas_document_settings",
+            "_show_connection_configuration_hint",
             "_configure_detailed_route_filter_options",
             "_configure_detailed_route_strategy_options",
             "_configure_preview_sort_options",

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -22,6 +22,9 @@ from qfit.ui.application.local_first_control_visibility import (
     update_local_first_mapbox_custom_style_visibility,
     update_local_first_point_sampling_visibility,
 )
+from qfit.ui.application.local_first_connection_controls import (
+    CONFIGURATION_OPENED_STATUS,
+)
 from qfit.ui.application.local_first_progress_facts import (
     build_current_local_first_progress_facts,
     current_local_first_activity_style_preset,
@@ -836,9 +839,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         callbacks.configure_connection()
         dock._open_configuration.assert_called_once_with()
         dock._show_info.assert_not_called()
-        dock._set_status.assert_called_once_with(
-            "qfit configuration opened; save credentials to continue."
-        )
+        dock._set_status.assert_called_once_with(CONFIGURATION_OPENED_STATUS)
         with patch.object(
             self.module,
             "set_local_first_analysis_mode",

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -66,6 +66,7 @@ from .local_first_control_moves import (
     local_first_widget_move_for_key,
     local_first_widget_move_keys,
 )
+from .local_first_connection_controls import request_local_first_connection_configuration
 from .local_first_control_installer import (
     after_local_first_control_move_installed,
     install_local_first_audited_controls,
@@ -208,6 +209,7 @@ __all__ = [
     "WIZARD_STEP_COUNT",
     "WIZARD_VERSION",
     "WIZARD_VERSION_KEY",
+    "request_local_first_connection_configuration",
     "RunAnalysisAction",
     "STEPPER_STATE_CURRENT",
     "STEPPER_STATE_DONE",

--- a/ui/application/local_first_connection_controls.py
+++ b/ui/application/local_first_connection_controls.py
@@ -1,0 +1,39 @@
+"""Local-first Settings page connection-control policies."""
+
+from collections.abc import Callable
+
+CONFIGURE_CONNECTION_TITLE = "Configure qfit connection"
+CONFIGURE_CONNECTION_BODY = (
+    "Open qfit → Configuration from the QGIS plugin menu to edit Strava "
+    "credentials, then return to the dock to continue the workflow."
+)
+CONFIGURATION_OPENED_STATUS = (
+    "qfit configuration opened; save credentials to continue."
+)
+CONFIGURATION_MENU_STATUS = "Open qfit → Configuration to edit Strava credentials."
+
+
+def request_local_first_connection_configuration(
+    *,
+    open_configuration: Callable[[], None] | None,
+    set_status: Callable[[str], None],
+    show_info: Callable[[str, str], None],
+) -> None:
+    """Handle the local-first Settings page Configure action."""
+
+    if open_configuration is not None:
+        open_configuration()
+        set_status(CONFIGURATION_OPENED_STATUS)
+        return
+
+    show_info(CONFIGURE_CONNECTION_TITLE, CONFIGURE_CONNECTION_BODY)
+    set_status(CONFIGURATION_MENU_STATUS)
+
+
+__all__ = [
+    "CONFIGURATION_MENU_STATUS",
+    "CONFIGURATION_OPENED_STATUS",
+    "CONFIGURE_CONNECTION_BODY",
+    "CONFIGURE_CONNECTION_TITLE",
+    "request_local_first_connection_configuration",
+]


### PR DESCRIPTION
## Summary

Move the local-first Settings page Configure action policy out of `QfitDockWidget` and into an application helper.

## Changes

- Added `local_first_connection_controls` for the configure-connection request flow and user-facing status copy.
- Wired the local-first dock callback through the new helper instead of a dock method.
- Retired the dock-level connection configuration hint method and added focused unittest/pytest coverage for the helper.

## Testing

- `python3 -m unittest tests.test_local_first_connection_controls tests.test_qfit_dockwidget_analysis_pure -q`
- `python3 -m pytest tests/test_local_first_connection_controls.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
