### PR TITLE
fix: simplify Mapbox line layout choices

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -358,6 +358,18 @@ def _extract_midrange_size(expr: object) -> float | None:
     return None
 
 
+def _line_layout_choice(expr: object, choices: set[str]) -> str | None:
+    if isinstance(expr, str) and expr in choices:
+        return expr
+    if not isinstance(expr, list) or len(expr) < 3 or expr[0] != "step":
+        return None
+    step_outputs = [expr[2], *expr[4::2]]
+    for item in reversed(step_outputs):
+        if isinstance(item, str) and item in choices:
+            return item
+    return None
+
+
 def _is_simple_text_field_reference(expr: object) -> bool:
     return isinstance(expr, list) and len(expr) == 2 and expr[0] == "get" and isinstance(expr[1], str)
 
@@ -520,6 +532,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     # We extract a z12-representative value and cap to a sane maximum.
     _WIDTH_PROPS = {"line-width", "line-gap-width", "line-offset"}
     _MAX_LINE_WIDTH_MM = 3.0  # ~11px at 96 DPI — sane max for cartographic lines
+    _LINE_LAYOUT_CHOICES = {
+        "line-cap": {"butt", "round", "square"},
+        "line-join": {"bevel", "round", "miter"},
+    }
     # Per-layer-id text-size overrides to restore cartographic hierarchy.
     _TEXT_SIZE_OVERRIDES: dict[str, object] = {
         "natural-point-label": 9.0,
@@ -598,6 +614,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         size = _extract_midrange_size(val)
                         if size is not None:
                             props[prop] = size
+                elif prop in _LINE_LAYOUT_CHOICES:
+                    choice = _line_layout_choice(val, _LINE_LAYOUT_CHOICES[prop])
+                    if choice is not None:
+                        props[prop] = choice
     return style
 
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -361,11 +361,8 @@ def _extract_midrange_size(expr: object) -> float | None:
 def _line_layout_choice(expr: object, choices: set[str]) -> str | None:
     if not isinstance(expr, list) or len(expr) < 3 or expr[0] != "step" or expr[1] != ["zoom"]:
         return None
-    step_outputs = [expr[2], *expr[4::2]]
-    for item in reversed(step_outputs):
-        if isinstance(item, str) and item in choices:
-            return item
-    return None
+    output = expr[-1] if len(expr) >= 5 else expr[2]
+    return output if isinstance(output, str) and output in choices else None
 
 
 def _is_simple_text_field_reference(expr: object) -> bool:

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -359,9 +359,7 @@ def _extract_midrange_size(expr: object) -> float | None:
 
 
 def _line_layout_choice(expr: object, choices: set[str]) -> str | None:
-    if isinstance(expr, str) and expr in choices:
-        return expr
-    if not isinstance(expr, list) or len(expr) < 3 or expr[0] != "step":
+    if not isinstance(expr, list) or len(expr) < 3 or expr[0] != "step" or expr[1] != ["zoom"]:
         return None
     step_outputs = [expr[2], *expr[4::2]]
     for item in reversed(step_outputs):

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -374,6 +374,21 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["line-join"], expression)
 
+    def test_data_driven_line_join_step_expression_is_left_unchanged(self):
+        expression = ["step", ["get", "rank"], "miter", 3, "round"]
+        style = {
+            "layers": [
+                {
+                    "paint": {},
+                    "layout": {"line-join": expression},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["line-join"], expression)
+
     def test_format_text_field_expression_uses_primary_label_field(self):
         style = {
             "layers": [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -331,6 +331,49 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         width = result["layers"][0]["paint"]["line-width"]
         self.assertEqual(width, 3.0)
 
+    def test_line_cap_step_expression_uses_high_zoom_choice(self):
+        style = {
+            "layers": [
+                {
+                    "paint": {},
+                    "layout": {"line-cap": ["step", ["zoom"], "butt", 14, "round"]},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["line-cap"], "round")
+
+    def test_line_join_step_expression_uses_high_zoom_choice(self):
+        style = {
+            "layers": [
+                {
+                    "paint": {},
+                    "layout": {"line-join": ["step", ["zoom"], "miter", 14, "round"]},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["line-join"], "round")
+
+    def test_unsupported_line_join_expression_is_left_unchanged(self):
+        expression = ["match", ["get", "class"], "path", "round", "miter"]
+        style = {
+            "layers": [
+                {
+                    "paint": {},
+                    "layout": {"line-join": expression},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["line-join"], expression)
+
     def test_format_text_field_expression_uses_primary_label_field(self):
         style = {
             "layers": [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -389,6 +389,21 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["line-join"], expression)
 
+    def test_line_join_step_expression_with_unsupported_high_zoom_choice_is_left_unchanged(self):
+        expression = ["step", ["zoom"], "miter", 14, "none"]
+        style = {
+            "layers": [
+                {
+                    "paint": {},
+                    "layout": {"line-join": expression},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["line-join"], expression)
+
     def test_format_text_field_expression_uses_primary_label_field(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary
- Simplify zoom-based Mapbox `line-cap` and `line-join` step expressions to concrete QGIS-friendly high-zoom layout choices.
- Preserve data-driven, non-step, and unsupported high-zoom layout expressions so unrelated styles keep their existing behavior/audit handling.
- Add regression tests for cap/join simplification and unsupported expression preservation.

## Why
Live #949 style audit showed Mapbox Outdoors still handed many road/water `line-cap` and `line-join` zoom-step expressions directly to QGIS. These expressions are typically low-zoom `butt`/`miter` with high-zoom `round`; qfit's comparison cameras are map-rendering views where the rounded high-zoom choice is the safer literal approximation.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py tests/test_mapbox_outdoors_style_audit.py -q` → `51 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1880 passed, 163 skipped, 124 subtests passed`
- Live style audit with local QGIS Mapbox token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T184312Z/audit.json`
  - `layout.line-cap`: 31 simplified, 0 unresolved
  - `layout.line-join`: 28 simplified, 0 unresolved
- Live comparison artifacts, run one camera per process:
  - `switzerland-alps-z5-outdoors/20260511T182427Z`
  - `valais-geneva-outdoors/20260511T182432Z`
  - `lausanne-lavaux-z10-outdoors/20260511T182437Z`
  - `chamonix-trails-z14-outdoors/20260511T182441Z`
  - `zermatt-trails-z18-outdoors/20260511T182445Z`
- Visual review: road/water/path geometry had no visible regression; the change is a small safe approximation and reduces audit debt.

Fixes part of #949.
