### PR TITLE
Hide route profile samples from layer tree

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -159,30 +159,17 @@ def _build_write_and_load_status(result: StoreActivitiesResult) -> str:
     )
 
 
-def _route_layer_load_status(
-    route_tracks_layer,
-    route_points_layer,
-    route_profile_samples_layer,
-) -> str:
-    if all(
-        layer is None
-        for layer in (
-            route_tracks_layer,
-            route_points_layer,
-            route_profile_samples_layer,
-        )
-    ):
+def _route_layer_load_status(route_tracks_layer, route_points_layer) -> str:
+    if route_tracks_layer is None and route_points_layer is None:
         return (
             "No saved route layers found; use Data → Sync saved routes "
             "before loading planned routes."
         )
     tracks = _safe_feature_count(route_tracks_layer)
     points = _safe_feature_count(route_points_layer)
-    samples = _safe_feature_count(route_profile_samples_layer)
     return (
-        "Loaded saved route layers: {tracks} route tracks, {points} route points, "
-        "and {samples} profile samples."
-    ).format(tracks=tracks, points=points, samples=samples)
+        "Loaded saved route layers: {tracks} route tracks and {points} route points."
+    ).format(tracks=tracks, points=points)
 
 
 def _safe_feature_count(layer) -> int:
@@ -342,7 +329,6 @@ class LoadDatasetWorkflow:
                 route_status=_route_layer_load_status(
                     route_tracks_layer,
                     route_points_layer,
-                    route_profile_samples_layer,
                 ),
             ),
         )

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -925,7 +925,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         status = (
             "Synced {fetched} saved routes into GeoPackage: inserted {inserted}, "
             "updated {updated}, unchanged {unchanged}, stored total {total}. "
-            "Loaded {tracks} route tracks, {points} route points, and {samples} profile samples."
+            "Loaded {tracks} route tracks and {points} route points."
         ).format(
             fetched=result.get("fetched_count", 0),
             inserted=sync.inserted if sync else 0,
@@ -934,7 +934,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             total=sync.total_count if sync else 0,
             tracks=result.get("route_track_count", 0),
             points=result.get("route_point_count", 0),
-            samples=result.get("route_profile_sample_count", 0),
         )
         if cancelled:
             status = "Route sync completed after cancellation was requested. " + status

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -103,9 +103,10 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
         self.assertEqual(result.route_profile_samples_layer, route_layers[2])
         self.assertIn("/tmp/existing.gpkg", result.status)
         self.assertIn(
-            "3 route tracks, 24 route points, and 16 profile samples",
+            "3 route tracks and 24 route points",
             result.status,
         )
+        self.assertNotIn("profile samples", result.status)
 
     def test_load_existing_status_explains_when_route_layers_are_missing(self):
         layer_gateway = MagicMock()

--- a/tests/test_project_layer_loader.py
+++ b/tests/test_project_layer_loader.py
@@ -135,6 +135,13 @@ class ProjectLayerLoaderRealTests(unittest.TestCase):
                 call("/tmp/out.gpkg|layername=route_profile_samples", "qfit route profile samples", "ogr"),
             ],
         )
+        project.addMapLayer.assert_has_calls(
+            [
+                call(routes, True),
+                call(points, True),
+                call(samples, False),
+            ]
+        )
 
     def test_load_layer_replaces_existing_display_name(self):
         loader = ProjectLayerLoader()
@@ -233,7 +240,7 @@ class ProjectLayerLoaderMockTests(unittest.TestCase):
         points = MagicMock()
         points.isValid.return_value = True
         samples = MagicMock()
-        samples.isValid.return_value = False
+        samples.isValid.return_value = True
 
         project = MagicMock()
         project.mapLayersByName.return_value = []
@@ -243,7 +250,7 @@ class ProjectLayerLoaderMockTests(unittest.TestCase):
             qgs_project.instance.return_value = project
             layers = self.loader.load_route_layers("/tmp/out.gpkg")
 
-        self.assertEqual(layers, (routes, points, None))
+        self.assertEqual(layers, (routes, points, samples))
         self.assertEqual(
             vector_layer.call_args_list,
             [
@@ -251,6 +258,13 @@ class ProjectLayerLoaderMockTests(unittest.TestCase):
                 call("/tmp/out.gpkg|layername=route_points", "qfit route points", "ogr"),
                 call("/tmp/out.gpkg|layername=route_profile_samples", "qfit route profile samples", "ogr"),
             ],
+        )
+        project.addMapLayer.assert_has_calls(
+            [
+                call(routes, True),
+                call(points, True),
+                call(samples, False),
+            ]
         )
 
     def test_load_output_layers_raises_last_error_when_no_activity_layer_can_be_loaded(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2475,10 +2475,13 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.layer_gateway.load_route_layers.assert_called_once_with("/tmp/qfit.gpkg")
         dock._mark_atlas_export_stale.assert_called_once_with()
         dock._set_status.assert_called_once()
+        status_message = dock._set_status.call_args.args[0]
         self.assertIn(
             "Stopped route GPX enrichment early",
-            dock._set_status.call_args.args[0],
+            status_message,
         )
+        self.assertIn("Loaded 2 route tracks and 6 route points.", status_message)
+        self.assertNotIn("profile samples", status_message)
 
     def test_handle_route_sync_task_finished_reports_missing_result_path(self):
         dock = object.__new__(self.module.QfitDockWidget)

--- a/visualization/infrastructure/project_layer_loader.py
+++ b/visualization/infrastructure/project_layer_loader.py
@@ -8,7 +8,7 @@ class ProjectLayerLoader:
     LAYER_FALLBACK_CRS = {
         "activity_atlas_pages": "EPSG:3857",
     }
-    HIDDEN_LAYER_NAMES = {"activity_atlas_pages"}
+    HIDDEN_LAYER_NAMES = {"activity_atlas_pages", "route_profile_samples"}
 
     ACTIVITIES_CANDIDATES = [
         ("activity_tracks", "qfit activities"),


### PR DESCRIPTION
## Summary

- keep loading `route_profile_samples` for internal consumers, but hide it from the QGIS layer tree
- update saved-route load and sync status text to mention only user-facing route tracks/points
- cover hidden route profile samples and cleaned status messages in tests

Fixes #930

## Tests

- `python3 -m pytest tests/test_project_layer_loader.py tests/test_load_workflow.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
