### PR TITLE
Record activity point stream availability

### DIFF
--- a/activities/infrastructure/geopackage/gpkg_point_layer_builder.py
+++ b/activities/infrastructure/geopackage/gpkg_point_layer_builder.py
@@ -43,6 +43,7 @@ def build_point_layer(records, write_activity_points=False, point_stride=1):
             continue
 
         stream_metrics = _stream_metrics(record, geometry_source)
+        stream_status = _stream_status(geometry_source, stream_metrics)
         sampled_points = _sample_points(source_points, stride)
         total_points = max(1, len(source_points) - 1)
         for point_index, lat, lon in sampled_points:
@@ -71,6 +72,7 @@ def build_point_layer(records, write_activity_points=False, point_stride=1):
             feature["start_date"] = record.get("start_date")
             feature["distance_m"] = record.get("distance_m")
             feature["geometry_source"] = geometry_source
+            feature["stream_status"] = stream_status
             feature["last_synced_at"] = record.get("last_synced_at")
             features.append(feature)
 
@@ -132,7 +134,24 @@ def _normalized_points(points):
 def _stream_metrics(record, geometry_source):
     if geometry_source != "stream":
         return {}
-    return ((record.get("details_json") or {}).get("stream_metrics") or {})
+    details_json = record.get("details_json") or {}
+    if not isinstance(details_json, dict):
+        return {}
+    return details_json.get("stream_metrics") or {}
+
+
+def _stream_status(geometry_source, stream_metrics):
+    if geometry_source == "stream":
+        return "stream_metrics" if _has_stream_metric_values(stream_metrics) else "stream_missing_metrics"
+    if geometry_source:
+        return f"{geometry_source}_no_stream_metrics"
+    return "no_geometry"
+
+
+def _has_stream_metric_values(stream_metrics):
+    if not isinstance(stream_metrics, dict):
+        return False
+    return any(isinstance(values, list) and bool(values) for values in stream_metrics.values())
 
 
 def _metric_value(stream_metrics, key, index, as_int=False):

--- a/activities/infrastructure/geopackage/gpkg_schema.py
+++ b/activities/infrastructure/geopackage/gpkg_schema.py
@@ -92,6 +92,7 @@ POINT_FIELDS = [
     ("start_date", QVariant.String),
     ("distance_m", QVariant.Double),
     ("geometry_source", QVariant.String),
+    ("stream_status", QVariant.String),
     ("last_synced_at", QVariant.String),
 ]
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -235,7 +235,8 @@ Primary purpose:
 | `activity_type` | TEXT | run, ride, etc. |
 | `start_date` | TEXT | ISO 8601 UTC |
 | `distance_m` | REAL | copied for filtering / styling |
-| `geometry_source` | TEXT | usually `stream` |
+| `geometry_source` | TEXT | point geometry source: `stream`, `summary_polyline`, or `start_end` |
+| `stream_status` | TEXT | whether detailed stream metrics are present (`stream_metrics`) or why sampled points only expose geometry, such as `summary_polyline_no_stream_metrics`, `start_end_no_stream_metrics`, or `stream_missing_metrics` |
 | `last_synced_at` | TEXT | last registry sync time |
 
 ## Layer: `activity_atlas_pages`

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -236,7 +236,7 @@ Primary purpose:
 | `start_date` | TEXT | ISO 8601 UTC |
 | `distance_m` | REAL | copied for filtering / styling |
 | `geometry_source` | TEXT | point geometry source: `stream`, `summary_polyline`, or `start_end` |
-| `stream_status` | TEXT | whether detailed stream metrics are present (`stream_metrics`) or why sampled points only expose geometry, such as `summary_polyline_no_stream_metrics`, `start_end_no_stream_metrics`, or `stream_missing_metrics` |
+| `stream_status` | TEXT | whether detailed stream metrics are present (`stream_metrics`) or why sampled points only expose geometry, such as `summary_polyline_no_stream_metrics`, `start_end_no_stream_metrics`, `stream_missing_metrics`, or `no_geometry` |
 | `last_synced_at` | TEXT | last registry sync time |
 
 ## Layer: `activity_atlas_pages`

