### PR TITLE
feat: group Mapbox audit unresolved summaries

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -135,7 +135,7 @@ Default audit outputs are written under:
 debug/mapbox-outdoors-style-audit/<style>/<UTC timestamp>/audit.md
 ```
 
-The audit summarizes each relevant style layer's source layer, filter, zoom band, paint/layout symbology, properties qfit preserves, properties qfit simplifies or substitutes before handing the style to QGIS, and cues that remain QGIS-dependent such as Mapbox filter expressions, sprites, patterns, fonts, or still-live paint/layout expressions. It also records expression operators used by unresolved expressions so follow-up work can distinguish broad buckets such as filters from concrete Mapbox operators like `match`, `step`, or `interpolate`.
+The audit summarizes each relevant style layer's source layer, filter, zoom band, paint/layout symbology, properties qfit preserves, properties qfit simplifies or substitutes before handing the style to QGIS, and cues that remain QGIS-dependent such as Mapbox filter expressions, sprites, patterns, fonts, or still-live paint/layout expressions. It also records unresolved properties and expression operators by visual layer group, so follow-up work can distinguish broad buckets such as filters from concrete Mapbox operators like `match`, `step`, or `interpolate` and see whether they concentrate in roads/trails, terrain/landcover, labels, or other groups.
 
 When PyQGIS is available, include QGIS' native Mapbox GL converter warnings to compare the raw Mapbox style with qfit's preprocessed style and see which warnings remain after qfit simplification:
 

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -177,9 +177,17 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         unresolved_counts = {
             item["property"]: item["count"] for item in summary["qfit_unresolved_by_property"]
         }
+        unresolved_group_counts = {
+            (item["group"], item["property"]): item["count"]
+            for item in summary["qfit_unresolved_by_layer_group_and_property"]
+        }
         operator_counts = {
             (item["property"], item["operator"]): item["count"]
             for item in summary["qfit_unresolved_expression_operators_by_property"]
+        }
+        operator_group_counts = {
+            (item["group"], item["property"], item["operator"]): item["count"]
+            for item in summary["qfit_unresolved_expression_operators_by_layer_group_and_property"]
         }
         self.assertEqual(simplified_counts["layout.text-field"], 2)
         self.assertEqual(simplified_counts["paint.line-width"], 1)
@@ -187,10 +195,16 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(unresolved_counts["filter"], 1)
         self.assertEqual(unresolved_counts["layout.icon-image"], 1)
         self.assertEqual(unresolved_counts["paint.line-dasharray"], 1)
+        self.assertEqual(unresolved_group_counts[("pois/labels", "filter")], 1)
+        self.assertEqual(unresolved_group_counts[("pois/labels", "layout.icon-image")], 1)
+        self.assertEqual(unresolved_group_counts[("roads/trails", "paint.line-dasharray")], 1)
         self.assertEqual(operator_counts[("filter", "==")], 1)
         self.assertEqual(operator_counts[("filter", "get")], 1)
         self.assertEqual(operator_counts[("layout.icon-image", "get")], 1)
         self.assertEqual(operator_counts[("paint.line-dasharray", "step")], 1)
+        self.assertEqual(operator_group_counts[("pois/labels", "filter", "==")], 1)
+        self.assertEqual(operator_group_counts[("pois/labels", "layout.icon-image", "get")], 1)
+        self.assertEqual(operator_group_counts[("roads/trails", "paint.line-dasharray", "step")], 1)
 
         layers = {layer["id"]: layer for layer in audit["layers"]}
         self.assertEqual(layers["background"]["group"], "background")
@@ -447,9 +461,15 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("### QGIS-dependent / unresolved", markdown)
         self.assertIn("| `filter` | 1 |", markdown)
         self.assertIn("| `layout.icon-image` | 1 |", markdown)
+        self.assertIn("### QGIS-dependent / unresolved by layer group", markdown)
+        self.assertIn("| `pois/labels` | `filter` | 1 |", markdown)
+        self.assertIn("| `roads/trails` | `paint.line-dasharray` | 1 |", markdown)
         self.assertIn("### Unresolved expression operators", markdown)
         self.assertIn("| `filter` | `==` | 1 |", markdown)
         self.assertIn("| `paint.line-dasharray` | `step` | 1 |", markdown)
+        self.assertIn("### Unresolved expression operators by layer group", markdown)
+        self.assertIn("| `pois/labels` | `filter` | `==` | 1 |", markdown)
+        self.assertIn("| `roads/trails` | `paint.line-dasharray` | `step` | 1 |", markdown)
         self.assertIn("## Layers", markdown)
         self.assertIn("composite / road", markdown)
         self.assertIn("`paint.line-width`", markdown)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -394,17 +394,35 @@ def build_layer_audit(
 def _property_count_summary(layers: list[dict[str, object]], key: str) -> list[dict[str, object]]:
     counts: Counter[str] = Counter()
     for layer in layers:
-        values = layer.get(key)
-        if not isinstance(values, list):
-            continue
-        for item in values:
-            if isinstance(item, str):
-                counts[item] += 1
-            elif isinstance(item, dict) and isinstance(item.get("property"), str):
-                counts[item["property"]] += 1
+        counts.update(_iter_property_names(layer, key))
     return [
         {"property": property_name, "count": count}
         for property_name, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def _iter_property_names(layer: dict[str, object], key: str) -> Iterable[str]:
+    values = layer.get(key)
+    if not isinstance(values, list):
+        return
+    for item in values:
+        if isinstance(item, str):
+            yield item
+        elif isinstance(item, dict) and isinstance(item.get("property"), str):
+            yield item["property"]
+
+
+def _property_group_count_summary(layers: list[dict[str, object]], key: str) -> list[dict[str, object]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for layer in layers:
+        group = str(layer.get("group") or "other")
+        counts.update((group, property_name) for property_name in _iter_property_names(layer, key))
+    return [
+        {"group": group, "property": property_name, "count": count}
+        for (group, property_name), count in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0][0], item[0][1]),
+        )
     ]
 
 
@@ -430,6 +448,23 @@ def _expression_operator_count_summary(layers: list[dict[str, object]]) -> list[
         for (property_name, operator), count in sorted(
             counts.items(),
             key=lambda item: (-item[1], item[0][0], item[0][1]),
+        )
+    ]
+
+
+def _expression_operator_group_count_summary(layers: list[dict[str, object]]) -> list[dict[str, object]]:
+    counts: Counter[tuple[str, str, str]] = Counter()
+    for layer in layers:
+        group = str(layer.get("group") or "other")
+        counts.update(
+            (group, property_name, operator)
+            for property_name, operator in _iter_expression_operator_pairs(layer)
+        )
+    return [
+        {"group": group, "property": property_name, "operator": operator, "count": count}
+        for (group, property_name, operator), count in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0][0], item[0][1], item[0][2]),
         )
     ]
 
@@ -608,7 +643,14 @@ def build_style_audit(
         "summary": {
             "qfit_simplifies_by_property": _property_count_summary(layers, "qfit_simplifies"),
             "qfit_unresolved_by_property": _property_count_summary(layers, "qfit_unresolved"),
+            "qfit_unresolved_by_layer_group_and_property": _property_group_count_summary(
+                layers,
+                "qfit_unresolved",
+            ),
             "qfit_unresolved_expression_operators_by_property": _expression_operator_count_summary(layers),
+            "qfit_unresolved_expression_operators_by_layer_group_and_property": (
+                _expression_operator_group_count_summary(layers)
+            ),
         },
         "layers": layers,
     }
@@ -677,6 +719,22 @@ def _markdown_count_table(items: list[dict[str, object]], *, empty: str = "—")
     return lines
 
 
+def _markdown_group_count_table(items: list[dict[str, object]], *, empty: str = "—") -> list[str]:
+    if not items:
+        return [empty, ""]
+    lines = ["| Layer group | Property | # Layers |", "| --- | --- | ---: |"]
+    for item in items:
+        lines.append(
+            "| `{group}` | `{property_name}` | {count} |".format(
+                group=item.get("group", ""),
+                property_name=item.get("property", ""),
+                count=item.get("count", 0),
+            )
+        )
+    lines.append("")
+    return lines
+
+
 def _markdown_expression_operator_table(items: list[dict[str, object]], *, empty: str = "—") -> list[str]:
     if not items:
         return [empty, ""]
@@ -684,6 +742,27 @@ def _markdown_expression_operator_table(items: list[dict[str, object]], *, empty
     for item in items:
         lines.append(
             "| `{property_name}` | `{operator}` | {count} |".format(
+                property_name=item.get("property", ""),
+                operator=item.get("operator", ""),
+                count=item.get("count", 0),
+            )
+        )
+    lines.append("")
+    return lines
+
+
+def _markdown_group_expression_operator_table(
+    items: list[dict[str, object]],
+    *,
+    empty: str = "—",
+) -> list[str]:
+    if not items:
+        return [empty, ""]
+    lines = ["| Layer group | Property | Operator | # Layers |", "| --- | --- | --- | ---: |"]
+    for item in items:
+        lines.append(
+            "| `{group}` | `{property_name}` | `{operator}` | {count} |".format(
+                group=item.get("group", ""),
                 property_name=item.get("property", ""),
                 operator=item.get("operator", ""),
                 count=item.get("count", 0),
@@ -798,10 +877,18 @@ def build_audit_markdown(audit: dict[str, object]) -> str:
         "### QGIS-dependent / unresolved",
         "",
         *_markdown_count_table(list(summary.get("qfit_unresolved_by_property") or [])),
+        "### QGIS-dependent / unresolved by layer group",
+        "",
+        *_markdown_group_count_table(list(summary.get("qfit_unresolved_by_layer_group_and_property") or [])),
         "### Unresolved expression operators",
         "",
         *_markdown_expression_operator_table(
             list(summary.get("qfit_unresolved_expression_operators_by_property") or [])
+        ),
+        "### Unresolved expression operators by layer group",
+        "",
+        *_markdown_group_expression_operator_table(
+            list(summary.get("qfit_unresolved_expression_operators_by_layer_group_and_property") or [])
         ),
         *_markdown_qgis_converter_warnings(audit.get("qgis_converter_warnings")),
         "## Layers",

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -856,19 +856,8 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
     return lines
 
 
-def build_audit_markdown(audit: dict[str, object]) -> str:
-    style = audit["style"] if isinstance(audit.get("style"), dict) else {}
-    layers = audit.get("layers") if isinstance(audit.get("layers"), list) else []
-    summary = audit.get("summary") if isinstance(audit.get("summary"), dict) else {}
-    lines = [
-        f"# Mapbox Outdoors style audit — {style.get('label', 'mapbox/outdoors-v12')}",
-        "",
-        f"Generated: {audit.get('generated_at', '')}",
-        f"Layers: {audit.get('layer_count', len(layers))}",
-        "",
-        "This developer audit compares the live Mapbox style rules with qfit's current QGIS preprocessing.",
-        "Use it to choose the next visual-parity slice before making rendering-sensitive changes.",
-        "",
+def _markdown_summary(summary: dict[str, object], qgis_converter_warnings: object) -> list[str]:
+    return [
         "## Summary",
         "",
         "### Simplified/substituted by qfit",
@@ -890,7 +879,45 @@ def build_audit_markdown(audit: dict[str, object]) -> str:
         *_markdown_group_expression_operator_table(
             list(summary.get("qfit_unresolved_expression_operators_by_layer_group_and_property") or [])
         ),
-        *_markdown_qgis_converter_warnings(audit.get("qgis_converter_warnings")),
+        *_markdown_qgis_converter_warnings(qgis_converter_warnings),
+    ]
+
+
+def _markdown_source_filter(layer_obj: dict[str, object]) -> str:
+    source_parts = [part for part in (layer_obj.get("source"), layer_obj.get("source_layer")) if part]
+    source_filter = " / ".join(str(part) for part in source_parts) or "—"
+    if layer_obj.get("filter") is not None:
+        source_filter += f"<br>`filter`: `{_compact_json(layer_obj.get('filter'))}`"
+    return source_filter
+
+
+def _markdown_layer_row(layer_obj: dict[str, object]) -> str:
+    layer_label = f"`{layer_obj.get('id', '')}`<br>{layer_obj.get('type', '')}"
+    return "| {layer} | {group} | {source_filter} | {zoom} | {preserved} | {simplified} | {unresolved} |".format(
+        layer=layer_label,
+        group=layer_obj.get("group", "other"),
+        source_filter=_markdown_source_filter(layer_obj),
+        zoom=layer_obj.get("zoom_band", "all zooms"),
+        preserved=_markdown_list(list(layer_obj.get("qfit_preserves") or [])),
+        simplified=_markdown_change_list(list(layer_obj.get("qfit_simplifies") or [])),
+        unresolved=_markdown_layer_unresolved(layer_obj),
+    )
+
+
+def build_audit_markdown(audit: dict[str, object]) -> str:
+    style = audit["style"] if isinstance(audit.get("style"), dict) else {}
+    layers = audit.get("layers") if isinstance(audit.get("layers"), list) else []
+    summary = audit.get("summary") if isinstance(audit.get("summary"), dict) else {}
+    lines = [
+        f"# Mapbox Outdoors style audit — {style.get('label', 'mapbox/outdoors-v12')}",
+        "",
+        f"Generated: {audit.get('generated_at', '')}",
+        f"Layers: {audit.get('layer_count', len(layers))}",
+        "",
+        "This developer audit compares the live Mapbox style rules with qfit's current QGIS preprocessing.",
+        "Use it to choose the next visual-parity slice before making rendering-sensitive changes.",
+        "",
+        *_markdown_summary(summary, audit.get("qgis_converter_warnings")),
         "## Layers",
         "",
         "| Layer | Group | Source/filter | Zoom | Preserved | Simplified/substituted by qfit | QGIS-dependent / unresolved |",
@@ -899,22 +926,7 @@ def build_audit_markdown(audit: dict[str, object]) -> str:
     for layer_obj in layers:
         if not isinstance(layer_obj, dict):
             continue
-        source_parts = [part for part in (layer_obj.get("source"), layer_obj.get("source_layer")) if part]
-        source_filter = " / ".join(str(part) for part in source_parts) or "—"
-        if layer_obj.get("filter") is not None:
-            source_filter += f"<br>`filter`: `{_compact_json(layer_obj.get('filter'))}`"
-        layer_label = f"`{layer_obj.get('id', '')}`<br>{layer_obj.get('type', '')}"
-        lines.append(
-            "| {layer} | {group} | {source_filter} | {zoom} | {preserved} | {simplified} | {unresolved} |".format(
-                layer=layer_label,
-                group=layer_obj.get("group", "other"),
-                source_filter=source_filter,
-                zoom=layer_obj.get("zoom_band", "all zooms"),
-                preserved=_markdown_list(list(layer_obj.get("qfit_preserves") or [])),
-                simplified=_markdown_change_list(list(layer_obj.get("qfit_simplifies") or [])),
-                unresolved=_markdown_layer_unresolved(layer_obj),
-            )
-        )
+        lines.append(_markdown_layer_row(layer_obj))
     lines.append("")
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- add layer-group/property summaries for unresolved Mapbox audit cues
- add layer-group/property/operator summaries for unresolved expression operators
- document the group summaries as a #949 planning aid for choosing focused visual-parity slices

## Evidence
- Refreshed live audit with local QGIS-profile Mapbox credentials, without printing the token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T213602Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T213602Z/audit.md`
- Live QGIS converter warning count remains raw 159 → qfit-preprocessed 121; this slice is reporting-only.
- The new group summaries show unresolved debt is not evenly distributed. Top live unresolved group/property rows:
  - `roads/trails` / `filter`: 100 layers
  - `roads/trails` / `paint.line-dasharray`: 16 layers
  - `roads/trails` / `paint.line-opacity`: 16 layers
  - `roads/trails` / `layout.icon-image`: 10 layers
  - `pois/labels` / `filter`: 9 layers
  - `terrain/landcover` / `filter`: 9 layers
- Top live grouped operator rows also concentrate in `roads/trails` filters: `get` 100, `==` 94, `all` 93, `geometry-type` 79, `match` 78.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
