### PR TITLE
feat: flag Mapbox filter expressions in audit

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -135,7 +135,7 @@ Default audit outputs are written under:
 debug/mapbox-outdoors-style-audit/<style>/<UTC timestamp>/audit.md
 ```
 
-The audit summarizes each relevant style layer's source layer, filter, zoom band, paint/layout symbology, properties qfit preserves, properties qfit simplifies or substitutes before handing the style to QGIS, and cues that remain QGIS-dependent such as sprites, patterns, fonts, or still-live expressions.
+The audit summarizes each relevant style layer's source layer, filter, zoom band, paint/layout symbology, properties qfit preserves, properties qfit simplifies or substitutes before handing the style to QGIS, and cues that remain QGIS-dependent such as Mapbox filter expressions, sprites, patterns, fonts, or still-live paint/layout expressions.
 
 When PyQGIS is available, include QGIS' native Mapbox GL converter warnings to compare the raw Mapbox style with qfit's preprocessed style and see which warnings remain after qfit simplification:
 

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -180,6 +180,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(simplified_counts["layout.text-field"], 2)
         self.assertEqual(simplified_counts["paint.line-width"], 1)
         self.assertEqual(simplified_counts["layout.visibility"], 1)
+        self.assertEqual(unresolved_counts["filter"], 1)
         self.assertEqual(unresolved_counts["layout.icon-image"], 1)
         self.assertEqual(unresolved_counts["paint.line-dasharray"], 1)
 
@@ -208,9 +209,11 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("layout.text-offset", layers["poi-label"]["qfit_preserves"])
 
         unresolved = {item["property"]: item["reason"] for item in layers["poi-label"]["qfit_unresolved"]}
+        self.assertIn("filter", unresolved)
         self.assertIn("layout.icon-image", unresolved)
         self.assertNotIn("layout.text-field", unresolved)
         self.assertNotIn("layout.text-offset", unresolved)
+        self.assertIn("filter expression", unresolved["filter"])
         self.assertIn("sprites", unresolved["layout.icon-image"])
 
         hidden_layer = layers["settlement-subdivision-label"]
@@ -346,6 +349,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("### Simplified/substituted by qfit", markdown)
         self.assertIn("| `paint.line-width` | 1 |", markdown)
         self.assertIn("### QGIS-dependent / unresolved", markdown)
+        self.assertIn("| `filter` | 1 |", markdown)
         self.assertIn("| `layout.icon-image` | 1 |", markdown)
         self.assertIn("## Layers", markdown)
         self.assertIn("composite / road", markdown)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -212,6 +212,15 @@ def _unresolved_cues(layer: dict[str, object], simplified_layer: dict[str, objec
 
     unresolved: list[dict[str, str]] = []
     comparison_layer = simplified_layer or layer
+    filter_value = comparison_layer.get("filter")
+    if isinstance(filter_value, list):
+        unresolved.append(
+            {
+                "property": "filter",
+                "value": _compact_json(filter_value),
+                "reason": "Mapbox filter expression is still handed to QGIS after qfit simplification; verify native support visually.",
+            }
+        )
     for section, prop, value in _iter_symbology(comparison_layer):
         reason = _UNSUPPORTED_CUES.get((section, prop))
         if reason is not None:


### PR DESCRIPTION
## Summary
- flag preserved Mapbox `filter` expressions as QGIS-dependent/unresolved in the Mapbox Outdoors style audit
- document that the audit now reports filter expressions alongside sprite/font/paint-layout expression gaps
- keep this as an audit/validation aid only; no rendering or style preprocessing behavior changes

## Evidence
- Live QGIS converter/property probes showed many remaining `Skipping unsupported expression` warnings are caused by preserved Mapbox filters (for example `landuse` dropped 10 warnings when its filter was removed in the local probe).
- Refreshed live audit with local QGIS-profile Mapbox credentials, without printing the token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T203038Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T203054Z/audit.md`
- Refreshed audit result: raw QGIS converter warnings 159 → qfit-preprocessed 121, unchanged by this reporting-only slice; top unresolved audit property is now `filter` across 139 layers, making the converter warning source visible.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
