### PR TITLE
refactor: add workflow page spec API

### DIFF
--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
-from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.application.workflow_page_specs import build_default_workflow_page_specs
 from qfit.ui.tokens import COLOR_MUTED
 
 
@@ -236,7 +236,7 @@ class AnalysisPageContentTest(unittest.TestCase):
 
     def test_installs_only_on_analysis_wizard_page_body(self):
         analysis_spec = next(
-            spec for spec in build_default_wizard_page_specs() if spec.key == "analysis"
+            spec for spec in build_default_workflow_page_specs() if spec.key == "analysis"
         )
         analysis_page = self.wizard_page.WizardPage(analysis_spec)
 
@@ -246,7 +246,7 @@ class AnalysisPageContentTest(unittest.TestCase):
 
     def test_rejects_installing_on_other_wizard_page(self):
         map_spec = next(
-            spec for spec in build_default_wizard_page_specs() if spec.key == "map"
+            spec for spec in build_default_workflow_page_specs() if spec.key == "map"
         )
         map_page = self.wizard_page.WizardPage(map_spec)
 

--- a/tests/test_atlas_page.py
+++ b/tests/test_atlas_page.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
-from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.application.workflow_page_specs import build_default_workflow_page_specs
 from qfit.ui.tokens import COLOR_MUTED
 
 
@@ -241,7 +241,7 @@ class AtlasPageContentTest(unittest.TestCase):
 
     def test_installs_only_on_atlas_wizard_page_body(self):
         atlas_spec = next(
-            spec for spec in build_default_wizard_page_specs() if spec.key == "atlas"
+            spec for spec in build_default_workflow_page_specs() if spec.key == "atlas"
         )
         atlas_page = self.wizard_page.WizardPage(atlas_spec)
 
@@ -251,7 +251,7 @@ class AtlasPageContentTest(unittest.TestCase):
 
     def test_install_forwards_seeded_document_settings(self):
         atlas_spec = next(
-            spec for spec in build_default_wizard_page_specs() if spec.key == "atlas"
+            spec for spec in build_default_workflow_page_specs() if spec.key == "atlas"
         )
         atlas_page = self.wizard_page.WizardPage(atlas_spec)
 
@@ -266,7 +266,7 @@ class AtlasPageContentTest(unittest.TestCase):
 
     def test_rejects_installing_on_other_wizard_page(self):
         analysis_spec = next(
-            spec for spec in build_default_wizard_page_specs() if spec.key == "analysis"
+            spec for spec in build_default_workflow_page_specs() if spec.key == "analysis"
         )
         analysis_page = self.wizard_page.WizardPage(analysis_spec)
 

--- a/tests/test_connection_page.py
+++ b/tests/test_connection_page.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
-from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.application.workflow_page_specs import build_default_workflow_page_specs
 from qfit.ui.tokens import COLOR_MUTED
 
 
@@ -167,7 +167,7 @@ class ConnectionPageContentTest(unittest.TestCase):
         self.assertEqual(calls, ["configure"])
 
     def test_installs_only_on_connection_wizard_page_body(self):
-        connection_spec = build_default_wizard_page_specs()[0]
+        connection_spec = build_default_workflow_page_specs()[0]
         connection_page = self.wizard_page.WizardPage(connection_spec)
 
         content = self.connection_page.install_connection_page_content(connection_page)
@@ -175,7 +175,7 @@ class ConnectionPageContentTest(unittest.TestCase):
         self.assertIs(connection_page.body_layout().widgets[-1], content)
 
     def test_rejects_installing_on_other_wizard_page(self):
-        map_spec = build_default_wizard_page_specs()[2]
+        map_spec = build_default_workflow_page_specs()[2]
         map_page = self.wizard_page.WizardPage(map_spec)
 
         with self.assertRaisesRegex(ValueError, "connection wizard page"):

--- a/tests/test_map_page.py
+++ b/tests/test_map_page.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
-from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.application.workflow_page_specs import build_default_workflow_page_specs
 from qfit.ui.tokens import COLOR_MUTED
 
 
