### PR TITLE
feat: summarize QGIS warnings by map layer group

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -137,7 +137,7 @@ debug/mapbox-outdoors-style-audit/<style>/<UTC timestamp>/audit.md
 
 The audit summarizes each relevant style layer's source layer, filter, zoom band, paint/layout symbology, properties qfit preserves, properties qfit simplifies or substitutes before handing the style to QGIS, and cues that remain QGIS-dependent such as Mapbox filter expressions, sprites, patterns, fonts, or still-live paint/layout expressions. It also records unresolved properties and expression operators by visual layer group, so follow-up work can distinguish broad buckets such as filters from concrete Mapbox operators like `match`, `step`, or `interpolate` and see whether they concentrate in roads/trails, terrain/landcover, labels, or other groups.
 
-When PyQGIS is available, include QGIS' native Mapbox GL converter warnings to compare the raw Mapbox style with qfit's preprocessed style and see which warnings remain after qfit simplification:
+When PyQGIS is available, include QGIS' native Mapbox GL converter warnings to compare the raw Mapbox style with qfit's preprocessed style and see which warnings remain after qfit simplification. The optional warning report includes message, layer, and visual layer-group summaries to show whether remaining converter gaps concentrate in categories such as roads/trails, terrain/landcover, or labels:
 
 ```bash
 QT_QPA_PLATFORM=offscreen \

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -248,10 +248,18 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
 
     def test_build_style_audit_can_include_qgis_converter_warning_summary(self):
         warning_report = {
-            "raw": {"count": 3},
+            "raw": {
+                "count": 3,
+                "warnings": [
+                    "road-primary: Skipping unsupported expression",
+                    "poi-label: Skipping unsupported expression",
+                    "poi-label: Referenced font DIN Pro Medium is not available on system",
+                ],
+            },
             "qfit_preprocessed": {
                 "count": 2,
                 "by_message": [{"message": "Skipping unsupported expression", "count": 2}],
+                "by_layer_group": [{"group": "pois/labels", "count": 2}],
                 "by_layer": [{"layer": "poi-label", "count": 2}],
                 "warnings": [
                     "poi-label: Skipping unsupported expression",
@@ -271,6 +279,18 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             )
 
         self.assertEqual(audit["qgis_converter_warnings"], warning_report)
+        self.assertEqual(
+            audit["qgis_converter_warnings"]["raw"]["by_layer_group"],
+            [{"group": "pois/labels", "count": 2}, {"group": "roads/trails", "count": 1}],
+        )
+        self.assertEqual(
+            audit["qgis_converter_warnings"]["qfit_preprocessed"]["by_layer_group"],
+            [{"group": "pois/labels", "count": 2}],
+        )
+        self.assertEqual(
+            audit["qgis_converter_warnings"]["reduced_by_qfit"]["by_layer_group"],
+            [{"group": "roads/trails", "raw_count": 1, "qfit_count": 0, "reduced_count": 1}],
+        )
         layers = {layer["id"]: layer for layer in audit["layers"]}
         self.assertEqual(
             layers["poi-label"]["qgis_converter_warnings"],
@@ -384,6 +404,20 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             [{"message": "Skipping unsupported expression", "count": 1}],
         )
 
+    def test_warning_group_count_summary_skips_unprefixed_warnings(self):
+        self.assertEqual(
+            mapbox_outdoors_style_audit._warning_group_count_summary(
+                [
+                    "road-primary: Skipping unsupported expression",
+                    "poi-label: Skipping unsupported expression",
+                    "poi-label: Referenced font DIN Pro Medium is not available on system",
+                    "Could not find sprite image",
+                ],
+                {"road-primary": "roads/trails", "poi-label": "pois/labels"},
+            ),
+            [{"group": "pois/labels", "count": 2}, {"group": "roads/trails", "count": 1}],
+        )
+
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):
         raw_style = {"layers": []}
         qfit_style = {"layers": [{"id": "poi-label"}]}
@@ -483,6 +517,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             "qfit_preprocessed": {
                 "count": 2,
                 "by_message": [{"message": "Skipping unsupported expression", "count": 2}],
+                "by_layer_group": [{"group": "pois/labels", "count": 2}],
                 "by_layer": [{"layer": "poi-label", "count": 2}],
                 "warnings": [
                     "poi-label: Skipping unsupported expression",
@@ -501,6 +536,9 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ],
                 "by_layer": [
                     {"layer": "water-depth", "raw_count": 4, "qfit_count": 0, "reduced_count": 4}
+                ],
+                "by_layer_group": [
+                    {"group": "water", "raw_count": 4, "qfit_count": 0, "reduced_count": 4}
                 ],
             },
         }
@@ -525,7 +563,11 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("#### Warnings reduced by qfit preprocessing", markdown)
         self.assertIn("| `Could not parse non-string color , skipping` | 3 | 0 | 3 |", markdown)
         self.assertIn("| `water-depth` | 4 | 0 | 4 |", markdown)
+        self.assertIn("#### Layer groups with fewer warnings after qfit preprocessing", markdown)
+        self.assertIn("| `water` | 4 | 0 | 4 |", markdown)
         self.assertIn("| `Skipping unsupported expression` | 2 |", markdown)
+        self.assertIn("#### Remaining warnings by layer group", markdown)
+        self.assertIn("| `pois/labels` | 2 |", markdown)
         self.assertIn("| `poi-label` | 2 |", markdown)
         self.assertIn("QGIS converter warnings: 2", markdown)
         self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -514,6 +514,57 @@ def _qgis_warning_summaries_by_layer(warnings: list[str]) -> dict[str, dict[str,
     }
 
 
+def _warning_group_count_summary(
+    warnings: list[str],
+    layer_groups: dict[str, str],
+) -> list[dict[str, object]]:
+    counts: Counter[str] = Counter()
+    for warning in warnings:
+        layer, separator, _message = warning.partition(": ")
+        if not separator or not layer:
+            continue
+        counts[layer_groups.get(layer, "other")] += 1
+    return [
+        {"group": group, "count": count}
+        for group, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def _annotate_warning_summary_groups(
+    summary: dict[str, object],
+    layer_groups: dict[str, str],
+) -> None:
+    warnings = summary.get("warnings")
+    if not isinstance(warnings, list):
+        return
+    summary["by_layer_group"] = _warning_group_count_summary(
+        [str(warning) for warning in warnings],
+        layer_groups,
+    )
+
+
+def _annotate_qgis_warning_group_summaries(
+    layers: list[dict[str, object]],
+    warning_report: dict[str, object],
+) -> None:
+    layer_groups = {str(layer.get("id") or ""): str(layer.get("group") or "other") for layer in layers}
+    raw_summary = warning_report.get("raw") if isinstance(warning_report.get("raw"), dict) else {}
+    qfit_summary = (
+        warning_report.get("qfit_preprocessed")
+        if isinstance(warning_report.get("qfit_preprocessed"), dict)
+        else {}
+    )
+    _annotate_warning_summary_groups(raw_summary, layer_groups)
+    _annotate_warning_summary_groups(qfit_summary, layer_groups)
+    reduced = warning_report.setdefault("reduced_by_qfit", {})
+    if isinstance(reduced, dict):
+        reduced["by_layer_group"] = _warning_reduction_summary(
+            list(raw_summary.get("by_layer_group") or []),
+            list(qfit_summary.get("by_layer_group") or []),
+            key="group",
+        )
+
+
 def _annotate_layers_with_qgis_warnings(
     layers: list[dict[str, object]],
     warning_report: dict[str, object],
@@ -659,6 +710,7 @@ def build_style_audit(
             raw_style=style_definition,
             qfit_preprocessed_style=simplified_style,
         )
+        _annotate_qgis_warning_group_summaries(layers, warning_report)
         audit["qgis_converter_warnings"] = warning_report
         _annotate_layers_with_qgis_warnings(layers, warning_report)
     return audit
@@ -819,6 +871,7 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
     reduced = report.get("reduced_by_qfit") if isinstance(report.get("reduced_by_qfit"), dict) else {}
     reduced_by_message = list(reduced.get("by_message") or [])
     reduced_by_layer = list(reduced.get("by_layer") or [])
+    reduced_by_group = list(reduced.get("by_layer_group") or [])
     lines = [
         "### QGIS converter warnings",
         "",
@@ -843,11 +896,22 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
                 *_markdown_warning_reduction_table(reduced_by_layer, key="layer", label="Layer"),
             ]
         )
+    if reduced_by_group:
+        lines.extend(
+            [
+                "#### Layer groups with fewer warnings after qfit preprocessing",
+                "",
+                *_markdown_warning_reduction_table(reduced_by_group, key="group", label="Layer group"),
+            ]
+        )
     lines.extend(
         [
             "#### Remaining warnings by message",
             "",
             *_markdown_named_count_table(list(qfit.get("by_message") or []), key="message", label="Message"),
+            "#### Remaining warnings by layer group",
+            "",
+            *_markdown_named_count_table(list(qfit.get("by_layer_group") or []), key="group", label="Layer group"),
             "#### Remaining warnings by layer",
             "",
             *_markdown_named_count_table(list(qfit.get("by_layer") or []), key="layer", label="Layer"),


### PR DESCRIPTION
## Summary
- add optional QGIS converter warning summaries by visual layer group
- include layer-group warning reductions in the optional `reduced_by_qfit` report
- render remaining/reduced QGIS warnings by group in Markdown and document the audit output

## Evidence
- Refreshed live audit with local QGIS-profile Mapbox credentials, without printing the token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T214528Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T214528Z/audit.md`
- Live QGIS converter warning count remains raw 159 → qfit-preprocessed 121; this slice is reporting-only.
- Remaining qfit-preprocessed warnings now summarize by visual group:
  - `roads/trails`: 66
  - `pois/labels`: 21
  - `settlements/places`: 15
  - `terrain/landcover`: 14
  - `water`: 3
  - `other`: 2
- Warning reductions by group also show qfit preprocessing already reduces warnings across all groups, especially `settlements/places` 25 → 15 and `roads/trails` 75 → 66.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
