### PR TITLE
fix: ignore literal dash arrays in Mapbox audit

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -50,6 +50,16 @@ SAMPLE_STYLE = {
             "layout": {"line-cap": "round"},
         },
         {
+            "id": "road-path",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "road",
+            "paint": {
+                "line-dasharray": ["step", ["zoom"], ["literal", [3, 3]], 12, ["literal", [4, 4]]],
+            },
+            "layout": {},
+        },
+        {
             "id": "poi-label",
             "type": "symbol",
             "source": "composite",
@@ -108,7 +118,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )
 
         self.assertEqual(audit["style"]["label"], "mapbox/outdoors-v12")
-        self.assertEqual(audit["layer_count"], 4)
+        self.assertEqual(audit["layer_count"], 5)
 
         layers = {layer["id"]: layer for layer in audit["layers"]}
         self.assertEqual(layers["background"]["group"], "background")
@@ -123,6 +133,9 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("layout.line-cap", layers["road-primary"]["qfit_preserves"])
         road_unresolved = {item["property"] for item in layers["road-primary"]["qfit_unresolved"]}
         self.assertNotIn("paint.line-dasharray", road_unresolved)
+
+        path_unresolved = {item["property"] for item in layers["road-path"]["qfit_unresolved"]}
+        self.assertIn("paint.line-dasharray", path_unresolved)
 
         poi_simplified = {change["property"] for change in layers["poi-label"]["qfit_simplifies"]}
         self.assertIn("layout.text-field", poi_simplified)
@@ -157,7 +170,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         rendered = render_audit(audit, output_format="json")
 
         decoded = json.loads(rendered)
-        self.assertEqual(decoded["layer_count"], 4)
+        self.assertEqual(decoded["layer_count"], 5)
         self.assertEqual(decoded["layers"][0]["id"], "background")
 
     def test_load_style_definition_requires_json_object(self):

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -44,6 +44,7 @@ SAMPLE_STYLE = {
             "minzoom": 5,
             "paint": {
                 "line-color": ["match", ["get", "class"], "primary", "#ffffff", "#cccccc"],
+                "line-dasharray": [3, 3],
                 "line-width": ["interpolate", ["linear"], ["zoom"], 5, 1, 12, 6],
             },
             "layout": {"line-cap": "round"},
@@ -118,7 +119,10 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         road_simplified = {change["property"] for change in layers["road-primary"]["qfit_simplifies"]}
         self.assertIn("paint.line-color", road_simplified)
         self.assertIn("paint.line-width", road_simplified)
+        self.assertIn("paint.line-dasharray", layers["road-primary"]["qfit_preserves"])
         self.assertIn("layout.line-cap", layers["road-primary"]["qfit_preserves"])
+        road_unresolved = {item["property"] for item in layers["road-primary"]["qfit_unresolved"]}
+        self.assertNotIn("paint.line-dasharray", road_unresolved)
 
         poi_simplified = {change["property"] for change in layers["poi-label"]["qfit_simplifies"]}
         self.assertIn("layout.text-field", poi_simplified)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -195,7 +195,7 @@ def _is_supported_simple_text_field(value: object) -> bool:
 
 
 def _is_literal_number_array(value: object) -> bool:
-    return isinstance(value, list) and all(isinstance(item, (int, float)) for item in value)
+    return isinstance(value, list) and len(value) > 0 and all(isinstance(item, (int, float)) for item in value)
 
 
 def _is_hidden_by_qfit(simplified_layer: dict[str, object] | None) -> bool:

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -194,6 +194,10 @@ def _is_supported_simple_text_field(value: object) -> bool:
     )
 
 
+def _is_literal_number_array(value: object) -> bool:
+    return isinstance(value, list) and all(isinstance(item, (int, float)) for item in value)
+
+
 def _is_hidden_by_qfit(simplified_layer: dict[str, object] | None) -> bool:
     if simplified_layer is None:
         return False
@@ -217,7 +221,8 @@ def _unresolved_cues(layer: dict[str, object], simplified_layer: dict[str, objec
                 }
             )
         elif isinstance(value, list) and not (
-            section == "layout" and prop == "text-field" and _is_supported_simple_text_field(value)
+            (section == "layout" and prop == "text-field" and _is_supported_simple_text_field(value))
+            or (section == "paint" and prop == "line-dasharray" and _is_literal_number_array(value))
         ):
             unresolved.append(
                 {


### PR DESCRIPTION
## Summary
- Stop flagging literal numeric `line-dasharray` arrays as unresolved Mapbox expressions in the style audit.
- Keep actual dasharray expressions visible in `qfit_unresolved`.
- Add regression coverage to the style-audit sample.

## Why
After #968, the live #949 audit still listed `paint.line-dasharray` as the largest unresolved category, but 14 of those entries were literal numeric arrays such as `[3, 3]`, not expressions. This PR keeps the audit focused on real unresolved expression work.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py tests/test_mapbox_config.py -q` → `51 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1880 passed, 163 skipped, 124 subtests passed`
- Live style audit with local QGIS Mapbox token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T185450Z/audit.json`
  - `paint.line-dasharray` unresolved count decreased from 33 to 19; remaining entries are actual expressions.

Fixes part of #949.