--- a/tests/test_gpkg_point_layer_builder.py
+++ b/tests/test_gpkg_point_layer_builder.py
@@ -23,19 +23,24 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover
 if QgsApplication is not None and _REAL_QGIS_PRESENT:
     from qfit.activities.infrastructure.geopackage.gpkg_point_layer_builder import (
         _activity_point_sequence,
+        _has_stream_metric_values,
         _metric_value,
         _normalized_points,
         _sample_points,
         _stream_metrics,
+        _stream_status,
         build_point_layer,
     )
 else:  # pragma: no cover
     _activity_point_sequence = None
+    _has_stream_metric_values = None
     _metric_value = None
     _normalized_points = None
     _sample_points = None
     _stream_metrics = None
+    _stream_status = None
     build_point_layer = None
+
 
 def _ensure_qgis_app():
     if not _REAL_QGIS_PRESENT:
@@ -43,10 +48,12 @@ def _ensure_qgis_app():
 
     global QgsApplication
     global _activity_point_sequence
+    global _has_stream_metric_values
     global _metric_value
     global _normalized_points
     global _sample_points
     global _stream_metrics
+    global _stream_status
     global build_point_layer
     if QgsApplication is None and _REAL_QGIS_PRESENT:
         for module_name in [
@@ -68,18 +75,22 @@ def _ensure_qgis_app():
         )
         from qfit.activities.infrastructure.geopackage.gpkg_point_layer_builder import (
             _activity_point_sequence as real_activity_point_sequence,
+            _has_stream_metric_values as real_has_stream_metric_values,
             _metric_value as real_metric_value,
             _normalized_points as real_normalized_points,
             _sample_points as real_sample_points,
             _stream_metrics as real_stream_metrics,
+            _stream_status as real_stream_status,
             build_point_layer as real_build_point_layer,
         )
 
         _activity_point_sequence = real_activity_point_sequence
+        _has_stream_metric_values = real_has_stream_metric_values
         _metric_value = real_metric_value
         _normalized_points = real_normalized_points
         _sample_points = real_sample_points
         _stream_metrics = real_stream_metrics
+        _stream_status = real_stream_status
         build_point_layer = real_build_point_layer
     return get_shared_qgis_app(QgsApplication)
 
@@ -144,6 +155,26 @@ class PointSequenceHelperTests(unittest.TestCase):
 
         self.assertEqual(_stream_metrics(record, "stream"), {"time": [0, 1]})
         self.assertEqual(_stream_metrics(record, "summary_polyline"), {})
