### PR TITLE
fix: place atlas PDF output before export action

### DIFF
--- a/tests/test_local_first_control_installer.py
+++ b/tests/test_local_first_control_installer.py
@@ -12,6 +12,7 @@ from qfit.ui.application.local_first_control_installer import (
     install_local_first_widget_controls,
     install_local_first_widget_move,
     local_first_after_install_hook_for_key,
+    local_first_layout_index_of,
 )
 from qfit.ui.application.local_first_control_moves import (
     HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
@@ -149,6 +150,14 @@ class LocalFirstControlInstallerTests(unittest.TestCase):
                 HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
             )
         )
+
+    def test_layout_index_falls_back_to_test_layout_widget_list(self):
+        anchor = object()
+        layout = SimpleNamespace(widgets=[object(), anchor])
+
+        self.assertEqual(local_first_layout_index_of(layout, anchor), 1)
+        self.assertIsNone(local_first_layout_index_of(layout, object()))
+        self.assertIsNone(local_first_layout_index_of(SimpleNamespace(), anchor))
 
     def test_installs_group_move_from_audited_inventory(self):
         source_layout = MagicMock()

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -111,6 +111,7 @@ class LocalFirstControlMoveTests(unittest.TestCase):
             move.after_install_hook_key,
             HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
         )
+        self.assertEqual(move.insert_before_attr, "action_row")
 
         backfill = local_first_control_move_for_key("backfill_routes")
         self.assertTrue(backfill.show_after_move)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -52,14 +52,23 @@ class _FakeLayout:
     def __init__(self):
         self.inserted = []
         self.added = []
+        self.widgets = []
         self.contents_margins = None
         self.spacing = None
 
+    def indexOf(self, widget):
+        try:
+            return self.widgets.index(widget)
+        except ValueError:
+            return -1
+
     def insertWidget(self, index, widget):
         self.inserted.append((index, widget))
+        self.widgets.insert(index, widget)
 
     def addWidget(self, widget):
         self.added.append(widget)
+        self.widgets.append(widget)
 
     def setContentsMargins(self, *margins):
         self.contents_margins = margins
@@ -1509,8 +1518,13 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         source_layout = _SourceLayout()
         source_parent = _SourceParent(source_layout)
         atlas_pdf_group = _AtlasPdfGroup(source_parent)
+        atlas_action_row = object()
         atlas_layout = _FakeLayout()
-        atlas_content = SimpleNamespace(outer_layout=lambda: atlas_layout)
+        atlas_layout.widgets.append(atlas_action_row)
+        atlas_content = SimpleNamespace(
+            action_row=atlas_action_row,
+            outer_layout=lambda: atlas_layout,
+        )
         composition = SimpleNamespace(atlas_content=atlas_content)
         dock.atlasPdfGroupBox = atlas_pdf_group
         dock.generateAtlasPdfButton = MagicMock()
@@ -1541,7 +1555,9 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIs(atlas_pdf_group.parentWidget(), atlas_content)
         self.assertEqual(atlas_pdf_group.title, "PDF output")
         self.assertTrue(atlas_pdf_group.shown)
-        self.assertEqual(atlas_layout.added, [atlas_pdf_group])
+        self.assertEqual(atlas_layout.added, [])
+        self.assertEqual(atlas_layout.inserted, [(0, atlas_pdf_group)])
+        self.assertEqual(atlas_layout.widgets, [atlas_pdf_group, atlas_action_row])
         self.assertEqual(dock.generateAtlasPdfButton.hide.call_count, 2)
         self.assertTrue(dock._local_first_atlas_pdf_controls_installed)
 

