### PR TITLE
Refine workflow page and shell APIs

### DIFF
--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -85,7 +85,7 @@ class WizardPageTest(unittest.TestCase):
     def test_page_container_builds_visible_placeholder_chrome(self):
         spec = build_default_workflow_page_specs()[2]
 
-        page = self.wizard_page.WizardPage(spec)
+        page = self.wizard_page.WorkflowPage(spec)
 
         self.assertEqual(page.objectName(), "qfitWizardMapPage")
         self.assertEqual(page.title_label.objectName(), "qfitWizardMapPageTitle")
@@ -123,15 +123,36 @@ class WizardPageTest(unittest.TestCase):
         )
         self.assertFalse(page.primary_hint_label.isVisible())
 
+    def test_workflow_page_is_canonical_export_with_wizard_alias(self):
+        spec = build_default_workflow_page_specs()[2]
+
+        page = self.wizard_page.WorkflowPage(spec)
+
+        self.assertIs(self.wizard_page.WizardPage, self.wizard_page.WorkflowPage)
+        self.assertEqual(page.objectName(), "qfitWizardMapPage")
+        self.assertIsInstance(page, self.wizard_page.WizardPage)
+        self.assertIn("WorkflowPage", self.wizard_page.__all__)
+        self.assertIn("WizardPage", self.wizard_page.__all__)
+
+    def test_workflow_page_builders_keep_wizard_compatibility_aliases(self):
+        self.assertIs(
+            self.wizard_page.build_wizard_pages,
+            self.wizard_page.build_workflow_pages,
+        )
+        self.assertIs(
+            self.wizard_page.install_wizard_pages,
+            self.wizard_page.install_workflow_pages,
+        )
+
     def test_build_pages_preserves_explicit_empty_specs(self):
-        pages = self.wizard_page.build_wizard_pages(specs=())
+        pages = self.wizard_page.build_workflow_pages(specs=())
 
         self.assertEqual(pages, ())
 
     def test_installs_default_pages_into_wizard_shell(self):
-        shell = self.wizard_shell.WizardShell()
+        shell = self.wizard_shell.WorkflowShell()
 
-        pages = self.wizard_page.install_wizard_pages(shell)
+        pages = self.wizard_page.install_workflow_pages(shell)
 
         self.assertEqual(shell.page_count(), 5)
         self.assertEqual([page.spec.key for page in pages], ["connection", "sync", "map", "analysis", "atlas"])

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -435,7 +435,7 @@ class WizardShellTest(unittest.TestCase):
         cls.wizard_shell = _load_wizard_shell_module()
 
     def test_builds_spec_shell_structure_with_empty_pages_stack(self):
-        shell = self.wizard_shell.WizardShell(footer_text="Ready")
+        shell = self.wizard_shell.WorkflowShell(footer_text="Ready")
 
         self.assertEqual(shell.objectName(), "qfitWizardShell")
         self.assertEqual(shell.stepper_bar.objectName(), "qfitStepperBar")
@@ -452,8 +452,17 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(shell.footer_bar.text(), "Ready")
         self.assertEqual(shell.footer_bar.path_label.text(), "Ready")
 
+    def test_workflow_shell_is_canonical_export_with_wizard_alias(self):
+        shell = self.wizard_shell.WorkflowShell()
+
+        self.assertIs(self.wizard_shell.WizardShell, self.wizard_shell.WorkflowShell)
+        self.assertEqual(shell.objectName(), "qfitWizardShell")
+        self.assertIsInstance(shell, self.wizard_shell.WizardShell)
+        self.assertIn("WorkflowShell", self.wizard_shell.__all__)
+        self.assertIn("WizardShell", self.wizard_shell.__all__)
+
     def test_outer_layout_matches_wizard_spec_order(self):
-        shell = self.wizard_shell.WizardShell()
+        shell = self.wizard_shell.WorkflowShell()
         layout = shell.outer_layout()
 
         self.assertEqual(layout.object_name, "qfitWizardOuterLayout")

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -62,6 +62,16 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertIn("WorkflowShellPresenter", self.composition.__all__)
         self.assertIn("WizardShellPresenter", self.composition.__all__)
 
