### PR TITLE
refactor: move dock host API to workflow module

### DIFF
--- a/tests/test_wizard_dock.py
+++ b/tests/test_wizard_dock.py
@@ -1,56 +1,25 @@
 import importlib
 import sys
 import unittest
-from types import SimpleNamespace
 from unittest.mock import patch
 
 from tests import _path  # noqa: F401
-from tests.test_wizard_shell import _FakeWidget, _fake_qt_modules
-
-
-class _FakeDockWidget(_FakeWidget):
-    DockWidgetClosable = 1
-    DockWidgetMovable = 2
-    DockWidgetFloatable = 4
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self._widget = None
-        self._features = None
-        self._allowed_areas = None
-        self._window_title = ""
-
-    def setWidget(self, widget):  # noqa: N802
-        self._widget = widget
-
-    def widget(self):
-        return self._widget
-
-    def setFeatures(self, features):  # noqa: N802
-        self._features = features
-
-    def features(self):
-        return self._features
-
-    def setAllowedAreas(self, allowed_areas):  # noqa: N802
-        self._allowed_areas = allowed_areas
-
-    def allowedAreas(self):  # noqa: N802
-        return self._allowed_areas
-
-    def setWindowTitle(self, title):  # noqa: N802
-        self._window_title = title
-
-    def windowTitle(self):  # noqa: N802
-        return self._window_title
+from tests.test_wizard_shell import _fake_qt_modules
+from tests.test_workflow_dock import _FakeDockWidget
 
 
 def _load_wizard_dock_module():
     for name in (
         "qfit.ui.dockwidget.wizard_dock",
+        "qfit.ui.dockwidget.workflow_dock",
         "qfit.ui.dockwidget._qt_compat",
     ):
         sys.modules.pop(name, None)
+    package = sys.modules.get("qfit.ui.dockwidget")
+    if package is not None:
+        for attribute in ("wizard_dock", "workflow_dock"):
+            if hasattr(package, attribute):
+                delattr(package, attribute)
     modules = _fake_qt_modules()
     modules["qgis.PyQt.QtCore"].Qt.LeftDockWidgetArea = 8
     modules["qgis.PyQt.QtCore"].Qt.RightDockWidgetArea = 16
@@ -64,7 +33,17 @@ class WizardDockWidgetTest(unittest.TestCase):
     def setUpClass(cls):
         cls.wizard_dock = _load_wizard_dock_module()
 
-    def test_workflow_dock_is_canonical_export_with_wizard_aliases(self):
+    def test_wizard_module_reexports_workflow_dock_api(self):
+        self.assertEqual(
+            self.wizard_dock.WorkflowDockWidget.__module__,
+            "qfit.ui.dockwidget.workflow_dock",
+        )
+        self.assertEqual(
+            self.wizard_dock.build_workflow_dock_widget.__module__,
+            "qfit.ui.dockwidget.workflow_dock",
+        )
+
+    def test_wizard_names_remain_stable_compatibility_aliases(self):
         self.assertIs(self.wizard_dock.WizardDockWidget, self.wizard_dock.WorkflowDockWidget)
         self.assertIs(
             self.wizard_dock.WizardShellCompositionLike,
@@ -78,45 +57,6 @@ class WizardDockWidgetTest(unittest.TestCase):
             self.wizard_dock.WIZARD_DOCK_OBJECT_NAME,
             self.wizard_dock.WORKFLOW_DOCK_OBJECT_NAME,
         )
