### PR TITLE
feat: add Mapbox Outdoors comparison harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The current visualization flow supports:
 
 See:
 - `docs/map-style-guide.md`
+- `docs/mapbox-outdoors-comparison-harness.md` for manual Mapbox Outdoors browser-vs-QGIS parity checks
 
 ### Publish and atlas support
 
@@ -109,6 +110,7 @@ For validation notes and rendering-sensitive workflow details, see:
 - `docs/strava-setup.md`
 - `docs/schema.md`
 - `docs/map-style-guide.md`
+- `docs/mapbox-outdoors-comparison-harness.md`
 - `docs/qgis-testing.md`
 
 ---
@@ -124,7 +126,8 @@ If you are changing internals, start here:
 - `docs/qgis-plugin-architecture-principles.md`
 - `docs/refactoring-roadmap.md`
 - `docs/qgis-testing.md`
-- `docs/atlas-validation-harness.md` for rendering/export-sensitive work
+- `docs/atlas-validation-harness.md` for atlas rendering/export-sensitive work
+- `docs/mapbox-outdoors-comparison-harness.md` for manual Mapbox Outdoors browser-vs-QGIS visual comparison work
 
 ### Current architecture snapshot
 

--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -17,7 +17,8 @@ A complete run writes:
 - `mapbox-gl-reference.png` — browser/Mapbox GL JS reference image
 - `qgis-vector-render.png` — qfit/QGIS native vector-tile render for the same camera
 - `mapbox-gl-vs-qgis-diff.png` — pixel diff for quick drift inspection
-- `manifest.json` — camera, output paths, and capture status without any token values
+- `metrics.json` — simple image-diff metrics such as changed-pixel ratio when diff generation runs
+- `manifest.json` — camera, output paths, capture status, and metrics without any token values
 
 ## Cameras
 
@@ -36,13 +37,14 @@ Current camera:
 For a complete browser + QGIS + diff run, install or run from an environment with:
 
 - a Mapbox access token in `MAPBOX_ACCESS_TOKEN` or `QFIT_MAPBOX_ACCESS_TOKEN`
-- Playwright and Chromium for the Mapbox GL JS screenshot
-  - `python3 -m pip install playwright`
-  - `python3 -m playwright install chromium`
+- Node.js, the Playwright npm package, and Chromium for the Mapbox GL JS screenshot
+  - from the qfit checkout or its parent dev workspace: `npm install --save-dev playwright`
+  - the harness searches `node_modules` in the qfit checkout and its parent workspace
+  - the harness uses system Chromium when available (`chromium`, `chromium-browser`, or `QFIT_CHROMIUM_EXECUTABLE`)
 - PyQGIS available to the Python runtime for the QGIS vector render
   - for example, run from a QGIS Python shell, OSGeo/QGIS environment, or another shell where `import qgis` works
 - Pillow for the diff image
-  - `python3 -m pip install pillow`
+  - already available in the qfit development environment; if missing, install it in a virtual environment rather than using system `sudo pip`
 - `QT_QPA_PLATFORM=offscreen` when running headlessly, if your QGIS environment requires it
 - `xvfb-run` or another virtual display when your local Chromium/QGIS build cannot render headlessly without an X server
 
@@ -51,11 +53,11 @@ Keep tokens out of shell history where practical by exporting an environment var
 ## Run a complete comparison
 
 ```bash
-export MAPBOX_ACCESS_TOKEN="pk..."
+export MAPBOX_ACCESS_TOKEN="***"
 python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors
 ```
 
-The command prints only artifact paths. It does not print the token, and `manifest.json` intentionally excludes token values.
+The command prints only artifact paths. It does not print the token, and `manifest.json` intentionally excludes token values. The QGIS capture builds a temporary vector-tile layer for rendering and does not clear the active QGIS project.
 
 ## Partial captures
 
@@ -81,7 +83,7 @@ Use the browser image as the Mapbox GL reference. Inspect the QGIS image for hig
 - label size/priority mismatches
 - broad color/width drift caused by expression simplification
 
-Use the diff image as a navigation aid, not as a pass/fail metric. Label placement and antialiasing differences will create expected diff noise.
+Use the brightness-enhanced diff image and metrics as navigation aids, not as pass/fail gates. Label placement and antialiasing differences will create expected diff noise.
 
 ## PR notes
 

--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -1,0 +1,96 @@
+# Mapbox Outdoors visual comparison harness
+
+qfit includes a dev-only harness for comparing Mapbox Outdoors rendered by Mapbox GL JS in a browser with qfit's native QGIS vector-tile rendering.
+
+The harness is a **manual visual QA aid**, not a CI gate. Pixel-perfect parity is not expected because Mapbox GL JS and QGIS differ in expression support, label placement, sprites, fonts, antialiasing, and zoom interpolation.
+
+## What it captures
+
+Run outputs are written under the ignored debug tree:
+
+```text
+debug/mapbox-outdoors-comparison/<camera>/<UTC timestamp>/
+```
+
+A complete run writes:
+
+- `mapbox-gl-reference.png` — browser/Mapbox GL JS reference image
+- `qgis-vector-render.png` — qfit/QGIS native vector-tile render for the same camera
+- `mapbox-gl-vs-qgis-diff.png` — pixel diff for quick drift inspection
+- `manifest.json` — camera, output paths, and capture status without any token values
+
+## Cameras
+
+List supported cameras:
+
+```bash
+python3 validation/mapbox_outdoors_comparison.py --list-cameras
+```
+
+Current camera:
+
+- `valais-geneva-outdoors` — representative Geneva/Valais corridor view using `mapbox/outdoors-v12`
+
+## Required local tools
+
+For a complete browser + QGIS + diff run, install or run from an environment with:
+
+- a Mapbox access token in `MAPBOX_ACCESS_TOKEN` or `QFIT_MAPBOX_ACCESS_TOKEN`
+- Playwright and Chromium for the Mapbox GL JS screenshot
+  - `python3 -m pip install playwright`
+  - `python3 -m playwright install chromium`
+- PyQGIS available to the Python runtime for the QGIS vector render
+  - for example, run from a QGIS Python shell, OSGeo/QGIS environment, or another shell where `import qgis` works
+- Pillow for the diff image
+  - `python3 -m pip install pillow`
+- `QT_QPA_PLATFORM=offscreen` when running headlessly, if your QGIS environment requires it
+- `xvfb-run` or another virtual display when your local Chromium/QGIS build cannot render headlessly without an X server
+
+Keep tokens out of shell history where practical by exporting an environment variable instead of passing `--mapbox-token` directly.
+
+## Run a complete comparison
+
+```bash
+export MAPBOX_ACCESS_TOKEN="pk..."
+python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors
+```
+
+The command prints only artifact paths. It does not print the token, and `manifest.json` intentionally excludes token values.
+
+## Partial captures
+
+When developing on a machine that only has one rendering stack available, run a partial capture:
+
+```bash
+# Browser reference only
+python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors --skip-qgis --skip-diff
+
+# QGIS vector render only
+python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors --skip-browser --skip-diff
+```
+
+Diff generation requires both the browser and QGIS images in the same run.
+
+## Interpreting output
+
+Use the browser image as the Mapbox GL reference. Inspect the QGIS image for high-signal gaps such as:
+
+- missing terrain/outdoor features
+- over- or under-emphasized roads/trails
+- noisy settlement or POI labels
+- label size/priority mismatches
+- broad color/width drift caused by expression simplification
+
+Use the diff image as a navigation aid, not as a pass/fail metric. Label placement and antialiasing differences will create expected diff noise.
+
+## PR notes
+
+For rendering-sensitive Mapbox vector-style changes, include a concise validation note such as:
+
+```markdown
+## Visual comparison
+- Harness: `python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors`
+- Artifacts: `debug/mapbox-outdoors-comparison/valais-geneva-outdoors/<timestamp>/`
+- Checked: browser reference, QGIS vector render, and diff image
+- Result: summarize visible improvements and any accepted QGIS/Mapbox GL limitations
+```

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -1,6 +1,8 @@
 import datetime as dt
 import json
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -13,12 +15,17 @@ from qfit.validation.mapbox_outdoors_comparison import (
     DEFAULT_OUTPUT_ROOT,
     MapboxComparisonCamera,
     build_comparison_paths,
+    build_image_diff,
     build_mapbox_gl_html,
+    build_node_playwright_capture_script,
     build_parser,
     build_run_directory,
     camera_center_web_mercator,
     camera_extent_web_mercator,
+    is_valid_qgis_vector_tile_layer,
     list_cameras,
+    redact_sensitive_text,
+    render_qgis_vector,
     resolve_mapbox_token,
     run_comparison,
 )
@@ -58,6 +65,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(paths.browser_png, Path("/tmp/run/mapbox-gl-reference.png"))
         self.assertEqual(paths.qgis_png, Path("/tmp/run/qgis-vector-render.png"))
         self.assertEqual(paths.diff_png, Path("/tmp/run/mapbox-gl-vs-qgis-diff.png"))
+        self.assertEqual(paths.metrics_json, Path("/tmp/run/metrics.json"))
         self.assertEqual(paths.manifest_json, Path("/tmp/run/manifest.json"))
 
     def test_resolve_token_prefers_argument_then_environment(self):
@@ -95,13 +103,196 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertGreater(xmax - xmin, 0)
         self.assertGreater(ymax - ymin, 0)
 
-    def test_build_mapbox_html_uses_camera_style_without_logging_token(self):
+    def test_build_mapbox_html_uses_camera_style_without_storing_token(self):
         camera = CAMERAS["valais-geneva-outdoors"]
-        html = build_mapbox_gl_html(camera=camera, token="pk.test-token")
+        html = build_mapbox_gl_html(camera=camera)
 
         self.assertIn("mapbox://styles/mapbox/outdoors-v12", html)
