### PR TITLE
refactor: add wizard workflow-sections compat module

### DIFF
--- a/tests/test_dock_workflow_sections.py
+++ b/tests/test_dock_workflow_sections.py
@@ -1,3 +1,4 @@
+import importlib
 import unittest
 
 from tests import _path  # noqa: F401
@@ -75,6 +76,35 @@ class DockWorkflowSectionsTests(unittest.TestCase):
         self.assertEqual(
             build_progress_workflow_step_statuses(progress),
             build_progress_wizard_step_statuses(progress),
+        )
+
+    def test_workflow_sections_star_exports_are_canonical(self):
+        module = importlib.import_module("qfit.ui.application.dock_workflow_sections")
+
+        self.assertIn("DockWorkflowProgress", module.__all__)
+        self.assertIn("build_workflow_step_statuses", module.__all__)
+        self.assertNotIn("DockWizardProgress", module.__all__)
+        self.assertNotIn("WIZARD_WORKFLOW_STEPS", module.__all__)
+        self.assertIs(module.DockWizardProgress, module.DockWorkflowProgress)
+
+    def test_wizard_workflow_sections_exports_compatibility_metadata(self):
+        module = importlib.import_module("qfit.ui.application.wizard_workflow_sections")
+
+        self.assertEqual(
+            module.__all__,
+            [
+                "DockWizardProgress",
+                "WIZARD_WORKFLOW_STEPS",
+                "build_initial_wizard_step_statuses",
+                "build_progress_wizard_step_statuses",
+                "build_wizard_step_statuses",
+            ],
+        )
+        self.assertIs(module.DockWizardProgress, DockWorkflowProgress)
+        self.assertIs(module.WIZARD_WORKFLOW_STEPS, WORKFLOW_STEPS)
+        self.assertIs(
+            module.build_wizard_step_statuses,
+            build_workflow_step_statuses,
         )
 
     def test_wizard_step_statuses_distinguish_unlocked_from_done(self):

--- a/tests/test_dock_workflow_sections.py
+++ b/tests/test_dock_workflow_sections.py
@@ -103,6 +103,14 @@ class DockWorkflowSectionsTests(unittest.TestCase):
         self.assertIs(module.DockWizardProgress, DockWorkflowProgress)
         self.assertIs(module.WIZARD_WORKFLOW_STEPS, WORKFLOW_STEPS)
         self.assertIs(
+            module.build_initial_wizard_step_statuses,
+            build_initial_workflow_step_statuses,
+        )
+        self.assertIs(
+            module.build_progress_wizard_step_statuses,
+            build_progress_workflow_step_statuses,
+        )
+        self.assertIs(
             module.build_wizard_step_statuses,
             build_workflow_step_statuses,
         )

--- a/ui/application/dock_workflow_sections.py
+++ b/ui/application/dock_workflow_sections.py
@@ -232,3 +232,18 @@ def _validate_workflow_keys(
     unknown_keys = all_provided_keys - known_keys
     if unknown_keys:
         raise KeyError(min(unknown_keys))
+
+
+__all__ = [
+    "CURRENT_DOCK_SECTIONS",
+    "DockWorkflowProgress",
+    "DockWorkflowSection",
+    "DockWorkflowStepState",
+    "DockWorkflowStepStatus",
+    "WORKFLOW_STEPS",
+    "build_current_dock_workflow_label",
+    "build_initial_workflow_step_statuses",
+    "build_progress_workflow_step_statuses",
+    "build_workflow_step_statuses",
+    "get_workflow_section",
+]

--- a/ui/application/wizard_workflow_sections.py
+++ b/ui/application/wizard_workflow_sections.py
@@ -1,0 +1,17 @@
+"""Compatibility re-exports for pre-#805 wizard workflow-section imports."""
+
+from .dock_workflow_sections import (
+    DockWizardProgress,
+    WIZARD_WORKFLOW_STEPS,
+    build_initial_wizard_step_statuses,
+    build_progress_wizard_step_statuses,
+    build_wizard_step_statuses,
+)
+
+__all__ = [
+    "DockWizardProgress",
+    "WIZARD_WORKFLOW_STEPS",
+    "build_initial_wizard_step_statuses",
+    "build_progress_wizard_step_statuses",
+    "build_wizard_step_statuses",
+]


### PR DESCRIPTION
## Summary
- add explicit `wizard_workflow_sections` compatibility module for legacy workflow-section aliases
- define canonical `dock_workflow_sections.__all__` with workflow-owned exports only while preserving direct named aliases
- cover canonical star-export boundaries and compatibility exports in tests

## Tests
- `python3 -m pytest tests/test_dock_workflow_sections.py tests/test_application_progress_exports.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
