### PR TITLE
refactor: lazy-load workflow section wizard aliases

### DIFF
--- a/tests/test_dock_workflow_sections.py
+++ b/tests/test_dock_workflow_sections.py
@@ -97,6 +97,8 @@ class DockWorkflowSectionsTests(unittest.TestCase):
 
         for name in alias_targets:
             with self.subTest(name=name):
+                # The module-level __getattr__ intentionally does not cache
+                # compatibility aliases, even after earlier direct imports.
                 self.assertNotIn(name, module.__dict__)
                 self.assertIs(getattr(module, name), getattr(module, alias_targets[name]))
 

--- a/tests/test_dock_workflow_sections.py
+++ b/tests/test_dock_workflow_sections.py
@@ -21,6 +21,10 @@ from qfit.ui.application.dock_workflow_sections import (
 )
 
 
+def _load_dock_workflow_sections_module():
+    return importlib.import_module("qfit.ui.application.dock_workflow_sections")
+
+
 class DockWorkflowSectionsTests(unittest.TestCase):
     def test_workflow_steps_keep_stable_order_and_labels(self):
         self.assertEqual(
@@ -87,8 +91,35 @@ class DockWorkflowSectionsTests(unittest.TestCase):
         self.assertNotIn("WIZARD_WORKFLOW_STEPS", module.__all__)
         self.assertIs(module.DockWizardProgress, module.DockWorkflowProgress)
 
+    def test_workflow_sections_resolve_wizard_aliases_lazily(self):
+        module = _load_dock_workflow_sections_module()
+        alias_targets = module._WIZARD_COMPAT_ALIAS_TARGETS
+
+        for name in alias_targets:
+            with self.subTest(name=name):
+                self.assertNotIn(name, module.__dict__)
+                self.assertIs(getattr(module, name), getattr(module, alias_targets[name]))
+
+    def test_lazy_wizard_alias_reports_missing_canonical_target_as_attribute_error(self):
+        module = _load_dock_workflow_sections_module()
+        module._WIZARD_COMPAT_ALIAS_TARGETS["BrokenWizardAlias"] = (
+            "MissingWorkflowAlias"
+        )
+        try:
+            self.assertFalse(hasattr(module, "BrokenWizardAlias"))
+            with self.assertRaisesRegex(
+                AttributeError,
+                "BrokenWizardAlias.*MissingWorkflowAlias",
+            ):
+                module.__getattr__("BrokenWizardAlias")
+        finally:
+            module._WIZARD_COMPAT_ALIAS_TARGETS.pop("BrokenWizardAlias", None)
+
     def test_wizard_workflow_sections_exports_compatibility_metadata(self):
         module = importlib.import_module("qfit.ui.application.wizard_workflow_sections")
+        workflow_module = importlib.import_module(
+            "qfit.ui.application.dock_workflow_sections"
+        )
 
         self.assertEqual(
             module.__all__,
@@ -100,19 +131,19 @@ class DockWorkflowSectionsTests(unittest.TestCase):
                 "build_wizard_step_statuses",
             ],
         )
-        self.assertIs(module.DockWizardProgress, DockWorkflowProgress)
-        self.assertIs(module.WIZARD_WORKFLOW_STEPS, WORKFLOW_STEPS)
+        self.assertIs(module.DockWizardProgress, workflow_module.DockWorkflowProgress)
+        self.assertIs(module.WIZARD_WORKFLOW_STEPS, workflow_module.WORKFLOW_STEPS)
         self.assertIs(
             module.build_initial_wizard_step_statuses,
-            build_initial_workflow_step_statuses,
+            workflow_module.build_initial_workflow_step_statuses,
         )
         self.assertIs(
             module.build_progress_wizard_step_statuses,
-            build_progress_workflow_step_statuses,
+            workflow_module.build_progress_workflow_step_statuses,
         )
         self.assertIs(
             module.build_wizard_step_statuses,
-            build_workflow_step_statuses,
+            workflow_module.build_workflow_step_statuses,
         )
 
     def test_wizard_step_statuses_distinguish_unlocked_from_done(self):

--- a/ui/application/dock_workflow_sections.py
+++ b/ui/application/dock_workflow_sections.py
@@ -52,10 +52,6 @@ class DockWorkflowProgress:
     visited_keys: frozenset[str] = frozenset()
 
 
-DockWizardProgress = DockWorkflowProgress
-"""Compatibility alias for pre-#805 wizard-named progress callers."""
-
-
 WORKFLOW_STEPS: tuple[DockWorkflowSection, ...] = (
     DockWorkflowSection(
         key="connection",
@@ -85,8 +81,6 @@ WORKFLOW_STEPS: tuple[DockWorkflowSection, ...] = (
         current_dock_overview_title="Publish",
     ),
 )
-WIZARD_WORKFLOW_STEPS = WORKFLOW_STEPS
-"""Compatibility alias for pre-#805 wizard-named workflow steps."""
 
 CURRENT_DOCK_SECTION_KEYS: frozenset[str] = frozenset({"sync", "map", "analysis", "atlas"})
 CURRENT_DOCK_SECTIONS: tuple[DockWorkflowSection, ...] = tuple(
@@ -164,14 +158,29 @@ def build_progress_workflow_step_statuses(
     )
 
 
-build_initial_wizard_step_statuses = build_initial_workflow_step_statuses
-"""Compatibility alias for pre-#805 wizard-named step status callers."""
+# Preserve direct named imports from the canonical workflow-section module lazily
+# while the explicit wizard_workflow_sections compatibility module remains the
+# preferred path for wizard-named imports.
+_WIZARD_COMPAT_ALIAS_TARGETS = {
+    "DockWizardProgress": "DockWorkflowProgress",
+    "WIZARD_WORKFLOW_STEPS": "WORKFLOW_STEPS",
+    "build_initial_wizard_step_statuses": "build_initial_workflow_step_statuses",
+    "build_wizard_step_statuses": "build_workflow_step_statuses",
+    "build_progress_wizard_step_statuses": "build_progress_workflow_step_statuses",
+}
 
-build_wizard_step_statuses = build_workflow_step_statuses
-"""Compatibility alias for pre-#805 wizard-named step status callers."""
 
-build_progress_wizard_step_statuses = build_progress_workflow_step_statuses
-"""Compatibility alias for pre-#805 wizard-named progress status callers."""
+def __getattr__(name: str) -> object:
+    alias_target = _WIZARD_COMPAT_ALIAS_TARGETS.get(name)
+    if alias_target is not None:
+        try:
+            return globals()[alias_target]
+        except KeyError:
+            raise AttributeError(
+                f"module {__name__!r} alias {name!r} target "
+                f"{alias_target!r} not found"
+            ) from None
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _build_workflow_step_status_tuple(


### PR DESCRIPTION
## Summary
- lazy-resolve wizard compatibility aliases in `dock_workflow_sections`
- keep canonical workflow-section star exports workflow-only
- preserve direct compatibility access and `wizard_workflow_sections` re-exports

## Tests
- `python3 -m pytest tests/test_dock_workflow_sections.py tests/test_wizard_shell_composition.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs ebelo/qfit#805
