### PR TITLE
Remove map preview sort control

### DIFF
--- a/activities/application/activity_preview.py
+++ b/activities/application/activity_preview.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Sequence
 
 from ..domain.activity_query import (
-    DEFAULT_SORT_LABEL,
     ActivityQuery,
     build_preview_lines,
     filter_activities,
@@ -28,7 +27,6 @@ class ActivityPreviewRequest:
     max_distance_km: float | int | None = None
     search_text: str | None = None
     detailed_route_filter: str | None = None
-    sort_label: str | None = DEFAULT_SORT_LABEL
     preview_limit: int = 10
 
 
@@ -50,7 +48,6 @@ def build_activity_preview_request(
     max_distance_km: float | int | None = None,
     search_text: str | None = None,
     detailed_route_filter: str | None = None,
-    sort_label: str | None = DEFAULT_SORT_LABEL,
     preview_limit: int = 10,
 ) -> ActivityPreviewRequest:
     return ActivityPreviewRequest(
@@ -62,7 +59,6 @@ def build_activity_preview_request(
         max_distance_km=max_distance_km,
         search_text=search_text,
         detailed_route_filter=detailed_route_filter,
-        sort_label=sort_label,
         preview_limit=preview_limit,
     )
 
@@ -76,7 +72,6 @@ def build_activity_query(request: ActivityPreviewRequest) -> ActivityQuery:
         max_distance_km=request.max_distance_km,
         search_text=request.search_text,
         detailed_route_filter=request.detailed_route_filter,
-        sort_label=request.sort_label or DEFAULT_SORT_LABEL,
     )
 
 
@@ -124,7 +119,7 @@ def build_activity_preview(request: ActivityPreviewRequest) -> ActivityPreviewRe
             preview_text="",
         )
 
-    fetched_activities = sort_activities(request.activities, DEFAULT_SORT_LABEL)
+    fetched_activities = sort_activities(request.activities)
     summary = summarize_activities(fetched_activities)
     query_summary_text = format_summary_text(summary)
     if selection_state.filtered_count != len(request.activities):

--- a/activities/application/activity_preview_service.py
+++ b/activities/application/activity_preview_service.py
@@ -17,6 +17,7 @@ class ActivityPreviewService:
         **legacy_kwargs,
     ) -> ActivityPreviewResult:
         if request is None:
+            legacy_kwargs.pop("sort_label", None)
             request = ActivityPreviewRequest(**legacy_kwargs)
         return build_activity_preview(request)
 

--- a/activities/domain/__init__.py
+++ b/activities/domain/__init__.py
@@ -10,8 +10,6 @@ from .activity_classification import (
     resolve_activity_family,
 )
 from .activity_query import (
-    DEFAULT_SORT_LABEL,
-    SORT_OPTIONS,
     ActivityQuery,
     ActivitySummary,
     build_preview_lines,

--- a/activities/domain/activity_query.py
+++ b/activities/domain/activity_query.py
@@ -21,15 +21,6 @@ class ActivitySummary:
     by_type: dict[str, int]
     latest_date: str | None
 
-DEFAULT_SORT_LABEL = "Start date (newest first)"
-SORT_OPTIONS = (
-    DEFAULT_SORT_LABEL,
-    "Start date (oldest first)",
-    "Distance (longest first)",
-    "Distance (shortest first)",
-    "Moving time (longest first)",
-    "Name (A–Z)",
-)
 DETAILED_ROUTE_FILTER_ANY = "any"
 DETAILED_ROUTE_FILTER_PRESENT = "present"
 DETAILED_ROUTE_FILTER_MISSING = "missing"
@@ -62,7 +53,6 @@ class ActivityQuery:
         search_text: str | None = None,
         detailed_only: bool = False,
         detailed_route_filter: str | None = None,
-        sort_label: str | None = DEFAULT_SORT_LABEL,
     ):
         self.activity_type = activity_type or "All"
         self.date_from = date_from or None
@@ -75,7 +65,6 @@ class ActivityQuery:
             detailed_route_filter,
             detailed_only=self.detailed_only,
         )
