### PR TITLE
chore: use workflow facts in wizard composition

### DIFF
--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -7,6 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application.dock_workflow_sections import DockWizardProgress
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 
 
 def _load_wizard_composition_module():
@@ -34,6 +35,9 @@ class WizardShellCompositionTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.composition = _load_wizard_composition_module()
+
+    def test_keeps_wizard_progress_facts_as_compatibility_alias(self):
+        self.assertIs(self.composition.WizardProgressFacts, WorkflowProgressFacts)
 
     def test_builds_placeholder_shell_with_pages_before_presenter_renders(self):
         assembled = self.composition.build_placeholder_wizard_shell(footer_text="Ready")

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -22,6 +22,7 @@ from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
     build_default_wizard_page_specs,
 )
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 from qfit.ui.application.wizard_progress import (
     WizardProgressFacts,
     build_wizard_progress_from_facts_and_settings,
@@ -95,7 +96,7 @@ def build_placeholder_wizard_shell(
     parent=None,
     footer_text: str = "",
     progress: DockWizardProgress | None = None,
-    progress_facts: WizardProgressFacts | None = None,
+    progress_facts: WorkflowProgressFacts | None = None,
     wizard_settings: WizardSettingsSnapshot | None = None,
     specs: Sequence[DockWizardPageSpec] | None = None,
     use_step_pages: bool = True,
@@ -213,7 +214,7 @@ def refresh_wizard_shell_composition(
     atlas_state: AtlasPageState | None = None,
     footer_text: str | None = None,
     progress: DockWizardProgress | None = None,
-    progress_facts: WizardProgressFacts | None = None,
+    progress_facts: WorkflowProgressFacts | None = None,
     wizard_settings: WizardSettingsSnapshot | None = None,
 ) -> WizardShellComposition:
     """Refresh installed wizard page state without rebuilding the shell.
@@ -421,21 +422,21 @@ def _connect_action_callbacks(
 def _resolve_progress(
     *,
     progress: DockWizardProgress | None,
-    progress_facts: WizardProgressFacts | None,
+    progress_facts: WorkflowProgressFacts | None,
     wizard_settings: WizardSettingsSnapshot | None,
 ) -> DockWizardProgress | None:
     if progress is not None and (progress_facts is not None or wizard_settings is not None):
         raise ValueError("Pass progress or progress_facts/wizard_settings, not both")
     if progress_facts is None and wizard_settings is None:
         return progress
-    facts = progress_facts or WizardProgressFacts()
+    facts = progress_facts or WorkflowProgressFacts()
     if wizard_settings is not None:
         return build_wizard_progress_from_facts_and_settings(facts, wizard_settings)
     return build_wizard_progress_from_facts(facts)
 
 
 def _page_state_defaults_from_progress_facts(
-    progress_facts: WizardProgressFacts | None,
+    progress_facts: WorkflowProgressFacts | None,
 ) -> WizardPageStateSnapshots | None:
     if progress_facts is None:
         return None
@@ -445,7 +446,7 @@ def _page_state_defaults_from_progress_facts(
 
 
 def _footer_facts_from_progress_facts(
-    progress_facts: WizardProgressFacts | None,
+    progress_facts: WorkflowProgressFacts | None,
 ) -> WizardFooterFacts | None:
     if progress_facts is None:
         return None


### PR DESCRIPTION
## Summary

Move the wizard shell composition internals to the neutral `WorkflowProgressFacts` type while preserving the existing `WizardProgressFacts` compatibility export.

## Changes

- Type `progress_facts` parameters and helper seams in `wizard_composition.py` against `WorkflowProgressFacts`.
- Default missing progress facts with `WorkflowProgressFacts()` instead of the wizard-named alias.
- Add a regression assertion that the composition module still exposes `WizardProgressFacts` as the neutral facts alias.

## Testing

- `python3 -m pytest tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
