### PR TITLE
refactor: add workflow dock step-page API

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -227,8 +227,31 @@ class StepPageTest(unittest.TestCase):
         )
         self.assertFalse(page.primary_hint_label.isVisible())
 
+    def test_workflow_step_page_is_canonical_export_with_wizard_alias(self):
+        spec = build_default_workflow_page_specs()[2]
+
+        page = self.step_page.WorkflowStepPage(spec, step_num=3, step_total=5)
+
+        self.assertIs(self.step_page.WizardStepPage, self.step_page.WorkflowStepPage)
+        self.assertEqual(page.objectName(), "qfitWizardMapPage")
+        self.assertIsInstance(page, self.step_page.WizardStepPage)
+
+    def test_workflow_step_page_builders_keep_wizard_compatibility_aliases(self):
+        self.assertIs(
+            self.step_page.build_wizard_step_pages,
+            self.step_page.build_workflow_step_pages,
+        )
+        self.assertIs(
+            self.step_page.install_wizard_step_pages,
+            self.step_page.install_workflow_step_pages,
+        )
+        self.assertIs(
+            self.step_page.apply_wizard_step_page_statuses,
+            self.step_page.apply_workflow_step_page_statuses,
+        )
+
     def test_builds_wizard_step_pages_from_default_specs(self):
-        pages = self.step_page.build_wizard_step_pages()
+        pages = self.step_page.build_workflow_step_pages()
 
         self.assertEqual(
             [page.spec.key for page in pages],
@@ -240,19 +263,19 @@ class StepPageTest(unittest.TestCase):
         )
 
     def test_build_wizard_step_pages_preserves_explicit_empty_specs(self):
-        pages = self.step_page.build_wizard_step_pages(specs=())
+        pages = self.step_page.build_workflow_step_pages(specs=())
 
         self.assertEqual(pages, ())
 
     def test_applies_progress_status_pills_to_step_pages(self):
-        pages = self.step_page.build_wizard_step_pages()
+        pages = self.step_page.build_workflow_step_pages()
         statuses = build_wizard_step_statuses(
             current_key="map",
             completed_keys={"connection", "sync"},
             unlocked_keys={"analysis"},
         )
 
