### PR TITLE
feat: support pinned Mapbox comparison styles

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -65,10 +65,20 @@ python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors
 
 The command prints only artifact paths. It does not print the token, and `manifest.json` intentionally excludes token values. The QGIS capture builds a temporary vector-tile layer for rendering and does not clear the active QGIS project.
 
+To compare against a pinned/downloaded style snapshot instead of fetching live style metadata, pass `--style-json`. The browser reference uses the same style object and the QGIS render uses it for qfit's style preprocessing; Mapbox vector tiles, glyphs, and sprites still require a token.
+
+```bash
+python3 validation/mapbox_outdoors_comparison.py \
+  valais-geneva-outdoors \
+  --style-json /tmp/mapbox-outdoors-v12.json
+```
+
 To refresh the full inspection matrix manually, run the z5-z18 camera matrix and compare the generated run directories:
 
 ```bash
-python3 validation/mapbox_outdoors_comparison.py --all-cameras
+python3 validation/mapbox_outdoors_comparison.py \
+  --all-cameras \
+  --style-json /tmp/mapbox-outdoors-v12.json
 ```
 
 `--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -26,6 +26,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     encode_browser_capture_html,
     is_valid_qgis_vector_tile_layer,
     list_cameras,
+    load_style_definition,
     redact_sensitive_text,
     render_qgis_vector,
     resolve_mapbox_token,
@@ -34,6 +35,16 @@ from qfit.validation.mapbox_outdoors_comparison import (
 
 
 PNG_PLACEHOLDER = b"not-a-real-png-for-unit-tests"
+SAMPLE_STYLE = {
+    "version": 8,
+    "sources": {
+        "composite": {
+            "type": "vector",
+            "url": "mapbox://mapbox.mapbox-streets-v8",
+        }
+    },
+    "layers": [{"id": "background", "type": "background"}],
+}
 
 
 class MapboxOutdoorsComparisonTests(unittest.TestCase):
@@ -125,6 +136,15 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("qfitMapboxReady", html)
         self.assertNotIn("test-mapbox-token", html)
 
+    def test_build_mapbox_html_can_inline_downloaded_style_json(self):
+        camera = CAMERAS["valais-geneva-outdoors"]
+        html = build_mapbox_gl_html(camera=camera, style_definition=SAMPLE_STYLE)
+
+        self.assertIn('"version": 8', html)
+        self.assertIn('"mapbox://mapbox.mapbox-streets-v8"', html)
+        self.assertNotIn("mapbox://styles/mapbox/outdoors-v12", html)
+        self.assertNotIn("test-mapbox-token", html)
+
     def test_node_capture_script_uses_playwright_and_file_url_without_token(self):
         script = build_node_playwright_capture_script()
 
@@ -145,6 +165,18 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("startQfitMapboxComparison", html)
         self.assertNotIn("test-mapbox-token", html)
         self.assertNotIn("accessToken", html)
+
+    def test_load_style_definition_requires_json_object(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "mapbox-outdoors.json"
+            path.write_text(json.dumps(SAMPLE_STYLE), encoding="utf-8")
+
+            self.assertEqual(load_style_definition(path), SAMPLE_STYLE)
+
+            bad_path = Path(tmpdir) / "bad-style.json"
+            bad_path.write_text("[]", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_style_definition(bad_path)
 
     def test_qgis_vector_tile_guard_rejects_raster_or_invalid_layers(self):
         class FakeVectorTileLayer:
@@ -255,7 +287,11 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         fake_qt_gui.QColor = lambda *values: values
 
         fake_mapbox_config = types.ModuleType("qfit.mapbox_config")
-        fake_mapbox_config.fetch_mapbox_style_definition = lambda *_args: {"version": 8}
+
+        def fail_fetch_style_definition(*_args):
+            raise AssertionError("style should be loaded from the provided style JSON")
+
+        fake_mapbox_config.fetch_mapbox_style_definition = fail_fetch_style_definition
         fake_mapbox_config.simplify_mapbox_style_expressions = lambda style: style
         fake_mapbox_config.extract_mapbox_vector_source_ids = lambda _style: ["mapbox.mapbox-streets-v8"]
         fake_mapbox_config.build_vector_tile_layer_uri = lambda *_args, **_kwargs: "vector://style"
@@ -281,6 +317,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 camera=CAMERAS["valais-geneva-outdoors"],
                 token="test-mapbox-token",
                 output_path=output_path,
+                style_definition=SAMPLE_STYLE,
             )
 
             self.assertEqual(output_path.read_bytes(), PNG_PLACEHOLDER)
@@ -357,6 +394,44 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(manifest["metrics"]["changed_pixel_ratio"], 0.25)
         self.assertEqual(metrics["changed_pixel_ratio"], 0.25)
 
+    def test_run_comparison_passes_downloaded_style_json_to_renderers(self):
+        captured_style_definitions = []
+
+        def fake_browser_renderer(*, output_path, style_definition, **_kwargs):
+            captured_style_definitions.append(("browser", style_definition))
+            output_path.write_bytes(PNG_PLACEHOLDER)
+
+        def fake_qgis_renderer(*, output_path, style_definition, **_kwargs):
+            captured_style_definitions.append(("qgis", style_definition))
+            output_path.write_bytes(PNG_PLACEHOLDER)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            style_path = root / "mapbox-outdoors-v12.json"
+            style_path.write_text(json.dumps(SAMPLE_STYLE), encoding="utf-8")
+
+            result = run_comparison(
+                ComparisonConfig(
+                    camera=CAMERAS["valais-geneva-outdoors"],
+                    token="test-mapbox-token",
+                    output_root=root,
+                    style_json_path=style_path,
+                    diff=False,
+                    now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
+                ),
+                browser_renderer=fake_browser_renderer,
+                qgis_renderer=fake_qgis_renderer,
+            )
+
+            manifest = json.loads(result.paths.manifest_json.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            captured_style_definitions,
+            [("browser", SAMPLE_STYLE), ("qgis", SAMPLE_STYLE)],
+        )
+        self.assertEqual(result.style_json_path, str(style_path))
+        self.assertEqual(manifest["style_json_path"], str(style_path))
+
     def test_run_comparison_skips_diff_when_one_capture_is_disabled(self):
         def fake_qgis_renderer(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
@@ -394,6 +469,8 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             "test-mapbox-token",
             "--output-root",
             "/tmp/qfit-mapbox",
+            "--style-json",
+            "/tmp/mapbox-outdoors-v12.json",
             "--skip-qgis",
             "--browser-timeout-ms",
             "5000",
@@ -402,6 +479,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(args.camera.name, "valais-geneva-outdoors")
         self.assertEqual(args.mapbox_token, "test-mapbox-token")
         self.assertEqual(args.output_root, "/tmp/qfit-mapbox")
+        self.assertEqual(args.style_json, Path("/tmp/mapbox-outdoors-v12.json"))
         self.assertTrue(args.skip_qgis)
         self.assertEqual(args.browser_timeout_ms, 5000)
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -431,6 +431,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         )
         self.assertEqual(result.style_json_path, str(style_path))
         self.assertEqual(manifest["style_json_path"], str(style_path))
+        self.assertIsNone(manifest["style_url"])
 
     def test_run_comparison_skips_diff_when_one_capture_is_disabled(self):
         def fake_qgis_renderer(*, output_path, **_kwargs):
@@ -589,6 +590,28 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
         self.assertEqual(result, 2)
         self.assertIn("Mapbox token required", "".join(call.args[0] for call in stderr_mock.write.call_args_list))
+
+    def test_main_returns_targeted_error_when_style_json_is_missing(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_path = Path(tmpdir) / "missing-style.json"
+            with patch.dict("os.environ", {"MAPBOX_ACCESS_TOKEN": "test-mapbox-token"}, clear=True):
+                with patch("sys.stderr") as stderr_mock:
+                    result = mapbox_outdoors_comparison.main([
+                        "valais-geneva-outdoors",
+                        "--style-json",
+                        str(missing_path),
+                        "--skip-browser",
+                        "--skip-qgis",
+                        "--skip-diff",
+                    ])
+
+        stderr_text = "".join(call.args[0] for call in stderr_mock.write.call_args_list)
+        self.assertEqual(result, 2)
+        self.assertIn("style JSON not found", stderr_text)
+        self.assertIn(str(missing_path), stderr_text)
+        self.assertNotIn("comparison capture failed", stderr_text)
 
     def test_main_uses_generic_error_for_runtime_failures(self):
         from qfit.validation import mapbox_outdoors_comparison

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -28,6 +28,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     list_cameras,
     load_style_definition,
     redact_sensitive_text,
+    render_browser_reference,
     render_qgis_vector,
     resolve_mapbox_token,
     run_comparison,
@@ -149,11 +150,12 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         script = build_node_playwright_capture_script()
 
         self.assertIn("require('playwright')", script)
-        self.assertIn("Buffer.from", script)
         self.assertIn("setContent", script)
         self.assertIn("startQfitMapboxComparison", script)
         self.assertIn("window.qfitMapboxReady", script)
+        self.assertIn("readFileSync(htmlPath", script)
         self.assertIn("readFileSync(0", script)
+        self.assertNotIn("Buffer.from", script)
         self.assertNotIn("accessToken", script)
         self.assertNotIn("MAPBOX_ACCESS_TOKEN", script)
         self.assertNotIn("pk.", script)
@@ -165,6 +167,37 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("startQfitMapboxComparison", html)
         self.assertNotIn("test-mapbox-token", html)
         self.assertNotIn("accessToken", html)
+
+    def test_render_browser_reference_passes_html_file_instead_of_large_argv(self):
+        captured = {}
+        large_style = {
+            **SAMPLE_STYLE,
+            "metadata": {"qfit-large-style-padding": "x" * 150_000},
+        }
+
+        def fake_run(command, **kwargs):
+            html_path = Path(command[2])
+            captured["command"] = command
+            captured["html"] = html_path.read_text(encoding="utf-8")
+            captured["input"] = kwargs["input"]
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "reference.png"
+            with patch("qfit.validation.mapbox_outdoors_comparison.shutil.which", return_value="/usr/bin/node"):
+                with patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run):
+                    render_browser_reference(
+                        camera=CAMERAS["valais-geneva-outdoors"],
+                        token="test-mapbox-token",
+                        output_path=output_path,
+                        timeout_ms=5_000,
+                        style_definition=large_style,
+                    )
+
+        self.assertEqual(captured["input"], "test-mapbox-token")
+        self.assertLess(max(len(value) for value in captured["command"]), 1_000)
+        self.assertIn("qfit-large-style-padding", captured["html"])
+        self.assertNotIn("test-mapbox-token", captured["html"])
 
     def test_load_style_definition_requires_json_object(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -153,7 +153,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("setContent", script)
         self.assertIn("startQfitMapboxComparison", script)
         self.assertIn("window.qfitMapboxReady", script)
-        self.assertIn("readFileSync(htmlPath", script)
+        self.assertIn("JSON.parse", script)
         self.assertIn("readFileSync(0", script)
         self.assertNotIn("Buffer.from", script)
         self.assertNotIn("accessToken", script)
@@ -168,7 +168,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertNotIn("test-mapbox-token", html)
         self.assertNotIn("accessToken", html)
 
-    def test_render_browser_reference_passes_html_file_instead_of_large_argv(self):
+    def test_render_browser_reference_passes_large_html_on_stdin_instead_of_argv(self):
         captured = {}
         large_style = {
             **SAMPLE_STYLE,
@@ -176,10 +176,8 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         }
 
         def fake_run(command, **kwargs):
-            html_path = Path(command[2])
             captured["command"] = command
-            captured["html"] = html_path.read_text(encoding="utf-8")
-            captured["input"] = kwargs["input"]
+            captured["payload"] = json.loads(kwargs["input"])
             return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -194,10 +192,10 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                         style_definition=large_style,
                     )
 
-        self.assertEqual(captured["input"], "test-mapbox-token")
+        self.assertEqual(captured["payload"]["credential"], "test-mapbox-token")
         self.assertLess(max(len(value) for value in captured["command"]), 1_000)
-        self.assertIn("qfit-large-style-padding", captured["html"])
-        self.assertNotIn("test-mapbox-token", captured["html"])
+        self.assertIn("qfit-large-style-padding", captured["payload"]["html"])
+        self.assertNotIn("test-mapbox-token", captured["payload"]["html"])
 
     def test_load_style_definition_requires_json_object(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -308,14 +308,15 @@ def build_node_playwright_capture_script() -> str:
 const fs = require('fs');
 const { chromium } = require('playwright');
 
-const [htmlPath, outputPath, widthText, heightText, timeoutText, executablePath] = process.argv.slice(2);
-const html = fs.readFileSync(htmlPath, 'utf8');
+const [outputPath, widthText, heightText, timeoutText, executablePath] = process.argv.slice(2);
+const payload = JSON.parse(fs.readFileSync(0, 'utf8'));
+const html = payload.html;
 const width = Number.parseInt(widthText, 10);
 const height = Number.parseInt(heightText, 10);
 const timeout = Number.parseInt(timeoutText, 10);
 
 (async () => {
-  const credential = fs.readFileSync(0, 'utf8').trim();
+  const credential = String(payload.credential || '').trim();
   if (!credential) {
     throw new Error('Mapbox token was not provided on stdin.');
   }
@@ -400,13 +401,10 @@ def render_browser_reference(  # pragma: no cover - depends on optional Node/Chr
     with tempfile.TemporaryDirectory(prefix="qfit-mapbox-reference-") as tmpdir:
         tmp_path = Path(tmpdir)
         script_path = tmp_path / "capture-reference.js"
-        html_path = tmp_path / "mapbox-reference.html"
         script_path.write_text(build_node_playwright_capture_script(), encoding="utf-8")
-        html_path.write_text(build_mapbox_gl_html(camera=camera, style_definition=style_definition), encoding="utf-8")
         command = [
             node_binary,
             str(script_path),
-            str(html_path),
             str(output_path),
             str(camera.width),
             str(camera.height),
@@ -417,7 +415,10 @@ def render_browser_reference(  # pragma: no cover - depends on optional Node/Chr
             command,
             cwd=REPO_ROOT,
             env=_node_capture_environment(),
-            input=token,
+            input=json.dumps({
+                "credential": token,
+                "html": build_mapbox_gl_html(camera=camera, style_definition=style_definition),
+            }),
             capture_output=True,
             text=True,
             timeout=max(5.0, timeout_ms / 1000.0 + 10.0),

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -231,7 +231,7 @@ def _redacted_manifest(
 ) -> dict[str, object]:
     return {
         "camera": dataclasses.asdict(camera),
-        "style_url": camera.style_url,
+        "style_url": None if result.style_json_path is not None else camera.style_url,
         "outputs": {
             "browser_reference": str(result.paths.browser_png),
             "qgis_vector_render": str(result.paths.qgis_png),
@@ -783,6 +783,9 @@ def main(argv: Iterable[str] | None = None) -> int:
         _run_and_print_configured_comparisons(args)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except FileNotFoundError as exc:
+        print(f"error: style JSON not found: {exc.filename}", file=sys.stderr)
         return 2
     except (RuntimeError, OSError):
         print("error: comparison capture failed; use --skip-browser or --skip-qgis to isolate setup issues.", file=sys.stderr)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -308,8 +308,8 @@ def build_node_playwright_capture_script() -> str:
 const fs = require('fs');
 const { chromium } = require('playwright');
 
-const [encodedHtml, outputPath, widthText, heightText, timeoutText, executablePath] = process.argv.slice(2);
-const html = Buffer.from(encodedHtml, 'base64').toString('utf8');
+const [htmlPath, outputPath, widthText, heightText, timeoutText, executablePath] = process.argv.slice(2);
+const html = fs.readFileSync(htmlPath, 'utf8');
 const width = Number.parseInt(widthText, 10);
 const height = Number.parseInt(heightText, 10);
 const timeout = Number.parseInt(timeoutText, 10);
@@ -400,11 +400,13 @@ def render_browser_reference(  # pragma: no cover - depends on optional Node/Chr
     with tempfile.TemporaryDirectory(prefix="qfit-mapbox-reference-") as tmpdir:
         tmp_path = Path(tmpdir)
         script_path = tmp_path / "capture-reference.js"
+        html_path = tmp_path / "mapbox-reference.html"
         script_path.write_text(build_node_playwright_capture_script(), encoding="utf-8")
+        html_path.write_text(build_mapbox_gl_html(camera=camera, style_definition=style_definition), encoding="utf-8")
         command = [
             node_binary,
             str(script_path),
-            encode_browser_capture_html(camera=camera, style_definition=style_definition),
+            str(html_path),
             str(output_path),
             str(camera.width),
             str(camera.height),

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -125,6 +125,7 @@ class ComparisonConfig:
     camera: MapboxComparisonCamera
     token: str
     output_root: Path
+    style_json_path: Path | None = None
     browser: bool = True
     qgis: bool = True
     diff: bool = True
@@ -139,6 +140,7 @@ class ComparisonResult:
     qgis_captured: bool
     diff_captured: bool
     image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
+    style_json_path: str | None = None
 
 
 def _utc_timestamp(now: dt.datetime | None = None) -> str:
@@ -210,6 +212,14 @@ def resolve_mapbox_token(*, provided_token: str | None, environ: dict[str, str] 
     return token
 
 
+def load_style_definition(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Mapbox style JSON must be an object: {path}")
+    return loaded
+
+
 def _ensure_output_directory(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
 
@@ -228,6 +238,7 @@ def _redacted_manifest(
             "diff": str(result.paths.diff_png),
             "metrics": str(result.paths.metrics_json),
         },
+        "style_json_path": result.style_json_path,
         "captured": {
             "browser_reference": result.browser_captured,
             "qgis_vector_render": result.qgis_captured,
@@ -246,10 +257,14 @@ def write_manifest(*, camera: MapboxComparisonCamera, result: ComparisonResult) 
     result.paths.manifest_json.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
 
-def build_mapbox_gl_html(*, camera: MapboxComparisonCamera) -> str:
+def build_mapbox_gl_html(
+    *,
+    camera: MapboxComparisonCamera,
+    style_definition: dict[str, object] | None = None,
+) -> str:
     """Return token-free temporary HTML for the browser reference capture."""
 
-    style_json = json.dumps(camera.style_url)
+    style_json = json.dumps(style_definition if style_definition is not None else camera.style_url)
     center_json = json.dumps([camera.longitude, camera.latitude])
     return f"""<!doctype html>
 <html>
@@ -358,8 +373,12 @@ def redact_sensitive_text(text: str, secret: str) -> str:
     return text.replace(secret, "<redacted>")
 
 
-def encode_browser_capture_html(*, camera: MapboxComparisonCamera) -> str:
-    html = build_mapbox_gl_html(camera=camera).encode("utf-8")
+def encode_browser_capture_html(
+    *,
+    camera: MapboxComparisonCamera,
+    style_definition: dict[str, object] | None = None,
+) -> str:
+    html = build_mapbox_gl_html(camera=camera, style_definition=style_definition).encode("utf-8")
     return base64.b64encode(html).decode("ascii")
 
 
@@ -369,6 +388,7 @@ def render_browser_reference(  # pragma: no cover - depends on optional Node/Chr
     token: str,
     output_path: Path,
     timeout_ms: int,
+    style_definition: dict[str, object] | None = None,
 ) -> None:
     node_binary = shutil.which("node")
     if not node_binary:
@@ -384,7 +404,7 @@ def render_browser_reference(  # pragma: no cover - depends on optional Node/Chr
         command = [
             node_binary,
             str(script_path),
-            encode_browser_capture_html(camera=camera),
+            encode_browser_capture_html(camera=camera, style_definition=style_definition),
             str(output_path),
             str(camera.width),
             str(camera.height),
@@ -425,6 +445,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     camera: MapboxComparisonCamera,
     token: str,
     output_path: Path,
+    style_definition: dict[str, object] | None = None,
 ) -> None:
     _ensure_package_parent_on_path()
     try:
@@ -460,9 +481,13 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
         app.initQgis()
 
     try:
-        style_definition = fetch_mapbox_style_definition(token, camera.style_owner, camera.style_id)
-        simplified_style = simplify_mapbox_style_expressions(style_definition)
-        tileset_ids = extract_mapbox_vector_source_ids(style_definition)
+        resolved_style_definition = (
+            style_definition
+            if style_definition is not None
+            else fetch_mapbox_style_definition(token, camera.style_owner, camera.style_id)
+        )
+        simplified_style = simplify_mapbox_style_expressions(resolved_style_definition)
+        tileset_ids = extract_mapbox_vector_source_ids(resolved_style_definition)
         layer_uri = build_vector_tile_layer_uri(
             token,
             camera.style_owner,
@@ -569,6 +594,11 @@ def run_comparison(
     qgis_captured = False
     diff_captured = False
     image_metrics: ImageMetrics = {}
+    style_definition = (
+        load_style_definition(config.style_json_path)
+        if config.style_json_path is not None
+        else None
+    )
 
     if config.browser:
         browser_renderer(
@@ -576,11 +606,17 @@ def run_comparison(
             token=config.token,
             output_path=paths.browser_png,
             timeout_ms=config.browser_timeout_ms,
+            style_definition=style_definition,
         )
         browser_captured = True
 
     if config.qgis:
-        qgis_renderer(camera=config.camera, token=config.token, output_path=paths.qgis_png)
+        qgis_renderer(
+            camera=config.camera,
+            token=config.token,
+            output_path=paths.qgis_png,
+            style_definition=style_definition,
+        )
         qgis_captured = True
 
     if config.diff and browser_captured and qgis_captured:
@@ -598,6 +634,7 @@ def run_comparison(
         qgis_captured=qgis_captured,
         diff_captured=diff_captured,
         image_metrics=image_metrics,
+        style_json_path=str(config.style_json_path) if config.style_json_path is not None else None,
     )
     write_manifest(camera=config.camera, result=result)
     return result
@@ -634,6 +671,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--mapbox-token",
         help="Mapbox access token. Prefer MAPBOX_ACCESS_TOKEN to avoid shell history exposure.",
+    )
+    parser.add_argument(
+        "--style-json",
+        type=Path,
+        help=(
+            "Use an already downloaded Mapbox style JSON snapshot for the browser reference "
+            "and QGIS style preprocessing instead of fetching live style metadata."
+        ),
     )
     parser.add_argument(
         "--output-root",
@@ -694,6 +739,7 @@ def _comparison_config(
         camera=camera,
         token=token,
         output_root=output_root,
+        style_json_path=args.style_json,
         browser=not args.skip_browser,
         qgis=not args.skip_qgis,
         diff=not args.skip_diff,


### PR DESCRIPTION
## Summary

Adds `--style-json` support to the Mapbox Outdoors comparison harness so visual QA can be run against a pinned/downloaded style snapshot instead of always fetching live style metadata.

## Changes

- Load an already downloaded Mapbox style JSON object for comparison runs.
- Use that style object for the browser reference and the QGIS style preprocessing path.
- Record the style JSON path in the debug manifest without storing tokens.
- Document the pinned-style workflow and add regression coverage.

## Testing

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `MAPBOX_ACCESS_TOKEN=test-mapbox-token python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors --style-json /tmp/qfit-mapbox-style-HfmFdZ.json --skip-browser --skip-qgis --skip-diff`

Refs ebelo/qfit#949
