### PR TITLE
Extract neutral workflow progress facts

### DIFF
--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _FakeQt, _fake_qt_modules
 
-from qfit.ui.application.wizard_progress import WizardProgressFacts
+from qfit.ui.application.local_first_progress_facts import LocalFirstProgressFacts
 
 
 def _load_local_first_composition_module():
@@ -36,7 +36,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
 
     def test_builds_shell_with_local_first_pages_and_reused_content(self):
         composition = self.module.build_local_first_dock_composition(
-            progress_facts=WizardProgressFacts(activities_stored=True),
+            progress_facts=LocalFirstProgressFacts(activities_stored=True),
         )
 
         self.assertEqual(composition.shell.objectName(), "qfitLocalFirstDockShell")
@@ -78,7 +78,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
 
     def test_data_page_is_local_first_and_navigation_is_not_step_locked(self):
         composition = self.module.build_local_first_dock_composition(
-            progress_facts=WizardProgressFacts(
+            progress_facts=LocalFirstProgressFacts(
                 activities_stored=True,
                 preferred_current_key="settings",
             ),
@@ -192,7 +192,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
 
         self.module.refresh_local_first_dock_composition(
             composition,
-            progress_facts=WizardProgressFacts(
+            progress_facts=LocalFirstProgressFacts(
                 connection_configured=True,
                 activities_stored=True,
                 activity_layers_loaded=True,
@@ -218,12 +218,12 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
 
     def test_refresh_preserves_current_page_without_explicit_preference(self):
         composition = self.module.build_local_first_dock_composition(
-            progress_facts=WizardProgressFacts(preferred_current_key="atlas"),
+            progress_facts=LocalFirstProgressFacts(preferred_current_key="atlas"),
         )
 
         self.module.refresh_local_first_dock_composition(
             composition,
-            progress_facts=WizardProgressFacts(activities_stored=True),
+            progress_facts=LocalFirstProgressFacts(activities_stored=True),
         )
 
         self.assertEqual(composition.shell.current_key(), "atlas")

--- a/tests/test_local_first_navigation.py
+++ b/tests/test_local_first_navigation.py
@@ -4,7 +4,7 @@ from qfit.ui.application.local_first_navigation import (
     build_local_first_dock_navigation_state,
     local_first_dock_page_keys,
 )
-from qfit.ui.application.wizard_progress import WizardProgressFacts
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 
 
 class LocalFirstDockNavigationTests(unittest.TestCase):
@@ -26,7 +26,7 @@ class LocalFirstDockNavigationTests(unittest.TestCase):
 
     def test_preferred_current_page_is_resolved_without_locking(self):
         navigation = build_local_first_dock_navigation_state(
-            WizardProgressFacts(preferred_current_key="atlas"),
+            WorkflowProgressFacts(preferred_current_key="atlas"),
         )
 
         self.assertEqual(navigation.current_key, "atlas")
@@ -38,7 +38,7 @@ class LocalFirstDockNavigationTests(unittest.TestCase):
 
     def test_explicit_preferred_current_page_overrides_fact_preference(self):
         navigation = build_local_first_dock_navigation_state(
-            WizardProgressFacts(preferred_current_key="settings"),
+            WorkflowProgressFacts(preferred_current_key="settings"),
             preferred_current_key="map",
         )
 
@@ -61,7 +61,7 @@ class LocalFirstDockNavigationTests(unittest.TestCase):
 
     def test_page_readiness_describes_state_without_gating_navigation(self):
         navigation = build_local_first_dock_navigation_state(
-            WizardProgressFacts(
+            WorkflowProgressFacts(
                 connection_configured=True,
                 activities_stored=True,
                 activity_layers_loaded=True,
@@ -81,7 +81,7 @@ class LocalFirstDockNavigationTests(unittest.TestCase):
         self.assertTrue(all(page.enabled for page in navigation.pages))
 
     def test_data_page_status_is_local_first_before_strava_configuration(self):
-        navigation = build_local_first_dock_navigation_state(WizardProgressFacts())
+        navigation = build_local_first_dock_navigation_state(WorkflowProgressFacts())
         data_page = navigation.pages[0]
 
         self.assertEqual(data_page.key, "data")

--- a/tests/test_local_first_progress_facts.py
+++ b/tests/test_local_first_progress_facts.py
@@ -6,6 +6,7 @@ from tests import _path  # noqa: F401
 
 from qfit.ui.application.dock_runtime_state import DockRuntimeState
 from qfit.ui.application.local_first_progress_facts import (
+    LocalFirstProgressFacts,
     build_current_local_first_progress_facts,
     current_local_first_activity_style_preset,
     current_local_first_atlas_output_path,
@@ -92,6 +93,7 @@ class TestLocalFirstProgressFacts(unittest.TestCase):
         self.assertEqual(facts.atlas_output_name, "exported.pdf")
         self.assertFalse(facts.background_enabled)
         self.assertEqual(facts.activity_style_preset, "Simple lines")
+        self.assertIsInstance(facts, LocalFirstProgressFacts)
         self.assertEqual(facts.last_sync_date, "2026-05-09")
 
     def test_connection_configured_requires_visible_credential_text(self):

--- a/tests/test_local_first_shell.py
+++ b/tests/test_local_first_shell.py
@@ -7,7 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application.local_first_navigation import build_local_first_dock_navigation_state
-from qfit.ui.application.wizard_progress import WizardProgressFacts
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 from qfit.ui.tokens import COLOR_GROUP_BORDER, COLOR_TITLE_BAR
 
 
@@ -101,7 +101,7 @@ class LocalFirstDockShellTests(unittest.TestCase):
 
     def test_navigation_state_sets_selection_metadata_without_step_locking(self):
         navigation = build_local_first_dock_navigation_state(
-            WizardProgressFacts(activities_stored=True, activity_layers_loaded=True),
+            WorkflowProgressFacts(activities_stored=True, activity_layers_loaded=True),
             preferred_current_key="map",
         )
         shell = self.shell_module.LocalFirstDockShell(navigation_state=navigation)

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -109,8 +109,13 @@ from .local_first_control_visibility import (
 )
 from .local_first_filter_summary import build_local_first_filter_description
 from .local_first_progress_facts import (
+    LocalFirstProgressFacts,
     current_local_first_last_sync_date,
     runtime_state_with_local_first_output_path,
+)
+from .workflow_progress_facts import (
+    WorkflowProgressFacts,
+    build_workflow_progress_facts_from_runtime_state,
 )
 from .dock_workflow_sections import (
     CURRENT_DOCK_SECTIONS,
@@ -215,6 +220,7 @@ __all__ = [
     "LocalFirstDockPageDefinition",
     "LocalFirstDockPageState",
     "LocalFirstParitySurface",
+    "LocalFirstProgressFacts",
     "LocalFirstWidgetMove",
     "WIZARD_WORKFLOW_STEPS",
     "WIZARD_STEP_COUNT",
@@ -232,6 +238,7 @@ __all__ = [
     "VisualWorkflowActionInputs",
     "VisualWorkflowSettingsSnapshot",
     "WizardProgressFacts",
+    "WorkflowProgressFacts",
     "WizardSettingsSnapshot",
     "build_advanced_fetch_visibility_update",
     "apply_local_first_visibility_update",
@@ -262,6 +269,7 @@ __all__ = [
     "build_startup_wizard_progress_facts",
     "current_local_first_last_sync_date",
     "build_wizard_filter_description",
+    "build_workflow_progress_facts_from_runtime_state",
     "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts",
     "build_wizard_progress_from_facts_and_settings",

--- a/ui/application/local_first_navigation.py
+++ b/ui/application/local_first_navigation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
-from .wizard_progress import WizardProgressFacts
+from .workflow_progress_facts import WorkflowProgressFacts
 
 
 @dataclass(frozen=True)
@@ -69,7 +69,7 @@ _DEFAULT_CURRENT_PAGE_KEY = "data"
 
 
 def build_local_first_dock_navigation_state(
-    facts: WizardProgressFacts | None = None,
+    facts: WorkflowProgressFacts | None = None,
     *,
     preferred_current_key: str | None = None,
 ) -> LocalFirstDockNavigationState:
@@ -81,7 +81,7 @@ def build_local_first_dock_navigation_state(
     export are not a strictly linear workflow.
     """
 
-    resolved_facts = facts or WizardProgressFacts()
+    resolved_facts = facts or WorkflowProgressFacts()
     current_key = _resolve_current_key(
         preferred_current_key or resolved_facts.preferred_current_key
     )
@@ -115,7 +115,7 @@ def _resolve_current_key(preferred_current_key: str | None) -> str:
     return _DEFAULT_CURRENT_PAGE_KEY
 
 
-def _page_ready(key: str, facts: WizardProgressFacts) -> bool:
+def _page_ready(key: str, facts: WorkflowProgressFacts) -> bool:
     if key == "data":
         return facts.activities_stored or facts.activities_fetched
     if key == "map":
@@ -129,7 +129,7 @@ def _page_ready(key: str, facts: WizardProgressFacts) -> bool:
     return False
 
 
-def _status_text(key: str, facts: WizardProgressFacts) -> str:
+def _status_text(key: str, facts: WorkflowProgressFacts) -> str:
     status_builders = {
         "data": _data_status_text,
         "map": _map_status_text,
@@ -140,7 +140,7 @@ def _status_text(key: str, facts: WizardProgressFacts) -> str:
     return status_builders.get(key, _available_status_text)(facts)
 
 
-def _data_status_text(facts: WizardProgressFacts) -> str:
+def _data_status_text(facts: WorkflowProgressFacts) -> str:
     if facts.sync_in_progress:
         return "Sync in progress"
     if facts.activities_stored:
@@ -150,23 +150,23 @@ def _data_status_text(facts: WizardProgressFacts) -> str:
     return "Choose a local GeoPackage or sync from Strava"
 
 
-def _map_status_text(facts: WizardProgressFacts) -> str:
+def _map_status_text(facts: WorkflowProgressFacts) -> str:
     return "Map layers loaded" if facts.activity_layers_loaded else "Map controls available"
 
 
-def _analysis_status_text(facts: WizardProgressFacts) -> str:
+def _analysis_status_text(facts: WorkflowProgressFacts) -> str:
     return "Analysis generated" if facts.analysis_generated else "Analysis is optional"
 
 
-def _atlas_status_text(facts: WizardProgressFacts) -> str:
+def _atlas_status_text(facts: WorkflowProgressFacts) -> str:
     return "Atlas exported" if facts.atlas_exported else "Atlas export available"
 
 
-def _settings_status_text(facts: WizardProgressFacts) -> str:
+def _settings_status_text(facts: WorkflowProgressFacts) -> str:
     return "Strava configured" if facts.connection_configured else "Settings available"
 
 
-def _available_status_text(_facts: WizardProgressFacts) -> str:
+def _available_status_text(_facts: WorkflowProgressFacts) -> str:
     return "Available"
 
 

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -272,6 +272,7 @@ def _current_local_first_background_name(dock) -> str | None:
 
 
 __all__ = [
+    "LocalFirstProgressFacts",
     "build_current_local_first_progress_facts",
     "current_local_first_activity_style_preset",
     "current_local_first_atlas_output_path",

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -7,7 +7,13 @@ from ...activities.application import build_activity_preview_selection_state
 from .local_first_activity_controls import build_current_activity_preview_request
 from ...visualization.application import DEFAULT_TEMPORAL_MODE_LABEL
 from .local_first_filter_summary import build_local_first_filter_description
-from .wizard_progress import build_wizard_progress_facts_from_runtime_state
+from .workflow_progress_facts import (
+    WorkflowProgressFacts,
+    build_workflow_progress_facts_from_runtime_state,
+)
+
+LocalFirstProgressFacts = WorkflowProgressFacts
+"""Local-first name for shared render-neutral workflow progress facts."""
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +43,7 @@ def build_current_local_first_progress_facts(dock):
         filtered_activity_count,
         filter_description,
     ) = current_local_first_filter_facts(dock, runtime_state)
-    return build_wizard_progress_facts_from_runtime_state(
+    return build_workflow_progress_facts_from_runtime_state(
         runtime_state,
         connection_configured=current_local_first_connection_configured(dock),
         atlas_exported=atlas_exported,

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
 from .workflow_progress_facts import (
     WorkflowProgressFacts,
@@ -93,32 +95,7 @@ def _wizard_progress_facts_with_preferred_current_key(
     *,
     preferred_current_key: str | None,
 ) -> WizardProgressFacts:
-    return WizardProgressFacts(
-        connection_configured=facts.connection_configured,
-        activities_fetched=facts.activities_fetched,
-        activities_stored=facts.activities_stored,
-        activity_layers_loaded=facts.activity_layers_loaded,
-        analysis_generated=facts.analysis_generated,
-        atlas_exported=facts.atlas_exported,
-        sync_in_progress=facts.sync_in_progress,
-        route_sync_in_progress=facts.route_sync_in_progress,
-        atlas_export_in_progress=facts.atlas_export_in_progress,
-        preferred_current_key=preferred_current_key,
-        fetched_activity_count=facts.fetched_activity_count,
-        activity_count=facts.activity_count,
-        output_name=facts.output_name,
-        analysis_output_name=facts.analysis_output_name,
-        atlas_output_name=facts.atlas_output_name,
-        background_enabled=facts.background_enabled,
-        background_layer_loaded=facts.background_layer_loaded,
-        background_name=facts.background_name,
-        filters_active=facts.filters_active,
-        filtered_activity_count=facts.filtered_activity_count,
-        filter_description=facts.filter_description,
-        activity_style_preset=facts.activity_style_preset,
-        loaded_layer_count=facts.loaded_layer_count,
-        last_sync_date=facts.last_sync_date,
-    )
+    return replace(facts, preferred_current_key=preferred_current_key)
 
 
 def _completed_keys_from_facts(facts: WizardProgressFacts) -> tuple[str, ...]:

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -1,110 +1,24 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path, PureWindowsPath
-
-from .dock_runtime_state import DockRuntimeState
 from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
+from .workflow_progress_facts import (
+    WorkflowProgressFacts,
+    build_workflow_progress_facts_from_runtime_state,
+)
 from .wizard_settings import (
     WizardSettingsSnapshot,
     preferred_current_key_from_settings,
 )
 
 
-@dataclass(frozen=True)
-class WizardProgressFacts:
-    """Render-neutral workflow facts for deriving #609 wizard progress.
-
-    The facts deliberately model completed work, not enabled buttons. This keeps
-    the future wizard stepper from marking a step done just because a downstream
-    page is reachable.
-    """
-
-    connection_configured: bool = False
-    activities_fetched: bool = False
-    activities_stored: bool = False
-    activity_layers_loaded: bool = False
-    analysis_generated: bool = False
-    atlas_exported: bool = False
-    sync_in_progress: bool = False
-    route_sync_in_progress: bool = False
-    atlas_export_in_progress: bool = False
-    preferred_current_key: str | None = None
-    fetched_activity_count: int | None = None
-    activity_count: int | None = None
-    output_name: str | None = None
-    analysis_output_name: str | None = None
-    atlas_output_name: str | None = None
-    background_enabled: bool = False
-    background_layer_loaded: bool = False
-    background_name: str | None = None
-    filters_active: bool = False
-    filtered_activity_count: int | None = None
-    filter_description: str | None = None
-    activity_style_preset: str | None = None
-    loaded_layer_count: int | None = None
-    last_sync_date: str | None = None
+WizardProgressFacts = WorkflowProgressFacts
+"""Compatibility alias for wizard progress callers during the #805 migration."""
 
 
-def build_wizard_progress_facts_from_runtime_state(
-    state: DockRuntimeState,
-    *,
-    connection_configured: bool = False,
-    atlas_exported: bool = False,
-    preferred_current_key: str | None = None,
-    atlas_output_path: str | None = None,
-    background_enabled: bool = False,
-    background_layer_loaded: bool = False,
-    background_name: str | None = None,
-    filters_active: bool = False,
-    filtered_activity_count: int | None = None,
-    filter_description: str | None = None,
-    activity_style_preset: str | None = None,
-    last_sync_date: str | None = None,
-) -> WizardProgressFacts:
-    """Derive #609 wizard progress facts from the dock runtime snapshot.
-
-    The future wizard dock needs a small, render-neutral adapter from the real
-    workflow state into ``WizardProgressFacts``. Keep connection and atlas
-    completion explicit because they live outside the current runtime snapshot:
-    connection is persisted in configuration settings, and atlas exports do not
-    yet retain a durable output artifact after the task completes. The runtime
-    ``activities`` tuple is a fetch payload, not a persisted dataset count, so
-    this adapter reports it separately as fetched work. Persisted dataset totals
-    come from the stored activity count captured during store/load transitions.
-    Atlas output is supplied separately because it currently lives in the dock
-    export controls, not the runtime snapshot.
-    """
-
-    output_name = _output_name(state.output_path)
-    analysis_output_name = _layer_name(state.analysis_layer)
-    atlas_output_name = _output_name(atlas_output_path)
-    return WizardProgressFacts(
-        connection_configured=connection_configured,
-        activities_fetched=bool(state.activities),
-        activities_stored=_has_stored_activities(state),
-        activity_layers_loaded=state.activities_layer is not None,
-        analysis_generated=state.analysis_layer is not None,
-        atlas_exported=atlas_exported,
-        sync_in_progress=_has_sync_task(state),
-        route_sync_in_progress=state.route_sync_task is not None,
-        atlas_export_in_progress=state.atlas_export_task is not None,
-        preferred_current_key=preferred_current_key,
-        fetched_activity_count=len(state.activities) if state.activities else None,
-        activity_count=_stored_activity_count(state),
-        output_name=output_name,
-        analysis_output_name=analysis_output_name,
-        atlas_output_name=atlas_output_name,
-        background_enabled=background_enabled,
-        background_layer_loaded=background_layer_loaded,
-        background_name=_optional_text(background_name),
-        filters_active=filters_active,
-        filtered_activity_count=filtered_activity_count,
-        filter_description=_optional_text(filter_description),
-        activity_style_preset=_optional_text(activity_style_preset),
-        loaded_layer_count=_loaded_dataset_layer_count(state),
-        last_sync_date=_optional_text(last_sync_date),
-    )
+build_wizard_progress_facts_from_runtime_state = (
+    build_workflow_progress_facts_from_runtime_state
+)
+"""Compatibility alias for wizard-named progress fact construction."""
 
 
 def build_wizard_progress_from_facts(facts: WizardProgressFacts) -> DockWizardProgress:
@@ -269,84 +183,6 @@ def _first_incomplete_key(completed_keys: set[str]) -> str:
 
 def _workflow_keys() -> tuple[str, ...]:
     return tuple(section.key for section in WIZARD_WORKFLOW_STEPS)
-
-
-def _has_stored_activities(state: DockRuntimeState) -> bool:
-    if state.stored_activity_count is not None:
-        return True
-    if _loaded_dataset_layer_count(state) > 0:
-        return True
-    output_path = (state.output_path or "").strip()
-    if not output_path:
-        return False
-    try:
-        return Path(output_path).exists()
-    except OSError:
-        return False
-
-
-def _has_sync_task(state: DockRuntimeState) -> bool:
-    return (
-        state.fetch_task is not None
-        or state.store_task is not None
-        or state.route_sync_task is not None
-    )
-
-
-def _stored_activity_count(state: DockRuntimeState) -> int | None:
-    count = state.stored_activity_count
-    if count is None:
-        return None
-    return max(int(count), 0)
-
-
-def _loaded_dataset_layer_count(state: DockRuntimeState) -> int | None:
-    count = sum(
-        layer is not None
-        for layer in (
-            state.activities_layer,
-            state.starts_layer,
-            state.points_layer,
-            state.atlas_layer,
-        )
-    )
-    return count
-
-
-def _output_name(output_path: str | None) -> str | None:
-    stripped = (output_path or "").strip()
-    if not stripped:
-        return None
-    if "\\" in stripped:
-        return PureWindowsPath(stripped).name or stripped
-    return Path(stripped).name or stripped
-
-
-def _optional_text(value: str | None) -> str | None:
-    stripped = (value or "").strip()
-    return stripped or None
-
-
-def _layer_name(layer) -> str | None:
-    if layer is None:
-        return None
-    try:
-        name_method = layer.name
-    except Exception:
-        # QGIS/Qt wrapper objects may raise different exception types once the
-        # underlying C++ layer has been deleted. The layer name is optional
-        # summary copy, so keep wizard refreshes resilient.
-        return None
-    if not callable(name_method):
-        return None
-    try:
-        name = name_method()
-    except Exception:
-        return None
-    if not isinstance(name, str):
-        return None
-    stripped = name.strip()
-    return stripped or None
 
 
 __all__ = [

--- a/ui/application/workflow_progress_facts.py
+++ b/ui/application/workflow_progress_facts.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+
+from .dock_runtime_state import DockRuntimeState
+
+
+@dataclass(frozen=True)
+class WorkflowProgressFacts:
+    """Render-neutral facts for deriving workflow progress and summaries.
+
+    These facts deliberately model completed work, not enabled controls. They are
+    shared by the dock-first local-first shell and the compatibility wizard
+    progress adapter so local-first navigation can avoid depending on a
+    wizard-named progress model.
+    """
+
+    connection_configured: bool = False
+    activities_fetched: bool = False
+    activities_stored: bool = False
+    activity_layers_loaded: bool = False
+    analysis_generated: bool = False
+    atlas_exported: bool = False
+    sync_in_progress: bool = False
+    route_sync_in_progress: bool = False
+    atlas_export_in_progress: bool = False
+    preferred_current_key: str | None = None
+    fetched_activity_count: int | None = None
+    activity_count: int | None = None
+    output_name: str | None = None
+    analysis_output_name: str | None = None
+    atlas_output_name: str | None = None
+    background_enabled: bool = False
+    background_layer_loaded: bool = False
+    background_name: str | None = None
+    filters_active: bool = False
+    filtered_activity_count: int | None = None
+    filter_description: str | None = None
+    activity_style_preset: str | None = None
+    loaded_layer_count: int | None = None
+    last_sync_date: str | None = None
+
+
+def build_workflow_progress_facts_from_runtime_state(
+    state: DockRuntimeState,
+    *,
+    connection_configured: bool = False,
+    atlas_exported: bool = False,
+    preferred_current_key: str | None = None,
+    atlas_output_path: str | None = None,
+    background_enabled: bool = False,
+    background_layer_loaded: bool = False,
+    background_name: str | None = None,
+    filters_active: bool = False,
+    filtered_activity_count: int | None = None,
+    filter_description: str | None = None,
+    activity_style_preset: str | None = None,
+    last_sync_date: str | None = None,
+) -> WorkflowProgressFacts:
+    """Derive render-neutral workflow progress facts from the dock runtime snapshot."""
+
+    output_name = _output_name(state.output_path)
+    analysis_output_name = _layer_name(state.analysis_layer)
+    atlas_output_name = _output_name(atlas_output_path)
+    return WorkflowProgressFacts(
+        connection_configured=connection_configured,
+        activities_fetched=bool(state.activities),
+        activities_stored=_has_stored_activities(state),
+        activity_layers_loaded=state.activities_layer is not None,
+        analysis_generated=state.analysis_layer is not None,
+        atlas_exported=atlas_exported,
+        sync_in_progress=_has_sync_task(state),
+        route_sync_in_progress=state.route_sync_task is not None,
+        atlas_export_in_progress=state.atlas_export_task is not None,
+        preferred_current_key=preferred_current_key,
+        fetched_activity_count=len(state.activities) if state.activities else None,
+        activity_count=_stored_activity_count(state),
+        output_name=output_name,
+        analysis_output_name=analysis_output_name,
+        atlas_output_name=atlas_output_name,
+        background_enabled=background_enabled,
+        background_layer_loaded=background_layer_loaded,
+        background_name=_optional_text(background_name),
+        filters_active=filters_active,
+        filtered_activity_count=filtered_activity_count,
+        filter_description=_optional_text(filter_description),
+        activity_style_preset=_optional_text(activity_style_preset),
+        loaded_layer_count=_loaded_dataset_layer_count(state),
+        last_sync_date=_optional_text(last_sync_date),
+    )
+
+
+def _has_stored_activities(state: DockRuntimeState) -> bool:
+    if state.stored_activity_count is not None:
+        return True
+    if _loaded_dataset_layer_count(state) > 0:
+        return True
+    output_path = (state.output_path or "").strip()
+    if not output_path:
+        return False
+    try:
+        return Path(output_path).exists()
+    except OSError:
+        return False
+
+
+def _has_sync_task(state: DockRuntimeState) -> bool:
+    return (
+        state.fetch_task is not None
+        or state.store_task is not None
+        or state.route_sync_task is not None
+    )
+
+
+def _stored_activity_count(state: DockRuntimeState) -> int | None:
+    count = state.stored_activity_count
+    if count is None:
+        return None
+    return max(int(count), 0)
+
+
+def _loaded_dataset_layer_count(state: DockRuntimeState) -> int | None:
+    count = sum(
+        layer is not None
+        for layer in (
+            state.activities_layer,
+            state.starts_layer,
+            state.points_layer,
+            state.atlas_layer,
+        )
+    )
+    return count
+
+
+def _output_name(output_path: str | None) -> str | None:
+    stripped = (output_path or "").strip()
+    if not stripped:
+        return None
+    if "\\" in stripped:
+        return PureWindowsPath(stripped).name or stripped
+    return Path(stripped).name or stripped
+
+
+def _optional_text(value: str | None) -> str | None:
+    stripped = (value or "").strip()
+    return stripped or None
+
+
+def _layer_name(layer) -> str | None:
+    if layer is None:
+        return None
+    try:
+        name_method = layer.name
+    except Exception:
+        # QGIS/Qt wrapper objects may raise different exception types once the
+        # underlying C++ layer has been deleted. The layer name is optional
+        # summary copy, so keep workflow refreshes resilient.
+        return None
+    if not callable(name_method):
+        return None
+    try:
+        name = name_method()
+    except Exception:
+        return None
+    if not isinstance(name, str):
+        return None
+    stripped = name.strip()
+    return stripped or None
+
+
+__all__ = [
+    "WorkflowProgressFacts",
+    "build_workflow_progress_facts_from_runtime_state",
+]

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, replace
 from qfit.ui.application.local_first_navigation import (
     build_local_first_dock_navigation_state,
 )
-from qfit.ui.application.wizard_progress import WizardProgressFacts
+from qfit.ui.application.local_first_progress_facts import LocalFirstProgressFacts
 
 from ._qt_compat import import_qt_module
 from .analysis_page import AnalysisPageContent, build_analysis_page_content
@@ -96,13 +96,13 @@ def build_local_first_dock_composition(
     *,
     parent=None,
     footer_text: str = "",
-    progress_facts: WizardProgressFacts | None = None,
+    progress_facts: LocalFirstProgressFacts | None = None,
     atlas_title: str = "qfit Activity Atlas",
     atlas_subtitle: str = "",
 ) -> LocalFirstDockComposition:
     """Build the reusable local-first dock shell without swapping production UI."""
 
-    facts = progress_facts or WizardProgressFacts()
+    facts = progress_facts or LocalFirstProgressFacts()
     shell = LocalFirstDockShell(
         parent=parent,
         navigation_state=build_local_first_dock_navigation_state(facts),
@@ -198,11 +198,11 @@ def connect_local_first_action_callbacks(
 def refresh_local_first_dock_composition(
     composition: LocalFirstDockComposition,
     *,
-    progress_facts: WizardProgressFacts | None = None,
+    progress_facts: LocalFirstProgressFacts | None = None,
 ) -> LocalFirstDockComposition:
     """Refresh navigation and page status from render-neutral workflow facts."""
 
-    facts = progress_facts or WizardProgressFacts()
+    facts = progress_facts or LocalFirstProgressFacts()
     page_states = build_workflow_page_states_from_facts(_content_facts(facts))
     current_key = facts.preferred_current_key or composition.shell.current_key()
     composition.shell.set_navigation_state(
@@ -221,7 +221,7 @@ def refresh_local_first_dock_composition(
     return composition
 
 
-def _content_facts(facts: WizardProgressFacts) -> WizardProgressFacts:
+def _content_facts(facts: LocalFirstProgressFacts) -> LocalFirstProgressFacts:
     """Adapt local-first page facts to legacy wizard content state helpers."""
 
     return replace(facts, preferred_current_key=None)
@@ -240,7 +240,7 @@ def _install_local_first_pages(shell: LocalFirstDockShell) -> dict[str, QWidget]
 def _install_local_first_page_content(
     pages: dict[str, QWidget],
     *,
-    facts: WizardProgressFacts,
+    facts: LocalFirstProgressFacts,
     atlas_title: str,
     atlas_subtitle: str,
 ) -> LocalFirstDockPageContent:


### PR DESCRIPTION
## Summary
- Extract shared workflow progress facts into a neutral application module.
- Keep wizard-named imports as compatibility aliases while moving local-first progress/navigation/composition code to neutral or local-first names.
- Update local-first tests to use the new neutral/local-first progress facts surface.

## Tests
- `python3 -m unittest tests.test_local_first_progress_facts tests.test_local_first_navigation tests.test_local_first_composition tests.test_wizard_progress`
- `python3 -m pytest tests/test_local_first_progress_facts.py tests/test_local_first_navigation.py tests/test_local_first_composition.py tests/test_wizard_progress.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
