### PR TITLE
Use workflow action row API in dock pages

### DIFF
--- a/tests/test_wizard_action_row.py
+++ b/tests/test_wizard_action_row.py
@@ -143,7 +143,7 @@ class WizardActionRowTest(unittest.TestCase):
         self.assertIsNotNone(button.cursor().shape())
 
     def test_unknown_action_role_is_rejected(self):
-        with self.assertRaisesRegex(ValueError, "Unknown wizard action button role"):
+        with self.assertRaisesRegex(ValueError, "Unknown workflow action button role"):
             self.action_row._button_stylesheet(role="primray")
 
     def test_action_availability_marks_blocked_and_available_buttons(self):

--- a/tests/test_wizard_action_row.py
+++ b/tests/test_wizard_action_row.py
@@ -38,6 +38,23 @@ class WizardActionRowTest(unittest.TestCase):
     def setUpClass(cls):
         cls.action_row = _load_action_row_module()
 
+    def test_workflow_names_are_canonical_exports_with_wizard_aliases(self):
+        button = self.action_row.QToolButton()
+
+        row = self.action_row.build_workflow_action_row(button)
+
+        self.assertIs(self.action_row.WizardActionRow, self.action_row.WorkflowActionRow)
+        self.assertIs(
+            self.action_row.build_wizard_action_row,
+            self.action_row.build_workflow_action_row,
+        )
+        self.assertIs(
+            self.action_row.set_wizard_action_availability,
+            self.action_row.set_workflow_action_availability,
+        )
+        self.assertIsInstance(row, self.action_row.WorkflowActionRow)
+        self.assertEqual(row.objectName(), "qfitWizardActionRow")
+
     def test_builds_scoped_row_with_supplied_buttons(self):
         primary = self.action_row.QToolButton()
         secondary = self.action_row.QToolButton()

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -31,8 +31,8 @@ ACTION_ROW_NARROW_WIDTH = 360
 COLOR_DANGER_BG = pill_tone_palette("danger")[0]
 
 
-class WizardActionRow(QWidget):
-    """Compact action container for one wizard page CTA area."""
+class WorkflowActionRow(QWidget):
+    """Compact action container for one workflow page CTA area."""
 
     def __init__(self, buttons: Iterable[QToolButton] = (), parent=None) -> None:
         super().__init__(parent)
@@ -90,14 +90,14 @@ class WizardActionRow(QWidget):
         return layout
 
 
-def build_wizard_action_row(
+def build_workflow_action_row(
     *buttons: QToolButton,
     parent=None,
     object_name: str = "qfitWizardActionRow",
-) -> WizardActionRow:
-    """Build a scoped action row for wizard page buttons."""
+) -> WorkflowActionRow:
+    """Build a scoped action row for workflow page buttons."""
 
-    row = WizardActionRow(buttons, parent=parent)
+    row = WorkflowActionRow(buttons, parent=parent)
     row.setObjectName(object_name)
     return row
 
