### PR TITLE
Populate heatmap analysis attributes

### DIFF
--- a/analysis/infrastructure/activity_heatmap_layer.py
+++ b/analysis/infrastructure/activity_heatmap_layer.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from qgis.core import QgsFeature, QgsGeometry, QgsPointXY, QgsVectorLayer
+from itertools import count
+
+from qgis.PyQt.QtCore import QVariant
+from qgis.core import QgsFeature, QgsField, QgsGeometry, QgsPointXY, QgsVectorLayer
 
 from ...visualization.infrastructure.layer_style_service import (
     build_qfit_visualize_heatmap_renderer,
@@ -22,7 +25,7 @@ def build_activity_heatmap_layer(activities_layer=None, points_layer=None):
         return None, 0
 
     heatmap_layer = _build_memory_heatmap_layer(source_layer)
-    features = _collect_heatmap_features(points_layer, activities_layer)
+    features = _collect_heatmap_features(heatmap_layer, points_layer, activities_layer)
 
     if not features:
         return None, 0
@@ -42,45 +45,106 @@ def _build_memory_heatmap_layer(source_layer):
         if layer_crs is not None and layer_crs.isValid()
         else "EPSG:3857"
     )
-    return QgsVectorLayer(
+    layer = QgsVectorLayer(
         f"Point?crs={authid}",
         ACTIVITY_HEATMAP_LAYER_NAME,
         "memory",
     )
+    layer.dataProvider().addAttributes(
+        [
+            QgsField("sample_index", QVariant.Int),
+            QgsField("source_layer", QVariant.String),
+            QgsField("source_feature_id", QVariant.Int),
+            QgsField("source_activity_id", QVariant.String),
+            QgsField("point_index", QVariant.Int),
+        ]
+    )
+    layer.updateFields()
+    return layer
 
 
-def _collect_heatmap_features(points_layer, activities_layer):
+def _collect_heatmap_features(heatmap_layer, points_layer, activities_layer):
     if _has_features(points_layer):
-        return list(_point_features_from_points_layer(points_layer))
+        return list(_point_features_from_points_layer(heatmap_layer, points_layer))
     if _has_features(activities_layer):
-        return list(_point_features_from_activity_layer(activities_layer))
+        return list(_point_features_from_activity_layer(heatmap_layer, activities_layer))
     return []
 
 
-def _point_features_from_points_layer(points_layer):
-    for source_feature in points_layer.getFeatures():
+def _point_features_from_points_layer(heatmap_layer, points_layer):
+    for sample_index, source_feature in enumerate(points_layer.getFeatures(), start=1):
         geometry = source_feature.geometry()
         if geometry is None or geometry.isEmpty():
             continue
         point = geometry.asPoint()
         if point.isEmpty():
             continue
-        yield _build_point_feature(point.x(), point.y())
+        yield _build_point_feature(
+            heatmap_layer,
+            x=point.x(),
+            y=point.y(),
+            sample_index=sample_index,
+            source_layer="activity_points",
+            source_feature=source_feature,
+            source_activity_id=_field_value(source_feature, "source_activity_id"),
+            point_index=_field_value(source_feature, "point_index"),
+        )
 
 
-def _point_features_from_activity_layer(activities_layer):
+def _point_features_from_activity_layer(heatmap_layer, activities_layer):
+    sample_indexes = count(1)
     for source_feature in activities_layer.getFeatures():
         geometry = source_feature.geometry()
         if geometry is None or geometry.isEmpty():
             continue
-        for vertex in geometry.vertices():
-            yield _build_point_feature(vertex.x(), vertex.y())
+        for point_index, vertex in enumerate(geometry.vertices(), start=1):
+            yield _build_point_feature(
+                heatmap_layer,
+                x=vertex.x(),
+                y=vertex.y(),
+                sample_index=next(sample_indexes),
+                source_layer="activity_tracks",
+                source_feature=source_feature,
+                source_activity_id=_field_value(source_feature, "source_activity_id"),
+                point_index=point_index,
+            )
 
 
-def _build_point_feature(x, y):
-    feature = QgsFeature()
+def _build_point_feature(
+    target_layer,
+    *,
+    x,
+    y,
+    sample_index,
+    source_layer,
+    source_feature,
+    source_activity_id,
+    point_index,
+):
+    feature = QgsFeature(target_layer.fields())
     feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(x, y)))
