### PR TITLE
test: codify local-first parity audit

### DIFF
--- a/tests/test_local_first_parity_audit.py
+++ b/tests/test_local_first_parity_audit.py
@@ -1,0 +1,118 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.local_first_control_moves import (
+    local_first_control_move_for_key,
+    local_first_widget_move_for_key,
+)
+from qfit.ui.application.local_first_parity_audit import (
+    ISSUE_805_REQUIRED_AREAS,
+    build_issue805_local_first_parity_surfaces,
+    issue805_local_first_coverage_by_area,
+    missing_issue805_local_first_areas,
+)
+
+
+class LocalFirstParityAuditTests(unittest.TestCase):
+    def test_issue_805_acceptance_areas_all_have_audited_surfaces(self):
+        self.assertEqual(missing_issue805_local_first_areas(), ())
+        self.assertEqual(
+            tuple(issue805_local_first_coverage_by_area()),
+            ISSUE_805_REQUIRED_AREAS,
+        )
+
+    def test_audit_documents_current_local_first_surfaces_by_area(self):
+        coverage = issue805_local_first_coverage_by_area()
+
+        self.assertEqual(
+            coverage,
+            {
+                "mapbox_background_map": ("basemap",),
+                "activity_visualization_options": (
+                    "activity_style",
+                    "activity_preview",
+                ),
+                "map_filters": ("map_filters", "map_actions"),
+                "data_storage_settings": ("storage", "data_actions"),
+                "advanced_fetch_settings": (
+                    "advanced_fetch",
+                    "backfill_routes",
+                ),
+                "analysis_controls": (
+                    "analysis_temporal",
+                    "analysis_actions",
+                ),
+                "atlas_export_controls": ("atlas_pdf", "atlas_actions"),
+                "connection_settings_controls": (
+                    "strava_credentials",
+                    "settings_configuration_action",
+                ),
+            },
+        )
+
+    def test_audit_uses_control_move_inventory_for_legacy_backed_widgets(self):
+        surfaces = {
+            surface.key: surface
+            for surface in build_issue805_local_first_parity_surfaces()
+        }
+
+        basemap = local_first_control_move_for_key("basemap")
+        self.assertEqual(surfaces["basemap"].local_first_page, "settings")
+        self.assertEqual(
+            surfaces["basemap"].required_widget_attrs,
+            basemap.required_widget_attrs,
+        )
+        self.assertIn("loadBackgroundButton", surfaces["basemap"].required_widget_attrs)
+
+        storage = local_first_control_move_for_key("storage")
+        self.assertEqual(surfaces["storage"].local_first_page, "settings")
+        self.assertEqual(
+            surfaces["storage"].required_widget_attrs,
+            storage.required_widget_attrs,
+        )
+        self.assertIn("browseButton", surfaces["storage"].required_widget_attrs)
+
+    def test_audit_includes_loose_widget_and_local_first_action_surfaces(self):
+        surfaces = {
+            surface.key: surface
+            for surface in build_issue805_local_first_parity_surfaces()
+        }
+
+        activity_style = local_first_widget_move_for_key("activity_style")
+        self.assertEqual(surfaces["activity_style"].local_first_page, "map")
+        self.assertEqual(
+            surfaces["activity_style"].required_widget_attrs,
+            activity_style.required_widget_attrs,
+        )
+        self.assertEqual(
+            surfaces["activity_style"].optional_widget_attrs,
+            ("previewSortLabel", "previewSortComboBox"),
+        )
+        self.assertEqual(
+            surfaces["analysis_actions"].action_names,
+            (
+                "runAnalysisRequested",
+                "clearAnalysisRequested",
+                "analysisModeChanged",
+            ),
+        )
+        self.assertEqual(
+            surfaces["settings_configuration_action"].action_names,
+            ("configureRequested",),
+        )
+
+    def test_application_package_reexports_parity_audit_helpers(self):
+        from qfit import ui
+        from qfit.ui import application
+
+        self.assertIn("LocalFirstParitySurface", application.__all__)
+        self.assertIs(
+            application.build_issue805_local_first_parity_surfaces,
+            build_issue805_local_first_parity_surfaces,
+        )
+        self.assertTrue(hasattr(ui.application, "missing_issue805_local_first_areas"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_local_first_parity_audit.py
+++ b/tests/test_local_first_parity_audit.py
@@ -1,4 +1,6 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from tests import _path  # noqa: F401
 
@@ -6,6 +8,7 @@ from qfit.ui.application.local_first_control_moves import (
     local_first_control_move_for_key,
     local_first_widget_move_for_key,
 )
+from qfit.ui.application import local_first_parity_audit as audit
 from qfit.ui.application.local_first_parity_audit import (
     ISSUE_805_REQUIRED_AREAS,
     build_issue805_local_first_parity_surfaces,
@@ -101,6 +104,53 @@ class LocalFirstParityAuditTests(unittest.TestCase):
             surfaces["settings_configuration_action"].action_names,
             ("configureRequested",),
         )
+
+    def test_coverage_by_area_keeps_empty_required_areas_visible(self):
+        with patch.object(
+            audit,
+            "build_issue805_local_first_parity_surfaces",
+            return_value=(),
+        ):
+            coverage = issue805_local_first_coverage_by_area()
+
+        self.assertEqual(tuple(coverage), ISSUE_805_REQUIRED_AREAS)
+        self.assertTrue(all(keys == () for keys in coverage.values()))
+
+    def test_audit_rejects_unmapped_move_keys_with_context(self):
+        move = SimpleNamespace(
+            key="new_control",
+            content_attr="sync_content",
+            required_widget_attrs=(),
+        )
+
+        with patch.object(audit, "LOCAL_FIRST_WIDGET_MOVES", ()), patch.object(
+            audit,
+            "LOCAL_FIRST_CONTROL_MOVES",
+            (move,),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "LOCAL_FIRST_CONTROL_MOVES key 'new_control'",
+            ):
+                build_issue805_local_first_parity_surfaces()
+
+    def test_audit_rejects_unknown_content_attrs_with_context(self):
+        move = SimpleNamespace(
+            key="advanced_fetch",
+            content_attr="onboarding_content",
+            required_widget_attrs=(),
+        )
+
+        with patch.object(audit, "LOCAL_FIRST_WIDGET_MOVES", ()), patch.object(
+            audit,
+            "LOCAL_FIRST_CONTROL_MOVES",
+            (move,),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "content_attr 'onboarding_content'",
+            ):
+                build_issue805_local_first_parity_surfaces()
 
     def test_application_package_reexports_parity_audit_helpers(self):
         from qfit import ui

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -35,6 +35,13 @@ from .local_first_navigation import (
     build_local_first_dock_navigation_state,
     local_first_dock_page_keys,
 )
+from .local_first_parity_audit import (
+    ISSUE_805_REQUIRED_AREAS,
+    LocalFirstParitySurface,
+    build_issue805_local_first_parity_surfaces,
+    issue805_local_first_coverage_by_area,
+    missing_issue805_local_first_areas,
+)
 from .local_first_activity_controls import (
     build_current_activity_preview_request,
     configure_detailed_route_filter_options,
@@ -191,6 +198,7 @@ __all__ = [
     "CURRENT_DOCK_SECTIONS",
     "LAST_STEP_INDEX_KEY",
     "LAST_STEP_INDEX_USER_SELECTED_KEY",
+    "ISSUE_805_REQUIRED_AREAS",
     "LOCAL_FIRST_CONTROL_MOVES",
     "LOCAL_FIRST_DOCK_PAGE_DEFINITIONS",
     "LOCAL_FIRST_WIDGET_MOVES",
@@ -205,6 +213,7 @@ __all__ = [
     "LocalFirstDockNavigationState",
     "LocalFirstDockPageDefinition",
     "LocalFirstDockPageState",
+    "LocalFirstParitySurface",
     "LocalFirstWidgetMove",
     "WIZARD_WORKFLOW_STEPS",
     "WIZARD_STEP_COUNT",
@@ -240,6 +249,7 @@ __all__ = [
     "build_detailed_fetch_visibility_update",
     "build_dock_summary_status",
     "build_initial_wizard_step_statuses",
+    "build_issue805_local_first_parity_surfaces",
     "build_local_first_dock_navigation_state",
     "build_local_first_conditional_visibility_updates",
     "build_mapbox_custom_style_visibility_update",
@@ -269,6 +279,7 @@ __all__ = [
     "install_local_first_group_controls",
     "install_local_first_widget_move",
     "install_local_first_widget_controls",
+    "issue805_local_first_coverage_by_area",
     "load_wizard_settings",
     "local_first_analysis_mode_options",
     "local_first_control_move_layout",
@@ -281,6 +292,7 @@ __all__ = [
     "local_first_widget_move_for_key",
     "local_first_widget_move_keys",
     "preferred_current_key_from_settings",
+    "missing_issue805_local_first_areas",
     "refresh_local_first_conditional_control_visibility",
     "refresh_local_first_control_visibility",
     "remove_widget_from_current_layout",

--- a/ui/application/local_first_parity_audit.py
+++ b/ui/application/local_first_parity_audit.py
@@ -106,7 +106,11 @@ def build_issue805_local_first_parity_surfaces() -> tuple[LocalFirstParitySurfac
         surfaces.append(
             LocalFirstParitySurface(
                 key=move.key,
-                issue_area=_WIDGET_MOVE_AREAS[move.key],
+                issue_area=_issue_area_for_move(
+                    _WIDGET_MOVE_AREAS,
+                    move.key,
+                    "LOCAL_FIRST_WIDGET_MOVES",
+                ),
                 local_first_page=_content_attr_page(move.content_attr),
                 surface_type="widget_move",
                 required_widget_attrs=move.required_widget_attrs,
@@ -117,7 +121,11 @@ def build_issue805_local_first_parity_surfaces() -> tuple[LocalFirstParitySurfac
         surfaces.append(
             LocalFirstParitySurface(
                 key=move.key,
-                issue_area=_CONTROL_MOVE_AREAS[move.key],
+                issue_area=_issue_area_for_move(
+                    _CONTROL_MOVE_AREAS,
+                    move.key,
+                    "LOCAL_FIRST_CONTROL_MOVES",
+                ),
                 local_first_page=_content_attr_page(move.content_attr),
                 surface_type="control_move",
                 required_widget_attrs=move.required_widget_attrs,
@@ -136,7 +144,6 @@ def issue805_local_first_coverage_by_area() -> dict[str, tuple[str, ...]]:
     return {
         area: tuple(coverage[area])
         for area in ISSUE_805_REQUIRED_AREAS
-        if area in coverage
     }
 
 
@@ -144,17 +151,36 @@ def missing_issue805_local_first_areas() -> tuple[str, ...]:
     """Return #805 areas that still lack an audited local-first surface."""
 
     coverage = issue805_local_first_coverage_by_area()
-    return tuple(area for area in ISSUE_805_REQUIRED_AREAS if area not in coverage)
+    return tuple(area for area in ISSUE_805_REQUIRED_AREAS if not coverage[area])
+
+
+def _issue_area_for_move(
+    area_map: dict[str, str],
+    key: str,
+    inventory_name: str,
+) -> str:
+    try:
+        return area_map[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"No #805 parity area mapping for {inventory_name} key {key!r}"
+        ) from exc
 
 
 def _content_attr_page(content_attr: str) -> str:
-    return {
+    pages = {
         "sync_content": "data",
         "map_content": "map",
         "analysis_content": "analysis",
         "atlas_content": "atlas",
         "settings_content": "settings",
-    }[content_attr]
+    }
+    try:
+        return pages[content_attr]
+    except KeyError as exc:
+        raise ValueError(
+            f"No local-first page mapping for content_attr {content_attr!r}"
+        ) from exc
 
 
 def _flatten_optional_widgets(move) -> tuple[str, ...]:

--- a/ui/application/local_first_parity_audit.py
+++ b/ui/application/local_first_parity_audit.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+from .local_first_control_moves import (
+    LOCAL_FIRST_CONTROL_MOVES,
+    LOCAL_FIRST_WIDGET_MOVES,
+)
+
+ISSUE_805_REQUIRED_AREAS = (
+    "mapbox_background_map",
+    "activity_visualization_options",
+    "map_filters",
+    "data_storage_settings",
+    "advanced_fetch_settings",
+    "analysis_controls",
+    "atlas_export_controls",
+    "connection_settings_controls",
+)
+
+_CONTROL_MOVE_AREAS = {
+    "advanced_fetch": "advanced_fetch_settings",
+    "activity_preview": "activity_visualization_options",
+    "backfill_routes": "advanced_fetch_settings",
+    "map_filters": "map_filters",
+    "atlas_pdf": "atlas_export_controls",
+    "strava_credentials": "connection_settings_controls",
+    "basemap": "mapbox_background_map",
+    "storage": "data_storage_settings",
+}
+
+_WIDGET_MOVE_AREAS = {
+    "activity_style": "activity_visualization_options",
+    "analysis_temporal": "analysis_controls",
+}
+
+
+@dataclass(frozen=True)
+class LocalFirstParitySurface:
+    """One audited local-first surface for a #805 acceptance area."""
+
+    key: str
+    issue_area: str
+    local_first_page: str
+    surface_type: str
+    required_widget_attrs: tuple[str, ...] = ()
+    optional_widget_attrs: tuple[str, ...] = ()
+    action_names: tuple[str, ...] = ()
+
+
+_ACTION_SURFACES = (
+    LocalFirstParitySurface(
+        key="data_actions",
+        issue_area="data_storage_settings",
+        local_first_page="data",
+        surface_type="page_actions",
+        action_names=(
+            "syncRequested",
+            "storeRequested",
+            "syncRoutesRequested",
+            "clearDatabaseRequested",
+            "loadActivitiesRequested",
+        ),
+    ),
+    LocalFirstParitySurface(
+        key="map_actions",
+        issue_area="map_filters",
+        local_first_page="map",
+        surface_type="page_actions",
+        action_names=("loadLayersRequested", "applyFiltersRequested"),
+    ),
+    LocalFirstParitySurface(
+        key="analysis_actions",
+        issue_area="analysis_controls",
+        local_first_page="analysis",
+        surface_type="page_actions",
+        action_names=(
+            "runAnalysisRequested",
+            "clearAnalysisRequested",
+            "analysisModeChanged",
+        ),
+    ),
+    LocalFirstParitySurface(
+        key="atlas_actions",
+        issue_area="atlas_export_controls",
+        local_first_page="atlas",
+        surface_type="page_actions",
+        action_names=("exportAtlasRequested", "atlasDocumentSettingsChanged"),
+    ),
+    LocalFirstParitySurface(
+        key="settings_configuration_action",
+        issue_area="connection_settings_controls",
+        local_first_page="settings",
+        surface_type="page_actions",
+        action_names=("configureRequested",),
+    ),
+)
+
+
+def build_issue805_local_first_parity_surfaces() -> tuple[LocalFirstParitySurface, ...]:
+    """Return the audited local-first surfaces for the #805 checklist."""
+
+    surfaces: list[LocalFirstParitySurface] = []
+    for move in LOCAL_FIRST_WIDGET_MOVES:
+        surfaces.append(
+            LocalFirstParitySurface(
+                key=move.key,
+                issue_area=_WIDGET_MOVE_AREAS[move.key],
+                local_first_page=_content_attr_page(move.content_attr),
+                surface_type="widget_move",
+                required_widget_attrs=move.required_widget_attrs,
+                optional_widget_attrs=_flatten_optional_widgets(move),
+            )
+        )
+    for move in LOCAL_FIRST_CONTROL_MOVES:
+        surfaces.append(
+            LocalFirstParitySurface(
+                key=move.key,
+                issue_area=_CONTROL_MOVE_AREAS[move.key],
+                local_first_page=_content_attr_page(move.content_attr),
+                surface_type="control_move",
+                required_widget_attrs=move.required_widget_attrs,
+            )
+        )
+    surfaces.extend(_ACTION_SURFACES)
+    return tuple(surfaces)
+
+
+def issue805_local_first_coverage_by_area() -> dict[str, tuple[str, ...]]:
+    """Map #805 issue areas to the local-first surfaces that cover them."""
+
+    coverage: defaultdict[str, list[str]] = defaultdict(list)
+    for surface in build_issue805_local_first_parity_surfaces():
+        coverage[surface.issue_area].append(surface.key)
+    return {
+        area: tuple(coverage[area])
+        for area in ISSUE_805_REQUIRED_AREAS
+        if area in coverage
+    }
+
+
+def missing_issue805_local_first_areas() -> tuple[str, ...]:
+    """Return #805 areas that still lack an audited local-first surface."""
+
+    coverage = issue805_local_first_coverage_by_area()
+    return tuple(area for area in ISSUE_805_REQUIRED_AREAS if area not in coverage)
+
+
+def _content_attr_page(content_attr: str) -> str:
+    return {
+        "sync_content": "data",
+        "map_content": "map",
+        "analysis_content": "analysis",
+        "atlas_content": "atlas",
+        "settings_content": "settings",
+    }[content_attr]
+
+
+def _flatten_optional_widgets(move) -> tuple[str, ...]:
+    optional_widgets: list[str] = []
+    for group in move.optional_widget_groups:
+        optional_widgets.extend(group)
+    optional_widgets.extend(move.optional_widget_attrs)
+    optional_widgets.extend(move.show_widget_attrs_after_move)
+    return tuple(optional_widgets)
+
+
+__all__ = [
+    "ISSUE_805_REQUIRED_AREAS",
+    "LocalFirstParitySurface",
+    "build_issue805_local_first_parity_surfaces",
+    "issue805_local_first_coverage_by_area",
+    "missing_issue805_local_first_areas",
+]


### PR DESCRIPTION
## Summary

- add a small #805 parity-audit helper that maps the remaining local-first acceptance areas to audited surfaces
- derive coverage from the existing local-first control/widget move inventories plus local-first page actions
- add unittest/pytest coverage so regressions show which #805 area lost explicit local-first coverage

Refs #805

## Tests

- `python3 -m unittest tests.test_local_first_parity_audit tests.test_local_first_control_moves`
- `python3 -m pytest tests/test_local_first_parity_audit.py tests/test_local_first_control_moves.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
