### PR TITLE
refactor: drop package wizard presenter export

### DIFF
--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -51,18 +51,13 @@ class WizardShellPresenterTest(unittest.TestCase):
             self.dockwidget_package.WorkflowShellPresenter,
             self.workflow_presenter.WorkflowShellPresenter,
         )
-        self.assertIs(
-            self.dockwidget_package.WizardShellPresenter,
-            self.workflow_presenter.WorkflowShellPresenter,
-        )
-        for module in (
-            self.workflow_presenter,
-            self.presenter,
-            self.dockwidget_package,
-        ):
+        self.assertFalse(hasattr(self.dockwidget_package, "WizardShellPresenter"))
+        for module in (self.workflow_presenter, self.presenter):
             with self.subTest(module=module.__name__):
                 self.assertIn("WorkflowShellPresenter", module.__all__)
                 self.assertIn("WizardShellPresenter", module.__all__)
+        self.assertIn("WorkflowShellPresenter", self.dockwidget_package.__all__)
+        self.assertNotIn("WizardShellPresenter", self.dockwidget_package.__all__)
 
     def _build_shell_with_pages(self):
         shell = self.wizard_shell.WizardShell()

--- a/ui/dockwidget/__init__.py
+++ b/ui/dockwidget/__init__.py
@@ -3,13 +3,10 @@
 from .stepper_bar import STEPPER_LABELS, STEPPER_STATES, StepperBar
 from .workflow_shell_presenter import WorkflowShellPresenter
 
-WizardShellPresenter = WorkflowShellPresenter
-"""Compatibility alias for pre-#805 wizard shell presenter imports."""
 
 __all__ = [
     "STEPPER_LABELS",
     "STEPPER_STATES",
     "StepperBar",
     "WorkflowShellPresenter",
-    "WizardShellPresenter",
 ]


### PR DESCRIPTION
## Summary
- stop exporting `WizardShellPresenter` from the canonical `qfit.ui.dockwidget` package namespace
- keep the explicit `wizard_shell_presenter` compatibility module intact while making the package-level surface workflow-only

## Tests
- `python3 -m pytest tests/test_wizard_shell_presenter.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