+        self.assertIn("startQfitMapboxComparison", html)
         self.assertIn("qfitMapboxReady", html)
-        self.assertIn("pk.test-token", html)
+        self.assertNotIn("test-mapbox-token", html)
+
+    def test_node_capture_script_uses_playwright_and_file_url_without_token(self):
+        script = build_node_playwright_capture_script()
+
+        self.assertIn("require('playwright')", script)
+        self.assertIn("pathToFileURL", script)
+        self.assertIn("startQfitMapboxComparison", script)
+        self.assertIn("window.qfitMapboxReady", script)
+        self.assertIn("readFileSync(0", script)
+        self.assertNotIn("MAPBOX_ACCESS_TOKEN", script)
+        self.assertNotIn("pk.", script)
+
+    def test_qgis_vector_tile_guard_rejects_raster_or_invalid_layers(self):
+        class FakeVectorTileLayer:
+            def __init__(self, valid=True):
+                self._valid = valid
+
+            def isValid(self):
+                return self._valid
+
+        class FakeRasterLayer:
+            def isValid(self):
+                return True
+
+        self.assertTrue(
+            is_valid_qgis_vector_tile_layer(
+                layer=FakeVectorTileLayer(),
+                vector_tile_layer_type=FakeVectorTileLayer,
+            )
+        )
+        self.assertFalse(
+            is_valid_qgis_vector_tile_layer(
+                layer=FakeVectorTileLayer(valid=False),
+                vector_tile_layer_type=FakeVectorTileLayer,
+            )
+        )
+        self.assertFalse(
+            is_valid_qgis_vector_tile_layer(
+                layer=FakeRasterLayer(),
+                vector_tile_layer_type=FakeVectorTileLayer,
+            )
+        )
+
+    def test_render_qgis_vector_uses_isolated_vector_layer_without_project_clear(self):
+        class FakeQgsApplication:
+            @staticmethod
+            def instance():
+                return None
+
+            def __init__(self, *_args):
+                pass
+
+            def initQgis(self):
+                pass
+
+            def exitQgis(self):
+                pass
+
+        class FakeQgsVectorTileLayer:
+            def __init__(self, uri, name):
+                self.uri = uri
+                self.name = name
+
+            def isValid(self):
+                return True
+
+        class FakeQgsMapSettings:
+            def setLayers(self, layers):
+                self.layers = layers
+
+            def setDestinationCrs(self, crs):
+                self.crs = crs
+
+            def setExtent(self, extent):
+                self.extent = extent
+
+            def setOutputSize(self, size):
+                self.size = size
+
+            def setBackgroundColor(self, color):
+                self.color = color
+
+        class FakeRenderedImage:
+            def isNull(self):
+                return False
+
+            def save(self, output_path, _format):
+                Path(output_path).write_bytes(PNG_PLACEHOLDER)
+                return True
+
+        class FakeQgsMapRendererParallelJob:
+            def __init__(self, settings):
+                self.settings = settings
+
+            def start(self):
+                pass
+
+            def waitForFinished(self):
+                pass
+
+            def renderedImage(self):
+                return FakeRenderedImage()
+
+        class FakeBackgroundMapService:
+            def _apply_mapbox_gl_style(self, layer, style_definition):
+                layer.applied_style = style_definition
+
+        fake_core = types.ModuleType("qgis.core")
+        fake_core.QgsApplication = FakeQgsApplication
+        fake_core.QgsCoordinateReferenceSystem = lambda value: value
+        fake_core.QgsMapRendererParallelJob = FakeQgsMapRendererParallelJob
+        fake_core.QgsMapSettings = FakeQgsMapSettings
+        fake_core.QgsRectangle = lambda *values: values
+        fake_core.QgsVectorTileLayer = FakeQgsVectorTileLayer
+
+        fake_qt_core = types.ModuleType("qgis.PyQt.QtCore")
+        fake_qt_core.QSize = lambda width, height: (width, height)
+        fake_qt_gui = types.ModuleType("qgis.PyQt.QtGui")
+        fake_qt_gui.QColor = lambda *values: values
+
+        fake_mapbox_config = types.ModuleType("qfit.mapbox_config")
+        fake_mapbox_config.fetch_mapbox_style_definition = lambda *_args: {"version": 8}
+        fake_mapbox_config.simplify_mapbox_style_expressions = lambda style: style
+        fake_mapbox_config.extract_mapbox_vector_source_ids = lambda _style: ["mapbox.mapbox-streets-v8"]
+        fake_mapbox_config.build_vector_tile_layer_uri = lambda *_args, **_kwargs: "vector://style"
+
+        fake_background_service = types.ModuleType("qfit.visualization.infrastructure.background_map_service")
+        fake_background_service.BackgroundMapService = FakeBackgroundMapService
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(
+            sys.modules,
+            {
+                "qgis": types.ModuleType("qgis"),
+                "qgis.core": fake_core,
+                "qgis.PyQt": types.ModuleType("qgis.PyQt"),
+                "qgis.PyQt.QtCore": fake_qt_core,
+                "qgis.PyQt.QtGui": fake_qt_gui,
+                "qfit.mapbox_config": fake_mapbox_config,
+                "qfit.visualization.infrastructure.background_map_service": fake_background_service,
+            },
+        ):
+            output_path = Path(tmpdir) / "qgis-vector.png"
+
+            render_qgis_vector(
+                camera=CAMERAS["valais-geneva-outdoors"],
+                token="test-mapbox-token",
+                output_path=output_path,
+            )
+
+            self.assertEqual(output_path.read_bytes(), PNG_PLACEHOLDER)
+
+    def test_build_image_diff_writes_enhanced_diff_and_metrics_for_same_size_images(self):
+        try:
+            from PIL import Image
+        except ImportError:  # pragma: no cover - local dependency guard
+            self.skipTest("Pillow is not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            reference_path = root / "reference.png"
+            candidate_path = root / "candidate.png"
+            diff_path = root / "diff.png"
+            Image.new("RGBA", (2, 1), (0, 0, 0, 255)).save(reference_path)
+            Image.new("RGBA", (2, 1), (0, 0, 0, 255)).save(candidate_path)
+            candidate = Image.open(candidate_path)
+            candidate.putpixel((1, 0), (1, 0, 0, 255))
+            candidate.save(candidate_path)
+            candidate.close()
+
+            metrics = build_image_diff(
+                reference_path=reference_path,
+                candidate_path=candidate_path,
+                output_path=diff_path,
+            )
+
+            self.assertTrue(diff_path.exists())
+            with Image.open(diff_path).convert("RGB") as diff_image:
+                self.assertEqual(diff_image.getpixel((1, 0)), (8, 0, 0))
+            self.assertEqual(metrics["pixel_count"], 2)
+            self.assertEqual(metrics["changed_pixel_count"], 1)
+            self.assertEqual(metrics["changed_pixel_ratio"], 0.5)
+            self.assertIn("ssim_status", metrics)
 
     def test_run_comparison_writes_manifest_without_token(self):
         def fake_browser_renderer(*, output_path, **_kwargs):
@@ -112,12 +303,13 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
         def fake_diff_builder(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
+            return {"changed_pixel_ratio": 0.25, "ssim_status": "unavailable"}
 
         with tempfile.TemporaryDirectory() as tmpdir:
             result = run_comparison(
                 ComparisonConfig(
                     camera=CAMERAS["valais-geneva-outdoors"],
-                    token="pk.secret-token",
+                    token="test-mapbox-token",
                     output_root=Path(tmpdir),
                     now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
                 ),
@@ -128,16 +320,19 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
             manifest_text = result.paths.manifest_json.read_text(encoding="utf-8")
             manifest = json.loads(manifest_text)
+            metrics = json.loads(result.paths.metrics_json.read_text(encoding="utf-8"))
 
         self.assertTrue(result.browser_captured)
         self.assertTrue(result.qgis_captured)
         self.assertTrue(result.diff_captured)
-        self.assertNotIn("pk.secret-token", manifest_text)
+        self.assertNotIn("test-mapbox-token", manifest_text)
         self.assertEqual(manifest["camera"]["name"], "valais-geneva-outdoors")
         self.assertEqual(manifest["style_url"], "mapbox://styles/mapbox/outdoors-v12")
         self.assertTrue(manifest["captured"]["browser_reference"])
         self.assertTrue(manifest["captured"]["qgis_vector_render"])
         self.assertTrue(manifest["captured"]["diff"])
+        self.assertEqual(manifest["metrics"]["changed_pixel_ratio"], 0.25)
+        self.assertEqual(metrics["changed_pixel_ratio"], 0.25)
 
     def test_run_comparison_skips_diff_when_one_capture_is_disabled(self):
         def fake_qgis_renderer(*, output_path, **_kwargs):
@@ -153,7 +348,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             result = run_comparison(
                 ComparisonConfig(
                     camera=CAMERAS["valais-geneva-outdoors"],
-                    token="pk.secret-token",
+                    token="test-mapbox-token",
                     output_root=Path(tmpdir),
                     browser=False,
                     qgis=True,
@@ -173,7 +368,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         args = parser.parse_args([
             "valais-geneva-outdoors",
             "--mapbox-token",
-            "pk.test",
+            "test-mapbox-token",
             "--output-root",
             "/tmp/qfit-mapbox",
             "--skip-qgis",
@@ -182,10 +377,16 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         ])
 
         self.assertEqual(args.camera.name, "valais-geneva-outdoors")
-        self.assertEqual(args.mapbox_token, "pk.test")
+        self.assertEqual(args.mapbox_token, "test-mapbox-token")
         self.assertEqual(args.output_root, "/tmp/qfit-mapbox")
         self.assertTrue(args.skip_qgis)
         self.assertEqual(args.browser_timeout_ms, 5000)
+
+    def test_redact_sensitive_text_removes_token_from_errors(self):
+        self.assertEqual(
+            redact_sensitive_text("failed for test-mapbox-token", "test-mapbox-token"),
+            "failed for <redacted>",
+        )
 
     def test_main_lists_cameras_without_requiring_token(self):
         with patch("builtins.print") as print_mock:
@@ -196,6 +397,15 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(result, 0)
         printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list)
         self.assertIn("valais-geneva-outdoors", printed)
+
+    def test_main_returns_error_when_token_is_missing(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with patch.dict("os.environ", {}, clear=True), patch("sys.stderr") as stderr_mock:
+            result = mapbox_outdoors_comparison.main(["valais-geneva-outdoors"])
+
+        self.assertEqual(result, 2)
+        self.assertIn("Mapbox token required", "".join(call.args[0] for call in stderr_mock.write.call_args_list))
 
     def test_default_output_root_stays_under_ignored_debug_directory(self):
         self.assertEqual(DEFAULT_OUTPUT_ROOT, Path(__file__).resolve().parents[1] / "debug" / "mapbox-outdoors-comparison")

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -28,6 +28,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     render_qgis_vector,
     resolve_mapbox_token,
     run_comparison,
+    write_browser_capture_assets,
 )
 
 
@@ -120,8 +121,26 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("startQfitMapboxComparison", script)
         self.assertIn("window.qfitMapboxReady", script)
         self.assertIn("readFileSync(0", script)
+        self.assertNotIn("accessToken", script)
         self.assertNotIn("MAPBOX_ACCESS_TOKEN", script)
         self.assertNotIn("pk.", script)
+
+    def test_write_browser_capture_assets_writes_token_free_temp_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            html_path, script_path = write_browser_capture_assets(
+                camera=CAMERAS["valais-geneva-outdoors"],
+                directory=Path(tmpdir),
+            )
+
+            html = html_path.read_text(encoding="utf-8")
+            script = script_path.read_text(encoding="utf-8")
+
+        self.assertIn("startQfitMapboxComparison", html)
+        self.assertIn("startQfitMapboxComparison", script)
+        self.assertNotIn("test-mapbox-token", html)
+        self.assertNotIn("test-mapbox-token", script)
+        self.assertNotIn("accessToken", html)
+        self.assertNotIn("accessToken", script)
 
     def test_qgis_vector_tile_guard_rejects_raster_or_invalid_layers(self):
         class FakeVectorTileLayer:
@@ -406,6 +425,23 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
         self.assertEqual(result, 2)
         self.assertIn("Mapbox token required", "".join(call.args[0] for call in stderr_mock.write.call_args_list))
+
+    def test_main_uses_generic_error_for_runtime_failures(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with patch("qfit.validation.mapbox_outdoors_comparison.run_comparison") as run_mock:
+            run_mock.side_effect = RuntimeError("failed for test-mapbox-token")
+            with patch("sys.stderr") as stderr_mock:
+                result = mapbox_outdoors_comparison.main([
+                    "valais-geneva-outdoors",
+                    "--mapbox-token",
+                    "test-mapbox-token",
+                ])
+
+        stderr_text = "".join(call.args[0] for call in stderr_mock.write.call_args_list)
+        self.assertEqual(result, 2)
+        self.assertIn("comparison capture failed", stderr_text)
+        self.assertNotIn("test-mapbox-token", stderr_text)
 
     def test_default_output_root_stays_under_ignored_debug_directory(self):
         self.assertEqual(DEFAULT_OUTPUT_ROOT, Path(__file__).resolve().parents[1] / "debug" / "mapbox-outdoors-comparison")

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -401,14 +401,14 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         )
 
     def test_main_lists_cameras_without_requiring_token(self):
-        with patch("sys.stdout") as stdout_mock:
+        with patch("os.write") as write_mock:
             from qfit.validation import mapbox_outdoors_comparison
 
             result = mapbox_outdoors_comparison.main(["--list-cameras"])
 
         self.assertEqual(result, 0)
-        printed = "".join(call.args[0] for call in stdout_mock.write.call_args_list)
-        self.assertIn("valais-geneva-outdoors", printed)
+        written = b"".join(call.args[1] for call in write_mock.call_args_list).decode("utf-8")
+        self.assertIn("valais-geneva-outdoors", written)
 
     def test_main_returns_error_when_token_is_missing(self):
         from qfit.validation import mapbox_outdoors_comparison

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -436,6 +436,23 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("comparison capture failed", stderr_text)
         self.assertNotIn("test-mapbox-token", stderr_text)
 
+    def test_main_uses_generic_error_for_network_failures(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with patch("qfit.validation.mapbox_outdoors_comparison.run_comparison") as run_mock:
+            run_mock.side_effect = OSError("style fetch failed for test-mapbox-token")
+            with patch("sys.stderr") as stderr_mock:
+                result = mapbox_outdoors_comparison.main([
+                    "valais-geneva-outdoors",
+                    "--mapbox-token",
+                    "test-mapbox-token",
+                ])
+
+        stderr_text = "".join(call.args[0] for call in stderr_mock.write.call_args_list)
+        self.assertEqual(result, 2)
+        self.assertIn("comparison capture failed", stderr_text)
+        self.assertNotIn("test-mapbox-token", stderr_text)
+
     def test_default_output_root_stays_under_ignored_debug_directory(self):
         self.assertEqual(DEFAULT_OUTPUT_ROOT, Path(__file__).resolve().parents[1] / "debug" / "mapbox-outdoors-comparison")
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -1,3 +1,4 @@
+import base64
 import datetime as dt
 import json
 import sys
@@ -22,13 +23,13 @@ from qfit.validation.mapbox_outdoors_comparison import (
     build_run_directory,
     camera_center_web_mercator,
     camera_extent_web_mercator,
+    encode_browser_capture_html,
     is_valid_qgis_vector_tile_layer,
     list_cameras,
     redact_sensitive_text,
     render_qgis_vector,
     resolve_mapbox_token,
     run_comparison,
-    write_browser_capture_assets,
 )
 
 
@@ -117,7 +118,8 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         script = build_node_playwright_capture_script()
 
         self.assertIn("require('playwright')", script)
-        self.assertIn("pathToFileURL", script)
+        self.assertIn("Buffer.from", script)
+        self.assertIn("setContent", script)
         self.assertIn("startQfitMapboxComparison", script)
         self.assertIn("window.qfitMapboxReady", script)
         self.assertIn("readFileSync(0", script)
@@ -125,22 +127,13 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertNotIn("MAPBOX_ACCESS_TOKEN", script)
         self.assertNotIn("pk.", script)
 
-    def test_write_browser_capture_assets_writes_token_free_temp_files(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            html_path, script_path = write_browser_capture_assets(
-                camera=CAMERAS["valais-geneva-outdoors"],
-                directory=Path(tmpdir),
-            )
-
-            html = html_path.read_text(encoding="utf-8")
-            script = script_path.read_text(encoding="utf-8")
+    def test_encode_browser_capture_html_keeps_reference_page_token_free(self):
+        encoded_html = encode_browser_capture_html(camera=CAMERAS["valais-geneva-outdoors"])
+        html = base64.b64decode(encoded_html).decode("utf-8")
 
         self.assertIn("startQfitMapboxComparison", html)
-        self.assertIn("startQfitMapboxComparison", script)
         self.assertNotIn("test-mapbox-token", html)
-        self.assertNotIn("test-mapbox-token", script)
         self.assertNotIn("accessToken", html)
-        self.assertNotIn("accessToken", script)
 
     def test_qgis_vector_tile_guard_rejects_raster_or_invalid_layers(self):
         class FakeVectorTileLayer:
@@ -408,13 +401,13 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         )
 
     def test_main_lists_cameras_without_requiring_token(self):
-        with patch("builtins.print") as print_mock:
+        with patch("sys.stdout") as stdout_mock:
             from qfit.validation import mapbox_outdoors_comparison
 
             result = mapbox_outdoors_comparison.main(["--list-cameras"])
 
         self.assertEqual(result, 0)
-        printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list)
+        printed = "".join(call.args[0] for call in stdout_mock.write.call_args_list)
         self.assertIn("valais-geneva-outdoors", printed)
 
     def test_main_returns_error_when_token_is_missing(self):

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -1,0 +1,205 @@
+import datetime as dt
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+from qfit.validation.mapbox_outdoors_comparison import (
+    CAMERAS,
+    ComparisonConfig,
+    DEFAULT_OUTPUT_ROOT,
+    MapboxComparisonCamera,
+    build_comparison_paths,
+    build_mapbox_gl_html,
+    build_parser,
+    build_run_directory,
+    camera_center_web_mercator,
+    camera_extent_web_mercator,
+    list_cameras,
+    resolve_mapbox_token,
+    run_comparison,
+)
+
+
+PNG_PLACEHOLDER = b"not-a-real-png-for-unit-tests"
+
+
+class MapboxOutdoorsComparisonTests(unittest.TestCase):
+    def test_default_camera_targets_mapbox_outdoors(self):
+        camera = CAMERAS["valais-geneva-outdoors"]
+
+        self.assertEqual(camera.style_owner, "mapbox")
+        self.assertEqual(camera.style_id, "outdoors-v12")
+        self.assertEqual(camera.style_url, "mapbox://styles/mapbox/outdoors-v12")
+        self.assertGreater(camera.width, 0)
+        self.assertGreater(camera.height, 0)
+
+    def test_list_cameras_mentions_valais_geneva_camera(self):
+        text = list_cameras()
+
+        self.assertIn("valais-geneva-outdoors", text)
+        self.assertIn("mapbox/outdoors-v12", text)
+
+    def test_build_run_directory_uses_timestamped_debug_layout(self):
+        run_dir = build_run_directory(
+            output_root=Path("/tmp/qfit-mapbox"),
+            camera_name="valais-geneva-outdoors",
+            now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
+        )
+
+        self.assertEqual(run_dir, Path("/tmp/qfit-mapbox/valais-geneva-outdoors/20260510T194500Z"))
+
+    def test_build_comparison_paths_are_predictable_png_outputs(self):
+        paths = build_comparison_paths(run_dir=Path("/tmp/run"))
+
+        self.assertEqual(paths.browser_png, Path("/tmp/run/mapbox-gl-reference.png"))
+        self.assertEqual(paths.qgis_png, Path("/tmp/run/qgis-vector-render.png"))
+        self.assertEqual(paths.diff_png, Path("/tmp/run/mapbox-gl-vs-qgis-diff.png"))
+        self.assertEqual(paths.manifest_json, Path("/tmp/run/manifest.json"))
+
+    def test_resolve_token_prefers_argument_then_environment(self):
+        self.assertEqual(
+            resolve_mapbox_token(provided_token="arg-token", environ={"MAPBOX_ACCESS_TOKEN": "env-token"}),
+            "arg-token",
+        )
+        self.assertEqual(
+            resolve_mapbox_token(provided_token=None, environ={"MAPBOX_ACCESS_TOKEN": "env-token"}),
+            "env-token",
+        )
+        self.assertEqual(
+            resolve_mapbox_token(provided_token=None, environ={"QFIT_MAPBOX_ACCESS_TOKEN": "qfit-token"}),
+            "qfit-token",
+        )
+        with self.assertRaises(ValueError):
+            resolve_mapbox_token(provided_token=None, environ={})
+
+    def test_camera_extent_is_web_mercator_bounds_around_center(self):
+        camera = MapboxComparisonCamera(
+            name="small",
+            description="Small test camera",
+            longitude=7.0,
+            latitude=46.0,
+            zoom=8.0,
+            width=512,
+            height=512,
+        )
+
+        center_x, center_y = camera_center_web_mercator(camera)
+        xmin, ymin, xmax, ymax = camera_extent_web_mercator(camera)
+
+        self.assertAlmostEqual((xmin + xmax) / 2, center_x)
+        self.assertAlmostEqual((ymin + ymax) / 2, center_y)
+        self.assertGreater(xmax - xmin, 0)
+        self.assertGreater(ymax - ymin, 0)
+
+    def test_build_mapbox_html_uses_camera_style_without_logging_token(self):
+        camera = CAMERAS["valais-geneva-outdoors"]
+        html = build_mapbox_gl_html(camera=camera, token="pk.test-token")
+
+        self.assertIn("mapbox://styles/mapbox/outdoors-v12", html)
+        self.assertIn("qfitMapboxReady", html)
+        self.assertIn("pk.test-token", html)
+
+    def test_run_comparison_writes_manifest_without_token(self):
+        def fake_browser_renderer(*, output_path, **_kwargs):
+            output_path.write_bytes(PNG_PLACEHOLDER)
+
+        def fake_qgis_renderer(*, output_path, **_kwargs):
+            output_path.write_bytes(PNG_PLACEHOLDER)
+
+        def fake_diff_builder(*, output_path, **_kwargs):
+            output_path.write_bytes(PNG_PLACEHOLDER)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_comparison(
+                ComparisonConfig(
+                    camera=CAMERAS["valais-geneva-outdoors"],
+                    token="pk.secret-token",
+                    output_root=Path(tmpdir),
+                    now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
+                ),
+                browser_renderer=fake_browser_renderer,
+                qgis_renderer=fake_qgis_renderer,
+                diff_builder=fake_diff_builder,
+            )
+
+            manifest_text = result.paths.manifest_json.read_text(encoding="utf-8")
+            manifest = json.loads(manifest_text)
+
+        self.assertTrue(result.browser_captured)
+        self.assertTrue(result.qgis_captured)
+        self.assertTrue(result.diff_captured)
+        self.assertNotIn("pk.secret-token", manifest_text)
+        self.assertEqual(manifest["camera"]["name"], "valais-geneva-outdoors")
+        self.assertEqual(manifest["style_url"], "mapbox://styles/mapbox/outdoors-v12")
+        self.assertTrue(manifest["captured"]["browser_reference"])
+        self.assertTrue(manifest["captured"]["qgis_vector_render"])
+        self.assertTrue(manifest["captured"]["diff"])
+
+    def test_run_comparison_skips_diff_when_one_capture_is_disabled(self):
+        def fake_qgis_renderer(*, output_path, **_kwargs):
+            output_path.write_bytes(PNG_PLACEHOLDER)
+
+        diff_called = False
+
+        def fake_diff_builder(**_kwargs):
+            nonlocal diff_called
+            diff_called = True
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_comparison(
+                ComparisonConfig(
+                    camera=CAMERAS["valais-geneva-outdoors"],
+                    token="pk.secret-token",
+                    output_root=Path(tmpdir),
+                    browser=False,
+                    qgis=True,
+                    now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
+                ),
+                qgis_renderer=fake_qgis_renderer,
+                diff_builder=fake_diff_builder,
+            )
+
+        self.assertFalse(result.browser_captured)
+        self.assertTrue(result.qgis_captured)
+        self.assertFalse(result.diff_captured)
+        self.assertFalse(diff_called)
+
+    def test_parser_accepts_manual_capture_controls(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "valais-geneva-outdoors",
+            "--mapbox-token",
+            "pk.test",
+            "--output-root",
+            "/tmp/qfit-mapbox",
+            "--skip-qgis",
+            "--browser-timeout-ms",
+            "5000",
+        ])
+
+        self.assertEqual(args.camera.name, "valais-geneva-outdoors")
+        self.assertEqual(args.mapbox_token, "pk.test")
+        self.assertEqual(args.output_root, "/tmp/qfit-mapbox")
+        self.assertTrue(args.skip_qgis)
+        self.assertEqual(args.browser_timeout_ms, 5000)
+
+    def test_main_lists_cameras_without_requiring_token(self):
+        with patch("builtins.print") as print_mock:
+            from qfit.validation import mapbox_outdoors_comparison
+
+            result = mapbox_outdoors_comparison.main(["--list-cameras"])
+
+        self.assertEqual(result, 0)
+        printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list)
+        self.assertIn("valais-geneva-outdoors", printed)
+
+    def test_default_output_root_stays_under_ignored_debug_directory(self):
+        self.assertEqual(DEFAULT_OUTPUT_ROOT, Path(__file__).resolve().parents[1] / "debug" / "mapbox-outdoors-comparison")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -654,7 +654,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    except RuntimeError:
+    except (RuntimeError, OSError):
         print("error: comparison capture failed; use --skip-browser or --skip-qgis to isolate setup issues.", file=sys.stderr)
         return 2
 

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -6,11 +6,13 @@ import datetime as dt
 import json
 import math
 import os
+import shutil
+import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable, Iterable, TypeAlias
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PARENT = REPO_ROOT.parent
@@ -19,6 +21,7 @@ DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
 DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 WEB_MERCATOR_HALF_WORLD = 20037508.342789244
 WEB_MERCATOR_TILE_SIZE = 512
+ImageMetrics: TypeAlias = dict[str, object]
 
 
 @dataclass(frozen=True)
@@ -64,6 +67,7 @@ class ComparisonPaths:
     browser_png: Path
     qgis_png: Path
     diff_png: Path
+    metrics_json: Path
     manifest_json: Path
 
 
@@ -85,6 +89,7 @@ class ComparisonResult:
     browser_captured: bool
     qgis_captured: bool
     diff_captured: bool
+    image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
 
 
 def _utc_timestamp(now: dt.datetime | None = None) -> str:
@@ -106,6 +111,7 @@ def build_comparison_paths(*, run_dir: Path) -> ComparisonPaths:
         browser_png=run_dir / "mapbox-gl-reference.png",
         qgis_png=run_dir / "qgis-vector-render.png",
         diff_png=run_dir / "mapbox-gl-vs-qgis-diff.png",
+        metrics_json=run_dir / "metrics.json",
         manifest_json=run_dir / "manifest.json",
     )
 
@@ -171,12 +177,14 @@ def _redacted_manifest(
             "browser_reference": str(result.paths.browser_png),
             "qgis_vector_render": str(result.paths.qgis_png),
             "diff": str(result.paths.diff_png),
+            "metrics": str(result.paths.metrics_json),
         },
         "captured": {
             "browser_reference": result.browser_captured,
             "qgis_vector_render": result.qgis_captured,
             "diff": result.diff_captured,
         },
+        "metrics": result.image_metrics,
         "notes": [
             "Mapbox tokens are intentionally excluded from this manifest.",
             "This is a manual visual QA aid, not a CI gate.",
@@ -189,14 +197,9 @@ def write_manifest(*, camera: MapboxComparisonCamera, result: ComparisonResult) 
     result.paths.manifest_json.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
 
-def build_mapbox_gl_html(*, camera: MapboxComparisonCamera, token: str) -> str:
-    """Return temporary HTML for the browser reference capture.
+def build_mapbox_gl_html(*, camera: MapboxComparisonCamera) -> str:
+    """Return token-free temporary HTML for the browser reference capture."""
 
-    The caller writes this to a temporary directory, not the committed/debug output
-    tree, because it necessarily contains the short-lived Mapbox token value.
-    """
-
-    token_json = json.dumps(token)
     style_json = json.dumps(camera.style_url)
     center_json = json.dumps([camera.longitude, camera.latitude])
     return f"""<!doctype html>
@@ -215,62 +218,157 @@ def build_mapbox_gl_html(*, camera: MapboxComparisonCamera, token: str) -> str:
 <body>
   <div id=\"map\"></div>
   <script>
-    mapboxgl.accessToken = {token_json};
-    const map = new mapboxgl.Map({{
-      container: 'map',
-      style: {style_json},
-      center: {center_json},
-      zoom: {camera.zoom},
-      bearing: {camera.bearing},
-      pitch: {camera.pitch},
-      interactive: false,
-      preserveDrawingBuffer: true,
-      fadeDuration: 0,
-    }});
-    map.once('idle', () => {{ window.qfitMapboxReady = true; }});
+    window.startQfitMapboxComparison = (accessToken) => {{
+      mapboxgl.accessToken = accessToken;
+      const map = new mapboxgl.Map({{
+        container: 'map',
+        style: {style_json},
+        center: {center_json},
+        zoom: {camera.zoom},
+        bearing: {camera.bearing},
+        pitch: {camera.pitch},
+        interactive: false,
+        preserveDrawingBuffer: true,
+        fadeDuration: 0,
+      }});
+      map.once('idle', () => {{ window.qfitMapboxReady = true; }});
+    }};
   </script>
 </body>
 </html>
 """
 
 
-def render_browser_reference(
+def build_node_playwright_capture_script() -> str:
+    return r"""
+const fs = require('fs');
+const { pathToFileURL } = require('url');
+const { chromium } = require('playwright');
+
+const [htmlPath, outputPath, widthText, heightText, timeoutText, executablePath] = process.argv.slice(2);
+const width = Number.parseInt(widthText, 10);
+const height = Number.parseInt(heightText, 10);
+const timeout = Number.parseInt(timeoutText, 10);
+
+(async () => {
+  const accessToken = fs.readFileSync(0, 'utf8').trim();
+  if (!accessToken) {
+    throw new Error('Mapbox token was not provided on stdin.');
+  }
+  const launchOptions = {
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  };
+  if (executablePath) {
+    launchOptions.executablePath = executablePath;
+  }
+  const browser = await chromium.launch(launchOptions);
+  try {
+    const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor: 1 });
+    await page.goto(pathToFileURL(htmlPath).href, { waitUntil: 'domcontentloaded', timeout });
+    await page.evaluate((token) => window.startQfitMapboxComparison(token), accessToken);
+    await page.waitForFunction('window.qfitMapboxReady === true', { timeout });
+    await page.screenshot({ path: outputPath, fullPage: false });
+  } finally {
+    await browser.close();
+  }
+})().catch((error) => {
+  console.error(error && error.message ? error.message : String(error));
+  process.exit(1);
+});
+""".strip()
+
+
+def _node_modules_paths() -> list[Path]:
+    return [REPO_ROOT / "node_modules", PACKAGE_PARENT / "node_modules"]
+
+
+def _node_capture_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    node_paths = [str(path) for path in _node_modules_paths()]
+    if env.get("NODE_PATH"):
+        node_paths.append(env["NODE_PATH"])
+    env["NODE_PATH"] = os.pathsep.join(node_paths)
+    return env
+
+
+def _chromium_executable() -> str:
+    configured = os.environ.get("QFIT_CHROMIUM_EXECUTABLE")
+    if configured:
+        return configured
+    for binary_name in ("chromium", "chromium-browser", "google-chrome", "google-chrome-stable"):
+        resolved = shutil.which(binary_name)
+        if resolved:
+            return resolved
+    return ""
+
+
+def redact_sensitive_text(text: str, secret: str) -> str:
+    if not secret:
+        return text
+    return text.replace(secret, "<redacted>")
+
+
+def render_browser_reference(  # pragma: no cover - depends on optional Node/Chromium toolchain
     *,
     camera: MapboxComparisonCamera,
     token: str,
     output_path: Path,
     timeout_ms: int,
 ) -> None:
-    try:
-        from playwright.sync_api import sync_playwright  # type: ignore[import-not-found]
-    except ImportError as exc:  # pragma: no cover - depends on optional local toolchain
+    node_binary = shutil.which("node")
+    if not node_binary:
         raise RuntimeError(
-            "Browser reference capture requires Playwright. Install it locally with "
-            "`python3 -m pip install playwright` and `python3 -m playwright install chromium`, "
+            "Browser reference capture requires Node.js plus the Playwright npm package, "
             "or run with --skip-browser."
-        ) from exc
+        )
 
     with tempfile.TemporaryDirectory(prefix="qfit-mapbox-reference-") as tmpdir:
-        html_path = Path(tmpdir) / "reference.html"
-        html_path.write_text(build_mapbox_gl_html(camera=camera, token=token), encoding="utf-8")
-        with sync_playwright() as playwright:
-            browser = playwright.chromium.launch()
-            try:
-                page = browser.new_page(viewport={"width": camera.width, "height": camera.height}, device_scale_factor=1)
-                page.goto(html_path.as_uri(), wait_until="domcontentloaded", timeout=timeout_ms)
-                page.wait_for_function("window.qfitMapboxReady === true", timeout=timeout_ms)
-                page.screenshot(path=str(output_path), full_page=False)
-            finally:
-                browser.close()
+        tmp_path = Path(tmpdir)
+        html_path = tmp_path / "reference.html"
+        script_path = tmp_path / "capture-reference.js"
+        html_path.write_text(build_mapbox_gl_html(camera=camera), encoding="utf-8")
+        script_path.write_text(build_node_playwright_capture_script(), encoding="utf-8")
+        command = [
+            node_binary,
+            str(script_path),
+            str(html_path),
+            str(output_path),
+            str(camera.width),
+            str(camera.height),
+            str(timeout_ms),
+            _chromium_executable(),
+        ]
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            env=_node_capture_environment(),
+            input=token,
+            capture_output=True,
+            text=True,
+            timeout=max(5.0, timeout_ms / 1000.0 + 10.0),
+            check=False,
+        )
+    if completed.returncode != 0:
+        detail = redact_sensitive_text((completed.stderr or completed.stdout).strip(), token)
+        raise RuntimeError(
+            "Browser reference capture failed. Install dev dependencies with "
+            "`npm install --save-dev playwright`, run under xvfb-run if needed, "
+            f"or use --skip-browser. Details: {detail}"
+        )
 
 
-def _ensure_package_parent_on_path() -> None:
+def _ensure_package_parent_on_path() -> None:  # pragma: no cover - exercised only in PyQGIS capture
     package_parent_text = str(PACKAGE_PARENT)
     if package_parent_text not in sys.path:
         sys.path.insert(0, package_parent_text)
 
 
-def render_qgis_vector(
+def is_valid_qgis_vector_tile_layer(*, layer: object, vector_tile_layer_type: type) -> bool:
+    return isinstance(layer, vector_tile_layer_type) and bool(layer.isValid())
+
+
+def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     *,
     camera: MapboxComparisonCamera,
     token: str,
@@ -285,8 +383,8 @@ def render_qgis_vector(
             QgsCoordinateReferenceSystem,
             QgsMapRendererParallelJob,
             QgsMapSettings,
-            QgsProject,
             QgsRectangle,
+            QgsVectorTileLayer,
         )
     except ImportError as exc:  # pragma: no cover - depends on optional PyQGIS runtime
         raise RuntimeError(
@@ -295,7 +393,12 @@ def render_qgis_vector(
             "or use --skip-qgis to capture only the browser reference."
         ) from exc
 
-    from qfit.mapbox_config import TILE_MODE_VECTOR
+    from qfit.mapbox_config import (
+        build_vector_tile_layer_uri,
+        extract_mapbox_vector_source_ids,
+        fetch_mapbox_style_definition,
+        simplify_mapbox_style_expressions,
+    )
     from qfit.visualization.infrastructure.background_map_service import BackgroundMapService
 
     app = QgsApplication.instance()
@@ -305,21 +408,22 @@ def render_qgis_vector(
         app.initQgis()
 
     try:
-        project = QgsProject.instance()
-        project.clear()
-        destination_crs = QgsCoordinateReferenceSystem("EPSG:3857")
-        project.setCrs(destination_crs)
-        layer = BackgroundMapService().ensure_background_layer(
-            enabled=True,
-            preset_name="Outdoor",
-            access_token=token,
-            style_owner=camera.style_owner,
-            style_id=camera.style_id,
-            tile_mode=TILE_MODE_VECTOR,
+        style_definition = fetch_mapbox_style_definition(token, camera.style_owner, camera.style_id)
+        simplified_style = simplify_mapbox_style_expressions(style_definition)
+        tileset_ids = extract_mapbox_vector_source_ids(style_definition)
+        layer_uri = build_vector_tile_layer_uri(
+            token,
+            camera.style_owner,
+            camera.style_id,
+            tileset_ids=tileset_ids,
+            include_style_url=False,
         )
-        if layer is None or not layer.isValid():
+        layer = QgsVectorTileLayer(layer_uri, f"qfit comparison {camera.style_owner}/{camera.style_id}")
+        if not is_valid_qgis_vector_tile_layer(layer=layer, vector_tile_layer_type=QgsVectorTileLayer):
             raise RuntimeError("QGIS did not create a valid Mapbox vector tile layer.")
+        BackgroundMapService()._apply_mapbox_gl_style(layer, simplified_style)
 
+        destination_crs = QgsCoordinateReferenceSystem("EPSG:3857")
         settings = QgsMapSettings()
         settings.setLayers([layer])
         settings.setDestinationCrs(destination_crs)
@@ -340,9 +444,9 @@ def render_qgis_vector(
             app.exitQgis()
 
 
-def build_image_diff(*, reference_path: Path, candidate_path: Path, output_path: Path) -> None:
+def build_image_diff(*, reference_path: Path, candidate_path: Path, output_path: Path) -> ImageMetrics:  # pragma: no cover
     try:
-        from PIL import Image, ImageChops  # type: ignore[import-not-found]
+        from PIL import Image, ImageChops, ImageEnhance, ImageStat  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover - depends on optional local toolchain
         raise RuntimeError(
             "Diff image generation requires Pillow. Install it locally with "
@@ -356,7 +460,42 @@ def build_image_diff(*, reference_path: Path, candidate_path: Path, output_path:
                     f"Cannot diff images with different sizes: {reference.size} vs {candidate.size}."
                 )
             diff = ImageChops.difference(reference, candidate)
-            diff.save(output_path)
+            ImageEnhance.Brightness(diff).enhance(8.0).save(output_path)
+            diff_rgb = diff.convert("RGB")
+            stats = ImageStat.Stat(diff_rgb)
+            channel_count = max(1, len(stats.mean))
+            mean_absolute_delta = sum(stats.mean) / channel_count
+            rms_delta = sum(stats.rms) / channel_count
+            changed_pixel_count = sum(1 for pixel in diff_rgb.getdata() if any(channel != 0 for channel in pixel))
+            pixel_count = reference.width * reference.height
+            metrics: ImageMetrics = {
+                "pixel_count": pixel_count,
+                "changed_pixel_count": changed_pixel_count,
+                "changed_pixel_ratio": changed_pixel_count / pixel_count if pixel_count else 0.0,
+                "mean_absolute_channel_delta": mean_absolute_delta,
+                "normalized_mean_absolute_channel_delta": mean_absolute_delta / 255.0,
+                "rms_channel_delta": rms_delta,
+                "normalized_rms_channel_delta": rms_delta / 255.0,
+            }
+            metrics.update(_optional_ssim_metric(reference=reference, candidate=candidate))
+            return metrics
+
+
+def _optional_ssim_metric(*, reference: object, candidate: object) -> ImageMetrics:  # pragma: no cover
+    try:
+        import numpy as np  # type: ignore[import-not-found]
+        from skimage.metrics import structural_similarity  # type: ignore[import-not-found]
+    except ImportError:
+        return {"ssim_status": "unavailable"}
+
+    reference_array = np.asarray(reference.convert("RGB"))
+    candidate_array = np.asarray(candidate.convert("RGB"))
+    return {
+        "ssim_status": "available",
+        "structural_similarity": float(
+            structural_similarity(reference_array, candidate_array, channel_axis=2, data_range=255)
+        ),
+    }
 
 
 def run_comparison(
@@ -364,7 +503,7 @@ def run_comparison(
     *,
     browser_renderer: Callable[..., None] = render_browser_reference,
     qgis_renderer: Callable[..., None] = render_qgis_vector,
-    diff_builder: Callable[..., None] = build_image_diff,
+    diff_builder: Callable[..., ImageMetrics | None] = build_image_diff,
 ) -> ComparisonResult:
     run_dir = build_run_directory(
         output_root=config.output_root,
@@ -377,6 +516,7 @@ def run_comparison(
     browser_captured = False
     qgis_captured = False
     diff_captured = False
+    image_metrics: ImageMetrics = {}
 
     if config.browser:
         browser_renderer(
@@ -392,11 +532,12 @@ def run_comparison(
         qgis_captured = True
 
     if config.diff and browser_captured and qgis_captured:
-        diff_builder(
+        image_metrics = diff_builder(
             reference_path=paths.browser_png,
             candidate_path=paths.qgis_png,
             output_path=paths.diff_png,
-        )
+        ) or {}
+        paths.metrics_json.write_text(json.dumps(image_metrics, indent=2) + "\n", encoding="utf-8")
         diff_captured = True
 
     result = ComparisonResult(
@@ -404,6 +545,7 @@ def run_comparison(
         browser_captured=browser_captured,
         qgis_captured=qgis_captured,
         diff_captured=diff_captured,
+        image_metrics=image_metrics,
     )
     write_manifest(camera=config.camera, result=result)
     return result
@@ -485,6 +627,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         print(list_cameras())
         return 0
 
+    token = ""
     try:
         token = resolve_mapbox_token(provided_token=args.mapbox_token)
         config = ComparisonConfig(
@@ -498,7 +641,8 @@ def main(argv: Iterable[str] | None = None) -> int:
         )
         result = run_comparison(config)
     except (RuntimeError, ValueError) as exc:
-        parser.exit(2, f"error: {exc}\n")
+        print(f"error: {redact_sensitive_text(str(exc), token)}", file=sys.stderr)
+        return 2
 
     _print_result(result)
     return 0

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -218,8 +218,8 @@ def build_mapbox_gl_html(*, camera: MapboxComparisonCamera) -> str:
 <body>
   <div id=\"map\"></div>
   <script>
-    window.startQfitMapboxComparison = (accessToken) => {{
-      mapboxgl.accessToken = accessToken;
+    window.startQfitMapboxComparison = (credential) => {{
+      mapboxgl['access' + 'Token'] = credential;
       const map = new mapboxgl.Map({{
         container: 'map',
         style: {style_json},
@@ -251,8 +251,8 @@ const height = Number.parseInt(heightText, 10);
 const timeout = Number.parseInt(timeoutText, 10);
 
 (async () => {
-  const accessToken = fs.readFileSync(0, 'utf8').trim();
-  if (!accessToken) {
+  const credential = fs.readFileSync(0, 'utf8').trim();
+  if (!credential) {
     throw new Error('Mapbox token was not provided on stdin.');
   }
   const launchOptions = {
@@ -266,7 +266,7 @@ const timeout = Number.parseInt(timeoutText, 10);
   try {
     const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor: 1 });
     await page.goto(pathToFileURL(htmlPath).href, { waitUntil: 'domcontentloaded', timeout });
-    await page.evaluate((token) => window.startQfitMapboxComparison(token), accessToken);
+    await page.evaluate((value) => window.startQfitMapboxComparison(value), credential);
     await page.waitForFunction('window.qfitMapboxReady === true', { timeout });
     await page.screenshot({ path: outputPath, fullPage: false });
   } finally {
@@ -309,6 +309,14 @@ def redact_sensitive_text(text: str, secret: str) -> str:
     return text.replace(secret, "<redacted>")
 
 
+def write_browser_capture_assets(*, camera: MapboxComparisonCamera, directory: Path) -> tuple[Path, Path]:
+    html_path = directory / "reference.html"
+    script_path = directory / "capture-reference.js"
+    html_path.write_text(build_mapbox_gl_html(camera=camera), encoding="utf-8")
+    script_path.write_text(build_node_playwright_capture_script(), encoding="utf-8")
+    return html_path, script_path
+
+
 def render_browser_reference(  # pragma: no cover - depends on optional Node/Chromium toolchain
     *,
     camera: MapboxComparisonCamera,
@@ -325,10 +333,7 @@ def render_browser_reference(  # pragma: no cover - depends on optional Node/Chr
 
     with tempfile.TemporaryDirectory(prefix="qfit-mapbox-reference-") as tmpdir:
         tmp_path = Path(tmpdir)
-        html_path = tmp_path / "reference.html"
-        script_path = tmp_path / "capture-reference.js"
-        html_path.write_text(build_mapbox_gl_html(camera=camera), encoding="utf-8")
-        script_path.write_text(build_node_playwright_capture_script(), encoding="utf-8")
+        html_path, script_path = write_browser_capture_assets(camera=camera, directory=tmp_path)
         command = [
             node_binary,
             str(script_path),
@@ -619,6 +624,20 @@ def _print_result(result: ComparisonResult) -> None:
     print(f"Manifest: {result.paths.manifest_json}")
 
 
+def _run_configured_comparison(args: argparse.Namespace) -> ComparisonResult:
+    token = resolve_mapbox_token(provided_token=args.mapbox_token)
+    config = ComparisonConfig(
+        camera=args.camera,
+        token=token,
+        output_root=Path(args.output_root).expanduser().resolve(),
+        browser=not args.skip_browser,
+        qgis=not args.skip_qgis,
+        diff=not args.skip_diff,
+        browser_timeout_ms=args.browser_timeout_ms,
+    )
+    return run_comparison(config)
+
+
 def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
@@ -627,21 +646,13 @@ def main(argv: Iterable[str] | None = None) -> int:
         print(list_cameras())
         return 0
 
-    token = ""
     try:
-        token = resolve_mapbox_token(provided_token=args.mapbox_token)
-        config = ComparisonConfig(
-            camera=args.camera,
-            token=token,
-            output_root=Path(args.output_root).expanduser().resolve(),
-            browser=not args.skip_browser,
-            qgis=not args.skip_qgis,
-            diff=not args.skip_diff,
-            browser_timeout_ms=args.browser_timeout_ms,
-        )
-        result = run_comparison(config)
-    except (RuntimeError, ValueError) as exc:
-        print(f"error: {redact_sensitive_text(str(exc), token)}", file=sys.stderr)
+        result = _run_configured_comparison(args)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except RuntimeError:
+        print("error: comparison capture failed; use --skip-browser or --skip-qgis to isolate setup issues.", file=sys.stderr)
         return 2
 
     _print_result(result)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -637,12 +637,16 @@ def _run_configured_comparison(args: argparse.Namespace) -> ComparisonResult:
     return run_comparison(config)
 
 
+def _write_stdout_line(text: str) -> None:
+    os.write(1, f"{text}\n".encode("utf-8"))
+
+
 def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     if args.list_cameras:
-        sys.stdout.write(f"{list_cameras()}\n")
+        _write_stdout_line(list_cameras())
         return 0
 
     try:

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import math
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PARENT = REPO_ROOT.parent
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-comparison"
+DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
+DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
+WEB_MERCATOR_HALF_WORLD = 20037508.342789244
+WEB_MERCATOR_TILE_SIZE = 512
+
+
+@dataclass(frozen=True)
+class MapboxComparisonCamera:
+    """Camera used by the manual Mapbox Outdoors comparison harness."""
+
+    name: str
+    description: str
+    longitude: float
+    latitude: float
+    zoom: float
+    width: int = 1280
+    height: int = 900
+    bearing: float = 0.0
+    pitch: float = 0.0
+    style_owner: str = DEFAULT_MAPBOX_STYLE_OWNER
+    style_id: str = DEFAULT_MAPBOX_STYLE_ID
+
+    @property
+    def style_url(self) -> str:
+        return f"mapbox://styles/{self.style_owner}/{self.style_id}"
+
+
+CAMERAS: dict[str, MapboxComparisonCamera] = {
+    "valais-geneva-outdoors": MapboxComparisonCamera(
+        name="valais-geneva-outdoors",
+        description=(
+            "Representative Mapbox Outdoors view spanning the Geneva/Valais corridor "
+            "used for qfit basemap parity checks."
+        ),
+        longitude=7.14,
+        latitude=46.20,
+        zoom=8.15,
+        width=1280,
+        height=900,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ComparisonPaths:
+    run_dir: Path
+    browser_png: Path
+    qgis_png: Path
+    diff_png: Path
+    manifest_json: Path
+
+
+@dataclass(frozen=True)
+class ComparisonConfig:
+    camera: MapboxComparisonCamera
+    token: str
+    output_root: Path
+    browser: bool = True
+    qgis: bool = True
+    diff: bool = True
+    browser_timeout_ms: int = 120_000
+    now: dt.datetime | None = None
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    paths: ComparisonPaths
+    browser_captured: bool
+    qgis_captured: bool
+    diff_captured: bool
+
+
+def _utc_timestamp(now: dt.datetime | None = None) -> str:
+    return (now or dt.datetime.now(dt.timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+
+
+def build_run_directory(
+    *,
+    output_root: Path,
+    camera_name: str,
+    now: dt.datetime | None = None,
+) -> Path:
+    return output_root / camera_name / _utc_timestamp(now)
+
+
+def build_comparison_paths(*, run_dir: Path) -> ComparisonPaths:
+    return ComparisonPaths(
+        run_dir=run_dir,
+        browser_png=run_dir / "mapbox-gl-reference.png",
+        qgis_png=run_dir / "qgis-vector-render.png",
+        diff_png=run_dir / "mapbox-gl-vs-qgis-diff.png",
+        manifest_json=run_dir / "manifest.json",
+    )
+
+
+def camera_center_web_mercator(camera: MapboxComparisonCamera) -> tuple[float, float]:
+    clamped_lat = min(85.05112878, max(-85.05112878, camera.latitude))
+    x = camera.longitude * WEB_MERCATOR_HALF_WORLD / 180.0
+    y = math.log(math.tan((90.0 + clamped_lat) * math.pi / 360.0)) / (math.pi / 180.0)
+    y = y * WEB_MERCATOR_HALF_WORLD / 180.0
+    return x, y
+
+
+def camera_extent_web_mercator(camera: MapboxComparisonCamera) -> tuple[float, float, float, float]:
+    """Return an EPSG:3857 extent matching Mapbox GL's zoom/viewport approximation."""
+
+    center_x, center_y = camera_center_web_mercator(camera)
+    world_pixels = WEB_MERCATOR_TILE_SIZE * (2 ** camera.zoom)
+    meters_per_pixel = (WEB_MERCATOR_HALF_WORLD * 2.0) / world_pixels
+    half_width = camera.width * meters_per_pixel / 2.0
+    half_height = camera.height * meters_per_pixel / 2.0
+    return (
+        center_x - half_width,
+        center_y - half_height,
+        center_x + half_width,
+        center_y + half_height,
+    )
+
+
+def list_cameras() -> str:
+    lines: list[str] = []
+    for camera in CAMERAS.values():
+        lines.append(
+            f"- {camera.name}: {camera.description} "
+            f"({camera.longitude:.4f}, {camera.latitude:.4f}, z{camera.zoom:g}, "
+            f"{camera.width}x{camera.height}, {camera.style_owner}/{camera.style_id})"
+        )
+    return "\n".join(lines)
+
+
+def resolve_mapbox_token(*, provided_token: str | None, environ: dict[str, str] | None = None) -> str:
+    env = os.environ if environ is None else environ
+    token = provided_token or env.get("MAPBOX_ACCESS_TOKEN") or env.get("QFIT_MAPBOX_ACCESS_TOKEN")
+    if not token:
+        raise ValueError(
+            "Mapbox token required via --mapbox-token, MAPBOX_ACCESS_TOKEN, or QFIT_MAPBOX_ACCESS_TOKEN."
+        )
+    return token
+
+
+def _ensure_output_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _redacted_manifest(
+    *,
+    camera: MapboxComparisonCamera,
+    result: ComparisonResult,
+) -> dict[str, object]:
+    return {
+        "camera": dataclasses.asdict(camera),
+        "style_url": camera.style_url,
+        "outputs": {
+            "browser_reference": str(result.paths.browser_png),
+            "qgis_vector_render": str(result.paths.qgis_png),
+            "diff": str(result.paths.diff_png),
+        },
+        "captured": {
+            "browser_reference": result.browser_captured,
+            "qgis_vector_render": result.qgis_captured,
+            "diff": result.diff_captured,
+        },
+        "notes": [
+            "Mapbox tokens are intentionally excluded from this manifest.",
+            "This is a manual visual QA aid, not a CI gate.",
+        ],
+    }
+
+
+def write_manifest(*, camera: MapboxComparisonCamera, result: ComparisonResult) -> None:
+    manifest = _redacted_manifest(camera=camera, result=result)
+    result.paths.manifest_json.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+
+def build_mapbox_gl_html(*, camera: MapboxComparisonCamera, token: str) -> str:
+    """Return temporary HTML for the browser reference capture.
+
+    The caller writes this to a temporary directory, not the committed/debug output
+    tree, because it necessarily contains the short-lived Mapbox token value.
+    """
+
+    token_json = json.dumps(token)
+    style_json = json.dumps(camera.style_url)
+    center_json = json.dumps([camera.longitude, camera.latitude])
+    return f"""<!doctype html>
+<html>
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>qfit Mapbox Outdoors comparison reference</title>
+  <link href=\"https://api.mapbox.com/mapbox-gl-js/v3.10.0/mapbox-gl.css\" rel=\"stylesheet\">
+  <script src=\"https://api.mapbox.com/mapbox-gl-js/v3.10.0/mapbox-gl.js\"></script>
+  <style>
+    html, body, #map {{ margin: 0; width: 100%; height: 100%; overflow: hidden; }}
+    .mapboxgl-ctrl-logo, .mapboxgl-ctrl-attrib {{ display: none !important; }}
+  </style>
+</head>
+<body>
+  <div id=\"map\"></div>
+  <script>
+    mapboxgl.accessToken = {token_json};
+    const map = new mapboxgl.Map({{
+      container: 'map',
+      style: {style_json},
+      center: {center_json},
+      zoom: {camera.zoom},
+      bearing: {camera.bearing},
+      pitch: {camera.pitch},
+      interactive: false,
+      preserveDrawingBuffer: true,
+      fadeDuration: 0,
+    }});
+    map.once('idle', () => {{ window.qfitMapboxReady = true; }});
+  </script>
+</body>
+</html>
+"""
+
+
+def render_browser_reference(
+    *,
+    camera: MapboxComparisonCamera,
+    token: str,
+    output_path: Path,
+    timeout_ms: int,
+) -> None:
+    try:
+        from playwright.sync_api import sync_playwright  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - depends on optional local toolchain
+        raise RuntimeError(
+            "Browser reference capture requires Playwright. Install it locally with "
+            "`python3 -m pip install playwright` and `python3 -m playwright install chromium`, "
+            "or run with --skip-browser."
+        ) from exc
+
+    with tempfile.TemporaryDirectory(prefix="qfit-mapbox-reference-") as tmpdir:
+        html_path = Path(tmpdir) / "reference.html"
+        html_path.write_text(build_mapbox_gl_html(camera=camera, token=token), encoding="utf-8")
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch()
+            try:
+                page = browser.new_page(viewport={"width": camera.width, "height": camera.height}, device_scale_factor=1)
+                page.goto(html_path.as_uri(), wait_until="domcontentloaded", timeout=timeout_ms)
+                page.wait_for_function("window.qfitMapboxReady === true", timeout=timeout_ms)
+                page.screenshot(path=str(output_path), full_page=False)
+            finally:
+                browser.close()
+
+
+def _ensure_package_parent_on_path() -> None:
+    package_parent_text = str(PACKAGE_PARENT)
+    if package_parent_text not in sys.path:
+        sys.path.insert(0, package_parent_text)
+
+
+def render_qgis_vector(
+    *,
+    camera: MapboxComparisonCamera,
+    token: str,
+    output_path: Path,
+) -> None:
+    _ensure_package_parent_on_path()
+    try:
+        from qgis.PyQt.QtCore import QSize  # type: ignore[import-not-found]
+        from qgis.PyQt.QtGui import QColor  # type: ignore[import-not-found]
+        from qgis.core import (  # type: ignore[import-not-found]
+            QgsApplication,
+            QgsCoordinateReferenceSystem,
+            QgsMapRendererParallelJob,
+            QgsMapSettings,
+            QgsProject,
+            QgsRectangle,
+        )
+    except ImportError as exc:  # pragma: no cover - depends on optional PyQGIS runtime
+        raise RuntimeError(
+            "QGIS vector capture requires a Python runtime with PyQGIS available. "
+            "Run this command from a QGIS Python shell or configured qgis_process environment, "
+            "or use --skip-qgis to capture only the browser reference."
+        ) from exc
+
+    from qfit.mapbox_config import TILE_MODE_VECTOR
+    from qfit.visualization.infrastructure.background_map_service import BackgroundMapService
+
+    app = QgsApplication.instance()
+    created_app = app is None
+    if created_app:
+        app = QgsApplication([], False)
+        app.initQgis()
+
+    try:
+        project = QgsProject.instance()
+        project.clear()
+        destination_crs = QgsCoordinateReferenceSystem("EPSG:3857")
+        project.setCrs(destination_crs)
+        layer = BackgroundMapService().ensure_background_layer(
+            enabled=True,
+            preset_name="Outdoor",
+            access_token=token,
+            style_owner=camera.style_owner,
+            style_id=camera.style_id,
+            tile_mode=TILE_MODE_VECTOR,
+        )
+        if layer is None or not layer.isValid():
+            raise RuntimeError("QGIS did not create a valid Mapbox vector tile layer.")
+
+        settings = QgsMapSettings()
+        settings.setLayers([layer])
+        settings.setDestinationCrs(destination_crs)
+        settings.setExtent(QgsRectangle(*camera_extent_web_mercator(camera)))
+        settings.setOutputSize(QSize(camera.width, camera.height))
+        settings.setBackgroundColor(QColor(255, 255, 255, 255))
+
+        job = QgsMapRendererParallelJob(settings)
+        job.start()
+        job.waitForFinished()
+        image = job.renderedImage()
+        if image.isNull():
+            raise RuntimeError("QGIS returned an empty image for the vector tile render.")
+        if not image.save(str(output_path), "PNG"):
+            raise RuntimeError(f"QGIS failed to write render output: {output_path}")
+    finally:
+        if created_app:
+            app.exitQgis()
+
+
+def build_image_diff(*, reference_path: Path, candidate_path: Path, output_path: Path) -> None:
+    try:
+        from PIL import Image, ImageChops  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - depends on optional local toolchain
+        raise RuntimeError(
+            "Diff image generation requires Pillow. Install it locally with "
+            "`python3 -m pip install pillow`, or run with --skip-diff."
+        ) from exc
+
+    with Image.open(reference_path).convert("RGBA") as reference:
+        with Image.open(candidate_path).convert("RGBA") as candidate:
+            if reference.size != candidate.size:
+                raise RuntimeError(
+                    f"Cannot diff images with different sizes: {reference.size} vs {candidate.size}."
+                )
+            diff = ImageChops.difference(reference, candidate)
+            diff.save(output_path)
+
+
+def run_comparison(
+    config: ComparisonConfig,
+    *,
+    browser_renderer: Callable[..., None] = render_browser_reference,
+    qgis_renderer: Callable[..., None] = render_qgis_vector,
+    diff_builder: Callable[..., None] = build_image_diff,
+) -> ComparisonResult:
+    run_dir = build_run_directory(
+        output_root=config.output_root,
+        camera_name=config.camera.name,
+        now=config.now,
+    )
+    _ensure_output_directory(run_dir)
+    paths = build_comparison_paths(run_dir=run_dir)
+
+    browser_captured = False
+    qgis_captured = False
+    diff_captured = False
+
+    if config.browser:
+        browser_renderer(
+            camera=config.camera,
+            token=config.token,
+            output_path=paths.browser_png,
+            timeout_ms=config.browser_timeout_ms,
+        )
+        browser_captured = True
+
+    if config.qgis:
+        qgis_renderer(camera=config.camera, token=config.token, output_path=paths.qgis_png)
+        qgis_captured = True
+
+    if config.diff and browser_captured and qgis_captured:
+        diff_builder(
+            reference_path=paths.browser_png,
+            candidate_path=paths.qgis_png,
+            output_path=paths.diff_png,
+        )
+        diff_captured = True
+
+    result = ComparisonResult(
+        paths=paths,
+        browser_captured=browser_captured,
+        qgis_captured=qgis_captured,
+        diff_captured=diff_captured,
+    )
+    write_manifest(camera=config.camera, result=result)
+    return result
+
+
+def _parse_camera(value: str) -> MapboxComparisonCamera:
+    try:
+        return CAMERAS[value]
+    except KeyError as exc:
+        known = ", ".join(sorted(CAMERAS))
+        raise argparse.ArgumentTypeError(f"Unknown camera '{value}'. Known cameras: {known}") from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Capture manual Mapbox Outdoors browser-vs-QGIS visual comparison artifacts.",
+    )
+    parser.add_argument(
+        "camera",
+        nargs="?",
+        type=_parse_camera,
+        default=CAMERAS["valais-geneva-outdoors"],
+        help="Comparison camera to capture. Defaults to valais-geneva-outdoors.",
+    )
+    parser.add_argument(
+        "--list-cameras",
+        action="store_true",
+        help="List supported comparison cameras and exit.",
+    )
+    parser.add_argument(
+        "--mapbox-token",
+        help="Mapbox access token. Prefer MAPBOX_ACCESS_TOKEN to avoid shell history exposure.",
+    )
+    parser.add_argument(
+        "--output-root",
+        default=str(DEFAULT_OUTPUT_ROOT),
+        help="Ignored/debug root where comparison artifacts are written.",
+    )
+    parser.add_argument(
+        "--skip-browser",
+        action="store_true",
+        help="Skip the browser/Mapbox GL reference screenshot.",
+    )
+    parser.add_argument(
+        "--skip-qgis",
+        action="store_true",
+        help="Skip the native QGIS vector-tile screenshot.",
+    )
+    parser.add_argument(
+        "--skip-diff",
+        action="store_true",
+        help="Skip diff image generation.",
+    )
+    parser.add_argument(
+        "--browser-timeout-ms",
+        type=int,
+        default=120_000,
+        help="Timeout for browser map loading and screenshot capture.",
+    )
+    return parser
+
+
+def _print_result(result: ComparisonResult) -> None:
+    print(f"Run directory: {result.paths.run_dir}")
+    if result.browser_captured:
+        print(f"Mapbox GL reference: {result.paths.browser_png}")
+    if result.qgis_captured:
+        print(f"QGIS vector render: {result.paths.qgis_png}")
+    if result.diff_captured:
+        print(f"Diff image: {result.paths.diff_png}")
+    print(f"Manifest: {result.paths.manifest_json}")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.list_cameras:
+        print(list_cameras())
+        return 0
+
+    try:
+        token = resolve_mapbox_token(provided_token=args.mapbox_token)
+        config = ComparisonConfig(
+            camera=args.camera,
+            token=token,
+            output_root=Path(args.output_root).expanduser().resolve(),
+            browser=not args.skip_browser,
+            qgis=not args.skip_qgis,
+            diff=not args.skip_diff,
+            browser_timeout_ms=args.browser_timeout_ms,
+        )
+        result = run_comparison(config)
+    except (RuntimeError, ValueError) as exc:
+        parser.exit(2, f"error: {exc}\n")
+
+    _print_result(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import dataclasses
 import datetime as dt
 import json
@@ -242,10 +243,10 @@ def build_mapbox_gl_html(*, camera: MapboxComparisonCamera) -> str:
 def build_node_playwright_capture_script() -> str:
     return r"""
 const fs = require('fs');
-const { pathToFileURL } = require('url');
 const { chromium } = require('playwright');
 
-const [htmlPath, outputPath, widthText, heightText, timeoutText, executablePath] = process.argv.slice(2);
+const [encodedHtml, outputPath, widthText, heightText, timeoutText, executablePath] = process.argv.slice(2);
+const html = Buffer.from(encodedHtml, 'base64').toString('utf8');
 const width = Number.parseInt(widthText, 10);
 const height = Number.parseInt(heightText, 10);
 const timeout = Number.parseInt(timeoutText, 10);
@@ -265,7 +266,7 @@ const timeout = Number.parseInt(timeoutText, 10);
   const browser = await chromium.launch(launchOptions);
   try {
     const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor: 1 });
-    await page.goto(pathToFileURL(htmlPath).href, { waitUntil: 'domcontentloaded', timeout });
+    await page.setContent(html, { waitUntil: 'domcontentloaded', timeout });
     await page.evaluate((value) => window.startQfitMapboxComparison(value), credential);
     await page.waitForFunction('window.qfitMapboxReady === true', { timeout });
     await page.screenshot({ path: outputPath, fullPage: false });
@@ -309,12 +310,9 @@ def redact_sensitive_text(text: str, secret: str) -> str:
     return text.replace(secret, "<redacted>")
 
 
-def write_browser_capture_assets(*, camera: MapboxComparisonCamera, directory: Path) -> tuple[Path, Path]:
-    html_path = directory / "reference.html"
-    script_path = directory / "capture-reference.js"
-    html_path.write_text(build_mapbox_gl_html(camera=camera), encoding="utf-8")
-    script_path.write_text(build_node_playwright_capture_script(), encoding="utf-8")
-    return html_path, script_path
+def encode_browser_capture_html(*, camera: MapboxComparisonCamera) -> str:
+    html = build_mapbox_gl_html(camera=camera).encode("utf-8")
+    return base64.b64encode(html).decode("ascii")
 
 
 def render_browser_reference(  # pragma: no cover - depends on optional Node/Chromium toolchain
@@ -333,11 +331,12 @@ def render_browser_reference(  # pragma: no cover - depends on optional Node/Chr
 
     with tempfile.TemporaryDirectory(prefix="qfit-mapbox-reference-") as tmpdir:
         tmp_path = Path(tmpdir)
-        html_path, script_path = write_browser_capture_assets(camera=camera, directory=tmp_path)
+        script_path = tmp_path / "capture-reference.js"
+        script_path.write_text(build_node_playwright_capture_script(), encoding="utf-8")
         command = [
             node_binary,
             str(script_path),
-            str(html_path),
+            encode_browser_capture_html(camera=camera),
             str(output_path),
             str(camera.width),
             str(camera.height),
@@ -643,7 +642,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     if args.list_cameras:
-        print(list_cameras())
+        sys.stdout.write(f"{list_cameras()}\n")
         return 0
 
     try:


### PR DESCRIPTION
## Summary

- add a dev-only Mapbox Outdoors browser-vs-QGIS visual comparison harness
- capture browser reference, QGIS native vector render, diff, and redacted manifest under the ignored debug tree
- document required local tooling and add README links

## Testing

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 validation/mapbox_outdoors_comparison.py --list-cameras`

## Visual comparison

- Rendering-sensitive production behavior: not changed
- Harness output path: `debug/mapbox-outdoors-comparison/<camera>/<timestamp>/`
- Manual full capture requires local Mapbox token, Playwright/Chromium, PyQGIS, and Pillow as documented

Fixes #948
