### PR TITLE
feat: show Mapbox filter probe residuals

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -146,7 +146,7 @@ python3 validation/mapbox_outdoors_style_audit.py \
   --include-qgis-converter-warnings
 ```
 
-This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, warnings reduced by qfit preprocessing, and per-layer qfit-preprocessed warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit. It also includes a diagnostic filter-removal probe that reports how many converter warnings would disappear if all qfit-preprocessed layer filters were removed; this is an upper-bound signal only, not a suggested rendering change, because Mapbox filters control feature inclusion.
+This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, warnings reduced by qfit preprocessing, and per-layer qfit-preprocessed warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit. It also includes a diagnostic filter-removal probe that reports how many converter warnings would disappear if all qfit-preprocessed layer filters were removed, plus the warnings that would still remain by message, layer group, group/message pair, and layer. This is an upper-bound signal only, not a suggested rendering change, because Mapbox filters control feature inclusion.
 
 Use the audit together with the screenshot harness: first identify high-signal gaps visually, then check the corresponding style layers to decide the smallest safe qfit preprocessing improvement.
 

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -697,7 +697,21 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             },
             "without_filters_probe": {
                 "filter_count_removed": 1,
-                "summary": {"count": 1},
+                "summary": {
+                    "count": 1,
+                    "by_message": [
+                        {"message": "Referenced font DIN Pro Medium is not available on system", "count": 1}
+                    ],
+                    "by_layer_group": [{"group": "pois/labels", "count": 1}],
+                    "by_layer_group_and_message": [
+                        {
+                            "group": "pois/labels",
+                            "message": "Referenced font DIN Pro Medium is not available on system",
+                            "count": 1,
+                        }
+                    ],
+                    "by_layer": [{"layer": "poi-label", "count": 1}],
+                },
                 "warning_count_delta_from_qfit": 1,
                 "reduced_from_qfit": {
                     "by_message": [
@@ -758,6 +772,17 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("##### Probe reductions by layer group", markdown)
         self.assertIn("| Layer group | Before probe | Without filters | Reduced |", markdown)
         self.assertIn("| `pois/labels` | 2 | 1 | 1 |", markdown)
+        self.assertIn("##### Remaining probe warnings by message", markdown)
+        self.assertIn("| `Referenced font DIN Pro Medium is not available on system` | 1 |", markdown)
+        self.assertIn("##### Remaining probe warnings by layer group", markdown)
+        self.assertIn("| `pois/labels` | 1 |", markdown)
+        self.assertIn("##### Remaining probe warnings by layer group and message", markdown)
+        self.assertIn(
+            "| `pois/labels` | `Referenced font DIN Pro Medium is not available on system` | 1 |",
+            markdown,
+        )
+        self.assertIn("##### Remaining probe warnings by layer", markdown)
+        self.assertIn("| `poi-label` | 1 |", markdown)
         self.assertIn("QGIS converter warnings: 2", markdown)
         self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)
 

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -19,6 +19,8 @@ DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 _DEFAULT_OUTPUT_STYLE_SLUG = "mapbox-outdoors-v12"
 _MARKDOWN_THREE_COLUMN_COUNT_SEPARATOR = "| --- | --- | ---: |"
 _MARKDOWN_LAYER_GROUP_LABEL = "Layer group"
+_MARKDOWN_MESSAGE_LABEL = "Message"
+_MARKDOWN_LAYER_LABEL = "Layer"
 
 if str(PACKAGE_PARENT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_PARENT))
@@ -1048,6 +1050,10 @@ def _markdown_filterless_probe(probe: object) -> list[str]:
     ]
     by_message = list(reduced.get("by_message") or [])
     by_group = list(reduced.get("by_layer_group") or [])
+    remaining_by_message = list(summary.get("by_message") or [])
+    remaining_by_group = list(summary.get("by_layer_group") or [])
+    remaining_by_group_message = list(summary.get("by_layer_group_and_message") or [])
+    remaining_by_layer = list(summary.get("by_layer") or [])
     if by_message:
         lines.extend(
             [
@@ -1056,7 +1062,7 @@ def _markdown_filterless_probe(probe: object) -> list[str]:
                 *_markdown_warning_reduction_table(
                     by_message,
                     key="message",
-                    label="Message",
+                    label=_MARKDOWN_MESSAGE_LABEL,
                     before_label="Before probe",
                     after_label="Without filters",
                 ),
@@ -1076,6 +1082,34 @@ def _markdown_filterless_probe(probe: object) -> list[str]:
                 ),
             ]
         )
+    lines.extend(
+        [
+            "##### Remaining probe warnings by message",
+            "",
+            *_markdown_named_count_table(
+                remaining_by_message,
+                key="message",
+                label=_MARKDOWN_MESSAGE_LABEL,
+            ),
+            "##### Remaining probe warnings by layer group",
+            "",
+            *_markdown_named_count_table(
+                remaining_by_group,
+                key="group",
+                label=_MARKDOWN_LAYER_GROUP_LABEL,
+            ),
+            "##### Remaining probe warnings by layer group and message",
+            "",
+            *_markdown_group_message_count_table(remaining_by_group_message),
+            "##### Remaining probe warnings by layer",
+            "",
+            *_markdown_named_count_table(
+                remaining_by_layer,
+                key="layer",
+                label=_MARKDOWN_LAYER_LABEL,
+            ),
+        ]
+    )
     return lines
 
 
@@ -1102,7 +1136,11 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
             [
                 "#### Warnings reduced by qfit preprocessing",
                 "",
-                *_markdown_warning_reduction_table(reduced_by_message, key="message", label="Message"),
+                *_markdown_warning_reduction_table(
+                    reduced_by_message,
+                    key="message",
+                    label=_MARKDOWN_MESSAGE_LABEL,
+                ),
             ]
         )
     if reduced_by_layer:
@@ -1110,7 +1148,11 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
             [
                 "#### Layers with fewer warnings after qfit preprocessing",
                 "",
-                *_markdown_warning_reduction_table(reduced_by_layer, key="layer", label="Layer"),
+                *_markdown_warning_reduction_table(
+                    reduced_by_layer,
+                    key="layer",
+                    label=_MARKDOWN_LAYER_LABEL,
+                ),
             ]
         )
     if reduced_by_group:
@@ -1129,7 +1171,11 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
         [
             "#### Remaining warnings by message",
             "",
-            *_markdown_named_count_table(list(qfit.get("by_message") or []), key="message", label="Message"),
+            *_markdown_named_count_table(
+                list(qfit.get("by_message") or []),
+                key="message",
+                label=_MARKDOWN_MESSAGE_LABEL,
+            ),
             "#### Remaining warnings by layer group",
             "",
             *_markdown_named_count_table(
@@ -1142,7 +1188,11 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
             *_markdown_group_message_count_table(list(qfit.get("by_layer_group_and_message") or [])),
             "#### Remaining warnings by layer",
             "",
-            *_markdown_named_count_table(list(qfit.get("by_layer") or []), key="layer", label="Layer"),
+            *_markdown_named_count_table(
+                list(qfit.get("by_layer") or []),
+                key="layer",
+                label=_MARKDOWN_LAYER_LABEL,
+            ),
             *_markdown_filterless_probe(filterless_probe),
         ]
     )


### PR DESCRIPTION
## Summary
- Expand the diagnostic filter-removal probe Markdown to show remaining warnings after filters are removed.
- Add tables by message, layer group, group/message pair, and layer so residual non-filter warning debt is visible without changing rendering behavior.
- Document the expanded probe output in the Mapbox Outdoors audit guide.

Refs #949.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live audit with local QGIS-profile Mapbox token, token not printed:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T234430Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260511T234431Z/audit.md`

## Evidence
- Filter-removal diagnostic probe still leaves 65 converter warnings.
- Top residual group/message rows:
  - `roads/trails` / `Skipping unsupported expression`: 12
  - `pois/labels` / `Referenced font DIN Pro Medium is not available on system`: 6
  - `roads/trails` / `Could not interpret sprite value list with method step`: 5
- Top residual layers include `airport-label`, `gate-label`, and `transit-label` at 3 warnings each.

This keeps the filter probe clearly diagnostic while making the next non-filter investigation target explicit.
