### PR TITLE
feat: add QGIS converter warnings to Mapbox audit

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -137,6 +137,17 @@ debug/mapbox-outdoors-style-audit/<style>/<UTC timestamp>/audit.md
 
 The audit summarizes each relevant style layer's source layer, filter, zoom band, paint/layout symbology, properties qfit preserves, properties qfit simplifies or substitutes before handing the style to QGIS, and cues that remain QGIS-dependent such as sprites, patterns, fonts, or still-live expressions.
 
+When PyQGIS is available, include QGIS' native Mapbox GL converter warnings to compare the raw Mapbox style with qfit's preprocessed style and see which warnings remain after qfit simplification:
+
+```bash
+QT_QPA_PLATFORM=offscreen \
+python3 validation/mapbox_outdoors_style_audit.py \
+  --format json \
+  --include-qgis-converter-warnings
+```
+
+This optional probe does not render screenshots. It records converter warning counts and warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit.
+
 Use the audit together with the screenshot harness: first identify high-signal gaps visually, then check the corresponding style layers to decide the smallest safe qfit preprocessing improvement.
 
 ## PR notes

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -1,8 +1,11 @@
 import datetime as dt
 import json
+import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import patch
 
 from tests import _path  # noqa: F401
@@ -91,6 +94,53 @@ SAMPLE_STYLE = {
 }
 
 
