### PR TITLE
refactor: move dock wizard aliases to compat module

### DIFF
--- a/tests/test_workflow_dock.py
+++ b/tests/test_workflow_dock.py
@@ -72,10 +72,8 @@ class WorkflowDockWidgetTest(unittest.TestCase):
             self.workflow_dock.WORKFLOW_DOCK_OBJECT_NAME,
             "qfitWizardDockWidget",
         )
-        self.assertEqual(
-            self.workflow_dock.WIZARD_DOCK_OBJECT_NAME,
-            self.workflow_dock.WORKFLOW_DOCK_OBJECT_NAME,
-        )
+        self.assertNotIn("WIZARD_DOCK_OBJECT_NAME", self.workflow_dock.__all__)
+        self.assertFalse(hasattr(self.workflow_dock, "WIZARD_DOCK_OBJECT_NAME"))
 
     def test_builds_qgis_dock_container_for_workflow_shell_composition(self):
         shell = _FakeWidget()
@@ -116,19 +114,13 @@ class WorkflowDockWidgetTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must expose a shell"):
             self.workflow_dock.WorkflowDockWidget(SimpleNamespace(shell=None))
 
-    def test_wizard_names_are_compatibility_aliases(self):
-        self.assertIs(
-            self.workflow_dock.WizardDockWidget,
-            self.workflow_dock.WorkflowDockWidget,
-        )
-        self.assertIs(
-            self.workflow_dock.WizardShellCompositionLike,
-            self.workflow_dock.WorkflowShellCompositionLike,
-        )
-        self.assertIs(
-            self.workflow_dock.build_wizard_dock_widget,
-            self.workflow_dock.build_workflow_dock_widget,
-        )
+    def test_workflow_dock_exports_only_workflow_names(self):
+        self.assertNotIn("WizardDockWidget", self.workflow_dock.__all__)
+        self.assertNotIn("WizardShellCompositionLike", self.workflow_dock.__all__)
+        self.assertNotIn("build_wizard_dock_widget", self.workflow_dock.__all__)
+        self.assertFalse(hasattr(self.workflow_dock, "WizardDockWidget"))
+        self.assertFalse(hasattr(self.workflow_dock, "WizardShellCompositionLike"))
+        self.assertFalse(hasattr(self.workflow_dock, "build_wizard_dock_widget"))
 
 
 if __name__ == "__main__":

--- a/ui/dockwidget/wizard_dock.py
+++ b/ui/dockwidget/wizard_dock.py
@@ -5,17 +5,25 @@ from .workflow_dock import (
     WORKFLOW_DOCK_FEATURES,
     WORKFLOW_DOCK_OBJECT_NAME,
     WORKFLOW_DOCK_TITLE,
-    WIZARD_DOCK_ALLOWED_AREAS,
-    WIZARD_DOCK_FEATURES,
-    WIZARD_DOCK_OBJECT_NAME,
-    WIZARD_DOCK_TITLE,
     WorkflowDockWidget,
     WorkflowShellCompositionLike,
-    WizardDockWidget,
-    WizardShellCompositionLike,
-    build_wizard_dock_widget,
     build_workflow_dock_widget,
 )
+
+WIZARD_DOCK_OBJECT_NAME = WORKFLOW_DOCK_OBJECT_NAME
+"""Compatibility alias for pre-#805 wizard dock imports."""
+WIZARD_DOCK_TITLE = WORKFLOW_DOCK_TITLE
+"""Compatibility alias for pre-#805 wizard dock imports."""
+WIZARD_DOCK_ALLOWED_AREAS = WORKFLOW_DOCK_ALLOWED_AREAS
+"""Compatibility alias for pre-#805 wizard dock imports."""
+WIZARD_DOCK_FEATURES = WORKFLOW_DOCK_FEATURES
+"""Compatibility alias for pre-#805 wizard dock imports."""
+WizardDockWidget = WorkflowDockWidget
+"""Compatibility alias for pre-#805 wizard dock imports."""
+WizardShellCompositionLike = WorkflowShellCompositionLike
+"""Compatibility alias for pre-#805 wizard dock imports."""
+build_wizard_dock_widget = build_workflow_dock_widget
+"""Compatibility alias for pre-#805 wizard dock imports."""
 
 __all__ = [
     "WORKFLOW_DOCK_ALLOWED_AREAS",

--- a/ui/dockwidget/workflow_dock.py
+++ b/ui/dockwidget/workflow_dock.py
@@ -24,14 +24,6 @@ WORKFLOW_DOCK_FEATURES = (
     | QDockWidget.DockWidgetFloatable
 )
 
-WIZARD_DOCK_OBJECT_NAME = WORKFLOW_DOCK_OBJECT_NAME
-"""Compatibility alias for pre-#805 wizard dock callers."""
-WIZARD_DOCK_TITLE = WORKFLOW_DOCK_TITLE
-"""Compatibility alias for pre-#805 wizard dock callers."""
-WIZARD_DOCK_ALLOWED_AREAS = WORKFLOW_DOCK_ALLOWED_AREAS
-"""Compatibility alias for pre-#805 wizard dock callers."""
-WIZARD_DOCK_FEATURES = WORKFLOW_DOCK_FEATURES
-"""Compatibility alias for pre-#805 wizard dock callers."""
 
 
 class WorkflowShellCompositionLike(Protocol):
@@ -39,9 +31,6 @@ class WorkflowShellCompositionLike(Protocol):
 
     shell: QWidget
 
-
-WizardShellCompositionLike = WorkflowShellCompositionLike
-"""Compatibility alias for pre-#805 wizard dock callers."""
 
 
 class WorkflowDockWidget(QDockWidget):
@@ -75,9 +64,6 @@ class WorkflowDockWidget(QDockWidget):
         self.composition = composition
 
 
-WizardDockWidget = WorkflowDockWidget
-"""Compatibility alias for pre-#805 wizard dock callers."""
-
 
 def build_workflow_dock_widget(
     composition: WorkflowShellCompositionLike,
@@ -89,9 +75,6 @@ def build_workflow_dock_widget(
 
     return WorkflowDockWidget(composition, parent=parent, title=title)
 
-
-build_wizard_dock_widget = build_workflow_dock_widget
-"""Compatibility alias for pre-#805 wizard dock callers."""
 
 
 def _composition_shell(composition: WorkflowShellCompositionLike):
@@ -108,12 +91,5 @@ __all__ = [
     "WORKFLOW_DOCK_TITLE",
     "WorkflowDockWidget",
     "WorkflowShellCompositionLike",
-    "WIZARD_DOCK_ALLOWED_AREAS",
-    "WIZARD_DOCK_FEATURES",
-    "WIZARD_DOCK_OBJECT_NAME",
-    "WIZARD_DOCK_TITLE",
-    "WizardDockWidget",
-    "WizardShellCompositionLike",
     "build_workflow_dock_widget",
-    "build_wizard_dock_widget",
 ]


### PR DESCRIPTION
## Summary
- remove wizard-named constants and builder/type aliases from canonical `workflow_dock`
- define those compatibility names only in the explicit `wizard_dock` module

## Tests
- `python3 -m pytest tests/test_workflow_dock.py tests/test_wizard_dock.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
