### PR TITLE
refactor: lazy-load step-page wizard aliases

### DIFF
--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -10,16 +10,29 @@ from qfit.ui.application.dock_workflow_sections import build_wizard_step_statuse
 from qfit.ui.application.workflow_page_specs import build_default_workflow_page_specs
 
 
-def _load_step_page_module():
-    for name in (
-        "qfit.ui.dockwidget.action_row",
-        "qfit.ui.dockwidget.wizard_step_page",
-        "qfit.ui.dockwidget.step_page",
-        "qfit.ui.dockwidget.wizard_shell",
-        "qfit.ui.dockwidget.stepper_bar",
-        "qfit.ui.dockwidget",
-    ):
+_STEP_PAGE_MODULES = (
+    "qfit.ui.dockwidget.action_row",
+    "qfit.ui.dockwidget.wizard_step_page",
+    "qfit.ui.dockwidget.step_page",
+    "qfit.ui.dockwidget.wizard_shell",
+    "qfit.ui.dockwidget.stepper_bar",
+    "qfit.ui.dockwidget",
+)
+
+
+def _clear_step_page_modules():
+    for name in _STEP_PAGE_MODULES:
         sys.modules.pop(name, None)
+
+
+def _load_only_step_page_module():
+    _clear_step_page_modules()
+    with patch.dict(sys.modules, _fake_qt_modules()):
+        return importlib.import_module("qfit.ui.dockwidget.step_page")
+
+
+def _load_step_page_module():
+    _clear_step_page_modules()
     with patch.dict(sys.modules, _fake_qt_modules()):
         step_page = importlib.import_module("qfit.ui.dockwidget.step_page")
         wizard_step_page = importlib.import_module("qfit.ui.dockwidget.wizard_step_page")
@@ -281,6 +294,31 @@ class StepPageTest(unittest.TestCase):
             self.step_page.apply_wizard_step_page_statuses,
             self.step_page.apply_workflow_step_page_statuses,
         )
+
+    def test_step_page_resolves_wizard_aliases_lazily(self):
+        module = _load_only_step_page_module()
+        alias_targets = module._WIZARD_COMPAT_ALIAS_TARGETS
+
+        for name in alias_targets:
+            with self.subTest(name=name):
+                self.assertNotIn(name, module.__dict__)
+                self.assertIs(getattr(module, name), getattr(module, alias_targets[name]))
+
+    def test_lazy_wizard_alias_reports_missing_canonical_target_as_attribute_error(self):
+        module = _load_only_step_page_module()
+        module._WIZARD_COMPAT_ALIAS_TARGETS["BrokenWizardAlias"] = (
+            "MissingWorkflowAlias"
+        )
+        try:
+            self.assertFalse(hasattr(module, "BrokenWizardAlias"))
+            with self.assertRaisesRegex(
+                AttributeError,
+                "BrokenWizardAlias.*MissingWorkflowAlias",
+            ):
+                module.__getattr__("BrokenWizardAlias")
+        finally:
+            module._WIZARD_COMPAT_ALIAS_TARGETS.pop("BrokenWizardAlias", None)
+            module.__dict__.pop("BrokenWizardAlias", None)
 
     def test_wizard_step_page_module_exports_compatibility_aliases(self):
         self.assertIs(

--- a/tests/test_step_page.py
+++ b/tests/test_step_page.py
@@ -318,7 +318,6 @@ class StepPageTest(unittest.TestCase):
                 module.__getattr__("BrokenWizardAlias")
         finally:
             module._WIZARD_COMPAT_ALIAS_TARGETS.pop("BrokenWizardAlias", None)
-            module.__dict__.pop("BrokenWizardAlias", None)
 
     def test_wizard_step_page_module_exports_compatibility_aliases(self):
         self.assertIs(

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -52,10 +52,6 @@ QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
 
 STEP_PAGE_NARROW_WIDTH = 360
-DockWizardPageSpec = DockWorkflowPageSpec
-"""Compatibility alias for pre-#805 wizard step page callers."""
-build_default_wizard_page_specs = build_default_workflow_page_specs
-"""Compatibility alias for pre-#805 wizard step page builders."""
 
 
 class StepPage(QWidget):
@@ -383,10 +379,6 @@ class WorkflowStepPage(StepPage):
         return label
 
 
-WizardStepPage = WorkflowStepPage
-"""Compatibility alias for pre-#805 wizard step-page callers."""
-
-
 def build_workflow_step_pages(
     *,
     parent=None,
@@ -407,10 +399,6 @@ def build_workflow_step_pages(
     )
 
 
-build_wizard_step_pages = build_workflow_step_pages
-"""Compatibility alias for pre-#805 wizard step-page callers."""
-
-
 def install_workflow_step_pages(
     shell,
     specs: Sequence[DockWorkflowPageSpec] | None = None,
@@ -421,10 +409,6 @@ def install_workflow_step_pages(
     for page in pages:
         shell.add_page(page)
     return pages
-
-
-install_wizard_step_pages = install_workflow_step_pages
-"""Compatibility alias for pre-#805 wizard step-page callers."""
 
 
 def apply_workflow_step_page_statuses(
@@ -448,8 +432,29 @@ def apply_workflow_step_page_statuses(
         page.set_status(text, tone=tone)
 
 
-apply_wizard_step_page_statuses = apply_workflow_step_page_statuses
-"""Compatibility alias for pre-#805 wizard step-page callers."""
+# Preserve direct named imports from the original step-page module lazily while
+# the explicit wizard_step_page compatibility module remains the preferred path.
+_WIZARD_COMPAT_ALIAS_TARGETS = {
+    "DockWizardPageSpec": "DockWorkflowPageSpec",
+    "build_default_wizard_page_specs": "build_default_workflow_page_specs",
+    "WizardStepPage": "WorkflowStepPage",
+    "build_wizard_step_pages": "build_workflow_step_pages",
+    "install_wizard_step_pages": "install_workflow_step_pages",
+    "apply_wizard_step_page_statuses": "apply_workflow_step_page_statuses",
+}
+
+
+def __getattr__(name: str) -> object:
+    alias_target = _WIZARD_COMPAT_ALIAS_TARGETS.get(name)
+    if alias_target is not None:
+        try:
+            return globals()[alias_target]
+        except KeyError:
+            raise AttributeError(
+                f"module {__name__!r} alias {name!r} target "
+                f"{alias_target!r} not found"
+            ) from None
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class _LayoutWidget(QWidget):


### PR DESCRIPTION
## Summary
- lazy-resolve simple wizard compatibility aliases in `step_page`
- keep canonical step-page star exports workflow-only
- preserve direct compatibility access and `wizard_step_page` re-exports

## Tests
- `python3 -m pytest tests/test_step_page.py tests/test_wizard_shell_composition.py tests/test_workflow_shell_composition.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