-        self.sort_label = sort_label or DEFAULT_SORT_LABEL
 
 
 def filter_activities(activities: Iterable[object], query: ActivityQuery) -> list[object]:
@@ -130,21 +119,8 @@ def filter_activities(activities: Iterable[object], query: ActivityQuery) -> lis
     return results
 
 
-def sort_activities(activities: Sequence[object], sort_label: str | None) -> list[object]:
-    sort_label = sort_label or DEFAULT_SORT_LABEL
+def sort_activities(activities: Sequence[object]) -> list[object]:
     items = list(activities)
-
-    if sort_label == "Start date (oldest first)":
-        return sorted(items, key=lambda activity: (_sort_datetime(activity) is None, _sort_datetime(activity) or datetime.min))
-    if sort_label == "Distance (longest first)":
-        return sorted(items, key=lambda activity: _distance_sort_value(activity), reverse=True)
-    if sort_label == "Distance (shortest first)":
-        return sorted(items, key=lambda activity: (_distance_sort_value(activity) is None, _distance_sort_value(activity) or float("inf")))
-    if sort_label == "Moving time (longest first)":
-        return sorted(items, key=lambda activity: _moving_time_sort_value(activity), reverse=True)
-    if sort_label == "Name (A–Z)":
-        return sorted(items, key=lambda activity: ((getattr(activity, "name", None) or "").casefold(), _sort_datetime(activity) or datetime.min), reverse=False)
-
     return sorted(items, key=lambda activity: (_sort_datetime(activity) or datetime.min, (getattr(activity, "name", None) or "").casefold()), reverse=True)
 
 

--- a/activities/domain/activity_query.py
+++ b/activities/domain/activity_query.py
@@ -120,8 +120,7 @@ def filter_activities(activities: Iterable[object], query: ActivityQuery) -> lis
 
 
 def sort_activities(activities: Sequence[object]) -> list[object]:
-    items = list(activities)
-    return sorted(items, key=lambda activity: (_sort_datetime(activity) or datetime.min, (getattr(activity, "name", None) or "").casefold()), reverse=True)
+    return sorted(activities, key=lambda activity: (_sort_datetime(activity) or datetime.min, (getattr(activity, "name", None) or "").casefold()), reverse=True)
 
 
 def summarize_activities(activities: Sequence[object]) -> ActivitySummary:
@@ -267,20 +266,6 @@ def _distance_km(activity: object) -> float | None:
     if not isinstance(distance_m, (int, float)):
         return None
     return float(distance_m) / 1000.0
-
-
-def _distance_sort_value(activity: object) -> float:
-    distance_m = getattr(activity, "distance_m", None)
-    if not isinstance(distance_m, (int, float)):
-        return -1.0
-    return float(distance_m)
-
-
-def _moving_time_sort_value(activity: object) -> int:
-    value = getattr(activity, "moving_time_s", None)
-    if not isinstance(value, (int, float)):
-        return -1
-    return int(value)
 
 
 def _sql_normalize_expr(field: str) -> str:

--- a/configuration/application/dock_settings_bindings.py
+++ b/configuration/application/dock_settings_bindings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .ui_settings_binding import UIFieldBinding
-from ...activities.domain.activity_query import DEFAULT_SORT_LABEL, DETAILED_ROUTE_FILTER_ANY
+from ...activities.domain.activity_query import DETAILED_ROUTE_FILTER_ANY
 from ...mapbox_config import DEFAULT_BACKGROUND_PRESET, TILE_MODE_RASTER
 
 
@@ -105,12 +105,6 @@ def build_dock_settings_bindings(dock) -> list[UIFieldBinding]:
             TILE_MODE_RASTER,
             lambda: dock.tileModeComboBox.currentText(),
             lambda value: dock._set_combo_value(dock.tileModeComboBox, value, TILE_MODE_RASTER),
