### PR TITLE
feat: summarize Mapbox audit property counts

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -120,6 +120,18 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
 
         self.assertEqual(audit["style"]["label"], "mapbox/outdoors-v12")
         self.assertEqual(audit["layer_count"], 5)
+        summary = audit["summary"]
+        simplified_counts = {
+            item["property"]: item["count"] for item in summary["qfit_simplifies_by_property"]
+        }
+        unresolved_counts = {
+            item["property"]: item["count"] for item in summary["qfit_unresolved_by_property"]
+        }
+        self.assertEqual(simplified_counts["layout.text-field"], 2)
+        self.assertEqual(simplified_counts["paint.line-width"], 1)
+        self.assertEqual(simplified_counts["layout.visibility"], 1)
+        self.assertEqual(unresolved_counts["layout.icon-image"], 1)
+        self.assertEqual(unresolved_counts["paint.line-dasharray"], 1)
 
         layers = {layer["id"]: layer for layer in audit["layers"]}
         self.assertEqual(layers["background"]["group"], "background")
@@ -163,6 +175,12 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
 
         self.assertIn("# Mapbox Outdoors style audit", markdown)
         self.assertIn("`road-primary`", markdown)
+        self.assertIn("## Summary", markdown)
+        self.assertIn("### Simplified/substituted by qfit", markdown)
+        self.assertIn("| `paint.line-width` | 1 |", markdown)
+        self.assertIn("### QGIS-dependent / unresolved", markdown)
+        self.assertIn("| `layout.icon-image` | 1 |", markdown)
+        self.assertIn("## Layers", markdown)
         self.assertIn("composite / road", markdown)
         self.assertIn("`paint.line-width`", markdown)
         self.assertIn("`layout.icon-image`", markdown)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -6,6 +6,7 @@ import datetime as dt
 import json
 import os
 import sys
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -255,6 +256,23 @@ def build_layer_audit(
     }
 
 
+def _property_count_summary(layers: list[dict[str, object]], key: str) -> list[dict[str, object]]:
+    counts: Counter[str] = Counter()
+    for layer in layers:
+        values = layer.get(key)
+        if not isinstance(values, list):
+            continue
+        for item in values:
+            if isinstance(item, str):
+                counts[item] += 1
+            elif isinstance(item, dict) and isinstance(item.get("property"), str):
+                counts[item["property"]] += 1
+    return [
+        {"property": property_name, "count": count}
+        for property_name, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
 def build_style_audit(
     style_definition: dict[str, object],
     *,
@@ -282,6 +300,10 @@ def build_style_audit(
         },
         "generated_at": generated_at.isoformat(),
         "layer_count": len(layers),
+        "summary": {
+            "qfit_simplifies_by_property": _property_count_summary(layers, "qfit_simplifies"),
+            "qfit_unresolved_by_property": _property_count_summary(layers, "qfit_unresolved"),
+        },
         "layers": layers,
     }
 
@@ -308,9 +330,20 @@ def _markdown_unresolved_list(unresolved: list[dict[str, str]], *, empty: str = 
     )
 
 
+def _markdown_count_table(items: list[dict[str, object]], *, empty: str = "—") -> list[str]:
+    if not items:
+        return [empty, ""]
+    lines = ["| Property | # Layers |", "| --- | ---: |"]
+    for item in items:
+        lines.append(f"| `{item.get('property', '')}` | {item.get('count', 0)} |")
+    lines.append("")
+    return lines
+
+
 def build_audit_markdown(audit: dict[str, object]) -> str:
     style = audit["style"] if isinstance(audit.get("style"), dict) else {}
     layers = audit.get("layers") if isinstance(audit.get("layers"), list) else []
+    summary = audit.get("summary") if isinstance(audit.get("summary"), dict) else {}
     lines = [
         f"# Mapbox Outdoors style audit — {style.get('label', 'mapbox/outdoors-v12')}",
         "",
@@ -319,6 +352,16 @@ def build_audit_markdown(audit: dict[str, object]) -> str:
         "",
         "This developer audit compares the live Mapbox style rules with qfit's current QGIS preprocessing.",
         "Use it to choose the next visual-parity slice before making rendering-sensitive changes.",
+        "",
+        "## Summary",
+        "",
+        "### Simplified/substituted by qfit",
+        "",
+        *_markdown_count_table(list(summary.get("qfit_simplifies_by_property") or [])),
+        "### QGIS-dependent / unresolved",
+        "",
+        *_markdown_count_table(list(summary.get("qfit_unresolved_by_property") or [])),
+        "## Layers",
         "",
         "| Layer | Group | Source/filter | Zoom | Preserved | Simplified/substituted by qfit | QGIS-dependent / unresolved |",
         "| --- | --- | --- | --- | --- | --- | --- |",


### PR DESCRIPTION
## Summary
- Add top-level Mapbox audit summary counts for qfit-simplified and unresolved properties.
- Render those counts in the markdown audit before the per-layer table.
- Cover the JSON and markdown summary output in audit tests.

## Why
#949 decisions are currently driven by repeated ad-hoc counters over `audit.json`. Putting the by-property counts directly into the generated audit makes each artifact self-contained and easier to use for the next visual-parity slice without changing rendering behavior.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py tests/test_mapbox_config.py -q` → `51 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1880 passed, 163 skipped, 124 subtests passed`
- Live style audit with local QGIS Mapbox token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T192631Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T192631Z/audit.md`
  - Summary reports current top unresolved properties: `paint.line-opacity` 25, `layout.text-font` 24, `layout.icon-image` 20, `paint.line-dasharray` 19, `paint.fill-opacity` 9.

Fixes part of #949.
