### PR TITLE
Create slope grade overlay layer

### DIFF
--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -185,7 +185,23 @@ def run_slope_grade_analysis(request: RunAnalysisRequest) -> RunAnalysisResult:
         route_points_layer=request.route_points_layer,
         route_profile_samples_layer=request.route_profile_samples_layer,
     )
-    return RunAnalysisResult(status=build_slope_grade_status(result), layer=None)
+    layer, _line_segments = _build_slope_grade_layer(request)
+    return RunAnalysisResult(status=build_slope_grade_status(result), layer=layer)
+
+
+def _build_slope_grade_layer(request: RunAnalysisRequest):
+    try:
+        from ..infrastructure.slope_grade_layer import build_slope_grade_layer
+    except ImportError:
+        return None, ()
+
+    return build_slope_grade_layer(
+        activities_layer=request.activities_layer,
+        points_layer=request.points_layer,
+        route_tracks_layer=request.route_tracks_layer,
+        route_points_layer=request.route_points_layer,
+        route_profile_samples_layer=request.route_profile_samples_layer,
+    )
 
 
 def build_slope_grade_analysis_result(

--- a/analysis/infrastructure/slope_grade_layer.py
+++ b/analysis/infrastructure/slope_grade_layer.py
@@ -17,6 +17,7 @@ from qgis.core import (
 from ..application.slope_grade_analysis import (
     SLOPE_GRADE_CLASSES,
     build_activity_slope_grade_line_segments,
+    build_slope_grade_analysis_plan,
     build_route_slope_grade_line_segments,
 )
 
@@ -33,11 +34,18 @@ def build_slope_grade_layer(
 ):
     """Create a styled memory line layer for slope-grade analysis segments."""
 
-    line_segments = []
-    if activities_layer is not None and points_layer is not None:
-        line_segments.extend(build_activity_slope_grade_line_segments(points_layer))
     route_sample_layer = route_profile_samples_layer or route_points_layer
-    if route_tracks_layer is not None and route_sample_layer is not None:
+    plan = build_slope_grade_analysis_plan(
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+        route_tracks_layer=route_tracks_layer,
+        route_points_layer=route_points_layer,
+        route_profile_samples_layer=route_profile_samples_layer,
+    )
+    line_segments = []
+    if _plan_enables_layer(plan, "activity_tracks"):
+        line_segments.extend(build_activity_slope_grade_line_segments(points_layer))
+    if _plan_enables_layer(plan, "saved_route_tracks"):
         line_segments.extend(build_route_slope_grade_line_segments(route_sample_layer))
 
     if not line_segments:
@@ -64,6 +72,10 @@ def build_slope_grade_layer(
     layer.updateExtents()
     _apply_slope_grade_style(layer)
     return layer, tuple(line_segments)
+
+
+def _plan_enables_layer(plan, layer_key):
+    return any(layer.key == layer_key for layer in plan.enabled_layers)
 
 
 def _build_memory_layer(source_layer):

--- a/analysis/infrastructure/slope_grade_layer.py
+++ b/analysis/infrastructure/slope_grade_layer.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtGui import QColor
+from qgis.core import (
+    QgsCategorizedSymbolRenderer,
+    QgsFeature,
+    QgsField,
+    QgsGeometry,
+    QgsLineSymbol,
+    QgsPointXY,
+    QgsRendererCategory,
+    QgsSimpleLineSymbolLayer,
+    QgsVectorLayer,
+)
+
+from ..application.slope_grade_analysis import (
+    SLOPE_GRADE_CLASSES,
+    build_activity_slope_grade_line_segments,
+    build_route_slope_grade_line_segments,
+)
+
+SLOPE_GRADE_LAYER_NAME = "qfit slope grade lines"
+
+
+def build_slope_grade_layer(
+    *,
+    activities_layer=None,
+    points_layer=None,
+    route_tracks_layer=None,
+    route_points_layer=None,
+    route_profile_samples_layer=None,
+):
+    """Create a styled memory line layer for slope-grade analysis segments."""
+
+    line_segments = []
+    if activities_layer is not None and points_layer is not None:
+        line_segments.extend(build_activity_slope_grade_line_segments(points_layer))
+    route_sample_layer = route_profile_samples_layer or route_points_layer
+    if route_tracks_layer is not None and route_sample_layer is not None:
+        line_segments.extend(build_route_slope_grade_line_segments(route_sample_layer))
+
+    if not line_segments:
+        return None, ()
+
+    layer = _build_memory_layer(_preferred_crs_layer(points_layer, route_sample_layer))
+    provider = layer.dataProvider()
+    provider.addAttributes(
+        [
+            QgsField("layer_key", QVariant.String),
+            QgsField("layer_label", QVariant.String),
+            QgsField("source", QVariant.String),
+            QgsField("source_id", QVariant.String),
+            QgsField("grade_class", QVariant.String),
+            QgsField("grade_label", QVariant.String),
+            QgsField("grade_percent", QVariant.Double),
+            QgsField("start_distance_m", QVariant.Double),
+            QgsField("end_distance_m", QVariant.Double),
+        ]
+    )
+    layer.updateFields()
+
+    provider.addFeatures(_features_for_segments(layer, line_segments))
+    layer.updateExtents()
+    _apply_slope_grade_style(layer)
+    return layer, tuple(line_segments)
+
+
+def _build_memory_layer(source_layer):
+    crs = _layer_crs(source_layer)
+    authid = crs.authid() if crs is not None and crs.isValid() else "EPSG:4326"
+    return QgsVectorLayer(
+        f"LineString?crs={authid}",
+        SLOPE_GRADE_LAYER_NAME,
+        "memory",
+    )
+
+
+def _preferred_crs_layer(points_layer, route_sample_layer):
+    if points_layer is not None:
+        return points_layer
+    return route_sample_layer
+
+
+def _layer_crs(layer):
+    crs = getattr(layer, "crs", None)
+    return crs() if callable(crs) else None
+
+
+def _features_for_segments(layer, line_segments):
+    features = []
+    for line_segment in line_segments:
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(
+            QgsGeometry.fromPolylineXY(
+                [
+                    QgsPointXY(*line_segment.start_xy),
+                    QgsPointXY(*line_segment.end_xy),
+                ]
+            )
+        )
+        feature["layer_key"] = line_segment.layer_key
+        feature["layer_label"] = line_segment.layer_label
+        feature["source"] = _string_or_empty(line_segment.source)
+        feature["source_id"] = _string_or_empty(line_segment.source_id)
+        feature["grade_class"] = line_segment.grade_class.key
+        feature["grade_label"] = line_segment.grade_class.label
+        feature["grade_percent"] = line_segment.grade_percent
+        feature["start_distance_m"] = line_segment.start_distance_m
+        feature["end_distance_m"] = line_segment.end_distance_m
+        features.append(feature)
+    return features
+
+
+def _string_or_empty(value):
+    return "" if value is None else str(value)
+
+
+def _apply_slope_grade_style(layer):
+    categories = []
+    for grade_class in SLOPE_GRADE_CLASSES:
+        symbol = _build_slope_grade_symbol(grade_class.color_hex)
+        categories.append(
+            QgsRendererCategory(grade_class.key, symbol, grade_class.label)
+        )
+    layer.setRenderer(QgsCategorizedSymbolRenderer("grade_class", categories))
+    layer.setOpacity(0.95)
+    layer.triggerRepaint()
+
+
+def _build_slope_grade_symbol(color_hex):
+    symbol = QgsLineSymbol()
+    symbol.deleteSymbolLayer(0)
+    line_layer = QgsSimpleLineSymbolLayer()
+    line_layer.setColor(QColor(color_hex))
+    line_layer.setWidth(0.9)
+    symbol.appendSymbolLayer(line_layer)
+    return symbol
+
+
+__all__ = [
+    "SLOPE_GRADE_LAYER_NAME",
+    "build_slope_grade_layer",
+]

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -50,6 +50,7 @@ from .analysis.application.analysis_request_builder import (
 from .analysis.infrastructure.frequent_start_points_layer import (
     FREQUENT_STARTING_POINTS_LAYER_NAME,
 )
+from .analysis.infrastructure.slope_grade_layer import SLOPE_GRADE_LAYER_NAME
 from .atlas.export_service import (
     AtlasExportResult,
     AtlasExportService,
@@ -1248,6 +1249,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         analysis_layer_names = {
             FREQUENT_STARTING_POINTS_LAYER_NAME,
             ACTIVITY_HEATMAP_LAYER_NAME,
+            SLOPE_GRADE_LAYER_NAME,
         }
         for layer in tuple(project.mapLayers().values()):
             if layer.name() not in analysis_layer_names:

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -681,6 +681,46 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         )
         self.assertIsNone(result.layer)
 
+    def test_run_slope_grade_analysis_returns_overlay_layer_when_available(self):
+        overlay_layer = object()
+        with patch(
+            "qfit.analysis.application.slope_grade_analysis._build_slope_grade_layer",
+            return_value=(overlay_layer, (object(),)),
+        ):
+            result = run_slope_grade_analysis(
+                RunAnalysisRequest(
+                    analysis_mode=SLOPE_GRADE_MODE,
+                    activities_layer=_Layer(fields=("name",)),
+                    points_layer=_FeatureLayer(
+                        (
+                            _FeatureSample(
+                                {
+                                    "source": "strava",
+                                    "source_activity_id": "a-1",
+                                    "stream_distance_m": 0,
+                                    "grade_smooth_pct": 0,
+                                }
+                            ),
+                            _FeatureSample(
+                                {
+                                    "source": "strava",
+                                    "source_activity_id": "a-1",
+                                    "stream_distance_m": 100,
+                                    "grade_smooth_pct": 4,
+                                }
+                            ),
+                        ),
+                        fields=("grade_smooth_pct", "stream_distance_m"),
+                    ),
+                )
+            )
+
+        self.assertIs(result.layer, overlay_layer)
+        self.assertEqual(
+            result.status,
+            "Slope grade line analysis classified activity tracks (1 segment).",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_slope_grade_layer.py
+++ b/tests/test_slope_grade_layer.py
@@ -1,0 +1,345 @@
+import importlib
+import sys
+import unittest
+from types import ModuleType
+
+from tests import _path  # noqa: F401
+
+
+class _FeatureSample:
+    def __init__(self, values, *, geometry=None):
+        self._values = values
+        self._geometry = geometry
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def geometry(self):
+        return self._geometry
+
+
+class _FeatureLayer:
+    def __init__(self, features, *, crs_authid="EPSG:4326"):
+        self._features = tuple(features)
+        self._crs = _Crs(crs_authid)
+
+    def getFeatures(self):
+        return iter(self._features)
+
+    def crs(self):
+        return self._crs
+
+
+class _Crs:
+    def __init__(self, authid):
+        self._authid = authid
+
+    def isValid(self):
+        return bool(self._authid)
+
+    def authid(self):
+        return self._authid
+
+
+class _Point:
+    def __init__(self, x, y):
+        self._x = x
+        self._y = y
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+
+class _Geometry:
+    def __init__(self, x, y):
+        self._point = _Point(x, y)
+
+    def isEmpty(self):
+        return False
+
+    def asPoint(self):
+        return self._point
+
+
+class SlopeGradeLayerTests(unittest.TestCase):
+    def test_builds_styled_memory_layer_from_activity_line_segments(self):
+        module = _load_slope_grade_layer_with_qgis_stub()
+        points_layer = _FeatureLayer(
+            (
+                _FeatureSample(
+                    {
+                        "source": "strava",
+                        "source_activity_id": "a-1",
+                        "stream_distance_m": 0,
+                        "grade_smooth_pct": 0.0,
+                    },
+                    geometry=_Geometry(6.6, 46.5),
+                ),
+                _FeatureSample(
+                    {
+                        "source": "strava",
+                        "source_activity_id": "a-1",
+                        "stream_distance_m": 100,
+                        "grade_smooth_pct": 4.0,
+                    },
+                    geometry=_Geometry(6.7, 46.6),
+                ),
+            ),
+            crs_authid="EPSG:2056",
+        )
+
+        layer, segments = module.build_slope_grade_layer(
+            activities_layer=object(),
+            points_layer=points_layer,
+        )
+
+        self.assertEqual(layer.name, module.SLOPE_GRADE_LAYER_NAME)
+        self.assertEqual(layer.crs_authid, "EPSG:2056")
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(len(layer.features), 1)
+        self.assertEqual(layer.features[0].attrs["grade_class"], "climb")
+        self.assertEqual(layer.features[0].attrs["source_id"], "a-1")
+        self.assertEqual(
+            layer.features[0].geometry,
+            ((6.6, 46.5), (6.7, 46.6)),
+        )
+        self.assertEqual(layer.renderer.field_name, "grade_class")
+        self.assertEqual(len(layer.renderer.categories), 5)
+        self.assertAlmostEqual(layer.opacity, 0.95)
+        self.assertEqual(layer.repaint_count, 1)
+
+    def test_builds_memory_layer_from_route_profile_lat_lon_segments(self):
+        module = _load_slope_grade_layer_with_qgis_stub()
+        profile_layer = _FeatureLayer(
+            (
+                _FeatureSample(
+                    {
+                        "sample_group_index": 1,
+                        "source": "strava",
+                        "source_route_id": "r-1",
+                        "lat": 46.5,
+                        "lon": 6.6,
+                        "distance_m": 0,
+                        "altitude_m": 100,
+                    }
+                ),
+                _FeatureSample(
+                    {
+                        "sample_group_index": 1,
+                        "source": "strava",
+                        "source_route_id": "r-1",
+                        "lat": 46.6,
+                        "lon": 6.7,
+                        "distance_m": 100,
+                        "altitude_m": 91,
+                    }
+                ),
+            )
+        )
+
+        layer, segments = module.build_slope_grade_layer(
+            route_tracks_layer=object(),
+            route_profile_samples_layer=profile_layer,
+        )
+
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(layer.features[0].attrs["layer_key"], "saved_route_tracks")
+        self.assertEqual(layer.features[0].attrs["grade_class"], "steep_descent")
+        self.assertEqual(
+            layer.features[0].geometry,
+            ((6.6, 46.5), (6.7, 46.6)),
+        )
+
+    def test_returns_empty_result_when_no_line_segments_are_available(self):
+        module = _load_slope_grade_layer_with_qgis_stub()
+
+        layer, segments = module.build_slope_grade_layer(
+            activities_layer=object(),
+            points_layer=_FeatureLayer(()),
+        )
+
+        self.assertIsNone(layer)
+        self.assertEqual(segments, ())
+
+
+class _QVariant:
+    String = "String"
+    Double = "Double"
+
+
+class _QColor:
+    def __init__(self, value):
+        self.value = value
+
+
+class _QgsField:
+    def __init__(self, name, field_type):
+        self.name = name
+        self.field_type = field_type
+
+
+class _QgsFeature:
+    def __init__(self, fields=None):
+        self.fields = fields
+        self.attrs = {}
+        self.geometry = None
+
+    def setGeometry(self, geometry):
+        self.geometry = geometry
+
+    def __setitem__(self, key, value):
+        self.attrs[key] = value
+
+
+class _QgsGeometry:
+    @staticmethod
+    def fromPolylineXY(points):
+        return tuple((point.x, point.y) for point in points)
+
+
+class _QgsPointXY:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+class _Provider:
+    def __init__(self, layer):
+        self.layer = layer
+
+    def addAttributes(self, fields):
+        self.layer.field_defs.extend(fields)
+
+    def addFeatures(self, features):
+        self.layer.features.extend(features)
+
+
+class _QgsVectorLayer:
+    def __init__(self, uri, name, provider_name):
+        self.uri = uri
+        self.name = name
+        self.provider_name = provider_name
+        self.crs_authid = uri.split("crs=", 1)[1]
+        self.field_defs = []
+        self.features = []
+        self.renderer = None
+        self.opacity = None
+        self.repaint_count = 0
+
+    def dataProvider(self):
+        return _Provider(self)
+
+    def updateFields(self):
+        pass
+
+    def fields(self):
+        return self.field_defs
+
+    def updateExtents(self):
+        pass
+
+    def setRenderer(self, renderer):
+        self.renderer = renderer
+
+    def setOpacity(self, opacity):
+        self.opacity = opacity
+
+    def triggerRepaint(self):
+        self.repaint_count += 1
+
+
+class _QgsCategorizedSymbolRenderer:
+    def __init__(self, field_name, categories):
+        self.field_name = field_name
+        self.categories = categories
+
+
+class _QgsRendererCategory:
+    def __init__(self, value, symbol, label):
+        self.value = value
+        self.symbol = symbol
+        self.label = label
+
+
+class _QgsLineSymbol:
+    def __init__(self):
+        self.layers = []
+
+    def deleteSymbolLayer(self, _index):
+        self.layers.clear()
+
+    def appendSymbolLayer(self, layer):
+        self.layers.append(layer)
+
+
+class _QgsSimpleLineSymbolLayer:
+    def __init__(self):
+        self.color = None
+        self.width = None
+
+    def setColor(self, color):
+        self.color = color
+
+    def setWidth(self, width):
+        self.width = width
+
+
+class _QgsCoordinateReferenceSystem:
+    pass
+
+
+def _load_slope_grade_layer_with_qgis_stub():
+    target = "qfit.analysis.infrastructure.slope_grade_layer"
+    qgis_modules = (
+        "qgis",
+        "qgis.core",
+        "qgis.PyQt",
+        "qgis.PyQt.QtCore",
+        "qgis.PyQt.QtGui",
+    )
+    saved = {name: sys.modules.get(name) for name in qgis_modules + (target,)}
+
+    qgis = ModuleType("qgis")
+    core = ModuleType("qgis.core")
+    pyqt = ModuleType("qgis.PyQt")
+    qtcore = ModuleType("qgis.PyQt.QtCore")
+    qtgui = ModuleType("qgis.PyQt.QtGui")
+
+    qtcore.QVariant = _QVariant
+    qtgui.QColor = _QColor
+    core.QgsCategorizedSymbolRenderer = _QgsCategorizedSymbolRenderer
+    core.QgsCoordinateReferenceSystem = _QgsCoordinateReferenceSystem
+    core.QgsFeature = _QgsFeature
+    core.QgsField = _QgsField
+    core.QgsGeometry = _QgsGeometry
+    core.QgsLineSymbol = _QgsLineSymbol
+    core.QgsPointXY = _QgsPointXY
+    core.QgsRendererCategory = _QgsRendererCategory
+    core.QgsSimpleLineSymbolLayer = _QgsSimpleLineSymbolLayer
+    core.QgsVectorLayer = _QgsVectorLayer
+
+    sys.modules.update(
+        {
+            "qgis": qgis,
+            "qgis.core": core,
+            "qgis.PyQt": pyqt,
+            "qgis.PyQt.QtCore": qtcore,
+            "qgis.PyQt.QtGui": qtgui,
+        }
+    )
+    sys.modules.pop(target, None)
+    try:
+        return importlib.import_module(target)
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_slope_grade_layer.py
+++ b/tests/test_slope_grade_layer.py
@@ -18,16 +18,36 @@ class _FeatureSample:
         return self._geometry
 
 
+class _Field:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
 class _FeatureLayer:
-    def __init__(self, features, *, crs_authid="EPSG:4326"):
+    def __init__(self, features, *, crs_authid="EPSG:4326", fields=()):
         self._features = tuple(features)
         self._crs = _Crs(crs_authid)
+        self._fields = tuple(_Field(name) for name in fields)
 
     def getFeatures(self):
         return iter(self._features)
 
     def crs(self):
         return self._crs
+
+    def fields(self):
+        return self._fields
+
+
+class _TargetLayer:
+    def __init__(self, geometry="LineString"):
+        self._geometry = geometry
+
+    def geometryType(self):
+        return self._geometry
 
 
 class _Crs:
@@ -89,10 +109,11 @@ class SlopeGradeLayerTests(unittest.TestCase):
                 ),
             ),
             crs_authid="EPSG:2056",
+            fields=("stream_distance_m", "grade_smooth_pct"),
         )
 
         layer, segments = module.build_slope_grade_layer(
-            activities_layer=object(),
+            activities_layer=_TargetLayer(),
             points_layer=points_layer,
         )
 
@@ -137,11 +158,12 @@ class SlopeGradeLayerTests(unittest.TestCase):
                         "altitude_m": 91,
                     }
                 ),
