### PR TITLE
refactor: lazy-load workflow page-state wizard aliases

### DIFF
--- a/tests/test_workflow_page_state.py
+++ b/tests/test_workflow_page_state.py
@@ -7,19 +7,32 @@ from tests import _path  # noqa: F401
 from tests.test_wizard_shell import _fake_qt_modules
 
 
-def _load_page_state_modules():
-    for name in (
-        "qfit.ui.dockwidget.wizard_page_state",
-        "qfit.ui.dockwidget.workflow_page_state",
-        "qfit.ui.dockwidget.analysis_page",
-        "qfit.ui.dockwidget.atlas_page",
-        "qfit.ui.dockwidget.connection_page",
-        "qfit.ui.dockwidget.map_page",
-        "qfit.ui.dockwidget.sync_page",
-        "qfit.ui.dockwidget.action_row",
-        "qfit.ui.dockwidget",
-    ):
+_PAGE_STATE_MODULES = (
+    "qfit.ui.dockwidget.wizard_page_state",
+    "qfit.ui.dockwidget.workflow_page_state",
+    "qfit.ui.dockwidget.analysis_page",
+    "qfit.ui.dockwidget.atlas_page",
+    "qfit.ui.dockwidget.connection_page",
+    "qfit.ui.dockwidget.map_page",
+    "qfit.ui.dockwidget.sync_page",
+    "qfit.ui.dockwidget.action_row",
+    "qfit.ui.dockwidget",
+)
+
+
+def _clear_page_state_modules():
+    for name in _PAGE_STATE_MODULES:
         sys.modules.pop(name, None)
+
+
+def _load_workflow_page_state_module():
+    _clear_page_state_modules()
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.workflow_page_state")
+
+
+def _load_page_state_modules():
+    _clear_page_state_modules()
     with patch.dict(sys.modules, _fake_qt_modules()):
         return (
             importlib.import_module("qfit.ui.dockwidget.workflow_page_state"),
@@ -56,6 +69,43 @@ class WorkflowPageStatePublicNamesTest(unittest.TestCase):
             self.module.build_wizard_page_states_from_facts,
             self.module.build_workflow_page_states_from_facts,
         )
+
+    def test_workflow_module_resolves_wizard_aliases_lazily(self):
+        module = _load_workflow_page_state_module()
+        alias_names = (
+            "WizardActionCallbacks",
+            "WizardPageStateSnapshots",
+            "build_wizard_page_states_from_facts",
+        )
+        for name in alias_names:
+            with self.subTest(name=name):
+                self.assertNotIn(name, module.__dict__)
+
+        self.assertIs(module.WizardActionCallbacks, module.DockWorkflowActionCallbacks)
+        self.assertIs(
+            module.WizardPageStateSnapshots,
+            module.WorkflowPageStateSnapshots,
+        )
+        self.assertIs(
+            module.build_wizard_page_states_from_facts,
+            module.build_workflow_page_states_from_facts,
+        )
+
+    def test_lazy_wizard_alias_reports_missing_canonical_target_as_attribute_error(self):
+        module = _load_workflow_page_state_module()
+        module._WIZARD_COMPAT_ALIAS_TARGETS["BrokenWizardAlias"] = (
+            "MissingWorkflowAlias"
+        )
+        try:
+            self.assertFalse(hasattr(module, "BrokenWizardAlias"))
+            with self.assertRaisesRegex(
+                AttributeError,
+                "BrokenWizardAlias.*MissingWorkflowAlias",
+            ):
+                module.__getattr__("BrokenWizardAlias")
+        finally:
+            module._WIZARD_COMPAT_ALIAS_TARGETS.pop("BrokenWizardAlias", None)
+            module.__dict__.pop("BrokenWizardAlias", None)
 
     def test_wizard_module_keeps_identity_preserving_compatibility_aliases(self):
         self.assertIs(

--- a/ui/dockwidget/workflow_page_state.py
+++ b/ui/dockwidget/workflow_page_state.py
@@ -611,11 +611,28 @@ def _atlas_output_summary(
     return default.output_summary_text
 
 
-# Preserve direct named imports from the original workflow module while the
-# explicit wizard_page_state compatibility module becomes the preferred path.
-WizardActionCallbacks = DockWorkflowActionCallbacks
-WizardPageStateSnapshots = WorkflowPageStateSnapshots
-build_wizard_page_states_from_facts = build_workflow_page_states_from_facts
+# Preserve direct named imports from the original workflow module lazily while
+# the explicit wizard_page_state compatibility module remains the preferred path.
+_WIZARD_COMPAT_ALIAS_TARGETS = {
+    "WizardActionCallbacks": "DockWorkflowActionCallbacks",
+    "WizardPageStateSnapshots": "WorkflowPageStateSnapshots",
+    "build_wizard_page_states_from_facts": "build_workflow_page_states_from_facts",
+}
+
+
+def __getattr__(name: str) -> object:
+    alias_target = _WIZARD_COMPAT_ALIAS_TARGETS.get(name)
+    if alias_target is not None:
+        try:
+            value = globals()[alias_target]
+        except KeyError:
+            raise AttributeError(
+                f"module {__name__!r} alias {name!r} target "
+                f"{alias_target!r} not found"
+            ) from None
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [

--- a/ui/dockwidget/workflow_page_state.py
+++ b/ui/dockwidget/workflow_page_state.py
@@ -630,7 +630,6 @@ def __getattr__(name: str) -> object:
                 f"module {__name__!r} alias {name!r} target "
                 f"{alias_target!r} not found"
             ) from None
-        globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 


### PR DESCRIPTION
## Summary
- lazy-resolve wizard compatibility aliases in `workflow_page_state`
- keep canonical workflow module star exports workflow-only
- preserve direct compatibility access and `wizard_page_state` re-exports

## Tests
- `python3 -m pytest tests/test_workflow_page_state.py tests/test_wizard_shell_composition.py tests/test_workflow_shell_composition.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
