### PR TITLE
refactor: narrow wizard presenter star exports

### DIFF
--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -62,9 +62,12 @@ class WizardShellPresenterTest(unittest.TestCase):
         self.assertNotIn("WizardShellPresenter", self.workflow_presenter.__all__)
         self.assertIn("DockWorkflowProgress", self.workflow_presenter.__all__)
         self.assertNotIn("DockWizardProgress", self.workflow_presenter.__all__)
-        self.assertIn("WorkflowShellPresenter", self.presenter.__all__)
-        self.assertIn("WizardShellPresenter", self.presenter.__all__)
-        self.assertIn("DockWizardProgress", self.presenter.__all__)
+        self.assertEqual(
+            self.presenter.__all__,
+            ["DockWizardProgress", "WizardShellPresenter"],
+        )
+        self.assertNotIn("WorkflowShellPresenter", self.presenter.__all__)
+        self.assertNotIn("DockWorkflowProgress", self.presenter.__all__)
         self.assertIn("WorkflowShellPresenter", self.dockwidget_package.__all__)
         self.assertNotIn("WizardShellPresenter", self.dockwidget_package.__all__)
 

--- a/tests/test_wizard_shell_presenter.py
+++ b/tests/test_wizard_shell_presenter.py
@@ -66,8 +66,6 @@ class WizardShellPresenterTest(unittest.TestCase):
             self.presenter.__all__,
             ["DockWizardProgress", "WizardShellPresenter"],
         )
-        self.assertNotIn("WorkflowShellPresenter", self.presenter.__all__)
-        self.assertNotIn("DockWorkflowProgress", self.presenter.__all__)
         self.assertIn("WorkflowShellPresenter", self.dockwidget_package.__all__)
         self.assertNotIn("WizardShellPresenter", self.dockwidget_package.__all__)
 

--- a/ui/dockwidget/wizard_shell_presenter.py
+++ b/ui/dockwidget/wizard_shell_presenter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from .workflow_shell_presenter import (
     DockWorkflowProgress,
     WorkflowShellPresenter,
@@ -11,8 +9,6 @@ WizardShellPresenter = WorkflowShellPresenter
 """Compatibility alias for pre-#805 wizard shell presenter imports."""
 
 __all__ = [
-    "DockWorkflowProgress",
     "DockWizardProgress",
-    "WorkflowShellPresenter",
     "WizardShellPresenter",
 ]


### PR DESCRIPTION
## Summary
- narrow `wizard_shell_presenter.__all__` to wizard compatibility names
- keep direct canonical workflow presenter/progress attributes available for compatibility
- remove an unused future import from the compatibility shim

## Tests
- `python3 -m pytest tests/test_wizard_shell_presenter.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
