### PR TITLE
Refresh map styling on preset changes

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -67,6 +67,7 @@ from .ui.application import (
     DockRuntimeStore,
     DockVisualWorkflowCoordinator,
     DockVisualWorkflowRequest,
+    RefreshVisualizationStyleAction,
     bind_local_first_analysis_mode_controls,
     bind_local_first_basemap_preset_controls,
     bind_local_first_conditional_visibility_controls,
@@ -465,6 +466,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.loadLayersButton.clicked.connect(self.on_load_layers_clicked)
         self.clearDatabaseButton.clicked.connect(self.on_clear_database_clicked)
         self.applyFiltersButton.clicked.connect(self.on_apply_filters_clicked)
+        self.stylePresetComboBox.currentTextChanged.connect(self.on_style_preset_changed)
         self.runAnalysisButton.clicked.connect(self.on_run_analysis_clicked)
         self.loadBackgroundButton.clicked.connect(self.on_load_background_clicked)
         bind_local_first_basemap_preset_controls(self)
@@ -1030,6 +1032,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def on_apply_filters_clicked(self):
         self._dispatch_dock_action(ApplyVisualizationAction)
+
+    def on_style_preset_changed(self, *_args):
+        self._dispatch_dock_action(RefreshVisualizationStyleAction)
 
     def on_run_analysis_clicked(self):
         self._dispatch_dock_action(RunAnalysisAction)

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1034,6 +1034,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._dispatch_dock_action(ApplyVisualizationAction)
 
     def on_style_preset_changed(self, *_args):
+        self._mark_atlas_export_stale()
         self._dispatch_dock_action(RefreshVisualizationStyleAction)
 
     def on_run_analysis_clicked(self):

--- a/tests/test_dock_action_dispatcher.py
+++ b/tests/test_dock_action_dispatcher.py
@@ -8,6 +8,7 @@ from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.ui.application import (
     ApplyVisualizationAction,
     DockActionDispatcher,
+    RefreshVisualizationStyleAction,
     RunAnalysisAction,
 )
 from qfit.visualization.application import BackgroundConfig, LayerRefs
@@ -53,6 +54,7 @@ class TestDockActionDispatcher(unittest.TestCase):
             temporal_mode="By month",
             background_config=action.background_config,
             apply_subset_filters=False,
+            update_background=True,
         )
         visual_apply.apply_request.assert_called_once_with("request")
         run_analysis.assert_called_once_with(
@@ -97,6 +99,46 @@ class TestDockActionDispatcher(unittest.TestCase):
         result = dispatcher.dispatch(action)
 
         self.assertEqual(result.status, "Applied current filters")
+        self.assertIsNone(result.background_layer)
+        self.assertEqual(result.background_error, "")
+
+    def test_dispatch_style_refresh_updates_style_without_filters_background_or_analysis(self):
+        visual_apply = MagicMock()
+        visual_apply.build_request.return_value = "request"
+        visual_apply.apply_request.return_value = SimpleNamespace(
+            status="Applied styling to qfit layers",
+            background_layer="ignored-layer",
+            background_error="ignored-error",
+        )
+        dispatcher = DockActionDispatcher(
+            visual_apply=visual_apply,
+            save_settings=MagicMock(),
+            run_analysis=MagicMock(),
+        )
+        selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=1)
+        action = RefreshVisualizationStyleAction(
+            layers=LayerRefs(activities=object()),
+            selection_state=selection_state,
+            style_preset="Track points",
+            temporal_mode="Off",
+            background_config=BackgroundConfig(enabled=True),
+            analysis_mode="Most frequent starting points",
+        )
+
+        result = dispatcher.dispatch(action)
+
+        visual_apply.build_request.assert_called_once_with(
+            layers=action.layers,
+            selection_state=selection_state,
+            style_preset="Track points",
+            temporal_mode="Off",
+            background_config=action.background_config,
+            apply_subset_filters=False,
+            update_background=False,
+        )
+        visual_apply.apply_request.assert_called_once_with("request")
+        dispatcher._run_analysis.assert_not_called()
+        self.assertEqual(result.status, "Applied styling to qfit layers")
         self.assertIsNone(result.background_layer)
         self.assertEqual(result.background_error, "")
 

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1008,6 +1008,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.backgroundPresetComboBox = SimpleNamespace(
             currentTextChanged=_FakeSignal(),
         )
+        dock.stylePresetComboBox = SimpleNamespace(currentTextChanged=_FakeSignal())
         dock.writeActivityPointsCheckBox = SimpleNamespace(toggled=_FakeSignal())
         dock.atlasPdfBrowseButton = SimpleNamespace(clicked=_FakeSignal())
         dock.atlasPdfPathLineEdit = SimpleNamespace(textChanged=_FakeSignal())
