### PR TITLE
feat: annotate Mapbox audit layers with QGIS warnings

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -146,7 +146,7 @@ python3 validation/mapbox_outdoors_style_audit.py \
   --include-qgis-converter-warnings
 ```
 
-This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, and warnings reduced by qfit preprocessing in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit.
+This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, warnings reduced by qfit preprocessing, and per-layer qfit-preprocessed warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit.
 
 Use the audit together with the screenshot harness: first identify high-signal gaps visually, then check the corresponding style layers to decide the smallest safe qfit preprocessing improvement.
 

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -447,6 +447,19 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("QGIS converter warnings: 2", markdown)
         self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)
 
+    def test_markdown_layer_unresolved_omits_empty_unresolved_sentinel_for_qgis_warnings(self):
+        rendered = mapbox_outdoors_style_audit._markdown_layer_unresolved(
+            {
+                "qfit_unresolved": [],
+                "qgis_converter_warnings": {
+                    "count": 1,
+                    "by_message": [{"message": "Skipping unsupported expression", "count": 1}],
+                },
+            }
+        )
+
+        self.assertEqual(rendered, "QGIS converter warnings: 1<br>`Skipping unsupported expression` (1)")
+
     def test_markdown_omits_qgis_reduction_sections_when_no_reductions_exist(self):
         audit = build_style_audit(SAMPLE_STYLE)
         audit["qgis_converter_warnings"] = {

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -229,6 +229,10 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 "count": 2,
                 "by_message": [{"message": "Skipping unsupported expression", "count": 2}],
                 "by_layer": [{"layer": "poi-label", "count": 2}],
+                "warnings": [
+                    "poi-label: Skipping unsupported expression",
+                    "poi-label: Referenced font DIN Pro Medium is not available on system",
+                ],
             },
             "warning_count_delta": 1,
         }
@@ -243,6 +247,22 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             )
 
         self.assertEqual(audit["qgis_converter_warnings"], warning_report)
+        layers = {layer["id"]: layer for layer in audit["layers"]}
+        self.assertEqual(
+            layers["poi-label"]["qgis_converter_warnings"],
+            {
+                "count": 2,
+                "by_message": [
+                    {"message": "Referenced font DIN Pro Medium is not available on system", "count": 1},
+                    {"message": "Skipping unsupported expression", "count": 1},
+                ],
+                "warnings": [
+                    "poi-label: Skipping unsupported expression",
+                    "poi-label: Referenced font DIN Pro Medium is not available on system",
+                ],
+            },
+        )
+        self.assertNotIn("qgis_converter_warnings", layers["road-primary"])
         report_mock.assert_called_once()
         self.assertIs(report_mock.call_args.kwargs["raw_style"], SAMPLE_STYLE)
         self.assertIsInstance(report_mock.call_args.kwargs["qfit_preprocessed_style"], dict)
@@ -272,6 +292,22 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 {"layer": "poi-label", "count": 2},
                 {"layer": "road-primary", "count": 1},
             ],
+        )
+
+    def test_qgis_warning_summaries_by_layer_skip_unprefixed_warnings(self):
+        summaries = mapbox_outdoors_style_audit._qgis_warning_summaries_by_layer(
+            [
+                "road-primary: Skipping unsupported expression",
+                "poi-label: Skipping unsupported expression",
+                "Could not find sprite image",
+            ]
+        )
+
+        self.assertEqual(sorted(summaries), ["poi-label", "road-primary"])
+        self.assertEqual(summaries["poi-label"]["count"], 1)
+        self.assertEqual(
+            summaries["road-primary"]["by_message"],
+            [{"message": "Skipping unsupported expression", "count": 1}],
         )
 
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):
@@ -365,6 +401,10 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 "count": 2,
                 "by_message": [{"message": "Skipping unsupported expression", "count": 2}],
                 "by_layer": [{"layer": "poi-label", "count": 2}],
+                "warnings": [
+                    "poi-label: Skipping unsupported expression",
+                    "poi-label: Referenced font DIN Pro Medium is not available on system",
+                ],
             },
             "warning_count_delta": 1,
             "reduced_by_qfit": {
@@ -381,6 +421,18 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ],
             },
         }
+        layers = {layer["id"]: layer for layer in audit["layers"]}
+        layers["poi-label"]["qgis_converter_warnings"] = {
+            "count": 2,
+            "by_message": [
+                {"message": "Referenced font DIN Pro Medium is not available on system", "count": 1},
+                {"message": "Skipping unsupported expression", "count": 1},
+            ],
+            "warnings": [
+                "poi-label: Skipping unsupported expression",
+                "poi-label: Referenced font DIN Pro Medium is not available on system",
+            ],
+        }
 
         markdown = build_audit_markdown(audit)
 
@@ -392,6 +444,8 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("| `water-depth` | 4 | 0 | 4 |", markdown)
         self.assertIn("| `Skipping unsupported expression` | 2 |", markdown)
         self.assertIn("| `poi-label` | 2 |", markdown)
+        self.assertIn("QGIS converter warnings: 2", markdown)
+        self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)
 
     def test_markdown_omits_qgis_reduction_sections_when_no_reductions_exist(self):
         audit = build_style_audit(SAMPLE_STYLE)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -311,6 +311,41 @@ def _qgis_warning_summary(warnings: list[str]) -> dict[str, object]:
     }
 
 
+def _qgis_warning_summaries_by_layer(warnings: list[str]) -> dict[str, dict[str, object]]:
+    grouped: dict[str, list[str]] = {}
+    for warning in warnings:
+        layer, separator, _message = warning.partition(": ")
+        if not separator or not layer:
+            continue
+        grouped.setdefault(layer, []).append(warning)
+    return {
+        layer: {
+            "count": len(layer_warnings),
+            "by_message": _warning_count_summary(layer_warnings, by_layer=False),
+            "warnings": layer_warnings,
+        }
+        for layer, layer_warnings in sorted(grouped.items())
+    }
+
+
+def _annotate_layers_with_qgis_warnings(
+    layers: list[dict[str, object]],
+    warning_report: dict[str, object],
+) -> None:
+    qfit_summary = warning_report.get("qfit_preprocessed")
+    if not isinstance(qfit_summary, dict):
+        return
+    warnings = qfit_summary.get("warnings")
+    if not isinstance(warnings, list):
+        return
+    warnings_by_layer = _qgis_warning_summaries_by_layer([str(warning) for warning in warnings])
+    for layer in layers:
+        layer_id = str(layer.get("id") or "")
+        layer_warnings = warnings_by_layer.get(layer_id)
+        if layer_warnings is not None:
+            layer["qgis_converter_warnings"] = layer_warnings
+
+
 def _warning_reduction_summary(
     raw_counts: list[dict[str, object]],
     qfit_counts: list[dict[str, object]],
@@ -426,10 +461,12 @@ def build_style_audit(
         "layers": layers,
     }
     if resolved_config.include_qgis_converter_warnings:
-        audit["qgis_converter_warnings"] = _qgis_converter_warning_report(
+        warning_report = _qgis_converter_warning_report(
             raw_style=style_definition,
             qfit_preprocessed_style=simplified_style,
         )
+        audit["qgis_converter_warnings"] = warning_report
+        _annotate_layers_with_qgis_warnings(layers, warning_report)
     return audit
 
 
@@ -453,6 +490,29 @@ def _markdown_unresolved_list(unresolved: list[dict[str, str]], *, empty: str = 
     return "<br>".join(
         f"`{item['property']}`: {item['reason']}" for item in unresolved
     )
+
+
+def _markdown_layer_qgis_warnings(layer_obj: dict[str, object]) -> str:
+    report = layer_obj.get("qgis_converter_warnings")
+    if not isinstance(report, dict) or not report.get("count"):
+        return ""
+    messages = report.get("by_message") if isinstance(report.get("by_message"), list) else []
+    warning_parts = [f"QGIS converter warnings: {report.get('count', 0)}"]
+    for item in messages[:3]:
+        if not isinstance(item, dict):
+            continue
+        warning_parts.append(f"`{item.get('message', '')}` ({item.get('count', 0)})")
+    return "<br>".join(warning_parts)
+
+
+def _markdown_layer_unresolved(layer_obj: dict[str, object]) -> str:
+    unresolved = _markdown_unresolved_list(list(layer_obj.get("qfit_unresolved") or []))
+    qgis_warnings = _markdown_layer_qgis_warnings(layer_obj)
+    if not qgis_warnings:
+        return unresolved
+    if unresolved == "—":
+        return qgis_warnings
+    return f"{unresolved}<br>{qgis_warnings}"
 
 
 def _markdown_count_table(items: list[dict[str, object]], *, empty: str = "—") -> list[str]:
@@ -592,7 +652,7 @@ def build_audit_markdown(audit: dict[str, object]) -> str:
                 zoom=layer_obj.get("zoom_band", "all zooms"),
                 preserved=_markdown_list(list(layer_obj.get("qfit_preserves") or [])),
                 simplified=_markdown_change_list(list(layer_obj.get("qfit_simplifies") or [])),
-                unresolved=_markdown_unresolved_list(list(layer_obj.get("qfit_unresolved") or [])),
+                unresolved=_markdown_layer_unresolved(layer_obj),
             )
         )
     lines.append("")

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -506,13 +506,13 @@ def _markdown_layer_qgis_warnings(layer_obj: dict[str, object]) -> str:
 
 
 def _markdown_layer_unresolved(layer_obj: dict[str, object]) -> str:
-    unresolved = _markdown_unresolved_list(list(layer_obj.get("qfit_unresolved") or []))
+    raw_unresolved = list(layer_obj.get("qfit_unresolved") or [])
     qgis_warnings = _markdown_layer_qgis_warnings(layer_obj)
     if not qgis_warnings:
-        return unresolved
-    if unresolved == "—":
+        return _markdown_unresolved_list(raw_unresolved)
+    if not raw_unresolved:
         return qgis_warnings
-    return f"{unresolved}<br>{qgis_warnings}"
+    return f"{_markdown_unresolved_list(raw_unresolved)}<br>{qgis_warnings}"
 
 
 def _markdown_count_table(items: list[dict[str, object]], *, empty: str = "—") -> list[str]:


### PR DESCRIPTION
## Summary
- annotate individual Mapbox Outdoors audit layer entries with qfit-preprocessed QGIS converter warnings when the optional converter probe is enabled
- include per-layer warning counts/messages in the Markdown layer table so visual/audit review no longer needs ad-hoc correlation scripts
- document that the optional converter probe now records per-layer warning summaries

## Evidence
- Refreshed live audit with local QGIS-profile Mapbox credentials, without printing the token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T204436Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T204437Z/audit.md`
- The live audit now annotates 65 layers with qfit-preprocessed QGIS converter warnings.
- Highest-signal examples in that artifact:
  - `landuse`: 10 warnings, all `Skipping unsupported expression`, alongside unresolved `filter` and `paint.fill-opacity` cues.
  - `settlement-major-label` / `settlement-minor-label`: 5 warnings each, combining unsupported expressions, sprite interpretation, and missing DIN font messages.
  - `road-number-shield` and `transit-label`: converter warnings now appear directly next to their unresolved filter/icon/text-font cues.
- This is audit/reporting-only; it does not change style preprocessing or rendering.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