-        self.step_page.apply_wizard_step_page_statuses(pages, statuses)
+        self.step_page.apply_workflow_step_page_statuses(pages, statuses)
 
         self.assertEqual(
             [page.status_pill.text() for page in pages],
@@ -270,7 +293,7 @@ class StepPageTest(unittest.TestCase):
     def test_installs_wizard_step_pages_into_shell(self):
         shell = self.wizard_shell.WizardShell()
 
-        pages = self.step_page.install_wizard_step_pages(shell)
+        pages = self.step_page.install_workflow_step_pages(shell)
 
         self.assertEqual(shell.page_count(), 5)
         self.assertEqual(shell.pages_stack.widgets, list(pages))

--- a/tests/test_wizard_dock.py
+++ b/tests/test_wizard_dock.py
@@ -64,19 +64,34 @@ class WizardDockWidgetTest(unittest.TestCase):
     def setUpClass(cls):
         cls.wizard_dock = _load_wizard_dock_module()
 
+    def test_workflow_dock_is_canonical_export_with_wizard_aliases(self):
+        self.assertIs(self.wizard_dock.WizardDockWidget, self.wizard_dock.WorkflowDockWidget)
+        self.assertIs(
+            self.wizard_dock.WizardShellCompositionLike,
+            self.wizard_dock.WorkflowShellCompositionLike,
+        )
+        self.assertIs(
+            self.wizard_dock.build_wizard_dock_widget,
+            self.wizard_dock.build_workflow_dock_widget,
+        )
+        self.assertEqual(
+            self.wizard_dock.WIZARD_DOCK_OBJECT_NAME,
+            self.wizard_dock.WORKFLOW_DOCK_OBJECT_NAME,
+        )
+
     def test_builds_qgis_dock_container_for_wizard_shell_composition(self):
         shell = _FakeWidget()
         parent = _FakeWidget()
         composition = SimpleNamespace(shell=shell)
 
-        dock = self.wizard_dock.build_wizard_dock_widget(
+        dock = self.wizard_dock.build_workflow_dock_widget(
             composition,
             parent=parent,
-            title="qfit wizard",
+            title="qfit workflow",
         )
 
         self.assertEqual(dock.objectName(), "qfitWizardDockWidget")
-        self.assertEqual(dock.windowTitle(), "qfit wizard")
+        self.assertEqual(dock.windowTitle(), "qfit workflow")
         self.assertIs(dock.parent, parent)
         self.assertIs(dock.composition, composition)
         self.assertIs(dock.widget(), shell)
@@ -87,6 +102,7 @@ class WizardDockWidgetTest(unittest.TestCase):
             | _FakeDockWidget.DockWidgetFloatable,
         )
         self.assertEqual(dock.allowedAreas(), 8 | 16)
+        self.assertIsInstance(dock, self.wizard_dock.WizardDockWidget)
 
     def test_can_replace_hosted_wizard_composition_without_recreating_dock(self):
         first = SimpleNamespace(shell=_FakeWidget())

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -311,8 +311,8 @@ class StepPage(QWidget):
         return layout
 
 
-class WizardStepPage(StepPage):
-    """Step-page adapter backed by the canonical #609 page spec.
+class WorkflowStepPage(StepPage):
+    """Step-page adapter backed by the canonical workflow page spec.
 
     ``WizardPage`` still powers the current placeholder shell, but the final
     dock swap needs spec-keyed pages with the richer ``StepPage`` chrome. This
@@ -372,17 +372,21 @@ class WizardStepPage(StepPage):
         return label
 
 
-def build_wizard_step_pages(
+WizardStepPage = WorkflowStepPage
+"""Compatibility alias for pre-#805 wizard step-page callers."""
+
+
+def build_workflow_step_pages(
     *,
     parent=None,
     specs: Sequence[DockWorkflowPageSpec] | None = None,
-) -> tuple[WizardStepPage, ...]:
-    """Build StepPage-backed pages in stable #609 wizard order."""
+) -> tuple[WorkflowStepPage, ...]:
+    """Build StepPage-backed pages in stable workflow order."""
 
     page_specs = build_default_workflow_page_specs() if specs is None else tuple(specs)
     step_total = len(page_specs)
     return tuple(
-        WizardStepPage(
+        WorkflowStepPage(
             spec,
             step_num=index + 1,
             step_total=step_total,
@@ -392,23 +396,31 @@ def build_wizard_step_pages(
     )
 
 
-def install_wizard_step_pages(
+build_wizard_step_pages = build_workflow_step_pages
+"""Compatibility alias for pre-#805 wizard step-page callers."""
+
+
+def install_workflow_step_pages(
     shell,
     specs: Sequence[DockWorkflowPageSpec] | None = None,
-) -> tuple[WizardStepPage, ...]:
-    """Create StepPage-backed wizard pages and append them to a shell."""
+) -> tuple[WorkflowStepPage, ...]:
+    """Create StepPage-backed workflow pages and append them to a shell."""
 
-    pages = build_wizard_step_pages(parent=shell, specs=specs)
+    pages = build_workflow_step_pages(parent=shell, specs=specs)
     for page in pages:
         shell.add_page(page)
     return pages
 
 
-def apply_wizard_step_page_statuses(
-    pages: Sequence[WizardStepPage],
+install_wizard_step_pages = install_workflow_step_pages
+"""Compatibility alias for pre-#805 wizard step-page callers."""
+
+
+def apply_workflow_step_page_statuses(
+    pages: Sequence[WorkflowStepPage],
     statuses: Sequence[DockWorkflowStepStatus],
 ) -> None:
-    """Render progress status pills on StepPage-backed wizard pages.
+    """Render progress status pills on StepPage-backed workflow pages.
 
     The stepper remains the source of truth for current-step navigation state.
     Header pills are therefore reserved for non-current states, avoiding a
@@ -423,6 +435,10 @@ def apply_wizard_step_page_statuses(
             continue
         text, tone = _step_status_pill(status.state)
         page.set_status(text, tone=tone)
+
+
+apply_wizard_step_page_statuses = apply_workflow_step_page_statuses
+"""Compatibility alias for pre-#805 wizard step-page callers."""
 
 
 class _LayoutWidget(QWidget):
@@ -534,10 +550,14 @@ __all__ = [
     "DockWorkflowPageSpec",
     "DockWizardPageSpec",
     "StepPage",
+    "WorkflowStepPage",
     "WizardStepPage",
+    "apply_workflow_step_page_statuses",
     "apply_wizard_step_page_statuses",
     "build_default_workflow_page_specs",
     "build_default_wizard_page_specs",
+    "build_workflow_step_pages",
     "build_wizard_step_pages",
+    "install_workflow_step_pages",
     "install_wizard_step_pages",
 ]

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -43,9 +43,9 @@ from .connection_page import (
 from .map_page import MapPageContent, MapPageState, install_map_page_content
 from .sync_page import SyncPageContent, SyncPageState, install_sync_page_content
 from .step_page import (
-    WizardStepPage,
-    apply_wizard_step_page_statuses,
-    install_wizard_step_pages,
+    WorkflowStepPage,
+    apply_workflow_step_page_statuses,
+    install_workflow_step_pages,
 )
 from .wizard_page import WizardPage, install_wizard_pages
 from .wizard_shell import WizardShell
@@ -65,7 +65,7 @@ DockWizardPageSpec = DockWorkflowPageSpec
 build_default_wizard_page_specs = build_default_workflow_page_specs
 """Compatibility alias for pre-#805 wizard composition builder callers."""
 _StateT = TypeVar("_StateT")
-WizardCompositionPage = WizardPage | WizardStepPage
+WizardCompositionPage = WizardPage | WorkflowStepPage
 WizardProgressFacts = WorkflowProgressFacts
 """Compatibility alias for wizard shell composition callers during #805."""
 DockWizardProgress = DockWorkflowProgress
@@ -545,7 +545,7 @@ def _install_shell_pages(
     use_step_pages: bool,
 ) -> tuple[WizardCompositionPage, ...]:
     if use_step_pages:
-        return install_wizard_step_pages(shell, specs=specs)
+        return install_workflow_step_pages(shell, specs=specs)
     return install_wizard_pages(shell, specs=specs)
 
 
@@ -557,7 +557,7 @@ def _connect_step_page_navigation(
     step_pages = tuple(
         (index, page)
         for index, page in enumerate(pages)
-        if isinstance(page, WizardStepPage)
+        if isinstance(page, WorkflowStepPage)
     )
     if not step_pages:
         return
@@ -608,7 +608,7 @@ def _sync_step_page_navigation_buttons(
     last_index = len(statuses) - 1
     page_titles_by_index = _step_page_titles_by_workflow_index(pages)
     for installed_index, page in enumerate(pages):
-        if not isinstance(page, WizardStepPage):
+        if not isinstance(page, WorkflowStepPage):
             continue
         previous_index, next_index = _step_page_navigation_targets(
             pages,
@@ -663,7 +663,7 @@ def _step_page_titles_by_workflow_index(
     return {
         step_index_for_key(page.spec.key): page.spec.title
         for page in pages
-        if isinstance(page, WizardStepPage)
+        if isinstance(page, WorkflowStepPage)
     }
 
 
@@ -671,10 +671,10 @@ def _sync_step_page_status_pills(
     pages: Sequence[WizardCompositionPage],
     presenter: WorkflowShellPresenter,
 ) -> None:
-    step_pages = tuple(page for page in pages if isinstance(page, WizardStepPage))
+    step_pages = tuple(page for page in pages if isinstance(page, WorkflowStepPage))
     if not step_pages:
         return
-    apply_wizard_step_page_statuses(
+    apply_workflow_step_page_statuses(
         step_pages,
         build_progress_workflow_step_statuses(presenter.progress),
     )

--- a/ui/dockwidget/wizard_dock.py
+++ b/ui/dockwidget/wizard_dock.py
@@ -15,78 +15,105 @@ Qt = _qtcore.Qt
 QDockWidget = _qtwidgets.QDockWidget
 QWidget = _qtwidgets.QWidget
 
-WIZARD_DOCK_OBJECT_NAME = "qfitWizardDockWidget"
-WIZARD_DOCK_TITLE = "qfit"
-WIZARD_DOCK_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
-WIZARD_DOCK_FEATURES = (
+WORKFLOW_DOCK_OBJECT_NAME = "qfitWizardDockWidget"
+WORKFLOW_DOCK_TITLE = "qfit"
+WORKFLOW_DOCK_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
+WORKFLOW_DOCK_FEATURES = (
     QDockWidget.DockWidgetClosable
     | QDockWidget.DockWidgetMovable
     | QDockWidget.DockWidgetFloatable
 )
 
+WIZARD_DOCK_OBJECT_NAME = WORKFLOW_DOCK_OBJECT_NAME
+"""Compatibility alias for pre-#805 wizard dock callers."""
+WIZARD_DOCK_TITLE = WORKFLOW_DOCK_TITLE
+"""Compatibility alias for pre-#805 wizard dock callers."""
+WIZARD_DOCK_ALLOWED_AREAS = WORKFLOW_DOCK_ALLOWED_AREAS
+"""Compatibility alias for pre-#805 wizard dock callers."""
+WIZARD_DOCK_FEATURES = WORKFLOW_DOCK_FEATURES
+"""Compatibility alias for pre-#805 wizard dock callers."""
 
-class WizardShellCompositionLike(Protocol):
-    """Small structural protocol for dock-hostable wizard compositions."""
+
+class WorkflowShellCompositionLike(Protocol):
+    """Small structural protocol for dock-hostable workflow compositions."""
 
     shell: QWidget
 
 
-class WizardDockWidget(QDockWidget):
-    """QDockWidget host for the #609 wizard shell composition.
+WizardShellCompositionLike = WorkflowShellCompositionLike
+"""Compatibility alias for pre-#805 wizard dock callers."""
 
-    The current production dock still uses the legacy ``.ui`` while the wizard
-    migrates page-by-page. This adapter captures the final dock-level shape from
-    the Option B spec now: a normal QGIS dock widget whose contents are the
-    reusable ``WizardShell`` composition, without coupling the shell back to the
-    long-scroll dock implementation.
+
+class WorkflowDockWidget(QDockWidget):
+    """QDockWidget host for the local-first workflow shell composition.
+
+    The visible dock is converging on the local-first workflow surface while
+    preserving stable Qt object names and thin wizard-named import aliases for
+    older callers during #805.
     """
 
     def __init__(
         self,
-        composition: WizardShellCompositionLike,
+        composition: WorkflowShellCompositionLike,
         *,
         parent=None,
-        title: str = WIZARD_DOCK_TITLE,
+        title: str = WORKFLOW_DOCK_TITLE,
     ) -> None:
         super().__init__(parent)
-        self.composition: WizardShellCompositionLike | None = None
-        self.setObjectName(WIZARD_DOCK_OBJECT_NAME)
+        self.composition: WorkflowShellCompositionLike | None = None
+        self.setObjectName(WORKFLOW_DOCK_OBJECT_NAME)
         self.setWindowTitle(title)
-        self.setFeatures(WIZARD_DOCK_FEATURES)
-        self.setAllowedAreas(WIZARD_DOCK_ALLOWED_AREAS)
+        self.setFeatures(WORKFLOW_DOCK_FEATURES)
+        self.setAllowedAreas(WORKFLOW_DOCK_ALLOWED_AREAS)
         self.set_composition(composition)
 
-    def set_composition(self, composition: WizardShellCompositionLike) -> None:
-        """Install or replace the hosted wizard composition shell."""
+    def set_composition(self, composition: WorkflowShellCompositionLike) -> None:
+        """Install or replace the hosted workflow composition shell."""
 
         shell = _composition_shell(composition)
         self.setWidget(shell)
         self.composition = composition
 
 
-def build_wizard_dock_widget(
-    composition: WizardShellCompositionLike,
+WizardDockWidget = WorkflowDockWidget
+"""Compatibility alias for pre-#805 wizard dock callers."""
+
+
+def build_workflow_dock_widget(
+    composition: WorkflowShellCompositionLike,
     *,
     parent=None,
-    title: str = WIZARD_DOCK_TITLE,
-) -> WizardDockWidget:
-    """Build the dock-level container for a reusable wizard composition."""
+    title: str = WORKFLOW_DOCK_TITLE,
+) -> WorkflowDockWidget:
+    """Build the dock-level container for a reusable workflow composition."""
 
-    return WizardDockWidget(composition, parent=parent, title=title)
+    return WorkflowDockWidget(composition, parent=parent, title=title)
 
 
-def _composition_shell(composition: WizardShellCompositionLike):
+build_wizard_dock_widget = build_workflow_dock_widget
+"""Compatibility alias for pre-#805 wizard dock callers."""
+
+
+def _composition_shell(composition: WorkflowShellCompositionLike):
     shell = getattr(composition, "shell", None)
     if shell is None:
-        raise ValueError("Wizard dock compositions must expose a shell widget")
+        raise ValueError("Workflow dock compositions must expose a shell widget")
     return shell
 
 
 __all__ = [
+    "WORKFLOW_DOCK_ALLOWED_AREAS",
+    "WORKFLOW_DOCK_FEATURES",
+    "WORKFLOW_DOCK_OBJECT_NAME",
+    "WORKFLOW_DOCK_TITLE",
+    "WorkflowDockWidget",
+    "WorkflowShellCompositionLike",
     "WIZARD_DOCK_ALLOWED_AREAS",
     "WIZARD_DOCK_FEATURES",
     "WIZARD_DOCK_OBJECT_NAME",
     "WIZARD_DOCK_TITLE",
     "WizardDockWidget",
+    "WizardShellCompositionLike",
+    "build_workflow_dock_widget",
     "build_wizard_dock_widget",
 ]


### PR DESCRIPTION
## Summary

- introduce workflow-named dock and step-page APIs for the local-first dock shell
- keep wizard-named imports as thin compatibility aliases and preserve stable qfitWizard* Qt object names
- route shell composition step-page wiring through the workflow-named API

## Testing

- `python3 -m pytest tests/test_step_page.py tests/test_wizard_dock.py tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