+
+    def test_stream_metrics_ignore_non_dict_details_json(self):
+        record = {"details_json": '{"stream_metrics": {"time": [0, 1]}}'}
+
+        self.assertEqual(_stream_metrics(record, "stream"), {})
+
+    def test_has_stream_metric_values_requires_non_empty_metric_lists(self):
+        self.assertTrue(_has_stream_metric_values({"time": [0]}))
+        self.assertFalse(_has_stream_metric_values({"time": []}))
+        self.assertFalse(_has_stream_metric_values({"time": None}))
+        self.assertFalse(_has_stream_metric_values(None))
+
+    def test_stream_status_records_unavailable_summary_geometry(self):
+        self.assertEqual(
+            _stream_status("summary_polyline", {}),
+            "summary_polyline_no_stream_metrics",
+        )
+        self.assertEqual(_stream_status("start_end", {}), "start_end_no_stream_metrics")
+        self.assertEqual(_stream_status("stream", {"time": [0]}), "stream_metrics")
+        self.assertEqual(_stream_status("stream", {}), "stream_missing_metrics")
 
     def test_activity_point_sequence_returns_empty_when_no_geometry_is_available(self):
         points, geometry_source = _activity_point_sequence(
@@ -243,9 +274,75 @@ class BuildPointLayerTests(unittest.TestCase):
         self.assertEqual(features[0]["activity_fk"], 1)
         self.assertEqual(features[0]["point_index"], 0)
         self.assertEqual(features[0]["altitude_m"], 400.0)
+        self.assertEqual(features[0]["stream_status"], "stream_metrics")
         self.assertEqual(features[-1]["point_index"], 2)
         self.assertEqual(features[-1]["altitude_m"], 410.0)
         self.assertEqual(features[-1]["point_ratio"], 1.0)
+
+    def test_summary_polyline_points_record_missing_stream_status(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "18449273890",
+                "name": "Morning Ride",
+                "activity_type": "Ride",
+                "summary_polyline": "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+                "details_json": {
+                    "average_cadence": 71.8,
+                    "weighted_average_watts": 140,
+                },
+            }
+        ]
+
+        layer = build_point_layer(records, write_activity_points=True, point_stride=1)
+
+        self.assertTrue(layer.isValid())
+        self.assertGreaterEqual(layer.featureCount(), 3)
+        features = list(layer.getFeatures())
+        self.assertEqual(features[0]["geometry_source"], "summary_polyline")
+        self.assertEqual(
+            features[0]["stream_status"],
+            "summary_polyline_no_stream_metrics",
+        )
+
+    def test_stream_metrics_populate_detailed_analysis_fields(self):
+        records = [
+            {
+                "source": "strava",
+                "source_activity_id": "18449273890",
+                "name": "Morning Ride",
+                "activity_type": "Ride",
+                "distance_m": 30240.0,
+                "geometry_points": [(46.50, 6.60), (46.51, 6.61)],
+                "details_json": {
+                    "average_cadence": 71.8,
+                    "weighted_average_watts": 140,
+                    "stream_metrics": {
+                        "time": [0, 60],
+                        "distance": [0.0, 250.0],
+                        "altitude": [520.0, 535.0],
+                        "heartrate": [130, 136],
+                        "cadence": [72, 75],
+                        "watts": [118, 180],
+                        "velocity_smooth": [5.2, 6.0],
+                        "grade_smooth": [1.5, 4.2],
+                    },
+                },
+            }
+        ]
+
+        layer = build_point_layer(records, write_activity_points=True, point_stride=1)
+
+        feature = list(layer.getFeatures())[1]
+        self.assertEqual(feature["stream_status"], "stream_metrics")
+        self.assertEqual(feature["stream_time_s"], 60)
+        self.assertEqual(feature["stream_distance_m"], 250.0)
+        self.assertEqual(feature["altitude_m"], 535.0)
+        self.assertEqual(feature["heartrate_bpm"], 136.0)
+        self.assertEqual(feature["cadence_rpm"], 75.0)
+        self.assertEqual(feature["watts"], 180.0)
+        self.assertEqual(feature["velocity_mps"], 6.0)
+        self.assertEqual(feature["grade_smooth_pct"], 4.2)
 
     def test_stride_reduces_feature_count(self):
         points = [(46.0 + i * 0.01, 6.0 + i * 0.01) for i in range(10)]

--- a/tests/test_gpkg_point_layer_builder.py
+++ b/tests/test_gpkg_point_layer_builder.py
@@ -279,7 +279,7 @@ class BuildPointLayerTests(unittest.TestCase):
         self.assertEqual(features[-1]["altitude_m"], 410.0)
         self.assertEqual(features[-1]["point_ratio"], 1.0)
 
-    def test_summary_polyline_points_record_missing_stream_status(self):
+    def test_summary_polyline_points_have_no_stream_metrics_status(self):
         records = [
             {
                 "source": "strava",


### PR DESCRIPTION
## Summary

- add a `stream_status` field to `activity_points` so sampled points distinguish real stream metrics from summary/fallback geometry
- record explicit statuses such as `summary_polyline_no_stream_metrics`, `start_end_no_stream_metrics`, and `stream_missing_metrics`
- cover the reported Morning Ride shape with regression tests for both unavailable streams and populated detailed stream fields

Closes #939.

## Validation

- `python3 -m pytest tests/test_gpkg_point_layer_builder.py tests/test_gpkg_write_orchestration.py tests/test_gpkg_io.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- verified the reported local activity record now builds `activity_points.stream_status = summary_polyline_no_stream_metrics` when only summary polyline geometry is available
