### PR TITLE
refactor: route composition through workflow progress

### DIFF
--- a/tests/test_workflow_progress.py
+++ b/tests/test_workflow_progress.py
@@ -1,9 +1,19 @@
 import unittest
 
 from qfit.ui.application import build_workflow_progress_from_facts as exported_builder
-from qfit.ui.application.workflow_progress import build_workflow_progress_from_facts
+from qfit.ui.application import (
+    build_workflow_progress_from_facts_and_settings as exported_settings_builder,
+)
+from qfit.ui.application.workflow_progress import (
+    build_workflow_progress_from_facts,
+    build_workflow_progress_from_facts_and_settings,
+)
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
-from qfit.ui.application.wizard_progress import build_wizard_progress_from_facts
+from qfit.ui.application.wizard_progress import (
+    build_wizard_progress_from_facts,
+    build_wizard_progress_from_facts_and_settings,
+)
+from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 
 class WorkflowProgressTests(unittest.TestCase):
@@ -51,8 +61,49 @@ class WorkflowProgressTests(unittest.TestCase):
             build_workflow_progress_from_facts(facts),
         )
 
+    def test_settings_builder_applies_reachable_persisted_step(self):
+        progress = build_workflow_progress_from_facts_and_settings(
+            WorkflowProgressFacts(
+                connection_configured=True,
+                activities_stored=True,
+                activity_layers_loaded=True,
+            ),
+            WizardSettingsSnapshot(
+                wizard_version=1,
+                last_step_index=2,
+                first_launch=False,
+            ),
+        )
+
+        self.assertEqual(progress.current_key, "map")
+        self.assertEqual(
+            progress.completed_keys,
+            frozenset({"connection", "sync", "map"}),
+        )
+
+    def test_wizard_settings_builder_delegates_to_neutral_workflow_builder(self):
+        facts = WorkflowProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+        )
+        settings = WizardSettingsSnapshot(
+            wizard_version=1,
+            last_step_index=4,
+            first_launch=False,
+        )
+
+        self.assertEqual(
+            build_wizard_progress_from_facts_and_settings(facts, settings),
+            build_workflow_progress_from_facts_and_settings(facts, settings),
+        )
+
     def test_application_package_exports_neutral_workflow_builder(self):
         self.assertIs(exported_builder, build_workflow_progress_from_facts)
+        self.assertIs(
+            exported_settings_builder,
+            build_workflow_progress_from_facts_and_settings,
+        )
 
 
 if __name__ == "__main__":

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -113,7 +113,10 @@ from .local_first_progress_facts import (
     current_local_first_last_sync_date,
     runtime_state_with_local_first_output_path,
 )