@@ -1031,6 +1032,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "on_load_layers_clicked",
             "on_clear_database_clicked",
             "on_apply_filters_clicked",
+            "on_style_preset_changed",
             "on_run_analysis_clicked",
             "on_load_background_clicked",
             "on_atlas_pdf_browse_clicked",
@@ -1059,6 +1061,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         self.assertEqual(
             len(dock.backgroundPresetComboBox.currentTextChanged.connected),
+            1,
+        )
+        self.assertEqual(
+            len(dock.stylePresetComboBox.currentTextChanged.connected),
             1,
         )
 
@@ -1670,6 +1676,16 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         dock._dispatch_dock_action.assert_called_once_with(
             self.module.ApplyVisualizationAction
+        )
+
+    def test_on_style_preset_changed_dispatches_style_refresh_action(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._dispatch_dock_action = MagicMock()
+
+        self.module.QfitDockWidget.on_style_preset_changed(dock)
+
+        dock._dispatch_dock_action.assert_called_once_with(
+            self.module.RefreshVisualizationStyleAction
         )
 
     def test_on_run_analysis_clicked_dispatches_run_analysis_action(self):

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -1678,12 +1678,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             self.module.ApplyVisualizationAction
         )
 
-    def test_on_style_preset_changed_dispatches_style_refresh_action(self):
+    def test_on_style_preset_changed_stales_atlas_and_dispatches_style_refresh_action(self):
         dock = object.__new__(self.module.QfitDockWidget)
+        dock._mark_atlas_export_stale = MagicMock()
         dock._dispatch_dock_action = MagicMock()
 
         self.module.QfitDockWidget.on_style_preset_changed(dock)
 
+        dock._mark_atlas_export_stale.assert_called_once_with()
         dock._dispatch_dock_action.assert_called_once_with(
             self.module.RefreshVisualizationStyleAction
         )

--- a/tests/test_visual_apply.py
+++ b/tests/test_visual_apply.py
@@ -66,6 +66,9 @@ class ShouldUpdateBackgroundTests(unittest.TestCase):
     def test_returns_false_when_applying_subset_filters(self):
         self.assertFalse(VisualApplyService.should_update_background(True))
 
+    def test_returns_false_when_background_updates_are_disabled(self):
+        self.assertFalse(VisualApplyService.should_update_background(False, False))
+
 
 class BuildRequestTests(unittest.TestCase):
     def test_build_request_returns_structured_request(self):
@@ -82,6 +85,7 @@ class BuildRequestTests(unittest.TestCase):
         self.assertIsInstance(request, VisualApplyRequest)
         self.assertEqual(request.style_preset, "By activity type")
         self.assertTrue(request.apply_subset_filters)
+        self.assertTrue(request.update_background)
 
 
 class ApplyWithSubsetFiltersTests(unittest.TestCase):
@@ -350,6 +354,22 @@ class ApplyWithoutSubsetFiltersTests(unittest.TestCase):
             tile_mode="raster",
         )
         self.assertIsNotNone(result.background_layer)
+
+    def test_skips_background_when_background_update_disabled(self):
+        result = self.service.apply(
+            layers=self.layers,
+            query=_make_query(),
+            style_preset="By activity type",
+            temporal_mode="Off",
+            background_config=_make_bg_config(enabled=True),
+            apply_subset_filters=False,
+            update_background=False,
+            filtered_count=0,
+        )
+
+        self.layer_manager.ensure_background_layer.assert_not_called()
+        self.assertIsNone(result.background_layer)
+        self.assertNotIn("background", result.status.lower())
 
     def test_status_mentions_styling_and_background(self):
         bg = _make_bg_config(enabled=True)

