### PR TITLE
refactor: extract workflow footer status

### DIFF
--- a/tests/test_wizard_footer_status.py
+++ b/tests/test_wizard_footer_status.py
@@ -2,53 +2,33 @@ import unittest
 
 from tests import _path  # noqa: F401
 
-from qfit.ui.application.wizard_footer_status import (
-    WizardFooterFacts,
-    build_wizard_footer_facts_from_progress_facts,
-    build_wizard_footer_status,
-)
+from qfit.ui.application import wizard_footer_status as wizard_footer
+from qfit.ui.application import workflow_footer_status as workflow_footer
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 
 
-class WizardFooterStatusTests(unittest.TestCase):
-    def test_builds_compact_status_from_wizard_page_facts(self):
-        self.assertEqual(
-            build_wizard_footer_status(
-                connection_status="Strava connected",
-                activity_summary="12 activities stored",
-                map_summary="3 layers loaded",
-                analysis_status="Analysis ready",
-                atlas_status="Atlas PDF not exported yet",
-            ),
-            "Strava connected · 12 activities stored · 3 layers loaded · "
-            "Analysis ready · Atlas PDF not exported yet",
+class WizardFooterStatusCompatibilityTests(unittest.TestCase):
+    def test_wizard_footer_facts_aliases_workflow_footer_facts(self):
+        self.assertIs(
+            wizard_footer.WizardFooterFacts,
+            workflow_footer.WorkflowFooterFacts,
         )
 
-    def test_omits_empty_and_duplicate_parts(self):
+    def test_wizard_footer_status_delegates_to_workflow_footer_status(self):
+        kwargs = {
+            "connection_status": "Strava connected",
+            "activity_summary": "12 activities stored",
+            "map_summary": "3 layers loaded",
+            "analysis_status": "Analysis ready",
+            "atlas_status": "Atlas PDF not exported yet",
+        }
+
         self.assertEqual(
-            build_wizard_footer_status(
-                connection_status="Ready",
-                activity_summary="",
-                map_summary=None,
-                analysis_status="Ready",
-                atlas_status=" ",
-            ),
-            "Ready",
+            wizard_footer.build_wizard_footer_status(**kwargs),
+            workflow_footer.build_workflow_footer_status(**kwargs),
         )
 
-    def test_falls_back_to_ready_when_no_status_parts_are_available(self):
-        self.assertEqual(
-            build_wizard_footer_status(
-                connection_status="",
-                activity_summary=None,
-                map_summary=" ",
-                analysis_status="",
-                atlas_status=None,
-            ),
-            "Ready",
-        )
-
-    def test_builds_explicit_footer_facts_from_progress_facts(self):
+    def test_wizard_footer_facts_builder_delegates_to_workflow_footer_builder(self):
         facts = WorkflowProgressFacts(
             connection_configured=True,
             activities_stored=True,
@@ -60,48 +40,18 @@ class WizardFooterStatusTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            build_wizard_footer_facts_from_progress_facts(facts),
-            WizardFooterFacts(
-                strava_connected=True,
-                activity_count=12,
-                layer_count=4,
-                gpkg_path="qfit.gpkg",
-                last_sync_date="2026-04-16",
-            ),
+            wizard_footer.build_wizard_footer_facts_from_progress_facts(facts),
+            workflow_footer.build_workflow_footer_facts_from_progress_facts(facts),
         )
 
-    def test_footer_facts_do_not_report_unstored_or_unloaded_counts(self):
-        facts = WorkflowProgressFacts(
-            connection_configured=True,
-            activities_fetched=True,
-            fetched_activity_count=5,
-            activity_count=99,
-            loaded_layer_count=4,
-        )
-
+    def test_wizard_footer_module_keeps_compat_exports(self):
         self.assertEqual(
-            build_wizard_footer_facts_from_progress_facts(facts),
-            WizardFooterFacts(
-                strava_connected=True,
-                activity_count=None,
-                layer_count=0,
-                gpkg_path=None,
-            ),
-        )
-
-    def test_footer_facts_fall_back_to_single_loaded_layer_when_count_unknown(self):
-        facts = WorkflowProgressFacts(activity_layers_loaded=True)
-
-        self.assertEqual(
-            build_wizard_footer_facts_from_progress_facts(facts).layer_count,
-            1,
-        )
-
-    def test_footer_facts_ignore_blank_last_sync_date(self):
-        facts = WorkflowProgressFacts(last_sync_date="   ")
-
-        self.assertIsNone(
-            build_wizard_footer_facts_from_progress_facts(facts).last_sync_date
+            set(wizard_footer.__all__),
+            {
+                "WizardFooterFacts",
+                "build_wizard_footer_facts_from_progress_facts",
+                "build_wizard_footer_status",
+            },
         )
 
 

--- a/tests/test_workflow_footer_status.py
+++ b/tests/test_workflow_footer_status.py
@@ -1,0 +1,109 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.workflow_footer_status import (
+    WorkflowFooterFacts,
+    build_workflow_footer_facts_from_progress_facts,
+    build_workflow_footer_status,
+)
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
+
+
+class WorkflowFooterStatusTests(unittest.TestCase):
+    def test_builds_compact_status_from_workflow_page_facts(self):
+        self.assertEqual(
+            build_workflow_footer_status(
+                connection_status="Strava connected",
+                activity_summary="12 activities stored",
+                map_summary="3 layers loaded",
+                analysis_status="Analysis ready",
+                atlas_status="Atlas PDF not exported yet",
+            ),
+            "Strava connected · 12 activities stored · 3 layers loaded · "
+            "Analysis ready · Atlas PDF not exported yet",
+        )
+
+    def test_omits_empty_and_duplicate_parts(self):
+        self.assertEqual(
+            build_workflow_footer_status(
+                connection_status="Ready",
+                activity_summary="",
+                map_summary=None,
+                analysis_status="Ready",
+                atlas_status=" ",
+            ),
+            "Ready",
+        )
+
+    def test_falls_back_to_ready_when_no_status_parts_are_available(self):
+        self.assertEqual(
+            build_workflow_footer_status(
+                connection_status="",
+                activity_summary=None,
+                map_summary=" ",
+                analysis_status="",
+                atlas_status=None,
+            ),
+            "Ready",
+        )
+
+    def test_builds_explicit_footer_facts_from_progress_facts(self):
+        facts = WorkflowProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_layers_loaded=True,
+            activity_count=12,
+            output_name="qfit.gpkg",
+            loaded_layer_count=4,
+            last_sync_date="2026-04-16",
+        )
+
+        self.assertEqual(
+            build_workflow_footer_facts_from_progress_facts(facts),
+            WorkflowFooterFacts(
+                strava_connected=True,
+                activity_count=12,
+                layer_count=4,
+                gpkg_path="qfit.gpkg",
+                last_sync_date="2026-04-16",
+            ),
+        )
+
+    def test_footer_facts_do_not_report_unstored_or_unloaded_counts(self):
+        facts = WorkflowProgressFacts(
+            connection_configured=True,
+            activities_fetched=True,
+            fetched_activity_count=5,
+            activity_count=99,
+            loaded_layer_count=4,
+        )
+
+        self.assertEqual(
+            build_workflow_footer_facts_from_progress_facts(facts),
+            WorkflowFooterFacts(
+                strava_connected=True,
+                activity_count=None,
+                layer_count=0,
+                gpkg_path=None,
+            ),
+        )
+
+    def test_footer_facts_fall_back_to_single_loaded_layer_when_count_unknown(self):
+        facts = WorkflowProgressFacts(activity_layers_loaded=True)
+
+        self.assertEqual(
+            build_workflow_footer_facts_from_progress_facts(facts).layer_count,
+            1,
+        )
+
+    def test_footer_facts_ignore_blank_last_sync_date(self):
+        facts = WorkflowProgressFacts(last_sync_date="   ")
+
+        self.assertIsNone(
+            build_workflow_footer_facts_from_progress_facts(facts).last_sync_date
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -115,6 +115,11 @@ from .local_first_progress_facts import (
     current_local_first_last_sync_date,
     runtime_state_with_local_first_output_path,
 )
+from .workflow_footer_status import (
+    WorkflowFooterFacts,
+    build_workflow_footer_facts_from_progress_facts,
+    build_workflow_footer_status,
+)
 from .workflow_progress import (
     build_startup_workflow_progress_facts,
     build_workflow_progress_from_facts,
@@ -258,6 +263,7 @@ __all__ = [
     "VisualWorkflowActionInputs",
     "VisualWorkflowSettingsSnapshot",
     "WizardProgressFacts",
+    "WorkflowFooterFacts",
     "WorkflowProgressFacts",
     "WizardSettingsSnapshot",
     "build_advanced_fetch_visibility_update",
@@ -290,6 +296,8 @@ __all__ = [
     "build_startup_workflow_progress_facts",
     "current_local_first_last_sync_date",
     "build_wizard_filter_description",
+    "build_workflow_footer_facts_from_progress_facts",
+    "build_workflow_footer_status",
     "build_workflow_progress_facts_from_runtime_state",
     "build_workflow_progress_from_facts",
     "build_workflow_progress_from_facts_and_settings",

--- a/ui/application/wizard_footer_status.py
+++ b/ui/application/wizard_footer_status.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
+from qfit.ui.application.workflow_footer_status import (
+    WorkflowFooterFacts,
+    build_workflow_footer_facts_from_progress_facts,
+    build_workflow_footer_status,
+)
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 
-
-@dataclass(frozen=True)
-class WizardFooterFacts:
-    """Render-neutral facts for the explicit #609 wizard footer controls."""
-
-    strava_connected: bool = False
-    activity_count: int | None = None
-    layer_count: int = 0
-    gpkg_path: str | None = None
-    last_sync_date: str | None = None
+WizardFooterFacts = WorkflowFooterFacts
+"""Compatibility alias for wizard footer callers during #805."""
 
 
 def build_wizard_footer_status(
@@ -24,75 +19,23 @@ def build_wizard_footer_status(
     analysis_status: str | None,
     atlas_status: str | None,
 ) -> str:
-    """Build the compact persistent footer text for the #609 wizard shell.
+    """Compatibility wrapper for :func:`build_workflow_footer_status`."""
 
-    The footer deliberately summarizes page-level render facts instead of
-    reading current dock widgets. That keeps the wizard replacement path free to
-    migrate one page at a time while still giving users the one-glance status
-    requested by the #608 UX audit.
-    """
-
-    return _join_unique_status_parts(
-        connection_status,
-        activity_summary,
-        map_summary,
-        analysis_status,
-        atlas_status,
+    return build_workflow_footer_status(
+        connection_status=connection_status,
+        activity_summary=activity_summary,
+        map_summary=map_summary,
+        analysis_status=analysis_status,
+        atlas_status=atlas_status,
     )
 
 
 def build_wizard_footer_facts_from_progress_facts(
     facts: WorkflowProgressFacts,
 ) -> WizardFooterFacts:
-    """Build footer pill/path facts from shared workflow progress facts.
+    """Compatibility wrapper for workflow footer fact construction."""
 
-    The compact text summary remains as a compatibility seam for the placeholder
-    shell. This adapter drives the footer's explicit Strava/activity/layer/path
-    controls from the same render-neutral state used by workflow pages, avoiding
-    any dependency on current long-scroll dock widgets.
-    """
-
-    return WizardFooterFacts(
-        strava_connected=facts.connection_configured,
-        activity_count=_stored_activity_count(facts),
-        layer_count=_loaded_layer_count(facts),
-        gpkg_path=facts.output_name,
-        last_sync_date=_optional_text(facts.last_sync_date),
-    )
-
-
-def _join_unique_status_parts(*values: str | None) -> str:
-    parts: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        part = (value or "").strip()
-        if not part or part in seen:
-            continue
-        parts.append(part)
-        seen.add(part)
-
-    if not parts:
-        return "Ready"
-    return " · ".join(parts)
-
-
-def _optional_text(value: str | None) -> str | None:
-    stripped = (value or "").strip()
-    return stripped or None
-
-
-def _stored_activity_count(facts) -> int | None:
-    if not facts.activities_stored or facts.activity_count is None:
-        return None
-    return max(int(facts.activity_count), 0)
-
-
-def _loaded_layer_count(facts) -> int:
-    if not facts.activity_layers_loaded:
-        return 0
-    if facts.loaded_layer_count is None:
-        return 1
-    return max(int(facts.loaded_layer_count), 0)
+    return build_workflow_footer_facts_from_progress_facts(facts)
 
 
 __all__ = [

--- a/ui/application/workflow_footer_status.py
+++ b/ui/application/workflow_footer_status.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
+
+
+@dataclass(frozen=True)
+class WorkflowFooterFacts:
+    """Render-neutral facts for the dock workflow footer controls."""
+
+    strava_connected: bool = False
+    activity_count: int | None = None
+    layer_count: int = 0
+    gpkg_path: str | None = None
+    last_sync_date: str | None = None
+
+
+def build_workflow_footer_status(
+    *,
+    connection_status: str | None,
+    activity_summary: str | None,
+    map_summary: str | None,
+    analysis_status: str | None,
+    atlas_status: str | None,
+) -> str:
+    """Build the compact persistent footer text for the dock workflow.
+
+    The footer summarizes page-level render facts instead of reading current dock
+    widgets. That keeps the local-first replacement path free to migrate one
+    page at a time while still giving users a one-glance workflow status.
+    """
+
+    return _join_unique_status_parts(
+        connection_status,
+        activity_summary,
+        map_summary,
+        analysis_status,
+        atlas_status,
+    )
+
+
+def build_workflow_footer_facts_from_progress_facts(
+    facts: WorkflowProgressFacts,
+) -> WorkflowFooterFacts:
+    """Build footer pill/path facts from shared workflow progress facts.
+
+    The compact text summary remains available separately for placeholder shells.
+    This adapter drives the footer's explicit Strava/activity/layer/path controls
+    from the same render-neutral state used by workflow pages, avoiding any
+    dependency on current long-scroll dock widgets.
+    """
+
+    return WorkflowFooterFacts(
+        strava_connected=facts.connection_configured,
+        activity_count=_stored_activity_count(facts),
+        layer_count=_loaded_layer_count(facts),
+        gpkg_path=facts.output_name,
+        last_sync_date=_optional_text(facts.last_sync_date),
+    )
+
+
+def _join_unique_status_parts(*values: str | None) -> str:
+    parts: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        part = (value or "").strip()
+        if not part or part in seen:
+            continue
+        parts.append(part)
+        seen.add(part)
+
+    if not parts:
+        return "Ready"
+    return " · ".join(parts)
+
+
+def _optional_text(value: str | None) -> str | None:
+    stripped = (value or "").strip()
+    return stripped or None
+
+
+def _stored_activity_count(facts: WorkflowProgressFacts) -> int | None:
+    if not facts.activities_stored or facts.activity_count is None:
+        return None
+    return max(int(facts.activity_count), 0)
+
+
+def _loaded_layer_count(facts: WorkflowProgressFacts) -> int:
+    if not facts.activity_layers_loaded:
+        return 0
+    if facts.loaded_layer_count is None:
+        return 1
+    return max(int(facts.loaded_layer_count), 0)
+
+
+__all__ = [
+    "WorkflowFooterFacts",
+    "build_workflow_footer_facts_from_progress_facts",
+    "build_workflow_footer_status",
+]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -13,10 +13,10 @@ from qfit.ui.application.stepper_presenter import (
     can_request_step,
     step_index_for_key,
 )
-from qfit.ui.application.wizard_footer_status import (
-    WizardFooterFacts,
-    build_wizard_footer_facts_from_progress_facts,
-    build_wizard_footer_status,
+from qfit.ui.application.workflow_footer_status import (
+    WorkflowFooterFacts,
+    build_workflow_footer_facts_from_progress_facts,
+    build_workflow_footer_status,
 )
 from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
@@ -448,15 +448,15 @@ def _page_state_defaults_from_progress_facts(
 
 def _footer_facts_from_progress_facts(
     progress_facts: WorkflowProgressFacts | None,
-) -> WizardFooterFacts | None:
+) -> WorkflowFooterFacts | None:
     if progress_facts is None:
         return None
-    return build_wizard_footer_facts_from_progress_facts(
+    return build_workflow_footer_facts_from_progress_facts(
         completed_prefix_facts(progress_facts)
     )
 
 
-def _apply_footer_facts(footer_bar, footer_facts: WizardFooterFacts | None) -> None:
+def _apply_footer_facts(footer_bar, footer_facts: WorkflowFooterFacts | None) -> None:
     if footer_facts is None:
         return
     footer_bar.set_strava(footer_facts.strava_connected)
@@ -512,7 +512,7 @@ def _build_default_footer_text(
     analysis_state: AnalysisPageState,
     atlas_state: AtlasPageState,
 ) -> str:
-    return build_wizard_footer_status(
+    return build_workflow_footer_status(
         connection_status=(
             connection_state.status_text if "connection" in installed_keys else None
         ),


### PR DESCRIPTION
## Summary

Extracts the footer status/facts implementation into neutral workflow-named application APIs while keeping the wizard footer module as a compatibility wrapper.

## Changes

- Add `workflow_footer_status` with neutral `WorkflowFooterFacts` and workflow footer builders.
- Route wizard composition through the neutral footer helpers.
- Keep `wizard_footer_status` public wrappers and compatibility tests.

## Testing

- `python3 -m pytest tests/test_workflow_footer_status.py tests/test_wizard_footer_status.py tests/test_wizard_shell_composition.py tests/test_application_progress_exports.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
