### PR TITLE
Reduce wizard progress import coupling

### DIFF
--- a/tests/test_application_progress_exports.py
+++ b/tests/test_application_progress_exports.py
@@ -1,0 +1,72 @@
+import importlib
+import sys
+import unittest
+
+from tests import _path  # noqa: F401
+
+
+class ApplicationProgressExportTests(unittest.TestCase):
+    def test_package_import_defers_wizard_progress_compatibility_exports(self):
+        saved_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == "qfit.ui.application"
+            or name.startswith("qfit.ui.application.")
+        }
+        ui_package = importlib.import_module("qfit.ui")
+        missing = object()
+        saved_application = getattr(ui_package, "application", missing)
+        for name in saved_modules:
+            sys.modules.pop(name, None)
+        if hasattr(ui_package, "application"):
+            delattr(ui_package, "application")
+
+        try:
+            app = importlib.import_module("qfit.ui.application")
+
+            self.assertNotIn("qfit.ui.application.wizard_progress", sys.modules)
+
+            from qfit.ui.application import (  # noqa: PLC0415
+                WizardProgressFacts,
+                build_startup_wizard_progress_facts,
+                build_wizard_progress_facts_from_runtime_state,
+                build_wizard_progress_from_facts,
+                build_wizard_progress_from_facts_and_settings,
+            )
+
+            wizard_progress = importlib.import_module(
+                "qfit.ui.application.wizard_progress"
+            )
+            compat_exports = {
+                "WizardProgressFacts": WizardProgressFacts,
+                "build_startup_wizard_progress_facts": (
+                    build_startup_wizard_progress_facts
+                ),
+                "build_wizard_progress_facts_from_runtime_state": (
+                    build_wizard_progress_facts_from_runtime_state
+                ),
+                "build_wizard_progress_from_facts": build_wizard_progress_from_facts,
+                "build_wizard_progress_from_facts_and_settings": (
+                    build_wizard_progress_from_facts_and_settings
+                ),
+            }
+            for name, value in compat_exports.items():
+                with self.subTest(name=name):
+                    self.assertIs(value, getattr(wizard_progress, name))
+                    self.assertIs(getattr(app, name), value)
+        finally:
+            for name in list(sys.modules):
+                if name == "qfit.ui.application" or name.startswith(
+                    "qfit.ui.application."
+                ):
+                    sys.modules.pop(name, None)
+            sys.modules.update(saved_modules)
+            if saved_application is missing:
+                if hasattr(ui_package, "application"):
+                    delattr(ui_package, "application")
+            else:
+                setattr(ui_package, "application", saved_application)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -1,5 +1,7 @@
 """Application-facing dock widget workflow helpers."""
 
+from importlib import import_module
+
 from .dock_action_dispatcher import (
     ApplyVisualizationAction,
     DockActionDispatcher,
@@ -166,13 +168,6 @@ from .wizard_settings import (
     save_last_step_index,
     wizard_step_key_for_index,
 )
-from .wizard_progress import (
-    WizardProgressFacts,
-    build_startup_wizard_progress_facts,
-    build_wizard_progress_facts_from_runtime_state,
-    build_wizard_progress_from_facts,
-    build_wizard_progress_from_facts_and_settings,
-)
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -182,6 +177,26 @@ from .visual_workflow_action_builder import VisualWorkflowActionInputs
 from .visual_workflow_action_builder import VisualWorkflowBackgroundInputs
 from .visual_workflow_action_builder import VisualWorkflowSettingsSnapshot
 from .visual_workflow_action_builder import build_visual_workflow_settings_snapshot
+
+_WIZARD_PROGRESS_COMPAT_EXPORTS = frozenset(
+    {
+        "WizardProgressFacts",
+        "build_startup_wizard_progress_facts",
+        "build_wizard_progress_facts_from_runtime_state",
+        "build_wizard_progress_from_facts",
+        "build_wizard_progress_from_facts_and_settings",
+    }
+)
+
+
+def __getattr__(name: str) -> object:
+    if name in _WIZARD_PROGRESS_COMPAT_EXPORTS:
+        wizard_progress = import_module(".wizard_progress", __name__)
+        value = getattr(wizard_progress, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "ApplyVisualizationAction",

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -27,7 +27,6 @@ from qfit.ui.application.workflow_progress import (
     build_workflow_progress_from_facts_and_settings,
 )
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
-from qfit.ui.application.wizard_progress import WizardProgressFacts
 from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 from .analysis_page import (
@@ -62,6 +61,8 @@ from .workflow_page_state import (
 
 _StateT = TypeVar("_StateT")
 WizardCompositionPage = WizardPage | WizardStepPage
+WizardProgressFacts = WorkflowProgressFacts
+"""Compatibility alias for wizard shell composition callers during #805."""
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- stop eagerly importing wizard progress compatibility exports from `qfit.ui.application`
- keep package-level wizard progress imports working via lazy compatibility resolution
- make `wizard_composition` expose its compatibility `WizardProgressFacts` alias from neutral workflow facts directly

Refs #805

## Tests

- `python3 -m pytest tests/test_application_progress_exports.py tests/test_workflow_progress.py tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
