### PR TITLE
Use workflow callback names in local-first dock

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -183,7 +183,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         """
 
         from .ui.dockwidget.local_first_composition import (
-            WizardActionCallbacks,
+            DockWorkflowActionCallbacks,
             build_local_first_dock_composition,
             connect_local_first_action_callbacks,
         )
@@ -196,7 +196,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self._local_first_dock_composition = connect_local_first_action_callbacks(
             composition,
-            WizardActionCallbacks(
+            DockWorkflowActionCallbacks(
                 configure_connection=(
                     lambda: request_local_first_connection_configuration(
                         open_configuration=getattr(

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -122,7 +122,7 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             atlas_subtitle="Road and trail",
         )
         calls = []
-        callbacks = self.module.WizardActionCallbacks(
+        callbacks = self.module.DockWorkflowActionCallbacks(
             configure_connection=lambda: calls.append("settings"),
             sync_activities=lambda: calls.append("sync"),
             store_activities=lambda: calls.append("store"),
@@ -229,8 +229,9 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         self.assertEqual(composition.shell.current_key(), "atlas")
         self.assertTrue(composition.shell.navigation_item_for_key("atlas").property("current"))
 
-    def test_public_exports_include_action_callbacks(self):
-        self.assertIn("WizardActionCallbacks", self.module.__all__)
+    def test_public_exports_include_canonical_workflow_action_callbacks(self):
+        self.assertIn("DockWorkflowActionCallbacks", self.module.__all__)
+        self.assertNotIn("WizardActionCallbacks", self.module.__all__)
 
     def test_local_first_composition_does_not_import_wizard_composition(self):
         self.assertNotIn("qfit.ui.dockwidget.wizard_composition", sys.modules)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -778,13 +778,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.settings = _FakeSettings()
         parent = object()
 
-        class FakeWizardActionCallbacks(SimpleNamespace):
+        class FakeDockWorkflowActionCallbacks(SimpleNamespace):
             pass
 
         fake_local_first_composition = ModuleType(
             "qfit.ui.dockwidget.local_first_composition"
         )
-        fake_local_first_composition.WizardActionCallbacks = FakeWizardActionCallbacks
+        fake_local_first_composition.DockWorkflowActionCallbacks = (
+            FakeDockWorkflowActionCallbacks
+        )
         fake_local_first_composition.build_local_first_dock_composition = MagicMock(
             return_value="composition"
         )

--- a/tests/test_workflow_page_state.py
+++ b/tests/test_workflow_page_state.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _fake_qt_modules
+
+
+def _load_workflow_page_state_module():
+    for name in (
+        "qfit.ui.dockwidget.workflow_page_state",
+        "qfit.ui.dockwidget.analysis_page",
+        "qfit.ui.dockwidget.atlas_page",
+        "qfit.ui.dockwidget.connection_page",
+        "qfit.ui.dockwidget.map_page",
+        "qfit.ui.dockwidget.sync_page",
+        "qfit.ui.dockwidget.action_row",
+        "qfit.ui.dockwidget",
+    ):
+        sys.modules.pop(name, None)
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.workflow_page_state")
+
+
+class WorkflowPageStatePublicNamesTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_workflow_page_state_module()
+
+    def test_exports_canonical_workflow_names(self):
+        self.assertIn("DockWorkflowActionCallbacks", self.module.__all__)
+        self.assertIn("WorkflowPageStateSnapshots", self.module.__all__)
+        self.assertIn("build_workflow_page_states_from_facts", self.module.__all__)
+
+    def test_keeps_wizard_names_as_identity_preserving_compatibility_aliases(self):
+        self.assertIs(
+            self.module.WizardActionCallbacks,
+            self.module.DockWorkflowActionCallbacks,
+        )
+        self.assertIs(
+            self.module.WizardPageStateSnapshots,
+            self.module.WorkflowPageStateSnapshots,
+        )
+        self.assertIs(
+            self.module.build_wizard_page_states_from_facts,
+            self.module.build_workflow_page_states_from_facts,
+        )
+        self.assertIn("WizardActionCallbacks", self.module.__all__)
+        self.assertIn("WizardPageStateSnapshots", self.module.__all__)
+        self.assertIn("build_wizard_page_states_from_facts", self.module.__all__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -29,8 +29,6 @@ from .workflow_page_state import (
     connect_optional_signal,
 )
 
-WizardActionCallbacks = DockWorkflowActionCallbacks
-
 _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
     "PyQt5.QtWidgets",
@@ -59,7 +57,7 @@ class LocalFirstDockComposition:
     shell: LocalFirstDockShell
     pages: dict[str, QWidget]
     page_content: LocalFirstDockPageContent
-    action_callbacks: WizardActionCallbacks | None = None
+    action_callbacks: DockWorkflowActionCallbacks | None = None
 
     @property
     def sync_content(self) -> SyncPageContent:
@@ -124,7 +122,7 @@ def build_local_first_dock_composition(
 
 def connect_local_first_action_callbacks(
     composition: LocalFirstDockComposition,
-    callbacks: WizardActionCallbacks,
+    callbacks: DockWorkflowActionCallbacks,
 ) -> LocalFirstDockComposition:
     """Connect concrete dock callbacks to local-first page content actions."""
 
@@ -333,8 +331,8 @@ class _LocalFirstDockPage(QWidget):
 
 __all__ = [
     "LocalFirstDockComposition",
+    "DockWorkflowActionCallbacks",
     "LocalFirstDockPageContent",
-    "WizardActionCallbacks",
     "build_local_first_dock_composition",
     "connect_local_first_action_callbacks",
     "refresh_local_first_dock_composition",


### PR DESCRIPTION
## Summary

- route the live local-first dock callback wiring through `DockWorkflowActionCallbacks`
- export the canonical workflow callback name from local-first composition instead of the wizard alias
- add coverage proving canonical workflow names are exported while wizard aliases remain identity-preserving in the compatibility state module

## Tests

- `python3 -m pytest tests/test_local_first_composition.py tests/test_workflow_page_state.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
