### PR TITLE
refactor: drop dock wizard settings alias

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -160,11 +160,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
         return ensure_workflow_settings(self.settings)
 
-    def _ensure_wizard_settings(self):
-        """Compatibility alias for pre-#805 wizard-named startup callers."""
-
-        return self._ensure_workflow_settings()
-
     def refresh_configuration_from_settings(self) -> None:
         """Reload saved configuration and refresh live workflow connection state."""
 


### PR DESCRIPTION
## Summary
- remove the unused `_ensure_wizard_settings` compatibility method from `QfitDockWidget`
- keep startup on the canonical `_ensure_workflow_settings` path only

## Tests
- `python3 -m pytest tests/test_dockwidget_dependencies.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
