### PR TITLE
fix: ignore literal numeric arrays in Mapbox audit

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -69,6 +69,7 @@ SAMPLE_STYLE = {
             "layout": {
                 "text-field": ["format", ["get", "name"], {}, "\n", {}, ["get", "name_en"], {}],
                 "text-size": ["interpolate", ["linear"], ["zoom"], 10, 10, 14, 14],
+                "text-offset": [0, 0.8],
                 "icon-image": ["get", "maki"],
             },
             "paint": {
@@ -142,10 +143,12 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("layout.text-size", poi_simplified)
         self.assertIn("paint.text-halo-color", poi_simplified)
         self.assertIn("filter", layers["poi-label"]["qfit_preserves"])
+        self.assertIn("layout.text-offset", layers["poi-label"]["qfit_preserves"])
 
         unresolved = {item["property"]: item["reason"] for item in layers["poi-label"]["qfit_unresolved"]}
         self.assertIn("layout.icon-image", unresolved)
         self.assertNotIn("layout.text-field", unresolved)
+        self.assertNotIn("layout.text-offset", unresolved)
         self.assertIn("sprites", unresolved["layout.icon-image"])
 
         hidden_layer = layers["settlement-subdivision-label"]

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -222,7 +222,7 @@ def _unresolved_cues(layer: dict[str, object], simplified_layer: dict[str, objec
             )
         elif isinstance(value, list) and not (
             (section == "layout" and prop == "text-field" and _is_supported_simple_text_field(value))
-            or (section == "paint" and prop == "line-dasharray" and _is_literal_number_array(value))
+            or _is_literal_number_array(value)
         ):
             unresolved.append(
                 {


### PR DESCRIPTION
## Summary
- Treat non-empty literal numeric arrays as preserved values in the Mapbox Outdoors style audit.
- Keep explicit unsupported cues and expression arrays visible in `qfit_unresolved`.
- Extend the audit fixture to cover literal `text-offset` arrays.

## Why
After #969, the live #949 audit still reported some literal numeric arrays such as `layout.text-offset: [0, 0.8]` as unresolved expressions. Those are literal style values, not expression-processing gaps, so they add noise to the parity backlog.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py tests/test_mapbox_config.py -q` → `51 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1880 passed, 163 skipped, 124 subtests passed`
- Live style audit with local QGIS Mapbox token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T191454Z/audit.json`
  - `layout.text-offset` unresolved count decreased from 5 to 3; remaining entries are actual expressions.

Fixes part of #949.
