### PR TITLE
refactor: add workflow placeholder hint metadata

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -217,6 +217,14 @@ class StepPageTest(unittest.TestCase):
             page.primary_hint_label.objectName(),
             "qfitWizardMapPagePrimaryHint",
         )
+        self.assertEqual(
+            page.primary_hint_label.property("workflowPlaceholderHint"),
+            "retired",
+        )
+        self.assertEqual(
+            page.primary_hint_label.property("wizardPlaceholderHint"),
+            "retired",
+        )
         self.assertFalse(page.primary_hint_label.isVisible())
 
     def test_wizard_step_page_retire_primary_hint_is_installer_compatible(self):
@@ -227,6 +235,10 @@ class StepPageTest(unittest.TestCase):
         page.retire_primary_action_hint()
 
         self.assertEqual(page.primary_hint_label.text(), "")
+        self.assertEqual(
+            page.primary_hint_label.property("workflowPlaceholderHint"),
+            "retired",
+        )
         self.assertEqual(
             page.primary_hint_label.property("wizardPlaceholderHint"),
             "retired",

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -120,6 +120,10 @@ class WizardPageTest(unittest.TestCase):
 
         self.assertEqual(page.primary_hint_label.text(), "")
         self.assertEqual(
+            page.primary_hint_label.property("workflowPlaceholderHint"),
+            "retired",
+        )
+        self.assertEqual(
             page.primary_hint_label.property("wizardPlaceholderHint"),
             "retired",
         )
@@ -135,6 +139,8 @@ class WizardPageTest(unittest.TestCase):
         self.assertIsInstance(page, self.workflow_page.WizardPage)
         self.assertIn("WorkflowPage", self.workflow_page.__all__)
         self.assertIn("WizardPage", self.workflow_page.__all__)
+        self.assertIn("WORKFLOW_PLACEHOLDER_HINT_PROPERTY", self.workflow_page.__all__)
+        self.assertIn("WIZARD_PLACEHOLDER_HINT_PROPERTY", self.workflow_page.__all__)
 
     def test_wizard_page_module_reexports_workflow_page_api(self):
         self.assertIs(self.wizard_page.WorkflowPage, self.workflow_page.WorkflowPage)

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -139,8 +139,10 @@ class WizardPageTest(unittest.TestCase):
         self.assertIsInstance(page, self.workflow_page.WizardPage)
         self.assertIn("WorkflowPage", self.workflow_page.__all__)
         self.assertIn("WizardPage", self.workflow_page.__all__)
+        self.assertIn("PLACEHOLDER_HINT_RETIRED", self.workflow_page.__all__)
         self.assertIn("WORKFLOW_PLACEHOLDER_HINT_PROPERTY", self.workflow_page.__all__)
         self.assertIn("WIZARD_PLACEHOLDER_HINT_PROPERTY", self.workflow_page.__all__)
+        self.assertIn("set_workflow_placeholder_hint_state", self.workflow_page.__all__)
 
     def test_wizard_page_module_reexports_workflow_page_api(self):
         self.assertIs(self.wizard_page.WorkflowPage, self.workflow_page.WorkflowPage)
@@ -153,6 +155,26 @@ class WizardPageTest(unittest.TestCase):
             self.wizard_page.install_workflow_pages,
             self.workflow_page.install_workflow_pages,
         )