--- a/ui/application/local_first_control_installer.py
+++ b/ui/application/local_first_control_installer.py
@@ -104,7 +104,7 @@ def install_local_first_group_controls(
         group.setParent(parent_panel)
     if move.title is not None and hasattr(group, "setTitle"):
         group.setTitle(move.title)
-    layout.addWidget(group)
+    add_local_first_group_to_layout(layout, group, content, move)
     show_local_first_control_group(group, move)
     refresh_local_first_control_visibility(content, move)
 
@@ -130,6 +130,44 @@ def local_first_control_move_layout(
 
     layout_getter = getattr(content, move.layout_getter_attr, None)
     return layout_getter() if callable(layout_getter) else None
+
+
+def add_local_first_group_to_layout(
+    layout,
+    group,
+    content,
+    move: LocalFirstControlMove,
+) -> None:
+    """Place a moved control group at its audited destination position."""
+
+    anchor_attr = move.insert_before_attr
+    anchor = getattr(content, anchor_attr, None) if anchor_attr is not None else None
+    anchor_index = local_first_layout_index_of(layout, anchor)
+    if anchor_index is not None and hasattr(layout, "insertWidget"):
+        layout.insertWidget(anchor_index, group)
+        return
+    layout.addWidget(group)
+
+
+def local_first_layout_index_of(layout, widget) -> int | None:
+    """Return a layout index for ``widget`` when the layout can report one."""
+
+    if widget is None:
+        return None
+    index_of = getattr(layout, "indexOf", None)
+    if callable(index_of):
+        index = index_of(widget)
+        if isinstance(index, int) and index >= 0:
+            return index
+    widgets = getattr(layout, "widgets", None)
+    if widgets is not None:
+        try:
+            index = widgets.index(widget)
+        except ValueError:
+            return None
+        if isinstance(index, int):
+            return index
+    return None
 
 
 def local_first_control_move_parent_panel(
@@ -248,6 +286,7 @@ def show_widget(widget) -> None:
 
 
 __all__ = [
+    "add_local_first_group_to_layout",
     "after_local_first_control_move_installed",
     "install_local_first_audited_controls",
     "install_local_first_control_move",
@@ -256,6 +295,7 @@ __all__ = [
     "install_local_first_widget_controls",
     "local_first_after_install_hook_for_key",
     "local_first_control_move_layout",
+    "local_first_layout_index_of",
     "local_first_control_move_parent_panel",
     "local_first_control_move_required_widgets_available",
     "local_first_widget_move_widgets",

--- a/ui/application/local_first_control_installer.py
+++ b/ui/application/local_first_control_installer.py
@@ -162,11 +162,9 @@ def local_first_layout_index_of(layout, widget) -> int | None:
     widgets = getattr(layout, "widgets", None)
     if widgets is not None:
         try:
-            index = widgets.index(widget)
+            return widgets.index(widget)
         except ValueError:
             return None
-        if isinstance(index, int):
-            return index
     return None
 
 

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -12,9 +12,10 @@ class LocalFirstControlMove:
     """Legacy-backed control group that is explicitly surfaced in local-first UI.
 
     ``post_install_visible_attr`` names an optional content method that refreshes
-    local-first visibility after a move. Keep it explicit instead of deriving it
-    from the layout name so inventory entries fail review when their contracts
-    drift.
+    local-first visibility after a move. ``insert_before_attr`` names an optional
+    destination-page widget that the group should be inserted before. Keep these
+    explicit instead of deriving them from layout names so inventory entries fail
+    review when their contracts drift.
     """
 
     key: str
@@ -29,6 +30,7 @@ class LocalFirstControlMove:
     parent_panel_attr: str | None = None
     post_install_visible_attr: str | None = None
     after_install_hook_key: str | None = None
+    insert_before_attr: str | None = None
 
 
 @dataclass(frozen=True)
@@ -114,6 +116,7 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         installed_target_attr="_local_first_atlas_pdf_controls_installed_target",
         title="PDF output",
         after_install_hook_key=HIDE_LEGACY_ATLAS_EXPORT_BUTTON_HOOK,
+        insert_before_attr="action_row",
     ),
     LocalFirstControlMove(
         key="basemap",


### PR DESCRIPTION
## Summary
- add an audited insertion anchor for local-first control groups
- move the Atlas PDF output group before the Atlas page primary action row
- keep the legacy generate button hidden after the move so the local-first Export atlas PDF button remains the final action

## Validation
- `python3 -m pytest tests/test_local_first_control_moves.py tests/test_local_first_control_installer.py tests/test_qfit_dockwidget_analysis_pure.py::TestQfitDockWidgetAnalysisPure::test_local_first_atlas_pdf_controls_move_to_atlas_page tests/test_atlas_page.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `git diff --check`

Closes #955
