### PR TITLE
fix: simplify formatted Mapbox labels

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -387,12 +387,7 @@ def _simplify_text_field(expr: object) -> object:
     if not isinstance(expr, list) or not expr:
         return expr
     op = expr[0]
-    if op == "coalesce":
-        # Return the first simple ['get', field] child
-        for child in expr[1:]:
-            if isinstance(child, list) and len(child) == 2 and child[0] == "get" and isinstance(child[1], str):
-                return child
-    if op in {"concat", "format", "to-string"}:
+    if op in {"coalesce", "concat", "format", "to-string"}:
         reference = _first_simple_text_field_reference(expr)
         if reference is not None:
             return reference

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -358,7 +358,7 @@ def _extract_midrange_size(expr: object) -> float | None:
     return None
 
 
-def _first_simple_text_field_reference(expr: object) -> object | None:
+def _first_simple_text_field_reference(expr: object, *, allow_concat: bool = True) -> object | None:
     """Return the first direct ``['get', field]`` from text-oriented expressions."""
     if not isinstance(expr, list) or not expr:
         return None
@@ -367,21 +367,24 @@ def _first_simple_text_field_reference(expr: object) -> object | None:
         return expr
     if op == "coalesce":
         for child in expr[1:]:
-            if isinstance(child, list) and len(child) == 2 and child[0] == "get" and isinstance(child[1], str):
-                return child
+            reference = _first_simple_text_field_reference(child, allow_concat=False)
+            if reference is not None:
+                return reference
         for child in expr[1:]:
             reference = _first_simple_text_field_reference(child)
             if reference is not None:
                 return reference
+    if op == "concat" and not allow_concat:
+        return None
     if op in {"concat", "format"}:
         for child in expr[1:]:
             if isinstance(child, dict):
                 continue
-            reference = _first_simple_text_field_reference(child)
+            reference = _first_simple_text_field_reference(child, allow_concat=allow_concat)
             if reference is not None:
                 return reference
     if op == "to-string" and len(expr) >= 2:
-        return _first_simple_text_field_reference(expr[1])
+        return _first_simple_text_field_reference(expr[1], allow_concat=allow_concat)
     return None
 
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -365,7 +365,15 @@ def _first_simple_text_field_reference(expr: object) -> object | None:
     op = expr[0]
     if op == "get" and len(expr) == 2 and isinstance(expr[1], str):
         return expr
-    if op in {"coalesce", "concat", "format"}:
+    if op == "coalesce":
+        for child in expr[1:]:
+            if isinstance(child, list) and len(child) == 2 and child[0] == "get" and isinstance(child[1], str):
+                return child
+        for child in expr[1:]:
+            reference = _first_simple_text_field_reference(child)
+            if reference is not None:
+                return reference
+    if op in {"concat", "format"}:
         for child in expr[1:]:
             if isinstance(child, dict):
                 continue

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -358,11 +358,31 @@ def _extract_midrange_size(expr: object) -> float | None:
     return None
 
 
+def _first_simple_text_field_reference(expr: object) -> object | None:
+    """Return the first direct ``['get', field]`` from text-oriented expressions."""
+    if not isinstance(expr, list) or not expr:
+        return None
+    op = expr[0]
+    if op == "get" and len(expr) == 2 and isinstance(expr[1], str):
+        return expr
+    if op in {"coalesce", "concat", "format"}:
+        for child in expr[1:]:
+            if isinstance(child, dict):
+                continue
+            reference = _first_simple_text_field_reference(child)
+            if reference is not None:
+                return reference
+    if op == "to-string" and len(expr) >= 2:
+        return _first_simple_text_field_reference(expr[1])
+    return None
+
+
 def _simplify_text_field(expr: object) -> object:
     """Simplify a Mapbox text-field expression to the first simple field reference.
 
-    QGIS handles ``['get', 'name']`` but not ``['coalesce', ['get', 'name_en'], ['get', 'name'], ...]``.
-    We extract the first ``['get', <field>]`` from a coalesce and return it directly.
+    QGIS handles ``['get', 'name']`` but not richer Mapbox label expressions such
+    as ``coalesce`` or ``format``. We extract the first useful ``['get', <field>]``
+    reference so formatted labels still render with their primary label text.
     """
     if not isinstance(expr, list) or not expr:
         return expr