@@ -324,7 +324,9 @@ class MapPageContentTest(unittest.TestCase):
         self.assertEqual(calls, ["load", "filter"])
 
     def test_installs_only_on_map_wizard_page_body(self):
-        map_spec = next(spec for spec in build_default_wizard_page_specs() if spec.key == "map")
+        map_spec = next(
+            spec for spec in build_default_workflow_page_specs() if spec.key == "map"
+        )
         map_page = self.wizard_page.WizardPage(map_spec)
 
         content = self.map_page.install_map_page_content(map_page)
@@ -332,7 +334,9 @@ class MapPageContentTest(unittest.TestCase):
         self.assertIs(map_page.body_layout().widgets[-1], content)
 
     def test_rejects_installing_on_other_wizard_page(self):
-        sync_spec = next(spec for spec in build_default_wizard_page_specs() if spec.key == "sync")
+        sync_spec = next(
+            spec for spec in build_default_workflow_page_specs() if spec.key == "sync"
+        )
         sync_page = self.wizard_page.WizardPage(sync_spec)
 
         with self.assertRaisesRegex(ValueError, "map wizard page"):

--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -7,7 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui.application.dock_workflow_sections import build_wizard_step_statuses
-from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.application.workflow_page_specs import build_default_workflow_page_specs
 
 
 def _load_step_page_module():
@@ -189,7 +189,7 @@ class StepPageTest(unittest.TestCase):
             page.add_extra_button(self.step_page.QToolButton(page), align="center")
 
     def test_wizard_step_page_adapts_canonical_spec_to_step_chrome(self):
-        spec = build_default_wizard_page_specs()[2]
+        spec = build_default_workflow_page_specs()[2]
 
         page = self.step_page.WizardStepPage(spec, step_num=3, step_total=5)
 
@@ -214,7 +214,7 @@ class StepPageTest(unittest.TestCase):
         self.assertFalse(page.primary_hint_label.isVisible())
 
     def test_wizard_step_page_retire_primary_hint_is_installer_compatible(self):
-        spec = build_default_wizard_page_specs()[0]
+        spec = build_default_workflow_page_specs()[0]
         page = self.step_page.WizardStepPage(spec, step_num=1, step_total=5)
 
         page.primary_hint_label.setVisible(True)

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
-from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui.application.workflow_page_specs import build_default_workflow_page_specs
 from qfit.ui.tokens import COLOR_MUTED
 
 
@@ -285,7 +285,7 @@ class SyncPageContentTest(unittest.TestCase):
 
     def test_installs_only_on_sync_wizard_page_body(self):
         sync_spec = next(
-            spec for spec in build_default_wizard_page_specs() if spec.key == "sync"
+            spec for spec in build_default_workflow_page_specs() if spec.key == "sync"
         )
         sync_page = self.wizard_page.WizardPage(sync_spec)
 
@@ -295,7 +295,7 @@ class SyncPageContentTest(unittest.TestCase):
 
     def test_rejects_installing_on_other_wizard_page(self):
         connection_spec = next(
-            spec for spec in build_default_wizard_page_specs() if spec.key == "connection"
+            spec for spec in build_default_workflow_page_specs() if spec.key == "connection"
         )
         connection_page = self.wizard_page.WizardPage(connection_spec)
 

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -6,14 +6,22 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
-from qfit.ui.application import wizard_page_specs
-from qfit.ui.application.wizard_page_specs import build_default_wizard_page_specs
+from qfit.ui import application
+from qfit.ui.application import workflow_page_specs
+from qfit.ui.application.wizard_page_specs import (
+    DockWizardPageSpec,
+    build_default_wizard_page_specs,
+)
+from qfit.ui.application.workflow_page_specs import (
+    DockWorkflowPageSpec,
+    build_default_workflow_page_specs,
+)
 from qfit.ui.tokens import COLOR_MUTED, COLOR_TEXT
 
 
