### PR TITLE
feat: add full Mapbox camera matrix capture

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -72,6 +72,7 @@ python3 validation/mapbox_outdoors_comparison.py --all-cameras
 ```
 
 `--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.
+Do not pass a positional camera name with `--all-cameras`; use one mode or the other.
 
 ## Partial captures
 

--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -65,19 +65,13 @@ python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors
 
 The command prints only artifact paths. It does not print the token, and `manifest.json` intentionally excludes token values. The QGIS capture builds a temporary vector-tile layer for rendering and does not clear the active QGIS project.
 
-To refresh the full inspection matrix manually, run each listed camera and compare the generated run directories:
+To refresh the full inspection matrix manually, run the z5-z18 camera matrix and compare the generated run directories:
 
 ```bash
-for camera in \
-  switzerland-alps-z5-outdoors \
-  valais-geneva-outdoors \
-  lausanne-lavaux-z10-outdoors \
-  chamonix-trails-z14-outdoors \
-  zermatt-trails-z18-outdoors
-do
-  python3 validation/mapbox_outdoors_comparison.py "$camera"
-done
+python3 validation/mapbox_outdoors_comparison.py --all-cameras
 ```
+
+`--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.
 
 ## Partial captures
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -405,6 +405,36 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(args.skip_qgis)
         self.assertEqual(args.browser_timeout_ms, 5000)
 
+    def test_main_all_cameras_runs_full_inspection_matrix(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        captured_camera_names = []
+
+        def fake_run_comparison(config):
+            captured_camera_names.append(config.camera.name)
+            paths = mapbox_outdoors_comparison.build_comparison_paths(
+                run_dir=Path("/tmp/qfit-mapbox") / config.camera.name / "20260511T130000Z"
+            )
+            return mapbox_outdoors_comparison.ComparisonResult(
+                paths=paths,
+                browser_captured=False,
+                qgis_captured=False,
+                diff_captured=False,
+            )
+
+        with patch.dict("os.environ", {"MAPBOX_ACCESS_TOKEN": "test-mapbox-token"}, clear=True):
+            with patch("qfit.validation.mapbox_outdoors_comparison.run_comparison", side_effect=fake_run_comparison):
+                with patch("builtins.print"):
+                    result = mapbox_outdoors_comparison.main([
+                        "--all-cameras",
+                        "--skip-browser",
+                        "--skip-qgis",
+                        "--skip-diff",
+                    ])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(captured_camera_names, list(CAMERAS))
+
     def test_redact_sensitive_text_removes_token_from_errors(self):
         self.assertEqual(
             redact_sensitive_text("failed for test-mapbox-token", "test-mapbox-token"),

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -435,6 +435,58 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertEqual(captured_camera_names, list(CAMERAS))
 
+    def test_main_rejects_single_camera_with_all_cameras(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with patch("qfit.validation.mapbox_outdoors_comparison.run_comparison") as run_mock:
+            with patch("sys.stderr") as stderr_mock:
+                result = mapbox_outdoors_comparison.main([
+                    "valais-geneva-outdoors",
+                    "--all-cameras",
+                ])
+
+        self.assertEqual(result, 2)
+        run_mock.assert_not_called()
+        stderr_text = "".join(call.args[0] for call in stderr_mock.write.call_args_list)
+        self.assertIn("either a single camera or --all-cameras", stderr_text)
+
+    def test_main_all_cameras_prints_finished_camera_before_later_failure(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        captured_camera_names = []
+
+        def fake_run_comparison(config):
+            captured_camera_names.append(config.camera.name)
+            if len(captured_camera_names) > 1:
+                raise RuntimeError("qgis setup failed")
+            paths = mapbox_outdoors_comparison.build_comparison_paths(
+                run_dir=Path("/tmp/qfit-mapbox") / config.camera.name / "20260511T130000Z"
+            )
+            return mapbox_outdoors_comparison.ComparisonResult(
+                paths=paths,
+                browser_captured=False,
+                qgis_captured=False,
+                diff_captured=False,
+            )
+
+        with patch.dict("os.environ", {"MAPBOX_ACCESS_TOKEN": "test-mapbox-token"}, clear=True):
+            with patch("qfit.validation.mapbox_outdoors_comparison.run_comparison", side_effect=fake_run_comparison):
+                with patch("builtins.print") as print_mock:
+                    with patch("sys.stderr"):
+                        result = mapbox_outdoors_comparison.main([
+                            "--all-cameras",
+                            "--skip-browser",
+                            "--skip-qgis",
+                            "--skip-diff",
+                        ])
+
+        self.assertEqual(result, 2)
+        self.assertEqual(captured_camera_names[:2], list(CAMERAS)[:2])
+        print_mock.assert_any_call("Camera: switzerland-alps-z5-outdoors")
+        print_mock.assert_any_call(
+            "Manifest: /tmp/qfit-mapbox/switzerland-alps-z5-outdoors/20260511T130000Z/manifest.json"
+        )
+
     def test_redact_sensitive_text_removes_token_from_errors(self):
         self.assertEqual(
             redact_sensitive_text("failed for test-mapbox-token", "test-mapbox-token"),

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -619,7 +619,6 @@ def build_parser() -> argparse.ArgumentParser:
         "camera",
         nargs="?",
         type=_parse_camera,
-        default=CAMERAS["valais-geneva-outdoors"],
         help="Comparison camera to capture. Defaults to valais-geneva-outdoors.",
     )
     parser.add_argument(
@@ -665,7 +664,9 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _print_result(result: ComparisonResult) -> None:
+def _print_result(result: ComparisonResult, *, camera_name: str | None = None) -> None:
+    if camera_name is not None:
+        print(f"Camera: {camera_name}")
     print(f"Run directory: {result.paths.run_dir}")
     if result.browser_captured:
         print(f"Mapbox GL reference: {result.paths.browser_png}")
@@ -679,34 +680,42 @@ def _print_result(result: ComparisonResult) -> None:
 def _selected_cameras(args: argparse.Namespace) -> list[MapboxComparisonCamera]:
     if args.all_cameras:
         return list(CAMERAS.values())
-    return [args.camera]
+    return [args.camera or CAMERAS["valais-geneva-outdoors"]]
 
 
-def _run_configured_comparisons(args: argparse.Namespace) -> list[ComparisonResult]:
+def _comparison_config(
+    *,
+    args: argparse.Namespace,
+    camera: MapboxComparisonCamera,
+    token: str,
+    output_root: Path,
+) -> ComparisonConfig:
+    return ComparisonConfig(
+        camera=camera,
+        token=token,
+        output_root=output_root,
+        browser=not args.skip_browser,
+        qgis=not args.skip_qgis,
+        diff=not args.skip_diff,
+        browser_timeout_ms=args.browser_timeout_ms,
+    )
+
+
+def _run_and_print_configured_comparisons(args: argparse.Namespace) -> None:
     token = resolve_mapbox_token(provided_token=args.mapbox_token)
     output_root = Path(args.output_root).expanduser().resolve()
-    return [
-        run_comparison(
-            ComparisonConfig(
+    cameras = _selected_cameras(args)
+    multiple_results = len(cameras) > 1
+    for camera in cameras:
+        result = run_comparison(
+            _comparison_config(
+                args=args,
                 camera=camera,
                 token=token,
                 output_root=output_root,
-                browser=not args.skip_browser,
-                qgis=not args.skip_qgis,
-                diff=not args.skip_diff,
-                browser_timeout_ms=args.browser_timeout_ms,
             )
         )
-        for camera in _selected_cameras(args)
-    ]
-
-
-def _print_results(results: list[ComparisonResult]) -> None:
-    multiple_results = len(results) > 1
-    for result in results:
-        if multiple_results:
-            print(f"Camera: {result.paths.run_dir.parent.name}")
-        _print_result(result)
+        _print_result(result, camera_name=camera.name if multiple_results else None)
 
 
 def _write_stdout_line(text: str) -> None:
@@ -720,9 +729,12 @@ def main(argv: Iterable[str] | None = None) -> int:
     if args.list_cameras:
         _write_stdout_line(list_cameras())
         return 0
+    if args.all_cameras and args.camera is not None:
+        print("error: pass either a single camera or --all-cameras, not both.", file=sys.stderr)
+        return 2
 
     try:
-        results = _run_configured_comparisons(args)
+        _run_and_print_configured_comparisons(args)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -730,7 +742,6 @@ def main(argv: Iterable[str] | None = None) -> int:
         print("error: comparison capture failed; use --skip-browser or --skip-qgis to isolate setup issues.", file=sys.stderr)
         return 2
 
-    _print_results(results)
     return 0
 
 

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -628,6 +628,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="List supported comparison cameras and exit.",
     )
     parser.add_argument(
+        "--all-cameras",
+        action="store_true",
+        help="Capture the full recommended z5-z18 inspection camera matrix.",
+    )
+    parser.add_argument(
         "--mapbox-token",
         help="Mapbox access token. Prefer MAPBOX_ACCESS_TOKEN to avoid shell history exposure.",
     )
@@ -671,18 +676,37 @@ def _print_result(result: ComparisonResult) -> None:
     print(f"Manifest: {result.paths.manifest_json}")
 
 
-def _run_configured_comparison(args: argparse.Namespace) -> ComparisonResult:
+def _selected_cameras(args: argparse.Namespace) -> list[MapboxComparisonCamera]:
+    if args.all_cameras:
+        return list(CAMERAS.values())
+    return [args.camera]
+
+
+def _run_configured_comparisons(args: argparse.Namespace) -> list[ComparisonResult]:
     token = resolve_mapbox_token(provided_token=args.mapbox_token)
-    config = ComparisonConfig(
-        camera=args.camera,
-        token=token,
-        output_root=Path(args.output_root).expanduser().resolve(),
-        browser=not args.skip_browser,
-        qgis=not args.skip_qgis,
-        diff=not args.skip_diff,
-        browser_timeout_ms=args.browser_timeout_ms,
-    )
-    return run_comparison(config)
+    output_root = Path(args.output_root).expanduser().resolve()
+    return [
+        run_comparison(
+            ComparisonConfig(
+                camera=camera,
+                token=token,
+                output_root=output_root,
+                browser=not args.skip_browser,
+                qgis=not args.skip_qgis,
+                diff=not args.skip_diff,
+                browser_timeout_ms=args.browser_timeout_ms,
+            )
+        )
+        for camera in _selected_cameras(args)
+    ]
+
+
+def _print_results(results: list[ComparisonResult]) -> None:
+    multiple_results = len(results) > 1
+    for result in results:
+        if multiple_results:
+            print(f"Camera: {result.paths.run_dir.parent.name}")
+        _print_result(result)
 
 
 def _write_stdout_line(text: str) -> None:
@@ -698,7 +722,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 0
 
     try:
-        result = _run_configured_comparison(args)
+        results = _run_configured_comparisons(args)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -706,7 +730,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         print("error: comparison capture failed; use --skip-browser or --skip-qgis to isolate setup issues.", file=sys.stderr)
         return 2
 
-    _print_result(result)
+    _print_results(results)
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds a `--all-cameras` option to the Mapbox Outdoors comparison harness so the required z5-z18 inspection matrix can be refreshed with one command instead of a manual shell loop.

## Changes

- Add `--all-cameras` CLI support for running every recommended comparison camera in order.
- Print each camera name before its artifact paths during multi-camera runs.
- Update the harness docs to use the new full-matrix command.
- Add regression coverage for the all-camera path.

## Testing

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `MAPBOX_ACCESS_TOKEN=test-mapbox-token python3 validation/mapbox_outdoors_comparison.py --all-cameras --skip-browser --skip-qgis --skip-diff`

Refs ebelo/qfit#949