+        self.assertEqual(
+            self.wizard_page.PLACEHOLDER_HINT_RETIRED,
+            self.workflow_page.PLACEHOLDER_HINT_RETIRED,
+        )
+        self.assertEqual(
+            self.wizard_page.WORKFLOW_PLACEHOLDER_HINT_PROPERTY,
+            self.workflow_page.WORKFLOW_PLACEHOLDER_HINT_PROPERTY,
+        )
+        self.assertEqual(
+            self.wizard_page.WIZARD_PLACEHOLDER_HINT_PROPERTY,
+            self.workflow_page.WIZARD_PLACEHOLDER_HINT_PROPERTY,
+        )
+        self.assertIs(
+            self.wizard_page.set_workflow_placeholder_hint_state,
+            self.workflow_page.set_workflow_placeholder_hint_state,
+        )
+        self.assertIn("PLACEHOLDER_HINT_RETIRED", self.wizard_page.__all__)
+        self.assertIn("WORKFLOW_PLACEHOLDER_HINT_PROPERTY", self.wizard_page.__all__)
+        self.assertIn("WIZARD_PLACEHOLDER_HINT_PROPERTY", self.wizard_page.__all__)
+        self.assertIn("set_workflow_placeholder_hint_state", self.wizard_page.__all__)
 
     def test_workflow_page_builders_keep_wizard_compatibility_aliases(self):
         self.assertIs(

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -12,6 +12,10 @@ from qfit.ui.application.workflow_page_specs import (
 )
 from .action_row import set_workflow_action_role
 from ._qt_compat import import_qt_module
+from .workflow_page import (
+    PLACEHOLDER_HINT_RETIRED,
+    set_workflow_placeholder_hint_state,
+)
 from qfit.ui.widgets.pill import set_pill_tone
 from qfit.ui.widgets.tokens import (
     COLOR_ACCENT,
@@ -365,13 +369,16 @@ class WorkflowStepPage(StepPage):
         """Keep compatibility with placeholder pages while avoiding extra copy."""
 
         self.primary_hint_label.setText("")
-        self.primary_hint_label.setProperty("wizardPlaceholderHint", "retired")
+        set_workflow_placeholder_hint_state(
+            self.primary_hint_label,
+            PLACEHOLDER_HINT_RETIRED,
+        )
         self.primary_hint_label.setVisible(False)
 
     def _build_primary_hint_label(self, text: str):
         label = QLabel(text, self)
         label.setObjectName(self.spec.primary_hint_object_name)
-        label.setProperty("wizardPlaceholderHint", "retired")
+        set_workflow_placeholder_hint_state(label, PLACEHOLDER_HINT_RETIRED)
         label.setVisible(False)
         return label
 

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from .workflow_page import (
     DockWorkflowPageSpec,
     DockWizardPageSpec,
+    PLACEHOLDER_HINT_RETIRED,
+    WIZARD_PLACEHOLDER_HINT_PROPERTY,
+    WORKFLOW_PLACEHOLDER_HINT_PROPERTY,
     WorkflowPage,
     WizardPage,
     build_default_wizard_page_specs,
@@ -11,11 +14,15 @@ from .workflow_page import (
     build_workflow_pages,
     install_wizard_pages,
     install_workflow_pages,
+    set_workflow_placeholder_hint_state,
 )
 
 __all__ = [
     "DockWorkflowPageSpec",
     "DockWizardPageSpec",
+    "PLACEHOLDER_HINT_RETIRED",
+    "WIZARD_PLACEHOLDER_HINT_PROPERTY",
+    "WORKFLOW_PLACEHOLDER_HINT_PROPERTY",
     "WorkflowPage",
     "WizardPage",
     "build_default_workflow_page_specs",
@@ -24,4 +31,5 @@ __all__ = [
     "build_wizard_pages",
     "install_workflow_pages",
     "install_wizard_pages",
+    "set_workflow_placeholder_hint_state",
 ]

--- a/ui/dockwidget/workflow_page.py
+++ b/ui/dockwidget/workflow_page.py
@@ -34,6 +34,9 @@ _TITLE_LABEL_QSS = (
 )
 _SUMMARY_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 _PRIMARY_HINT_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
+WORKFLOW_PLACEHOLDER_HINT_PROPERTY = "workflowPlaceholderHint"
+WIZARD_PLACEHOLDER_HINT_PROPERTY = "wizardPlaceholderHint"
+PLACEHOLDER_HINT_RETIRED = "retired"
 
 
 DockWizardPageSpec = DockWorkflowPageSpec
@@ -87,7 +90,10 @@ class WorkflowPage(QWidget):
         """
 
         self.primary_hint_label.setText("")
-        self.primary_hint_label.setProperty("wizardPlaceholderHint", "retired")
+        set_workflow_placeholder_hint_state(
+            self.primary_hint_label,
+            PLACEHOLDER_HINT_RETIRED,
+        )
         self.primary_hint_label.setVisible(False)
 
     def outer_layout(self):
@@ -143,6 +149,14 @@ build_wizard_pages = build_workflow_pages
 """Compatibility alias for pre-#805 wizard page callers."""
 
 
+def set_workflow_placeholder_hint_state(label, state: str) -> None:
+    """Tag placeholder hint labels with canonical metadata plus legacy alias."""
+
+    label.setProperty(WORKFLOW_PLACEHOLDER_HINT_PROPERTY, state)
+    # Preserve the wizard-named property while #805 retires older shell naming.
+    label.setProperty(WIZARD_PLACEHOLDER_HINT_PROPERTY, state)
+
+
 def install_workflow_pages(
     shell,
     specs: Sequence[DockWorkflowPageSpec] | None = None,
@@ -162,6 +176,9 @@ install_wizard_pages = install_workflow_pages
 __all__ = [
     "DockWorkflowPageSpec",
     "DockWizardPageSpec",
+    "PLACEHOLDER_HINT_RETIRED",
+    "WIZARD_PLACEHOLDER_HINT_PROPERTY",
+    "WORKFLOW_PLACEHOLDER_HINT_PROPERTY",
     "WorkflowPage",
     "WizardPage",
     "build_default_workflow_page_specs",
@@ -170,4 +187,5 @@ __all__ = [
     "build_wizard_pages",
     "install_workflow_pages",
     "install_wizard_pages",
+    "set_workflow_placeholder_hint_state",
 ]


### PR DESCRIPTION
## Summary
- add canonical `workflowPlaceholderHint` metadata for retired workflow placeholder copy
- keep `wizardPlaceholderHint` as a compatibility alias while #805 retires older shell naming
- share the placeholder metadata helper between placeholder pages and StepPage-backed workflow pages

## Tests
- `python3 -m pytest tests/test_wizard_pages.py tests/test_step_page.py tests/test_wizard_shell_composition.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