-        ),
-        UIFieldBinding(
-            "preview_sort",
-            DEFAULT_SORT_LABEL,
-            lambda: dock.previewSortComboBox.currentText(),
-            lambda value: dock._set_combo_value(dock.previewSortComboBox, value, DEFAULT_SORT_LABEL),
         ),
         UIFieldBinding(
             "style_preset",

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -482,7 +482,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self.minDistanceSpinBox.valueChanged,
             self.maxDistanceSpinBox.valueChanged,
             self.detailedRouteStatusComboBox.currentIndexChanged,
-            self.previewSortComboBox.currentTextChanged,
         ]
         for signal in preview_inputs:
             signal.connect(self._refresh_activity_preview)

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -475,16 +475,6 @@
                </item>
               </widget>
              </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="previewSortLabel">
-               <property name="text">
-                <string>Preview sort</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QComboBox" name="previewSortComboBox"/>
-             </item>
             </layout>
            </item>
            <item>

--- a/tests/test_activity_preview.py
+++ b/tests/test_activity_preview.py
@@ -14,7 +14,7 @@ from qfit.activities.application.activity_preview import (
     build_activity_query,
     build_activity_selection_state,
 )
-from qfit.activities.domain.activity_query import DEFAULT_SORT_LABEL, DETAILED_ROUTE_FILTER_MISSING
+from qfit.activities.domain.activity_query import DETAILED_ROUTE_FILTER_MISSING
 
 
 class ActivityPreviewTests(unittest.TestCase):
@@ -50,7 +50,6 @@ class ActivityPreviewTests(unittest.TestCase):
             max_distance_km=8,
             search_text="lunch",
             detailed_route_filter=DETAILED_ROUTE_FILTER_MISSING,
-            sort_label="Name (A–Z)",
         )
 
         query = build_activity_query(request)
@@ -62,7 +61,7 @@ class ActivityPreviewTests(unittest.TestCase):
         self.assertEqual(query.max_distance_km, 8.0)
         self.assertEqual(query.search_text, "lunch")
         self.assertEqual(query.detailed_route_filter, DETAILED_ROUTE_FILTER_MISSING)
-        self.assertEqual(query.sort_label, "Name (A–Z)")
+        self.assertFalse(hasattr(query, "sort_label"))
 
     def test_build_activity_preview_query_delegates_to_activity_query_builder(self):
         request = ActivityPreviewRequest(
@@ -108,7 +107,6 @@ class ActivityPreviewTests(unittest.TestCase):
             max_distance_km=8,
             search_text="lunch",
             detailed_route_filter=DETAILED_ROUTE_FILTER_MISSING,
-            sort_label="Name (A–Z)",
             preview_limit=5,
         )
 
@@ -121,7 +119,6 @@ class ActivityPreviewTests(unittest.TestCase):
         self.assertEqual(request.max_distance_km, 8)
         self.assertEqual(request.search_text, "lunch")
         self.assertEqual(request.detailed_route_filter, DETAILED_ROUTE_FILTER_MISSING)
-        self.assertEqual(request.sort_label, "Name (A–Z)")
         self.assertEqual(request.preview_limit, 5)
 
     def test_build_activity_selection_state_filters_with_query(self):
@@ -184,14 +181,13 @@ class ActivityPreviewTests(unittest.TestCase):
             ActivityPreviewRequest(
                 activities=self.activities,
                 preview_limit=1,
-                sort_label="Name (A–Z)",
             )
         )
 
         self.assertEqual(result.fetched_activities[0].name, "Lunch Run")
         self.assertEqual(len(result.preview_text.splitlines()), 2)
         self.assertIn("… and 1 more", result.preview_text)
-        self.assertEqual(result.selection_state.query.sort_label, "Name (A–Z)")
+        self.assertFalse(hasattr(result.selection_state.query, "sort_label"))
 
 
 if __name__ == "__main__":

--- a/tests/test_activity_preview_service.py
+++ b/tests/test_activity_preview_service.py
@@ -39,7 +39,7 @@ class ActivityPreviewServiceTests(unittest.TestCase):
         request = build_preview.call_args.args[0]
         self.assertIsInstance(request, ActivityPreviewRequest)
         self.assertEqual(request.activity_type, "Run")
