### PR TITLE
chore: add neutral workflow settings API

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -74,7 +74,7 @@ from .ui.application import (
     build_visual_layer_refs,
     set_local_first_analysis_mode,
     update_local_first_atlas_document_settings,
-    ensure_wizard_settings,
+    ensure_workflow_settings,
     request_local_first_connection_configuration,
     install_local_first_audited_controls,
     sync_local_first_basemap_style_fields,
@@ -156,9 +156,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._install_live_local_first_dock()
 
     def _ensure_wizard_settings(self):
-        """Persist first-launch wizard defaults for the #609 dock migration."""
+        """Persist first-launch workflow defaults for the local-first dock."""
 
-        return ensure_wizard_settings(self.settings)
+        return ensure_workflow_settings(self.settings)
 
     def refresh_configuration_from_settings(self) -> None:
         """Reload saved configuration and refresh live wizard connection state."""

--- a/tests/test_workflow_progress.py
+++ b/tests/test_workflow_progress.py
@@ -13,12 +13,12 @@ from qfit.ui.application.workflow_progress import (
     build_workflow_progress_from_facts_and_settings,
 )
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
+from qfit.ui.application.workflow_settings import WorkflowSettingsSnapshot
 from qfit.ui.application.wizard_progress import (
     build_startup_wizard_progress_facts,
     build_wizard_progress_from_facts,
     build_wizard_progress_from_facts_and_settings,
 )
-from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
 
 
 class WorkflowProgressTests(unittest.TestCase):
@@ -73,8 +73,8 @@ class WorkflowProgressTests(unittest.TestCase):
                 activities_stored=True,
                 activity_layers_loaded=True,
             ),
-            WizardSettingsSnapshot(
-                wizard_version=1,
+            WorkflowSettingsSnapshot(
+                settings_version=1,
                 last_step_index=2,
                 first_launch=False,
             ),
@@ -92,8 +92,8 @@ class WorkflowProgressTests(unittest.TestCase):
             activities_stored=True,
             activity_layers_loaded=True,
         )
-        settings = WizardSettingsSnapshot(
-            wizard_version=1,
+        settings = WorkflowSettingsSnapshot(
+            settings_version=1,
             last_step_index=4,
             first_launch=False,
         )
@@ -104,8 +104,8 @@ class WorkflowProgressTests(unittest.TestCase):
         )
 
     def test_startup_facts_skip_configured_connection_restore_target(self):
