### PR TITLE
refactor: route wizard page specs through workflow steps

### DIFF
--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -7,7 +7,7 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 from qfit.ui import application
-from qfit.ui.application import workflow_page_specs
+from qfit.ui.application import wizard_page_specs, workflow_page_specs
 from qfit.ui.application.wizard_page_specs import (
     DockWizardPageSpec,
     build_default_wizard_page_specs,
@@ -60,6 +60,14 @@ class WorkflowPageSpecsTests(unittest.TestCase):
             build_default_wizard_page_specs(),
             build_default_workflow_page_specs(),
         )
+
+    def test_wizard_page_specs_wrapper_uses_canonical_workflow_steps(self):
+        custom_step = type("CustomStep", (), {"key": "sync", "title": "Custom Sync"})()
+
+        with patch.object(wizard_page_specs, "WORKFLOW_STEPS", (custom_step,)):
+            specs = build_default_wizard_page_specs()
+
+        self.assertEqual([(spec.key, spec.title) for spec in specs], [("sync", "Custom Sync")])
 
 
 def _load_wizard_modules():

--- a/ui/application/wizard_page_specs.py
+++ b/ui/application/wizard_page_specs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from .dock_workflow_sections import DockWorkflowSection, WIZARD_WORKFLOW_STEPS
+from .dock_workflow_sections import DockWorkflowSection, WORKFLOW_STEPS
 from .workflow_page_specs import (
     DockWorkflowPageSpec,
     build_default_workflow_page_specs,
@@ -18,7 +18,7 @@ def build_default_wizard_page_specs(
 ) -> tuple[DockWizardPageSpec, ...]:
     """Compatibility wrapper for the workflow-named page spec builder."""
 
-    steps = WIZARD_WORKFLOW_STEPS if workflow_steps is None else tuple(workflow_steps)
+    steps = WORKFLOW_STEPS if workflow_steps is None else tuple(workflow_steps)
     return build_default_workflow_page_specs(workflow_steps=steps)
 
 


### PR DESCRIPTION
## Summary
- route the wizard page-spec compatibility wrapper through canonical `WORKFLOW_STEPS`
- keep the wizard-named page-spec API as a thin compatibility facade
- add a regression test proving the facade follows the canonical workflow step source

## Tests
- `python3 -m pytest tests/test_wizard_pages.py tests/test_dock_workflow_sections.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