-        self.assertEqual(request.sort_label, "Name (A–Z)")
+        self.assertFalse(hasattr(request, "sort_label"))
 
 
 if __name__ == "__main__":

--- a/tests/test_activity_query.py
+++ b/tests/test_activity_query.py
@@ -86,16 +86,17 @@ class ActivityQueryTests(unittest.TestCase):
 
         self.assertEqual([activity.source_activity_id for activity in results], ["2", "3"])
 
-    def test_sort_activities_supports_distance_and_name(self):
-        by_distance = sort_activities(self.activities, "Distance (longest first)")
-        by_name = sort_activities(self.activities, "Name (A–Z)")
+    def test_sort_activities_always_uses_newest_start_date_first(self):
+        sorted_activities = sort_activities(self.activities)
 
-        self.assertEqual([activity.source_activity_id for activity in by_distance], ["1", "3", "2"])
-        self.assertEqual([activity.source_activity_id for activity in by_name], ["3", "2", "1"])
+        self.assertEqual(
+            [activity.source_activity_id for activity in sorted_activities],
+            ["3", "2", "1"],
+        )
 
     def test_summarize_activities_and_preview_lines(self):
         summary = summarize_activities(self.activities)
-        lines = build_preview_lines(sort_activities(self.activities, None), limit=2)
+        lines = build_preview_lines(sort_activities(self.activities), limit=2)
 
         self.assertEqual(summary.count, 3)
         self.assertEqual(summary.total_distance_km, 70.7)

--- a/tests/test_dock_settings_bindings.py
+++ b/tests/test_dock_settings_bindings.py
@@ -4,7 +4,7 @@ from tests import _path  # noqa: F401
 
 from qfit.configuration.infrastructure.credential_store import InMemoryCredentialStore
 from qfit.configuration.application.settings_service import SettingsService
-from qfit.activities.domain.activity_query import DEFAULT_SORT_LABEL, DETAILED_ROUTE_FILTER_ANY
+from qfit.activities.domain.activity_query import DETAILED_ROUTE_FILTER_ANY
 from qfit.configuration.application.dock_settings_bindings import build_dock_settings_bindings
 from qfit.configuration.application.ui_settings_binding import load_bindings, save_bindings
 from qfit.mapbox_config import DEFAULT_BACKGROUND_PRESET, TILE_MODE_RASTER
@@ -112,7 +112,6 @@ class FakeDock:
         self.analysisModeComboBox = ComboWidget(["None", "Most frequent starting points"])
         self.backgroundPresetComboBox = ComboWidget([DEFAULT_BACKGROUND_PRESET, "Custom"])
         self.tileModeComboBox = ComboWidget([TILE_MODE_RASTER, "Vector"])
-        self.previewSortComboBox = ComboWidget([DEFAULT_SORT_LABEL, "Newest first"])
         self.stylePresetComboBox = ComboWidget(["Simple lines", "By activity type", "Track points"])
 
     def _default_output_path(self):
@@ -180,7 +179,6 @@ class DockSettingsBindingsTests(unittest.TestCase):
         "analysis_mode",
         "background_preset",
         "tile_mode",
-        "preview_sort",
         "style_preset",
     }
 
@@ -198,7 +196,6 @@ class DockSettingsBindingsTests(unittest.TestCase):
                 "qfit/use_background_map": True,
                 "qfit/atlas_title": "Spring Atlas",
                 "qfit/atlas_subtitle": "Selected rides",
-                "qfit/preview_sort": "Newest first",
                 "qfit/style_preset": "Heatmap",
             }
         )
@@ -212,7 +209,6 @@ class DockSettingsBindingsTests(unittest.TestCase):
         self.assertTrue(dock.backgroundMapCheckBox.isChecked())
         self.assertEqual(dock.atlasTitleLineEdit.text(), "Spring Atlas")
         self.assertEqual(dock.atlasSubtitleLineEdit.text(), "Selected rides")
-        self.assertEqual(dock.previewSortComboBox.currentText(), "Newest first")
         self.assertEqual(dock.stylePresetComboBox.currentText(), "By activity type")
         self.assertEqual(dock.analysisModeComboBox.currentText(), "None")
 
