### PR TITLE
refactor: expose workflow-backed app aliases

### DIFF
--- a/tests/test_application_progress_exports.py
+++ b/tests/test_application_progress_exports.py
@@ -6,7 +6,7 @@ from tests import _path  # noqa: F401
 
 
 class ApplicationProgressExportTests(unittest.TestCase):
-    def test_package_import_defers_wizard_progress_compatibility_exports(self):
+    def test_package_import_routes_wizard_aliases_through_workflow_exports(self):
         saved_modules = {
             name: module
             for name, module in sys.modules.items()
@@ -24,32 +24,71 @@ class ApplicationProgressExportTests(unittest.TestCase):
         try:
             app = importlib.import_module("qfit.ui.application")
 
-            self.assertNotIn("qfit.ui.application.wizard_progress", sys.modules)
+            for module_name in (
+                "qfit.ui.application.wizard_footer_status",
+                "qfit.ui.application.wizard_page_specs",
+                "qfit.ui.application.wizard_progress",
+                "qfit.ui.application.wizard_settings",
+            ):
+                with self.subTest(module_name=module_name):
+                    self.assertNotIn(module_name, sys.modules)
 
-            from qfit.ui.application import (  # noqa: PLC0415
-                WizardProgressFacts,
-                build_startup_wizard_progress_facts,
-                build_wizard_progress_facts_from_runtime_state,
-                build_wizard_progress_from_facts,
-                build_wizard_progress_from_facts_and_settings,
+            workflow_footer = importlib.import_module(
+                "qfit.ui.application.workflow_footer_status"
+            )
+            workflow_pages = importlib.import_module(
+                "qfit.ui.application.workflow_page_specs"
+            )
+            workflow_settings = importlib.import_module(
+                "qfit.ui.application.workflow_settings"
             )
 
+            self.assertIs(
+                app.DockWizardPageSpec,
+                workflow_pages.DockWorkflowPageSpec,
+            )
+            self.assertIs(
+                app.WizardFooterFacts,
+                workflow_footer.WorkflowFooterFacts,
+            )
+            self.assertIs(
+                app.WizardSettingsSnapshot,
+                workflow_settings.WorkflowSettingsSnapshot,
+            )
+            self.assertIs(
+                app.build_default_wizard_page_specs,
+                workflow_pages.build_default_workflow_page_specs,
+            )
+            self.assertIs(
+                app.build_wizard_footer_facts_from_progress_facts,
+                workflow_footer.build_workflow_footer_facts_from_progress_facts,
+            )
+            self.assertIs(
+                app.build_wizard_footer_status,
+                workflow_footer.build_workflow_footer_status,
+            )
+
+            for module_name in (
+                "qfit.ui.application.wizard_footer_status",
+                "qfit.ui.application.wizard_page_specs",
+                "qfit.ui.application.wizard_settings",
+            ):
+                with self.subTest(module_name=module_name):
+                    self.assertNotIn(module_name, sys.modules)
+
+            progress_export_names = (
+                "WizardProgressFacts",
+                "build_startup_wizard_progress_facts",
+                "build_wizard_progress_facts_from_runtime_state",
+                "build_wizard_progress_from_facts",
+                "build_wizard_progress_from_facts_and_settings",
+            )
+            compat_exports = {
+                name: getattr(app, name) for name in progress_export_names
+            }
             wizard_progress = importlib.import_module(
                 "qfit.ui.application.wizard_progress"
             )
-            compat_exports = {
-                "WizardProgressFacts": WizardProgressFacts,
-                "build_startup_wizard_progress_facts": (
-                    build_startup_wizard_progress_facts
-                ),
-                "build_wizard_progress_facts_from_runtime_state": (
-                    build_wizard_progress_facts_from_runtime_state
-                ),
-                "build_wizard_progress_from_facts": build_wizard_progress_from_facts,
-                "build_wizard_progress_from_facts_and_settings": (
-                    build_wizard_progress_from_facts_and_settings
-                ),
-            }
             for name, value in compat_exports.items():
                 with self.subTest(name=name):
                     self.assertIs(value, getattr(wizard_progress, name))

--- a/tests/test_application_progress_exports.py
+++ b/tests/test_application_progress_exports.py
@@ -71,6 +71,7 @@ class ApplicationProgressExportTests(unittest.TestCase):
             for module_name in (
                 "qfit.ui.application.wizard_footer_status",
                 "qfit.ui.application.wizard_page_specs",
+                "qfit.ui.application.wizard_progress",
                 "qfit.ui.application.wizard_settings",
             ):
                 with self.subTest(module_name=module_name):

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -120,6 +120,12 @@ from .workflow_footer_status import (
     build_workflow_footer_facts_from_progress_facts,
     build_workflow_footer_status,
 )
+
+WizardFooterFacts = WorkflowFooterFacts
+build_wizard_footer_facts_from_progress_facts = (
+    build_workflow_footer_facts_from_progress_facts
+)
+build_wizard_footer_status = build_workflow_footer_status
 from .workflow_progress import (
     build_startup_workflow_progress_facts,
     build_workflow_progress_from_facts,
@@ -164,6 +170,9 @@ from .workflow_page_specs import (
     DockWorkflowPageSpec,
     build_default_workflow_page_specs,
 )
+
+DockWizardPageSpec = DockWorkflowPageSpec
+build_default_wizard_page_specs = build_default_workflow_page_specs
 from .workflow_settings import (
     COLLAPSED_GROUPS_KEY,
     DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,
@@ -242,6 +251,7 @@ __all__ = [
     "DockVisualWorkflowCoordinator",
     "DockVisualWorkflowRequest",
     "DockWizardProgress",
+    "DockWizardPageSpec",
     "DockWorkflowPageSpec",
     "DockWorkflowProgress",
     "DockWorkflowSection",
@@ -286,6 +296,7 @@ __all__ = [
     "VisualWorkflowBackgroundInputs",
     "VisualWorkflowActionInputs",
     "VisualWorkflowSettingsSnapshot",
+    "WizardFooterFacts",
     "WizardProgressFacts",
     "WorkflowFooterFacts",
     "WorkflowProgressFacts",
@@ -323,8 +334,11 @@ __all__ = [
     "build_startup_workflow_progress_facts",
     "current_local_first_last_sync_date",
     "build_wizard_filter_description",
+    "build_wizard_footer_facts_from_progress_facts",
+    "build_wizard_footer_status",
     "build_workflow_footer_facts_from_progress_facts",
     "build_workflow_footer_status",
+    "build_default_wizard_page_specs",
     "build_default_workflow_page_specs",
     "build_workflow_progress_facts_from_runtime_state",
     "build_workflow_progress_from_facts",

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -126,6 +126,7 @@ build_wizard_footer_facts_from_progress_facts = (
     build_workflow_footer_facts_from_progress_facts
 )
 build_wizard_footer_status = build_workflow_footer_status
+
 from .workflow_progress import (
     build_startup_workflow_progress_facts,
     build_workflow_progress_from_facts,
@@ -173,6 +174,7 @@ from .workflow_page_specs import (
 
 DockWizardPageSpec = DockWorkflowPageSpec
 build_default_wizard_page_specs = build_default_workflow_page_specs
+
 from .workflow_settings import (
     COLLAPSED_GROUPS_KEY,
     DEFAULT_COLLAPSED_GROUP_OBJECT_NAMES,


### PR DESCRIPTION
## Summary

- expose wizard-named application package aliases directly from workflow-backed APIs
- keep compatibility modules thin while avoiding application-package import of wizard-named wrapper modules
- extend import/export coverage for the canonical routing and legacy aliases

Refs #805

## Testing

- `python3 -m pytest tests/test_application_progress_exports.py tests/test_workflow_settings.py tests/test_wizard_pages.py tests/test_wizard_footer_status.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
