### PR TITLE
Report slope grade segment counts

### DIFF
--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -198,7 +198,11 @@ def build_slope_grade_analysis_result(
                 route_profile_samples_layer or route_points_layer
             )
         else:
-            segments = ()
+            raise ValueError(
+                "Unsupported slope-grade layer key: {key}".format(
+                    key=layer_plan.key
+                )
+            )
         layer_results.append(
             SlopeGradeLayerResult(
                 key=layer_plan.key,
@@ -233,13 +237,16 @@ def build_slope_grade_status(result_or_plan) -> str:
 
 def _build_slope_grade_result_status(result: SlopeGradeAnalysisResult) -> str:
     if result.layers and result.segment_count > 0:
+        classified_layers = tuple(
+            layer for layer in result.layers if layer.segment_count > 0
+        )
         summaries = ", ".join(
             "{label} ({count} {segment_word})".format(
                 label=layer.label,
                 count=layer.segment_count,
                 segment_word="segment" if layer.segment_count == 1 else "segments",
             )
-            for layer in result.layers
+            for layer in classified_layers
         )
         return f"Slope grade line analysis classified {summaries}."
 

--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -96,6 +96,31 @@ class SlopeGradeAnalysisPlan:
         return tuple(layer for layer in self.layers if layer.enabled)
 
 
+@dataclass(frozen=True)
+class SlopeGradeLayerResult:
+    """Classified segment result for one slope-grade target layer."""
+
+    key: str
+    label: str
+    segments: tuple[SlopeGradeSegment, ...] = ()
+
+    @property
+    def segment_count(self) -> int:
+        return len(self.segments)
+
+
+@dataclass(frozen=True)
+class SlopeGradeAnalysisResult:
+    """Render-neutral slope-grade execution result for eligible line layers."""
+
+    plan: SlopeGradeAnalysisPlan
+    layers: tuple[SlopeGradeLayerResult, ...] = ()
+
+    @property
+    def segment_count(self) -> int:
+        return sum(layer.segment_count for layer in self.layers)
+
+
 SLOPE_GRADE_LEGEND = tuple(grade_class.label for grade_class in SLOPE_GRADE_CLASSES)
 
 
@@ -137,19 +162,60 @@ def build_slope_grade_analysis_plan(
 def run_slope_grade_analysis(request: RunAnalysisRequest) -> RunAnalysisResult:
     """Return clear feedback for slope-grade line-analysis eligibility."""
 
-    plan = build_slope_grade_analysis_plan(
+    result = build_slope_grade_analysis_result(
         activities_layer=request.activities_layer,
         points_layer=request.points_layer,
         route_tracks_layer=request.route_tracks_layer,
         route_points_layer=request.route_points_layer,
         route_profile_samples_layer=request.route_profile_samples_layer,
     )
-    return RunAnalysisResult(status=build_slope_grade_status(plan), layer=None)
+    return RunAnalysisResult(status=build_slope_grade_status(result), layer=None)
 
 
-def build_slope_grade_status(plan: SlopeGradeAnalysisPlan) -> str:
+def build_slope_grade_analysis_result(
+    *,
+    activities_layer=None,
+    points_layer=None,
+    route_tracks_layer=None,
+    route_points_layer=None,
+    route_profile_samples_layer=None,
+) -> SlopeGradeAnalysisResult:
+    """Classify slope-grade segments for eligible line-layer targets."""
+
+    plan = build_slope_grade_analysis_plan(
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+        route_tracks_layer=route_tracks_layer,
+        route_points_layer=route_points_layer,
+        route_profile_samples_layer=route_profile_samples_layer,
+    )
+    layer_results = []
+    for layer_plan in plan.enabled_layers:
+        if layer_plan.key == "activity_tracks":
+            segments = build_activity_slope_grade_segments(points_layer)
+        elif layer_plan.key == "saved_route_tracks":
+            segments = build_route_slope_grade_segments(
+                route_profile_samples_layer or route_points_layer
+            )
+        else:
+            segments = ()
+        layer_results.append(
+            SlopeGradeLayerResult(
+                key=layer_plan.key,
+                label=layer_plan.label,
+                segments=segments,
+            )
+        )
+    return SlopeGradeAnalysisResult(plan=plan, layers=tuple(layer_results))
+
+
+def build_slope_grade_status(result_or_plan) -> str:
     """Summarize which line layers can be styled by slope-grade analysis."""
 
+    if isinstance(result_or_plan, SlopeGradeAnalysisResult):
+        return _build_slope_grade_result_status(result_or_plan)
+
+    plan = result_or_plan
     enabled = plan.enabled_layers
     if enabled:
         labels = ", ".join(layer.label for layer in enabled)
@@ -163,6 +229,28 @@ def build_slope_grade_status(plan: SlopeGradeAnalysisPlan) -> str:
     if reasons:
         return "Slope grade line analysis unchanged: " + "; ".join(reasons)
     return "Slope grade line analysis unchanged: no eligible line layers found."
+
+
+def _build_slope_grade_result_status(result: SlopeGradeAnalysisResult) -> str:
+    if result.layers and result.segment_count > 0:
+        summaries = ", ".join(
+            "{label} ({count} {segment_word})".format(
+                label=layer.label,
+                count=layer.segment_count,
+                segment_word="segment" if layer.segment_count == 1 else "segments",
+            )
+            for layer in result.layers
+        )
+        return f"Slope grade line analysis classified {summaries}."
+
+    if result.plan.enabled_layers:
+        labels = ", ".join(layer.label for layer in result.plan.enabled_layers)
+        return (
+            "Slope grade line analysis found eligible {labels}, but no grade "
+            "segments could be classified."
+        ).format(labels=labels)
+
+    return build_slope_grade_status(result.plan)
 
 
 def slope_grade_class_for_percent(grade_percent: float) -> SlopeGradeClass:
@@ -471,10 +559,13 @@ __all__ = [
     "SLOPE_GRADE_LEGEND",
     "SLOPE_GRADE_MODE",
     "SlopeGradeAnalysisPlan",
+    "SlopeGradeAnalysisResult",
     "SlopeGradeClass",
     "SlopeGradeLayerPlan",
+    "SlopeGradeLayerResult",
     "SlopeGradeSegment",
     "build_activity_slope_grade_segments",
+    "build_slope_grade_analysis_result",
     "build_slope_grade_analysis_plan",
     "build_slope_grade_segments",
     "build_slope_grade_status",

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -9,6 +9,7 @@ from qfit.analysis.application.slope_grade_analysis import (
     SLOPE_GRADE_MODE,
     build_activity_slope_grade_segments,
     build_route_slope_grade_segments,
+    build_slope_grade_analysis_result,
     build_slope_grade_analysis_plan,
     build_slope_grade_segments,
     build_slope_grade_status,
@@ -62,11 +63,15 @@ class _FeatureSample:
 
 
 class _FeatureLayer:
-    def __init__(self, features):
+    def __init__(self, features, *, fields=()):
         self._features = tuple(features)
+        self._fields = tuple(_Field(name) for name in fields)
 
     def getFeatures(self):
         return iter(self._features)
+
+    def fields(self):
+        return self._fields
 
 
 class SlopeGradeAnalysisTests(unittest.TestCase):
@@ -268,6 +273,79 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertEqual(build_activity_slope_grade_segments(None), ())
         self.assertEqual(build_route_slope_grade_segments(None), ())
 
+    def test_analysis_result_classifies_segments_for_eligible_line_targets(self):
+        result = build_slope_grade_analysis_result(
+            activities_layer=_Layer(fields=("name",)),
+            points_layer=_FeatureLayer(
+                (
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 0,
+                            "grade_smooth_pct": 0,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 100,
+                            "grade_smooth_pct": 4,
+                        }
+                    ),
+                ),
+                fields=("stream_distance_m", "grade_smooth_pct"),
+            ),
+            route_tracks_layer=_Layer(fields=("name",)),
+            route_profile_samples_layer=_FeatureLayer(
+                (
+                    _FeatureSample(
+                        {"sample_group_index": 1, "distance_m": 0, "altitude_m": 100}
+                    ),
+                    _FeatureSample(
+                        {"sample_group_index": 1, "distance_m": 100, "altitude_m": 91}
+                    ),
+                ),
+                fields=("distance_m", "altitude_m"),
+            ),
+        )
+
+        self.assertEqual(result.segment_count, 2)
+        self.assertEqual(
+            tuple(layer.segment_count for layer in result.layers),
+            (1, 1),
+        )
+        self.assertEqual(
+            tuple(layer.segments[0].grade_class.key for layer in result.layers),
+            ("climb", "steep_descent"),
+        )
+        self.assertEqual(
+            build_slope_grade_status(result),
+            (
+                "Slope grade line analysis classified activity tracks (1 segment), "
+                "saved route tracks (1 segment)."
+            ),
+        )
+
+    def test_analysis_result_reports_when_eligible_layers_have_no_segments(self):
+        result = build_slope_grade_analysis_result(
+            activities_layer=_Layer(fields=("name",)),
+            points_layer=_FeatureLayer(
+                (),
+                fields=("stream_distance_m", "grade_smooth_pct"),
+            ),
+        )
+
+        self.assertEqual(result.segment_count, 0)
+        self.assertEqual(
+            build_slope_grade_status(result),
+            (
+                "Slope grade line analysis found eligible activity tracks, but no "
+                "grade segments could be classified."
+            ),
+        )
+
     def test_segments_skip_invalid_or_non_forward_samples_and_recover(self):
         segments = build_slope_grade_segments(
             (
@@ -393,13 +471,33 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
             RunAnalysisRequest(
                 analysis_mode=SLOPE_GRADE_MODE,
                 activities_layer=_Layer(fields=("name",)),
-                points_layer=_Layer(fields=("grade_smooth_pct", "stream_distance_m")),
+                points_layer=_FeatureLayer(
+                    (
+                        _FeatureSample(
+                            {
+                                "source": "strava",
+                                "source_activity_id": "a-1",
+                                "stream_distance_m": 0,
+                                "grade_smooth_pct": 0,
+                            }
+                        ),
+                        _FeatureSample(
+                            {
+                                "source": "strava",
+                                "source_activity_id": "a-1",
+                                "stream_distance_m": 100,
+                                "grade_smooth_pct": 4,
+                            }
+                        ),
+                    ),
+                    fields=("grade_smooth_pct", "stream_distance_m"),
+                ),
             )
         )
 
         self.assertEqual(
             result.status,
-            "Slope grade line analysis ready for activity tracks.",
+            "Slope grade line analysis classified activity tracks (1 segment).",
         )
         self.assertIsNone(result.layer)
 

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from tests import _path  # noqa: F401
 
@@ -7,6 +8,10 @@ from qfit.analysis.application.slope_grade_analysis import (
     SLOPE_GRADE_CLASSES,
     SLOPE_GRADE_LEGEND,
     SLOPE_GRADE_MODE,
+    SlopeGradeAnalysisPlan,
+    SlopeGradeAnalysisResult,
+    SlopeGradeLayerPlan,
+    SlopeGradeLayerResult,
     build_activity_slope_grade_segments,
     build_route_slope_grade_segments,
     build_slope_grade_analysis_result,
@@ -345,6 +350,54 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
                 "grade segments could be classified."
             ),
         )
+
+    def test_status_only_reports_layers_with_classified_segments(self):
+        result = SlopeGradeAnalysisResult(
+            plan=SlopeGradeAnalysisPlan(layers=()),
+            layers=(
+                SlopeGradeLayerResult(
+                    key="activity_tracks",
+                    label="activity tracks",
+                    segments=(
+                        build_slope_grade_segments(
+                            (
+                                {"distance_m": 0, "altitude_m": 100},
+                                {"distance_m": 100, "altitude_m": 104},
+                            )
+                        )[0],
+                    ),
+                ),
+                SlopeGradeLayerResult(
+                    key="saved_route_tracks",
+                    label="saved route tracks",
+                    segments=(),
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            build_slope_grade_status(result),
+            "Slope grade line analysis classified activity tracks (1 segment).",
+        )
+
+    def test_analysis_result_rejects_unhandled_plan_layer_keys(self):
+        with patch(
+            "qfit.analysis.application.slope_grade_analysis.build_slope_grade_analysis_plan",
+            return_value=SlopeGradeAnalysisPlan(
+                layers=(
+                    SlopeGradeLayerPlan(
+                        key="future_layer",
+                        label="future layer",
+                        enabled=True,
+                    ),
+                )
+            ),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Unsupported slope-grade layer key: future_layer",
+            ):
+                build_slope_grade_analysis_result()
 
     def test_segments_skip_invalid_or_non_forward_samples_and_recover(self):
         segments = build_slope_grade_segments(


### PR DESCRIPTION
## Summary

- classify slope-grade segments during analysis execution for eligible activity and route line targets
- return render-neutral per-layer segment results and segment counts
- surface clear feedback when eligible layers have no classifiable grade segments

## Notes

This is a small #815 slice between layer sample extraction and renderer work. It keeps the result QGIS-free while making the analysis action consume the segment builders and report what would be styled next.

Refs #815.

## Tests

- `python3 -m pytest tests/test_slope_grade_analysis.py -q`
- `python3 -m pytest tests/test_analysis_execution_dispatch.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