--- a/tests/test_visual_workflow_action_builder.py
+++ b/tests/test_visual_workflow_action_builder.py
@@ -5,6 +5,7 @@ from qfit.activities.application.activity_selection_state import ActivitySelecti
 from qfit.activities.domain.activity_query import ActivityQuery
 from qfit.ui.application import (
     ApplyVisualizationAction,
+    RefreshVisualizationStyleAction,
     RunAnalysisAction,
     VisualWorkflowBackgroundInputs,
     VisualWorkflowActionInputs,
@@ -171,6 +172,27 @@ class TestVisualWorkflowActionBuilder(unittest.TestCase):
         self.assertFalse(action.apply_subset_filters)
         self.assertEqual(action.starts_layer, "starts")
         self.assertFalse(action.background_config.enabled)
+
+    def test_builds_style_refresh_action_without_filters_or_background(self):
+        selection_state = ActivitySelectionState(query=ActivityQuery(), filtered_count=1)
+
+        action = build_visual_workflow_action(
+            RefreshVisualizationStyleAction,
+            VisualWorkflowActionInputs(
+                layers=LayerRefs(activities="activities"),
+                selection_state=selection_state,
+                style_preset="Track points",
+                temporal_mode="Off",
+                background_config=BackgroundConfig(enabled=True),
+                analysis_mode="None",
+                apply_subset_filters=True,
+            ),
+        )
+
+        self.assertIsInstance(action, RefreshVisualizationStyleAction)
+        self.assertFalse(action.apply_subset_filters)
+        self.assertFalse(action.update_background)
+        self.assertEqual(action.style_preset, "Track points")
 
     def test_rejects_unsupported_action_types(self):
         with self.assertRaises(TypeError):

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -6,6 +6,7 @@ from .dock_action_dispatcher import (
     ApplyVisualizationAction,
     DockActionDispatcher,
     DockActionResult,
+    RefreshVisualizationStyleAction,
     RunAnalysisAction,
 )
 from .dock_activity_workflow import (

--- a/ui/application/dock_action_dispatcher.py
+++ b/ui/application/dock_action_dispatcher.py
@@ -35,6 +35,9 @@ class ApplyVisualizationAction(_BaseVisualWorkflowAction):
 class RefreshVisualizationStyleAction(_BaseVisualWorkflowAction):
     """Normalized request for refreshing styling without changing filters."""
 
+    apply_subset_filters: bool = False
+    update_background: bool = False
+
 
 @dataclass(frozen=True)
 class RunAnalysisAction(_BaseVisualWorkflowAction):
@@ -123,8 +126,8 @@ class DockActionDispatcher:
             style_preset=action.style_preset,
             temporal_mode=action.temporal_mode,
             background_config=action.background_config,
-            apply_subset_filters=False,
-            update_background=False,
+            apply_subset_filters=action.apply_subset_filters,
+            update_background=action.update_background,
         )
         visual_result = self.visual_apply.apply_request(request)
         return DockActionResult(status=visual_result.status)

--- a/ui/application/dock_action_dispatcher.py
+++ b/ui/application/dock_action_dispatcher.py
@@ -15,6 +15,7 @@ class _BaseVisualWorkflowAction:
     analysis_mode: str
     starts_layer: object = None
     apply_subset_filters: bool = True
+    update_background: bool = True
 
     @property
     def query(self):
@@ -28,6 +29,11 @@ class _BaseVisualWorkflowAction:
 @dataclass(frozen=True)
 class ApplyVisualizationAction(_BaseVisualWorkflowAction):
     """Normalized request for an apply-visualization dock action."""
+
+
+@dataclass(frozen=True)
+class RefreshVisualizationStyleAction(_BaseVisualWorkflowAction):
+    """Normalized request for refreshing styling without changing filters."""
 
 
 @dataclass(frozen=True)
@@ -61,6 +67,8 @@ class DockActionDispatcher:
         self._run_analysis = run_analysis
 
     def dispatch(self, action: Any) -> DockActionResult:
+        if isinstance(action, RefreshVisualizationStyleAction):
+            return self._dispatch_style_refresh(action)
         if isinstance(action, (ApplyVisualizationAction, RunAnalysisAction)):
             return self._dispatch_visual_workflow(action)
         return DockActionResult(
@@ -80,12 +88,16 @@ class DockActionDispatcher:
             temporal_mode=action.temporal_mode,
             background_config=action.background_config,
             apply_subset_filters=action.apply_subset_filters,
+            update_background=action.update_background,
         )
         visual_result = self.visual_apply.apply_request(request)
 
         background_layer = None
         background_error = ""
-        if self.visual_apply.should_update_background(action.apply_subset_filters):
+        if self.visual_apply.should_update_background(
+            action.apply_subset_filters,
+            action.update_background,
+        ):
             background_layer = visual_result.background_layer
             background_error = visual_result.background_error
 
@@ -100,6 +112,22 @@ class DockActionDispatcher:
             background_error=background_error,
             analysis_status=analysis_status,
         )