-        settings = WizardSettingsSnapshot(
-            wizard_version=1,
+        settings = WorkflowSettingsSnapshot(
+            settings_version=1,
             last_step_index=0,
             first_launch=False,
         )
@@ -123,8 +123,8 @@ class WorkflowProgressTests(unittest.TestCase):
         self.assertEqual(progress.completed_keys, frozenset({"connection"}))
 
     def test_startup_facts_preserve_explicit_user_selected_connection_step(self):
-        settings = WizardSettingsSnapshot(
-            wizard_version=1,
+        settings = WorkflowSettingsSnapshot(
+            settings_version=1,
             last_step_index=0,
             last_step_index_user_selected=True,
             first_launch=False,
@@ -144,8 +144,8 @@ class WorkflowProgressTests(unittest.TestCase):
 
     def test_wizard_startup_facts_builder_delegates_to_neutral_workflow_builder(self):
         facts = WorkflowProgressFacts(connection_configured=True)
-        settings = WizardSettingsSnapshot(
-            wizard_version=1,
+        settings = WorkflowSettingsSnapshot(
+            settings_version=1,
             last_step_index=0,
             first_launch=False,
         )

--- a/tests/test_workflow_settings.py
+++ b/tests/test_workflow_settings.py
@@ -1,0 +1,141 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.application.workflow_settings import (
+    COLLAPSED_GROUPS_KEY,
+    DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
+    LAST_STEP_INDEX_KEY,
+    LAST_STEP_INDEX_USER_SELECTED_KEY,
+    WORKFLOW_SETTINGS_VERSION,
+    WORKFLOW_SETTINGS_VERSION_KEY,
+    WorkflowSettingsSnapshot,
+    clamp_workflow_step_index,
+    ensure_workflow_settings,
+    load_workflow_settings,
+    preferred_current_key_from_workflow_settings,
+    save_workflow_step_index,
+    workflow_step_key_for_index,
+)
+from qfit.ui.application.wizard_settings import (
+    WIZARD_VERSION,
+    WIZARD_VERSION_KEY,
+    WizardSettingsSnapshot,
+    ensure_wizard_settings,
+    load_wizard_settings,
+    save_last_step_index,
+)
+
+
+class FakeSettingsPort:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+        self.writes = []
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set(self, key, value):
+        self.values[key] = value
+        self.writes.append((key, value))
+
+
+class WorkflowSettingsTests(unittest.TestCase):
+    def test_load_defaults_match_first_launch_workflow_spec(self):
+        snapshot = load_workflow_settings(FakeSettingsPort())
+
+        self.assertIsNone(snapshot.settings_version)
+        self.assertIsNone(snapshot.wizard_version)
+        self.assertTrue(snapshot.first_launch)
+        self.assertEqual(snapshot.last_step_index, 0)
+        self.assertFalse(snapshot.last_step_index_user_selected)
+        self.assertEqual(snapshot.collapsed_groups, DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES)
+
+    def test_ensure_writes_workflow_defaults_to_existing_storage_keys(self):
+        settings = FakeSettingsPort()
+
+        snapshot = ensure_workflow_settings(settings)
+
+        self.assertEqual(snapshot.settings_version, WORKFLOW_SETTINGS_VERSION)
+        self.assertTrue(snapshot.first_launch)
+        self.assertEqual(
+            settings.writes,
+            [
+                (WORKFLOW_SETTINGS_VERSION_KEY, WORKFLOW_SETTINGS_VERSION),
+                (COLLAPSED_GROUPS_KEY, list(DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES)),
+            ],
+        )
+
+    def test_existing_legacy_storage_values_load_as_workflow_settings(self):
+        settings = FakeSettingsPort(
+            {
+                WORKFLOW_SETTINGS_VERSION_KEY: "1",
+                LAST_STEP_INDEX_KEY: "3",
+                LAST_STEP_INDEX_USER_SELECTED_KEY: "true",
+                COLLAPSED_GROUPS_KEY: ["temporalGroup"],
+            }
+        )
+
+        snapshot = load_workflow_settings(settings)
+
+        self.assertFalse(snapshot.first_launch)
+        self.assertEqual(snapshot.settings_version, 1)
+        self.assertEqual(snapshot.last_step_index, 3)
+        self.assertTrue(snapshot.last_step_index_user_selected)
+        self.assertEqual(snapshot.collapsed_groups, ("temporalGroup",))
+
+    def test_step_index_is_clamped_for_restore_and_save(self):
+        settings = FakeSettingsPort({LAST_STEP_INDEX_KEY: "99"})
+        self.assertEqual(load_workflow_settings(settings).last_step_index, 4)
+        self.assertEqual(clamp_workflow_step_index("bad"), 0)
+        self.assertEqual(clamp_workflow_step_index(-2), 0)
+
+        saved = save_workflow_step_index(settings, 8)
+
+        self.assertEqual(saved, 4)
+        self.assertEqual(settings.values[LAST_STEP_INDEX_KEY], 4)
+        self.assertTrue(settings.values[LAST_STEP_INDEX_USER_SELECTED_KEY])
+
+    def test_persisted_step_index_maps_to_stable_workflow_key(self):
+        self.assertEqual(workflow_step_key_for_index(2), "map")
+        self.assertEqual(workflow_step_key_for_index(99), "atlas")
+
+    def test_existing_settings_restore_preferred_current_key(self):
+        snapshot = load_workflow_settings(
+            FakeSettingsPort(
+                {
+                    WORKFLOW_SETTINGS_VERSION_KEY: WORKFLOW_SETTINGS_VERSION,
+                    LAST_STEP_INDEX_KEY: 3,
+                }
+            )
+        )
+
+        self.assertEqual(
+            preferred_current_key_from_workflow_settings(snapshot),
+            "analysis",
+        )
+
+    def test_wizard_wrapper_preserves_legacy_api_and_aliases(self):
+        settings = FakeSettingsPort()
+        wrapper_snapshot = ensure_wizard_settings(settings)
+
+        self.assertIs(WizardSettingsSnapshot, WorkflowSettingsSnapshot)
+        self.assertEqual(WIZARD_VERSION, WORKFLOW_SETTINGS_VERSION)
+        self.assertEqual(WIZARD_VERSION_KEY, WORKFLOW_SETTINGS_VERSION_KEY)
+        reloaded_snapshot = load_wizard_settings(settings)
+        self.assertTrue(wrapper_snapshot.first_launch)
+        self.assertFalse(reloaded_snapshot.first_launch)
+        self.assertEqual(reloaded_snapshot.settings_version, WORKFLOW_SETTINGS_VERSION)
+        self.assertEqual(wrapper_snapshot.wizard_version, WORKFLOW_SETTINGS_VERSION)
+        self.assertEqual(save_last_step_index(settings, 2), 2)
+        self.assertEqual(settings.values[LAST_STEP_INDEX_KEY], 2)
+
+    def test_snapshot_accepts_legacy_wizard_version_keyword(self):
+        snapshot = WizardSettingsSnapshot(wizard_version=WORKFLOW_SETTINGS_VERSION)
+
+        self.assertEqual(snapshot.settings_version, WORKFLOW_SETTINGS_VERSION)
+        self.assertEqual(snapshot.wizard_version, WORKFLOW_SETTINGS_VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -156,23 +156,34 @@ from .stepper_presenter import (
     step_key_for_index,
 )
 from .wizard_filter_summary import build_wizard_filter_description
-from .wizard_settings import (
+from .workflow_settings import (
     COLLAPSED_GROUPS_KEY,
     DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
     LAST_STEP_INDEX_KEY,
     LAST_STEP_INDEX_USER_SELECTED_KEY,
-    WIZARD_STEP_COUNT,
-    WIZARD_VERSION,
-    WIZARD_VERSION_KEY,
-    WizardSettingsSnapshot,
-    clamp_wizard_step_index,
-    ensure_wizard_settings,
-    load_wizard_settings,
-    preferred_current_key_from_settings,
+    WORKFLOW_SETTINGS_VERSION,
+    WORKFLOW_SETTINGS_VERSION_KEY,
+    WORKFLOW_STEP_COUNT,
+    WorkflowSettingsSnapshot,
+    clamp_workflow_step_index,
+    ensure_workflow_settings,
+    load_workflow_settings,
+    preferred_current_key_from_workflow_settings,
     save_collapsed_groups,
-    save_last_step_index,
-    wizard_step_key_for_index,
+    save_workflow_step_index,
+    workflow_step_key_for_index,
 )
+
+WIZARD_VERSION = WORKFLOW_SETTINGS_VERSION
+WIZARD_VERSION_KEY = WORKFLOW_SETTINGS_VERSION_KEY
+WIZARD_STEP_COUNT = WORKFLOW_STEP_COUNT
+WizardSettingsSnapshot = WorkflowSettingsSnapshot
+clamp_wizard_step_index = clamp_workflow_step_index
+ensure_wizard_settings = ensure_workflow_settings
+load_wizard_settings = load_workflow_settings
+preferred_current_key_from_settings = preferred_current_key_from_workflow_settings
+save_last_step_index = save_workflow_step_index
+wizard_step_key_for_index = workflow_step_key_for_index
 from .visual_workflow_action_builder import build_visual_workflow_action
 from .visual_workflow_action_builder import build_visual_workflow_action_inputs
 from .visual_workflow_action_builder import build_visual_workflow_background_inputs
@@ -248,6 +259,9 @@ __all__ = [
     "LocalFirstProgressFacts",
     "LocalFirstWidgetMove",
     "WIZARD_WORKFLOW_STEPS",
+    "WORKFLOW_SETTINGS_VERSION",
+    "WORKFLOW_SETTINGS_VERSION_KEY",
+    "WORKFLOW_STEP_COUNT",
     "WIZARD_STEP_COUNT",
     "WIZARD_VERSION",
     "WIZARD_VERSION_KEY",
@@ -265,6 +279,7 @@ __all__ = [
     "WizardProgressFacts",
     "WorkflowFooterFacts",
     "WorkflowProgressFacts",
+    "WorkflowSettingsSnapshot",
     "WizardSettingsSnapshot",
     "build_advanced_fetch_visibility_update",
     "apply_local_first_visibility_update",
@@ -312,7 +327,9 @@ __all__ = [
     "build_visual_workflow_selection_state_handoff",
     "build_visual_workflow_settings_snapshot",
     "can_request_step",
+    "clamp_workflow_step_index",
     "clamp_wizard_step_index",
+    "ensure_workflow_settings",
     "ensure_wizard_settings",
     "get_workflow_section",
     "install_local_first_audited_controls",
@@ -321,6 +338,7 @@ __all__ = [
     "install_local_first_widget_move",
     "install_local_first_widget_controls",
     "issue805_local_first_coverage_by_area",
+    "load_workflow_settings",
     "load_wizard_settings",
     "local_first_analysis_mode_options",
     "local_first_control_move_layout",
@@ -333,12 +351,14 @@ __all__ = [
     "local_first_widget_move_for_key",
     "local_first_widget_move_keys",
     "preferred_current_key_from_settings",
+    "preferred_current_key_from_workflow_settings",
     "missing_issue805_local_first_areas",
     "refresh_local_first_conditional_control_visibility",
     "refresh_local_first_control_visibility",
     "remove_widget_from_current_layout",
     "runtime_state_with_local_first_output_path",
     "save_collapsed_groups",
+    "save_workflow_step_index",
     "save_last_step_index",
     "set_local_first_analysis_mode",
     "show_local_first_control_group",
@@ -348,5 +368,6 @@ __all__ = [
     "step_index_for_key",
     "step_key_for_index",
     "update_local_first_atlas_document_settings",
+    "workflow_step_key_for_index",
     "wizard_step_key_for_index",
 ]

--- a/ui/application/wizard_settings.py
+++ b/ui/application/wizard_settings.py
@@ -1,75 +1,42 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
 from ...configuration.application.settings_port import SettingsPort
-from .dock_workflow_sections import WIZARD_WORKFLOW_STEPS
-
-WIZARD_VERSION = 1
-WIZARD_VERSION_KEY = "ui/wizard_version"
-LAST_STEP_INDEX_KEY = "ui/last_step_index"
-LAST_STEP_INDEX_USER_SELECTED_KEY = "ui/last_step_index_user_selected"
-COLLAPSED_GROUPS_KEY = "ui/collapsed_groups"
-WIZARD_STEP_COUNT = 5
-
-DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES: tuple[str, ...] = (
-    "advancedOptionsGroup",
-    "layoutGroup",
-    "temporalGroup",
+from .workflow_settings import (
+    COLLAPSED_GROUPS_KEY,
+    DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
+    LAST_STEP_INDEX_KEY,
+    LAST_STEP_INDEX_USER_SELECTED_KEY,
+    WORKFLOW_SETTINGS_VERSION,
+    WORKFLOW_SETTINGS_VERSION_KEY,
+    WORKFLOW_STEP_COUNT,
+    WorkflowSettingsSnapshot,
+    clamp_workflow_step_index,
+    ensure_workflow_settings,
+    load_workflow_settings,
+    preferred_current_key_from_workflow_settings,
+    save_collapsed_groups,
+    save_workflow_step_index,
+    workflow_step_key_for_index,
 )
 
-
-@dataclass(frozen=True)
-class WizardSettingsSnapshot:
-    """UI-neutral persisted settings for the future wizard dock shell."""
-
-    wizard_version: int | None
-    last_step_index: int = 0
-    last_step_index_user_selected: bool = False
-    collapsed_groups: tuple[str, ...] = DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
-    first_launch: bool = True
+WIZARD_VERSION = WORKFLOW_SETTINGS_VERSION
+WIZARD_VERSION_KEY = WORKFLOW_SETTINGS_VERSION_KEY
+WIZARD_STEP_COUNT = WORKFLOW_STEP_COUNT
+WizardSettingsSnapshot = WorkflowSettingsSnapshot
 
 
 def load_wizard_settings(settings: SettingsPort) -> WizardSettingsSnapshot:
-    """Load persisted wizard settings without writing defaults."""
+    """Compatibility wrapper for loading local-first workflow settings."""
 
-    raw_version = settings.get(WIZARD_VERSION_KEY)
-    wizard_version = _coerce_int(raw_version)
-    return WizardSettingsSnapshot(
-        wizard_version=wizard_version,
-        last_step_index=clamp_wizard_step_index(settings.get(LAST_STEP_INDEX_KEY, 0)),
-        last_step_index_user_selected=_coerce_bool(
-            settings.get(LAST_STEP_INDEX_USER_SELECTED_KEY, False)
-        ),
-        collapsed_groups=_normalise_collapsed_groups(
-            settings.get(COLLAPSED_GROUPS_KEY, DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES)
-        ),
-        first_launch=wizard_version is None,
-    )
+    return load_workflow_settings(settings)
 
 
 def ensure_wizard_settings(settings: SettingsPort) -> WizardSettingsSnapshot:
-    """Write first-launch defaults and return the populated wizard snapshot.
+    """Compatibility wrapper for ensuring local-first workflow settings."""
 
-    On first launch, this persists ``qfit/ui/wizard_version`` and returns a
-    snapshot with ``wizard_version`` populated while preserving
-    ``first_launch=True`` so the wizard can still apply the spec's initial step
-    state. Existing wizard settings are returned unchanged.
-    """
-
-    snapshot = load_wizard_settings(settings)
-    if snapshot.first_launch:
-        settings.set(WIZARD_VERSION_KEY, WIZARD_VERSION)
-        settings.set(COLLAPSED_GROUPS_KEY, list(snapshot.collapsed_groups))
-        return WizardSettingsSnapshot(
-            wizard_version=WIZARD_VERSION,
-            last_step_index=snapshot.last_step_index,
-            last_step_index_user_selected=snapshot.last_step_index_user_selected,
-            collapsed_groups=snapshot.collapsed_groups,
-            first_launch=snapshot.first_launch,
-        )
-    return snapshot
+    return ensure_workflow_settings(settings)
 
 
 def save_last_step_index(
@@ -78,85 +45,29 @@ def save_last_step_index(
     *,
     user_selected: bool = True,
 ) -> int:
-    """Persist the wizard's last step index after clamping to the valid range."""
+    """Compatibility wrapper for persisting the selected workflow step."""
 
-    clamped_index = clamp_wizard_step_index(index)
-    settings.set(LAST_STEP_INDEX_KEY, clamped_index)
-    settings.set(LAST_STEP_INDEX_USER_SELECTED_KEY, bool(user_selected))
-    return clamped_index
-
-
-def save_collapsed_groups(settings: SettingsPort, object_names: list[str] | tuple[str, ...]) -> tuple[str, ...]:
-    """Persist known collapsible group object names in stable spec order."""
-
-    collapsed_groups = _normalise_collapsed_groups(object_names)
-    settings.set(COLLAPSED_GROUPS_KEY, list(collapsed_groups))
-    return collapsed_groups
+    return save_workflow_step_index(settings, index, user_selected=user_selected)
 
 
 def wizard_step_key_for_index(index: int) -> str:
-    """Return the stable wizard step key for a persisted step index."""
+    """Compatibility wrapper for resolving workflow step keys by index."""
 
-    return WIZARD_WORKFLOW_STEPS[clamp_wizard_step_index(index)].key
+    return workflow_step_key_for_index(index)
 
 
 def preferred_current_key_from_settings(
     snapshot: WizardSettingsSnapshot,
 ) -> str | None:
-    """Return the restore target from persisted wizard settings.
+    """Compatibility wrapper for resolving the preferred workflow page."""
 
-    First launch intentionally has no restore target: the #609 spec requires the
-    connection page to be current with all other steps locked. Once wizard
-    settings already exist, the saved index becomes a preferred target that
-    progress derivation can still gate behind incomplete prerequisites.
-    """
-
-    if snapshot.first_launch:
-        return None
-    return wizard_step_key_for_index(snapshot.last_step_index)
+    return preferred_current_key_from_workflow_settings(snapshot)
 
 
 def clamp_wizard_step_index(value: Any) -> int:
-    """Coerce a persisted step index into the wizard's 0-based page range."""
+    """Compatibility wrapper for clamping workflow step indexes."""
 
-    step_index = _coerce_int(value)
-    if step_index is None:
-        step_index = 0
-    return min(max(step_index, 0), WIZARD_STEP_COUNT - 1)
-
-
-def _coerce_int(value: Any) -> int | None:
-    if value in (None, ""):
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _coerce_bool(value: Any) -> bool:
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
-
-
-def _normalise_collapsed_groups(value: Any) -> tuple[str, ...]:
-    raw_names = _as_string_sequence(value)
-    requested = {name for name in raw_names if name in DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES}
-    return tuple(name for name in DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES if name in requested)
-
-
-def _as_string_sequence(value: Any) -> tuple[str, ...]:
-    if value in (None, ""):
-        return DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
-    if isinstance(value, str):
-        if "," in value:
-            return tuple(part.strip() for part in value.split(",") if part.strip())
-        return (value,)
-    try:
-        return tuple(str(item) for item in value)
-    except TypeError:
-        return DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
+    return clamp_workflow_step_index(value)
 
 
 __all__ = [
@@ -171,8 +82,8 @@ __all__ = [
     "clamp_wizard_step_index",
     "ensure_wizard_settings",
     "load_wizard_settings",
+    "preferred_current_key_from_settings",
     "save_collapsed_groups",
     "save_last_step_index",
-    "preferred_current_key_from_settings",
     "wizard_step_key_for_index",
 ]

--- a/ui/application/workflow_progress.py
+++ b/ui/application/workflow_progress.py
@@ -5,9 +5,9 @@ from typing import cast
 
 from .dock_workflow_sections import DockWizardProgress, WIZARD_WORKFLOW_STEPS
 from .workflow_progress_facts import WorkflowProgressFacts
-from .wizard_settings import (
-    WizardSettingsSnapshot,
-    preferred_current_key_from_settings,
+from .workflow_settings import (
+    WorkflowSettingsSnapshot,
+    preferred_current_key_from_workflow_settings,
 )
 
 
@@ -36,7 +36,7 @@ def build_workflow_progress_from_facts(
 
 def build_workflow_progress_from_facts_and_settings(
     facts: WorkflowProgressFacts,
-    settings: WizardSettingsSnapshot,
+    settings: WorkflowSettingsSnapshot,
 ) -> DockWizardProgress:
     """Build workflow progress while honoring a persisted step preference.
 
@@ -50,14 +50,16 @@ def build_workflow_progress_from_facts_and_settings(
     return build_workflow_progress_from_facts(
         _workflow_progress_facts_with_preferred_current_key(
             facts,
-            preferred_current_key=preferred_current_key_from_settings(settings),
+            preferred_current_key=preferred_current_key_from_workflow_settings(
+                settings
+            ),
         )
     )
 
 
 def build_startup_workflow_progress_facts(
     facts: WorkflowProgressFacts,
-    settings: WizardSettingsSnapshot,
+    settings: WorkflowSettingsSnapshot,
 ) -> WorkflowProgressFacts:
     """Return startup-only facts for the first visible workflow page.
 
@@ -66,7 +68,7 @@ def build_startup_workflow_progress_facts(
     users reconfirm an already-completed prerequisite before continuing.
     """
 
-    preferred_current_key = preferred_current_key_from_settings(settings)
+    preferred_current_key = preferred_current_key_from_workflow_settings(settings)
     if (
         preferred_current_key == "connection"
         and facts.connection_configured

--- a/ui/application/workflow_settings.py
+++ b/ui/application/workflow_settings.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ...configuration.application.settings_port import SettingsPort
+from .dock_workflow_sections import WIZARD_WORKFLOW_STEPS
+
+WORKFLOW_SETTINGS_VERSION = 1
+WORKFLOW_SETTINGS_VERSION_KEY = "ui/wizard_version"
+LAST_STEP_INDEX_KEY = "ui/last_step_index"
+LAST_STEP_INDEX_USER_SELECTED_KEY = "ui/last_step_index_user_selected"
+COLLAPSED_GROUPS_KEY = "ui/collapsed_groups"
+WORKFLOW_STEP_COUNT = 5
+
+DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES: tuple[str, ...] = (
+    "advancedOptionsGroup",
+    "layoutGroup",
+    "temporalGroup",
+)
+
+
+@dataclass(frozen=True, init=False)
+class WorkflowSettingsSnapshot:
+    """UI-neutral persisted settings for the local-first workflow shell."""
+
+    settings_version: int | None
+    last_step_index: int = 0
+    last_step_index_user_selected: bool = False
+    collapsed_groups: tuple[str, ...] = DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
+    first_launch: bool = True
+
+    def __init__(
+        self,
+        settings_version: int | None = None,
+        last_step_index: int = 0,
+        last_step_index_user_selected: bool = False,
+        collapsed_groups: tuple[str, ...] = DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
+        first_launch: bool = True,
+        *,
+        wizard_version: int | None = None,
+    ) -> None:
+        """Create a workflow settings snapshot.
+
+        ``wizard_version`` remains accepted as a keyword-only compatibility seam
+        for callers that still construct the previous wizard-named snapshot.
+        """
+
+        if settings_version is not None and wizard_version is not None:
+            if settings_version != wizard_version:
+                raise ValueError("settings_version and wizard_version must match")
+        resolved_version = (
+            settings_version if settings_version is not None else wizard_version
+        )
+        object.__setattr__(self, "settings_version", resolved_version)
+        object.__setattr__(self, "last_step_index", last_step_index)
+        object.__setattr__(
+            self,
+            "last_step_index_user_selected",
+            last_step_index_user_selected,
+        )
+        object.__setattr__(self, "collapsed_groups", collapsed_groups)
+        object.__setattr__(self, "first_launch", first_launch)
+
+    @property
+    def wizard_version(self) -> int | None:
+        """Compatibility alias for the persisted workflow settings version."""
+
+        return self.settings_version
+
+
+def load_workflow_settings(settings: SettingsPort) -> WorkflowSettingsSnapshot:
+    """Load persisted workflow settings without writing defaults."""
+
+    raw_version = settings.get(WORKFLOW_SETTINGS_VERSION_KEY)
+    settings_version = _coerce_int(raw_version)
+    return WorkflowSettingsSnapshot(
+        settings_version=settings_version,
+        last_step_index=clamp_workflow_step_index(settings.get(LAST_STEP_INDEX_KEY, 0)),
+        last_step_index_user_selected=_coerce_bool(
+            settings.get(LAST_STEP_INDEX_USER_SELECTED_KEY, False)
+        ),
+        collapsed_groups=_normalise_collapsed_groups(
+            settings.get(COLLAPSED_GROUPS_KEY, DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES)
+        ),
+        first_launch=settings_version is None,
+    )
+
+
+def ensure_workflow_settings(settings: SettingsPort) -> WorkflowSettingsSnapshot:
+    """Write first-launch defaults and return the populated workflow snapshot.
+
+    The stored keys intentionally keep their legacy values so existing user
+    preferences migrate into the local-first workflow shell without data loss.
+    """
+
+    snapshot = load_workflow_settings(settings)
+    if snapshot.first_launch:
+        settings.set(WORKFLOW_SETTINGS_VERSION_KEY, WORKFLOW_SETTINGS_VERSION)
+        settings.set(COLLAPSED_GROUPS_KEY, list(snapshot.collapsed_groups))
+        return WorkflowSettingsSnapshot(
+            settings_version=WORKFLOW_SETTINGS_VERSION,
+            last_step_index=snapshot.last_step_index,
+            last_step_index_user_selected=snapshot.last_step_index_user_selected,
+            collapsed_groups=snapshot.collapsed_groups,
+            first_launch=snapshot.first_launch,
+        )
+    return snapshot
+
+
+def save_workflow_step_index(
+    settings: SettingsPort,
+    index: int,
+    *,
+    user_selected: bool = True,
+) -> int:
+    """Persist the workflow's last step index after clamping to the valid range."""
+
+    clamped_index = clamp_workflow_step_index(index)
+    settings.set(LAST_STEP_INDEX_KEY, clamped_index)
+    settings.set(LAST_STEP_INDEX_USER_SELECTED_KEY, bool(user_selected))
+    return clamped_index
+
+
+def save_collapsed_groups(
+    settings: SettingsPort,
+    object_names: list[str] | tuple[str, ...],
+) -> tuple[str, ...]:
+    """Persist known collapsible group object names in stable spec order."""
+
+    collapsed_groups = _normalise_collapsed_groups(object_names)
+    settings.set(COLLAPSED_GROUPS_KEY, list(collapsed_groups))
+    return collapsed_groups
+
+
+def workflow_step_key_for_index(index: int) -> str:
+    """Return the stable workflow step key for a persisted step index."""
+
+    return WIZARD_WORKFLOW_STEPS[clamp_workflow_step_index(index)].key
+
+
+def preferred_current_key_from_workflow_settings(
+    snapshot: WorkflowSettingsSnapshot,
+) -> str | None:
+    """Return the restore target from persisted workflow settings.
+
+    First launch intentionally has no restore target: the local-first workflow
+    should start from the initial connection page state. Once settings already
+    exist, the saved index becomes a preferred target that progress derivation
+    can still gate behind incomplete prerequisites.
+    """
+
+    if snapshot.first_launch:
+        return None
+    return workflow_step_key_for_index(snapshot.last_step_index)
+
+
+def clamp_workflow_step_index(value: Any) -> int:
+    """Coerce a persisted step index into the workflow's 0-based page range."""
+
+    step_index = _coerce_int(value)
+    if step_index is None:
+        step_index = 0
+    return min(max(step_index, 0), WORKFLOW_STEP_COUNT - 1)
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _normalise_collapsed_groups(value: Any) -> tuple[str, ...]:
+    raw_names = _as_string_sequence(value)
+    requested = {
+        name for name in raw_names if name in DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
+    }
+    return tuple(name for name in DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES if name in requested)
+
+
+def _as_string_sequence(value: Any) -> tuple[str, ...]:
+    if value in (None, ""):
+        return DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
+    if isinstance(value, str):
+        if "," in value:
+            return tuple(part.strip() for part in value.split(",") if part.strip())
+        return (value,)
+    try:
+        return tuple(str(item) for item in value)
+    except TypeError:
+        return DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES
+
+
+__all__ = [
+    "COLLAPSED_GROUPS_KEY",
+    "DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES",
+    "LAST_STEP_INDEX_KEY",
+    "LAST_STEP_INDEX_USER_SELECTED_KEY",
+    "WORKFLOW_SETTINGS_VERSION",
+    "WORKFLOW_SETTINGS_VERSION_KEY",
+    "WORKFLOW_STEP_COUNT",
+    "WorkflowSettingsSnapshot",
+    "clamp_workflow_step_index",
+    "ensure_workflow_settings",
+    "load_workflow_settings",
+    "preferred_current_key_from_workflow_settings",
+    "save_collapsed_groups",
+    "save_workflow_step_index",
+    "workflow_step_key_for_index",
+]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -27,7 +27,9 @@ from qfit.ui.application.workflow_progress import (
     build_workflow_progress_from_facts_and_settings,
 )
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
-from qfit.ui.application.wizard_settings import WizardSettingsSnapshot
+from qfit.ui.application.workflow_settings import WorkflowSettingsSnapshot
+
+WizardSettingsSnapshot = WorkflowSettingsSnapshot
 
 from .analysis_page import (
     AnalysisPageContent,

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -29,8 +29,6 @@ from qfit.ui.application.workflow_progress import (
 from qfit.ui.application.workflow_progress_facts import WorkflowProgressFacts
 from qfit.ui.application.workflow_settings import WorkflowSettingsSnapshot
 
-WizardSettingsSnapshot = WorkflowSettingsSnapshot
-
 from .analysis_page import (
     AnalysisPageContent,
     AnalysisPageState,
@@ -61,6 +59,7 @@ from .workflow_page_state import (
 )
 
 
+WizardSettingsSnapshot = WorkflowSettingsSnapshot
 _StateT = TypeVar("_StateT")
 WizardCompositionPage = WizardPage | WizardStepPage
 WizardProgressFacts = WorkflowProgressFacts


### PR DESCRIPTION
## Summary

- Add neutral `workflow_settings` APIs for persisted local-first workflow state while keeping the existing storage keys for migration compatibility.
- Keep `wizard_settings` as a thin compatibility wrapper/export surface.
- Route workflow progress and production settings imports through the neutral workflow settings module.
- Add unittest-discoverable coverage for the canonical workflow settings API and wizard compatibility aliases.

Refs #805

## Tests

- `python3 -m pytest tests/test_workflow_settings.py tests/test_wizard_settings.py tests/test_workflow_progress.py tests/test_wizard_progress.py tests/test_wizard_shell_composition.py tests/test_application_progress_exports.py tests/test_dockwidget_dependencies.py -q --tb=short`
- `python3 -m unittest tests.test_workflow_settings tests.test_wizard_settings -q`
- `python3 -m pytest tests/ -x -q --tb=short`
