### PR TITLE
refactor: route app filter alias through local-first API

### DIFF
--- a/tests/test_application_progress_exports.py
+++ b/tests/test_application_progress_exports.py
@@ -25,6 +25,7 @@ class ApplicationProgressExportTests(unittest.TestCase):
             app = importlib.import_module("qfit.ui.application")
 
             for module_name in (
+                "qfit.ui.application.wizard_filter_summary",
                 "qfit.ui.application.wizard_footer_status",
                 "qfit.ui.application.wizard_page_specs",
                 "qfit.ui.application.wizard_progress",
@@ -33,6 +34,9 @@ class ApplicationProgressExportTests(unittest.TestCase):
                 with self.subTest(module_name=module_name):
                     self.assertNotIn(module_name, sys.modules)
 
+            local_first_filter = importlib.import_module(
+                "qfit.ui.application.local_first_filter_summary"
+            )
             workflow_footer = importlib.import_module(
                 "qfit.ui.application.workflow_footer_status"
             )
@@ -60,6 +64,10 @@ class ApplicationProgressExportTests(unittest.TestCase):
                 workflow_pages.build_default_workflow_page_specs,
             )
             self.assertIs(
+                app.build_wizard_filter_description,
+                local_first_filter.build_local_first_filter_description,
+            )
+            self.assertIs(
                 app.build_wizard_footer_facts_from_progress_facts,
                 workflow_footer.build_workflow_footer_facts_from_progress_facts,
             )
@@ -69,6 +77,7 @@ class ApplicationProgressExportTests(unittest.TestCase):
             )
 
             for module_name in (
+                "qfit.ui.application.wizard_filter_summary",
                 "qfit.ui.application.wizard_footer_status",
                 "qfit.ui.application.wizard_page_specs",
                 "qfit.ui.application.wizard_progress",

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -110,6 +110,9 @@ from .local_first_control_visibility import (
     update_local_first_mapbox_custom_style_visibility,
 )
 from .local_first_filter_summary import build_local_first_filter_description
+
+build_wizard_filter_description = build_local_first_filter_description
+
 from .local_first_progress_facts import (
     LocalFirstProgressFacts,
     current_local_first_last_sync_date,
@@ -166,7 +169,6 @@ from .stepper_presenter import (
     step_index_for_key,
     step_key_for_index,
 )
-from .wizard_filter_summary import build_wizard_filter_description
 from .workflow_page_specs import (
     DockWorkflowPageSpec,
     build_default_workflow_page_specs,


### PR DESCRIPTION
## Summary
- route the package-level `build_wizard_filter_description` alias directly through the local-first filter summary builder
- avoid eagerly importing the `wizard_filter_summary` compatibility module from `qfit.ui.application`
- extend application export coverage to assert the alias identity and deferred compat import behavior

Refs #805

## Tests
- `python3 -m pytest tests/test_application_progress_exports.py tests/test_local_first_filter_summary.py tests/test_wizard_filter_summary.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
