### PR TITLE
refactor: drop workflow presenter wizard alias

### DIFF
--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -47,15 +47,16 @@ class WizardShellPresenterTest(unittest.TestCase):
             self.presenter.WizardShellPresenter,
             self.workflow_presenter.WorkflowShellPresenter,
         )
+        self.assertFalse(hasattr(self.workflow_presenter, "WizardShellPresenter"))
         self.assertIs(
             self.dockwidget_package.WorkflowShellPresenter,
             self.workflow_presenter.WorkflowShellPresenter,
         )
         self.assertFalse(hasattr(self.dockwidget_package, "WizardShellPresenter"))
-        for module in (self.workflow_presenter, self.presenter):
-            with self.subTest(module=module.__name__):
-                self.assertIn("WorkflowShellPresenter", module.__all__)
-                self.assertIn("WizardShellPresenter", module.__all__)
+        self.assertIn("WorkflowShellPresenter", self.workflow_presenter.__all__)
+        self.assertNotIn("WizardShellPresenter", self.workflow_presenter.__all__)
+        self.assertIn("WorkflowShellPresenter", self.presenter.__all__)
+        self.assertIn("WizardShellPresenter", self.presenter.__all__)
         self.assertIn("WorkflowShellPresenter", self.dockwidget_package.__all__)
         self.assertNotIn("WizardShellPresenter", self.dockwidget_package.__all__)
 

--- a/ui/dockwidget/wizard_shell_presenter.py
+++ b/ui/dockwidget/wizard_shell_presenter.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from .workflow_shell_presenter import (
     DockWizardProgress,
     DockWorkflowProgress,
-    WizardShellPresenter,
     WorkflowShellPresenter,
 )
+
+WizardShellPresenter = WorkflowShellPresenter
+"""Compatibility alias for pre-#805 wizard shell presenter imports."""
 
 __all__ = [
     "DockWorkflowProgress",

--- a/ui/dockwidget/workflow_shell_presenter.py
+++ b/ui/dockwidget/workflow_shell_presenter.py
@@ -180,13 +180,9 @@ def _missing_completion_prerequisites(
 
 DockWizardProgress = DockWorkflowProgress
 """Compatibility alias for pre-#805 wizard shell presenter tests/callers."""
-WizardShellPresenter = WorkflowShellPresenter
-"""Compatibility alias for pre-#805 wizard shell presenter callers."""
-
 
 __all__ = [
     "DockWorkflowProgress",
     "DockWizardProgress",
     "WorkflowShellPresenter",
-    "WizardShellPresenter",
 ]


### PR DESCRIPTION
## Summary
- remove `WizardShellPresenter` from the canonical `workflow_shell_presenter` module exports
- keep the explicit `wizard_shell_presenter` compatibility module as the wizard-named import path

## Tests
- `python3 -m pytest tests/test_wizard_shell_presenter.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