@@ -372,6 +392,10 @@ def _simplify_text_field(expr: object) -> object:
         for child in expr[1:]:
             if isinstance(child, list) and len(child) == 2 and child[0] == "get" and isinstance(child[1], str):
                 return child
+    if op in {"concat", "format", "to-string"}:
+        reference = _first_simple_text_field_reference(expr)
+        if reference is not None:
+            return reference
     if op == "step":
         # step expressions for text-field — find the first literal string fallback
         for item in expr[1:]:

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -362,24 +362,42 @@ def _is_simple_text_field_reference(expr: object) -> bool:
     return isinstance(expr, list) and len(expr) == 2 and expr[0] == "get" and isinstance(expr[1], str)
 
 
-def _first_text_field_reference_child(children: list[object], *, allow_concat: bool) -> object | None:
+def _first_text_field_reference_child(
+    children: list[object],
+    *,
+    allow_concat: bool,
+    allow_to_string: bool = True,
+) -> object | None:
     for child in children:
         if isinstance(child, dict):
             continue
-        reference = _first_simple_text_field_reference(child, allow_concat=allow_concat)
+        reference = _first_simple_text_field_reference(
+            child,
+            allow_concat=allow_concat,
+            allow_to_string=allow_to_string,
+        )
         if reference is not None:
             return reference
     return None
 
 
 def _first_coalesced_text_field_reference(expr: list[object]) -> object | None:
-    reference = _first_text_field_reference_child(expr[1:], allow_concat=False)
+    reference = _first_text_field_reference_child(
+        expr[1:],
+        allow_concat=False,
+        allow_to_string=False,
+    )
     if reference is not None:
         return reference
     return _first_text_field_reference_child(expr[1:], allow_concat=True)
 
 
-def _first_simple_text_field_reference(expr: object, *, allow_concat: bool = True) -> object | None:
+def _first_simple_text_field_reference(
+    expr: object,
+    *,
+    allow_concat: bool = True,
+    allow_to_string: bool = True,
+) -> object | None:
     """Return the first direct ``['get', field]`` from text-oriented expressions."""
     if not isinstance(expr, list) or not expr:
         return None
