### PR TITLE
refactor: move page wizard aliases to compat module

### DIFF
--- a/tests/test_wizard_pages.py
+++ b/tests/test_wizard_pages.py
@@ -137,20 +137,26 @@ class WizardPageTest(unittest.TestCase):
         )
         self.assertFalse(page.primary_hint_label.isVisible())
 
-    def test_workflow_page_is_canonical_export_with_wizard_alias(self):
+    def test_workflow_page_exports_only_workflow_page_api(self):
         spec = build_default_workflow_page_specs()[2]
 
         page = self.workflow_page.WorkflowPage(spec)
 
-        self.assertIs(self.workflow_page.WizardPage, self.workflow_page.WorkflowPage)
         self.assertEqual(page.objectName(), "qfitWizardMapPage")
-        self.assertIsInstance(page, self.workflow_page.WizardPage)
         self.assertIn("WorkflowPage", self.workflow_page.__all__)
-        self.assertIn("WizardPage", self.workflow_page.__all__)
         self.assertIn("PLACEHOLDER_HINT_RETIRED", self.workflow_page.__all__)
         self.assertIn("WORKFLOW_PLACEHOLDER_HINT_PROPERTY", self.workflow_page.__all__)
-        self.assertIn("WIZARD_PLACEHOLDER_HINT_PROPERTY", self.workflow_page.__all__)
         self.assertIn("set_workflow_placeholder_hint_state", self.workflow_page.__all__)
+        for name in (
+            "DockWizardPageSpec",
+            "WizardPage",
+            "build_default_wizard_page_specs",
+            "build_wizard_pages",
+            "install_wizard_pages",
+            "WIZARD_PLACEHOLDER_HINT_PROPERTY",
+        ):
+            self.assertNotIn(name, self.workflow_page.__all__)
+            self.assertFalse(hasattr(self.workflow_page, name))
 
     def test_wizard_page_module_reexports_workflow_page_api(self):
         self.assertIs(self.wizard_page.WorkflowPage, self.workflow_page.WorkflowPage)