+    def test_exports_workflow_shell_and_page_as_canonical_composition_api(self):
+        self.assertEqual(self.composition.WorkflowShell.__name__, "WorkflowShell")
+        self.assertEqual(self.composition.WorkflowPage.__name__, "WorkflowPage")
+        self.assertIs(self.composition.WizardShell, self.composition.WorkflowShell)
+        self.assertIs(self.composition.WizardPage, self.composition.WorkflowPage)
+        self.assertIn("WorkflowShell", self.composition.__all__)
+        self.assertIn("WizardShell", self.composition.__all__)
+        self.assertIn("WorkflowPage", self.composition.__all__)
+        self.assertIn("WizardPage", self.composition.__all__)
+
     def test_keeps_wizard_progress_facts_as_compatibility_alias(self):
         self.assertIs(self.composition.WizardProgressFacts, WorkflowProgressFacts)
 

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Collection, Sequence
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import TypeAlias, TypeVar
 
 from qfit.ui.application.dock_workflow_sections import (
     DockWorkflowProgress,
@@ -65,7 +65,7 @@ DockWizardPageSpec = DockWorkflowPageSpec
 build_default_wizard_page_specs = build_default_workflow_page_specs
 """Compatibility alias for pre-#805 wizard composition builder callers."""
 _StateT = TypeVar("_StateT")
-WizardCompositionPage = WorkflowPage | WorkflowStepPage
+WizardCompositionPage: TypeAlias = WorkflowPage | WorkflowStepPage
 WizardProgressFacts = WorkflowProgressFacts
 """Compatibility alias for wizard shell composition callers during #805."""
 DockWizardProgress = DockWorkflowProgress

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -47,8 +47,8 @@ from .step_page import (
     apply_workflow_step_page_statuses,
     install_workflow_step_pages,
 )
-from .wizard_page import WizardPage, install_wizard_pages
-from .wizard_shell import WizardShell
+from .wizard_page import WorkflowPage, install_workflow_pages
+from .wizard_shell import WorkflowShell
 from .workflow_shell_presenter import WorkflowShellPresenter
 from .workflow_page_state import (
     DockWorkflowActionCallbacks as WizardActionCallbacks,
@@ -65,10 +65,14 @@ DockWizardPageSpec = DockWorkflowPageSpec
 build_default_wizard_page_specs = build_default_workflow_page_specs
 """Compatibility alias for pre-#805 wizard composition builder callers."""
 _StateT = TypeVar("_StateT")
-WizardCompositionPage = WizardPage | WorkflowStepPage
+WizardCompositionPage = WorkflowPage | WorkflowStepPage
 WizardProgressFacts = WorkflowProgressFacts
 """Compatibility alias for wizard shell composition callers during #805."""
 DockWizardProgress = DockWorkflowProgress
+"""Compatibility alias for pre-#805 wizard shell composition callers."""
+WizardShell = WorkflowShell
+"""Compatibility alias for pre-#805 wizard shell composition callers."""
+WizardPage = WorkflowPage
 """Compatibility alias for pre-#805 wizard shell composition callers."""
 WizardShellPresenter = WorkflowShellPresenter
 """Compatibility alias for pre-#805 wizard shell composition callers."""
@@ -84,7 +88,7 @@ class WizardShellComposition:
     this slice focused on wizard-forward UI structure.
     """
 
-    shell: WizardShell
+    shell: WorkflowShell
     pages: tuple[WizardCompositionPage, ...]
     presenter: WorkflowShellPresenter
     connection_content: ConnectionPageContent | None = None
@@ -122,7 +126,7 @@ def build_placeholder_wizard_shell(
     Pages are installed before the presenter renders so the initial progress
     snapshot selects the matching visible page immediately. The helper does not
     bind any current long-scroll dock controls into the shell; page content can
-    migrate later through the stable ``WizardPage.body_layout()`` seams. The
+    migrate later through the stable ``WorkflowPage.body_layout()`` seams. The
     optional step-change callback is the future dock's seam for persisting
     ``ui/last_step_index`` when users navigate the wizard. The shell now uses
     the richer StepPage chrome from the Option B spec by default while preserving
@@ -163,7 +167,7 @@ def build_placeholder_wizard_shell(
     )
     footer_facts = _footer_facts_from_progress_facts(progress_facts)
     page_specs = _resolve_page_specs(specs)
-    shell = WizardShell(
+    shell = WorkflowShell(
         parent=parent,
         footer_text=footer_text
         or _build_default_footer_text(
@@ -539,18 +543,18 @@ def _build_default_footer_text(
 
 
 def _install_shell_pages(
-    shell: WizardShell,
+    shell: WorkflowShell,
     *,
     specs: Sequence[DockWorkflowPageSpec],
     use_step_pages: bool,
 ) -> tuple[WizardCompositionPage, ...]:
     if use_step_pages:
         return install_workflow_step_pages(shell, specs=specs)
-    return install_wizard_pages(shell, specs=specs)
+    return install_workflow_pages(shell, specs=specs)
 
 
 def _connect_step_page_navigation(
-    shell: WizardShell,
+    shell: WorkflowShell,
     pages: Sequence[WizardCompositionPage],
     presenter: WorkflowShellPresenter,
 ) -> None:
@@ -793,11 +797,15 @@ __all__ = [
     "DockWizardPageSpec",
     "DockWizardProgress",
     "WizardActionCallbacks",
+    "WizardPage",
     "WizardPageStateSnapshots",
     "WizardProgressFacts",
     "WizardSettingsSnapshot",
+    "WizardShell",
     "WizardShellComposition",
     "WizardShellPresenter",
+    "WorkflowPage",
+    "WorkflowShell",
     "WorkflowShellPresenter",
     "WorkflowProgressFacts",
     "build_default_workflow_page_specs",

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -42,13 +42,12 @@ build_default_wizard_page_specs = build_default_workflow_page_specs
 """Compatibility alias for pre-#805 wizard page builders."""
 
 
-class WizardPage(QWidget):
-    """Reusable visible page container for the #609 wizard shell.
+class WorkflowPage(QWidget):
+    """Reusable visible page container for the workflow shell.
 
-    The container supplies stable chrome for the future wizard pages while
-    leaving real page controls to later focused slices. It is deliberately not
-    wired into the current dock yet, so it remains compatible with the shell
-    structure without locking in the old scroll layout.
+    The container supplies stable chrome for the workflow pages while leaving
+    real page controls to focused slices. It preserves the stable
+    ``qfitWizard*`` object names used by QSS and existing tests.
     """
 
     def __init__(self, spec: DockWorkflowPageSpec, parent=None) -> None:
@@ -125,35 +124,50 @@ class WizardPage(QWidget):
         return layout
 
 
-def build_wizard_pages(
+WizardPage = WorkflowPage
+"""Compatibility alias for pre-#805 wizard page callers."""
+
+
+def build_workflow_pages(
     *,
     parent=None,
     specs: Sequence[DockWorkflowPageSpec] | None = None,
-) -> tuple[WizardPage, ...]:
-    """Build visible wizard page containers from render-neutral specs."""
+) -> tuple[WorkflowPage, ...]:
+    """Build visible workflow page containers from render-neutral specs."""
 
     page_specs = build_default_workflow_page_specs() if specs is None else tuple(specs)
-    return tuple(WizardPage(spec, parent) for spec in page_specs)
+    return tuple(WorkflowPage(spec, parent) for spec in page_specs)
 
 
-def install_wizard_pages(
+build_wizard_pages = build_workflow_pages
+"""Compatibility alias for pre-#805 wizard page callers."""
+
+
+def install_workflow_pages(
     shell,
     specs: Sequence[DockWorkflowPageSpec] | None = None,
-) -> tuple[WizardPage, ...]:
-    """Create default wizard pages and append them to a :class:`WizardShell`."""
+) -> tuple[WorkflowPage, ...]:
+    """Create default workflow pages and append them to a shell."""
 
-    pages = build_wizard_pages(parent=shell, specs=specs)
+    pages = build_workflow_pages(parent=shell, specs=specs)
     for page in pages:
         shell.add_page(page)
     return pages
 
 
+install_wizard_pages = install_workflow_pages
+"""Compatibility alias for pre-#805 wizard page callers."""
+
+
 __all__ = [
     "DockWorkflowPageSpec",
     "DockWizardPageSpec",
+    "WorkflowPage",
     "WizardPage",
     "build_default_workflow_page_specs",
     "build_default_wizard_page_specs",
+    "build_workflow_pages",
     "build_wizard_pages",
+    "install_workflow_pages",
     "install_wizard_pages",
 ]

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -26,13 +26,13 @@ QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
 
 
-class WizardShell(QWidget):
-    """Reusable dock shell matching the #609 wizard page structure.
+class WorkflowShell(QWidget):
+    """Reusable dock shell for the local-first workflow structure.
 
     The shell intentionally owns only the structural chrome: stepper, separator,
-    scrollable stacked pages, and compact footer. Page content remains external so
-    the future wizard can migrate one page at a time without binding the current
-    long-scroll dock to another round of cosmetic changes.
+    scrollable stacked pages, and compact footer. Page content remains external
+    so workflow pages can migrate one page at a time. Stable ``qfitWizard*``
+    object names are preserved for QSS and compatibility.
     """
 
     def __init__(self, parent=None, *, footer_text: str = "") -> None:
@@ -156,4 +156,8 @@ class WizardShell(QWidget):
         return FooterStatusBar(self, footer_text=footer_text)
 
 
-__all__ = ["STEPPER_LABELS", "WizardShell"]
+WizardShell = WorkflowShell
+"""Compatibility alias for pre-#805 wizard shell callers."""
+
+
+__all__ = ["STEPPER_LABELS", "WorkflowShell", "WizardShell"]


### PR DESCRIPTION
## Summary
- Introduce canonical `WorkflowPage` / `WorkflowShell` dock APIs while keeping `WizardPage` / `WizardShell` compatibility aliases.
- Add canonical `build_workflow_pages` and `install_workflow_pages` helpers with wizard-named aliases preserved.
- Route the shell composition internals through workflow-named page/shell APIs without changing stable `qfitWizard*` object names or UX.

## Tests
- `python3 -m pytest tests/test_wizard_pages.py tests/test_wizard_shell.py tests/test_wizard_shell_composition.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