@@ -391,9 +409,19 @@ def _first_simple_text_field_reference(expr: object, *, allow_concat: bool = Tru
     if op == "concat" and not allow_concat:
         return None
     if op in {"concat", "format"}:
-        return _first_text_field_reference_child(expr[1:], allow_concat=allow_concat)
+        return _first_text_field_reference_child(
+            expr[1:],
+            allow_concat=allow_concat,
+            allow_to_string=allow_to_string,
+        )
     if op == "to-string" and len(expr) >= 2:
-        return _first_simple_text_field_reference(expr[1], allow_concat=allow_concat)
+        if not allow_to_string:
+            return None
+        return _first_simple_text_field_reference(
+            expr[1],
+            allow_concat=allow_concat,
+            allow_to_string=allow_to_string,
+        )
     return None
 
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -358,31 +358,40 @@ def _extract_midrange_size(expr: object) -> float | None:
     return None
 
 
+def _is_simple_text_field_reference(expr: object) -> bool:
+    return isinstance(expr, list) and len(expr) == 2 and expr[0] == "get" and isinstance(expr[1], str)
+
+
+def _first_text_field_reference_child(children: list[object], *, allow_concat: bool) -> object | None:
+    for child in children:
+        if isinstance(child, dict):
+            continue
+        reference = _first_simple_text_field_reference(child, allow_concat=allow_concat)
+        if reference is not None:
+            return reference
+    return None
+
+
+def _first_coalesced_text_field_reference(expr: list[object]) -> object | None:
+    reference = _first_text_field_reference_child(expr[1:], allow_concat=False)
+    if reference is not None:
+        return reference
+    return _first_text_field_reference_child(expr[1:], allow_concat=True)
+
+
 def _first_simple_text_field_reference(expr: object, *, allow_concat: bool = True) -> object | None:
     """Return the first direct ``['get', field]`` from text-oriented expressions."""
     if not isinstance(expr, list) or not expr:
         return None
-    op = expr[0]
-    if op == "get" and len(expr) == 2 and isinstance(expr[1], str):
+    if _is_simple_text_field_reference(expr):
         return expr
+    op = expr[0]
     if op == "coalesce":
-        for child in expr[1:]:
-            reference = _first_simple_text_field_reference(child, allow_concat=False)
-            if reference is not None:
-                return reference
-        for child in expr[1:]:
-            reference = _first_simple_text_field_reference(child)
-            if reference is not None:
-                return reference
+        return _first_coalesced_text_field_reference(expr)
     if op == "concat" and not allow_concat:
         return None
     if op in {"concat", "format"}:
-        for child in expr[1:]:
-            if isinstance(child, dict):
-                continue
-            reference = _first_simple_text_field_reference(child, allow_concat=allow_concat)
-            if reference is not None:
-                return reference
+        return _first_text_field_reference_child(expr[1:], allow_concat=allow_concat)
     if op == "to-string" and len(expr) >= 2:
         return _first_simple_text_field_reference(expr[1], allow_concat=allow_concat)
     return None

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -411,6 +411,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
 
+    def test_coalesce_text_field_expression_preserves_formatted_operand_order(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "coalesce",
+                            ["format", ["get", "name_en"], {}],
+                            ["get", "name"],
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name_en"])
+
     def test_concat_text_field_expression_uses_first_stringified_field(self):
         style = {
             "layers": [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -392,6 +392,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
 
+    def test_coalesce_text_field_expression_preserves_direct_fallback_before_nested_optional_field(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "coalesce",
+                            ["concat", ["get", "ref"], " ", ["get", "name"]],
+                            ["get", "name"],
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
+
     def test_concat_text_field_expression_uses_first_stringified_field(self):
         style = {
             "layers": [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -331,6 +331,68 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         width = result["layers"][0]["paint"]["line-width"]
         self.assertEqual(width, 3.0)
 
+    def test_format_text_field_expression_uses_primary_label_field(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "format",
+                            ["get", "name"],
+                            {"font-scale": 1.0},
+                            "\n",
+                            {},
+                            ["get", "ele"],
+                            {"font-scale": 0.8},
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
+
+    def test_nested_format_text_field_expression_uses_first_coalesced_field(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "format",
+                            ["coalesce", ["get", "name_en"], ["get", "name"]],
+                            {"font-scale": 1.0},
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name_en"])
+
+    def test_concat_text_field_expression_uses_first_stringified_field(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "concat",
+                            ["to-string", ["get", "ref"]],
+                            " ",
+                            ["get", "name"],
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "ref"])
+
     def test_original_style_not_mutated(self):
         expr = ["match", ["get", "class"], "motorway", "hsl(15, 100%, 75%)", "hsl(35, 89%, 75%)"]
         style = {"layers": [{"paint": {"line-color": expr}, "layout": {}}]}

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -373,6 +373,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name_en"])
 
+    def test_coalesce_text_field_expression_searches_nested_stringified_field(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "coalesce",
+                            ["to-string", ["get", "name"]],
+                            "",
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
+
     def test_concat_text_field_expression_uses_first_stringified_field(self):
         style = {
             "layers": [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -411,6 +411,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
 
+    def test_coalesce_text_field_expression_preserves_direct_fallback_before_stringified_optional_field(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "coalesce",
+                            ["to-string", ["get", "ref"]],
+                            ["get", "name"],
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
+
     def test_coalesce_text_field_expression_preserves_formatted_operand_order(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

- Simplify Mapbox `format`, `concat`, and `to-string` text-field expressions to a QGIS-compatible `['get', field]` label reference before style conversion.
- Preserve safer `coalesce` fallback behavior so optional `concat`/`to-string` operands do not hide later direct label fallbacks, while formatted primary labels still keep operand order.
- Add regression coverage for formatted, concatenated, stringified, and coalesced label expressions.

## Testing

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 validation/mapbox_outdoors_comparison.py --list-cameras`

## Visual comparison

- Attempted: `QT_QPA_PLATFORM=offscreen python3 validation/mapbox_outdoors_comparison.py lausanne-lavaux-z10-outdoors`
- Blocked locally: no `MAPBOX_ACCESS_TOKEN` or `QFIT_MAPBOX_ACCESS_TOKEN` is configured in this environment.
- QGIS import is available locally, so the harness can be run once a Mapbox token is provided.

Refs ebelo/qfit#949
