### PR TITLE
refactor: move dock page API to workflow module

### DIFF
--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -65,6 +65,7 @@ class WorkflowPageSpecsTests(unittest.TestCase):
 def _load_wizard_modules():
     for name in (
         "qfit.ui.dockwidget.wizard_page",
+        "qfit.ui.dockwidget.workflow_page",
         "qfit.ui.dockwidget.wizard_shell",
         "qfit.ui.dockwidget.stepper_bar",
         "qfit.ui.dockwidget",
@@ -73,6 +74,7 @@ def _load_wizard_modules():
     with patch.dict(sys.modules, _fake_qt_modules()):
         return (
             importlib.import_module("qfit.ui.dockwidget.wizard_page"),
+            importlib.import_module("qfit.ui.dockwidget.workflow_page"),
             importlib.import_module("qfit.ui.dockwidget.wizard_shell"),
         )
 
@@ -80,7 +82,7 @@ def _load_wizard_modules():
 class WizardPageTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.wizard_page, cls.wizard_shell = _load_wizard_modules()
+        cls.wizard_page, cls.workflow_page, cls.wizard_shell = _load_wizard_modules()
 
     def test_page_container_builds_visible_placeholder_chrome(self):
         spec = build_default_workflow_page_specs()[2]
@@ -126,13 +128,25 @@ class WizardPageTest(unittest.TestCase):
     def test_workflow_page_is_canonical_export_with_wizard_alias(self):
         spec = build_default_workflow_page_specs()[2]
 
-        page = self.wizard_page.WorkflowPage(spec)
+        page = self.workflow_page.WorkflowPage(spec)
 
-        self.assertIs(self.wizard_page.WizardPage, self.wizard_page.WorkflowPage)
+        self.assertIs(self.workflow_page.WizardPage, self.workflow_page.WorkflowPage)
         self.assertEqual(page.objectName(), "qfitWizardMapPage")
-        self.assertIsInstance(page, self.wizard_page.WizardPage)
-        self.assertIn("WorkflowPage", self.wizard_page.__all__)
-        self.assertIn("WizardPage", self.wizard_page.__all__)
+        self.assertIsInstance(page, self.workflow_page.WizardPage)
+        self.assertIn("WorkflowPage", self.workflow_page.__all__)
+        self.assertIn("WizardPage", self.workflow_page.__all__)
+
+    def test_wizard_page_module_reexports_workflow_page_api(self):
+        self.assertIs(self.wizard_page.WorkflowPage, self.workflow_page.WorkflowPage)
+        self.assertIs(self.wizard_page.WizardPage, self.workflow_page.WorkflowPage)
+        self.assertIs(
+            self.wizard_page.build_workflow_pages,
+            self.workflow_page.build_workflow_pages,
+        )
+        self.assertIs(
+            self.wizard_page.install_workflow_pages,
+            self.workflow_page.install_workflow_pages,
+        )
 
     def test_workflow_page_builders_keep_wizard_compatibility_aliases(self):
         self.assertIs(

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -47,7 +47,7 @@ from .step_page import (
     apply_workflow_step_page_statuses,
     install_workflow_step_pages,
 )
-from .wizard_page import WorkflowPage, install_workflow_pages
+from .workflow_page import WorkflowPage, install_workflow_pages
 from .wizard_shell import WorkflowShell
 from .workflow_shell_presenter import WorkflowShellPresenter
 from .workflow_page_state import (

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -1,163 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-
-from qfit.ui.application.workflow_page_specs import (
+from .workflow_page import (
     DockWorkflowPageSpec,
+    DockWizardPageSpec,
+    WorkflowPage,
+    WizardPage,
+    build_default_wizard_page_specs,
     build_default_workflow_page_specs,
+    build_wizard_pages,
+    build_workflow_pages,
+    install_wizard_pages,
+    install_workflow_pages,
 )
-from qfit.ui.tokens import COLOR_MUTED, COLOR_TEXT
-
-from ._qt_compat import import_qt_module
-from .page_content_style import configure_fluid_text_label
-
-_qtwidgets = import_qt_module(
-    "qgis.PyQt.QtWidgets",
-    "PyQt5.QtWidgets",
-    (
-        "QLabel",
-        "QVBoxLayout",
-        "QWidget",
-    ),
-)
-
-QLabel = _qtwidgets.QLabel
-QVBoxLayout = _qtwidgets.QVBoxLayout
-QWidget = _qtwidgets.QWidget
-
-_TITLE_LABEL_QSS = (
-    "QLabel { "
-    f"color: {COLOR_TEXT}; "
-    "font-size: 15px; "
-    "font-weight: 700; "
-    "}"
-)
-_SUMMARY_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
-_PRIMARY_HINT_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
-
-
-DockWizardPageSpec = DockWorkflowPageSpec
-"""Compatibility alias for pre-#805 wizard page callers."""
-build_default_wizard_page_specs = build_default_workflow_page_specs
-"""Compatibility alias for pre-#805 wizard page builders."""
-
-
-class WorkflowPage(QWidget):
-    """Reusable visible page container for the workflow shell.
-
-    The container supplies stable chrome for the workflow pages while leaving
-    real page controls to focused slices. It preserves the stable
-    ``qfitWizard*`` object names used by QSS and existing tests.
-    """
-
-    def __init__(self, spec: DockWorkflowPageSpec, parent=None) -> None:
-        super().__init__(parent)
-        self.spec = spec
-        self.setObjectName(spec.page_object_name)
-        self.title_label = self._build_label(
-            spec.title,
-            spec.title_object_name,
-            style=_TITLE_LABEL_QSS,
-        )
-        self.summary_label = self._build_label(
-            spec.summary,
-            spec.summary_object_name,
-            style=_SUMMARY_LABEL_QSS,
-        )
-        self.body_container, self._body_layout = self._build_body_container()
-        self.primary_hint_label = self._build_label(
-            spec.primary_action_hint,
-            spec.primary_hint_object_name,
-            style=_PRIMARY_HINT_LABEL_QSS,
-        )
-        self._layout = self._build_layout()
-
-    def body_layout(self):
-        """Expose the empty content layout for future page-specific controls."""
-
-        return self._body_layout
-
-    def retire_primary_action_hint(self) -> None:
-        """Hide placeholder CTA copy once concrete page actions are installed.
-
-        The first wizard slices used a textual primary-action hint as a safe
-        placeholder. Once a page owns real action buttons, keeping that hint
-        visible competes with the single primary CTA and adds the textual noise
-        called out in #608.
-        """
-
-        self.primary_hint_label.setText("")
-        self.primary_hint_label.setProperty("wizardPlaceholderHint", "retired")
-        self.primary_hint_label.setVisible(False)
-
-    def outer_layout(self):
-        """Expose the page layout for adapter wiring and pure tests."""
-
-        return self._layout
-
-    def _build_label(self, text: str, object_name: str, *, style: str = ""):
-        label = QLabel(text, self)
-        label.setObjectName(object_name)
-        configure_fluid_text_label(label)
-        if style:
-            label.setStyleSheet(style)
-        return label
-
-    def _build_body_container(self):
-        body = QWidget(self)
-        body.setObjectName(self.spec.body_object_name)
-        body_layout = QVBoxLayout(body)
-        body_layout.setContentsMargins(0, 0, 0, 0)
-        body_layout.setSpacing(8)
-        return body, body_layout
-
-    def _build_layout(self):
-        layout = QVBoxLayout(self)
-        if hasattr(layout, "setObjectName"):
-            layout.setObjectName(f"{self.spec.page_object_name}Layout")
-        layout.setContentsMargins(12, 12, 12, 12)
-        layout.setSpacing(8)
-        layout.addWidget(self.title_label)
-        layout.addWidget(self.summary_label)
-        layout.addWidget(self.body_container)
-        layout.addWidget(self.primary_hint_label)
-        return layout
-
-
-WizardPage = WorkflowPage
-"""Compatibility alias for pre-#805 wizard page callers."""
-
-
-def build_workflow_pages(
-    *,
-    parent=None,
-    specs: Sequence[DockWorkflowPageSpec] | None = None,
-) -> tuple[WorkflowPage, ...]:
-    """Build visible workflow page containers from render-neutral specs."""
-
-    page_specs = build_default_workflow_page_specs() if specs is None else tuple(specs)
-    return tuple(WorkflowPage(spec, parent) for spec in page_specs)
-
-
-build_wizard_pages = build_workflow_pages
-"""Compatibility alias for pre-#805 wizard page callers."""
-
-
-def install_workflow_pages(
-    shell,
-    specs: Sequence[DockWorkflowPageSpec] | None = None,
-) -> tuple[WorkflowPage, ...]:
-    """Create default workflow pages and append them to a shell."""
-
-    pages = build_workflow_pages(parent=shell, specs=specs)
-    for page in pages:
-        shell.add_page(page)
-    return pages
-
-
-install_wizard_pages = install_workflow_pages
-"""Compatibility alias for pre-#805 wizard page callers."""
-
 
 __all__ = [
     "DockWorkflowPageSpec",

--- a/ui/dockwidget/workflow_page.py
+++ b/ui/dockwidget/workflow_page.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from qfit.ui.application.workflow_page_specs import (
+    DockWorkflowPageSpec,
+    build_default_workflow_page_specs,
+)
+from qfit.ui.tokens import COLOR_MUTED, COLOR_TEXT
+
+from ._qt_compat import import_qt_module
+from .page_content_style import configure_fluid_text_label
+
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    (
+        "QLabel",
+        "QVBoxLayout",
+        "QWidget",
+    ),
+)
+
+QLabel = _qtwidgets.QLabel
+QVBoxLayout = _qtwidgets.QVBoxLayout
+QWidget = _qtwidgets.QWidget
+
+_TITLE_LABEL_QSS = (
+    "QLabel { "
+    f"color: {COLOR_TEXT}; "
+    "font-size: 15px; "
+    "font-weight: 700; "
+    "}"
+)
+_SUMMARY_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
+_PRIMARY_HINT_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
+
+
+DockWizardPageSpec = DockWorkflowPageSpec
+"""Compatibility alias for pre-#805 wizard page callers."""
+build_default_wizard_page_specs = build_default_workflow_page_specs
+"""Compatibility alias for pre-#805 wizard page builders."""
+
+
+class WorkflowPage(QWidget):
+    """Reusable visible page container for the workflow shell.
+
+    The container supplies stable chrome for the workflow pages while leaving
+    real page controls to focused slices. It preserves the stable
+    ``qfitWizard*`` object names used by QSS and existing tests.
+    """
+
+    def __init__(self, spec: DockWorkflowPageSpec, parent=None) -> None:
+        super().__init__(parent)
+        self.spec = spec
+        self.setObjectName(spec.page_object_name)
+        self.title_label = self._build_label(
+            spec.title,
+            spec.title_object_name,
+            style=_TITLE_LABEL_QSS,
+        )
+        self.summary_label = self._build_label(
+            spec.summary,
+            spec.summary_object_name,
+            style=_SUMMARY_LABEL_QSS,
+        )
+        self.body_container, self._body_layout = self._build_body_container()
+        self.primary_hint_label = self._build_label(
+            spec.primary_action_hint,
+            spec.primary_hint_object_name,
+            style=_PRIMARY_HINT_LABEL_QSS,
+        )
+        self._layout = self._build_layout()
+
+    def body_layout(self):
+        """Expose the empty content layout for future page-specific controls."""
+
+        return self._body_layout
+
+    def retire_primary_action_hint(self) -> None:
+        """Hide placeholder CTA copy once concrete page actions are installed.
+
+        The first wizard slices used a textual primary-action hint as a safe
+        placeholder. Once a page owns real action buttons, keeping that hint
+        visible competes with the single primary CTA and adds the textual noise
+        called out in #608.
+        """
+
+        self.primary_hint_label.setText("")
+        self.primary_hint_label.setProperty("wizardPlaceholderHint", "retired")
+        self.primary_hint_label.setVisible(False)
+
+    def outer_layout(self):
+        """Expose the page layout for adapter wiring and pure tests."""
+
+        return self._layout
+
+    def _build_label(self, text: str, object_name: str, *, style: str = ""):
+        label = QLabel(text, self)
+        label.setObjectName(object_name)
+        configure_fluid_text_label(label)
+        if style:
+            label.setStyleSheet(style)
+        return label
+
+    def _build_body_container(self):
+        body = QWidget(self)
+        body.setObjectName(self.spec.body_object_name)
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+        body_layout.setSpacing(8)
+        return body, body_layout
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        if hasattr(layout, "setObjectName"):
+            layout.setObjectName(f"{self.spec.page_object_name}Layout")
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(8)
+        layout.addWidget(self.title_label)
+        layout.addWidget(self.summary_label)
+        layout.addWidget(self.body_container)
+        layout.addWidget(self.primary_hint_label)
+        return layout
+
+
+WizardPage = WorkflowPage
+"""Compatibility alias for pre-#805 wizard page callers."""
+
+
+def build_workflow_pages(
+    *,
+    parent=None,
+    specs: Sequence[DockWorkflowPageSpec] | None = None,
+) -> tuple[WorkflowPage, ...]:
+    """Build visible workflow page containers from render-neutral specs."""
+
+    page_specs = build_default_workflow_page_specs() if specs is None else tuple(specs)
+    return tuple(WorkflowPage(spec, parent) for spec in page_specs)
+
+
+build_wizard_pages = build_workflow_pages
+"""Compatibility alias for pre-#805 wizard page callers."""
+
+
+def install_workflow_pages(
+    shell,
+    specs: Sequence[DockWorkflowPageSpec] | None = None,
+) -> tuple[WorkflowPage, ...]:
+    """Create default workflow pages and append them to a shell."""
+
+    pages = build_workflow_pages(parent=shell, specs=specs)
+    for page in pages:
+        shell.add_page(page)
+    return pages
+
+
+install_wizard_pages = install_workflow_pages
+"""Compatibility alias for pre-#805 wizard page callers."""
+
+
+__all__ = [
+    "DockWorkflowPageSpec",
+    "DockWizardPageSpec",
+    "WorkflowPage",
+    "WizardPage",
+    "build_default_workflow_page_specs",
+    "build_default_wizard_page_specs",
+    "build_workflow_pages",
+    "build_wizard_pages",
+    "install_workflow_pages",
+    "install_wizard_pages",
+]


### PR DESCRIPTION
## Summary
- move the canonical dock page container/build/install API into `ui.dockwidget.workflow_page`
- reduce `wizard_page` to a compatibility re-export module
- route shell composition internals through the workflow page module and cover the alias identity in tests

Refs #805

## Tests
- `python3 -m pytest tests/test_wizard_pages.py tests/test_wizard_shell_composition.py tests/test_wizard_shell_presenter.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