@@ -233,7 +229,6 @@ class DockSettingsBindingsTests(unittest.TestCase):
         dock.analysisModeComboBox.setCurrentIndex(1)
         dock.backgroundPresetComboBox.setCurrentIndex(1)
         dock.tileModeComboBox.setCurrentIndex(1)
-        dock.previewSortComboBox.setCurrentIndex(1)
         dock.stylePresetComboBox.setCurrentIndex(1)
 
         settings = _settings()

--- a/tests/test_local_first_activity_controls.py
+++ b/tests/test_local_first_activity_controls.py
@@ -6,17 +6,14 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 
 from qfit.activities.domain.activity_query import (
-    DEFAULT_SORT_LABEL,
     DETAILED_ROUTE_FILTER_ANY,
     DETAILED_ROUTE_FILTER_MISSING,
     DETAILED_ROUTE_FILTER_PRESENT,
-    SORT_OPTIONS,
 )
 from qfit.ui.application.local_first_activity_controls import (
     build_current_activity_preview_request,
     configure_detailed_route_filter_options,
     configure_local_first_activity_preview_options,
-    configure_preview_sort_options,
 )
 
 
@@ -181,35 +178,15 @@ class LocalFirstActivityControlsTests(unittest.TestCase):
             ],
         )
 
-    def test_configure_preview_sort_populates_sort_options(self):
-        combo = FakeComboBox()
-        combo.addItem("stale")
-        dock = SimpleNamespace(previewSortComboBox=combo)
-
-        configure_preview_sort_options(dock)
-
-        self.assertTrue(combo.cleared)
-        self.assertEqual(
-            combo.items,
-            [(label, None) for label in SORT_OPTIONS],
-        )
-        self.assertEqual(combo.items[0], (DEFAULT_SORT_LABEL, None))
-
-    def test_configure_activity_preview_options_populates_backing_combos(self):
+    def test_configure_activity_preview_options_populates_route_filter_combo(self):
         route_status_combo = FakeComboBox()
-        sort_combo = FakeComboBox()
         dock = SimpleNamespace(
             detailedRouteStatusComboBox=route_status_combo,
-            previewSortComboBox=sort_combo,
         )
 
         configure_local_first_activity_preview_options(dock)
 
         self.assertEqual(route_status_combo.items[0], ("Any routes", "any"))
-        self.assertEqual(
-            sort_combo.items,
-            [(label, None) for label in SORT_OPTIONS],
-        )
 
     def test_build_current_activity_preview_request_reads_local_first_backing_controls(self):
         activities = [SimpleNamespace(name="Morning Ride")]
@@ -220,8 +197,6 @@ class LocalFirstActivityControlsTests(unittest.TestCase):
             "Detailed routes only",
             DETAILED_ROUTE_FILTER_PRESENT,
         )
-        preview_sort_combo = FakeComboBox()
-        preview_sort_combo.addItem("Newest first")
         dock = SimpleNamespace(
             runtime_state=SimpleNamespace(activities=activities),
             activityTypeComboBox=activity_type_combo,
@@ -231,7 +206,6 @@ class LocalFirstActivityControlsTests(unittest.TestCase):
             maxDistanceSpinBox=FakeSpinBox(120),
             activitySearchLineEdit=FakeLineEdit("  gravel  "),
             detailedRouteStatusComboBox=detailed_route_status_combo,
-            previewSortComboBox=preview_sort_combo,
         )
 
         request = build_current_activity_preview_request(dock)
@@ -244,13 +218,12 @@ class LocalFirstActivityControlsTests(unittest.TestCase):
         self.assertEqual(request.max_distance_km, 120)
         self.assertEqual(request.search_text, "gravel")
         self.assertEqual(request.detailed_route_filter, DETAILED_ROUTE_FILTER_PRESENT)
-        self.assertEqual(request.sort_label, "Newest first")
+        self.assertFalse(hasattr(request, "sort_label"))
 
     def test_build_current_activity_preview_request_uses_safe_defaults(self):
         activity_type_combo = FakeComboBox()
         detailed_route_status_combo = FakeComboBox()
         detailed_route_status_combo.addItem("Any routes", DETAILED_ROUTE_FILTER_ANY)
