### PR TITLE
feat: add Mapbox filter warning probe

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -146,7 +146,7 @@ python3 validation/mapbox_outdoors_style_audit.py \
   --include-qgis-converter-warnings
 ```
 
-This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, warnings reduced by qfit preprocessing, and per-layer qfit-preprocessed warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit.
+This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, warnings reduced by qfit preprocessing, and per-layer qfit-preprocessed warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit. It also includes a diagnostic filter-removal probe that reports how many converter warnings would disappear if all qfit-preprocessed layer filters were removed; this is an upper-bound signal only, not a suggested rendering change, because Mapbox filters control feature inclusion.
 
 Use the audit together with the screenshot harness: first identify high-signal gaps visually, then check the corresponding style layers to decide the smallest safe qfit preprocessing improvement.
 

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -534,7 +534,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
 
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):
         raw_style = {"layers": []}
-        qfit_style = {"layers": [{"id": "poi-label"}]}
+        qfit_style = {"layers": [{"id": "poi-label", "filter": ["==", ["get", "maki"], "park"]}]}
         fake_qgis, fake_core, fake_app, fake_converter = _fake_qgis_modules(
             [
                 [
@@ -542,6 +542,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                     "poi-label: Skipping unsupported expression",
                 ],
                 ["poi-label: Skipping unsupported expression"],
+                [],
             ]
         )
 
@@ -557,6 +558,25 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(report["raw"]["count"], 2)
         self.assertEqual(report["qfit_preprocessed"]["count"], 1)
         self.assertEqual(report["warning_count_delta"], 1)
+        self.assertEqual(report["without_filters_probe"]["filter_count_removed"], 1)
+        self.assertEqual(report["without_filters_probe"]["summary"]["count"], 0)
+        self.assertEqual(report["without_filters_probe"]["warning_count_delta_from_qfit"], 1)
+        self.assertEqual(
+            report["without_filters_probe"]["reduced_from_qfit"],
+            {
+                "by_message": [
+                    {
+                        "message": "Skipping unsupported expression",
+                        "raw_count": 1,
+                        "qfit_count": 0,
+                        "reduced_count": 1,
+                    }
+                ],
+                "by_layer": [
+                    {"layer": "poi-label", "raw_count": 1, "qfit_count": 0, "reduced_count": 1}
+                ],
+            },
+        )
         self.assertEqual(
             report["reduced_by_qfit"],
             {
@@ -573,7 +593,9 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ],
             },
         )
-        self.assertEqual(fake_converter.converted_styles, [raw_style, qfit_style])
+        self.assertEqual(fake_converter.converted_styles[:2], [raw_style, qfit_style])
+        self.assertEqual(fake_converter.converted_styles[2], {"layers": [{"id": "poi-label"}]})
+        self.assertIn("filter", qfit_style["layers"][0])
         self.assertEqual(len(fake_app.created), 1)
         self.assertEqual(fake_app.created[0].args, [])
         self.assertFalse(fake_app.created[0].gui_enabled)
@@ -583,7 +605,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
     def test_qgis_converter_warning_report_reuses_existing_qgis_app(self):
         existing_app = object()
         fake_qgis, fake_core, fake_app, _fake_converter = _fake_qgis_modules(
-            [["raw warning"], ["qfit warning"]],
+            [["raw warning"], ["qfit warning"], ["filterless warning"]],
             existing_app=existing_app,
         )
 
@@ -595,6 +617,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
 
         self.assertEqual(report["raw"]["warnings"], ["raw warning"])
         self.assertEqual(report["qfit_preprocessed"]["warnings"], ["qfit warning"])
+        self.assertEqual(report["without_filters_probe"]["summary"]["warnings"], ["filterless warning"])
         self.assertEqual(fake_app.created, [])
 
     def test_markdown_summarizes_source_filter_preserved_and_unresolved_cues(self):
@@ -672,6 +695,24 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                     {"group": "water", "raw_count": 4, "qfit_count": 0, "reduced_count": 4}
                 ],
             },
+            "without_filters_probe": {
+                "filter_count_removed": 1,
+                "summary": {"count": 1},
+                "warning_count_delta_from_qfit": 1,
+                "reduced_from_qfit": {
+                    "by_message": [
+                        {
+                            "message": "Skipping unsupported expression",
+                            "raw_count": 2,
+                            "qfit_count": 1,
+                            "reduced_count": 1,
+                        }
+                    ],
+                    "by_layer_group": [
+                        {"group": "pois/labels", "raw_count": 2, "qfit_count": 1, "reduced_count": 1}
+                    ],
+                },
+            },
         }
         layers = {layer["id"]: layer for layer in audit["layers"]}
         layers["poi-label"]["qgis_converter_warnings"] = {
@@ -706,6 +747,17 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )
         self.assertIn("| `pois/labels` | `Skipping unsupported expression` | 1 |", markdown)
         self.assertIn("| `poi-label` | 2 |", markdown)
+        self.assertIn("#### Diagnostic filter-removal probe", markdown)
+        self.assertIn("This is not a rendering-safe qfit preprocessing mode", markdown)
+        self.assertIn("Filters removed in probe: 1", markdown)
+        self.assertIn("Warnings after removing filters: 1", markdown)
+        self.assertIn("Warning count delta from qfit preprocessing: 1", markdown)
+        self.assertIn("##### Probe reductions by message", markdown)
+        self.assertIn("| Message | Before probe | Without filters | Reduced |", markdown)
+        self.assertIn("| `Skipping unsupported expression` | 2 | 1 | 1 |", markdown)
+        self.assertIn("##### Probe reductions by layer group", markdown)
+        self.assertIn("| Layer group | Before probe | Without filters | Reduced |", markdown)
+        self.assertIn("| `pois/labels` | 2 | 1 | 1 |", markdown)
         self.assertIn("QGIS converter warnings: 2", markdown)
         self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)
 

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -18,6 +18,7 @@ DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
 DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 _DEFAULT_OUTPUT_STYLE_SLUG = "mapbox-outdoors-v12"
 _MARKDOWN_THREE_COLUMN_COUNT_SEPARATOR = "| --- | --- | ---: |"
+_MARKDOWN_LAYER_GROUP_LABEL = "Layer group"
 
 if str(PACKAGE_PARENT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_PARENT))
@@ -636,6 +637,24 @@ def _annotate_qgis_warning_group_summaries(
             list(qfit_summary.get("by_layer_group") or []),
             key="group",
         )
+    filterless_probe = (
+        warning_report.get("without_filters_probe")
+        if isinstance(warning_report.get("without_filters_probe"), dict)
+        else {}
+    )
+    filterless_summary = (
+        filterless_probe.get("summary")
+        if isinstance(filterless_probe.get("summary"), dict)
+        else {}
+    )
+    _annotate_warning_summary_groups(filterless_summary, layer_groups)
+    reduced_from_qfit = filterless_probe.setdefault("reduced_from_qfit", {})
+    if isinstance(reduced_from_qfit, dict):
+        reduced_from_qfit["by_layer_group"] = _warning_reduction_summary(
+            list(qfit_summary.get("by_layer_group") or []),
+            list(filterless_summary.get("by_layer_group") or []),
+            key="group",
+        )
 
 
 def _annotate_layers_with_qgis_warnings(
@@ -696,6 +715,21 @@ def _qgis_warning_reduction_report(
     }
 
 
+def _style_without_filters(style_definition: dict[str, object]) -> tuple[dict[str, object], int]:
+    """Return a copy of a style with layer filters removed for converter diagnostics only."""
+    style_without_filters = copy.deepcopy(style_definition)
+    removed_count = 0
+    layers = style_without_filters.get("layers")
+    if not isinstance(layers, list):
+        return style_without_filters, removed_count
+    for layer in layers:
+        if not isinstance(layer, dict) or "filter" not in layer:
+            continue
+        layer.pop("filter")
+        removed_count += 1
+    return style_without_filters, removed_count
+
+
 def _collect_qgis_converter_warnings(style_definition: dict[str, object]) -> list[str]:
     from qgis.core import QgsMapBoxGlStyleConverter  # noqa: PLC0415
 
@@ -724,16 +758,25 @@ def _qgis_converter_warning_report(
     try:
         raw_warnings = _collect_qgis_converter_warnings(raw_style)
         qfit_warnings = _collect_qgis_converter_warnings(qfit_preprocessed_style)
+        filterless_style, filter_count_removed = _style_without_filters(qfit_preprocessed_style)
+        filterless_warnings = _collect_qgis_converter_warnings(filterless_style)
     finally:
         if created_app:
             app.exitQgis()
     raw_summary = _qgis_warning_summary(raw_warnings)
     qfit_summary = _qgis_warning_summary(qfit_warnings)
+    filterless_summary = _qgis_warning_summary(filterless_warnings)
     return {
         "raw": raw_summary,
         "qfit_preprocessed": qfit_summary,
         "warning_count_delta": len(raw_warnings) - len(qfit_warnings),
         "reduced_by_qfit": _qgis_warning_reduction_report(raw_summary, qfit_summary),
+        "without_filters_probe": {
+            "filter_count_removed": filter_count_removed,
+            "summary": filterless_summary,
+            "warning_count_delta_from_qfit": len(qfit_warnings) - len(filterless_warnings),
+            "reduced_from_qfit": _qgis_warning_reduction_report(qfit_summary, filterless_summary),
+        },
     }
 
 
@@ -967,11 +1010,13 @@ def _markdown_warning_reduction_table(
     *,
     key: str,
     label: str,
+    before_label: str = "Raw",
+    after_label: str = "After qfit",
     empty: str = "—",
 ) -> list[str]:
     if not items:
         return [empty, ""]
-    lines = [f"| {label} | Raw | After qfit | Reduced |", "| --- | ---: | ---: | ---: |"]
+    lines = [f"| {label} | {before_label} | {after_label} | Reduced |", "| --- | ---: | ---: | ---: |"]
     for item in items:
         lines.append(
             "| `{name}` | {raw_count} | {qfit_count} | {reduced_count} |".format(
@@ -985,6 +1030,55 @@ def _markdown_warning_reduction_table(
     return lines
 
 
+def _markdown_filterless_probe(probe: object) -> list[str]:
+    if not isinstance(probe, dict):
+        return []
+    summary = probe.get("summary") if isinstance(probe.get("summary"), dict) else {}
+    reduced = probe.get("reduced_from_qfit") if isinstance(probe.get("reduced_from_qfit"), dict) else {}
+    lines = [
+        "#### Diagnostic filter-removal probe",
+        "",
+        "This is not a rendering-safe qfit preprocessing mode; filters control feature inclusion.",
+        "Use it only as an upper-bound signal for how much converter warning debt is tied to filters.",
+        "",
+        f"Filters removed in probe: {probe.get('filter_count_removed', 0)}",
+        f"Warnings after removing filters: {summary.get('count', 0)}",
+        f"Warning count delta from qfit preprocessing: {probe.get('warning_count_delta_from_qfit', 0)}",
+        "",
+    ]
+    by_message = list(reduced.get("by_message") or [])
+    by_group = list(reduced.get("by_layer_group") or [])
+    if by_message:
+        lines.extend(
+            [
+                "##### Probe reductions by message",
+                "",
+                *_markdown_warning_reduction_table(
+                    by_message,
+                    key="message",
+                    label="Message",
+                    before_label="Before probe",
+                    after_label="Without filters",
+                ),
+            ]
+        )
+    if by_group:
+        lines.extend(
+            [
+                "##### Probe reductions by layer group",
+                "",
+                *_markdown_warning_reduction_table(
+                    by_group,
+                    key="group",
+                    label=_MARKDOWN_LAYER_GROUP_LABEL,
+                    before_label="Before probe",
+                    after_label="Without filters",
+                ),
+            ]
+        )
+    return lines
+
+
 def _markdown_qgis_converter_warnings(report: object) -> list[str]:
     if not isinstance(report, dict):
         return []
@@ -994,6 +1088,7 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
     reduced_by_message = list(reduced.get("by_message") or [])
     reduced_by_layer = list(reduced.get("by_layer") or [])
     reduced_by_group = list(reduced.get("by_layer_group") or [])
+    filterless_probe = report.get("without_filters_probe")
     lines = [
         "### QGIS converter warnings",
         "",
@@ -1023,7 +1118,11 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
             [
                 "#### Layer groups with fewer warnings after qfit preprocessing",
                 "",
-                *_markdown_warning_reduction_table(reduced_by_group, key="group", label="Layer group"),
+                *_markdown_warning_reduction_table(
+                    reduced_by_group,
+                    key="group",
+                    label=_MARKDOWN_LAYER_GROUP_LABEL,
+                ),
             ]
         )
     lines.extend(
@@ -1033,13 +1132,18 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
             *_markdown_named_count_table(list(qfit.get("by_message") or []), key="message", label="Message"),
             "#### Remaining warnings by layer group",
             "",
-            *_markdown_named_count_table(list(qfit.get("by_layer_group") or []), key="group", label="Layer group"),
+            *_markdown_named_count_table(
+                list(qfit.get("by_layer_group") or []),
+                key="group",
+                label=_MARKDOWN_LAYER_GROUP_LABEL,
+            ),
             "#### Remaining warnings by layer group and message",
             "",
             *_markdown_group_message_count_table(list(qfit.get("by_layer_group_and_message") or [])),
             "#### Remaining warnings by layer",
             "",
             *_markdown_named_count_table(list(qfit.get("by_layer") or []), key="layer", label="Layer"),
+            *_markdown_filterless_probe(filterless_probe),
         ]
     )
     return lines


### PR DESCRIPTION
## Summary
- Add a diagnostic QGIS converter warning probe that removes filters from the qfit-preprocessed Mapbox style copy.
- Report the probe as an unsafe upper bound only, so filter-related warning debt is visible without suggesting qfit should drop filters.
- Document the probe in the Mapbox Outdoors comparison/audit guide.

Refs #949.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live audit with local QGIS-profile Mapbox token, token not printed:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T232519Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T232546Z/audit.md`

## Evidence
- Raw QGIS converter warnings: 159
- After qfit preprocessing: 121
- Diagnostic no-filter probe: 65 warnings after removing 140 filters
- Probe delta from qfit preprocessing: 56 fewer warnings, concentrated in `Skipping unsupported expression` and `roads/trails` (36 fewer group warnings)

The probe confirms filters explain substantial remaining converter warnings, but it also documents why removing them is not a rendering-safe fix because filters control feature inclusion.