@@ -141,13 +141,13 @@ def style_destructive_action_button(
     return button
 
 
-def set_wizard_action_availability(
+def set_workflow_action_availability(
     button: QToolButton,
     *,
     enabled: bool,
     tooltip: str = "",
 ) -> QToolButton:
-    """Apply a wizard-specific availability state to an action button.
+    """Apply a workflow-specific availability state to an action button.
 
     The tooltip is only shown while the action is blocked; available actions
     clear it so stale prerequisite copy does not linger after state refreshes.
@@ -158,6 +158,11 @@ def set_wizard_action_availability(
     button.setProperty("wizardActionAvailability", action_availability)
     button.setToolTip("" if enabled else tooltip)
     return button
+
+
+WizardActionRow = WorkflowActionRow
+build_wizard_action_row = build_workflow_action_row
+set_wizard_action_availability = set_workflow_action_availability
 
 
 def _allow_button_shrink(button: QToolButton) -> None:
@@ -214,8 +219,11 @@ def _button_stylesheet(*, role: str) -> str:
 
 
 __all__ = [
+    "WorkflowActionRow",
     "WizardActionRow",
+    "build_workflow_action_row",
     "build_wizard_action_row",
+    "set_workflow_action_availability",
     "set_wizard_action_availability",
     "style_destructive_action_button",
     "style_primary_action_button",

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -107,7 +107,7 @@ def style_primary_action_button(
     *,
     action_name: str,
 ) -> QToolButton:
-    """Mark a wizard button as the one primary CTA for its page."""
+    """Mark a workflow button as the one primary CTA for its page."""
 
     button.setProperty("primaryAction", action_name)
     button.setProperty("wizardActionRole", "primary")
@@ -120,7 +120,7 @@ def style_secondary_action_button(
     *,
     action_name: str,
 ) -> QToolButton:
-    """Mark a wizard button as a secondary page action."""
+    """Mark a workflow button as a secondary page action."""
 
     button.setProperty("secondaryAction", action_name)
     button.setProperty("wizardActionRole", "secondary")
@@ -133,7 +133,7 @@ def style_destructive_action_button(
     *,
     action_name: str,
 ) -> QToolButton:
-    """Mark a wizard button as a destructive page action."""
+    """Mark a workflow button as a destructive page action."""
 
     button.setProperty("destructiveAction", action_name)
     button.setProperty("wizardActionRole", "destructive")
@@ -215,7 +215,7 @@ def _button_stylesheet(*, role: str) -> str:
         )
     if role == "secondary":
         return ""
-    raise ValueError(f"Unknown wizard action button role: {role!r}")
+    raise ValueError(f"Unknown workflow action button role: {role!r}")
 
 
 __all__ = [

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 
 from ._qt_compat import import_qt_module
 from .action_row import (
-    build_wizard_action_row,
-    set_wizard_action_availability,
+    build_workflow_action_row,
+    set_workflow_action_availability,
     style_primary_action_button,
     style_secondary_action_button,
 )
@@ -111,7 +111,7 @@ class AnalysisPageContent(QWidget):
             action_name="clear_analysis",
         )
         self.clear_analysis_button.clicked.connect(self.clearAnalysisRequested.emit)
-        self.action_row = build_wizard_action_row(
+        self.action_row = build_workflow_action_row(
             self.run_analysis_button,
             self.clear_analysis_button,
             parent=self,
@@ -159,13 +159,13 @@ class AnalysisPageContent(QWidget):
             if state.primary_action_enabled is None
             else state.primary_action_enabled
         )
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.run_analysis_button,
             enabled=primary_action_enabled,
             tooltip=state.primary_action_blocked_tooltip,
         )
         self.clear_analysis_button.setText(state.clear_action_label)
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.clear_analysis_button,
             enabled=state.clear_action_enabled,
         )

--- a/ui/dockwidget/atlas_page.py
+++ b/ui/dockwidget/atlas_page.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 
 from ._qt_compat import import_qt_module
 from .action_row import (
-    build_wizard_action_row,
-    set_wizard_action_availability,
+    build_workflow_action_row,
+    set_workflow_action_availability,
     style_primary_action_button,
 )
 from .page_content_style import (
@@ -107,7 +107,7 @@ class AtlasPageContent(QWidget):
             action_name="export_atlas_pdf",
         )
         self.export_atlas_button.clicked.connect(self.exportAtlasRequested.emit)
-        self.action_row = build_wizard_action_row(
+        self.action_row = build_workflow_action_row(
             self.export_atlas_button,
             parent=self,
             object_name="qfitWizardAtlasActionRow",
@@ -153,7 +153,7 @@ class AtlasPageContent(QWidget):
             if state.primary_action_enabled is None
             else state.primary_action_enabled
         )
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.export_atlas_button,
             enabled=primary_action_enabled,
             tooltip=state.primary_action_blocked_tooltip,

--- a/ui/dockwidget/connection_page.py
+++ b/ui/dockwidget/connection_page.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 
 from ._qt_compat import import_qt_module
 from .action_row import (
-    build_wizard_action_row,
-    set_wizard_action_availability,
+    build_workflow_action_row,
+    set_workflow_action_availability,
     style_primary_action_button,
 )
 from .page_content_style import (
@@ -81,7 +81,7 @@ class ConnectionPageContent(QWidget):
             action_name="configure_connection",
         )
         self.configure_button.clicked.connect(self.configureRequested.emit)
-        self.action_row = build_wizard_action_row(
+        self.action_row = build_workflow_action_row(
             self.configure_button,
             parent=self,
             object_name="qfitWizardConnectionActionRow",
@@ -105,7 +105,7 @@ class ConnectionPageContent(QWidget):
             "connected" if state.connected else "not_connected",
         )
         self.configure_button.setText(state.primary_action_label)
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.configure_button,
             enabled=state.primary_action_enabled,
             tooltip=state.primary_action_blocked_tooltip,

--- a/ui/dockwidget/map_page.py
+++ b/ui/dockwidget/map_page.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 
 from ._qt_compat import import_qt_module
 from .action_row import (
-    build_wizard_action_row,
-    set_wizard_action_availability,
+    build_workflow_action_row,
+    set_workflow_action_availability,
     style_primary_action_button,
     style_secondary_action_button,
 )
@@ -105,7 +105,7 @@ class MapPageContent(QWidget):
             action_name="apply_map_filters",
         )
         self.apply_filters_button.clicked.connect(self.applyFiltersRequested.emit)
-        self.action_row = build_wizard_action_row(
+        self.action_row = build_workflow_action_row(
             self.load_layers_button,
             self.apply_filters_button,
             parent=self,
@@ -137,7 +137,7 @@ class MapPageContent(QWidget):
         self.filter_summary_label.setText(state.filter_summary_text)
         self.filter_summary_label.setProperty("mapState", map_state)
         self.load_layers_button.setText(state.load_action_label)
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.load_layers_button,
             enabled=state.load_action_enabled,
             tooltip=state.load_action_blocked_tooltip,
@@ -149,7 +149,7 @@ class MapPageContent(QWidget):
             if state.apply_action_enabled is None
             else state.apply_action_enabled
         )
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.apply_filters_button,
             enabled=apply_action_enabled,
             tooltip=state.apply_action_blocked_tooltip,

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 
 from ._qt_compat import import_qt_module
 from .action_row import (
-    build_wizard_action_row,
-    set_wizard_action_availability,
+    build_workflow_action_row,
+    set_workflow_action_availability,
     style_destructive_action_button,
     style_primary_action_button,
     style_secondary_action_button,
@@ -113,14 +113,14 @@ class SyncPageContent(QWidget):
             action_name="clear_database",
         )
         self.clear_button.clicked.connect(self.clearDatabaseRequested.emit)
-        self.action_row = build_wizard_action_row(
+        self.action_row = build_workflow_action_row(
             self.load_button,
             self.routes_button,
             self.sync_button,
             parent=self,
             object_name="qfitWizardSyncActionRow",
         )
-        self.clear_action_row = build_wizard_action_row(
+        self.clear_action_row = build_workflow_action_row(
             self.clear_button,
             parent=self,
             object_name="qfitWizardSyncDestructiveActionRow",
@@ -140,25 +140,25 @@ class SyncPageContent(QWidget):
         self.activity_summary_label.setProperty("syncState", sync_state)
         self._primary_action_kind = state.primary_action_kind
         self.sync_button.setText(state.primary_action_label)
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.sync_button,
             enabled=state.primary_action_enabled,
             tooltip=state.primary_action_blocked_tooltip,
         )
         self.load_button.setText(state.local_action_label)
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.load_button,
             enabled=state.local_action_enabled,
             tooltip=state.local_action_blocked_tooltip,
         )
         self.routes_button.setText(state.routes_action_label)
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.routes_button,
             enabled=state.routes_action_enabled,
             tooltip=state.routes_action_blocked_tooltip,
         )
         self.clear_button.setText(state.clear_action_label)
-        set_wizard_action_availability(
+        set_workflow_action_availability(
             self.clear_button,
             enabled=state.clear_action_enabled,
             tooltip=state.clear_action_blocked_tooltip,


### PR DESCRIPTION
## Summary
- add workflow-named action row APIs as the canonical dock page surface
- keep the existing wizard-named class/function exports as identity-preserving compatibility aliases
- route dock page production code through the workflow action row names without changing object names or UX

## Tests
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