-        preview_sort_combo = FakeComboBox()
         dock = SimpleNamespace(
             runtime_state=SimpleNamespace(activities=[]),
             activityTypeComboBox=activity_type_combo,
@@ -260,7 +233,6 @@ class LocalFirstActivityControlsTests(unittest.TestCase):
             maxDistanceSpinBox=FakeSpinBox(0),
             activitySearchLineEdit=FakeLineEdit(""),
             detailedRouteStatusComboBox=detailed_route_status_combo,
-            previewSortComboBox=preview_sort_combo,
         )
 
         request = build_current_activity_preview_request(dock)
@@ -268,7 +240,7 @@ class LocalFirstActivityControlsTests(unittest.TestCase):
         self.assertEqual(request.activity_type, "All")
         self.assertIsNone(request.date_from)
         self.assertIsNone(request.date_to)
-        self.assertEqual(request.sort_label, DEFAULT_SORT_LABEL)
+        self.assertFalse(hasattr(request, "sort_label"))
 
 
 if __name__ == "__main__":

--- a/tests/test_local_first_control_installer.py
+++ b/tests/test_local_first_control_installer.py
@@ -213,15 +213,11 @@ class LocalFirstControlInstallerTests(unittest.TestCase):
         source_parent = SimpleNamespace(layout=lambda: source_layout)
         style_label = MagicMock()
         style_combo = MagicMock()
-        preview_label = MagicMock()
-        preview_combo = MagicMock()
-        for widget in (style_label, style_combo, preview_label, preview_combo):
+        for widget in (style_label, style_combo):
             widget.parentWidget.return_value = source_parent
         dock = SimpleNamespace(
             stylePresetLabel=style_label,
             stylePresetComboBox=style_combo,
-            previewSortLabel=preview_label,
-            previewSortComboBox=preview_combo,
         )
         target_layout = MagicMock()
         panel = object()
@@ -240,13 +236,13 @@ class LocalFirstControlInstallerTests(unittest.TestCase):
         self.assertTrue(installed)
         self.assertEqual(
             source_layout.removeWidget.call_args_list,
-            [call(style_label), call(style_combo), call(preview_label), call(preview_combo)],
+            [call(style_label), call(style_combo)],
         )
         self.assertEqual(
             target_layout.addWidget.call_args_list,
-            [call(style_label), call(style_combo), call(preview_label), call(preview_combo)],
+            [call(style_label), call(style_combo)],
         )
-        for widget in (style_label, style_combo, preview_label, preview_combo):
+        for widget in (style_label, style_combo):
             widget.setParent.assert_called_once_with(panel)
             widget.show.assert_called_once_with()
         map_content.set_style_controls_visible.assert_called_once_with()

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -154,10 +154,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
             activity_style.required_widget_attrs,
             ("stylePresetLabel", "stylePresetComboBox"),
         )
-        self.assertEqual(
-            activity_style.optional_widget_groups,
-            (("previewSortLabel", "previewSortComboBox"),),
-        )
+        self.assertEqual(activity_style.optional_widget_groups, ())
         self.assertEqual(activity_style.optional_widget_attrs, ())
         self.assertEqual(activity_style.layout_getter_attr, "style_controls_layout")
         self.assertEqual(activity_style.parent_panel_attr, "style_controls_panel")

--- a/tests/test_local_first_parity_audit.py
+++ b/tests/test_local_first_parity_audit.py
@@ -86,10 +86,7 @@ class LocalFirstParityAuditTests(unittest.TestCase):
             surfaces["activity_style"].required_widget_attrs,
             activity_style.required_widget_attrs,
         )
