### PR TITLE
refactor: add workflow action metadata aliases

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -63,12 +63,14 @@ class StepPageTest(unittest.TestCase):
         self.assertEqual(page.content_container.objectName(), "qfitWizardStepContent")
         self.assertEqual(page.content_layout().contents_margins, (0, 0, 0, 0))
         self.assertEqual(page.back_button.text(), "Précédent")
+        self.assertEqual(page.back_button.property("workflowActionRole"), "back")
         self.assertEqual(page.back_button.property("wizardActionRole"), "back")
         self.assertEqual(
             page.back_button.cursor().shape(),
             self.step_page.Qt.PointingHandCursor,
         )
         self.assertEqual(page.next_button.text(), "Suivant →")
+        self.assertEqual(page.next_button.property("workflowActionRole"), "primary")
         self.assertEqual(page.next_button.property("wizardActionRole"), "primary")
         self.assertEqual(
             page.next_button.cursor().shape(),
@@ -116,9 +118,11 @@ class StepPageTest(unittest.TestCase):
         self.assertEqual(page.next_button.text(), "Lancer l'analyse")
         self.assertFalse(page.next_button.isEnabled())
         self.assertFalse(page.next_button.isVisible())
+        self.assertEqual(page.next_button.property("workflowActionRole"), "secondary")
         self.assertEqual(page.next_button.property("wizardActionRole"), "secondary")
         self.assertEqual(page.back_button.text(), "Retour")
         self.assertFalse(page.back_button.isEnabled())
+        self.assertEqual(page.back_button.property("workflowActionRole"), "back")
 
     def test_content_and_extra_buttons_are_extensible_for_concrete_pages(self):
         page = self.step_page.StepPage(5, 5, "Atlas PDF", "Configure l'export.")
@@ -128,6 +132,7 @@ class StepPageTest(unittest.TestCase):
         page.add_extra_button(extra_button)
         page.content_layout().addWidget(content_widget)
 
+        self.assertEqual(extra_button.property("workflowActionRole"), "extra")
         self.assertEqual(extra_button.property("wizardActionRole"), "extra")
         self.assertEqual(extra_button.minimumWidth(), 0)
         self.assertIn(extra_button, page._extra_right_layout.widgets)

--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -12,6 +12,7 @@ from qfit.ui.application.workflow_page_specs import build_default_workflow_page_
 
 def _load_step_page_module():
     for name in (
+        "qfit.ui.dockwidget.action_row",
         "qfit.ui.dockwidget.step_page",
         "qfit.ui.dockwidget.wizard_shell",
         "qfit.ui.dockwidget.stepper_bar",

--- a/tests/test_wizard_action_row.py
+++ b/tests/test_wizard_action_row.py
@@ -52,6 +52,10 @@ class WizardActionRowTest(unittest.TestCase):
             self.action_row.set_wizard_action_availability,
             self.action_row.set_workflow_action_availability,
         )
+        self.assertIs(
+            self.action_row.set_wizard_action_role,
+            self.action_row.set_workflow_action_role,
+        )
         self.assertIsInstance(row, self.action_row.WorkflowActionRow)
         self.assertEqual(row.objectName(), "qfitWizardActionRow")
 
@@ -108,6 +112,7 @@ class WizardActionRowTest(unittest.TestCase):
 
         self.assertIs(returned, button)
         self.assertEqual(button.property("primaryAction"), "sync_activities")
+        self.assertEqual(button.property("workflowActionRole"), "primary")
         self.assertEqual(button.property("wizardActionRole"), "primary")
         self.assertIn("font-weight: 700", button.styleSheet())
         self.assertIn("QToolButton:disabled", button.styleSheet())
@@ -123,6 +128,7 @@ class WizardActionRowTest(unittest.TestCase):
 
         self.assertIs(returned, button)
         self.assertEqual(button.property("secondaryAction"), "load_activity_layers")
+        self.assertEqual(button.property("workflowActionRole"), "secondary")
         self.assertEqual(button.property("wizardActionRole"), "secondary")
         self.assertEqual(button.styleSheet(), "")
         self.assertIsNotNone(button.cursor().shape())
@@ -137,6 +143,7 @@ class WizardActionRowTest(unittest.TestCase):
 
         self.assertIs(returned, button)
         self.assertEqual(button.property("destructiveAction"), "clear_database")
+        self.assertEqual(button.property("workflowActionRole"), "destructive")
         self.assertEqual(button.property("wizardActionRole"), "destructive")
         self.assertIn("#c01c28", button.styleSheet())
         self.assertNotIn("#589632", button.styleSheet())
@@ -157,12 +164,14 @@ class WizardActionRowTest(unittest.TestCase):
 
         self.assertIs(returned, button)
         self.assertFalse(button.isEnabled())
+        self.assertEqual(button.property("workflowActionAvailability"), "blocked")
         self.assertEqual(button.property("wizardActionAvailability"), "blocked")
         self.assertEqual(button.toolTip(), "Load activity layers first.")
 
         self.action_row.set_wizard_action_availability(button, enabled=True)
 
         self.assertTrue(button.isEnabled())
+        self.assertEqual(button.property("workflowActionAvailability"), "available")
         self.assertEqual(button.property("wizardActionAvailability"), "available")
         self.assertEqual(button.toolTip(), "")
 

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -29,6 +29,10 @@ QWidget = _qtwidgets.QWidget
 
 ACTION_ROW_NARROW_WIDTH = 360
 COLOR_DANGER_BG = pill_tone_palette("danger")[0]
+WORKFLOW_ACTION_ROLE_PROPERTY = "workflowActionRole"
+WIZARD_ACTION_ROLE_PROPERTY = "wizardActionRole"
+WORKFLOW_ACTION_AVAILABILITY_PROPERTY = "workflowActionAvailability"
+WIZARD_ACTION_AVAILABILITY_PROPERTY = "wizardActionAvailability"
 
 
 class WorkflowActionRow(QWidget):
@@ -110,7 +114,7 @@ def style_primary_action_button(
     """Mark a workflow button as the one primary CTA for its page."""
 
     button.setProperty("primaryAction", action_name)
-    button.setProperty("wizardActionRole", "primary")
+    set_workflow_action_role(button, role="primary")
     _apply_button_chrome(button, role="primary")
     return button
 
@@ -123,7 +127,7 @@ def style_secondary_action_button(
     """Mark a workflow button as a secondary page action."""
 
     button.setProperty("secondaryAction", action_name)
-    button.setProperty("wizardActionRole", "secondary")
+    set_workflow_action_role(button, role="secondary")
     _apply_button_chrome(button, role="secondary")
     return button
 
@@ -136,8 +140,22 @@ def style_destructive_action_button(
     """Mark a workflow button as a destructive page action."""
 
     button.setProperty("destructiveAction", action_name)
-    button.setProperty("wizardActionRole", "destructive")
+    set_workflow_action_role(button, role="destructive")
     _apply_button_chrome(button, role="destructive")
+    return button
+
+
+def set_workflow_action_role(
+    button: QToolButton,
+    *,
+    role: str,
+) -> QToolButton:
+    """Tag a workflow action with canonical metadata plus legacy aliases."""
+
+    button.setProperty(WORKFLOW_ACTION_ROLE_PROPERTY, role)
+    # Keep the old dynamic property until the QSS/tests that still target the
+    # pre-#805 wizard naming are fully retired.
+    button.setProperty(WIZARD_ACTION_ROLE_PROPERTY, role)
     return button
 
 
@@ -155,13 +173,16 @@ def set_workflow_action_availability(
 
     button.setEnabled(enabled)
     action_availability = "available" if enabled else "blocked"
-    button.setProperty("wizardActionAvailability", action_availability)
+    button.setProperty(WORKFLOW_ACTION_AVAILABILITY_PROPERTY, action_availability)
+    # Compatibility alias for remaining wizard-named selectors during #805.
+    button.setProperty(WIZARD_ACTION_AVAILABILITY_PROPERTY, action_availability)
     button.setToolTip("" if enabled else tooltip)
     return button
 
 
 WizardActionRow = WorkflowActionRow
 build_wizard_action_row = build_workflow_action_row
+set_wizard_action_role = set_workflow_action_role
 set_wizard_action_availability = set_workflow_action_availability
 
 
@@ -224,7 +245,9 @@ __all__ = [
     "build_workflow_action_row",
     "build_wizard_action_row",
     "set_workflow_action_availability",
+    "set_workflow_action_role",
     "set_wizard_action_availability",
+    "set_wizard_action_role",
     "style_destructive_action_button",
     "style_primary_action_button",
     "style_secondary_action_button",

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -10,6 +10,7 @@ from qfit.ui.application.workflow_page_specs import (
     DockWorkflowPageSpec,
     build_default_workflow_page_specs,
 )
+from .action_row import set_workflow_action_role
 from ._qt_compat import import_qt_module
 from qfit.ui.widgets.pill import set_pill_tone
 from qfit.ui.widgets.tokens import (
@@ -125,7 +126,10 @@ class StepPage(QWidget):
         self._apply_navigation_button_texts()
         self.next_button.setEnabled(enabled)
         self.next_button.setVisible(visible)
-        self.next_button.setProperty("wizardActionRole", "primary" if primary else "secondary")
+        set_workflow_action_role(
+            self.next_button,
+            role="primary" if primary else "secondary",
+        )
         self.next_button.setStyleSheet(
             _primary_button_stylesheet() if primary else _ghost_button_stylesheet()
         )
@@ -136,7 +140,7 @@ class StepPage(QWidget):
         self._back_label = label
         self._apply_navigation_button_texts()
         self.back_button.setEnabled(enabled)
-        self.back_button.setProperty("wizardActionRole", "back")
+        set_workflow_action_role(self.back_button, role="back")
         self.back_button.setStyleSheet(_ghost_button_stylesheet())
 
     def _apply_navigation_button_texts(self) -> None:
@@ -154,7 +158,7 @@ class StepPage(QWidget):
     def add_extra_button(self, btn, align: str = "right") -> None:
         """Add a page-specific secondary button to the navigation row."""
 
-        btn.setProperty("wizardActionRole", "extra")
+        set_workflow_action_role(btn, role="extra")
         _configure_responsive_button(btn)
         if align == "left":
             self._extra_left_layout.addWidget(btn)


### PR DESCRIPTION
## Summary
- add canonical `workflowActionRole` / `workflowActionAvailability` dynamic properties for dock workflow buttons
- keep the existing wizard-named properties as compatibility aliases while #805 retires the old naming
- route step-page navigation/extra button metadata through the shared workflow helper

## Tests
- `python3 -m pytest tests/test_wizard_action_row.py tests/test_step_page.py tests/test_connection_page.py tests/test_sync_page.py tests/test_map_page.py tests/test_analysis_page.py tests/test_atlas_page.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