@@ -173,7 +179,7 @@ class WizardPageTest(unittest.TestCase):
         )
         self.assertEqual(
             self.wizard_page.WIZARD_PLACEHOLDER_HINT_PROPERTY,
-            self.workflow_page.WIZARD_PLACEHOLDER_HINT_PROPERTY,
+            "wizardPlaceholderHint",
         )
         self.assertIs(
             self.wizard_page.set_workflow_placeholder_hint_state,

--- a/ui/dockwidget/wizard_page.py
+++ b/ui/dockwidget/wizard_page.py
@@ -2,20 +2,27 @@ from __future__ import annotations
 
 from .workflow_page import (
     DockWorkflowPageSpec,
-    DockWizardPageSpec,
     PLACEHOLDER_HINT_RETIRED,
-    WIZARD_PLACEHOLDER_HINT_PROPERTY,
     WORKFLOW_PLACEHOLDER_HINT_PROPERTY,
     WorkflowPage,
-    WizardPage,
-    build_default_wizard_page_specs,
     build_default_workflow_page_specs,
-    build_wizard_pages,
     build_workflow_pages,
-    install_wizard_pages,
     install_workflow_pages,
     set_workflow_placeholder_hint_state,
 )
+
+DockWizardPageSpec = DockWorkflowPageSpec
+"""Compatibility alias for pre-#805 wizard page imports."""
+build_default_wizard_page_specs = build_default_workflow_page_specs
+"""Compatibility alias for pre-#805 wizard page imports."""
+WizardPage = WorkflowPage
+"""Compatibility alias for pre-#805 wizard page imports."""
+build_wizard_pages = build_workflow_pages
+"""Compatibility alias for pre-#805 wizard page imports."""
+install_wizard_pages = install_workflow_pages
+"""Compatibility alias for pre-#805 wizard page imports."""
+WIZARD_PLACEHOLDER_HINT_PROPERTY = "wizardPlaceholderHint"
+"""Compatibility alias for pre-#805 wizard placeholder metadata imports."""
 
 __all__ = [
     "DockWorkflowPageSpec",

--- a/ui/dockwidget/workflow_page.py
+++ b/ui/dockwidget/workflow_page.py
@@ -37,6 +37,7 @@ _PRIMARY_HINT_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 WORKFLOW_PLACEHOLDER_HINT_PROPERTY = "workflowPlaceholderHint"
 PLACEHOLDER_HINT_RETIRED = "retired"
 
+
 class WorkflowPage(QWidget):
     """Reusable visible page container for the workflow shell.
 
@@ -121,6 +122,7 @@ class WorkflowPage(QWidget):
         layout.addWidget(self.primary_hint_label)
         return layout
 
+
 def build_workflow_pages(
     *,
     parent=None,
@@ -131,12 +133,14 @@ def build_workflow_pages(
     page_specs = build_default_workflow_page_specs() if specs is None else tuple(specs)
     return tuple(WorkflowPage(spec, parent) for spec in page_specs)
 
+
 def set_workflow_placeholder_hint_state(label, state: str) -> None:
     """Tag placeholder hint labels with canonical metadata plus legacy alias."""
 
     label.setProperty(WORKFLOW_PLACEHOLDER_HINT_PROPERTY, state)
     # Preserve the wizard-named property while #805 retires older shell naming.
     label.setProperty("wizardPlaceholderHint", state)
+
 
 def install_workflow_pages(
     shell,
@@ -148,6 +152,7 @@ def install_workflow_pages(
     for page in pages:
         shell.add_page(page)
     return pages
+
 
 __all__ = [
     "DockWorkflowPageSpec",

--- a/ui/dockwidget/workflow_page.py
+++ b/ui/dockwidget/workflow_page.py
@@ -37,8 +37,6 @@ _PRIMARY_HINT_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 WORKFLOW_PLACEHOLDER_HINT_PROPERTY = "workflowPlaceholderHint"
 PLACEHOLDER_HINT_RETIRED = "retired"
 
-
-
 class WorkflowPage(QWidget):
     """Reusable visible page container for the workflow shell.
 
@@ -123,8 +121,6 @@ class WorkflowPage(QWidget):
         layout.addWidget(self.primary_hint_label)
         return layout
 
-
-
 def build_workflow_pages(
     *,
     parent=None,
@@ -135,15 +131,12 @@ def build_workflow_pages(
     page_specs = build_default_workflow_page_specs() if specs is None else tuple(specs)
     return tuple(WorkflowPage(spec, parent) for spec in page_specs)
 
-
-
 def set_workflow_placeholder_hint_state(label, state: str) -> None:
     """Tag placeholder hint labels with canonical metadata plus legacy alias."""
 
     label.setProperty(WORKFLOW_PLACEHOLDER_HINT_PROPERTY, state)
     # Preserve the wizard-named property while #805 retires older shell naming.
     label.setProperty("wizardPlaceholderHint", state)
-
 
 def install_workflow_pages(
     shell,
@@ -155,8 +148,6 @@ def install_workflow_pages(
     for page in pages:
         shell.add_page(page)
     return pages
-
-
 
 __all__ = [
     "DockWorkflowPageSpec",

--- a/ui/dockwidget/workflow_page.py
+++ b/ui/dockwidget/workflow_page.py
@@ -35,14 +35,8 @@ _TITLE_LABEL_QSS = (
 _SUMMARY_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 _PRIMARY_HINT_LABEL_QSS = f"QLabel {{ color: {COLOR_MUTED}; }}"
 WORKFLOW_PLACEHOLDER_HINT_PROPERTY = "workflowPlaceholderHint"
-WIZARD_PLACEHOLDER_HINT_PROPERTY = "wizardPlaceholderHint"
 PLACEHOLDER_HINT_RETIRED = "retired"
 
-
-DockWizardPageSpec = DockWorkflowPageSpec
-"""Compatibility alias for pre-#805 wizard page callers."""
-build_default_wizard_page_specs = build_default_workflow_page_specs
-"""Compatibility alias for pre-#805 wizard page builders."""
 
 
 class WorkflowPage(QWidget):
@@ -130,9 +124,6 @@ class WorkflowPage(QWidget):
         return layout
 
 
-WizardPage = WorkflowPage
-"""Compatibility alias for pre-#805 wizard page callers."""
-
 
 def build_workflow_pages(
     *,
@@ -145,16 +136,13 @@ def build_workflow_pages(
     return tuple(WorkflowPage(spec, parent) for spec in page_specs)
 
 
-build_wizard_pages = build_workflow_pages
-"""Compatibility alias for pre-#805 wizard page callers."""
-
 
 def set_workflow_placeholder_hint_state(label, state: str) -> None:
     """Tag placeholder hint labels with canonical metadata plus legacy alias."""
 
     label.setProperty(WORKFLOW_PLACEHOLDER_HINT_PROPERTY, state)
     # Preserve the wizard-named property while #805 retires older shell naming.
-    label.setProperty(WIZARD_PLACEHOLDER_HINT_PROPERTY, state)
+    label.setProperty("wizardPlaceholderHint", state)
 
 
 def install_workflow_pages(
@@ -169,23 +157,14 @@ def install_workflow_pages(
     return pages
 
 
-install_wizard_pages = install_workflow_pages
-"""Compatibility alias for pre-#805 wizard page callers."""
-
 
 __all__ = [
     "DockWorkflowPageSpec",
-    "DockWizardPageSpec",
     "PLACEHOLDER_HINT_RETIRED",
-    "WIZARD_PLACEHOLDER_HINT_PROPERTY",
     "WORKFLOW_PLACEHOLDER_HINT_PROPERTY",
     "WorkflowPage",
-    "WizardPage",
     "build_default_workflow_page_specs",
-    "build_default_wizard_page_specs",
     "build_workflow_pages",
-    "build_wizard_pages",
     "install_workflow_pages",
-    "install_wizard_pages",
     "set_workflow_placeholder_hint_state",
 ]


### PR DESCRIPTION
## Summary
- remove wizard-named page/spec/builder aliases from canonical `workflow_page`
- keep the wizard compatibility API in the explicit `wizard_page` module
- preserve legacy `wizardPlaceholderHint` tagging when workflow placeholder hints are retired

## Tests
- `python3 -m pytest tests/test_wizard_pages.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
