### PR TITLE
feat: summarize Mapbox warning reductions

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -146,7 +146,7 @@ python3 validation/mapbox_outdoors_style_audit.py \
   --include-qgis-converter-warnings
 ```
 
-This optional probe does not render screenshots. It records converter warning counts and warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit.
+This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, and warnings reduced by qfit preprocessing in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit.
 
 Use the audit together with the screenshot harness: first identify high-signal gaps visually, then check the corresponding style layers to decide the smallest safe qfit preprocessing improvement.
 

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -276,8 +276,11 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         qfit_style = {"layers": [{"id": "poi-label"}]}
         fake_qgis, fake_core, fake_app, fake_converter = _fake_qgis_modules(
             [
-                ["road-primary: Skipping unsupported expression"],
-                ["poi-label: Referenced font DIN Pro Medium is not available on system"],
+                [
+                    "road-primary: Skipping unsupported expression",
+                    "poi-label: Skipping unsupported expression",
+                ],
+                ["poi-label: Skipping unsupported expression"],
             ]
         )
 
@@ -290,9 +293,25 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 qfit_preprocessed_style=qfit_style,
             )
 
-        self.assertEqual(report["raw"]["count"], 1)
+        self.assertEqual(report["raw"]["count"], 2)
         self.assertEqual(report["qfit_preprocessed"]["count"], 1)
-        self.assertEqual(report["warning_count_delta"], 0)
+        self.assertEqual(report["warning_count_delta"], 1)
+        self.assertEqual(
+            report["reduced_by_qfit"],
+            {
+                "by_message": [
+                    {
+                        "message": "Skipping unsupported expression",
+                        "raw_count": 2,
+                        "qfit_count": 1,
+                        "reduced_count": 1,
+                    }
+                ],
+                "by_layer": [
+                    {"layer": "road-primary", "raw_count": 1, "qfit_count": 0, "reduced_count": 1}
+                ],
+            },
+        )
         self.assertEqual(fake_converter.converted_styles, [raw_style, qfit_style])
         self.assertEqual(len(fake_app.created), 1)
         self.assertEqual(fake_app.created[0].args, [])
@@ -344,6 +363,19 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 "by_layer": [{"layer": "poi-label", "count": 2}],
             },
             "warning_count_delta": 1,
+            "reduced_by_qfit": {
+                "by_message": [
+                    {
+                        "message": "Could not parse non-string color , skipping",
+                        "raw_count": 3,
+                        "qfit_count": 0,
+                        "reduced_count": 3,
+                    }
+                ],
+                "by_layer": [
+                    {"layer": "water-depth", "raw_count": 4, "qfit_count": 0, "reduced_count": 4}
+                ],
+            },
         }
 
         markdown = build_audit_markdown(audit)
@@ -351,8 +383,29 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("### QGIS converter warnings", markdown)
         self.assertIn("Raw style warnings: 3", markdown)
         self.assertIn("After qfit preprocessing: 2", markdown)
+        self.assertIn("#### Warnings reduced by qfit preprocessing", markdown)
+        self.assertIn("| `Could not parse non-string color , skipping` | 3 | 0 | 3 |", markdown)
+        self.assertIn("| `water-depth` | 4 | 0 | 4 |", markdown)
         self.assertIn("| `Skipping unsupported expression` | 2 |", markdown)
         self.assertIn("| `poi-label` | 2 |", markdown)
+
+    def test_markdown_omits_qgis_reduction_sections_when_no_reductions_exist(self):
+        audit = build_style_audit(SAMPLE_STYLE)
+        audit["qgis_converter_warnings"] = {
+            "raw": {"count": 1},
+            "qfit_preprocessed": {
+                "count": 1,
+                "by_message": [{"message": "Skipping unsupported expression", "count": 1}],
+                "by_layer": [{"layer": "poi-label", "count": 1}],
+            },
+            "warning_count_delta": 0,
+        }
+
+        markdown = build_audit_markdown(audit)
+
+        self.assertNotIn("#### Warnings reduced by qfit preprocessing", markdown)
+        self.assertNotIn("#### Layers with fewer warnings after qfit preprocessing", markdown)
+        self.assertIn("#### Remaining warnings by message", markdown)
 
     def test_render_json_returns_machine_readable_audit(self):
         audit = build_style_audit(SAMPLE_STYLE)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -302,6 +302,46 @@ def _qgis_warning_summary(warnings: list[str]) -> dict[str, object]:
     }
 
 
+def _warning_reduction_summary(
+    raw_counts: list[dict[str, object]],
+    qfit_counts: list[dict[str, object]],
+    *,
+    key: str,
+) -> list[dict[str, object]]:
+    raw_by_key = {str(item.get(key) or ""): int(item.get("count") or 0) for item in raw_counts}
+    qfit_by_key = {str(item.get(key) or ""): int(item.get("count") or 0) for item in qfit_counts}
+    reductions = []
+    for name, raw_count in raw_by_key.items():
+        if not name:
+            continue
+        qfit_count = qfit_by_key.get(name, 0)
+        reduced_count = raw_count - qfit_count
+        if reduced_count > 0:
+            reductions.append(
+                {
+                    key: name,
+                    "raw_count": raw_count,
+                    "qfit_count": qfit_count,
+                    "reduced_count": reduced_count,
+                }
+            )
+    return sorted(reductions, key=lambda item: (-int(item["reduced_count"]), str(item[key])))
+
+
+def _qgis_warning_reduction_report(
+    raw_summary: dict[str, object],
+    qfit_summary: dict[str, object],
+) -> dict[str, object]:
+    raw_by_message = list(raw_summary.get("by_message") or [])
+    qfit_by_message = list(qfit_summary.get("by_message") or [])
+    raw_by_layer = list(raw_summary.get("by_layer") or [])
+    qfit_by_layer = list(qfit_summary.get("by_layer") or [])
+    return {
+        "by_message": _warning_reduction_summary(raw_by_message, qfit_by_message, key="message"),
+        "by_layer": _warning_reduction_summary(raw_by_layer, qfit_by_layer, key="layer"),
+    }
+
+
 def _collect_qgis_converter_warnings(style_definition: dict[str, object]) -> list[str]:
     from qgis.core import QgsMapBoxGlStyleConverter  # noqa: PLC0415
 
@@ -333,10 +373,13 @@ def _qgis_converter_warning_report(
     finally:
         if created_app:
             app.exitQgis()
+    raw_summary = _qgis_warning_summary(raw_warnings)
+    qfit_summary = _qgis_warning_summary(qfit_warnings)
     return {
-        "raw": _qgis_warning_summary(raw_warnings),
-        "qfit_preprocessed": _qgis_warning_summary(qfit_warnings),
+        "raw": raw_summary,
+        "qfit_preprocessed": qfit_summary,
         "warning_count_delta": len(raw_warnings) - len(qfit_warnings),
+        "reduced_by_qfit": _qgis_warning_reduction_report(raw_summary, qfit_summary),
     }
 
 
@@ -429,11 +472,37 @@ def _markdown_named_count_table(
     return lines
 
 
+def _markdown_warning_reduction_table(
+    items: list[dict[str, object]],
+    *,
+    key: str,
+    label: str,
+    empty: str = "—",
+) -> list[str]:
+    if not items:
+        return [empty, ""]
+    lines = [f"| {label} | Raw | After qfit | Reduced |", "| --- | ---: | ---: | ---: |"]
+    for item in items:
+        lines.append(
+            "| `{name}` | {raw_count} | {qfit_count} | {reduced_count} |".format(
+                name=item.get(key, ""),
+                raw_count=item.get("raw_count", 0),
+                qfit_count=item.get("qfit_count", 0),
+                reduced_count=item.get("reduced_count", 0),
+            )
+        )
+    lines.append("")
+    return lines
+
+
 def _markdown_qgis_converter_warnings(report: object) -> list[str]:
     if not isinstance(report, dict):
         return []
     raw = report.get("raw") if isinstance(report.get("raw"), dict) else {}
     qfit = report.get("qfit_preprocessed") if isinstance(report.get("qfit_preprocessed"), dict) else {}
+    reduced = report.get("reduced_by_qfit") if isinstance(report.get("reduced_by_qfit"), dict) else {}
+    reduced_by_message = list(reduced.get("by_message") or [])
+    reduced_by_layer = list(reduced.get("by_layer") or [])
     lines = [
         "### QGIS converter warnings",
         "",
@@ -441,13 +510,33 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
         f"After qfit preprocessing: {qfit.get('count', 0)}",
         f"Warning count delta: {report.get('warning_count_delta', 0)}",
         "",
-        "#### Remaining warnings by message",
-        "",
-        *_markdown_named_count_table(list(qfit.get("by_message") or []), key="message", label="Message"),
-        "#### Remaining warnings by layer",
-        "",
-        *_markdown_named_count_table(list(qfit.get("by_layer") or []), key="layer", label="Layer"),
     ]
+    if reduced_by_message:
+        lines.extend(
+            [
+                "#### Warnings reduced by qfit preprocessing",
+                "",
+                *_markdown_warning_reduction_table(reduced_by_message, key="message", label="Message"),
+            ]
+        )
+    if reduced_by_layer:
+        lines.extend(
+            [
+                "#### Layers with fewer warnings after qfit preprocessing",
+                "",
+                *_markdown_warning_reduction_table(reduced_by_layer, key="layer", label="Layer"),
+            ]
+        )
+    lines.extend(
+        [
+            "#### Remaining warnings by message",
+            "",
+            *_markdown_named_count_table(list(qfit.get("by_message") or []), key="message", label="Message"),
+            "#### Remaining warnings by layer",
+            "",
+            *_markdown_named_count_table(list(qfit.get("by_layer") or []), key="layer", label="Layer"),
+        ]
+    )
     return lines
 
 


### PR DESCRIPTION
## Summary
- Add `reduced_by_qfit` summaries to the optional QGIS converter-warning audit report.
- Render Markdown tables for warning messages and layers that have fewer converter warnings after qfit preprocessing.
- Keep remaining-warning tables intact, with tests and docs for the new reduction summary.

## Why
PR #972 made QGIS converter warnings visible. The live audit immediately showed that qfit preprocessing reduces the raw Mapbox Outdoors converter warnings by 38, but the artifact only exposed the total delta. This follow-up makes the reduction breakdown first-class so future #949 slices can distinguish already-improved categories from remaining QGIS gaps.

## Live evidence
Using the local QGIS profile Mapbox token without printing it:
- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T200120Z/audit.json`
- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T200121Z/audit.md`
- Raw Mapbox Outdoors converter warnings: 159
- After qfit preprocessing: 121
- Delta: 38 fewer warnings
- Top warning-message reductions:
  - `Skipping unsupported expression`: 93 → 70 (23 fewer)
  - `Could not set opacity of layer, opacity already defined in stroke color`: 7 → 0 (7 fewer)
  - `Cubic-bezier interpolation is not supported, linear used instead.`: 5 → 0 (5 fewer)
  - `Could not parse non-string color , skipping`: 3 → 0 (3 fewer)
- Top layer reductions:
  - `water-depth`: 4 → 0 (4 fewer)
  - `country-label`: 4 → 2 (2 fewer)
  - `natural-line-label`: 3 → 1 (2 fewer)
  - `natural-point-label`: 4 → 2 (2 fewer)
  - `poi-label`: 5 → 3 (2 fewer)

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py tests/test_mapbox_config.py -q` → `57 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1886 passed, 163 skipped, 124 subtests passed`
- Live audit command with local token source and `QT_QPA_PLATFORM=offscreen` generated the artifacts above and confirmed the new Markdown reduction section.

Fixes part of #949.
