### PR TITLE
Make slope grade analysis activity-only

### DIFF
--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -141,9 +141,7 @@ SLOPE_GRADE_LEGEND = tuple(grade_class.label for grade_class in SLOPE_GRADE_CLAS
 
 
 ACTIVITY_TRACKS_LABEL = "activity tracks"
-SAVED_ROUTE_TRACKS_LABEL = "saved route tracks"
 _ACTIVITY_POINT_GRADE_FIELDS = ("grade_smooth_pct", "stream_distance_m")
-_ROUTE_ELEVATION_SAMPLE_FIELDS = ("distance_m", "altitude_m")
 _LINE_GEOMETRY_TYPE = 1
 _LINE_WKB_TYPES = frozenset((2, 5))
 
@@ -158,20 +156,13 @@ def build_slope_grade_analysis_plan(
 ) -> SlopeGradeAnalysisPlan:
     """Build a pure eligibility plan for slope-grade line styling.
 
-    The first #815 slice keeps the QGIS-facing styling work behind this
-    render-neutral contract. It deliberately targets only the loaded activity
-    track and saved-route track line layers, and documents why a target remains
-    unchanged when the companion elevation/distance samples are unavailable.
+    The QGIS-facing styling work stays behind this render-neutral contract.
+    Slope grade is intentionally activity-only: saved route layers are ignored
+    even when loaded so route-profile/sample data never drives this analysis.
     """
 
     return SlopeGradeAnalysisPlan(
-        layers=(
-            _activity_track_plan(activities_layer, points_layer),
-            _route_track_plan(
-                route_tracks_layer,
-                route_profile_samples_layer or route_points_layer,
-            ),
-        )
+        layers=(_activity_track_plan(activities_layer, points_layer),)
     )
 
 
@@ -181,9 +172,6 @@ def run_slope_grade_analysis(request: RunAnalysisRequest) -> RunAnalysisResult:
     result = build_slope_grade_analysis_result(
         activities_layer=request.activities_layer,
         points_layer=request.points_layer,
-        route_tracks_layer=request.route_tracks_layer,
-        route_points_layer=request.route_points_layer,
-        route_profile_samples_layer=request.route_profile_samples_layer,
     )
     layer, _line_segments = _build_slope_grade_layer(request)
     return RunAnalysisResult(status=build_slope_grade_status(result), layer=layer)
@@ -198,9 +186,6 @@ def _build_slope_grade_layer(request: RunAnalysisRequest):
     return build_slope_grade_layer(
         activities_layer=request.activities_layer,
         points_layer=request.points_layer,
-        route_tracks_layer=request.route_tracks_layer,
-        route_points_layer=request.route_points_layer,
-        route_profile_samples_layer=request.route_profile_samples_layer,
     )
 
 
@@ -217,18 +202,11 @@ def build_slope_grade_analysis_result(
     plan = build_slope_grade_analysis_plan(
         activities_layer=activities_layer,
         points_layer=points_layer,
-        route_tracks_layer=route_tracks_layer,
-        route_points_layer=route_points_layer,
-        route_profile_samples_layer=route_profile_samples_layer,
     )
     layer_results = []
     for layer_plan in plan.enabled_layers:
         if layer_plan.key == "activity_tracks":
             segments = build_activity_slope_grade_segments(points_layer)
-        elif layer_plan.key == "saved_route_tracks":
-            segments = build_route_slope_grade_segments(
-                route_profile_samples_layer or route_points_layer
-            )
         else:
             raise ValueError(
                 "Unsupported slope-grade layer key: {key}".format(
@@ -372,17 +350,6 @@ def build_activity_slope_grade_segments(points_layer) -> tuple[SlopeGradeSegment
     )
 
 
-def build_route_slope_grade_segments(sample_layer) -> tuple[SlopeGradeSegment, ...]:
-    """Build saved-route slope-grade segments from route profile samples."""
-
-    return _build_grouped_slope_grade_segments(
-        _layer_features(sample_layer),
-        group_field_sets=(("sample_group_index",), ("source", "source_route_id")),
-        distance_field="distance_m",
-        elevation_field="altitude_m",
-    )
-
-
 def build_activity_slope_grade_line_segments(
     points_layer,
 ) -> tuple[SlopeGradeLineSegment, ...]:
@@ -398,23 +365,6 @@ def build_activity_slope_grade_line_segments(
         distance_field="stream_distance_m",
         elevation_field=None,
         grade_field="grade_smooth_pct",
-    )
-
-
-def build_route_slope_grade_line_segments(
-    sample_layer,
-) -> tuple[SlopeGradeLineSegment, ...]:
-    """Build render-ready saved-route line segments from route samples."""
-
-    return _build_grouped_slope_grade_line_segments(
-        _layer_features(sample_layer),
-        layer_key="saved_route_tracks",
-        layer_label=SAVED_ROUTE_TRACKS_LABEL,
-        group_field_sets=(("sample_group_index",), ("source", "source_route_id")),
-        source_field="source",
-        source_id_field="source_route_id",
-        distance_field="distance_m",
-        elevation_field="altitude_m",
     )
 
 
@@ -713,38 +663,6 @@ def _activity_track_plan(activities_layer, points_layer) -> SlopeGradeLayerPlan:
     )
 
 
-def _route_track_plan(route_tracks_layer, sample_layer) -> SlopeGradeLayerPlan:
-    if route_tracks_layer is None:
-        return SlopeGradeLayerPlan(
-            key="saved_route_tracks",
-            label=SAVED_ROUTE_TRACKS_LABEL,
-            blocked_reason="saved route track lines are not loaded",
-        )
-    if not _is_line_layer(route_tracks_layer):
-        return SlopeGradeLayerPlan(
-            key="saved_route_tracks",
-            label=SAVED_ROUTE_TRACKS_LABEL,
-            layer=route_tracks_layer,
-            blocked_reason="saved route target is not a line layer",
-        )
-    if not _has_fields(sample_layer, _ROUTE_ELEVATION_SAMPLE_FIELDS):
-        return SlopeGradeLayerPlan(
-            key="saved_route_tracks",
-            label=SAVED_ROUTE_TRACKS_LABEL,
-            layer=route_tracks_layer,
-            blocked_reason=(
-                "saved routes need profile or route point samples with "
-                "distance_m and altitude_m"
-            ),
-        )
-    return SlopeGradeLayerPlan(
-        key="saved_route_tracks",
-        label=SAVED_ROUTE_TRACKS_LABEL,
-        layer=route_tracks_layer,
-        enabled=True,
-        source_fields=_ROUTE_ELEVATION_SAMPLE_FIELDS,
-    )
-
 
 def _has_fields(layer, expected: Iterable[str]) -> bool:
     field_names = _field_names(layer)
@@ -811,12 +729,10 @@ __all__ = [
     "SlopeGradeSegment",
     "build_activity_slope_grade_line_segments",
     "build_activity_slope_grade_segments",
-    "build_route_slope_grade_line_segments",
     "build_slope_grade_analysis_result",
     "build_slope_grade_analysis_plan",
     "build_slope_grade_segments",
     "build_slope_grade_status",
-    "build_route_slope_grade_segments",
     "run_slope_grade_analysis",
     "slope_grade_class_for_percent",
 ]

--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -142,6 +142,9 @@ SLOPE_GRADE_LEGEND = tuple(grade_class.label for grade_class in SLOPE_GRADE_CLAS
 
 ACTIVITY_TRACKS_LABEL = "activity tracks"
 _ACTIVITY_POINT_GRADE_FIELDS = ("grade_smooth_pct", "stream_distance_m")
+_IGNORED_ROUTE_LAYER_KWARGS = frozenset(
+    ("route_tracks_layer", "route_points_layer", "route_profile_samples_layer")
+)
 _LINE_GEOMETRY_TYPE = 1
 _LINE_WKB_TYPES = frozenset((2, 5))
 
@@ -150,6 +153,7 @@ def build_slope_grade_analysis_plan(
     *,
     activities_layer=None,
     points_layer=None,
+    **route_layers,
 ) -> SlopeGradeAnalysisPlan:
     """Build a pure eligibility plan for slope-grade line styling.
 
@@ -158,6 +162,7 @@ def build_slope_grade_analysis_plan(
     even when loaded so route-profile/sample data never drives this analysis.
     """
 
+    _ignore_route_layer_kwargs(route_layers)
     return SlopeGradeAnalysisPlan(
         layers=(_activity_track_plan(activities_layer, points_layer),)
     )
@@ -190,9 +195,11 @@ def build_slope_grade_analysis_result(
     *,
     activities_layer=None,
     points_layer=None,
+    **route_layers,
 ) -> SlopeGradeAnalysisResult:
     """Classify slope-grade segments for eligible line-layer targets."""
 
+    _ignore_route_layer_kwargs(route_layers)
     plan = build_slope_grade_analysis_plan(
         activities_layer=activities_layer,
         points_layer=points_layer,
@@ -215,6 +222,13 @@ def build_slope_grade_analysis_result(
             )
         )
     return SlopeGradeAnalysisResult(plan=plan, layers=tuple(layer_results))
+
+
+def _ignore_route_layer_kwargs(route_layers):
+    unexpected = set(route_layers) - _IGNORED_ROUTE_LAYER_KWARGS
+    if unexpected:
+        unexpected_names = ", ".join(sorted(unexpected))
+        raise TypeError(f"Unexpected slope-grade layer kwargs: {unexpected_names}")
 
 
 def build_slope_grade_status(result_or_plan) -> str:

--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -102,7 +102,7 @@ class SlopeGradeLineSegment:
 
 @dataclass(frozen=True)
 class SlopeGradeAnalysisPlan:
-    """Render-neutral plan for #815 slope-grade line analysis."""
+    """Render-neutral plan for activity-only slope-grade line analysis."""
 
     layers: tuple[SlopeGradeLayerPlan, ...]
     grade_classes: tuple[SlopeGradeClass, ...] = SLOPE_GRADE_CLASSES
@@ -160,6 +160,8 @@ def build_slope_grade_analysis_plan(
     The QGIS-facing styling work stays behind this render-neutral contract.
     Slope grade is intentionally activity-only: saved route layers are ignored
     even when loaded so route-profile/sample data never drives this analysis.
+    Route-layer keyword arguments are still accepted as a compatibility shim
+    for callers that pass the full loaded layer set.
     """
 
     _ignore_route_layer_kwargs(route_layers)
@@ -197,7 +199,11 @@ def build_slope_grade_analysis_result(
     points_layer=None,
     **route_layers,
 ) -> SlopeGradeAnalysisResult:
-    """Classify slope-grade segments for eligible line-layer targets."""
+    """Classify activity slope-grade segments.
+
+    Route-layer keyword arguments are accepted only for compatibility and are
+    ignored because slope grade is an activity-only analysis.
+    """
 
     _ignore_route_layer_kwargs(route_layers)
     plan = build_slope_grade_analysis_plan(
@@ -669,8 +675,6 @@ def _activity_track_plan(activities_layer, points_layer) -> SlopeGradeLayerPlan:
         enabled=True,
         source_fields=_ACTIVITY_POINT_GRADE_FIELDS,
     )
-
-
 
 def _has_fields(layer, expected: Iterable[str]) -> bool:
     field_names = _field_names(layer)

--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -150,9 +150,6 @@ def build_slope_grade_analysis_plan(
     *,
     activities_layer=None,
     points_layer=None,
-    route_tracks_layer=None,
-    route_points_layer=None,
-    route_profile_samples_layer=None,
 ) -> SlopeGradeAnalysisPlan:
     """Build a pure eligibility plan for slope-grade line styling.
 
@@ -193,9 +190,6 @@ def build_slope_grade_analysis_result(
     *,
     activities_layer=None,
     points_layer=None,
-    route_tracks_layer=None,
-    route_points_layer=None,
-    route_profile_samples_layer=None,
 ) -> SlopeGradeAnalysisResult:
     """Classify slope-grade segments for eligible line-layer targets."""
 

--- a/analysis/infrastructure/slope_grade_layer.py
+++ b/analysis/infrastructure/slope_grade_layer.py
@@ -18,7 +18,6 @@ from ..application.slope_grade_analysis import (
     SLOPE_GRADE_CLASSES,
     build_activity_slope_grade_line_segments,
     build_slope_grade_analysis_plan,
-    build_route_slope_grade_line_segments,
 )
 
 SLOPE_GRADE_LAYER_NAME = "qfit slope grade lines"
@@ -34,7 +33,6 @@ def build_slope_grade_layer(
 ):
     """Create a styled memory line layer for slope-grade analysis segments."""
 
-    route_sample_layer = route_profile_samples_layer or route_points_layer
     plan = build_slope_grade_analysis_plan(
         activities_layer=activities_layer,
         points_layer=points_layer,
@@ -45,13 +43,11 @@ def build_slope_grade_layer(
     line_segments = []
     if _plan_enables_layer(plan, "activity_tracks"):
         line_segments.extend(build_activity_slope_grade_line_segments(points_layer))
-    if _plan_enables_layer(plan, "saved_route_tracks"):
-        line_segments.extend(build_route_slope_grade_line_segments(route_sample_layer))
 
     if not line_segments:
         return None, ()
 
-    layer = _build_memory_layer(_preferred_crs_layer(points_layer, route_sample_layer))
+    layer = _build_memory_layer(points_layer)
     provider = layer.dataProvider()
     provider.addAttributes(
         [
@@ -87,11 +83,6 @@ def _build_memory_layer(source_layer):
         "memory",
     )
 
-
-def _preferred_crs_layer(points_layer, route_sample_layer):
-    if points_layer is not None:
-        return points_layer
-    return route_sample_layer
 
 
 def _layer_crs(layer):

--- a/analysis/infrastructure/slope_grade_layer.py
+++ b/analysis/infrastructure/slope_grade_layer.py
@@ -27,18 +27,12 @@ def build_slope_grade_layer(
     *,
     activities_layer=None,
     points_layer=None,
-    route_tracks_layer=None,
-    route_points_layer=None,
-    route_profile_samples_layer=None,
 ):
     """Create a styled memory line layer for slope-grade analysis segments."""
 
     plan = build_slope_grade_analysis_plan(
         activities_layer=activities_layer,
         points_layer=points_layer,
-        route_tracks_layer=route_tracks_layer,
-        route_points_layer=route_points_layer,
-        route_profile_samples_layer=route_profile_samples_layer,
     )
     line_segments = []
     if _plan_enables_layer(plan, "activity_tracks"):

--- a/analysis/infrastructure/slope_grade_layer.py
+++ b/analysis/infrastructure/slope_grade_layer.py
@@ -29,7 +29,11 @@ def build_slope_grade_layer(
     points_layer=None,
     **route_layers,
 ):
-    """Create a styled memory line layer for slope-grade analysis segments."""
+    """Create a styled memory line layer for activity slope-grade segments.
+
+    Route-layer keyword arguments are accepted only for compatibility and are
+    ignored because slope grade is an activity-only analysis.
+    """
 
     plan = build_slope_grade_analysis_plan(
         activities_layer=activities_layer,

--- a/analysis/infrastructure/slope_grade_layer.py
+++ b/analysis/infrastructure/slope_grade_layer.py
@@ -27,12 +27,14 @@ def build_slope_grade_layer(
     *,
     activities_layer=None,
     points_layer=None,
+    **route_layers,
 ):
     """Create a styled memory line layer for slope-grade analysis segments."""
 
     plan = build_slope_grade_analysis_plan(
         activities_layer=activities_layer,
         points_layer=points_layer,
+        **route_layers,
     )
     line_segments = []
     if _plan_enables_layer(plan, "activity_tracks"):
@@ -76,8 +78,6 @@ def _build_memory_layer(source_layer):
         SLOPE_GRADE_LAYER_NAME,
         "memory",
     )
-
-
 
 def _layer_crs(layer):
     crs = getattr(layer, "crs", None)

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -14,8 +14,6 @@ from qfit.analysis.application.slope_grade_analysis import (
     SlopeGradeLayerResult,
     build_activity_slope_grade_line_segments,
     build_activity_slope_grade_segments,
-    build_route_slope_grade_line_segments,
-    build_route_slope_grade_segments,
     build_slope_grade_analysis_result,
     build_slope_grade_analysis_plan,
     build_slope_grade_segments,
@@ -253,59 +251,8 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
             ("climb", "descent"),
         )
 
-    def test_builds_route_segments_from_sample_layer_features(self):
-        segments = build_route_slope_grade_segments(
-            _FeatureLayer(
-                (
-                    _FeatureSample(
-                        {
-                            "sample_group_index": 1,
-                            "distance_m": 0,
-                            "altitude_m": 100,
-                        }
-                    ),
-                    _FeatureSample(
-                        {
-                            "sample_group_index": 1,
-                            "distance_m": 100,
-                            "altitude_m": 108,
-                        }
-                    ),
-                )
-            )
-        )
-
-        self.assertEqual(len(segments), 1)
-        self.assertEqual(segments[0].grade_class.key, "steep_climb")
-
-    def test_builds_route_segments_per_sample_group(self):
-        segments = build_route_slope_grade_segments(
-            _FeatureLayer(
-                (
-                    _FeatureSample(
-                        {"sample_group_index": 1, "distance_m": 0, "altitude_m": 100}
-                    ),
-                    _FeatureSample(
-                        {"sample_group_index": 1, "distance_m": 100, "altitude_m": 104}
-                    ),
-                    _FeatureSample(
-                        {"sample_group_index": 2, "distance_m": 0, "altitude_m": 100}
-                    ),
-                    _FeatureSample(
-                        {"sample_group_index": 2, "distance_m": 100, "altitude_m": 91}
-                    ),
-                )
-            )
-        )
-
-        self.assertEqual(
-            tuple(segment.grade_class.key for segment in segments),
-            ("climb", "steep_descent"),
-        )
-
     def test_layer_segment_builders_ignore_missing_layers(self):
         self.assertEqual(build_activity_slope_grade_segments(None), ())
-        self.assertEqual(build_route_slope_grade_segments(None), ())
 
     def test_builds_activity_line_segments_from_point_sample_geometry(self):
         segments = build_activity_slope_grade_line_segments(
@@ -340,43 +287,6 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertEqual(segments[0].end_xy, (6.7, 46.6))
         self.assertEqual(segments[0].grade_class.key, "climb")
 
-    def test_builds_route_line_segments_from_lat_lon_profile_samples(self):
-        segments = build_route_slope_grade_line_segments(
-            _FeatureLayer(
-                (
-                    _FeatureSample(
-                        {
-                            "sample_group_index": 1,
-                            "source": "strava",
-                            "source_route_id": "r-1",
-                            "lat": 46.5,
-                            "lon": 6.6,
-                            "distance_m": 0,
-                            "altitude_m": 100,
-                        }
-                    ),
-                    _FeatureSample(
-                        {
-                            "sample_group_index": 1,
-                            "source": "strava",
-                            "source_route_id": "r-1",
-                            "lat": 46.6,
-                            "lon": 6.7,
-                            "distance_m": 100,
-                            "altitude_m": 91,
-                        }
-                    ),
-                )
-            )
-        )
-
-        self.assertEqual(len(segments), 1)
-        self.assertEqual(segments[0].layer_key, "saved_route_tracks")
-        self.assertEqual(segments[0].source_id, "r-1")
-        self.assertEqual(segments[0].start_xy, (6.6, 46.5))
-        self.assertEqual(segments[0].end_xy, (6.7, 46.6))
-        self.assertEqual(segments[0].grade_class.key, "steep_descent")
-
     def test_line_segment_builders_do_not_connect_across_sample_groups(self):
         segments = build_activity_slope_grade_line_segments(
             _FeatureLayer(
@@ -405,7 +315,7 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
 
         self.assertEqual(segments, ())
 
-    def test_analysis_result_classifies_segments_for_eligible_line_targets(self):
+    def test_analysis_result_classifies_segments_for_eligible_activity_line_targets(self):
         result = build_slope_grade_analysis_result(
             activities_layer=_Layer(fields=("name",)),
             points_layer=_FeatureLayer(
@@ -443,21 +353,18 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
             ),
         )
 
-        self.assertEqual(result.segment_count, 2)
+        self.assertEqual(result.segment_count, 1)
         self.assertEqual(
             tuple(layer.segment_count for layer in result.layers),
-            (1, 1),
+            (1,),
         )
         self.assertEqual(
             tuple(layer.segments[0].grade_class.key for layer in result.layers),
-            ("climb", "steep_descent"),
+            ("climb",),
         )
         self.assertEqual(
             build_slope_grade_status(result),
-            (
-                "Slope grade line analysis classified activity tracks (1 segment), "
-                "saved route tracks (1 segment)."
-            ),
+            "Slope grade line analysis classified activity tracks (1 segment).",
         )
 
     def test_analysis_result_reports_when_eligible_layers_have_no_segments(self):
@@ -495,8 +402,8 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
                     ),
                 ),
                 SlopeGradeLayerResult(
-                    key="saved_route_tracks",
-                    label="saved route tracks",
+                    key="empty_layer",
+                    label="empty layer",
                     segments=(),
                 ),
             ),
@@ -557,7 +464,7 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertAlmostEqual(segments[0].grade_percent, 4.0)
         self.assertEqual(segments[0].grade_class.key, "climb")
 
-    def test_plan_targets_only_eligible_activity_and_route_line_layers(self):
+    def test_plan_targets_only_eligible_activity_line_layers(self):
         activity_tracks = _Layer(fields=("name",))
         activity_points = _Layer(
             fields=("grade_smooth_pct", "stream_distance_m", "altitude_m")
@@ -574,16 +481,16 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
 
         self.assertEqual(
             tuple(layer.key for layer in plan.enabled_layers),
-            ("activity_tracks", "saved_route_tracks"),
+            ("activity_tracks",),
         )
         self.assertEqual(
             plan.layers[0].source_fields,
             ("grade_smooth_pct", "stream_distance_m"),
         )
-        self.assertEqual(plan.layers[1].source_fields, ("distance_m", "altitude_m"))
+        self.assertEqual(len(plan.layers), 1)
         self.assertEqual(
             build_slope_grade_status(plan),
-            "Slope grade line analysis ready for activity tracks, saved route tracks.",
+            "Slope grade line analysis ready for activity tracks.",
         )
 
     def test_plan_rejects_non_line_targets_without_touching_other_layers(self):
@@ -598,8 +505,8 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         )
 
         self.assertEqual(plan.enabled_layers, ())
+        self.assertEqual(len(plan.layers), 1)
         self.assertIn("activity track target is not a line layer", plan.layers[0].blocked_reason)
-        self.assertIn("saved route target is not a line layer", plan.layers[1].blocked_reason)
 
     def test_plan_uses_wkb_type_fallback_without_confusing_point_and_line_codes(self):
         point_wkb_layer = _WkbLayer(
@@ -619,7 +526,7 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
 
         self.assertEqual(
             tuple(layer.key for layer in plan.enabled_layers),
-            ("activity_tracks", "saved_route_tracks"),
+            ("activity_tracks",),
         )
 
         rejected_plan = build_slope_grade_analysis_plan(
@@ -644,7 +551,7 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertEqual(plan.enabled_layers, ())
         status = build_slope_grade_status(plan)
         self.assertIn("activity tracks need point samples", status)
-        self.assertIn("saved routes need profile or route point samples", status)
+        self.assertNotIn("saved routes", status)
 
     def test_run_slope_grade_analysis_returns_status_without_creating_overlay_layer(self):
         result = run_slope_grade_analysis(

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -318,6 +318,18 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
     def test_analysis_result_classifies_segments_for_eligible_activity_line_targets(self):
         result = build_slope_grade_analysis_result(
             activities_layer=_Layer(fields=("name",)),
+            route_tracks_layer=_Layer(fields=("name",)),
+            route_profile_samples_layer=_FeatureLayer(
+                (
+                    _FeatureSample(
+                        {"sample_group_index": 1, "distance_m": 0, "altitude_m": 100}
+                    ),
+                    _FeatureSample(
+                        {"sample_group_index": 1, "distance_m": 100, "altitude_m": 91}
+                    ),
+                ),
+                fields=("distance_m", "altitude_m"),
+            ),
             points_layer=_FeatureLayer(
                 (
                     _FeatureSample(
@@ -460,6 +472,8 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         plan = build_slope_grade_analysis_plan(
             activities_layer=activity_tracks,
             points_layer=activity_points,
+            route_tracks_layer=_Layer(fields=("name", "has_elevation")),
+            route_profile_samples_layer=_Layer(fields=("distance_m", "altitude_m")),
         )
 
         self.assertEqual(

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -339,18 +339,6 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
                 ),
                 fields=("stream_distance_m", "grade_smooth_pct"),
             ),
-            route_tracks_layer=_Layer(fields=("name",)),
-            route_profile_samples_layer=_FeatureLayer(
-                (
-                    _FeatureSample(
-                        {"sample_group_index": 1, "distance_m": 0, "altitude_m": 100}
-                    ),
-                    _FeatureSample(
-                        {"sample_group_index": 1, "distance_m": 100, "altitude_m": 91}
-                    ),
-                ),
-                fields=("distance_m", "altitude_m"),
-            ),
         )
 
         self.assertEqual(result.segment_count, 1)
@@ -469,14 +457,9 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         activity_points = _Layer(
             fields=("grade_smooth_pct", "stream_distance_m", "altitude_m")
         )
-        route_tracks = _Layer(fields=("name", "has_elevation"))
-        route_samples = _Layer(fields=("distance_m", "altitude_m"))
-
         plan = build_slope_grade_analysis_plan(
             activities_layer=activity_tracks,
             points_layer=activity_points,
-            route_tracks_layer=route_tracks,
-            route_profile_samples_layer=route_samples,
         )
 
         self.assertEqual(
@@ -495,13 +478,9 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
 
     def test_plan_rejects_non_line_targets_without_touching_other_layers(self):
         polygon_layer = _Layer(geometry="Polygon", fields=("grade_smooth_pct",))
-        route_samples = _Layer(fields=("distance_m", "altitude_m"))
-
         plan = build_slope_grade_analysis_plan(
             activities_layer=polygon_layer,
             points_layer=polygon_layer,
-            route_tracks_layer=polygon_layer,
-            route_profile_samples_layer=route_samples,
         )
 
         self.assertEqual(plan.enabled_layers, ())
@@ -514,14 +493,9 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
             fields=("grade_smooth_pct", "stream_distance_m"),
         )
         line_wkb_layer = _WkbLayer(wkb_type=2, fields=("name",))
-        multi_line_wkb_layer = _WkbLayer(wkb_type=5, fields=("name",))
-        route_samples = _Layer(fields=("distance_m", "altitude_m"))
-
         plan = build_slope_grade_analysis_plan(
             activities_layer=line_wkb_layer,
             points_layer=point_wkb_layer,
-            route_tracks_layer=multi_line_wkb_layer,
-            route_profile_samples_layer=route_samples,
         )
 
         self.assertEqual(
@@ -540,18 +514,47 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
             rejected_plan.layers[0].blocked_reason,
         )
 
-    def test_plan_reports_missing_elevation_distance_sources_gracefully(self):
+    def test_plan_reports_missing_activity_grade_sources_gracefully(self):
         plan = build_slope_grade_analysis_plan(
             activities_layer=_Layer(fields=("name",)),
             points_layer=_Layer(fields=("stream_distance_m",)),
-            route_tracks_layer=_Layer(fields=("name",)),
-            route_points_layer=_Layer(fields=("distance_m",)),
         )
 
         self.assertEqual(plan.enabled_layers, ())
         status = build_slope_grade_status(plan)
         self.assertIn("activity tracks need point samples", status)
         self.assertNotIn("saved routes", status)
+
+    def test_run_slope_grade_analysis_ignores_saved_route_layers(self):
+        result = run_slope_grade_analysis(
+            RunAnalysisRequest(
+                analysis_mode=SLOPE_GRADE_MODE,
+                route_tracks_layer=_Layer(fields=("name",)),
+                route_profile_samples_layer=_FeatureLayer(
+                    (
+                        _FeatureSample(
+                            {
+                                "sample_group_index": 1,
+                                "distance_m": 0,
+                                "altitude_m": 100,
+                            }
+                        ),
+                        _FeatureSample(
+                            {
+                                "sample_group_index": 1,
+                                "distance_m": 100,
+                                "altitude_m": 91,
+                            }
+                        ),
+                    ),
+                    fields=("distance_m", "altitude_m"),
+                ),
+            )
+        )
+
+        self.assertIsNone(result.layer)
+        self.assertIn("activity track lines are not loaded", result.status)
+        self.assertNotIn("saved route", result.status)
 
     def test_run_slope_grade_analysis_returns_status_without_creating_overlay_layer(self):
         result = run_slope_grade_analysis(

--- a/tests/test_slope_grade_analysis.py
+++ b/tests/test_slope_grade_analysis.py
@@ -539,6 +539,13 @@ class SlopeGradeAnalysisTests(unittest.TestCase):
         self.assertIn("activity tracks need point samples", status)
         self.assertNotIn("saved routes", status)
 
+    def test_plan_rejects_unexpected_layer_kwargs(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "Unexpected slope-grade layer kwargs: future_layer",
+        ):
+            build_slope_grade_analysis_plan(future_layer=object())
+
     def test_run_slope_grade_analysis_ignores_saved_route_layers(self):
         result = run_slope_grade_analysis(
             RunAnalysisRequest(

--- a/tests/test_slope_grade_layer.py
+++ b/tests/test_slope_grade_layer.py
@@ -132,7 +132,7 @@ class SlopeGradeLayerTests(unittest.TestCase):
         self.assertAlmostEqual(layer.opacity, 0.95)
         self.assertEqual(layer.repaint_count, 1)
 
-    def test_builds_memory_layer_from_route_profile_lat_lon_segments(self):
+    def test_ignores_saved_route_profile_samples(self):
         module = _load_slope_grade_layer_with_qgis_stub()
         profile_layer = _FeatureLayer(
             (
@@ -167,13 +167,8 @@ class SlopeGradeLayerTests(unittest.TestCase):
             route_profile_samples_layer=profile_layer,
         )
 
-        self.assertEqual(len(segments), 1)
-        self.assertEqual(layer.features[0].attrs["layer_key"], "saved_route_tracks")
-        self.assertEqual(layer.features[0].attrs["grade_class"], "steep_descent")
-        self.assertEqual(
-            layer.features[0].geometry,
-            ((6.6, 46.5), (6.7, 46.6)),
-        )
+        self.assertIsNone(layer)
+        self.assertEqual(segments, ())
 
     def test_returns_empty_result_when_no_line_segments_are_available(self):
         module = _load_slope_grade_layer_with_qgis_stub()

--- a/tests/test_slope_grade_layer.py
+++ b/tests/test_slope_grade_layer.py
@@ -146,6 +146,20 @@ class SlopeGradeLayerTests(unittest.TestCase):
         self.assertIsNone(layer)
         self.assertEqual(segments, ())
 
+    def test_accepts_but_ignores_saved_route_layers(self):
+        module = _load_slope_grade_layer_with_qgis_stub()
+
+        layer, segments = module.build_slope_grade_layer(
+            route_tracks_layer=_TargetLayer(),
+            route_profile_samples_layer=_FeatureLayer(
+                (),
+                fields=("distance_m", "altitude_m"),
+            ),
+        )
+
+        self.assertIsNone(layer)
+        self.assertEqual(segments, ())
+
     def test_does_not_build_overlay_when_activity_target_is_not_a_line_layer(self):
         module = _load_slope_grade_layer_with_qgis_stub()
         points_layer = _FeatureLayer(

--- a/tests/test_slope_grade_layer.py
+++ b/tests/test_slope_grade_layer.py
@@ -132,44 +132,6 @@ class SlopeGradeLayerTests(unittest.TestCase):
         self.assertAlmostEqual(layer.opacity, 0.95)
         self.assertEqual(layer.repaint_count, 1)
 
-    def test_ignores_saved_route_profile_samples(self):
-        module = _load_slope_grade_layer_with_qgis_stub()
-        profile_layer = _FeatureLayer(
-            (
-                _FeatureSample(
-                    {
-                        "sample_group_index": 1,
-                        "source": "strava",
-                        "source_route_id": "r-1",
-                        "lat": 46.5,
-                        "lon": 6.6,
-                        "distance_m": 0,
-                        "altitude_m": 100,
-                    }
-                ),
-                _FeatureSample(
-                    {
-                        "sample_group_index": 1,
-                        "source": "strava",
-                        "source_route_id": "r-1",
-                        "lat": 46.6,
-                        "lon": 6.7,
-                        "distance_m": 100,
-                        "altitude_m": 91,
-                    }
-                ),
-            ),
-            fields=("distance_m", "altitude_m"),
-        )
-
-        layer, segments = module.build_slope_grade_layer(
-            route_tracks_layer=_TargetLayer(),
-            route_profile_samples_layer=profile_layer,
-        )
-
-        self.assertIsNone(layer)
-        self.assertEqual(segments, ())
-
     def test_returns_empty_result_when_no_line_segments_are_available(self):
         module = _load_slope_grade_layer_with_qgis_stub()
 


### PR DESCRIPTION
## Summary

- make slope-grade eligibility activity-only and ignore saved route layers/profile samples
- remove saved-route slope-grade segment/overlay builders from the analysis path
- update slope-grade tests to cover route exclusion and activity-only status/overlay behavior

Fixes #934.

## Tests

- `python3 -m pytest tests/test_slope_grade_analysis.py tests/test_slope_grade_layer.py tests/test_analysis_execution_dispatch.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
