### PR TITLE
refactor: move filter summary to local-first policy

### DIFF
--- a/tests/test_local_first_filter_summary.py
+++ b/tests/test_local_first_filter_summary.py
@@ -1,0 +1,68 @@
+import unittest
+from types import SimpleNamespace
+
+from qfit.activities.domain.activity_query import (
+    DETAILED_ROUTE_FILTER_ANY,
+    DETAILED_ROUTE_FILTER_MISSING,
+    DETAILED_ROUTE_FILTER_PRESENT,
+)
+from qfit.ui.application.local_first_filter_summary import (
+    build_local_first_filter_description,
+)
+
+
+class LocalFirstFilterSummaryTests(unittest.TestCase):
+    def test_build_local_first_filter_description_skips_default_controls(self):
+        request = SimpleNamespace(
+            activity_type="All",
+            search_text="  ",
+            date_from=None,
+            date_to=None,
+            min_distance_km=0,
+            max_distance_km=None,
+            detailed_route_filter=DETAILED_ROUTE_FILTER_ANY,
+        )
+
+        self.assertIsNone(build_local_first_filter_description(request))
+
+    def test_build_local_first_filter_description_lists_active_controls_compactly(self):
+        request = SimpleNamespace(
+            activity_type="Run",
+            search_text="alps",
+            date_from="2026-04-01",
+            date_to="2026-04-30",
+            min_distance_km=5,
+            max_distance_km=42.5,
+            detailed_route_filter=DETAILED_ROUTE_FILTER_PRESENT,
+        )
+
+        description = build_local_first_filter_description(request)
+
+        self.assertEqual(
+            description,
+            "type: Run · search: “alps” · dates: 2026-04-01–2026-04-30 · "
+            "distance: 5–42.5 km · routes: detailed only",
+        )
+
+    def test_build_local_first_filter_description_handles_open_bounds_and_missing_routes(self):
+        request = SimpleNamespace(
+            activity_type="Ride",
+            search_text=None,
+            date_from=None,
+            date_to="2026-05-01",
+            min_distance_km=None,
+            max_distance_km=80,
+            detailed_route_filter=DETAILED_ROUTE_FILTER_MISSING,
+        )
+
+        description = build_local_first_filter_description(request)
+
+        self.assertEqual(
+            description,
+            "type: Ride · dates: until 2026-05-01 · distance: ≤ 80 km · "
+            "routes: missing details",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -107,6 +107,7 @@ from .local_first_control_visibility import (
     refresh_local_first_conditional_control_visibility,
     update_local_first_mapbox_custom_style_visibility,
 )
+from .local_first_filter_summary import build_local_first_filter_description
 from .local_first_progress_facts import (
     current_local_first_last_sync_date,
     runtime_state_with_local_first_output_path,
@@ -252,6 +253,7 @@ __all__ = [
     "build_issue805_local_first_parity_surfaces",
     "build_local_first_dock_navigation_state",
     "build_local_first_conditional_visibility_updates",
+    "build_local_first_filter_description",
     "build_mapbox_custom_style_visibility_update",
     "build_point_sampling_visibility_update",
     "build_progress_wizard_step_statuses",

--- a/ui/application/local_first_filter_summary.py
+++ b/ui/application/local_first_filter_summary.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any
+
+from qfit.activities.domain.activity_query import (
+    DETAILED_ROUTE_FILTER_ANY,
+    DETAILED_ROUTE_FILTER_MISSING,
+    DETAILED_ROUTE_FILTER_PRESENT,
+)
+
+ALL_ACTIVITY_TYPES = "All"
+
+
+def build_local_first_filter_description(request: Any) -> str | None:
+    """Describe active local-first map filters without depending on dock widgets."""
+
+    parts = tuple(_filter_description_parts(request))
+    if not parts:
+        return None
+    return " · ".join(parts)
+
+
+def _filter_description_parts(request: Any) -> list[str]:
+    parts: list[str] = []
+    activity_type = _normalised_text(getattr(request, "activity_type", None))
+    if activity_type and activity_type != ALL_ACTIVITY_TYPES:
+        parts.append(f"type: {activity_type}")
+
+    search_text = _normalised_text(getattr(request, "search_text", None))
+    if search_text:
+        parts.append(f"search: {_quote(search_text)}")
+
+    date_part = _date_range_part(
+        _normalised_text(getattr(request, "date_from", None)),
+        _normalised_text(getattr(request, "date_to", None)),
+    )
+    if date_part is not None:
+        parts.append(date_part)
+
+    distance_part = _distance_range_part(
+        getattr(request, "min_distance_km", None),
+        getattr(request, "max_distance_km", None),
+    )
+    if distance_part is not None:
+        parts.append(distance_part)
+
+    route_part = _route_filter_part(
+        _normalised_text(getattr(request, "detailed_route_filter", None))
+    )
+    if route_part is not None:
+        parts.append(route_part)
+
+    return parts
+
+
+def _date_range_part(date_from: str | None, date_to: str | None) -> str | None:
+    if date_from and date_to:
+        return f"dates: {date_from}–{date_to}"
+    if date_from:
+        return f"dates: from {date_from}"
+    if date_to:
+        return f"dates: until {date_to}"
+    return None
+
+
+def _distance_range_part(
+    min_distance_km: float | int | None,
+    max_distance_km: float | int | None,
+) -> str | None:
+    minimum = _positive_number(min_distance_km)
+    maximum = _positive_number(max_distance_km)
+    if minimum is not None and maximum is not None:
+        return f"distance: {_format_km(minimum)}–{_format_km(maximum)} km"
+    if minimum is not None:
+        return f"distance: ≥ {_format_km(minimum)} km"
+    if maximum is not None:
+        return f"distance: ≤ {_format_km(maximum)} km"
+    return None
+
+
+def _route_filter_part(value: str | None) -> str | None:
+    if value in (None, "", DETAILED_ROUTE_FILTER_ANY):
+        return None
+    if value == DETAILED_ROUTE_FILTER_PRESENT:
+        return "routes: detailed only"
+    if value == DETAILED_ROUTE_FILTER_MISSING:
+        return "routes: missing details"
+    return f"routes: {value}"
+
+
+def _normalised_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    stripped = str(value).strip()
+    return stripped or None
+
+
+def _positive_number(value: float | int | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number
+
+
+def _format_km(value: float) -> str:
+    if value.is_integer():
+        return str(int(value))
+    return f"{value:g}"
+
+
+def _quote(value: str) -> str:
+    return f"“{value}”"
+
+
+__all__ = ["build_local_first_filter_description"]

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from ...activities.application import build_activity_preview_selection_state
 from .local_first_activity_controls import build_current_activity_preview_request
 from ...visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
-from .wizard_filter_summary import build_wizard_filter_description
+from .local_first_filter_summary import build_local_first_filter_description
 from .wizard_progress import build_wizard_progress_facts_from_runtime_state
 
 logger = logging.getLogger(__name__)
@@ -180,7 +180,7 @@ def current_local_first_filter_facts(dock, runtime_state) -> tuple[bool, int | N
     return (
         True,
         selection_state.filtered_count,
-        build_wizard_filter_description(preview_request),
+        build_local_first_filter_description(preview_request),
     )
 
 

--- a/ui/application/wizard_filter_summary.py
+++ b/ui/application/wizard_filter_summary.py
@@ -2,125 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from qfit.activities.domain.activity_query import (
-    DETAILED_ROUTE_FILTER_ANY,
-    DETAILED_ROUTE_FILTER_MISSING,
-    DETAILED_ROUTE_FILTER_PRESENT,
-)
-
-ALL_ACTIVITY_TYPES = "All"
+from .local_first_filter_summary import build_local_first_filter_description
 
 
 def build_wizard_filter_description(request: Any) -> str | None:
-    """Describe active activity filters without depending on dock widgets.
+    """Compatibility wrapper for the local-first filter summary policy."""
 
-    The wizard map page needs compact, user-facing filter copy that can migrate
-    away from the current long-scroll controls. This helper reads the existing
-    activity preview request shape and returns short clauses suitable for a
-    status row; it intentionally skips default/unset controls.
-    """
-
-    parts = tuple(_filter_description_parts(request))
-    if not parts:
-        return None
-    return " · ".join(parts)
-
-
-def _filter_description_parts(request: Any) -> list[str]:
-    parts: list[str] = []
-    activity_type = _normalised_text(getattr(request, "activity_type", None))
-    if activity_type and activity_type != ALL_ACTIVITY_TYPES:
-        parts.append(f"type: {activity_type}")
-
-    search_text = _normalised_text(getattr(request, "search_text", None))
-    if search_text:
-        parts.append(f"search: {_quote(search_text)}")
-
-    date_part = _date_range_part(
-        _normalised_text(getattr(request, "date_from", None)),
-        _normalised_text(getattr(request, "date_to", None)),
-    )
-    if date_part is not None:
-        parts.append(date_part)
-
-    distance_part = _distance_range_part(
-        getattr(request, "min_distance_km", None),
-        getattr(request, "max_distance_km", None),
-    )
-    if distance_part is not None:
-        parts.append(distance_part)
-
-    route_part = _route_filter_part(
-        _normalised_text(getattr(request, "detailed_route_filter", None))
-    )
-    if route_part is not None:
-        parts.append(route_part)
-
-    return parts
-
-
-def _date_range_part(date_from: str | None, date_to: str | None) -> str | None:
-    if date_from and date_to:
-        return f"dates: {date_from}–{date_to}"
-    if date_from:
-        return f"dates: from {date_from}"
-    if date_to:
-        return f"dates: until {date_to}"
-    return None
-
-
-def _distance_range_part(
-    min_distance_km: float | int | None,
-    max_distance_km: float | int | None,
-) -> str | None:
-    minimum = _positive_number(min_distance_km)
-    maximum = _positive_number(max_distance_km)
-    if minimum is not None and maximum is not None:
-        return f"distance: {_format_km(minimum)}–{_format_km(maximum)} km"
-    if minimum is not None:
-        return f"distance: ≥ {_format_km(minimum)} km"
-    if maximum is not None:
-        return f"distance: ≤ {_format_km(maximum)} km"
-    return None
-
-
-def _route_filter_part(value: str | None) -> str | None:
-    if value in (None, "", DETAILED_ROUTE_FILTER_ANY):
-        return None
-    if value == DETAILED_ROUTE_FILTER_PRESENT:
-        return "routes: detailed only"
-    if value == DETAILED_ROUTE_FILTER_MISSING:
-        return "routes: missing details"
-    return f"routes: {value}"
-
-
-def _normalised_text(value: Any) -> str | None:
-    if value is None:
-        return None
-    stripped = str(value).strip()
-    return stripped or None
-
-
-def _positive_number(value: float | int | None) -> float | None:
-    if value is None:
-        return None
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        return None
-    if number <= 0:
-        return None
-    return number
-
-
-def _format_km(value: float) -> str:
-    if value.is_integer():
-        return str(int(value))
-    return f"{value:g}"
-
-
-def _quote(value: str) -> str:
-    return f"“{value}”"
+    return build_local_first_filter_description(request)
 
 
 __all__ = ["build_wizard_filter_description"]


### PR DESCRIPTION
## Summary

- move activity filter summary copy into a local-first application policy module
- update local-first progress facts to call the local-first filter summary directly
- keep the wizard-named filter summary module as a thin compatibility wrapper for existing imports

## Why

This keeps #805 focused on consolidating the dock-first/local-first implementation instead of letting local-first progress depend on wizard-era policy modules. The visible dock-first UX is unchanged.

Refs #805

## Tests

- `PYTHONPATH=.. python3 -m unittest tests.test_local_first_filter_summary tests.test_wizard_filter_summary tests.test_qfit_dockwidget_analysis_pure -q`
- `python3 -m pytest tests/ -x -q --tb=short`
