### PR TITLE
refactor: expose startup workflow progress facts

### DIFF
--- a/tests/test_workflow_progress.py
+++ b/tests/test_workflow_progress.py
@@ -2,14 +2,19 @@ import unittest
 
 from qfit.ui.application import build_workflow_progress_from_facts as exported_builder
 from qfit.ui.application import (
+    build_startup_workflow_progress_facts as exported_startup_facts_builder,
+)
+from qfit.ui.application import (
     build_workflow_progress_from_facts_and_settings as exported_settings_builder,
 )
 from qfit.ui.application.workflow_progress import (
+    build_startup_workflow_progress_facts,
     build_workflow_progress_from_facts,
     build_workflow_progress_from_facts_and_settings,
 )
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 from qfit.ui.application.wizard_progress import (
+    build_startup_wizard_progress_facts,
     build_wizard_progress_from_facts,
     build_wizard_progress_from_facts_and_settings,
 )
@@ -98,11 +103,67 @@ class WorkflowProgressTests(unittest.TestCase):
             build_workflow_progress_from_facts_and_settings(facts, settings),
         )
 
+    def test_startup_facts_skip_configured_connection_restore_target(self):
+        settings = WizardSettingsSnapshot(
+            wizard_version=1,
+            last_step_index=0,
+            first_launch=False,
+        )
+        startup_facts = build_startup_workflow_progress_facts(
+            WorkflowProgressFacts(connection_configured=True),
+            settings,
+        )
+
+        progress = build_workflow_progress_from_facts_and_settings(
+            startup_facts,
+            settings,
+        )
+
+        self.assertEqual(progress.current_key, "sync")
+        self.assertEqual(progress.completed_keys, frozenset({"connection"}))
+
+    def test_startup_facts_preserve_explicit_user_selected_connection_step(self):
+        settings = WizardSettingsSnapshot(
+            wizard_version=1,
+            last_step_index=0,
+            last_step_index_user_selected=True,
+            first_launch=False,
+        )
+        startup_facts = build_startup_workflow_progress_facts(
+            WorkflowProgressFacts(connection_configured=True),
+            settings,
+        )
+
+        progress = build_workflow_progress_from_facts_and_settings(
+            startup_facts,
+            settings,
+        )
+
+        self.assertEqual(progress.current_key, "connection")
+        self.assertEqual(progress.completed_keys, frozenset({"connection"}))
+
+    def test_wizard_startup_facts_builder_delegates_to_neutral_workflow_builder(self):
+        facts = WorkflowProgressFacts(connection_configured=True)
+        settings = WizardSettingsSnapshot(
+            wizard_version=1,
+            last_step_index=0,
+            first_launch=False,
+        )
+
+        self.assertEqual(
+            build_startup_wizard_progress_facts(facts, settings),
+            build_startup_workflow_progress_facts(facts, settings),
+        )
+
     def test_application_package_exports_neutral_workflow_builder(self):
         self.assertIs(exported_builder, build_workflow_progress_from_facts)
         self.assertIs(
             exported_settings_builder,
             build_workflow_progress_from_facts_and_settings,
+        )
+        self.assertIs(
+            exported_startup_facts_builder,
+            build_startup_workflow_progress_facts,
         )
 
 

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -114,6 +114,7 @@ from .local_first_progress_facts import (
     runtime_state_with_local_first_output_path,
 )
 from .workflow_progress import (
+    build_startup_workflow_progress_facts,
     build_workflow_progress_from_facts,
     build_workflow_progress_from_facts_and_settings,
 )