+    feature["sample_index"] = sample_index
+    feature["source_layer"] = source_layer
+    feature["source_feature_id"] = _feature_id(source_feature)
+    feature["source_activity_id"] = source_activity_id
+    feature["point_index"] = point_index
     return feature
+
+
+def _field_value(feature, field_name):
+    fields = getattr(feature, "fields", lambda: None)()
+    field_names = fields.names() if fields is not None and hasattr(fields, "names") else []
+    if field_name not in field_names:
+        return None
+    try:
+        return feature[field_name]
+    except (KeyError, RuntimeError):
+        return None
+
+
+def _feature_id(feature):
+    feature_id = getattr(feature, "id", None)
+    return feature_id() if callable(feature_id) else None
 
 
 def _has_features(layer):

--- a/analysis/infrastructure/activity_heatmap_layer.py
+++ b/analysis/infrastructure/activity_heatmap_layer.py
@@ -72,7 +72,8 @@ def _collect_heatmap_features(heatmap_layer, points_layer, activities_layer):
 
 
 def _point_features_from_points_layer(heatmap_layer, points_layer):
-    for sample_index, source_feature in enumerate(points_layer.getFeatures(), start=1):
+    sample_indexes = count(1)
+    for source_feature in points_layer.getFeatures():
         geometry = source_feature.geometry()
         if geometry is None or geometry.isEmpty():
             continue
@@ -83,7 +84,7 @@ def _point_features_from_points_layer(heatmap_layer, points_layer):
             heatmap_layer,
             x=point.x(),
             y=point.y(),
-            sample_index=sample_index,
+            sample_index=next(sample_indexes),
             source_layer="activity_points",
             source_feature=source_feature,
             source_activity_id=_field_value(source_feature, "source_activity_id"),

--- a/tests/test_activity_heatmap_layer_pure.py
+++ b/tests/test_activity_heatmap_layer_pure.py
@@ -46,6 +46,10 @@ class _FakeGeometry:
 class _FakeFeature:
     _next_id = 1
 
+    @classmethod
+    def _reset_id(cls):
+        cls._next_id = 1
+
     def __init__(self, fields=None, geometry=None, attrs=None):
         if isinstance(fields, _FakeGeometry):
             geometry = fields
@@ -177,6 +181,7 @@ class _FakeSourceLayer:
 
 class ActivityHeatmapLayerPureTests(unittest.TestCase):
     def setUp(self):
+        _FakeFeature._reset_id()
         qgis_mod = types.ModuleType("qgis")
         qgis_pyqt = types.ModuleType("qgis.PyQt")
         qgis_qtcore = types.ModuleType("qgis.PyQt.QtCore")
@@ -353,6 +358,26 @@ class ActivityHeatmapLayerPureTests(unittest.TestCase):
 
         self.assertIsNone(layer)
         self.assertEqual(count, 0)
