### PR TITLE
refactor: move presenter wizard progress alias

### DIFF
--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -53,10 +53,18 @@ class WizardShellPresenterTest(unittest.TestCase):
             self.workflow_presenter.WorkflowShellPresenter,
         )
         self.assertFalse(hasattr(self.dockwidget_package, "WizardShellPresenter"))
+        self.assertFalse(hasattr(self.workflow_presenter, "DockWizardProgress"))
+        self.assertIs(
+            self.presenter.DockWizardProgress,
+            self.workflow_presenter.DockWorkflowProgress,
+        )
         self.assertIn("WorkflowShellPresenter", self.workflow_presenter.__all__)
         self.assertNotIn("WizardShellPresenter", self.workflow_presenter.__all__)
+        self.assertIn("DockWorkflowProgress", self.workflow_presenter.__all__)
+        self.assertNotIn("DockWizardProgress", self.workflow_presenter.__all__)
         self.assertIn("WorkflowShellPresenter", self.presenter.__all__)
         self.assertIn("WizardShellPresenter", self.presenter.__all__)
+        self.assertIn("DockWizardProgress", self.presenter.__all__)
         self.assertIn("WorkflowShellPresenter", self.dockwidget_package.__all__)
         self.assertNotIn("WizardShellPresenter", self.dockwidget_package.__all__)
 

--- a/ui/dockwidget/wizard_shell_presenter.py
+++ b/ui/dockwidget/wizard_shell_presenter.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from .workflow_shell_presenter import (
-    DockWizardProgress,
     DockWorkflowProgress,
     WorkflowShellPresenter,
 )
 
+DockWizardProgress = DockWorkflowProgress
+"""Compatibility alias for pre-#805 wizard shell presenter imports."""
 WizardShellPresenter = WorkflowShellPresenter
 """Compatibility alias for pre-#805 wizard shell presenter imports."""
 

--- a/ui/dockwidget/workflow_shell_presenter.py
+++ b/ui/dockwidget/workflow_shell_presenter.py
@@ -178,11 +178,7 @@ def _missing_completion_prerequisites(
     )
 
 
-DockWizardProgress = DockWorkflowProgress
-"""Compatibility alias for pre-#805 wizard shell presenter tests/callers."""
-
 __all__ = [
     "DockWorkflowProgress",
-    "DockWizardProgress",
     "WorkflowShellPresenter",
 ]


### PR DESCRIPTION
## Summary
- remove `DockWizardProgress` from canonical `workflow_shell_presenter` exports
- define that compatibility alias only in the explicit `wizard_shell_presenter` module

## Tests
- `python3 -m pytest tests/test_wizard_shell_presenter.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
