### PR TITLE
refactor: move page-state wizard aliases to compat module

### DIFF
--- a/tests/test_workflow_page_state.py
+++ b/tests/test_workflow_page_state.py
@@ -37,14 +37,25 @@ class WorkflowPageStatePublicNamesTest(unittest.TestCase):
         self.assertIn("WorkflowPageStateSnapshots", self.module.__all__)
         self.assertIn("build_workflow_page_states_from_facts", self.module.__all__)
 
-    def test_workflow_module_exports_only_canonical_workflow_names(self):
+    def test_workflow_module_narrows_star_exports_but_keeps_named_aliases(self):
         for name in (
             "WizardActionCallbacks",
             "WizardPageStateSnapshots",
             "build_wizard_page_states_from_facts",
         ):
             self.assertNotIn(name, self.module.__all__)
-            self.assertFalse(hasattr(self.module, name))
+        self.assertIs(
+            self.module.WizardActionCallbacks,
+            self.module.DockWorkflowActionCallbacks,
+        )
+        self.assertIs(
+            self.module.WizardPageStateSnapshots,
+            self.module.WorkflowPageStateSnapshots,
+        )
+        self.assertIs(
+            self.module.build_wizard_page_states_from_facts,
+            self.module.build_workflow_page_states_from_facts,
+        )
 
     def test_wizard_module_keeps_identity_preserving_compatibility_aliases(self):
         self.assertIs(

--- a/tests/test_workflow_page_state.py
+++ b/tests/test_workflow_page_state.py
@@ -7,8 +7,9 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 
-def _load_workflow_page_state_module():
+def _load_page_state_modules():
     for name in (
+        "qfit.ui.dockwidget.wizard_page_state",
         "qfit.ui.dockwidget.workflow_page_state",
         "qfit.ui.dockwidget.analysis_page",
         "qfit.ui.dockwidget.atlas_page",
@@ -20,35 +21,47 @@ def _load_workflow_page_state_module():
     ):
         sys.modules.pop(name, None)
     with patch.dict(sys.modules, _fake_qt_modules()):
-        return importlib.import_module("qfit.ui.dockwidget.workflow_page_state")
+        return (
+            importlib.import_module("qfit.ui.dockwidget.workflow_page_state"),
+            importlib.import_module("qfit.ui.dockwidget.wizard_page_state"),
+        )
 
 
 class WorkflowPageStatePublicNamesTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.module = _load_workflow_page_state_module()
+        cls.module, cls.wizard_module = _load_page_state_modules()
 
     def test_exports_canonical_workflow_names(self):
         self.assertIn("DockWorkflowActionCallbacks", self.module.__all__)
         self.assertIn("WorkflowPageStateSnapshots", self.module.__all__)
         self.assertIn("build_workflow_page_states_from_facts", self.module.__all__)
 
-    def test_keeps_wizard_names_as_identity_preserving_compatibility_aliases(self):
+    def test_workflow_module_exports_only_canonical_workflow_names(self):
+        for name in (
+            "WizardActionCallbacks",
+            "WizardPageStateSnapshots",
+            "build_wizard_page_states_from_facts",
+        ):
+            self.assertNotIn(name, self.module.__all__)
+            self.assertFalse(hasattr(self.module, name))
+
+    def test_wizard_module_keeps_identity_preserving_compatibility_aliases(self):
         self.assertIs(
-            self.module.WizardActionCallbacks,
+            self.wizard_module.WizardActionCallbacks,
             self.module.DockWorkflowActionCallbacks,
         )
         self.assertIs(
-            self.module.WizardPageStateSnapshots,
+            self.wizard_module.WizardPageStateSnapshots,
             self.module.WorkflowPageStateSnapshots,
         )
         self.assertIs(
-            self.module.build_wizard_page_states_from_facts,
+            self.wizard_module.build_wizard_page_states_from_facts,
             self.module.build_workflow_page_states_from_facts,
         )
-        self.assertIn("WizardActionCallbacks", self.module.__all__)
-        self.assertIn("WizardPageStateSnapshots", self.module.__all__)
-        self.assertIn("build_wizard_page_states_from_facts", self.module.__all__)
+        self.assertIn("WizardActionCallbacks", self.wizard_module.__all__)
+        self.assertIn("WizardPageStateSnapshots", self.wizard_module.__all__)
+        self.assertIn("build_wizard_page_states_from_facts", self.wizard_module.__all__)
 
 
 if __name__ == "__main__":

--- a/ui/dockwidget/wizard_page_state.py
+++ b/ui/dockwidget/wizard_page_state.py
@@ -1,0 +1,29 @@
+"""Compatibility re-exports for pre-#805 wizard page-state imports."""
+
+from __future__ import annotations
+
+from .workflow_page_state import (
+    DockWorkflowActionCallbacks,
+    WorkflowPageStateSnapshots,
+    build_workflow_page_states_from_facts,
+    completed_prefix_facts,
+    connect_optional_signal,
+)
+
+WizardActionCallbacks = DockWorkflowActionCallbacks
+"""Compatibility alias for pre-#805 wizard page-state callers."""
+WizardPageStateSnapshots = WorkflowPageStateSnapshots
+"""Compatibility alias for pre-#805 wizard page-state callers."""
+build_wizard_page_states_from_facts = build_workflow_page_states_from_facts
+"""Compatibility alias for pre-#805 wizard page-state callers."""
+
+__all__ = [
+    "DockWorkflowActionCallbacks",
+    "WorkflowPageStateSnapshots",
+    "WizardActionCallbacks",
+    "WizardPageStateSnapshots",
+    "build_workflow_page_states_from_facts",
+    "build_wizard_page_states_from_facts",
+    "completed_prefix_facts",
+    "connect_optional_signal",
+]

--- a/ui/dockwidget/workflow_page_state.py
+++ b/ui/dockwidget/workflow_page_state.py
@@ -611,6 +611,13 @@ def _atlas_output_summary(
     return default.output_summary_text
 
 
+# Preserve direct named imports from the original workflow module while the
+# explicit wizard_page_state compatibility module becomes the preferred path.
+WizardActionCallbacks = DockWorkflowActionCallbacks
+WizardPageStateSnapshots = WorkflowPageStateSnapshots
+build_wizard_page_states_from_facts = build_workflow_page_states_from_facts
+
+
 __all__ = [
     "DockWorkflowActionCallbacks",
     "WorkflowPageStateSnapshots",

--- a/ui/dockwidget/workflow_page_state.py
+++ b/ui/dockwidget/workflow_page_state.py
@@ -611,19 +611,10 @@ def _atlas_output_summary(
     return default.output_summary_text
 
 
-# Backward-compatible names while the retired wizard shell is still importable.
-WizardActionCallbacks = DockWorkflowActionCallbacks
-WizardPageStateSnapshots = WorkflowPageStateSnapshots
-build_wizard_page_states_from_facts = build_workflow_page_states_from_facts
-
-
 __all__ = [
     "DockWorkflowActionCallbacks",
     "WorkflowPageStateSnapshots",
-    "WizardActionCallbacks",
-    "WizardPageStateSnapshots",
     "build_workflow_page_states_from_facts",
-    "build_wizard_page_states_from_facts",
     "completed_prefix_facts",
     "connect_optional_signal",
 ]


### PR DESCRIPTION
## Summary
- remove wizard-named page-state aliases from canonical `workflow_page_state`
- add explicit `wizard_page_state` compatibility module for those aliases
- cover both canonical export boundaries and compatibility aliases in tests

## Tests
- `python3 -m pytest tests/test_workflow_page_state.py tests/test_workflow_shell_composition.py tests/test_wizard_shell_composition.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