-        self.assertEqual(
-            surfaces["activity_style"].optional_widget_attrs,
-            ("previewSortLabel", "previewSortComboBox"),
-        )
+        self.assertEqual(surfaces["activity_style"].optional_widget_attrs, ())
         self.assertEqual(
             surfaces["analysis_actions"].action_names,
             (

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1022,7 +1022,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.detailedRouteStatusComboBox = SimpleNamespace(
             currentIndexChanged=_FakeSignal(),
         )
-        dock.previewSortComboBox = SimpleNamespace(currentTextChanged=_FakeSignal())
         for name in (
             "on_browse_clicked",
             "on_refresh_clicked",
@@ -1103,19 +1102,13 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         parent_widget = SimpleNamespace(layout=lambda: parent_layout)
         style_label = MagicMock()
         style_combo = MagicMock()
-        preview_sort_label = MagicMock()
-        preview_sort_combo = MagicMock()
         for widget in (
             style_label,
             style_combo,
-            preview_sort_label,
-            preview_sort_combo,
         ):
             widget.parentWidget.return_value = parent_widget
         dock.stylePresetLabel = style_label
         dock.stylePresetComboBox = style_combo
-        dock.previewSortLabel = preview_sort_label
-        dock.previewSortComboBox = preview_sort_combo
         panel = object()
         style_layout = MagicMock()
         map_content = SimpleNamespace(
@@ -1135,8 +1128,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             [
                 call(style_label),
                 call(style_combo),
-                call(preview_sort_label),
-                call(preview_sort_combo),
             ],
         )
         self.assertEqual(
@@ -1144,15 +1135,11 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             [
                 call(style_label),
                 call(style_combo),
-                call(preview_sort_label),
-                call(preview_sort_combo),
             ],
         )
         for widget in (
             style_label,
             style_combo,
-            preview_sort_label,
-            preview_sort_combo,
         ):
             widget.show.assert_called_once_with()
         map_content.set_style_controls_visible.assert_called_once_with()

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -434,9 +434,6 @@ class QgisSmokeTests(unittest.TestCase):
 
         dock = QfitDockWidget(self.iface, dependencies=dependencies)
         try:
-            preview_sort_text = dock.previewSortComboBox.itemText(
-                1 if dock.previewSortComboBox.count() > 1 else 0
-            )
             style_preset_text = dock.stylePresetComboBox.itemText(
                 1 if dock.stylePresetComboBox.count() > 1 else 0
             )
@@ -447,7 +444,6 @@ class QgisSmokeTests(unittest.TestCase):
             dock.outputPathLineEdit.setText("/tmp/roundtrip.gpkg")
             dock.backgroundMapCheckBox.setChecked(True)
             dock.backgroundPresetComboBox.setCurrentText(background_preset_text)
-            dock.previewSortComboBox.setCurrentText(preview_sort_text)
             dock.stylePresetComboBox.setCurrentText(style_preset_text)
             dock.analysisModeComboBox.setCurrentText("Most frequent starting points")
             dock.atlasTitleLineEdit.setText("Spring Atlas")
@@ -466,7 +462,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertIsNone(settings.get("detailed_route_strategy"))
             self.assertTrue(settings.get_bool("use_background_map"))
             self.assertEqual(settings.get("background_preset"), background_preset_text)
-            self.assertEqual(settings.get("preview_sort"), preview_sort_text)
+            self.assertIsNone(settings.get("preview_sort"))
             self.assertEqual(settings.get("style_preset"), style_preset_text)
             self.assertIsNone(settings.get("temporal_mode"))
             self.assertEqual(settings.get("analysis_mode"), "Most frequent starting points")
@@ -484,7 +480,7 @@ class QgisSmokeTests(unittest.TestCase):
             self.assertEqual(dock_reloaded.outputPathLineEdit.text(), "/tmp/roundtrip.gpkg")
             self.assertTrue(dock_reloaded.backgroundMapCheckBox.isChecked())
             self.assertEqual(dock_reloaded.backgroundPresetComboBox.currentText(), background_preset_text)
-            self.assertEqual(dock_reloaded.previewSortComboBox.currentText(), preview_sort_text)
+            self.assertFalse(hasattr(dock_reloaded, "previewSortComboBox"))
             self.assertEqual(dock_reloaded.stylePresetComboBox.currentText(), style_preset_text)
             self.assertFalse(hasattr(dock_reloaded, "temporalModeComboBox"))
             self.assertEqual(dock_reloaded.analysisModeComboBox.currentText(), "Most frequent starting points")

--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -30,7 +30,6 @@ def _make_query(**overrides):
         search_text="",
         detailed_only=False,
         detailed_route_filter="any",
-        sort_label="Date (newest first)",
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -51,7 +51,6 @@ from .local_first_activity_controls import (
     build_current_activity_preview_request,
     configure_detailed_route_filter_options,
     configure_local_first_activity_preview_options,
-    configure_preview_sort_options,
 )
 from .local_first_analysis_controls import (
     ANALYSIS_MODE_LABELS,
@@ -318,7 +317,6 @@ __all__ = [
     "configure_local_first_activity_preview_options",
     "configure_local_first_analysis_mode_backing_controls",
     "configure_local_first_basemap_options",
-    "configure_preview_sort_options",
     "build_current_dock_workflow_label",
     "build_current_activity_preview_request",
     "build_dock_summary_status",

--- a/ui/application/local_first_activity_controls.py
+++ b/ui/application/local_first_activity_controls.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from ...activities.domain.activity_query import (
-    DEFAULT_SORT_LABEL,
     DETAILED_ROUTE_FILTER_ANY,
     DETAILED_ROUTE_FILTER_MISSING,
     DETAILED_ROUTE_FILTER_PRESENT,
-    SORT_OPTIONS,
 )
 from ...activities.application import build_activity_preview_request
 
@@ -32,7 +30,6 @@ def build_current_activity_preview_request(dock):
         max_distance_km=dock.maxDistanceSpinBox.value(),
         search_text=dock.activitySearchLineEdit.text().strip(),
         detailed_route_filter=dock.detailedRouteStatusComboBox.currentData(),
-        sort_label=dock.previewSortComboBox.currentText() or DEFAULT_SORT_LABEL,
     )
 
 
@@ -40,7 +37,6 @@ def configure_local_first_activity_preview_options(dock) -> None:
     """Prepare activity preview backing controls for the Data page."""
 
     configure_detailed_route_filter_options(dock)
-    configure_preview_sort_options(dock)
 
 
 def configure_detailed_route_filter_options(dock) -> None:
@@ -65,20 +61,8 @@ def configure_detailed_route_filter_options(dock) -> None:
     combo.setToolTip("Filter activities by detailed-route availability")
 
 
-def configure_preview_sort_options(dock) -> None:
-    """Populate the activity preview sort backing combo."""
-
-    combo = getattr(dock, "previewSortComboBox", None)
-    if combo is None:
-        return
-    combo.clear()
-    for label in SORT_OPTIONS:
-        combo.addItem(label)
-
-
 __all__ = [
     "build_current_activity_preview_request",
     "configure_detailed_route_filter_options",
     "configure_local_first_activity_preview_options",
-    "configure_preview_sort_options",
 ]

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -60,7 +60,6 @@ LOCAL_FIRST_WIDGET_MOVES: tuple[LocalFirstWidgetMove, ...] = (
         required_widget_attrs=("stylePresetLabel", "stylePresetComboBox"),
         installed_attr="_local_first_activity_style_controls_installed",
         installed_target_attr="_local_first_activity_style_controls_installed_target",
-        optional_widget_groups=(("previewSortLabel", "previewSortComboBox"),),
         layout_getter_attr="style_controls_layout",
         parent_panel_attr="style_controls_panel",
         post_install_visible_attr="set_style_controls_visible",


### PR DESCRIPTION
## Summary
- remove the Map tab Preview sort label/dropdown and related settings binding
- make activity previews always use the internal newest-start-date-first ordering
- remove obsolete sort options/plumbing and update UI/settings/local-first tests

Closes #932.

## Tests
- `python3 -m pytest tests/test_activity_query.py tests/test_activity_preview.py tests/test_activity_preview_service.py tests/test_local_first_activity_controls.py tests/test_local_first_control_moves.py tests/test_local_first_control_installer.py tests/test_local_first_parity_audit.py tests/test_dock_settings_bindings.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
