### PR TITLE
refactor: type footer status with workflow facts

### DIFF
--- a/tests/test_wizard_footer_status.py
+++ b/tests/test_wizard_footer_status.py
@@ -7,7 +7,7 @@ from qfit.ui.application.wizard_footer_status import (
     build_wizard_footer_facts_from_progress_facts,
     build_wizard_footer_status,
 )
-from qfit.ui.application.wizard_progress import WizardProgressFacts
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 
 
 class WizardFooterStatusTests(unittest.TestCase):
@@ -49,7 +49,7 @@ class WizardFooterStatusTests(unittest.TestCase):
         )
 
     def test_builds_explicit_footer_facts_from_progress_facts(self):
-        facts = WizardProgressFacts(
+        facts = WorkflowProgressFacts(
             connection_configured=True,
             activities_stored=True,
             activity_layers_loaded=True,
@@ -71,7 +71,7 @@ class WizardFooterStatusTests(unittest.TestCase):
         )
 
     def test_footer_facts_do_not_report_unstored_or_unloaded_counts(self):
-        facts = WizardProgressFacts(
+        facts = WorkflowProgressFacts(
             connection_configured=True,
             activities_fetched=True,
             fetched_activity_count=5,
@@ -90,7 +90,7 @@ class WizardFooterStatusTests(unittest.TestCase):
         )
 
     def test_footer_facts_fall_back_to_single_loaded_layer_when_count_unknown(self):
-        facts = WizardProgressFacts(activity_layers_loaded=True)
+        facts = WorkflowProgressFacts(activity_layers_loaded=True)
 
         self.assertEqual(
             build_wizard_footer_facts_from_progress_facts(facts).layer_count,
@@ -98,7 +98,7 @@ class WizardFooterStatusTests(unittest.TestCase):
         )
 
     def test_footer_facts_ignore_blank_last_sync_date(self):
-        facts = WizardProgressFacts(last_sync_date="   ")
+        facts = WorkflowProgressFacts(last_sync_date="   ")
 
         self.assertIsNone(
             build_wizard_footer_facts_from_progress_facts(facts).last_sync_date

--- a/ui/application/wizard_footer_status.py
+++ b/ui/application/wizard_footer_status.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from qfit.ui.application.wizard_progress import WizardProgressFacts
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 
 
 @dataclass(frozen=True)
@@ -42,13 +42,13 @@ def build_wizard_footer_status(
 
 
 def build_wizard_footer_facts_from_progress_facts(
-    facts: WizardProgressFacts,
+    facts: WorkflowProgressFacts,
 ) -> WizardFooterFacts:
-    """Build footer pill/path facts from the shared wizard progress facts.
+    """Build footer pill/path facts from shared workflow progress facts.
 
     The compact text summary remains as a compatibility seam for the placeholder
     shell. This adapter drives the footer's explicit Strava/activity/layer/path
-    controls from the same render-neutral state used by wizard pages, avoiding
+    controls from the same render-neutral state used by workflow pages, avoiding
     any dependency on current long-scroll dock widgets.
     """
 


### PR DESCRIPTION
## Summary

- type the wizard footer status adapter against neutral `WorkflowProgressFacts`
- update footer status tests to construct the neutral facts directly
- keep the existing wizard footer module/API names as compatibility seams

## Testing

- `PYTHONPATH=.. python3 -m pytest tests/test_wizard_footer_status.py -q --tb=short`
- `PYTHONPATH=.. python3 -m pytest tests/test_wizard_shell_composition.py tests/test_wizard_footer_status.py -q --tb=short`
- `PYTHONPATH=.. python3 -m pytest tests/ -x -q --tb=short`

Refs #805