-            )
+            ),
+            fields=("distance_m", "altitude_m"),
         )
 
         layer, segments = module.build_slope_grade_layer(
-            route_tracks_layer=object(),
+            route_tracks_layer=_TargetLayer(),
             route_profile_samples_layer=profile_layer,
         )
 
@@ -157,8 +179,45 @@ class SlopeGradeLayerTests(unittest.TestCase):
         module = _load_slope_grade_layer_with_qgis_stub()
 
         layer, segments = module.build_slope_grade_layer(
-            activities_layer=object(),
-            points_layer=_FeatureLayer(()),
+            activities_layer=_TargetLayer(),
+            points_layer=_FeatureLayer(
+                (),
+                fields=("stream_distance_m", "grade_smooth_pct"),
+            ),
+        )
+
+        self.assertIsNone(layer)
+        self.assertEqual(segments, ())
+
+    def test_does_not_build_overlay_when_activity_target_is_not_a_line_layer(self):
+        module = _load_slope_grade_layer_with_qgis_stub()
+        points_layer = _FeatureLayer(
+            (
+                _FeatureSample(
+                    {
+                        "source": "strava",
+                        "source_activity_id": "a-1",
+                        "stream_distance_m": 0,
+                        "grade_smooth_pct": 0.0,
+                    },
+                    geometry=_Geometry(6.6, 46.5),
+                ),
+                _FeatureSample(
+                    {
+                        "source": "strava",
+                        "source_activity_id": "a-1",
+                        "stream_distance_m": 100,
+                        "grade_smooth_pct": 4.0,
+                    },
+                    geometry=_Geometry(6.7, 46.6),
+                ),
+            ),
+            fields=("stream_distance_m", "grade_smooth_pct"),
+        )
+
+        layer, segments = module.build_slope_grade_layer(
+            activities_layer=_TargetLayer(geometry="Point"),
+            points_layer=points_layer,
         )
 
         self.assertIsNone(layer)


### PR DESCRIPTION
## Summary

- create a styled `qfit slope grade lines` memory line layer from classified slope-grade segments
- return the overlay layer from slope-grade analysis so the existing analysis workflow adds it to the project
- clear stale slope-grade analysis layers alongside existing heatmap/frequent-start overlays

## Notes

This is the first QGIS-facing #815 slice. It keeps sample classification in the application layer and contains QGIS renderer/memory-layer mechanics in `analysis/infrastructure`.

Refs #815.

## Tests

- `python3 -m pytest tests/test_slope_grade_analysis.py tests/test_slope_grade_layer.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
