### PR TITLE
docs: clarify Mapbox raster vector parity expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ See:
 
 qfit can load an optional Mapbox basemap and keep it below the qfit layers in the QGIS layer tree.
 
+For Mapbox basemaps, raster mode is the recommended choice when you need the closest visual match to Mapbox's own rendering. Vector mode is rendered natively by QGIS and should be treated as a practical local approximation: it can be more interactive and inspectable inside QGIS, but fonts, labels, sprites, antialiasing, and zoom interpolation will not be pixel-identical to Mapbox GL JS.
+
 The current visualization flow supports:
 
 - semantic activity styling by activity type

--- a/docs/map-style-guide.md
+++ b/docs/map-style-guide.md
@@ -317,6 +317,27 @@ Outline:
 
 ## 9. QGIS Implementation
 
+### Mapbox raster vs vector expectations
+
+Use **Mapbox raster tiles** when the goal is the closest visual parity with
+Mapbox's own renderer. Raster tiles are pre-rendered by Mapbox, so they preserve
+Mapbox GL styling decisions such as labels, sprites, fonts, antialiasing, and
+zoom interpolation more faithfully.
+
+Use **Mapbox vector tiles** when the goal is native QGIS rendering for an
+interactive/local workflow. qfit converts and simplifies Mapbox style rules for
+QGIS, but this remains an approximation: QGIS and Mapbox GL JS differ in
+expression support, label placement and collision behavior, symbol/sprite
+handling, font substitution, antialiasing, and zoom-stop interpolation.
+
+For Mapbox Outdoors specifically:
+
+- raster mode is the user-facing choice for highest visual fidelity;
+- vector mode is intended to be a useful QGIS-native approximation, not a
+  pixel-perfect clone;
+- rendering-sensitive vector changes should be checked with the manual visual
+  comparison harness in `docs/mapbox-outdoors-comparison-harness.md`.
+
 ### Symbology
 
 Layer Properties → Symbology → Categorized  


### PR DESCRIPTION
## Summary
- document Mapbox raster mode as the closest visual-parity option
- clarify that Mapbox vector mode is a QGIS-native approximation, not pixel-perfect Mapbox GL JS rendering
- point rendering-sensitive vector changes to the manual Mapbox Outdoors comparison harness

## Tests
- `grep -RIn "raster mode is the recommended\|Mapbox raster vs vector expectations\|pixel-perfect" README.md docs/map-style-guide.md`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

Closes #950
