### PR TITLE
refactor: introduce canonical workflow steps

### DIFF
--- a/tests/test_dock_workflow_sections.py
+++ b/tests/test_dock_workflow_sections.py
@@ -4,6 +4,7 @@ from tests import _path  # noqa: F401
 
 from qfit.ui.application.dock_workflow_sections import (
     CURRENT_DOCK_SECTIONS,
+    WORKFLOW_STEPS,
     WIZARD_WORKFLOW_STEPS,
     DockWizardProgress,
     DockWorkflowProgress,
@@ -20,17 +21,17 @@ from qfit.ui.application.dock_workflow_sections import (
 
 
 class DockWorkflowSectionsTests(unittest.TestCase):
-    def test_wizard_steps_keep_stable_order_and_labels(self):
+    def test_workflow_steps_keep_stable_order_and_labels(self):
         self.assertEqual(
-            [section.key for section in WIZARD_WORKFLOW_STEPS],
+            [section.key for section in WORKFLOW_STEPS],
             ["connection", "sync", "map", "analysis", "atlas"],
         )
         self.assertEqual(
-            [section.title for section in WIZARD_WORKFLOW_STEPS],
+            [section.title for section in WORKFLOW_STEPS],
             ["Connection", "Synchronization", "Map & filters", "Spatial analysis (optional)", "Atlas PDF"],
         )
 
-    def test_current_dock_sections_reuse_wizard_steps_without_connection_page(self):
+    def test_current_dock_sections_reuse_workflow_steps_without_connection_page(self):
         self.assertEqual(
             [section.key for section in CURRENT_DOCK_SECTIONS],
             ["sync", "map", "analysis", "atlas"],
@@ -60,6 +61,7 @@ class DockWorkflowSectionsTests(unittest.TestCase):
             completed_keys=frozenset({"connection", "sync"}),
         )
 
+        self.assertIs(WIZARD_WORKFLOW_STEPS, WORKFLOW_STEPS)
         self.assertIs(DockWizardProgress, DockWorkflowProgress)
         self.assertIs(
             build_initial_wizard_step_statuses,

--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -40,7 +40,7 @@ class WorkflowPageSpecsTests(unittest.TestCase):
     def test_default_specs_reject_missing_page_copy_with_clear_message(self):
         unknown_step = type("UnknownStep", (), {"key": "review", "title": "Review"})()
 
-        with patch.object(workflow_page_specs, "WIZARD_WORKFLOW_STEPS", (unknown_step,)):
+        with patch.object(workflow_page_specs, "WORKFLOW_STEPS", (unknown_step,)):
             with self.assertRaisesRegex(
                 KeyError,
                 "No page copy found for workflow step 'review'",

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -141,6 +141,7 @@ from .workflow_progress_facts import (
 )
 from .dock_workflow_sections import (
     CURRENT_DOCK_SECTIONS,
+    WORKFLOW_STEPS,
     WIZARD_WORKFLOW_STEPS,
     DockWizardProgress,
     DockWorkflowProgress,
@@ -282,6 +283,7 @@ __all__ = [
     "LocalFirstParitySurface",
     "LocalFirstProgressFacts",
     "LocalFirstWidgetMove",
+    "WORKFLOW_STEPS",
     "WIZARD_WORKFLOW_STEPS",
     "WORKFLOW_SETTINGS_VERSION",
     "WORKFLOW_SETTINGS_VERSION_KEY",

--- a/ui/application/dock_workflow_sections.py
+++ b/ui/application/dock_workflow_sections.py
@@ -56,7 +56,7 @@ DockWizardProgress = DockWorkflowProgress
 """Compatibility alias for pre-#805 wizard-named progress callers."""
 
 
-WIZARD_WORKFLOW_STEPS: tuple[DockWorkflowSection, ...] = (
+WORKFLOW_STEPS: tuple[DockWorkflowSection, ...] = (
     DockWorkflowSection(
         key="connection",
         title="Connection",
@@ -85,10 +85,12 @@ WIZARD_WORKFLOW_STEPS: tuple[DockWorkflowSection, ...] = (
         current_dock_overview_title="Publish",
     ),
 )
+WIZARD_WORKFLOW_STEPS = WORKFLOW_STEPS
+"""Compatibility alias for pre-#805 wizard-named workflow steps."""
 
 CURRENT_DOCK_SECTION_KEYS: frozenset[str] = frozenset({"sync", "map", "analysis", "atlas"})
 CURRENT_DOCK_SECTIONS: tuple[DockWorkflowSection, ...] = tuple(
-    section for section in WIZARD_WORKFLOW_STEPS if section.key in CURRENT_DOCK_SECTION_KEYS
+    section for section in WORKFLOW_STEPS if section.key in CURRENT_DOCK_SECTION_KEYS
 )
 
 
@@ -102,7 +104,7 @@ def build_current_dock_workflow_label() -> str:
 def get_workflow_section(key: str) -> DockWorkflowSection:
     """Return a workflow section by stable key."""
 
-    for section in WIZARD_WORKFLOW_STEPS:
+    for section in WORKFLOW_STEPS:
         if section.key == key:
             return section
     raise KeyError(key)
@@ -179,7 +181,7 @@ def _build_workflow_step_status_tuple(
     unlocked_keys: set[str],
 ) -> tuple[DockWorkflowStepStatus, ...]:
     statuses = []
-    for index, section in enumerate(WIZARD_WORKFLOW_STEPS):
+    for index, section in enumerate(WORKFLOW_STEPS):
         statuses.append(
             DockWorkflowStepStatus(
                 key=section.key,
@@ -197,7 +199,7 @@ def _derive_unlocked_step_keys(
     visited_keys: set[str],
 ) -> set[str]:
     unlocked = set(visited_keys)
-    for previous, section in zip(WIZARD_WORKFLOW_STEPS, WIZARD_WORKFLOW_STEPS[1:]):
+    for previous, section in zip(WORKFLOW_STEPS, WORKFLOW_STEPS[1:]):
         if previous.key in completed_keys:
             unlocked.add(section.key)
     if "map" in completed_keys:
@@ -225,7 +227,7 @@ def _validate_workflow_keys(
     completed_keys: Collection[str],
     unlocked_keys: Collection[str],
 ) -> None:
-    known_keys = {section.key for section in WIZARD_WORKFLOW_STEPS}
+    known_keys = {section.key for section in WORKFLOW_STEPS}
     all_provided_keys = {current_key} | set(completed_keys) | set(unlocked_keys)
     unknown_keys = all_provided_keys - known_keys
     if unknown_keys:

--- a/ui/application/stepper_presenter.py
+++ b/ui/application/stepper_presenter.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 from .dock_workflow_sections import (
-    WIZARD_WORKFLOW_STEPS,
+    WORKFLOW_STEPS,
     DockWorkflowStepState,
     DockWorkflowStepStatus,
 )
@@ -68,17 +68,17 @@ def can_request_step(
 
 
 def step_key_for_index(index: int) -> str:
-    """Return the stable wizard step key for a StepperBar index."""
+    """Return the stable workflow step key for a StepperBar index."""
 
-    if index < 0 or index >= len(WIZARD_WORKFLOW_STEPS):
+    if index < 0 or index >= len(WORKFLOW_STEPS):
         raise IndexError(index)
-    return WIZARD_WORKFLOW_STEPS[index].key
+    return WORKFLOW_STEPS[index].key
 
 
 def step_index_for_key(key: str) -> int:
-    """Return the StepperBar index for a stable wizard step key."""
+    """Return the StepperBar index for a stable workflow step key."""
 
-    for index, section in enumerate(WIZARD_WORKFLOW_STEPS):
+    for index, section in enumerate(WORKFLOW_STEPS):
         if section.key == key:
             return index
     raise KeyError(key)

--- a/ui/application/workflow_page_specs.py
+++ b/ui/application/workflow_page_specs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from .dock_workflow_sections import DockWorkflowSection, WIZARD_WORKFLOW_STEPS
+from .dock_workflow_sections import DockWorkflowSection, WORKFLOW_STEPS
 
 
 @dataclass(frozen=True)
@@ -72,7 +72,7 @@ def build_default_workflow_page_specs(
 ) -> tuple[DockWorkflowPageSpec, ...]:
     """Return local-first dock page specs in stable workflow order."""
 
-    steps = WIZARD_WORKFLOW_STEPS if workflow_steps is None else tuple(workflow_steps)
+    steps = WORKFLOW_STEPS if workflow_steps is None else tuple(workflow_steps)
     specs = []
     for step in steps:
         if step.key not in _PAGE_COPY_BY_KEY:

--- a/ui/application/workflow_progress.py
+++ b/ui/application/workflow_progress.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 from typing import cast
 
-from .dock_workflow_sections import DockWorkflowProgress, WIZARD_WORKFLOW_STEPS
+from .dock_workflow_sections import DockWorkflowProgress, WORKFLOW_STEPS
 from .workflow_progress_facts import WorkflowProgressFacts
 from .workflow_settings import (
     WorkflowSettingsSnapshot,
@@ -154,7 +154,7 @@ def _first_incomplete_key(completed_keys: set[str]) -> str:
 
 
 def _workflow_keys() -> tuple[str, ...]:
-    return tuple(section.key for section in WIZARD_WORKFLOW_STEPS)
+    return tuple(section.key for section in WORKFLOW_STEPS)
 
 
 __all__ = [

--- a/ui/application/workflow_settings.py
+++ b/ui/application/workflow_settings.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ...configuration.application.settings_port import SettingsPort
-from .dock_workflow_sections import WIZARD_WORKFLOW_STEPS
+from .dock_workflow_sections import WORKFLOW_STEPS
 
 WORKFLOW_SETTINGS_VERSION = 1
 WORKFLOW_SETTINGS_VERSION_KEY = "ui/wizard_version"
@@ -136,7 +136,7 @@ def save_collapsed_groups(
 def workflow_step_key_for_index(index: int) -> str:
     """Return the stable workflow step key for a persisted step index."""
 
-    return WIZARD_WORKFLOW_STEPS[clamp_workflow_step_index(index)].key
+    return WORKFLOW_STEPS[clamp_workflow_step_index(index)].key
 
 
 def preferred_current_key_from_workflow_settings(

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from qfit.ui.application.dock_workflow_sections import WIZARD_WORKFLOW_STEPS
+from qfit.ui.application.dock_workflow_sections import WORKFLOW_STEPS
 from qfit.ui.application.stepper_presenter import (
     STEPPER_STATE_CURRENT,
     STEPPER_STATE_DONE,
@@ -15,7 +15,7 @@ from qfit.ui.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARAT
 
 from ._qt_compat import import_qt_module
 
-STEPPER_LABELS = tuple(section.title for section in WIZARD_WORKFLOW_STEPS)
+STEPPER_LABELS = tuple(section.title for section in WORKFLOW_STEPS)
 STEPPER_STATES = frozenset(
     {
         STEPPER_STATE_DONE,


### PR DESCRIPTION
## Summary
- introduce canonical `WORKFLOW_STEPS` metadata for dock workflow sections
- keep `WIZARD_WORKFLOW_STEPS` as a compatibility alias
- move workflow-owned callers off the wizard-named step list while leaving the wizard facade intact

## Tests
- `python3 -m pytest tests/test_dock_workflow_sections.py tests/test_wizard_pages.py tests/test_stepper_presenter.py tests/test_stepper_bar.py tests/test_workflow_settings.py tests/test_workflow_progress.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
