### PR TITLE
feat: add Mapbox Outdoors comparison zoom matrix

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -28,9 +28,15 @@ List supported cameras:
 python3 validation/mapbox_outdoors_comparison.py --list-cameras
 ```
 
-Current camera:
+Recommended z5-z18 inspection matrix:
 
-- `valais-geneva-outdoors` — representative Geneva/Valais corridor view using `mapbox/outdoors-v12`
+| Camera | Band | Purpose |
+| --- | --- | --- |
+| `switzerland-alps-z5-outdoors` | z5 | Country-wide Switzerland/Alps context: landcover, terrain/water balance, major roads, label density. |
+| `valais-geneva-outdoors` | z7-z8 | Regional qfit map context: terrain/outdoor features, main road hierarchy, settlement visibility. |
+| `lausanne-lavaux-z10-outdoors` | z9-z11 | Primary qfit activity-area target: road/trail hierarchy, labels, feature density, color/width balance. |
+| `chamonix-trails-z14-outdoors` | z13-z14 | Local outdoor detail: paths/trails, minor roads, POIs, label emphasis. |
+| `zermatt-trails-z18-outdoors` | z18 | Street/trail-level stress test: casing, widths, local labels, POIs, high-detail symbols. |
 
 ## Required local tools
 
@@ -58,6 +64,20 @@ python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors
 ```
 
 The command prints only artifact paths. It does not print the token, and `manifest.json` intentionally excludes token values. The QGIS capture builds a temporary vector-tile layer for rendering and does not clear the active QGIS project.
+
+To refresh the full inspection matrix manually, run each listed camera and compare the generated run directories:
+
+```bash
+for camera in \
+  switzerland-alps-z5-outdoors \
+  valais-geneva-outdoors \
+  lausanne-lavaux-z10-outdoors \
+  chamonix-trails-z14-outdoors \
+  zermatt-trails-z18-outdoors
+do
+  python3 validation/mapbox_outdoors_comparison.py "$camera"
+done
+```
 
 ## Partial captures
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -52,6 +52,17 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("valais-geneva-outdoors", text)
         self.assertIn("mapbox/outdoors-v12", text)
 
+    def test_camera_matrix_covers_required_mapbox_outdoors_zoom_bands(self):
+        self.assertLessEqual(CAMERAS["switzerland-alps-z5-outdoors"].zoom, 5.5)
+        self.assertTrue(7.0 <= CAMERAS["valais-geneva-outdoors"].zoom <= 8.5)
+        self.assertTrue(9.0 <= CAMERAS["lausanne-lavaux-z10-outdoors"].zoom <= 11.0)
+        self.assertTrue(13.0 <= CAMERAS["chamonix-trails-z14-outdoors"].zoom <= 14.5)
+        self.assertGreaterEqual(CAMERAS["zermatt-trails-z18-outdoors"].zoom, 18.0)
+
+        listed = list_cameras()
+        for camera_name in CAMERAS:
+            self.assertIn(camera_name, listed)
+
     def test_build_run_directory_uses_timestamped_debug_layout(self):
         run_dir = build_run_directory(
             output_root=Path("/tmp/qfit-mapbox"),

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -53,7 +53,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("mapbox/outdoors-v12", text)
 
     def test_camera_matrix_covers_required_mapbox_outdoors_zoom_bands(self):
-        self.assertLessEqual(CAMERAS["switzerland-alps-z5-outdoors"].zoom, 5.5)
+        self.assertTrue(5.0 <= CAMERAS["switzerland-alps-z5-outdoors"].zoom <= 5.5)
         self.assertTrue(7.0 <= CAMERAS["valais-geneva-outdoors"].zoom <= 8.5)
         self.assertTrue(9.0 <= CAMERAS["lausanne-lavaux-z10-outdoors"].zoom <= 11.0)
         self.assertTrue(13.0 <= CAMERAS["chamonix-trails-z14-outdoors"].zoom <= 14.5)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -47,15 +47,63 @@ class MapboxComparisonCamera:
 
 
 CAMERAS: dict[str, MapboxComparisonCamera] = {
+    "switzerland-alps-z5-outdoors": MapboxComparisonCamera(
+        name="switzerland-alps-z5-outdoors",
+        description=(
+            "z5 broad Switzerland-Alps context for landcover, terrain/water balance, "
+            "major roads, and country-scale label density."
+        ),
+        longitude=8.20,
+        latitude=46.80,
+        zoom=5.35,
+        width=1280,
+        height=900,
+    ),
     "valais-geneva-outdoors": MapboxComparisonCamera(
         name="valais-geneva-outdoors",
         description=(
-            "Representative Mapbox Outdoors view spanning the Geneva/Valais corridor "
-            "used for qfit basemap parity checks."
+            "z7-z8 regional qfit map context spanning the Geneva/Valais corridor "
+            "for terrain/outdoor features, main roads, and settlement visibility."
         ),
         longitude=7.14,
         latitude=46.20,
         zoom=8.15,
+        width=1280,
+        height=900,
+    ),
+    "lausanne-lavaux-z10-outdoors": MapboxComparisonCamera(
+        name="lausanne-lavaux-z10-outdoors",
+        description=(
+            "z9-z11 primary qfit activity-area target around Lausanne/Lavaux for "
+            "road/trail hierarchy, labels, feature density, and color/width balance."
+        ),
+        longitude=6.72,
+        latitude=46.49,
+        zoom=10.25,
+        width=1280,
+        height=900,
+    ),
+    "chamonix-trails-z14-outdoors": MapboxComparisonCamera(
+        name="chamonix-trails-z14-outdoors",
+        description=(
+            "z13-z14 local outdoor detail around Chamonix for paths/trails, minor "
+            "roads, POIs, and label emphasis."
+        ),
+        longitude=6.868,
+        latitude=45.923,
+        zoom=13.75,
+        width=1280,
+        height=900,
+    ),
+    "zermatt-trails-z18-outdoors": MapboxComparisonCamera(
+        name="zermatt-trails-z18-outdoors",
+        description=(
+            "z18 street/trail-level stress test around Zermatt for casing, widths, "
+            "local labels, POIs, and high-detail symbol behavior."
+        ),
+        longitude=7.748,
+        latitude=46.020,
+        zoom=18.0,
         width=1280,
         height=900,
     ),


### PR DESCRIPTION
## Summary
- add a Mapbox Outdoors z5-z18 camera matrix to the manual comparison harness
- document the recommended inspection bands and a loop for refreshing the full matrix
- test that the harness covers the required zoom bands and lists every camera

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q`
- `python3 validation/mapbox_outdoors_comparison.py --list-cameras`
- `python3 -m pytest tests/ -x -q --tb=short`
- `PYTHON_KEYRING_BACKEND=keyring.backends.fail.Keyring coverage run -m unittest discover -s tests -v` + `coverage report validation/mapbox_outdoors_comparison.py` (85%)
- `python3 scripts/package_plugin.py`

Refs #949
