### PR TITLE
refactor: add workflow stepper state alias

### DIFF
--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -306,6 +306,7 @@ class StepperBarTest(unittest.TestCase):
         buttons = bar.step_buttons()
         self.assertEqual(bar.states(), ("done", "current", "upcoming", "locked", "upcoming"))
         self.assertTrue(buttons[0].text().startswith("✓"))
+        self.assertEqual(buttons[1].property("workflowState"), "current")
         self.assertEqual(buttons[1].property("wizardState"), "current")
         self.assertTrue(buttons[2].isEnabled())
         self.assertEqual(buttons[2].toolTip(), "Map & filters")
@@ -315,6 +316,14 @@ class StepperBarTest(unittest.TestCase):
             "Complete Map & filters before opening Spatial analysis (optional).",
         )
         self.assertEqual(buttons[3].cursor().shape(), _FakeQt.ForbiddenCursor)
+        self.assertEqual(
+            [connector.property("workflowState") for connector in bar._connectors],
+            ["done", "upcoming", "upcoming", "upcoming"],
+        )
+        self.assertEqual(
+            [connector.property("wizardState") for connector in bar._connectors],
+            ["done", "upcoming", "upcoming", "upcoming"],
+        )
 
     def test_set_current_marks_other_steps_upcoming(self):
         bar = self.stepper.StepperBar()

--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -263,6 +263,18 @@ class StepperBarTest(unittest.TestCase):
             ),
         )
 
+    def test_workflow_state_properties_are_public_exports(self):
+        self.assertIn("WORKFLOW_STEPPER_STATE_PROPERTY", self.stepper.__all__)
+        self.assertIn("WIZARD_STEPPER_STATE_PROPERTY", self.stepper.__all__)
+        self.assertEqual(
+            self.stepper.WORKFLOW_STEPPER_STATE_PROPERTY,
+            "workflowState",
+        )
+        self.assertEqual(
+            self.stepper.WIZARD_STEPPER_STATE_PROPERTY,
+            "wizardState",
+        )
+
     def test_qt_import_guard_requires_all_widget_classes(self):
         incomplete_qtwidgets = types.ModuleType("qgis.PyQt.QtWidgets")
         incomplete_qtwidgets.QWidget = object

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -44,6 +44,8 @@ QWidget = _qtwidgets.QWidget
 STEPPER_COMPACT_WIDTH = 520
 STEPPER_WIDE_HEIGHT = 36
 STEPPER_COMPACT_HEIGHT = 32
+WORKFLOW_STEPPER_STATE_PROPERTY = "workflowState"
+WIZARD_STEPPER_STATE_PROPERTY = "wizardState"
 
 
 class StepperBar(QWidget):
@@ -151,7 +153,7 @@ class StepperBar(QWidget):
     def _configure_button(self, button: QToolButton, index: int, state: str) -> None:
         button.setText(_button_text(index, state, compact=self._compact))
         button.setProperty("stepIndex", index)
-        button.setProperty("wizardState", state)
+        _set_workflow_step_state(button, state)
         button.setProperty("responsiveMode", "compact" if self._compact else "wide")
         button.setEnabled(state != "locked")
         button.setCursor(
@@ -164,8 +166,9 @@ class StepperBar(QWidget):
         for index, connector in enumerate(self._connectors):
             previous_step_is_done = self._states[index] == "done"
             color = COLOR_ACCENT if previous_step_is_done else COLOR_SEPARATOR
-            connector.setProperty(
-                "wizardState", "done" if previous_step_is_done else "upcoming"
+            _set_workflow_step_state(
+                connector,
+                "done" if previous_step_is_done else "upcoming",
             )
             connector.setStyleSheet(
                 f"QFrame#{connector.objectName()} {{ border: 0; background: {color}; }}"
@@ -185,6 +188,14 @@ def _validate_states(states: Sequence[str]) -> tuple[str, ...]:
         known = ", ".join(sorted(STEPPER_STATES))
         raise ValueError(f"Unknown stepper state(s): {', '.join(invalid_states)}; expected one of: {known}")
     return values
+
+
+def _set_workflow_step_state(widget, state: str) -> None:
+    """Tag workflow step chrome with canonical state plus legacy alias."""
+
+    widget.setProperty(WORKFLOW_STEPPER_STATE_PROPERTY, state)
+    # Preserve the wizard-named selector while #805 retires older shell naming.
+    widget.setProperty(WIZARD_STEPPER_STATE_PROPERTY, state)
 
 
 def _button_text(index: int, state: str, *, compact: bool = False) -> str:

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -252,4 +252,11 @@ def _button_stylesheet(state: str, *, compact: bool = False) -> str:
         f"QToolButton:hover:enabled {{ background: {COLOR_HOVER}; color: {COLOR_TEXT}; }}"    )
 
 
-__all__ = ["STEPPER_LABELS", "STEPPER_STATES", "StepperBar", "import_qt_module"]
+__all__ = [
+    "STEPPER_LABELS",
+    "STEPPER_STATES",
+    "StepperBar",
+    "WIZARD_STEPPER_STATE_PROPERTY",
+    "WORKFLOW_STEPPER_STATE_PROPERTY",
+    "import_qt_module",
+]


### PR DESCRIPTION
## Summary
- add canonical `workflowState` metadata for workflow stepper buttons/connectors
- keep `wizardState` as a compatibility alias while #805 retires older shell naming
- centralize stepper state property writes behind one helper

## Tests
- `python3 -m pytest tests/test_stepper_bar.py tests/test_step_page.py tests/test_wizard_action_row.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