+
+    def _dispatch_style_refresh(
+        self, action: RefreshVisualizationStyleAction
+    ) -> DockActionResult:
+        self._save_settings()
+        request = self.visual_apply.build_request(
+            layers=action.layers,
+            selection_state=action.selection_state,
+            style_preset=action.style_preset,
+            temporal_mode=action.temporal_mode,
+            background_config=action.background_config,
+            apply_subset_filters=False,
+            update_background=False,
+        )
+        visual_result = self.visual_apply.apply_request(request)
+        return DockActionResult(status=visual_result.status)
 
     @staticmethod
     def _combine_statuses(primary: str, secondary: str) -> str:

--- a/ui/application/visual_workflow_action_builder.py
+++ b/ui/application/visual_workflow_action_builder.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass
 
-from .dock_action_dispatcher import ApplyVisualizationAction, RunAnalysisAction
+from .dock_action_dispatcher import (
+    ApplyVisualizationAction,
+    RefreshVisualizationStyleAction,
+    RunAnalysisAction,
+)
 from ...activities.application.activity_selection_state import ActivitySelectionState
 from ...visualization.application import BackgroundConfig, LayerRefs
 
@@ -128,8 +132,18 @@ def build_visual_workflow_action(
 ):
     """Build a normalized visual workflow action from dock-edge inputs."""
 
-    if action_type not in (ApplyVisualizationAction, RunAnalysisAction):
+    if action_type not in (
+        ApplyVisualizationAction,
+        RefreshVisualizationStyleAction,
+        RunAnalysisAction,
+    ):
         raise TypeError(f"Unsupported visual workflow action type: {action_type!r}")
+
+    apply_subset_filters = inputs.apply_subset_filters
+    update_background = True
+    if action_type is RefreshVisualizationStyleAction:
+        apply_subset_filters = False
+        update_background = False
 
     return action_type(
         layers=inputs.layers,
@@ -139,5 +153,6 @@ def build_visual_workflow_action(
         background_config=inputs.background_config,
         analysis_mode=inputs.analysis_mode,
         starts_layer=inputs.layers.starts,
-        apply_subset_filters=inputs.apply_subset_filters,
+        apply_subset_filters=apply_subset_filters,
+        update_background=update_background,
     )

--- a/visualization/application/visual_apply.py
+++ b/visualization/application/visual_apply.py
@@ -52,6 +52,7 @@ class ApplyVisualizationRequest:
     temporal_mode: str = ""
     background_config: BackgroundConfig = field(default_factory=BackgroundConfig)
     apply_subset_filters: bool = False
+    update_background: bool = True
 
     @property
     def query(self):
@@ -86,9 +87,9 @@ class VisualApplyService:
         self.layer_gateway = layer_gateway
 
     @staticmethod
-    def should_update_background(apply_subset_filters):
+    def should_update_background(apply_subset_filters, update_background=True):
         """Background layer is only updated on initial load, not on filter-only applies."""
-        return not apply_subset_filters
+        return bool(update_background) and not apply_subset_filters
 
     @staticmethod
     def build_request(
@@ -97,6 +98,7 @@ class VisualApplyService:
         temporal_mode,
         background_config,
         apply_subset_filters,
+        update_background=True,
         selection_state=None,
         query=None,
         filtered_count=0,
@@ -113,6 +115,7 @@ class VisualApplyService:
             temporal_mode=temporal_mode,
             background_config=background_config,
             apply_subset_filters=apply_subset_filters,
+            update_background=update_background,
         )
 
     def apply(self, request: ApplyVisualizationRequest | None = None, **legacy_kwargs):
@@ -154,7 +157,10 @@ class VisualApplyService:
             )
 
         background_layer = None
-        if self.should_update_background(request.apply_subset_filters):
+        if self.should_update_background(
+            request.apply_subset_filters,
+            request.update_background,
+        ):
             background_layer, bg_error = self._ensure_background(request.background_config)
             if bg_error is not None:
                 failure_status = build_visual_apply_background_failure_result_status(
@@ -171,7 +177,7 @@ class VisualApplyService:
             has_layers=has_layers,
             apply_subset_filters=request.apply_subset_filters,
             filtered_count=request.filtered_count,
-            wants_background=request.background_config.enabled,
+            wants_background=request.update_background and request.background_config.enabled,
             background_loaded=background_layer is not None,
             temporal_note=temporal_note,
         )


### PR DESCRIPTION
## Summary
- refresh qfit map styling immediately when the Map tab style preset changes
- keep style refresh separate from Apply filters by skipping filter, analysis, and background updates for style-only changes
- add workflow/application tests for style-refresh dispatch and background-skip behavior

Closes #933.

## Tests
- `python3 -m pytest tests/test_visual_apply.py tests/test_dock_action_dispatcher.py tests/test_visual_workflow_action_builder.py tests/test_qfit_dockwidget_analysis_pure.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
