### PR TITLE
chore: route dock startup through workflow settings

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -155,13 +155,18 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         )
         self._install_live_local_first_dock()
 
-    def _ensure_wizard_settings(self):
+    def _ensure_workflow_settings(self):
         """Persist first-launch workflow defaults for the local-first dock."""
 
         return ensure_workflow_settings(self.settings)
 
+    def _ensure_wizard_settings(self):
+        """Compatibility alias for pre-#805 wizard-named startup callers."""
+
+        return self._ensure_workflow_settings()
+
     def refresh_configuration_from_settings(self) -> None:
-        """Reload saved configuration and refresh live wizard connection state."""
+        """Reload saved configuration and refresh live workflow connection state."""
 
         self._load_settings()
         self._update_connection_status()

--- a/tests/test_dockwidget_dependencies.py
+++ b/tests/test_dockwidget_dependencies.py
@@ -563,7 +563,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
                 performed_steps=(
                     "set_features",
                     "set_allowed_areas",
-                    "ensure_wizard_settings",
+                    "ensure_workflow_settings",
                     "configure_local_first_backing_controls",
                     "remove_stale_qfit_layers",
                     "apply_contextual_help",
@@ -586,7 +586,7 @@ class DockStartupCoordinatorTests(unittest.TestCase):
             [
                 call.setFeatures(sentinel.features),
                 call.setAllowedAreas(sentinel.allowed_areas),
-                call._ensure_wizard_settings(),
+                call._ensure_workflow_settings(),
                 call._remove_stale_qfit_layers(),
                 call._apply_contextual_help(),
                 call._load_settings(),

--- a/tests/test_workflow_progress.py
+++ b/tests/test_workflow_progress.py
@@ -11,6 +11,7 @@ from qfit.ui.application import (
 from qfit.ui.application import (
     build_workflow_progress_from_facts_and_settings as exported_settings_builder,
 )
+from qfit.ui.application import wizard_progress as wizard_progress_module
 from qfit.ui.application.workflow_progress import (
     build_startup_workflow_progress_facts,
     build_workflow_progress_from_facts,
@@ -92,6 +93,12 @@ class WorkflowProgressTests(unittest.TestCase):
         self.assertEqual(
             progress.completed_keys,
             frozenset({"connection", "sync", "map"}),
+        )
+
+    def test_wizard_progress_module_preserves_settings_snapshot_alias(self):
+        self.assertIs(
+            wizard_progress_module.WizardSettingsSnapshot,
+            WorkflowSettingsSnapshot,
         )
 
     def test_wizard_settings_builder_delegates_to_neutral_workflow_builder(self):

--- a/tests/test_workflow_settings.py
+++ b/tests/test_workflow_settings.py
@@ -2,6 +2,7 @@ import unittest
 
 from tests import _path  # noqa: F401
 
+from qfit.ui import application as application_exports
 from qfit.ui.application.workflow_settings import (
     COLLAPSED_GROUPS_KEY,
     DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
@@ -113,6 +114,36 @@ class WorkflowSettingsTests(unittest.TestCase):
         self.assertEqual(
             preferred_current_key_from_workflow_settings(snapshot),
             "analysis",
+        )
+
+    def test_application_package_exports_workflow_settings_api_and_compat_aliases(self):
+        self.assertIs(
+            application_exports.WorkflowSettingsSnapshot,
+            WorkflowSettingsSnapshot,
+        )
+        self.assertIs(
+            application_exports.ensure_workflow_settings,
+            ensure_workflow_settings,
+        )
+        self.assertIs(
+            application_exports.load_workflow_settings,
+            load_workflow_settings,
+        )
+        self.assertIs(
+            application_exports.WizardSettingsSnapshot,
+            WorkflowSettingsSnapshot,
+        )
+        self.assertIs(
+            application_exports.ensure_wizard_settings,
+            ensure_workflow_settings,
+        )
+        self.assertIs(
+            application_exports.load_wizard_settings,
+            load_workflow_settings,
+        )
+        self.assertIs(
+            application_exports.save_last_step_index,
+            save_workflow_step_index,
         )
 
     def test_wizard_wrapper_preserves_legacy_api_and_aliases(self):

--- a/ui/application/wizard_progress.py
+++ b/ui/application/wizard_progress.py
@@ -10,8 +10,11 @@ from .workflow_progress_facts import (
     WorkflowProgressFacts,
     build_workflow_progress_facts_from_runtime_state,
 )
-from .wizard_settings import WizardSettingsSnapshot
+from .workflow_settings import WorkflowSettingsSnapshot
 
+
+WizardSettingsSnapshot = WorkflowSettingsSnapshot
+"""Compatibility alias for wizard progress callers during the #805 migration."""
 
 WizardProgressFacts = WorkflowProgressFacts
 """Compatibility alias for wizard progress callers during the #805 migration."""

--- a/ui/dock_startup_coordinator.py
+++ b/ui/dock_startup_coordinator.py
@@ -42,8 +42,8 @@ class DockStartupCoordinator:
         dock.setAllowedAreas(dock.STARTUP_ALLOWED_AREAS)
         performed_steps.append("set_allowed_areas")
 
-        dock._ensure_wizard_settings()
-        performed_steps.append("ensure_wizard_settings")
+        dock._ensure_workflow_settings()
+        performed_steps.append("ensure_workflow_settings")
 
         configure_local_first_backing_controls(dock)
         performed_steps.append("configure_local_first_backing_controls")


### PR DESCRIPTION
## Summary

- Route dock startup through the canonical workflow settings entry point instead of the production wizard-named method.
- Keep `_ensure_wizard_settings` as a thin compatibility alias for older callers.
- Point the wizard progress compatibility module at the canonical workflow settings snapshot while preserving wizard aliases.

Refs #805

## Testing

- `python3 -m pytest tests/test_workflow_settings.py tests/test_workflow_progress.py tests/test_wizard_progress.py tests/test_dockwidget_dependencies.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

## Rendering proof

- Not rendering-sensitive; this is a startup/settings routing compatibility refactor only.
