### PR TITLE
Refactor local-first activity preview request policy

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -17,13 +17,9 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox,
 )
 
-from .activities.domain.activity_query import (
-    DEFAULT_SORT_LABEL,
-)
 from .activities.application import (
     ActivitySelectionState,
     ActivityTypeOptionsResult,
-    build_activity_preview_request,
     build_activity_preview_selection_state,
     build_activity_type_options_from_activities,
     build_activity_type_options_from_records,
@@ -72,6 +68,7 @@ from .ui.application import (
     bind_local_first_analysis_mode_controls,
     bind_local_first_basemap_preset_controls,
     bind_local_first_conditional_visibility_controls,
+    build_current_activity_preview_request,
     RunAnalysisAction,
     build_dock_summary_status,
     build_visual_layer_refs,
@@ -1276,17 +1273,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             logger.debug("Failed to refresh map canvas", exc_info=True)
 
     def _current_activity_preview_request(self):
-        return build_activity_preview_request(
-            activities=self.runtime_state.activities,
-            activity_type=self.activityTypeComboBox.currentText() or "All",
-            date_from=self.dateFromEdit.date().toString("yyyy-MM-dd") if self.dateFromEdit.date().isValid() else None,
-            date_to=self.dateToEdit.date().toString("yyyy-MM-dd") if self.dateToEdit.date().isValid() else None,
-            min_distance_km=self.minDistanceSpinBox.value(),
-            max_distance_km=self.maxDistanceSpinBox.value(),
-            search_text=self.activitySearchLineEdit.text().strip(),
-            detailed_route_filter=self.detailedRouteStatusComboBox.currentData(),
-            sort_label=self.previewSortComboBox.currentText() or DEFAULT_SORT_LABEL,
-        )
+        return build_current_activity_preview_request(self)
 
     def _refresh_activity_preview(self):
         preview = self.activity_workflow.build_preview_result(

--- a/tests/test_local_first_activity_controls.py
+++ b/tests/test_local_first_activity_controls.py
@@ -14,6 +14,7 @@ from qfit.activities.domain.activity_query import (
 )
 from qfit.detailed_route_strategy import detailed_route_strategy_labels
 from qfit.ui.application.local_first_activity_controls import (
+    build_current_activity_preview_request,
     configure_detailed_route_filter_options,
     configure_detailed_route_strategy_options,
     configure_local_first_activity_preview_options,
@@ -44,6 +45,53 @@ class FakeComboBox:
 
     def parentWidget(self):
         return self._parent
+
+    def currentText(self):
+        if not self.items:
+            return ""
+        return self.items[0][0]
+
+    def currentData(self):
+        if not self.items:
+            return None
+        return self.items[0][1]
+
+
+class FakeDate:
+    def __init__(self, value, valid=True):
+        self.value = value
+        self.valid = valid
+
+    def isValid(self):
+        return self.valid
+
+    def toString(self, format_string):
+        self.format_string = format_string
+        return self.value
+
+
+class FakeDateEdit:
+    def __init__(self, date):
+        self._date = date
+
+    def date(self):
+        return self._date
+
+
+class FakeLineEdit:
+    def __init__(self, text):
+        self._text = text
+
+    def text(self):
+        return self._text
+
+
+class FakeSpinBox:
+    def __init__(self, value):
+        self._value = value
+
+    def value(self):
+        return self._value
 
 
 class FakeLayout:
@@ -186,6 +234,65 @@ class LocalFirstActivityControlsTests(unittest.TestCase):
             sort_combo.items,
             [(label, None) for label in SORT_OPTIONS],
         )
+
+    def test_build_current_activity_preview_request_reads_local_first_backing_controls(self):
+        activities = [SimpleNamespace(name="Morning Ride")]
+        activity_type_combo = FakeComboBox()
+        activity_type_combo.addItem("Ride", "ride")
+        detailed_route_status_combo = FakeComboBox()
+        detailed_route_status_combo.addItem(
+            "Detailed routes only",
+            DETAILED_ROUTE_FILTER_PRESENT,
+        )
+        preview_sort_combo = FakeComboBox()
+        preview_sort_combo.addItem("Newest first")
+        dock = SimpleNamespace(
+            runtime_state=SimpleNamespace(activities=activities),
+            activityTypeComboBox=activity_type_combo,
+            dateFromEdit=FakeDateEdit(FakeDate("2026-05-01")),
+            dateToEdit=FakeDateEdit(FakeDate("", valid=False)),
+            minDistanceSpinBox=FakeSpinBox(12),
+            maxDistanceSpinBox=FakeSpinBox(120),
+            activitySearchLineEdit=FakeLineEdit("  gravel  "),
+            detailedRouteStatusComboBox=detailed_route_status_combo,
+            previewSortComboBox=preview_sort_combo,
+        )
+
+        request = build_current_activity_preview_request(dock)
+
+        self.assertIs(request.activities, activities)
+        self.assertEqual(request.activity_type, "Ride")
+        self.assertEqual(request.date_from, "2026-05-01")
+        self.assertIsNone(request.date_to)
+        self.assertEqual(request.min_distance_km, 12)
+        self.assertEqual(request.max_distance_km, 120)
+        self.assertEqual(request.search_text, "gravel")
+        self.assertEqual(request.detailed_route_filter, DETAILED_ROUTE_FILTER_PRESENT)
+        self.assertEqual(request.sort_label, "Newest first")
+
+    def test_build_current_activity_preview_request_uses_safe_defaults(self):
+        activity_type_combo = FakeComboBox()
+        detailed_route_status_combo = FakeComboBox()
+        detailed_route_status_combo.addItem("Any routes", DETAILED_ROUTE_FILTER_ANY)
+        preview_sort_combo = FakeComboBox()
+        dock = SimpleNamespace(
+            runtime_state=SimpleNamespace(activities=[]),
+            activityTypeComboBox=activity_type_combo,
+            dateFromEdit=FakeDateEdit(FakeDate("", valid=False)),
+            dateToEdit=FakeDateEdit(FakeDate("", valid=False)),
+            minDistanceSpinBox=FakeSpinBox(0),
+            maxDistanceSpinBox=FakeSpinBox(0),
+            activitySearchLineEdit=FakeLineEdit(""),
+            detailedRouteStatusComboBox=detailed_route_status_combo,
+            previewSortComboBox=preview_sort_combo,
+        )
+
+        request = build_current_activity_preview_request(dock)
+
+        self.assertEqual(request.activity_type, "All")
+        self.assertIsNone(request.date_from)
+        self.assertIsNone(request.date_to)
+        self.assertEqual(request.sort_label, DEFAULT_SORT_LABEL)
 
 
 if __name__ == "__main__":

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2194,39 +2194,19 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIs(build_options.call_args.args[0], dock.runtime_state.activities)
         dock._apply_activity_type_options.assert_called_once_with(result)
 
-    def test_current_activity_preview_request_reads_current_ui_filters(self):
+    def test_current_activity_preview_request_delegates_to_local_first_policy(self):
         dock = object.__new__(self.module.QfitDockWidget)
-        dock.activities = ["a1", "a2"]
-        dock.activityTypeComboBox = _FakeComboBox(current_text="Run")
-        dock.dateFromEdit = _FakeDateEdit("2026-04-01")
-        dock.dateToEdit = _FakeDateEdit("2026-04-30")
-        dock.minDistanceSpinBox = _FakeSpinBox(5)
-        dock.maxDistanceSpinBox = _FakeSpinBox(42)
-        dock.activitySearchLineEdit = _FakeLineEdit(" lunch ")
-        dock.detailedRouteStatusComboBox = SimpleNamespace(currentData=lambda: "missing")
-        dock.previewSortComboBox = _FakeComboBox(current_text="Name (A–Z)")
         preview_request = SimpleNamespace()
 
         with patch.object(
             self.module,
-            "build_activity_preview_request",
+            "build_current_activity_preview_request",
             return_value=preview_request,
         ) as build_request:
             request = self.module.QfitDockWidget._current_activity_preview_request(dock)
 
         self.assertIs(request, preview_request)
-        build_request.assert_called_once_with(
-            activities=("a1", "a2"),
-            activity_type="Run",
-            date_from="2026-04-01",
-            date_to="2026-04-30",
-            min_distance_km=5,
-            max_distance_km=42,
-            search_text="lunch",
-            detailed_route_filter="missing",
-            sort_label="Name (A–Z)",
-        )
-        self.assertIs(build_request.call_args.kwargs["activities"], dock.runtime_state.activities)
+        build_request.assert_called_once_with(dock)
 
     def test_refresh_activity_preview_delegates_and_updates_widgets(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -36,6 +36,7 @@ from .local_first_navigation import (
     local_first_dock_page_keys,
 )
 from .local_first_activity_controls import (
+    build_current_activity_preview_request,
     configure_detailed_route_filter_options,
     configure_detailed_route_strategy_options,
     configure_local_first_activity_preview_options,
@@ -235,6 +236,7 @@ __all__ = [
     "configure_local_first_basemap_options",
     "configure_preview_sort_options",
     "build_current_dock_workflow_label",
+    "build_current_activity_preview_request",
     "build_detailed_fetch_visibility_update",
     "build_dock_summary_status",
     "build_initial_wizard_step_statuses",

--- a/ui/application/local_first_activity_controls.py
+++ b/ui/application/local_first_activity_controls.py
@@ -1,12 +1,40 @@
 from __future__ import annotations
 
 from ...activities.domain.activity_query import (
+    DEFAULT_SORT_LABEL,
     DETAILED_ROUTE_FILTER_ANY,
     DETAILED_ROUTE_FILTER_MISSING,
     DETAILED_ROUTE_FILTER_PRESENT,
     SORT_OPTIONS,
 )
+from ...activities.application import build_activity_preview_request
 from ...detailed_route_strategy import detailed_route_strategy_labels
+
+
+def build_current_activity_preview_request(dock):
+    """Build the activity preview request from local-first backing controls."""
+
+    date_from = dock.dateFromEdit.date()
+    date_to = dock.dateToEdit.date()
+    return build_activity_preview_request(
+        activities=dock.runtime_state.activities,
+        activity_type=dock.activityTypeComboBox.currentText() or "All",
+        date_from=(
+            date_from.toString("yyyy-MM-dd")
+            if date_from.isValid()
+            else None
+        ),
+        date_to=(
+            date_to.toString("yyyy-MM-dd")
+            if date_to.isValid()
+            else None
+        ),
+        min_distance_km=dock.minDistanceSpinBox.value(),
+        max_distance_km=dock.maxDistanceSpinBox.value(),
+        search_text=dock.activitySearchLineEdit.text().strip(),
+        detailed_route_filter=dock.detailedRouteStatusComboBox.currentData(),
+        sort_label=dock.previewSortComboBox.currentText() or DEFAULT_SORT_LABEL,
+    )
 
 
 def configure_local_first_activity_preview_options(dock) -> None:
@@ -62,6 +90,7 @@ def configure_preview_sort_options(dock) -> None:
 
 
 __all__ = [
+    "build_current_activity_preview_request",
     "configure_detailed_route_filter_options",
     "configure_detailed_route_strategy_options",
     "configure_local_first_activity_preview_options",


### PR DESCRIPTION
## Summary

Move the activity-preview request-building policy out of `QfitDockWidget` and into the local-first activity application helper module.

## Changes

- Added `build_current_activity_preview_request` alongside local-first activity control setup helpers.
- Reduced `QfitDockWidget._current_activity_preview_request` to a compatibility delegate.
- Added unittest/pytest coverage for reading local-first backing controls and safe defaults.

## Testing

- `python3 -m unittest tests.test_local_first_activity_controls tests.test_qfit_dockwidget_analysis_pure -q`
- `python3 -m pytest tests/test_local_first_activity_controls.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
