### PR TITLE
chore: add neutral workflow progress builder

### DIFF
--- a/tests/test_workflow_progress.py
+++ b/tests/test_workflow_progress.py
@@ -1,0 +1,59 @@
+import unittest
+
+from qfit.ui.application import build_workflow_progress_from_facts as exported_builder
+from qfit.ui.application.workflow_progress import build_workflow_progress_from_facts
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
+from qfit.ui.application.wizard_progress import build_wizard_progress_from_facts
+
+
+class WorkflowProgressTests(unittest.TestCase):
+    def test_builder_prefix_gates_completed_workflow_steps(self):
+        progress = build_workflow_progress_from_facts(
+            WorkflowProgressFacts(
+                connection_configured=True,
+                activity_layers_loaded=True,
+                analysis_generated=True,
+                atlas_exported=True,
+            )
+        )
+
+        self.assertEqual(progress.current_key, "sync")
+        self.assertEqual(progress.completed_keys, frozenset({"connection"}))
+        self.assertEqual(progress.visited_keys, frozenset({"sync"}))
+
+    def test_builder_allows_reachable_preferred_current_key(self):
+        progress = build_workflow_progress_from_facts(
+            WorkflowProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+                preferred_current_key="atlas",
+            )
+        )
+
+        self.assertEqual(progress.current_key, "atlas")
+        self.assertEqual(
+            progress.completed_keys,
+            frozenset({"connection", "sync", "map"}),
+        )
+
+    def test_wizard_builder_delegates_to_neutral_workflow_builder(self):
+        facts = WorkflowProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            analysis_generated=True,
+            preferred_current_key="atlas",
+        )
+
+        self.assertEqual(
+            build_wizard_progress_from_facts(facts),
+            build_workflow_progress_from_facts(facts),
+        )
+
+    def test_application_package_exports_neutral_workflow_builder(self):
+        self.assertIs(exported_builder, build_workflow_progress_from_facts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -113,6 +113,7 @@ from .local_first_progress_facts import (
     current_local_first_last_sync_date,
     runtime_state_with_local_first_output_path,
 )
+from .workflow_progress import build_workflow_progress_from_facts
 from .workflow_progress_facts import (
     WorkflowProgressFacts,
     build_workflow_progress_facts_from_runtime_state,
@@ -270,6 +271,7 @@ __all__ = [
     "current_local_first_last_sync_date",
     "build_wizard_filter_description",
     "build_workflow_progress_facts_from_runtime_state",
+    "build_workflow_progress_from_facts",
     "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts",
     "build_wizard_progress_from_facts_and_settings",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
+from .dock_workflow_sections import DockWizardProgress
+from .workflow_progress import build_workflow_progress_from_facts
 from .workflow_progress_facts import (
     WorkflowProgressFacts,
     build_workflow_progress_facts_from_runtime_state,
@@ -24,24 +25,9 @@ build_wizard_progress_facts_from_runtime_state = (
 
 
 def build_wizard_progress_from_facts(facts: WizardProgressFacts) -> DockWizardProgress:
-    """Build a safe wizard progress snapshot from current workflow facts.
+    """Compatibility wrapper for neutral workflow progress construction."""
 
-    Completed steps are prefix-gated so a later fact cannot make the stepper
-    skip over an incomplete prerequisite. The preferred current key is accepted
-    only while that page is reachable from the completed prefix; otherwise the
-    first incomplete step remains current.
-    """
-
-    completed_keys = _completed_keys_from_facts(facts)
-    current_key = _resolve_current_key(
-        completed_keys=completed_keys,
-        preferred_current_key=facts.preferred_current_key,
-    )
-    return DockWizardProgress(
-        current_key=current_key,
-        completed_keys=frozenset(completed_keys),
-        visited_keys=frozenset({current_key}),
-    )
+    return build_workflow_progress_from_facts(facts)
 
 
 def build_wizard_progress_from_facts_and_settings(
@@ -96,70 +82,6 @@ def _wizard_progress_facts_with_preferred_current_key(
     preferred_current_key: str | None,
 ) -> WizardProgressFacts:
     return replace(facts, preferred_current_key=preferred_current_key)
-
-
-def _completed_keys_from_facts(facts: WizardProgressFacts) -> tuple[str, ...]:
-    connection_complete = facts.connection_configured or facts.activities_stored
-    completed: list[str] = []
-    for key, complete in (
-        ("connection", connection_complete),
-        ("sync", facts.activities_stored),
-        ("map", facts.activity_layers_loaded),
-    ):
-        if not complete:
-            return tuple(completed)
-        completed.append(key)
-
-    if facts.analysis_generated:
-        completed.append("analysis")
-    if facts.atlas_exported:
-        completed.append("atlas")
-    return tuple(completed)
-
-
-def _resolve_current_key(
-    *,
-    completed_keys: tuple[str, ...],
-    preferred_current_key: str | None,
-) -> str:
-    known_keys = _workflow_keys()
-    completed = set(completed_keys)
-    first_incomplete_key = _first_incomplete_key(completed)
-    if preferred_current_key is None:
-        return first_incomplete_key
-    if preferred_current_key not in known_keys:
-        raise KeyError(preferred_current_key)
-    reachable_keys = _reachable_preferred_keys(
-        completed_keys=completed,
-        first_incomplete_key=first_incomplete_key,
-    )
-    if preferred_current_key in reachable_keys:
-        return preferred_current_key
-    return first_incomplete_key
-
-
-def _reachable_preferred_keys(
-    *,
-    completed_keys: set[str],
-    first_incomplete_key: str,
-) -> set[str]:
-    reachable = completed_keys | {first_incomplete_key}
-    if "map" in completed_keys:
-        reachable.update({"analysis", "atlas"})
-    return reachable
-
-
-def _first_incomplete_key(completed_keys: set[str]) -> str:
-    if "atlas" in completed_keys:
-        return "atlas"
-    for key in _workflow_keys():
-        if key not in completed_keys:
-            return key
-    return _workflow_keys()[-1]
-
-
-def _workflow_keys() -> tuple[str, ...]:
-    return tuple(section.key for section in WIZARD_WORKFLOW_STEPS)
 
 
 __all__ = [

--- a/ui/application/workflow_progress.py
+++ b/ui/application/workflow_progress.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
+from .workflow_progress_facts import WorkflowProgressFacts
+
+
+def build_workflow_progress_from_facts(
+    facts: WorkflowProgressFacts,
+) -> DockWizardProgress:
+    """Build a safe workflow progress snapshot from current workflow facts.
+
+    Completed steps are prefix-gated so a later fact cannot make the stepper
+    skip over an incomplete prerequisite. The preferred current key is accepted
+    only while that page is reachable from the completed prefix; otherwise the
+    first incomplete step remains current.
+    """
+
+    completed_keys = _completed_keys_from_facts(facts)
+    current_key = _resolve_current_key(
+        completed_keys=completed_keys,
+        preferred_current_key=facts.preferred_current_key,
+    )
+    return DockWizardProgress(
+        current_key=current_key,
+        completed_keys=frozenset(completed_keys),
+        visited_keys=frozenset({current_key}),
+    )
+
+
+def _completed_keys_from_facts(facts: WorkflowProgressFacts) -> tuple[str, ...]:
+    connection_complete = facts.connection_configured or facts.activities_stored
+    completed: list[str] = []
+    for key, complete in (
+        ("connection", connection_complete),
+        ("sync", facts.activities_stored),
+        ("map", facts.activity_layers_loaded),
+    ):
+        if not complete:
+            return tuple(completed)
+        completed.append(key)
+
+    if facts.analysis_generated:
+        completed.append("analysis")
+    if facts.atlas_exported:
+        completed.append("atlas")
+    return tuple(completed)
+
+
+def _resolve_current_key(
+    *,
+    completed_keys: tuple[str, ...],
+    preferred_current_key: str | None,
+) -> str:
+    known_keys = _workflow_keys()
+    completed = set(completed_keys)
+    first_incomplete_key = _first_incomplete_key(completed)
+    if preferred_current_key is None:
+        return first_incomplete_key
+    if preferred_current_key not in known_keys:
+        raise KeyError(preferred_current_key)
+    reachable_keys = _reachable_preferred_keys(
+        completed_keys=completed,
+        first_incomplete_key=first_incomplete_key,
+    )
+    if preferred_current_key in reachable_keys:
+        return preferred_current_key
+    return first_incomplete_key
+
+
+def _reachable_preferred_keys(
+    *,
+    completed_keys: set[str],
+    first_incomplete_key: str,
+) -> set[str]:
+    reachable = completed_keys | {first_incomplete_key}
+    if "map" in completed_keys:
+        reachable.update({"analysis", "atlas"})
+    return reachable
+
+
+def _first_incomplete_key(completed_keys: set[str]) -> str:
+    if "atlas" in completed_keys:
+        return "atlas"
+    for key in _workflow_keys():
+        if key not in completed_keys:
+            return key
+    return _workflow_keys()[-1]
+
+
+def _workflow_keys() -> tuple[str, ...]:
+    return tuple(section.key for section in WIZARD_WORKFLOW_STEPS)
+
+
+__all__ = ["build_workflow_progress_from_facts"]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -22,11 +22,11 @@ from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
     build_default_wizard_page_specs,
 )
+from qfit.ui.application.workflow_progress import build_workflow_progress_from_facts
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 from qfit.ui.application.wizard_progress import (
     WizardProgressFacts,
     build_wizard_progress_from_facts_and_settings,
-    build_wizard_progress_from_facts,
 )
 from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
@@ -432,7 +432,7 @@ def _resolve_progress(
     facts = progress_facts or WorkflowProgressFacts()
     if wizard_settings is not None:
         return build_wizard_progress_from_facts_and_settings(facts, wizard_settings)
-    return build_wizard_progress_from_facts(facts)
+    return build_workflow_progress_from_facts(facts)
 
 
 def _page_state_defaults_from_progress_facts(

--- a/ui/dockwidget/workflow_page_state.py
+++ b/ui/dockwidget/workflow_page_state.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from qfit.ui.application.workflow_progress import build_workflow_progress_from_facts
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
-from qfit.ui.application.wizard_progress import build_wizard_progress_from_facts
 
 from .analysis_page import AnalysisPageState
 from .atlas_page import AtlasPageState
@@ -78,7 +78,7 @@ def connect_optional_signal(content, signal_name: str, callback) -> None:
 
 
 def completed_prefix_facts(facts: WorkflowProgressFacts) -> WorkflowProgressFacts:
-    completed = build_wizard_progress_from_facts(facts).completed_keys
+    completed = build_workflow_progress_from_facts(facts).completed_keys
     return WorkflowProgressFacts(
         connection_configured=facts.connection_configured,
         activities_fetched=facts.activities_fetched,


### PR DESCRIPTION
## Summary

Add a neutral workflow progress builder so dock-first page state code no longer imports the wizard progress compatibility adapter.

## Changes

- Move prefix-gated workflow progress construction into `ui/application/workflow_progress.py`.
- Keep `build_wizard_progress_from_facts` as a compatibility wrapper.
- Update dock workflow page state and the no-settings wizard composition path to call the neutral builder.
- Add coverage for the neutral builder export and compatibility delegation.

## Testing

- `python3 -m pytest tests/test_workflow_progress.py tests/test_wizard_progress.py tests/test_wizard_shell_composition.py tests/test_local_first_navigation.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
