### PR TITLE
Build slope grade segments

### DIFF
--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -262,6 +262,10 @@ def _normalize_slope_grade_sample(sample, distance_field, elevation_field, grade
 def _sample_value(sample, field_name):
     if isinstance(sample, dict):
         return sample.get(field_name)
+    try:
+        return sample[field_name]
+    except (KeyError, IndexError, TypeError, AttributeError):
+        pass
     value = getattr(sample, field_name, None)
     if callable(value):
         return value()

--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -28,7 +28,7 @@ class SlopeGradeClass:
 SLOPE_GRADE_CLASSES: tuple[SlopeGradeClass, ...] = (
     SlopeGradeClass(
         key="steep_descent",
-        label="Steep descent (≤ -8%)",
+        label="Steep descent (< -8%)",
         color_hex="#2c7fb8",
         max_percent=-8.0,
     ),
@@ -210,12 +210,13 @@ def build_slope_grade_segments(
         end_distance, end_elevation, end_grade = current
         distance_delta = end_distance - start_distance
         if distance_delta <= 0:
-            previous = current
             continue
         grade_percent = end_grade
         if grade_percent is None:
-            if start_elevation is None or end_elevation is None:
+            if start_elevation is None:
                 previous = current
+                continue
+            if end_elevation is None:
                 continue
             grade_percent = (
                 (end_elevation - start_elevation) / distance_delta

--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -75,6 +75,16 @@ class SlopeGradeLayerPlan:
 
 
 @dataclass(frozen=True)
+class SlopeGradeSegment:
+    """Pure per-distance segment classification for slope-grade styling."""
+
+    start_distance_m: float
+    end_distance_m: float
+    grade_percent: float
+    grade_class: SlopeGradeClass
+
+
+@dataclass(frozen=True)
 class SlopeGradeAnalysisPlan:
     """Render-neutral plan for #815 slope-grade line analysis."""
 
@@ -153,6 +163,118 @@ def build_slope_grade_status(plan: SlopeGradeAnalysisPlan) -> str:
     if reasons:
         return "Slope grade line analysis unchanged: " + "; ".join(reasons)
     return "Slope grade line analysis unchanged: no eligible line layers found."
+
+
+def slope_grade_class_for_percent(grade_percent: float) -> SlopeGradeClass:
+    """Return the deterministic legend class for a percent-grade value."""
+
+    for grade_class in SLOPE_GRADE_CLASSES:
+        if _grade_class_contains(grade_class, grade_percent):
+            return grade_class
+    return SLOPE_GRADE_CLASSES[-1]
+
+
+def build_slope_grade_segments(
+    samples: Iterable[object],
+    *,
+    distance_field: str = "distance_m",
+    elevation_field: str | None = "altitude_m",
+    grade_field: str | None = None,
+) -> tuple[SlopeGradeSegment, ...]:
+    """Build deterministic slope-grade segments from ordered sample rows.
+
+    Activity samples can pass ``grade_field`` to reuse an existing smoothed
+    grade, while saved-route samples can pass elevation/distance fields so the
+    segment grade is computed from the elevation delta. Non-numeric or
+    non-forward samples are skipped rather than aborting the whole analysis.
+    """
+
+    normalized = tuple(
+        _normalize_slope_grade_sample(
+            sample,
+            distance_field,
+            elevation_field,
+            grade_field,
+        )
+        for sample in samples
+    )
+    segments: list[SlopeGradeSegment] = []
+    previous = None
+    for current in normalized:
+        if current is None:
+            continue
+        if previous is None:
+            previous = current
+            continue
+        start_distance, start_elevation, _start_grade = previous
+        end_distance, end_elevation, end_grade = current
+        distance_delta = end_distance - start_distance
+        if distance_delta <= 0:
+            previous = current
+            continue
+        grade_percent = end_grade
+        if grade_percent is None:
+            if start_elevation is None or end_elevation is None:
+                previous = current
+                continue
+            grade_percent = (
+                (end_elevation - start_elevation) / distance_delta
+            ) * 100.0
+        segments.append(
+            SlopeGradeSegment(
+                start_distance_m=start_distance,
+                end_distance_m=end_distance,
+                grade_percent=grade_percent,
+                grade_class=slope_grade_class_for_percent(grade_percent),
+            )
+        )
+        previous = current
+    return tuple(segments)
+
+
+def _grade_class_contains(grade_class: SlopeGradeClass, grade_percent: float) -> bool:
+    if (
+        grade_class.min_percent is not None
+        and grade_percent < grade_class.min_percent
+    ):
+        return False
+    if (
+        grade_class.max_percent is not None
+        and grade_percent >= grade_class.max_percent
+    ):
+        return False
+    return True
+
+
+def _normalize_slope_grade_sample(sample, distance_field, elevation_field, grade_field):
+    distance = _numeric_value(_sample_value(sample, distance_field))
+    if distance is None:
+        return None
+    elevation = None
+    if elevation_field:
+        elevation = _numeric_value(_sample_value(sample, elevation_field))
+    grade = None
+    if grade_field:
+        grade = _numeric_value(_sample_value(sample, grade_field))
+    return distance, elevation, grade
+
+
+def _sample_value(sample, field_name):
+    if isinstance(sample, dict):
+        return sample.get(field_name)
+    value = getattr(sample, field_name, None)
+    if callable(value):
+        return value()
+    return value
+
+
+def _numeric_value(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _activity_track_plan(activities_layer, points_layer) -> SlopeGradeLayerPlan:
@@ -280,7 +402,10 @@ __all__ = [
     "SlopeGradeAnalysisPlan",
     "SlopeGradeClass",
     "SlopeGradeLayerPlan",
+    "SlopeGradeSegment",
     "build_slope_grade_analysis_plan",
+    "build_slope_grade_segments",
     "build_slope_grade_status",
     "run_slope_grade_analysis",
+    "slope_grade_class_for_percent",
 ]

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -65,7 +65,7 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertEqual(
             SLOPE_GRADE_LEGEND,
             (
-                "Steep descent (≤ -8%)",
+                "Steep descent (< -8%)",
                 "Descent (-8% to -3%)",
                 "Flat / rolling (-3% to +3%)",
                 "Climb (+3% to +8%)",
@@ -132,7 +132,7 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertAlmostEqual(segments[0].grade_percent, -10.0)
         self.assertEqual(segments[0].grade_class.key, "steep_descent")
 
-    def test_segments_skip_invalid_or_non_forward_samples(self):
+    def test_segments_skip_invalid_or_non_forward_samples_and_recover(self):
         segments = build_slope_grade_segments(
             (
                 {"distance_m": 0, "altitude_m": 100},
@@ -143,7 +143,25 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(segments, ())
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0].start_distance_m, 0.0)
+        self.assertEqual(segments[0].end_distance_m, 200.0)
+        self.assertAlmostEqual(segments[0].grade_percent, 2.0)
+
+    def test_segments_recover_after_missing_midstream_elevation_sample(self):
+        segments = build_slope_grade_segments(
+            (
+                {"distance_m": 0, "altitude_m": 100},
+                {"distance_m": 50, "altitude_m": None},
+                {"distance_m": 100, "altitude_m": 104},
+            )
+        )
+
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0].start_distance_m, 0.0)
+        self.assertEqual(segments[0].end_distance_m, 100.0)
+        self.assertAlmostEqual(segments[0].grade_percent, 4.0)
+        self.assertEqual(segments[0].grade_class.key, "climb")
 
     def test_plan_targets_only_eligible_activity_and_route_line_layers(self):
         activity_tracks = _Layer(fields=("name",))

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -8,8 +8,10 @@ from qfit.analysis.application.slope_grade_analysis import (
     SLOPE_GRADE_LEGEND,
     SLOPE_GRADE_MODE,
     build_slope_grade_analysis_plan,
+    build_slope_grade_segments,
     build_slope_grade_status,
     run_slope_grade_analysis,
+    slope_grade_class_for_percent,
 )
 
 
@@ -42,6 +44,13 @@ class _WkbLayer(_Layer):
         return self._wkb_type
 
 
+class _Sample:
+    def __init__(self, *, stream_distance_m, altitude_m=None, grade_smooth_pct=None):
+        self.stream_distance_m = stream_distance_m
+        self.altitude_m = altitude_m
+        self.grade_smooth_pct = grade_smooth_pct
+
+
 class SlopeGradeAnalysisTests(unittest.TestCase):
     def test_legend_uses_documented_deterministic_percent_grade_classes(self):
         self.assertEqual(SLOPE_GRADE_MODE, "Slope grade lines")
@@ -59,6 +68,62 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
             [grade_class.color_hex for grade_class in SLOPE_GRADE_CLASSES],
             ["#2c7fb8", "#7fcdbb", "#f0f0f0", "#fdae61", "#d7191c"],
         )
+
+    def test_classifies_percent_grade_boundaries_deterministically(self):
+        self.assertEqual(slope_grade_class_for_percent(-9.0).key, "steep_descent")
+        self.assertEqual(slope_grade_class_for_percent(-8.0).key, "descent")
+        self.assertEqual(slope_grade_class_for_percent(-3.0).key, "flat")
+        self.assertEqual(slope_grade_class_for_percent(3.0).key, "climb")
+        self.assertEqual(slope_grade_class_for_percent(8.0).key, "steep_climb")
+
+    def test_builds_route_segments_from_elevation_distance_samples(self):
+        segments = build_slope_grade_segments(
+            (
+                {"distance_m": 0, "altitude_m": 100},
+                {"distance_m": 100, "altitude_m": 104},
+                {"distance_m": 200, "altitude_m": 94},
+            )
+        )
+
+        self.assertEqual(len(segments), 2)
+        self.assertEqual(segments[0].start_distance_m, 0.0)
+        self.assertEqual(segments[0].end_distance_m, 100.0)
+        self.assertAlmostEqual(segments[0].grade_percent, 4.0)
+        self.assertEqual(segments[0].grade_class.key, "climb")
+        self.assertAlmostEqual(segments[1].grade_percent, -10.0)
+        self.assertEqual(segments[1].grade_class.key, "steep_descent")
+
+    def test_builds_activity_segments_from_existing_smoothed_grade_samples(self):
+        segments = build_slope_grade_segments(
+            (
+                _Sample(stream_distance_m=0, grade_smooth_pct=0.0),
+                _Sample(stream_distance_m=20, grade_smooth_pct="2.5"),
+                _Sample(stream_distance_m=40, grade_smooth_pct="9.1"),
+            ),
+            distance_field="stream_distance_m",
+            elevation_field=None,
+            grade_field="grade_smooth_pct",
+        )
+
+        self.assertEqual(
+            tuple(segment.grade_class.key for segment in segments),
+            ("flat", "steep_climb"),
+        )
+        self.assertEqual(segments[0].grade_percent, 2.5)
+        self.assertEqual(segments[1].grade_percent, 9.1)
+
+    def test_segments_skip_invalid_or_non_forward_samples(self):
+        segments = build_slope_grade_segments(
+            (
+                {"distance_m": 0, "altitude_m": 100},
+                {"distance_m": 0, "altitude_m": 101},
+                {"distance_m": "bad", "altitude_m": 102},
+                {"distance_m": 100, "altitude_m": None},
+                {"distance_m": 200, "altitude_m": 104},
+            )
+        )
+
+        self.assertEqual(segments, ())
 
     def test_plan_targets_only_eligible_activity_and_route_line_layers(self):
         activity_tracks = _Layer(fields=("name",))

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -51,6 +51,14 @@ class _Sample:
         self.grade_smooth_pct = grade_smooth_pct
 
 
+class _FeatureSample:
+    def __init__(self, values):
+        self._values = values
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+
 class SlopeGradeAnalysisTests(unittest.TestCase):
     def test_legend_uses_documented_deterministic_percent_grade_classes(self):
         self.assertEqual(SLOPE_GRADE_MODE, "Slope grade lines")
@@ -111,6 +119,18 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         )
         self.assertEqual(segments[0].grade_percent, 2.5)
         self.assertEqual(segments[1].grade_percent, 9.1)
+
+    def test_builds_segments_from_feature_item_access_rows(self):
+        segments = build_slope_grade_segments(
+            (
+                _FeatureSample({"distance_m": 0, "altitude_m": 100}),
+                _FeatureSample({"distance_m": 50, "altitude_m": 95}),
+            )
+        )
+
+        self.assertEqual(len(segments), 1)
+        self.assertAlmostEqual(segments[0].grade_percent, -10.0)
+        self.assertEqual(segments[0].grade_class.key, "steep_descent")
 
     def test_segments_skip_invalid_or_non_forward_samples(self):
         segments = build_slope_grade_segments(


### PR DESCRIPTION
## Summary

- add pure slope-grade segment classification for the #815 analysis path
- compute route segment grade from elevation/distance samples
- reuse activity `grade_smooth_pct` samples when available and skip invalid/non-forward rows gracefully

## Notes

This is the next small #815 slice after the mode/planning contract. It still does not apply a QGIS renderer; it adds the deterministic segment computation that a renderer/adapter can consume next.

Refs #815.

## Tests

- `python3 -m pytest tests/test_slope_grade_analysis.py -q`
- `python3 -m pytest tests/test_slope_grade_analysis.py tests/test_analysis_execution_dispatch.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
