### PR TITLE
refactor: drop workflow shell wizard alias

### DIFF
--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -456,14 +456,14 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(shell.footer_bar.text(), "Ready")
         self.assertEqual(shell.footer_bar.path_label.text(), "Ready")
 
-    def test_workflow_shell_is_canonical_export_with_wizard_alias(self):
+    def test_workflow_shell_is_canonical_export_without_wizard_alias(self):
         shell = self.workflow_shell.WorkflowShell()
 
-        self.assertIs(self.workflow_shell.WizardShell, self.workflow_shell.WorkflowShell)
+        self.assertFalse(hasattr(self.workflow_shell, "WizardShell"))
         self.assertEqual(shell.objectName(), "qfitWizardShell")
-        self.assertIsInstance(shell, self.workflow_shell.WizardShell)
+        self.assertIsInstance(shell, self.workflow_shell.WorkflowShell)
         self.assertIn("WorkflowShell", self.workflow_shell.__all__)
-        self.assertIn("WizardShell", self.workflow_shell.__all__)
+        self.assertNotIn("WizardShell", self.workflow_shell.__all__)
 
     def test_wizard_shell_module_reexports_workflow_shell_api(self):
         self.assertIs(self.wizard_shell.WorkflowShell, self.workflow_shell.WorkflowShell)

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
-from .workflow_shell import FooterStatusBar, STEPPER_LABELS, WorkflowShell, WizardShell
+from .workflow_shell import FooterStatusBar, STEPPER_LABELS, WorkflowShell
+
+WizardShell = WorkflowShell
+"""Compatibility alias for pre-#805 wizard shell imports."""
 
 __all__ = ["FooterStatusBar", "STEPPER_LABELS", "WorkflowShell", "WizardShell"]

--- a/ui/dockwidget/workflow_shell.py
+++ b/ui/dockwidget/workflow_shell.py
@@ -156,8 +156,4 @@ class WorkflowShell(QWidget):
         return FooterStatusBar(self, footer_text=footer_text)
 
 
-WizardShell = WorkflowShell
-"""Compatibility alias for pre-#805 wizard shell callers."""
-
-
-__all__ = ["STEPPER_LABELS", "WorkflowShell", "WizardShell"]
+__all__ = ["STEPPER_LABELS", "WorkflowShell"]


### PR DESCRIPTION
## Summary
- remove `WizardShell` from the canonical `workflow_shell` module exports
- keep the explicit `wizard_shell` compatibility module as the only wizard-named shell import path

## Tests
- `python3 -m pytest tests/test_wizard_shell.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
