### PR TITLE
Derive slope grade segments from layers

### DIFF
--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -233,6 +233,27 @@ def build_slope_grade_segments(
     return tuple(segments)
 
 
+def build_activity_slope_grade_segments(points_layer) -> tuple[SlopeGradeSegment, ...]:
+    """Build activity slope-grade segments from a point-sample layer."""
+
+    return build_slope_grade_segments(
+        _layer_features(points_layer),
+        distance_field="stream_distance_m",
+        elevation_field=None,
+        grade_field="grade_smooth_pct",
+    )
+
+
+def build_route_slope_grade_segments(sample_layer) -> tuple[SlopeGradeSegment, ...]:
+    """Build saved-route slope-grade segments from route profile samples."""
+
+    return build_slope_grade_segments(
+        _layer_features(sample_layer),
+        distance_field="distance_m",
+        elevation_field="altitude_m",
+    )
+
+
 def _grade_class_contains(grade_class: SlopeGradeClass, grade_percent: float) -> bool:
     if (
         grade_class.min_percent is not None
@@ -258,6 +279,15 @@ def _normalize_slope_grade_sample(sample, distance_field, elevation_field, grade
     if grade_field:
         grade = _numeric_value(_sample_value(sample, grade_field))
     return distance, elevation, grade
+
+
+def _layer_features(layer):
+    if layer is None:
+        return ()
+    features = getattr(layer, "getFeatures", None)
+    if not callable(features):
+        return ()
+    return features()
 
 
 def _sample_value(sample, field_name):
@@ -408,9 +438,11 @@ __all__ = [
     "SlopeGradeClass",
     "SlopeGradeLayerPlan",
     "SlopeGradeSegment",
+    "build_activity_slope_grade_segments",
     "build_slope_grade_analysis_plan",
     "build_slope_grade_segments",
     "build_slope_grade_status",
+    "build_route_slope_grade_segments",
     "run_slope_grade_analysis",
     "slope_grade_class_for_percent",
 ]

--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -236,8 +236,9 @@ def build_slope_grade_segments(
 def build_activity_slope_grade_segments(points_layer) -> tuple[SlopeGradeSegment, ...]:
     """Build activity slope-grade segments from a point-sample layer."""
 
-    return build_slope_grade_segments(
+    return _build_grouped_slope_grade_segments(
         _layer_features(points_layer),
+        group_field_sets=(("source", "source_activity_id"),),
         distance_field="stream_distance_m",
         elevation_field=None,
         grade_field="grade_smooth_pct",
@@ -247,11 +248,38 @@ def build_activity_slope_grade_segments(points_layer) -> tuple[SlopeGradeSegment
 def build_route_slope_grade_segments(sample_layer) -> tuple[SlopeGradeSegment, ...]:
     """Build saved-route slope-grade segments from route profile samples."""
 
-    return build_slope_grade_segments(
+    return _build_grouped_slope_grade_segments(
         _layer_features(sample_layer),
+        group_field_sets=(("sample_group_index",), ("source", "source_route_id")),
         distance_field="distance_m",
         elevation_field="altitude_m",
     )
+
+
+def _build_grouped_slope_grade_segments(
+    samples,
+    *,
+    group_field_sets,
+    distance_field,
+    elevation_field,
+    grade_field=None,
+):
+    groups: dict[tuple[object, ...], list[object]] = {}
+    for sample in samples:
+        key = _sample_group_key(sample, group_field_sets)
+        groups.setdefault(key, []).append(sample)
+
+    segments: list[SlopeGradeSegment] = []
+    for group_samples in groups.values():
+        segments.extend(
+            build_slope_grade_segments(
+                group_samples,
+                distance_field=distance_field,
+                elevation_field=elevation_field,
+                grade_field=grade_field,
+            )
+        )
+    return tuple(segments)
 
 
 def _grade_class_contains(grade_class: SlopeGradeClass, grade_percent: float) -> bool:
@@ -288,6 +316,14 @@ def _layer_features(layer):
     if not callable(features):
         return ()
     return features()
+
+
+def _sample_group_key(sample, group_field_sets):
+    for group_fields in group_field_sets:
+        values = tuple(_sample_value(sample, field_name) for field_name in group_fields)
+        if any(value not in (None, "") for value in values):
+            return values
+    return (None,)
 
 
 def _sample_value(sample, field_name):

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -7,6 +7,8 @@ from qfit.analysis.application.slope_grade_analysis import (
     SLOPE_GRADE_CLASSES,
     SLOPE_GRADE_LEGEND,
     SLOPE_GRADE_MODE,
+    build_activity_slope_grade_segments,
+    build_route_slope_grade_segments,
     build_slope_grade_analysis_plan,
     build_slope_grade_segments,
     build_slope_grade_status,
@@ -57,6 +59,14 @@ class _FeatureSample:
 
     def __getitem__(self, key):
         return self._values[key]
+
+
+class _FeatureLayer:
+    def __init__(self, features):
+        self._features = tuple(features)
+
+    def getFeatures(self):
+        return iter(self._features)
 
 
 class SlopeGradeAnalysisTests(unittest.TestCase):
@@ -131,6 +141,40 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertEqual(len(segments), 1)
         self.assertAlmostEqual(segments[0].grade_percent, -10.0)
         self.assertEqual(segments[0].grade_class.key, "steep_descent")
+
+    def test_builds_activity_segments_from_point_layer_features(self):
+        segments = build_activity_slope_grade_segments(
+            _FeatureLayer(
+                (
+                    _FeatureSample(
+                        {"stream_distance_m": 0, "grade_smooth_pct": 0.0}
+                    ),
+                    _FeatureSample(
+                        {"stream_distance_m": 50, "grade_smooth_pct": -4.0}
+                    ),
+                )
+            )
+        )
+
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0].grade_class.key, "descent")
+
+    def test_builds_route_segments_from_sample_layer_features(self):
+        segments = build_route_slope_grade_segments(
+            _FeatureLayer(
+                (
+                    _FeatureSample({"distance_m": 0, "altitude_m": 100}),
+                    _FeatureSample({"distance_m": 100, "altitude_m": 108}),
+                )
+            )
+        )
+
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0].grade_class.key, "steep_climb")
+
+    def test_layer_segment_builders_ignore_missing_layers(self):
+        self.assertEqual(build_activity_slope_grade_segments(None), ())
+        self.assertEqual(build_route_slope_grade_segments(None), ())
 
     def test_segments_skip_invalid_or_non_forward_samples_and_recover(self):
         segments = build_slope_grade_segments(

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -147,10 +147,20 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
             _FeatureLayer(
                 (
                     _FeatureSample(
-                        {"stream_distance_m": 0, "grade_smooth_pct": 0.0}
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 0,
+                            "grade_smooth_pct": 0.0,
+                        }
                     ),
                     _FeatureSample(
-                        {"stream_distance_m": 50, "grade_smooth_pct": -4.0}
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 50,
+                            "grade_smooth_pct": -4.0,
+                        }
                     ),
                 )
             )
@@ -159,18 +169,100 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertEqual(len(segments), 1)
         self.assertEqual(segments[0].grade_class.key, "descent")
 
+    def test_builds_activity_segments_per_activity_key(self):
+        segments = build_activity_slope_grade_segments(
+            _FeatureLayer(
+                (
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 0,
+                            "grade_smooth_pct": 4.0,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 100,
+                            "grade_smooth_pct": 4.0,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-2",
+                            "stream_distance_m": 0,
+                            "grade_smooth_pct": -4.0,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-2",
+                            "stream_distance_m": 100,
+                            "grade_smooth_pct": -4.0,
+                        }
+                    ),
+                )
+            )
+        )
+
+        self.assertEqual(
+            tuple(segment.grade_class.key for segment in segments),
+            ("climb", "descent"),
+        )
+
     def test_builds_route_segments_from_sample_layer_features(self):
         segments = build_route_slope_grade_segments(
             _FeatureLayer(
                 (
-                    _FeatureSample({"distance_m": 0, "altitude_m": 100}),
-                    _FeatureSample({"distance_m": 100, "altitude_m": 108}),
+                    _FeatureSample(
+                        {
+                            "sample_group_index": 1,
+                            "distance_m": 0,
+                            "altitude_m": 100,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "sample_group_index": 1,
+                            "distance_m": 100,
+                            "altitude_m": 108,
+                        }
+                    ),
                 )
             )
         )
 
         self.assertEqual(len(segments), 1)
         self.assertEqual(segments[0].grade_class.key, "steep_climb")
+
+    def test_builds_route_segments_per_sample_group(self):
+        segments = build_route_slope_grade_segments(
+            _FeatureLayer(
+                (
+                    _FeatureSample(
+                        {"sample_group_index": 1, "distance_m": 0, "altitude_m": 100}
+                    ),
+                    _FeatureSample(
+                        {"sample_group_index": 1, "distance_m": 100, "altitude_m": 104}
+                    ),
+                    _FeatureSample(
+                        {"sample_group_index": 2, "distance_m": 0, "altitude_m": 100}
+                    ),
+                    _FeatureSample(
+                        {"sample_group_index": 2, "distance_m": 100, "altitude_m": 91}
+                    ),
+                )
+            )
+        )
+
+        self.assertEqual(
+            tuple(segment.grade_class.key for segment in segments),
+            ("climb", "steep_descent"),
+        )
 
     def test_layer_segment_builders_ignore_missing_layers(self):
         self.assertEqual(build_activity_slope_grade_segments(None), ())


### PR DESCRIPTION
## Summary

- add layer-to-segment helpers for activity point samples and saved-route profile samples
- keep the extraction QGIS-free by consuming feature iterables through the existing item-access sample path
- cover missing layers and feature-backed activity/route samples in tests

## Notes

This is a small follow-up #815 slice after segment classification. It bridges loaded sample layers to the pure segment builder without applying renderer changes yet.

Refs #815.

## Tests

- `python3 -m pytest tests/test_slope_grade_analysis.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
