### PR TITLE
feat: summarize QGIS warning messages by map group

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -137,7 +137,7 @@ debug/mapbox-outdoors-style-audit/<style>/<UTC timestamp>/audit.md
 
 The audit summarizes each relevant style layer's source layer, filter, zoom band, paint/layout symbology, properties qfit preserves, properties qfit simplifies or substitutes before handing the style to QGIS, and cues that remain QGIS-dependent such as Mapbox filter expressions, sprites, patterns, fonts, or still-live paint/layout expressions. It also records unresolved properties and expression operators by visual layer group, so follow-up work can distinguish broad buckets such as filters from concrete Mapbox operators like `match`, `step`, or `interpolate` and see whether they concentrate in roads/trails, terrain/landcover, labels, or other groups.
 
-When PyQGIS is available, include QGIS' native Mapbox GL converter warnings to compare the raw Mapbox style with qfit's preprocessed style and see which warnings remain after qfit simplification. The optional warning report includes message, layer, and visual layer-group summaries to show whether remaining converter gaps concentrate in categories such as roads/trails, terrain/landcover, or labels:
+When PyQGIS is available, include QGIS' native Mapbox GL converter warnings to compare the raw Mapbox style with qfit's preprocessed style and see which warnings remain after qfit simplification. The optional warning report includes message, layer, visual layer-group, and layer-group-by-message summaries to show which converter messages concentrate in categories such as roads/trails, terrain/landcover, or labels:
 
 ```bash
 QT_QPA_PLATFORM=offscreen \

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -258,8 +258,23 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             },
             "qfit_preprocessed": {
                 "count": 2,
-                "by_message": [{"message": "Skipping unsupported expression", "count": 2}],
+                "by_message": [
+                    {"message": "Referenced font DIN Pro Medium is not available on system", "count": 1},
+                    {"message": "Skipping unsupported expression", "count": 1},
+                ],
                 "by_layer_group": [{"group": "pois/labels", "count": 2}],
+                "by_layer_group_and_message": [
+                    {
+                        "group": "pois/labels",
+                        "message": "Referenced font DIN Pro Medium is not available on system",
+                        "count": 1,
+                    },
+                    {
+                        "group": "pois/labels",
+                        "message": "Skipping unsupported expression",
+                        "count": 1,
+                    }
+                ],
                 "by_layer": [{"layer": "poi-label", "count": 2}],
                 "warnings": [
                     "poi-label: Skipping unsupported expression",
@@ -284,8 +299,31 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             [{"group": "pois/labels", "count": 2}, {"group": "roads/trails", "count": 1}],
         )
         self.assertEqual(
+            audit["qgis_converter_warnings"]["raw"]["by_layer_group_and_message"],
+            [
+                {
+                    "group": "pois/labels",
+                    "message": "Referenced font DIN Pro Medium is not available on system",
+                    "count": 1,
+                },
+                {"group": "pois/labels", "message": "Skipping unsupported expression", "count": 1},
+                {"group": "roads/trails", "message": "Skipping unsupported expression", "count": 1},
+            ],
+        )
+        self.assertEqual(
             audit["qgis_converter_warnings"]["qfit_preprocessed"]["by_layer_group"],
             [{"group": "pois/labels", "count": 2}],
+        )
+        self.assertEqual(
+            audit["qgis_converter_warnings"]["qfit_preprocessed"]["by_layer_group_and_message"],
+            [
+                {
+                    "group": "pois/labels",
+                    "message": "Referenced font DIN Pro Medium is not available on system",
+                    "count": 1,
+                },
+                {"group": "pois/labels", "message": "Skipping unsupported expression", "count": 1},
+            ],
         )
         self.assertEqual(
             audit["qgis_converter_warnings"]["reduced_by_qfit"]["by_layer_group"],
@@ -418,6 +456,29 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             [{"group": "pois/labels", "count": 2}, {"group": "roads/trails", "count": 1}],
         )
 
+    def test_warning_group_message_count_summary_skips_unprefixed_warnings(self):
+        self.assertEqual(
+            mapbox_outdoors_style_audit._warning_group_message_count_summary(
+                [
+                    "road-primary: Skipping unsupported expression",
+                    "poi-label: Skipping unsupported expression",
+                    "poi-label: Referenced font DIN Pro Medium is not available on system",
+                    "poi-label: Skipping unsupported expression",
+                    "Could not find sprite image",
+                ],
+                {"road-primary": "roads/trails", "poi-label": "pois/labels"},
+            ),
+            [
+                {"group": "pois/labels", "message": "Skipping unsupported expression", "count": 2},
+                {
+                    "group": "pois/labels",
+                    "message": "Referenced font DIN Pro Medium is not available on system",
+                    "count": 1,
+                },
+                {"group": "roads/trails", "message": "Skipping unsupported expression", "count": 1},
+            ],
+        )
+
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):
         raw_style = {"layers": []}
         qfit_style = {"layers": [{"id": "poi-label"}]}
@@ -516,8 +577,23 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             "raw": {"count": 3},
             "qfit_preprocessed": {
                 "count": 2,
-                "by_message": [{"message": "Skipping unsupported expression", "count": 2}],
+                "by_message": [
+                    {"message": "Referenced font DIN Pro Medium is not available on system", "count": 1},
+                    {"message": "Skipping unsupported expression", "count": 1},
+                ],
                 "by_layer_group": [{"group": "pois/labels", "count": 2}],
+                "by_layer_group_and_message": [
+                    {
+                        "group": "pois/labels",
+                        "message": "Referenced font DIN Pro Medium is not available on system",
+                        "count": 1,
+                    },
+                    {
+                        "group": "pois/labels",
+                        "message": "Skipping unsupported expression",
+                        "count": 1,
+                    }
+                ],
                 "by_layer": [{"layer": "poi-label", "count": 2}],
                 "warnings": [
                     "poi-label: Skipping unsupported expression",
@@ -565,9 +641,15 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("| `water-depth` | 4 | 0 | 4 |", markdown)
         self.assertIn("#### Layer groups with fewer warnings after qfit preprocessing", markdown)
         self.assertIn("| `water` | 4 | 0 | 4 |", markdown)
-        self.assertIn("| `Skipping unsupported expression` | 2 |", markdown)
+        self.assertIn("| `Skipping unsupported expression` | 1 |", markdown)
         self.assertIn("#### Remaining warnings by layer group", markdown)
         self.assertIn("| `pois/labels` | 2 |", markdown)
+        self.assertIn("#### Remaining warnings by layer group and message", markdown)
+        self.assertIn(
+            "| `pois/labels` | `Referenced font DIN Pro Medium is not available on system` | 1 |",
+            markdown,
+        )
+        self.assertIn("| `pois/labels` | `Skipping unsupported expression` | 1 |", markdown)
         self.assertIn("| `poi-label` | 2 |", markdown)
         self.assertIn("QGIS converter warnings: 2", markdown)
         self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -17,6 +17,7 @@ DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-style-audit"
 DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
 DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 _DEFAULT_OUTPUT_STYLE_SLUG = "mapbox-outdoors-v12"
+_MARKDOWN_THREE_COLUMN_COUNT_SEPARATOR = "| --- | --- | ---: |"
 
 if str(PACKAGE_PARENT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_PARENT))
@@ -530,6 +531,25 @@ def _warning_group_count_summary(
     ]
 
 
+def _warning_group_message_count_summary(
+    warnings: list[str],
+    layer_groups: dict[str, str],
+) -> list[dict[str, object]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for warning in warnings:
+        layer, separator, message = warning.partition(": ")
+        if not separator or not layer or not message:
+            continue
+        counts[(layer_groups.get(layer, "other"), message)] += 1
+    return [
+        {"group": group, "message": message, "count": count}
+        for (group, message), count in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0][0], item[0][1]),
+        )
+    ]
+
+
 def _annotate_warning_summary_groups(
     summary: dict[str, object],
     layer_groups: dict[str, str],
@@ -537,8 +557,13 @@ def _annotate_warning_summary_groups(
     warnings = summary.get("warnings")
     if not isinstance(warnings, list):
         return
+    warning_strings = [str(warning) for warning in warnings]
     summary["by_layer_group"] = _warning_group_count_summary(
-        [str(warning) for warning in warnings],
+        warning_strings,
+        layer_groups,
+    )
+    summary["by_layer_group_and_message"] = _warning_group_message_count_summary(
+        warning_strings,
         layer_groups,
     )
 
@@ -774,7 +799,7 @@ def _markdown_count_table(items: list[dict[str, object]], *, empty: str = "—")
 def _markdown_group_count_table(items: list[dict[str, object]], *, empty: str = "—") -> list[str]:
     if not items:
         return [empty, ""]
-    lines = ["| Layer group | Property | # Layers |", "| --- | --- | ---: |"]
+    lines = ["| Layer group | Property | # Layers |", _MARKDOWN_THREE_COLUMN_COUNT_SEPARATOR]
     for item in items:
         lines.append(
             "| `{group}` | `{property_name}` | {count} |".format(
@@ -790,7 +815,7 @@ def _markdown_group_count_table(items: list[dict[str, object]], *, empty: str = 
 def _markdown_expression_operator_table(items: list[dict[str, object]], *, empty: str = "—") -> list[str]:
     if not items:
         return [empty, ""]
-    lines = ["| Property | Operator | # Layers |", "| --- | --- | ---: |"]
+    lines = ["| Property | Operator | # Layers |", _MARKDOWN_THREE_COLUMN_COUNT_SEPARATOR]
     for item in items:
         lines.append(
             "| `{property_name}` | `{operator}` | {count} |".format(
@@ -836,6 +861,26 @@ def _markdown_named_count_table(
     lines = [f"| {label} | Count |", "| --- | ---: |"]
     for item in items:
         lines.append(f"| `{item.get(key, '')}` | {item.get('count', 0)} |")
+    lines.append("")
+    return lines
+
+
+def _markdown_group_message_count_table(
+    items: list[dict[str, object]],
+    *,
+    empty: str = "—",
+) -> list[str]:
+    if not items:
+        return [empty, ""]
+    lines = ["| Layer group | Message | Count |", _MARKDOWN_THREE_COLUMN_COUNT_SEPARATOR]
+    for item in items:
+        lines.append(
+            "| `{group}` | `{message}` | {count} |".format(
+                group=item.get("group", ""),
+                message=item.get("message", ""),
+                count=item.get("count", 0),
+            )
+        )
     lines.append("")
     return lines
 
@@ -912,6 +957,9 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
             "#### Remaining warnings by layer group",
             "",
             *_markdown_named_count_table(list(qfit.get("by_layer_group") or []), key="group", label="Layer group"),
+            "#### Remaining warnings by layer group and message",
+            "",
+            *_markdown_group_message_count_table(list(qfit.get("by_layer_group_and_message") or [])),
             "#### Remaining warnings by layer",
             "",
             *_markdown_named_count_table(list(qfit.get("by_layer") or []), key="layer", label="Layer"),


### PR DESCRIPTION
## Summary
- add optional QGIS converter warning summaries by visual layer group and warning message
- render the grouped message table in the Mapbox Outdoors audit Markdown
- document the richer warning report for #949 planning

## Evidence
- Refreshed live audit with local QGIS-profile Mapbox credentials, without printing the token:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T215551Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T215552Z/audit.md`
- Live QGIS converter warning count remains raw 159 → qfit-preprocessed 121; this slice is reporting-only.
- Top remaining qfit-preprocessed warning group/message rows now show where follow-up work should focus:
  - `roads/trails`: `Skipping unsupported expression` = 48
  - `terrain/landcover`: `Skipping unsupported expression` = 12
  - `pois/labels`: `Referenced font DIN Pro Medium is not available on system` = 6
  - `settlements/places`: `Skipping unsupported expression` = 6
  - `roads/trails`: `Could not interpret sprite value list with method step` = 5

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