+def _fake_qgis_modules(warning_sets, *, existing_app=None):
+    qgis_module = ModuleType("qgis")
+    qgis_core = ModuleType("qgis.core")
+
+    class FakeQgsApplication:
+        current_instance = existing_app
+        created = []
+
+        def __init__(self, args, gui_enabled):
+            self.args = args
+            self.gui_enabled = gui_enabled
+            self.init_qgis_calls = 0
+            self.exit_qgis_calls = 0
+            FakeQgsApplication.current_instance = self
+            FakeQgsApplication.created.append(self)
+
+        @classmethod
+        def instance(cls):
+            return cls.current_instance
+
+        def initQgis(self):
+            self.init_qgis_calls += 1
+
+        def exitQgis(self):
+            self.exit_qgis_calls += 1
+            FakeQgsApplication.current_instance = None
+
+    class FakeQgsMapBoxGlStyleConverter:
+        converted_styles = []
+        created_count = 0
+
+        def __init__(self):
+            self.index = FakeQgsMapBoxGlStyleConverter.created_count
+            FakeQgsMapBoxGlStyleConverter.created_count += 1
+
+        def convert(self, style_definition):
+            FakeQgsMapBoxGlStyleConverter.converted_styles.append(style_definition)
+
+        def warnings(self):
+            return warning_sets[self.index]
+
+    qgis_core.QgsApplication = FakeQgsApplication
+    qgis_core.QgsMapBoxGlStyleConverter = FakeQgsMapBoxGlStyleConverter
+    qgis_module.core = qgis_core
+    return qgis_module, qgis_core, FakeQgsApplication, FakeQgsMapBoxGlStyleConverter
+
+
 class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
     def test_resolve_token_prefers_argument_then_environment(self):
         self.assertEqual(
@@ -169,6 +219,104 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(hidden_changes["layout.visibility"]["to"], '"none"')
         self.assertEqual(hidden_layer["qfit_unresolved"], [])
 
+    def test_build_style_audit_can_include_qgis_converter_warning_summary(self):
+        warning_report = {
+            "raw": {"count": 3},
+            "qfit_preprocessed": {
+                "count": 2,
+                "by_message": [{"message": "Skipping unsupported expression", "count": 2}],
+                "by_layer": [{"layer": "poi-label", "count": 2}],
+            },
+            "warning_count_delta": 1,
+        }
+        with patch.object(
+            mapbox_outdoors_style_audit,
+            "_qgis_converter_warning_report",
+            return_value=warning_report,
+        ) as report_mock:
+            audit = build_style_audit(
+                SAMPLE_STYLE,
+                config=StyleAuditConfig(include_qgis_converter_warnings=True),
+            )
+
+        self.assertEqual(audit["qgis_converter_warnings"], warning_report)
+        report_mock.assert_called_once()
+        self.assertIs(report_mock.call_args.kwargs["raw_style"], SAMPLE_STYLE)
+        self.assertIsInstance(report_mock.call_args.kwargs["qfit_preprocessed_style"], dict)
+
+    def test_qgis_warning_summary_counts_by_message_and_layer(self):
+        summary = mapbox_outdoors_style_audit._qgis_warning_summary(
+            [
+                "road-primary: Skipping unsupported expression",
+                "poi-label: Skipping unsupported expression",
+                "poi-label: Referenced font DIN Pro Medium is not available on system",
+                "Could not find sprite image",
+            ]
+        )
+
+        self.assertEqual(summary["count"], 4)
+        self.assertEqual(
+            summary["by_message"],
+            [
+                {"message": "Skipping unsupported expression", "count": 2},
+                {"message": "Could not find sprite image", "count": 1},
+                {"message": "Referenced font DIN Pro Medium is not available on system", "count": 1},
+            ],
+        )
+        self.assertEqual(
+            summary["by_layer"],
+            [
+                {"layer": "poi-label", "count": 2},
+                {"layer": "road-primary", "count": 1},
+            ],
+        )
+
+    def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):
+        raw_style = {"layers": []}
+        qfit_style = {"layers": [{"id": "poi-label"}]}
+        fake_qgis, fake_core, fake_app, fake_converter = _fake_qgis_modules(
+            [
+                ["road-primary: Skipping unsupported expression"],
+                ["poi-label: Referenced font DIN Pro Medium is not available on system"],
+            ]
+        )
+
+        with patch.dict(sys.modules, {"qgis": fake_qgis, "qgis.core": fake_core}), patch.dict(
+            os.environ, {}, clear=False
+        ):
+            os.environ.pop("QT_QPA_PLATFORM", None)
+            report = mapbox_outdoors_style_audit._qgis_converter_warning_report(
+                raw_style=raw_style,
+                qfit_preprocessed_style=qfit_style,
+            )
+
+        self.assertEqual(report["raw"]["count"], 1)
+        self.assertEqual(report["qfit_preprocessed"]["count"], 1)
+        self.assertEqual(report["warning_count_delta"], 0)
+        self.assertEqual(fake_converter.converted_styles, [raw_style, qfit_style])
+        self.assertEqual(len(fake_app.created), 1)
+        self.assertEqual(fake_app.created[0].args, [])
+        self.assertFalse(fake_app.created[0].gui_enabled)
+        self.assertEqual(fake_app.created[0].init_qgis_calls, 1)
+        self.assertEqual(fake_app.created[0].exit_qgis_calls, 1)
+
+    def test_qgis_converter_warning_report_reuses_existing_qgis_app(self):
+        existing_app = object()
+        fake_qgis, fake_core, fake_app, _fake_converter = _fake_qgis_modules(
+            [["raw warning"], ["qfit warning"]],
+            existing_app=existing_app,
+        )
+
+        with patch.dict(sys.modules, {"qgis": fake_qgis, "qgis.core": fake_core}):
+            report = mapbox_outdoors_style_audit._qgis_converter_warning_report(
+                raw_style={"layers": []},
+                qfit_preprocessed_style={"layers": []},
+            )
+
+        self.assertEqual(report["raw"]["warnings"], ["raw warning"])
+        self.assertEqual(report["qfit_preprocessed"]["warnings"], ["qfit warning"])
+        self.assertEqual(fake_app.created, [])
+
     def test_markdown_summarizes_source_filter_preserved_and_unresolved_cues(self):
         audit = build_style_audit(SAMPLE_STYLE)
         markdown = build_audit_markdown(audit)
@@ -185,6 +333,26 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("`paint.line-width`", markdown)
         self.assertIn("`layout.icon-image`", markdown)
         self.assertIn("Mapbox sprite references", markdown)
+
+    def test_markdown_can_include_qgis_converter_warning_summary(self):
+        audit = build_style_audit(SAMPLE_STYLE)
+        audit["qgis_converter_warnings"] = {
+            "raw": {"count": 3},
+            "qfit_preprocessed": {
+                "count": 2,
+                "by_message": [{"message": "Skipping unsupported expression", "count": 2}],
+                "by_layer": [{"layer": "poi-label", "count": 2}],
+            },
+            "warning_count_delta": 1,
+        }
+
+        markdown = build_audit_markdown(audit)
+
+        self.assertIn("### QGIS converter warnings", markdown)
+        self.assertIn("Raw style warnings: 3", markdown)
+        self.assertIn("After qfit preprocessing: 2", markdown)
+        self.assertIn("| `Skipping unsupported expression` | 2 |", markdown)
+        self.assertIn("| `poi-label` | 2 |", markdown)
 
     def test_render_json_returns_machine_readable_audit(self):
         audit = build_style_audit(SAMPLE_STYLE)