-class WizardPageSpecsTests(unittest.TestCase):
-    def test_default_specs_follow_stable_wizard_order(self):
-        specs = build_default_wizard_page_specs()
+class WorkflowPageSpecsTests(unittest.TestCase):
+    def test_default_specs_follow_stable_workflow_order(self):
+        specs = build_default_workflow_page_specs()
 
         self.assertEqual(
             [(spec.key, spec.title) for spec in specs],
@@ -32,9 +40,26 @@ class WizardPageSpecsTests(unittest.TestCase):
     def test_default_specs_reject_missing_page_copy_with_clear_message(self):
         unknown_step = type("UnknownStep", (), {"key": "review", "title": "Review"})()
 
-        with patch.object(wizard_page_specs, "WIZARD_WORKFLOW_STEPS", (unknown_step,)):
-            with self.assertRaisesRegex(KeyError, "No page copy found for wizard step 'review'"):
-                build_default_wizard_page_specs()
+        with patch.object(workflow_page_specs, "WIZARD_WORKFLOW_STEPS", (unknown_step,)):
+            with self.assertRaisesRegex(
+                KeyError,
+                "No page copy found for workflow step 'review'",
+            ):
+                build_default_workflow_page_specs()
+
+    def test_application_package_exports_workflow_page_api(self):
+        self.assertIs(application.DockWorkflowPageSpec, DockWorkflowPageSpec)
+        self.assertEqual(
+            application.build_default_workflow_page_specs(),
+            build_default_workflow_page_specs(),
+        )
+
+    def test_wizard_named_api_remains_compatibility_alias(self):
+        self.assertIs(DockWizardPageSpec, DockWorkflowPageSpec)
+        self.assertEqual(
+            build_default_wizard_page_specs(),
+            build_default_workflow_page_specs(),
+        )
 
 
 def _load_wizard_modules():
@@ -58,7 +83,7 @@ class WizardPageTest(unittest.TestCase):
         cls.wizard_page, cls.wizard_shell = _load_wizard_modules()
 
     def test_page_container_builds_visible_placeholder_chrome(self):
-        spec = build_default_wizard_page_specs()[2]
+        spec = build_default_workflow_page_specs()[2]
 
         page = self.wizard_page.WizardPage(spec)
 
@@ -86,7 +111,7 @@ class WizardPageTest(unittest.TestCase):
         )
 
     def test_retiring_primary_hint_removes_placeholder_copy(self):
-        spec = build_default_wizard_page_specs()[1]
+        spec = build_default_workflow_page_specs()[1]
         page = self.wizard_page.WizardPage(spec)
 
         page.retire_primary_action_hint()

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -319,7 +319,7 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertFalse(assembled.pages[2].next_button.isEnabled())
 
     def test_step_page_navigation_uses_installed_page_keys(self):