-from .workflow_progress import build_workflow_progress_from_facts
+from .workflow_progress import (
+    build_workflow_progress_from_facts,
+    build_workflow_progress_from_facts_and_settings,
+)
 from .workflow_progress_facts import (
     WorkflowProgressFacts,
     build_workflow_progress_facts_from_runtime_state,
@@ -272,6 +275,7 @@ __all__ = [
     "build_wizard_filter_description",
     "build_workflow_progress_facts_from_runtime_state",
     "build_workflow_progress_from_facts",
+    "build_workflow_progress_from_facts_and_settings",
     "build_wizard_progress_facts_from_runtime_state",
     "build_wizard_progress_from_facts",
     "build_wizard_progress_from_facts_and_settings",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from dataclasses import replace
 
 from .dock_workflow_sections import DockWizardProgress
-from .workflow_progress import build_workflow_progress_from_facts
+from .workflow_progress import (
+    build_workflow_progress_from_facts,
+    build_workflow_progress_from_facts_and_settings,
+)
 from .workflow_progress_facts import (
     WorkflowProgressFacts,
     build_workflow_progress_facts_from_runtime_state,
@@ -34,21 +37,9 @@ def build_wizard_progress_from_facts_and_settings(
     facts: WizardProgressFacts,
     settings: WizardSettingsSnapshot,
 ) -> DockWizardProgress:
-    """Build wizard progress while honoring a persisted step preference.
+    """Compatibility wrapper for settings-aware workflow progress."""
 
-    The persisted step is a preference, not an unlock rule. The normal progress
-    builder still gates it behind completed prerequisites so the wizard cannot
-    restore into a page that should remain locked.
-    """
-
-    if facts.preferred_current_key is not None:
-        return build_wizard_progress_from_facts(facts)
-    return build_wizard_progress_from_facts(
-        _wizard_progress_facts_with_preferred_current_key(
-            facts,
-            preferred_current_key=preferred_current_key_from_settings(settings),
-        )
-    )
+    return build_workflow_progress_from_facts_and_settings(facts, settings)
 
 
 def build_startup_wizard_progress_facts(

--- a/ui/application/workflow_progress.py
+++ b/ui/application/workflow_progress.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
 from .workflow_progress_facts import WorkflowProgressFacts
+from .wizard_settings import (
+    WizardSettingsSnapshot,
+    preferred_current_key_from_settings,
+)
 
 
 def build_workflow_progress_from_facts(
@@ -24,6 +30,27 @@ def build_workflow_progress_from_facts(
         current_key=current_key,
         completed_keys=frozenset(completed_keys),
         visited_keys=frozenset({current_key}),
+    )
+
+
+def build_workflow_progress_from_facts_and_settings(
+    facts: WorkflowProgressFacts,
+    settings: WizardSettingsSnapshot,
+) -> DockWizardProgress:
+    """Build workflow progress while honoring a persisted step preference.
+
+    The persisted step is a preference, not an unlock rule. The normal progress
+    builder still gates it behind completed prerequisites so the workflow cannot
+    restore into a page that should remain locked.
+    """
+
+    if facts.preferred_current_key is not None:
+        return build_workflow_progress_from_facts(facts)
+    return build_workflow_progress_from_facts(
+        replace(
+            facts,
+            preferred_current_key=preferred_current_key_from_settings(settings),
+        )
     )
 
 
@@ -91,4 +118,7 @@ def _workflow_keys() -> tuple[str, ...]:
     return tuple(section.key for section in WIZARD_WORKFLOW_STEPS)
 
 
-__all__ = ["build_workflow_progress_from_facts"]
+__all__ = [
+    "build_workflow_progress_from_facts",
+    "build_workflow_progress_from_facts_and_settings",
+]

--- a/ui/application/workflow_progress.py
+++ b/ui/application/workflow_progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import cast
 
 from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
 from .workflow_progress_facts import WorkflowProgressFacts
@@ -46,11 +47,15 @@ def build_workflow_progress_from_facts_and_settings(
 
     if facts.preferred_current_key is not None:
         return build_workflow_progress_from_facts(facts)
-    facts_with_preference: WorkflowProgressFacts = replace(
-        facts,
-        preferred_current_key=preferred_current_key_from_settings(settings),
+    return build_workflow_progress_from_facts(
+        cast(
+            WorkflowProgressFacts,
+            replace(
+                facts,
+                preferred_current_key=preferred_current_key_from_settings(settings),
+            ),
+        )
     )
-    return build_workflow_progress_from_facts(facts_with_preference)
 
 
 def _completed_keys_from_facts(facts: WorkflowProgressFacts) -> tuple[str, ...]:

--- a/ui/application/workflow_progress.py
+++ b/ui/application/workflow_progress.py
@@ -46,12 +46,11 @@ def build_workflow_progress_from_facts_and_settings(
 
     if facts.preferred_current_key is not None:
         return build_workflow_progress_from_facts(facts)
-    return build_workflow_progress_from_facts(
-        replace(
-            facts,
-            preferred_current_key=preferred_current_key_from_settings(settings),
-        )
+    facts_with_preference: WorkflowProgressFacts = replace(
+        facts,
+        preferred_current_key=preferred_current_key_from_settings(settings),
     )
+    return build_workflow_progress_from_facts(facts_with_preference)
 
 
 def _completed_keys_from_facts(facts: WorkflowProgressFacts) -> tuple[str, ...]:

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -27,6 +27,7 @@ from qfit.ui.application.workflow_progress import (
     build_workflow_progress_from_facts_and_settings,
 )
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
+from qfit.ui.application.wizard_progress import WizardProgressFacts
 from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 from .analysis_page import (
@@ -61,8 +62,6 @@ from .workflow_page_state import (
 
 _StateT = TypeVar("_StateT")
 WizardCompositionPage = WizardPage | WizardStepPage
-WizardProgressFacts = WorkflowProgressFacts
-"""Compatibility alias for wizard composition callers during the #805 migration."""
 
 
 @dataclass

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -22,12 +22,11 @@ from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
     build_default_wizard_page_specs,
 )
-from qfit.ui.application.workflow_progress import build_workflow_progress_from_facts
-from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
-from qfit.ui.application.wizard_progress import (
-    WizardProgressFacts,
-    build_wizard_progress_from_facts_and_settings,
+from qfit.ui.application.workflow_progress import (
+    build_workflow_progress_from_facts,
+    build_workflow_progress_from_facts_and_settings,
 )
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 from .analysis_page import (
@@ -62,6 +61,8 @@ from .workflow_page_state import (
 
 _StateT = TypeVar("_StateT")
 WizardCompositionPage = WizardPage | WizardStepPage
+WizardProgressFacts = WorkflowProgressFacts
+"""Compatibility alias for wizard composition callers during the #805 migration."""
 
 
 @dataclass
@@ -431,7 +432,7 @@ def _resolve_progress(
         return progress
     facts = progress_facts or WorkflowProgressFacts()
     if wizard_settings is not None:
-        return build_wizard_progress_from_facts_and_settings(facts, wizard_settings)
+        return build_workflow_progress_from_facts_and_settings(facts, wizard_settings)
     return build_workflow_progress_from_facts(facts)
 
 


### PR DESCRIPTION
## Summary

Move settings-aware workflow progress construction into the neutral workflow progress module, keep the wizard-named wrapper as compatibility, and have wizard composition use the neutral builder directly while retaining its `WizardProgressFacts` compatibility alias.

## Changes

- Add `build_workflow_progress_from_facts_and_settings` alongside the neutral workflow progress builder
- Delegate `build_wizard_progress_from_facts_and_settings` to the neutral builder
- Remove `wizard_composition.py`'s production import from `wizard_progress.py`
- Cover the neutral settings-aware builder and package export in workflow progress tests

## Testing

- `python3 -m pytest tests/test_workflow_progress.py tests/test_wizard_progress.py tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
