### PR TITLE
fix: prefer Mapbox fallback labels

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -381,15 +381,59 @@ def _first_text_field_reference_child(
     return None
 
 
+def _text_field_reference_name(reference: object) -> str | None:
+    if (
+        isinstance(reference, list)
+        and len(reference) == 2
+        and reference[0] == "get"
+        and isinstance(reference[1], str)
+    ):
+        return reference[1]
+    return None
+
+
+def _prefer_generic_name_reference(references: list[object]) -> object | None:
+    for reference in references:
+        if _text_field_reference_name(reference) == "name":
+            return reference
+    return references[0] if references else None
+
+
+def _text_field_references_from_children(
+    children: list[object],
+    *,
+    allow_concat: bool,
+    allow_to_string: bool,
+) -> list[object]:
+    references: list[object] = []
+    for child in children:
+        if isinstance(child, dict):
+            continue
+        reference = _first_simple_text_field_reference(
+            child,
+            allow_concat=allow_concat,
+            allow_to_string=allow_to_string,
+        )
+        if reference is not None:
+            references.append(reference)
+    return references
+
+
 def _first_coalesced_text_field_reference(expr: list[object]) -> object | None:
-    reference = _first_text_field_reference_child(
+    references = _text_field_references_from_children(
         expr[1:],
         allow_concat=False,
         allow_to_string=False,
     )
-    if reference is not None:
-        return reference
-    return _first_text_field_reference_child(expr[1:], allow_concat=True)
+    if references:
+        return _prefer_generic_name_reference(references)
+    return _prefer_generic_name_reference(
+        _text_field_references_from_children(
+            expr[1:],
+            allow_concat=True,
+            allow_to_string=True,
+        )
+    )
 
 
 def _first_simple_text_field_reference(

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -394,7 +394,7 @@ def _text_field_reference_name(reference: object) -> str | None:
 
 def _is_localized_name_reference(reference: object) -> bool:
     name = _text_field_reference_name(reference)
-    return name is not None and (name.startswith("name_") or name.startswith("name:"))
+    return name is not None and name.startswith(("name_", "name:"))
 
 
 def _prefer_generic_name_reference(references: list[object]) -> object | None:

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -392,10 +392,16 @@ def _text_field_reference_name(reference: object) -> str | None:
     return None
 
 
+def _is_localized_name_reference(reference: object) -> bool:
+    name = _text_field_reference_name(reference)
+    return name is not None and (name.startswith("name_") or name.startswith("name:"))
+
+
 def _prefer_generic_name_reference(references: list[object]) -> object | None:
-    for reference in references:
+    for index, reference in enumerate(references):
         if _text_field_reference_name(reference) == "name":
-            return reference
+            if index == 0 or all(_is_localized_name_reference(item) for item in references[:index]):
+                return reference
     return references[0] if references else None
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -354,7 +354,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
 
-    def test_nested_format_text_field_expression_uses_first_coalesced_field(self):
+    def test_nested_format_text_field_expression_prefers_generic_name_fallback(self):
         style = {
             "layers": [
                 {
@@ -371,7 +371,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name_en"])
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
 
     def test_coalesce_text_field_expression_searches_nested_stringified_field(self):
         style = {
@@ -430,7 +430,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
 
-    def test_coalesce_text_field_expression_preserves_formatted_operand_order(self):
+    def test_coalesce_text_field_expression_prefers_generic_name_over_formatted_locale(self):
         style = {
             "layers": [
                 {
@@ -439,6 +439,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                             "coalesce",
                             ["format", ["get", "name_en"], {}],
                             ["get", "name"],
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
+
+    def test_coalesce_text_field_expression_keeps_first_reference_without_generic_name(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "coalesce",
+                            ["get", "name_en"],
+                            ["get", "name_fr"],
                         ]
                     },
                 }

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -468,6 +468,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name_en"])
 
+    def test_coalesce_text_field_expression_preserves_non_locale_primary_before_name(self):
+        style = {
+            "layers": [
+                {
+                    "layout": {
+                        "text-field": [
+                            "coalesce",
+                            ["get", "ref"],
+                            ["get", "name"],
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "ref"])
+
     def test_concat_text_field_expression_uses_first_stringified_field(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary
- Prefer the generic `name` field when simplifying Mapbox `coalesce(name_en, name)` label expressions for QGIS.
- Keep the previous first-reference behavior when no generic `name` fallback is available.
- Add regression coverage for nested/formatted coalesce expressions.

## Why
Live #949 audit/comparison showed qfit was collapsing Mapbox Outdoors labels such as roads, POIs, settlements, ferries, and paths to `name_en`. Many local Swiss features do not expose `name_en`, so QGIS rendered large areas with missing labels even though Mapbox GL fell back to `name`.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py tests/test_mapbox_outdoors_style_audit.py -q` → `45 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1874 passed, 163 skipped, 124 subtests passed`
- Live style audit with local QGIS Mapbox token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T180513Z/audit.json`
  - verified `road-label`, `path-pedestrian-label`, `poi-label`, `ferry-aerialway-label`, and settlement labels now simplify to `["get", "name"]`.
- Live comparison artifacts, run one camera per process:
  - `switzerland-alps-z5-outdoors/20260511T180521Z`
  - `valais-geneva-outdoors/20260511T180527Z`
  - `lausanne-lavaux-z10-outdoors/20260511T180532Z`
  - `chamonix-trails-z14-outdoors/20260511T180536Z`
  - `zermatt-trails-z18-outdoors/20260511T180540Z`
- Visual review: labels that were missing before now appear broadly in Lausanne, Chamonix, and Zermatt; no major clutter regression observed.

Fixes part of #949.