@@ -223,10 +391,13 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             print_mock.assert_called_once_with(output_path)
 
     def test_parser_exposes_json_and_style_json_options(self):
-        args = build_parser().parse_args(["--style-json", "style.json", "--format", "json"])
+        args = build_parser().parse_args(
+            ["--style-json", "style.json", "--format", "json", "--include-qgis-converter-warnings"]
+        )
 
         self.assertEqual(args.style_json, Path("style.json"))
         self.assertEqual(args.format, "json")
+        self.assertTrue(args.include_qgis_converter_warnings)
 
 
 if __name__ == "__main__":

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -54,6 +54,7 @@ class StyleAuditConfig:
     style_owner: str = DEFAULT_MAPBOX_STYLE_OWNER
     style_id: str = DEFAULT_MAPBOX_STYLE_ID
     generated_at: dt.datetime | None = None
+    include_qgis_converter_warnings: bool = False
 
 
 def _utc_timestamp(now: dt.datetime | None = None) -> str:
@@ -273,6 +274,72 @@ def _property_count_summary(layers: list[dict[str, object]], key: str) -> list[d
     ]
 
 
+def _warning_count_summary(warnings: list[str], *, by_layer: bool) -> list[dict[str, object]]:
+    counts: Counter[str] = Counter()
+    for warning in warnings:
+        layer, separator, message = warning.partition(": ")
+        if not separator:
+            key = "" if by_layer else warning
+        elif by_layer:
+            key = layer
+        else:
+            key = message
+        if key:
+            counts[key] += 1
+    key_name = "layer" if by_layer else "message"
+    return [
+        {key_name: key, "count": count}
+        for key, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def _qgis_warning_summary(warnings: list[str]) -> dict[str, object]:
+    return {
+        "count": len(warnings),
+        "by_message": _warning_count_summary(warnings, by_layer=False),
+        "by_layer": _warning_count_summary(warnings, by_layer=True),
+        "warnings": warnings,
+    }
+
+
+def _collect_qgis_converter_warnings(style_definition: dict[str, object]) -> list[str]:
+    from qgis.core import QgsMapBoxGlStyleConverter  # noqa: PLC0415
+
+    converter = QgsMapBoxGlStyleConverter()
+    converter.convert(style_definition)
+    return list(converter.warnings())
+
+
+def _qgis_converter_warning_report(
+    *,
+    raw_style: dict[str, object],
+    qfit_preprocessed_style: dict[str, object],
+) -> dict[str, object]:
+    # Converter-only audits do not render, but headless environments can still abort when Qt
+    # defaults to xcb. Prefer offscreen unless the caller explicitly chose another platform.
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from qgis.core import QgsApplication  # noqa: PLC0415
+
+    app = QgsApplication.instance()
+    created_app = False
+    if app is None:
+        app = QgsApplication([], False)
+        app.initQgis()
+        created_app = True
+
+    try:
+        raw_warnings = _collect_qgis_converter_warnings(raw_style)
+        qfit_warnings = _collect_qgis_converter_warnings(qfit_preprocessed_style)
+    finally:
+        if created_app:
+            app.exitQgis()
+    return {
+        "raw": _qgis_warning_summary(raw_warnings),
+        "qfit_preprocessed": _qgis_warning_summary(qfit_warnings),
+        "warning_count_delta": len(raw_warnings) - len(qfit_warnings),
+    }
+
+
 def build_style_audit(
     style_definition: dict[str, object],
     *,
@@ -292,7 +359,7 @@ def build_style_audit(
         if isinstance(layer, dict)
     ]
     generated_at = resolved_config.generated_at or dt.datetime.now(dt.timezone.utc)
-    return {
+    audit = {
         "style": {
             "owner": resolved_config.style_owner,
             "id": resolved_config.style_id,
@@ -306,6 +373,12 @@ def build_style_audit(
         },
         "layers": layers,
     }
+    if resolved_config.include_qgis_converter_warnings:
+        audit["qgis_converter_warnings"] = _qgis_converter_warning_report(
+            raw_style=style_definition,
+            qfit_preprocessed_style=simplified_style,
+        )
+    return audit
 
 
 def _markdown_list(items: list[str], *, empty: str = "—") -> str:
@@ -340,6 +413,44 @@ def _markdown_count_table(items: list[dict[str, object]], *, empty: str = "—")
     return lines
 
 
+def _markdown_named_count_table(
+    items: list[dict[str, object]],
+    *,
+    key: str,
+    label: str,
+    empty: str = "—",
+) -> list[str]:
+    if not items:
+        return [empty, ""]
+    lines = [f"| {label} | Count |", "| --- | ---: |"]
+    for item in items:
+        lines.append(f"| `{item.get(key, '')}` | {item.get('count', 0)} |")
+    lines.append("")
+    return lines
+
+
+def _markdown_qgis_converter_warnings(report: object) -> list[str]:
+    if not isinstance(report, dict):
+        return []
+    raw = report.get("raw") if isinstance(report.get("raw"), dict) else {}
+    qfit = report.get("qfit_preprocessed") if isinstance(report.get("qfit_preprocessed"), dict) else {}
+    lines = [
+        "### QGIS converter warnings",
+        "",
+        f"Raw style warnings: {raw.get('count', 0)}",
+        f"After qfit preprocessing: {qfit.get('count', 0)}",
+        f"Warning count delta: {report.get('warning_count_delta', 0)}",
+        "",
+        "#### Remaining warnings by message",
+        "",
+        *_markdown_named_count_table(list(qfit.get("by_message") or []), key="message", label="Message"),
+        "#### Remaining warnings by layer",
+        "",
+        *_markdown_named_count_table(list(qfit.get("by_layer") or []), key="layer", label="Layer"),
+    ]
+    return lines
+
+
 def build_audit_markdown(audit: dict[str, object]) -> str:
     style = audit["style"] if isinstance(audit.get("style"), dict) else {}
     layers = audit.get("layers") if isinstance(audit.get("layers"), list) else []
@@ -361,6 +472,7 @@ def build_audit_markdown(audit: dict[str, object]) -> str:
         "### QGIS-dependent / unresolved",
         "",
         *_markdown_count_table(list(summary.get("qfit_unresolved_by_property") or [])),
+        *_markdown_qgis_converter_warnings(audit.get("qgis_converter_warnings")),
         "## Layers",
         "",
         "| Layer | Group | Source/filter | Zoom | Preserved | Simplified/substituted by qfit | QGIS-dependent / unresolved |",
@@ -446,6 +558,14 @@ def build_parser() -> argparse.ArgumentParser:
         default="markdown",
         help="Audit output format. Defaults to markdown.",
     )
+    parser.add_argument(
+        "--include-qgis-converter-warnings",
+        action="store_true",
+        help=(
+            "Also run QGIS' Mapbox GL style converter on the raw and qfit-preprocessed "
+            "style to summarize native conversion warnings. Requires PyQGIS."
+        ),
+    )
     return parser
 
 
@@ -461,7 +581,11 @@ def main(argv: list[str] | None = None) -> int:
 
     audit = build_style_audit(
         style_definition,
-        config=StyleAuditConfig(style_owner=args.style_owner, style_id=args.style_id),
+        config=StyleAuditConfig(
+            style_owner=args.style_owner,
+            style_id=args.style_id,
+            include_qgis_converter_warnings=args.include_qgis_converter_warnings,
+        ),
     )
     content = render_audit(audit, output_format=args.format)
     output_path = write_audit(content, output_format=args.format)


### PR DESCRIPTION
## Summary
- Add an optional `--include-qgis-converter-warnings` mode to the Mapbox Outdoors style audit.
- Compare QGIS `QgsMapBoxGlStyleConverter` warnings for the raw Mapbox style vs qfit's preprocessed style.
- Include warning counts/summaries in JSON and Markdown audit artifacts, with tests and docs.

## Why
Emman's current #949 direction is to spend time researching better Mapbox/QGIS styling approaches instead of rushing closure. QGIS already exposes converter warnings for Mapbox GL style gaps, so surfacing those warnings in the audit gives us a more direct evidence source for future PR-sized rendering slices.

## Live evidence
Using the local QGIS profile Mapbox token without printing it:
- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T195614Z/audit.json`
- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T195615Z/audit.md`
- Raw Mapbox Outdoors converter warnings: 159
- After qfit preprocessing: 121
- Delta: 38 fewer warnings
- Top remaining qfit-preprocessed warning messages:
  - `Skipping unsupported expression`: 70
  - `Referenced font DIN Pro Medium is not available on system`: 10
  - `Could not interpret sprite value list with method step`: 8
  - `Referenced font DIN Pro Italic is not available on system`: 6
  - `Referenced font DIN Pro Regular is not available on system`: 5

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py tests/test_mapbox_config.py -q` → `56 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1885 passed, 163 skipped, 124 subtests passed`
- Live audit command with local token source and `QT_QPA_PLATFORM=offscreen` generated the artifacts above.

Fixes part of #949.
