### PR TITLE
refactor: narrow wizard shell star exports

### DIFF
--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -474,8 +474,6 @@ class WizardShellTest(unittest.TestCase):
             self.workflow_shell.FooterStatusBar,
         )
         self.assertEqual(self.wizard_shell.__all__, ["WizardShell"])
-        self.assertNotIn("FooterStatusBar", self.wizard_shell.__all__)
-        self.assertNotIn("WorkflowShell", self.wizard_shell.__all__)
 
     def test_outer_layout_matches_wizard_spec_order(self):
         shell = self.wizard_shell.WorkflowShell()

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -465,7 +465,7 @@ class WizardShellTest(unittest.TestCase):
         self.assertIn("WorkflowShell", self.workflow_shell.__all__)
         self.assertNotIn("WizardShell", self.workflow_shell.__all__)
 
-    def test_wizard_shell_module_reexports_workflow_shell_api(self):
+    def test_wizard_shell_module_keeps_direct_aliases_but_stars_wizard_api(self):
         self.assertIs(self.wizard_shell.WorkflowShell, self.workflow_shell.WorkflowShell)
         self.assertIs(self.wizard_shell.WizardShell, self.workflow_shell.WorkflowShell)
         self.assertIs(self.wizard_shell.STEPPER_LABELS, self.workflow_shell.STEPPER_LABELS)
@@ -473,9 +473,9 @@ class WizardShellTest(unittest.TestCase):
             self.wizard_shell.FooterStatusBar,
             self.workflow_shell.FooterStatusBar,
         )
-        self.assertIn("FooterStatusBar", self.wizard_shell.__all__)
-        self.assertIn("WorkflowShell", self.wizard_shell.__all__)
-        self.assertIn("WizardShell", self.wizard_shell.__all__)
+        self.assertEqual(self.wizard_shell.__all__, ["WizardShell"])
+        self.assertNotIn("FooterStatusBar", self.wizard_shell.__all__)
+        self.assertNotIn("WorkflowShell", self.wizard_shell.__all__)
 
     def test_outer_layout_matches_wizard_spec_order(self):
         shell = self.wizard_shell.WorkflowShell()

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -5,4 +5,4 @@ from .workflow_shell import FooterStatusBar, STEPPER_LABELS, WorkflowShell
 WizardShell = WorkflowShell
 """Compatibility alias for pre-#805 wizard shell imports."""
 
-__all__ = ["FooterStatusBar", "STEPPER_LABELS", "WorkflowShell", "WizardShell"]
+__all__ = ["WizardShell"]


### PR DESCRIPTION
## Summary
- narrow `wizard_shell.__all__` to the wizard compatibility API
- keep direct canonical workflow shell attributes available for compatibility
- cover the wizard facade star-export boundary in tests

## Tests
- `python3 -m pytest tests/test_wizard_shell.py tests/test_step_page.py tests/test_wizard_pages.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