@@ -271,6 +272,7 @@ __all__ = [
     "build_stepper_items",
     "build_stepper_states",
     "build_startup_wizard_progress_facts",
+    "build_startup_workflow_progress_facts",
     "current_local_first_last_sync_date",
     "build_wizard_filter_description",
     "build_workflow_progress_facts_from_runtime_state",

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import replace
-
 from .dock_workflow_sections import DockWizardProgress
 from .workflow_progress import (
+    build_startup_workflow_progress_facts,
     build_workflow_progress_from_facts,
     build_workflow_progress_from_facts_and_settings,
 )
@@ -11,10 +10,7 @@ from .workflow_progress_facts import (
     WorkflowProgressFacts,
     build_workflow_progress_facts_from_runtime_state,
 )
-from .wizard_settings import (
-    WizardSettingsSnapshot,
-    preferred_current_key_from_settings,
-)
+from .wizard_settings import WizardSettingsSnapshot
 
 
 WizardProgressFacts = WorkflowProgressFacts
@@ -53,26 +49,7 @@ def build_startup_wizard_progress_facts(
     users reconfirm an already-completed prerequisite before continuing.
     """
 
-    preferred_current_key = preferred_current_key_from_settings(settings)
-    if (
-        preferred_current_key == "connection"
-        and facts.connection_configured
-        and not settings.last_step_index_user_selected
-    ):
-        progress = build_wizard_progress_from_facts(facts)
-        return _wizard_progress_facts_with_preferred_current_key(
-            facts,
-            preferred_current_key=progress.current_key,
-        )
-    return facts
-
-
-def _wizard_progress_facts_with_preferred_current_key(
-    facts: WizardProgressFacts,
-    *,
-    preferred_current_key: str | None,
-) -> WizardProgressFacts:
-    return replace(facts, preferred_current_key=preferred_current_key)
+    return build_startup_workflow_progress_facts(facts, settings)
 
 
 __all__ = [

--- a/ui/application/workflow_progress.py
+++ b/ui/application/workflow_progress.py
@@ -48,13 +48,46 @@ def build_workflow_progress_from_facts_and_settings(
     if facts.preferred_current_key is not None:
         return build_workflow_progress_from_facts(facts)
     return build_workflow_progress_from_facts(
-        cast(
-            WorkflowProgressFacts,
-            replace(
-                facts,
-                preferred_current_key=preferred_current_key_from_settings(settings),
-            ),
+        _workflow_progress_facts_with_preferred_current_key(
+            facts,
+            preferred_current_key=preferred_current_key_from_settings(settings),
         )
+    )
+
+
+def build_startup_workflow_progress_facts(
+    facts: WorkflowProgressFacts,
+    settings: WizardSettingsSnapshot,
+) -> WorkflowProgressFacts:
+    """Return startup-only facts for the first visible workflow page.
+
+    Persisted step settings still control normal refreshes. Startup is the one
+    place where a saved default Connection target should not make configured
+    users reconfirm an already-completed prerequisite before continuing.
+    """
+
+    preferred_current_key = preferred_current_key_from_settings(settings)
+    if (
+        preferred_current_key == "connection"
+        and facts.connection_configured
+        and not settings.last_step_index_user_selected
+    ):
+        progress = build_workflow_progress_from_facts(facts)
+        return _workflow_progress_facts_with_preferred_current_key(
+            facts,
+            preferred_current_key=progress.current_key,
+        )
+    return facts
+
+
+def _workflow_progress_facts_with_preferred_current_key(
+    facts: WorkflowProgressFacts,
+    *,
+    preferred_current_key: str | None,
+) -> WorkflowProgressFacts:
+    return cast(
+        WorkflowProgressFacts,
+        replace(facts, preferred_current_key=preferred_current_key),
     )
 
 
@@ -123,6 +156,7 @@ def _workflow_keys() -> tuple[str, ...]:
 
 
 __all__ = [
+    "build_startup_workflow_progress_facts",
     "build_workflow_progress_from_facts",
     "build_workflow_progress_from_facts_and_settings",
 ]


### PR DESCRIPTION
## Summary
- expose a neutral `build_startup_workflow_progress_facts` helper
- keep `build_startup_wizard_progress_facts` as a compatibility wrapper
- cover the neutral startup helper and package export in workflow progress tests

## Tests
- `python3 -m pytest tests/test_workflow_progress.py tests/test_wizard_progress.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