-
-    def test_builds_qgis_dock_container_for_wizard_shell_composition(self):
-        shell = _FakeWidget()
-        parent = _FakeWidget()
-        composition = SimpleNamespace(shell=shell)
-
-        dock = self.wizard_dock.build_workflow_dock_widget(
-            composition,
-            parent=parent,
-            title="qfit workflow",
-        )
-
-        self.assertEqual(dock.objectName(), "qfitWizardDockWidget")
-        self.assertEqual(dock.windowTitle(), "qfit workflow")
-        self.assertIs(dock.parent, parent)
-        self.assertIs(dock.composition, composition)
-        self.assertIs(dock.widget(), shell)
-        self.assertEqual(
-            dock.features(),
-            _FakeDockWidget.DockWidgetClosable
-            | _FakeDockWidget.DockWidgetMovable
-            | _FakeDockWidget.DockWidgetFloatable,
-        )
-        self.assertEqual(dock.allowedAreas(), 8 | 16)
-        self.assertIsInstance(dock, self.wizard_dock.WizardDockWidget)
-
-    def test_can_replace_hosted_wizard_composition_without_recreating_dock(self):
-        first = SimpleNamespace(shell=_FakeWidget())
-        second = SimpleNamespace(shell=_FakeWidget())
-        dock = self.wizard_dock.WizardDockWidget(first)
-
-        dock.set_composition(second)
-
-        self.assertIs(dock.composition, second)
-        self.assertIs(dock.widget(), second.shell)
-
-    def test_rejects_compositions_without_shell_widget(self):
-        with self.assertRaisesRegex(ValueError, "must expose a shell"):
-            self.wizard_dock.WizardDockWidget(SimpleNamespace(shell=None))
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_dock.py
+++ b/tests/test_workflow_dock.py
@@ -1,0 +1,135 @@
+import importlib
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from tests.test_wizard_shell import _FakeWidget, _fake_qt_modules
+
+
+class _FakeDockWidget(_FakeWidget):
+    DockWidgetClosable = 1
+    DockWidgetMovable = 2
+    DockWidgetFloatable = 4
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._widget = None
+        self._features = None
+        self._allowed_areas = None
+        self._window_title = ""
+
+    def setWidget(self, widget):  # noqa: N802
+        self._widget = widget
+
+    def widget(self):
+        return self._widget
+
+    def setFeatures(self, features):  # noqa: N802
+        self._features = features
+
+    def features(self):
+        return self._features
+
+    def setAllowedAreas(self, allowed_areas):  # noqa: N802
+        self._allowed_areas = allowed_areas
+
+    def allowedAreas(self):  # noqa: N802
+        return self._allowed_areas
+
+    def setWindowTitle(self, title):  # noqa: N802
+        self._window_title = title
+
+    def windowTitle(self):  # noqa: N802
+        return self._window_title
+
+
+def _load_workflow_dock_module():
+    for name in (
+        "qfit.ui.dockwidget.workflow_dock",
+        "qfit.ui.dockwidget._qt_compat",
+    ):
+        sys.modules.pop(name, None)
+    package = sys.modules.get("qfit.ui.dockwidget")
+    if package is not None and hasattr(package, "workflow_dock"):
+        delattr(package, "workflow_dock")
+    modules = _fake_qt_modules()
+    modules["qgis.PyQt.QtCore"].Qt.LeftDockWidgetArea = 8
+    modules["qgis.PyQt.QtCore"].Qt.RightDockWidgetArea = 16
+    modules["qgis.PyQt.QtWidgets"].QDockWidget = _FakeDockWidget
+    with patch.dict(sys.modules, modules):
+        return importlib.import_module("qfit.ui.dockwidget.workflow_dock")
+
+
+class WorkflowDockWidgetTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow_dock = _load_workflow_dock_module()
+
+    def test_workflow_dock_keeps_stable_qfit_wizard_object_name(self):
+        self.assertEqual(
+            self.workflow_dock.WORKFLOW_DOCK_OBJECT_NAME,
+            "qfitWizardDockWidget",
+        )
+        self.assertEqual(
+            self.workflow_dock.WIZARD_DOCK_OBJECT_NAME,
+            self.workflow_dock.WORKFLOW_DOCK_OBJECT_NAME,
+        )
+
+    def test_builds_qgis_dock_container_for_workflow_shell_composition(self):
+        shell = _FakeWidget()
+        parent = _FakeWidget()
+        composition = SimpleNamespace(shell=shell)
+
+        dock = self.workflow_dock.build_workflow_dock_widget(
+            composition,
+            parent=parent,
+            title="qfit workflow",
+        )
+
+        self.assertEqual(dock.objectName(), "qfitWizardDockWidget")
+        self.assertEqual(dock.windowTitle(), "qfit workflow")
+        self.assertIs(dock.parent, parent)
+        self.assertIs(dock.composition, composition)
+        self.assertIs(dock.widget(), shell)
+        self.assertEqual(
+            dock.features(),
+            _FakeDockWidget.DockWidgetClosable
+            | _FakeDockWidget.DockWidgetMovable
+            | _FakeDockWidget.DockWidgetFloatable,
+        )
+        self.assertEqual(dock.allowedAreas(), 8 | 16)
+        self.assertIsInstance(dock, self.workflow_dock.WorkflowDockWidget)
+
+    def test_can_replace_hosted_workflow_composition_without_recreating_dock(self):
+        first = SimpleNamespace(shell=_FakeWidget())
+        second = SimpleNamespace(shell=_FakeWidget())
+        dock = self.workflow_dock.WorkflowDockWidget(first)
+
+        dock.set_composition(second)
+
+        self.assertIs(dock.composition, second)
+        self.assertIs(dock.widget(), second.shell)
+
+    def test_rejects_compositions_without_shell_widget(self):
+        with self.assertRaisesRegex(ValueError, "must expose a shell"):
+            self.workflow_dock.WorkflowDockWidget(SimpleNamespace(shell=None))
+
+    def test_wizard_names_are_compatibility_aliases(self):
+        self.assertIs(
+            self.workflow_dock.WizardDockWidget,
+            self.workflow_dock.WorkflowDockWidget,
+        )
+        self.assertIs(
+            self.workflow_dock.WizardShellCompositionLike,
+            self.workflow_dock.WorkflowShellCompositionLike,
+        )
+        self.assertIs(
+            self.workflow_dock.build_wizard_dock_widget,
+            self.workflow_dock.build_workflow_dock_widget,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/dockwidget/wizard_dock.py
+++ b/ui/dockwidget/wizard_dock.py
@@ -1,105 +1,21 @@
 from __future__ import annotations
 
-from typing import Protocol
-
-from ._qt_compat import import_qt_module
-
-_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt",))
-_qtwidgets = import_qt_module(
-    "qgis.PyQt.QtWidgets",
-    "PyQt5.QtWidgets",
-    ("QDockWidget", "QWidget"),
+from .workflow_dock import (
+    WORKFLOW_DOCK_ALLOWED_AREAS,
+    WORKFLOW_DOCK_FEATURES,
+    WORKFLOW_DOCK_OBJECT_NAME,
+    WORKFLOW_DOCK_TITLE,
+    WIZARD_DOCK_ALLOWED_AREAS,
+    WIZARD_DOCK_FEATURES,
+    WIZARD_DOCK_OBJECT_NAME,
+    WIZARD_DOCK_TITLE,
+    WorkflowDockWidget,
+    WorkflowShellCompositionLike,
+    WizardDockWidget,
+    WizardShellCompositionLike,
+    build_wizard_dock_widget,
+    build_workflow_dock_widget,
 )
-
-Qt = _qtcore.Qt
-QDockWidget = _qtwidgets.QDockWidget
-QWidget = _qtwidgets.QWidget
-
-WORKFLOW_DOCK_OBJECT_NAME = "qfitWizardDockWidget"
-WORKFLOW_DOCK_TITLE = "qfit"
-WORKFLOW_DOCK_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
-WORKFLOW_DOCK_FEATURES = (
-    QDockWidget.DockWidgetClosable
-    | QDockWidget.DockWidgetMovable
-    | QDockWidget.DockWidgetFloatable
-)
-
-WIZARD_DOCK_OBJECT_NAME = WORKFLOW_DOCK_OBJECT_NAME
-"""Compatibility alias for pre-#805 wizard dock callers."""
-WIZARD_DOCK_TITLE = WORKFLOW_DOCK_TITLE
-"""Compatibility alias for pre-#805 wizard dock callers."""
-WIZARD_DOCK_ALLOWED_AREAS = WORKFLOW_DOCK_ALLOWED_AREAS
-"""Compatibility alias for pre-#805 wizard dock callers."""
-WIZARD_DOCK_FEATURES = WORKFLOW_DOCK_FEATURES
-"""Compatibility alias for pre-#805 wizard dock callers."""
-
-
-class WorkflowShellCompositionLike(Protocol):
-    """Small structural protocol for dock-hostable workflow compositions."""
-
-    shell: QWidget
-
-
-WizardShellCompositionLike = WorkflowShellCompositionLike
-"""Compatibility alias for pre-#805 wizard dock callers."""
-
-
-class WorkflowDockWidget(QDockWidget):
-    """QDockWidget host for the local-first workflow shell composition.
-
-    The visible dock is converging on the local-first workflow surface while
-    preserving stable Qt object names and thin wizard-named import aliases for
-    older callers during #805.
-    """
-
-    def __init__(
-        self,
-        composition: WorkflowShellCompositionLike,
-        *,
-        parent=None,
-        title: str = WORKFLOW_DOCK_TITLE,
-    ) -> None:
-        super().__init__(parent)
-        self.composition: WorkflowShellCompositionLike | None = None
-        self.setObjectName(WORKFLOW_DOCK_OBJECT_NAME)
-        self.setWindowTitle(title)
-        self.setFeatures(WORKFLOW_DOCK_FEATURES)
-        self.setAllowedAreas(WORKFLOW_DOCK_ALLOWED_AREAS)
-        self.set_composition(composition)
-
-    def set_composition(self, composition: WorkflowShellCompositionLike) -> None:
-        """Install or replace the hosted workflow composition shell."""
-
-        shell = _composition_shell(composition)
-        self.setWidget(shell)
-        self.composition = composition
-
-
-WizardDockWidget = WorkflowDockWidget
-"""Compatibility alias for pre-#805 wizard dock callers."""
-
-
-def build_workflow_dock_widget(
-    composition: WorkflowShellCompositionLike,
-    *,
-    parent=None,
-    title: str = WORKFLOW_DOCK_TITLE,
-) -> WorkflowDockWidget:
-    """Build the dock-level container for a reusable workflow composition."""
-
-    return WorkflowDockWidget(composition, parent=parent, title=title)
-
-
-build_wizard_dock_widget = build_workflow_dock_widget
-"""Compatibility alias for pre-#805 wizard dock callers."""
-
-
-def _composition_shell(composition: WorkflowShellCompositionLike):
-    shell = getattr(composition, "shell", None)
-    if shell is None:
-        raise ValueError("Workflow dock compositions must expose a shell widget")
-    return shell
-
 
 __all__ = [
     "WORKFLOW_DOCK_ALLOWED_AREAS",

--- a/ui/dockwidget/workflow_dock.py
+++ b/ui/dockwidget/workflow_dock.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from ._qt_compat import import_qt_module
+
+_qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt",))
+_qtwidgets = import_qt_module(
+    "qgis.PyQt.QtWidgets",
+    "PyQt5.QtWidgets",
+    ("QDockWidget", "QWidget"),
+)
+
+Qt = _qtcore.Qt
+QDockWidget = _qtwidgets.QDockWidget
+QWidget = _qtwidgets.QWidget
+
+WORKFLOW_DOCK_OBJECT_NAME = "qfitWizardDockWidget"
+WORKFLOW_DOCK_TITLE = "qfit"
+WORKFLOW_DOCK_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
+WORKFLOW_DOCK_FEATURES = (
+    QDockWidget.DockWidgetClosable
+    | QDockWidget.DockWidgetMovable
+    | QDockWidget.DockWidgetFloatable
+)
+
+WIZARD_DOCK_OBJECT_NAME = WORKFLOW_DOCK_OBJECT_NAME
+"""Compatibility alias for pre-#805 wizard dock callers."""
+WIZARD_DOCK_TITLE = WORKFLOW_DOCK_TITLE
+"""Compatibility alias for pre-#805 wizard dock callers."""
+WIZARD_DOCK_ALLOWED_AREAS = WORKFLOW_DOCK_ALLOWED_AREAS
+"""Compatibility alias for pre-#805 wizard dock callers."""
+WIZARD_DOCK_FEATURES = WORKFLOW_DOCK_FEATURES
+"""Compatibility alias for pre-#805 wizard dock callers."""
+
+
+class WorkflowShellCompositionLike(Protocol):
+    """Small structural protocol for dock-hostable workflow compositions."""
+
+    shell: QWidget
+
+
+WizardShellCompositionLike = WorkflowShellCompositionLike
+"""Compatibility alias for pre-#805 wizard dock callers."""
+
+
+class WorkflowDockWidget(QDockWidget):
+    """QDockWidget host for the local-first workflow shell composition.
+
+    The visible dock is converging on the local-first workflow surface while
+    preserving stable Qt object names and thin wizard-named import aliases for
+    older callers during #805.
+    """
+
+    def __init__(
+        self,
+        composition: WorkflowShellCompositionLike,
+        *,
+        parent=None,
+        title: str = WORKFLOW_DOCK_TITLE,
+    ) -> None:
+        super().__init__(parent)
+        self.composition: WorkflowShellCompositionLike | None = None
+        self.setObjectName(WORKFLOW_DOCK_OBJECT_NAME)
+        self.setWindowTitle(title)
+        self.setFeatures(WORKFLOW_DOCK_FEATURES)
+        self.setAllowedAreas(WORKFLOW_DOCK_ALLOWED_AREAS)
+        self.set_composition(composition)
+
+    def set_composition(self, composition: WorkflowShellCompositionLike) -> None:
+        """Install or replace the hosted workflow composition shell."""
+
+        shell = _composition_shell(composition)
+        self.setWidget(shell)
+        self.composition = composition
+
+
+WizardDockWidget = WorkflowDockWidget
+"""Compatibility alias for pre-#805 wizard dock callers."""
+
+
+def build_workflow_dock_widget(
+    composition: WorkflowShellCompositionLike,
+    *,
+    parent=None,
+    title: str = WORKFLOW_DOCK_TITLE,
+) -> WorkflowDockWidget:
+    """Build the dock-level container for a reusable workflow composition."""
+
+    return WorkflowDockWidget(composition, parent=parent, title=title)
+
+
+build_wizard_dock_widget = build_workflow_dock_widget
+"""Compatibility alias for pre-#805 wizard dock callers."""
+
+
+def _composition_shell(composition: WorkflowShellCompositionLike):
+    shell = getattr(composition, "shell", None)
+    if shell is None:
+        raise ValueError("Workflow dock compositions must expose a shell widget")
+    return shell
+
+
+__all__ = [
+    "WORKFLOW_DOCK_ALLOWED_AREAS",
+    "WORKFLOW_DOCK_FEATURES",
+    "WORKFLOW_DOCK_OBJECT_NAME",
+    "WORKFLOW_DOCK_TITLE",
+    "WorkflowDockWidget",
+    "WorkflowShellCompositionLike",
+    "WIZARD_DOCK_ALLOWED_AREAS",
+    "WIZARD_DOCK_FEATURES",
+    "WIZARD_DOCK_OBJECT_NAME",
+    "WIZARD_DOCK_TITLE",
+    "WizardDockWidget",
+    "WizardShellCompositionLike",
+    "build_workflow_dock_widget",
+    "build_wizard_dock_widget",
+]


### PR DESCRIPTION
## Summary

Move the dock host API into a canonical `workflow_dock` module while keeping the wizard-named module as a thin compatibility wrapper.

## Changes

- Add `ui/dockwidget/workflow_dock.py` as the source of truth for `WorkflowDockWidget` and dock builder exports.
- Reduce `ui/dockwidget/wizard_dock.py` to re-export the workflow dock API and existing wizard compatibility aliases.
- Add workflow-dock tests and keep wizard-wrapper tests focused on compatibility and stable `qfitWizard*` object naming.

## Testing

- `python3 -m pytest tests/test_workflow_dock.py tests/test_wizard_dock.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #805