+
+    def test_points_layer_sample_indexes_skip_empty_geometries_without_gaps(self):
+        points_layer = _FakeSourceLayer(
+            features=[
+                _FakeFeature(_FakeGeometry(point=_FakePoint(6.62, 46.52))),
+                _FakeFeature(_FakeGeometry(empty=True)),
+                _FakeFeature(_FakeGeometry(point=_FakePoint(6.63, 46.53))),
+            ]
+        )
+
+        layer, count = self.module.build_activity_heatmap_layer(
+            activities_layer=None,
+            points_layer=points_layer,
+        )
+
+        self.assertEqual(count, 2)
+        self.assertEqual(
+            [feature["sample_index"] for feature in layer.dataProvider().added],
+            [1, 2],
+        )
 
     def test_defaults_output_crs_when_source_crs_is_invalid(self):
         activities_layer = _FakeSourceLayer(

--- a/tests/test_activity_heatmap_layer_pure.py
+++ b/tests/test_activity_heatmap_layer_pure.py
@@ -44,8 +44,17 @@ class _FakeGeometry:
 
 
 class _FakeFeature:
-    def __init__(self, geometry=None):
+    _next_id = 1
+
+    def __init__(self, fields=None, geometry=None, attrs=None):
+        if isinstance(fields, _FakeGeometry):
+            geometry = fields
+            fields = None
         self._geometry = geometry
+        self._fields = fields or _FakeFields()
+        self._attrs = dict(attrs or {})
+        self._id = _FakeFeature._next_id
+        _FakeFeature._next_id += 1
 
     def geometry(self):
         return self._geometry
@@ -53,10 +62,43 @@ class _FakeFeature:
     def setGeometry(self, geometry):
         self._geometry = geometry
 
+    def fields(self):
+        return self._fields
+
+    def id(self):
+        return self._id
+
+    def __getitem__(self, key):
+        return self._attrs[key]
+
+    def __setitem__(self, key, value):
+        self._attrs[key] = value
+
+
+class _FakeFields:
+    def __init__(self, names=None):
+        self._names = list(names or [])
+
+    def names(self):
+        return list(self._names)
+
+
+class _FakeField:
+    def __init__(self, name, _variant_type):
+        self._name = name
+
+    def name(self):
+        return self._name
+
 
 class _FakeProvider:
-    def __init__(self):
+    def __init__(self, layer=None):
+        self._layer = layer
         self.added = []
+
+    def addAttributes(self, fields):
+        if self._layer is not None:
+            self._layer.field_names.extend(field.name() for field in fields)
 
     def addFeatures(self, features):
         self.added.extend(features)
@@ -79,7 +121,8 @@ class _FakeMemoryLayer:
         self.spec = spec
         self._name = name
         self.provider_key = provider_key
-        self._provider = _FakeProvider()
+        self.field_names = []
+        self._provider = _FakeProvider(self)
         self.renderer = None
         self.opacity = None
         self.repainted = False
@@ -90,6 +133,12 @@ class _FakeMemoryLayer:
 
     def updateExtents(self):
         self.extents_updated = True
+
+    def updateFields(self):
+        pass
+
+    def fields(self):
+        return _FakeFields(self.field_names)
 
     def setRenderer(self, renderer):
         self.renderer = renderer
@@ -129,8 +178,12 @@ class _FakeSourceLayer:
 class ActivityHeatmapLayerPureTests(unittest.TestCase):
     def setUp(self):
         qgis_mod = types.ModuleType("qgis")
+        qgis_pyqt = types.ModuleType("qgis.PyQt")
+        qgis_qtcore = types.ModuleType("qgis.PyQt.QtCore")
+        qgis_qtcore.QVariant = types.SimpleNamespace(Int=1, String=2)
         qgis_core = types.ModuleType("qgis.core")
         qgis_core.QgsFeature = _FakeFeature
+        qgis_core.QgsField = _FakeField
         qgis_core.QgsGeometry = _FakeGeometry
         qgis_core.QgsPointXY = _FakePoint
         qgis_core.QgsVectorLayer = _FakeMemoryLayer
@@ -144,6 +197,8 @@ class ActivityHeatmapLayerPureTests(unittest.TestCase):
 
         self._modules = {
             "qgis": qgis_mod,
+            "qgis.PyQt": qgis_pyqt,
+            "qgis.PyQt.QtCore": qgis_qtcore,
             "qgis.core": qgis_core,
             "qfit.visualization.infrastructure.layer_style_service": layer_style_service,
         }
@@ -160,6 +215,15 @@ class ActivityHeatmapLayerPureTests(unittest.TestCase):
 
     def test_returns_none_without_valid_source_layers(self):
         layer, count = self.module.build_activity_heatmap_layer(None, None)
+
+        self.assertIsNone(layer)
+        self.assertEqual(count, 0)
+
+    def test_returns_none_when_current_filters_match_no_features(self):
+        layer, count = self.module.build_activity_heatmap_layer(
+            activities_layer=_FakeSourceLayer(features=[]),
+            points_layer=_FakeSourceLayer(features=[]),
+        )
 
         self.assertIsNone(layer)
         self.assertEqual(count, 0)
@@ -189,9 +253,66 @@ class ActivityHeatmapLayerPureTests(unittest.TestCase):
         self.assertEqual(layer.spec, "Point?crs=EPSG:4326")
         self.assertEqual(count, 2)
         self.assertEqual(layer.featureCount(), 2)
+        self.assertEqual(
+            layer.field_names,
+            [
+                "sample_index",
+                "source_layer",
+                "source_feature_id",
+                "source_activity_id",
+                "point_index",
+            ],
+        )
         self.assertIs(layer.renderer, sentinel.heatmap_renderer)
         self.assertEqual(layer.opacity, 1.0)
         self.assertTrue(layer.repainted)
+
+    def test_populates_attribute_rows_from_points_layer(self):
+        fields = _FakeFields(["source_activity_id", "point_index"])
+        points_layer = _FakeSourceLayer(
+            features=[
+                _FakeFeature(
+                    fields=fields,
+                    geometry=_FakeGeometry(point=_FakePoint(6.62, 46.52)),
+                    attrs={"source_activity_id": "ride-1", "point_index": 7},
+                ),
+            ]
+        )
+
+        layer, count = self.module.build_activity_heatmap_layer(
+            activities_layer=None,
+            points_layer=points_layer,
+        )
+
+        self.assertEqual(count, 1)
+        [feature] = layer.dataProvider().added
+        self.assertEqual(feature["sample_index"], 1)
+        self.assertEqual(feature["source_layer"], "activity_points")
+        self.assertEqual(feature["source_activity_id"], "ride-1")
+        self.assertEqual(feature["point_index"], 7)
+
+    def test_populates_attribute_rows_from_activity_line_fallback(self):
+        fields = _FakeFields(["source_activity_id"])
+        activities_layer = _FakeSourceLayer(
+            features=[
+                _FakeFeature(
+                    fields=fields,
+                    geometry=_FakeGeometry(vertices=[_FakePoint(6.60, 46.50)]),
+                    attrs={"source_activity_id": "ride-2"},
+                )
+            ]
+        )
+
+        layer, count = self.module.build_activity_heatmap_layer(
+            activities_layer=activities_layer,
+            points_layer=None,
+        )
+
+        self.assertEqual(count, 1)
+        [feature] = layer.dataProvider().added
+        self.assertEqual(feature["source_layer"], "activity_tracks")
+        self.assertEqual(feature["source_activity_id"], "ride-2")
+        self.assertEqual(feature["point_index"], 1)
 
     def test_falls_back_to_activity_vertices_when_points_layer_missing(self):
         activities_layer = _FakeSourceLayer(

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -1488,6 +1488,8 @@ class QgisSmokeTests(unittest.TestCase):
                 self.assertIn("activity heatmap", status)
                 self.assertIsNotNone(dock.analysis_layer)
                 self.assertEqual(dock.analysis_layer.name(), "qfit activity heatmap")
+                self.assertGreater(dock.analysis_layer.featureCount(), 0)
+                self.assertIn("source_activity_id", dock.analysis_layer.fields().names())
                 image = self._render_layers_to_image(
                     [dock.analysis_layer],
                     dock.activities_layer.extent(),
@@ -1519,6 +1521,8 @@ class QgisSmokeTests(unittest.TestCase):
 
                 self.assertIn("activity heatmap", status)
                 self.assertIsNotNone(dock.analysis_layer)
+                self.assertGreater(dock.analysis_layer.featureCount(), 0)
+                self.assertIn("source_activity_id", dock.analysis_layer.fields().names())
                 image = self._render_layers_to_image(
                     [dock.analysis_layer],
                     dock.activities_layer.extent(),


### PR DESCRIPTION
## Summary

- Add attribute fields to the generated heatmap analysis memory layer so its table has inspectable rows.
- Populate heatmap feature metadata from sampled activity points, with the activity-line fallback preserving source activity IDs.
- Keep the empty-filter case returning the existing clear “No activity heatmap data matched the current filters” result.

Fixes #937.

## Tests

- `python3 -m pytest tests/test_activity_heatmap_layer_pure.py tests/test_activity_heatmap_analysis.py tests/test_analysis_result_builder.py tests/test_analysis_execution_dispatch.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