-        specs = self.composition.build_default_wizard_page_specs()
+        specs = self.composition.build_default_workflow_page_specs()
         assembled = self.composition.build_placeholder_wizard_shell(
             specs=(specs[0], specs[4]),
             progress_facts=WorkflowProgressFacts(

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -160,6 +160,10 @@ from .stepper_presenter import (
     step_key_for_index,
 )
 from .wizard_filter_summary import build_wizard_filter_description
+from .workflow_page_specs import (
+    DockWorkflowPageSpec,
+    build_default_workflow_page_specs,
+)
 from .workflow_settings import (
     COLLAPSED_GROUPS_KEY,
     DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
@@ -238,6 +242,7 @@ __all__ = [
     "DockVisualWorkflowCoordinator",
     "DockVisualWorkflowRequest",
     "DockWizardProgress",
+    "DockWorkflowPageSpec",
     "DockWorkflowProgress",
     "DockWorkflowSection",
     "DockWorkflowStepState",
@@ -320,6 +325,7 @@ __all__ = [
     "build_wizard_filter_description",
     "build_workflow_footer_facts_from_progress_facts",
     "build_workflow_footer_status",
+    "build_default_workflow_page_specs",
     "build_workflow_progress_facts_from_runtime_state",
     "build_workflow_progress_from_facts",
     "build_workflow_progress_from_facts_and_settings",

--- a/ui/application/wizard_page_specs.py
+++ b/ui/application/wizard_page_specs.py
@@ -1,94 +1,25 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Sequence
 
-from .dock_workflow_sections import WIZARD_WORKFLOW_STEPS
+from .dock_workflow_sections import DockWorkflowSection, WIZARD_WORKFLOW_STEPS
+from .workflow_page_specs import (
+    DockWorkflowPageSpec,
+    build_default_workflow_page_specs,
+)
 
-
-@dataclass(frozen=True)
-class DockWizardPageSpec:
-    """Render-neutral metadata for one wizard page placeholder.
-
-    The page spec is intentionally small: it gives the wizard shell stable page
-    keys, object names, and visible copy without deciding the final controls for
-    each page. That lets the dock migrate page-by-page toward #609 without
-    entrenching the current long-scroll UI.
-    """
-
-    key: str
-    title: str
-    summary: str
-    primary_action_hint: str
-
-    @property
-    def page_object_name(self) -> str:
-        return f"qfitWizard{_camel_case_key(self.key)}Page"
-
-    @property
-    def title_object_name(self) -> str:
-        return f"{self.page_object_name}Title"
-
-    @property
-    def summary_object_name(self) -> str:
-        return f"{self.page_object_name}Summary"
-
-    @property
-    def body_object_name(self) -> str:
-        return f"{self.page_object_name}Body"
-
-    @property
-    def primary_hint_object_name(self) -> str:
-        return f"{self.page_object_name}PrimaryHint"
+DockWizardPageSpec = DockWorkflowPageSpec
+"""Compatibility alias for pre-#805 wizard-named page spec callers."""
 
 
-_PAGE_COPY_BY_KEY = {
-    "connection": (
-        "Connect qfit to Strava before syncing activities.",
-        "Primary action: configure connection",
-    ),
-    "sync": (
-        "Sync Strava activities or load an existing GeoPackage.",
-        "Primary action: sync activities; secondary action: load activities",
-    ),
-    "map": (
-        "Load stored map layers, choose a background map, and refine filters.",
-        "Primary action: apply map filters",
-    ),
-    "analysis": (
-        "Optionally run heatmap, corridor, and start-point analysis from loaded data.",
-        "Optional action: run spatial analysis",
-    ),
-    "atlas": (
-        "Configure and export multi-activity PDF atlases.",
-        "Primary action: export atlas PDF",
-    ),
-}
+def build_default_wizard_page_specs(
+    *,
+    workflow_steps: Sequence[DockWorkflowSection] | None = None,
+) -> tuple[DockWizardPageSpec, ...]:
+    """Compatibility wrapper for the workflow-named page spec builder."""
 
-
-def build_default_wizard_page_specs() -> tuple[DockWizardPageSpec, ...]:
-    """Return the first page placeholders in stable #609 wizard order."""
-
-    specs = []
-    for step in WIZARD_WORKFLOW_STEPS:
-        if step.key not in _PAGE_COPY_BY_KEY:
-            raise KeyError(
-                f"No page copy found for wizard step {step.key!r}. "
-                "Add an entry to _PAGE_COPY_BY_KEY."
-            )
-        summary, primary_action_hint = _PAGE_COPY_BY_KEY[step.key]
-        specs.append(
-            DockWizardPageSpec(
-                key=step.key,
-                title=step.title,
-                summary=summary,
-                primary_action_hint=primary_action_hint,
-            )
-        )
-    return tuple(specs)
-
-
-def _camel_case_key(key: str) -> str:
-    return "".join(part.capitalize() for part in key.split("_"))
+    steps = WIZARD_WORKFLOW_STEPS if workflow_steps is None else tuple(workflow_steps)
+    return build_default_workflow_page_specs(workflow_steps=steps)
 
 
 __all__ = ["DockWizardPageSpec", "build_default_wizard_page_specs"]

--- a/ui/application/workflow_page_specs.py
+++ b/ui/application/workflow_page_specs.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .dock_workflow_sections import DockWorkflowSection, WIZARD_WORKFLOW_STEPS
+
+
+@dataclass(frozen=True)
+class DockWorkflowPageSpec:
+    """Render-neutral metadata for one dock workflow page.
+
+    The page spec is intentionally small: it gives the local-first dock shell
+    stable page keys, object names, and visible copy without deciding the final
+    controls for each page. That lets the dock migrate page-by-page toward the
+    #805 local-first workflow without entrenching the legacy long-scroll UI.
+    """
+
+    key: str
+    title: str
+    summary: str
+    primary_action_hint: str
+
+    @property
+    def page_object_name(self) -> str:
+        return f"qfitWizard{_camel_case_key(self.key)}Page"
+
+    @property
+    def title_object_name(self) -> str:
+        return f"{self.page_object_name}Title"
+
+    @property
+    def summary_object_name(self) -> str:
+        return f"{self.page_object_name}Summary"
+
+    @property
+    def body_object_name(self) -> str:
+        return f"{self.page_object_name}Body"
+
+    @property
+    def primary_hint_object_name(self) -> str:
+        return f"{self.page_object_name}PrimaryHint"
+
+
+_PAGE_COPY_BY_KEY = {
+    "connection": (
+        "Connect qfit to Strava before syncing activities.",
+        "Primary action: configure connection",
+    ),
+    "sync": (
+        "Sync Strava activities or load an existing GeoPackage.",
+        "Primary action: sync activities; secondary action: load activities",
+    ),
+    "map": (
+        "Load stored map layers, choose a background map, and refine filters.",
+        "Primary action: apply map filters",
+    ),
+    "analysis": (
+        "Optionally run heatmap, corridor, and start-point analysis from loaded data.",
+        "Optional action: run spatial analysis",
+    ),
+    "atlas": (
+        "Configure and export multi-activity PDF atlases.",
+        "Primary action: export atlas PDF",
+    ),
+}
+
+
+def build_default_workflow_page_specs(
+    *,
+    workflow_steps: Sequence[DockWorkflowSection] | None = None,
+) -> tuple[DockWorkflowPageSpec, ...]:
+    """Return local-first dock page specs in stable workflow order."""
+
+    steps = WIZARD_WORKFLOW_STEPS if workflow_steps is None else tuple(workflow_steps)
+    specs = []
+    for step in steps:
+        if step.key not in _PAGE_COPY_BY_KEY:
+            raise KeyError(
+                f"No page copy found for workflow step {step.key!r}. "
+                "Add an entry to _PAGE_COPY_BY_KEY."
+            )
+        summary, primary_action_hint = _PAGE_COPY_BY_KEY[step.key]
+        specs.append(
+            DockWorkflowPageSpec(
+                key=step.key,
+                title=step.title,
+                summary=summary,
+                primary_action_hint=primary_action_hint,
+            )
+        )
+    return tuple(specs)
+
+
+def _camel_case_key(key: str) -> str:
+    return "".join(part.capitalize() for part in key.split("_"))
+
+
+__all__ = ["DockWorkflowPageSpec", "build_default_workflow_page_specs"]

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -6,9 +6,9 @@ from qfit.ui.application.dock_workflow_sections import (
     DockWorkflowStepState,
     DockWorkflowStepStatus,
 )
-from qfit.ui.application.wizard_page_specs import (
-    DockWizardPageSpec,
-    build_default_wizard_page_specs,
+from qfit.ui.application.workflow_page_specs import (
+    DockWorkflowPageSpec,
+    build_default_workflow_page_specs,
 )
 from ._qt_compat import import_qt_module
 from qfit.ui.widgets.pill import set_pill_tone
@@ -47,6 +47,10 @@ QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
 
 STEP_PAGE_NARROW_WIDTH = 360
+DockWizardPageSpec = DockWorkflowPageSpec
+"""Compatibility alias for pre-#805 wizard step page callers."""
+build_default_wizard_page_specs = build_default_workflow_page_specs
+"""Compatibility alias for pre-#805 wizard step page builders."""
 
 
 class StepPage(QWidget):
@@ -320,7 +324,7 @@ class WizardStepPage(StepPage):
 
     def __init__(
         self,
-        spec: DockWizardPageSpec,
+        spec: DockWorkflowPageSpec,
         *,
         step_num: int,
         step_total: int,
@@ -371,11 +375,11 @@ class WizardStepPage(StepPage):
 def build_wizard_step_pages(
     *,
     parent=None,
-    specs: Sequence[DockWizardPageSpec] | None = None,
+    specs: Sequence[DockWorkflowPageSpec] | None = None,
 ) -> tuple[WizardStepPage, ...]:
     """Build StepPage-backed pages in stable #609 wizard order."""
 
-    page_specs = build_default_wizard_page_specs() if specs is None else tuple(specs)
+    page_specs = build_default_workflow_page_specs() if specs is None else tuple(specs)
     step_total = len(page_specs)
     return tuple(
         WizardStepPage(
@@ -390,7 +394,7 @@ def build_wizard_step_pages(
 
 def install_wizard_step_pages(
     shell,
-    specs: Sequence[DockWizardPageSpec] | None = None,
+    specs: Sequence[DockWorkflowPageSpec] | None = None,
 ) -> tuple[WizardStepPage, ...]:
     """Create StepPage-backed wizard pages and append them to a shell."""
 
@@ -527,9 +531,13 @@ def _ghost_button_stylesheet() -> str:
 
 
 __all__ = [
+    "DockWorkflowPageSpec",
+    "DockWizardPageSpec",
     "StepPage",
     "WizardStepPage",
     "apply_wizard_step_page_statuses",
+    "build_default_workflow_page_specs",
+    "build_default_wizard_page_specs",
     "build_wizard_step_pages",
     "install_wizard_step_pages",
 ]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -18,9 +18,9 @@ from qfit.ui.application.workflow_footer_status import (
     build_workflow_footer_facts_from_progress_facts,
     build_workflow_footer_status,
 )
-from qfit.ui.application.wizard_page_specs import (
-    DockWizardPageSpec,
-    build_default_wizard_page_specs,
+from qfit.ui.application.workflow_page_specs import (
+    DockWorkflowPageSpec,
+    build_default_workflow_page_specs,
 )
 from qfit.ui.application.workflow_progress import (
     build_workflow_progress_from_facts,
@@ -60,6 +60,10 @@ from .workflow_page_state import (
 
 
 WizardSettingsSnapshot = WorkflowSettingsSnapshot
+DockWizardPageSpec = DockWorkflowPageSpec
+"""Compatibility alias for pre-#805 wizard composition page spec callers."""
+build_default_wizard_page_specs = build_default_workflow_page_specs
+"""Compatibility alias for pre-#805 wizard composition builder callers."""
 _StateT = TypeVar("_StateT")
 WizardCompositionPage = WizardPage | WizardStepPage
 WizardProgressFacts = WorkflowProgressFacts
@@ -102,7 +106,7 @@ def build_placeholder_wizard_shell(
     progress: DockWorkflowProgress | None = None,
     progress_facts: WorkflowProgressFacts | None = None,
     wizard_settings: WizardSettingsSnapshot | None = None,
-    specs: Sequence[DockWizardPageSpec] | None = None,
+    specs: Sequence[DockWorkflowPageSpec] | None = None,
     use_step_pages: bool = True,
     connection_state: ConnectionPageState | None = None,
     sync_state: SyncPageState | None = None,
@@ -499,10 +503,10 @@ def _resolve_state(
 
 
 def _resolve_page_specs(
-    specs: Sequence[DockWizardPageSpec] | None,
-) -> tuple[DockWizardPageSpec, ...]:
+    specs: Sequence[DockWorkflowPageSpec] | None,
+) -> tuple[DockWorkflowPageSpec, ...]:
     if specs is None:
-        return build_default_wizard_page_specs()
+        return build_default_workflow_page_specs()
     return tuple(specs)
 
 
@@ -535,7 +539,7 @@ def _build_default_footer_text(
 def _install_shell_pages(
     shell: WizardShell,
     *,
-    specs: Sequence[DockWizardPageSpec],
+    specs: Sequence[DockWorkflowPageSpec],
     use_step_pages: bool,
 ) -> tuple[WizardCompositionPage, ...]:
     if use_step_pages:
@@ -782,7 +786,9 @@ def _install_atlas_content(
 
 
 __all__ = [
+    "DockWorkflowPageSpec",
     "DockWorkflowProgress",
+    "DockWizardPageSpec",
     "DockWizardProgress",
     "WizardActionCallbacks",
     "WizardPageStateSnapshots",
@@ -790,6 +796,8 @@ __all__ = [
     "WizardSettingsSnapshot",
     "WizardShellComposition",
     "WorkflowProgressFacts",
+    "build_default_workflow_page_specs",
+    "build_default_wizard_page_specs",
     "build_placeholder_wizard_shell",
     "build_wizard_page_states_from_facts",
     "connect_wizard_action_callbacks",

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from qfit.ui.application.wizard_page_specs import (
-    DockWizardPageSpec,
-    build_default_wizard_page_specs,
+from qfit.ui.application.workflow_page_specs import (
+    DockWorkflowPageSpec,
+    build_default_workflow_page_specs,
 )
 from qfit.ui.tokens import COLOR_MUTED, COLOR_TEXT
 
@@ -36,6 +36,12 @@ _SUMMARY_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 _PRIMARY_HINT_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 
 
+DockWizardPageSpec = DockWorkflowPageSpec
+"""Compatibility alias for pre-#805 wizard page callers."""
+build_default_wizard_page_specs = build_default_workflow_page_specs
+"""Compatibility alias for pre-#805 wizard page builders."""
+
+
 class WizardPage(QWidget):
     """Reusable visible page container for the #609 wizard shell.
 
@@ -45,7 +51,7 @@ class WizardPage(QWidget):
     structure without locking in the old scroll layout.
     """
 
-    def __init__(self, spec: DockWizardPageSpec, parent=None) -> None:
+    def __init__(self, spec: DockWorkflowPageSpec, parent=None) -> None:
         super().__init__(parent)
         self.spec = spec
         self.setObjectName(spec.page_object_name)
@@ -122,15 +128,18 @@ class WizardPage(QWidget):
 def build_wizard_pages(
     *,
     parent=None,
-    specs: Sequence[DockWizardPageSpec] | None = None,
+    specs: Sequence[DockWorkflowPageSpec] | None = None,
 ) -> tuple[WizardPage, ...]:
     """Build visible wizard page containers from render-neutral specs."""
 
-    page_specs = build_default_wizard_page_specs() if specs is None else tuple(specs)
+    page_specs = build_default_workflow_page_specs() if specs is None else tuple(specs)
     return tuple(WizardPage(spec, parent) for spec in page_specs)
 
 
-def install_wizard_pages(shell, specs: Sequence[DockWizardPageSpec] | None = None) -> tuple[WizardPage, ...]:
+def install_wizard_pages(
+    shell,
+    specs: Sequence[DockWorkflowPageSpec] | None = None,
+) -> tuple[WizardPage, ...]:
     """Create default wizard pages and append them to a :class:`WizardShell`."""
 
     pages = build_wizard_pages(parent=shell, specs=specs)
@@ -139,4 +148,12 @@ def install_wizard_pages(shell, specs: Sequence[DockWizardPageSpec] | None = Non
     return pages
 
 
-__all__ = ["WizardPage", "build_wizard_pages", "install_wizard_pages"]
+__all__ = [
+    "DockWorkflowPageSpec",
+    "DockWizardPageSpec",
+    "WizardPage",
+    "build_default_workflow_page_specs",
+    "build_default_wizard_page_specs",
+    "build_wizard_pages",
+    "install_wizard_pages",
+]


### PR DESCRIPTION
## Summary

- Add canonical workflow-named page spec APIs for the dock workflow page metadata.
- Keep wizard-named page spec modules, symbols, and dockwidget aliases as compatibility wrappers.
- Route production dock page builders and affected tests through the workflow-named API without renaming Qt widget classes or object names.

## Testing

- `python3 -m pytest tests/test_wizard_pages.py tests/test_step_page.py tests/test_wizard_shell_composition.py tests/test_connection_page.py tests/test_sync_page.py tests/test_map_page.py tests/test_analysis_page.py tests/test_atlas_page.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
