### PR TITLE
feat: summarize Mapbox filter probe residual cues

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -146,7 +146,7 @@ python3 validation/mapbox_outdoors_style_audit.py \
   --include-qgis-converter-warnings
 ```
 
-This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, warnings reduced by qfit preprocessing, and per-layer qfit-preprocessed warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit. It also includes a diagnostic filter-removal probe that reports how many converter warnings would disappear if all qfit-preprocessed layer filters were removed, plus the warnings that would still remain by message, layer group, group/message pair, and layer. This is an upper-bound signal only, not a suggested rendering change, because Mapbox filters control feature inclusion.
+This optional probe does not render screenshots. It records converter warning counts, remaining warning summaries, warnings reduced by qfit preprocessing, and per-layer qfit-preprocessed warning summaries in the audit artifact so the next #949 slice can target issues QGIS itself reports, not just qfit's static style-expression audit. It also includes a diagnostic filter-removal probe that reports how many converter warnings would disappear if all qfit-preprocessed layer filters were removed, plus the warnings that would still remain by message, layer group, group/message pair, layer, and non-filter qfit unresolved property. This is an upper-bound signal only, not a suggested rendering change, because Mapbox filters control feature inclusion.
 
 Use the audit together with the screenshot harness: first identify high-signal gaps visually, then check the corresponding style layers to decide the smallest safe qfit preprocessing improvement.
 

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -289,6 +289,13 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ],
             },
             "warning_count_delta": 1,
+            "without_filters_probe": {
+                "summary": {
+                    "count": 1,
+                    "warnings": ["poi-label: Skipping unsupported expression"],
+                },
+                "reduced_from_qfit": {},
+            },
         }
         with patch.object(
             mapbox_outdoors_style_audit,
@@ -335,6 +342,21 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(
             audit["qgis_converter_warnings"]["reduced_by_qfit"]["by_layer_group"],
             [{"group": "roads/trails", "raw_count": 1, "qfit_count": 0, "reduced_count": 1}],
+        )
+        self.assertEqual(
+            audit["qgis_converter_warnings"]["without_filters_probe"]["summary"]["by_layer_group"],
+            [{"group": "pois/labels", "count": 1}],
+        )
+        self.assertEqual(
+            audit["qgis_converter_warnings"]["without_filters_probe"][
+                "remaining_warning_layers_by_unresolved_property"
+            ],
+            {
+                "by_property": [{"property": "layout.icon-image", "count": 1}],
+                "by_layer_group_and_property": [
+                    {"group": "pois/labels", "property": "layout.icon-image", "count": 1}
+                ],
+            },
         )
         layers = {layer["id"]: layer for layer in audit["layers"]}
         self.assertEqual(
@@ -484,6 +506,56 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 },
                 {"group": "roads/trails", "message": "Skipping unsupported expression", "count": 1},
             ],
+        )
+
+    def test_warning_layer_unresolved_property_summaries_skip_filters_for_probe(self):
+        layers = [
+            {
+                "id": "road-primary",
+                "group": "roads/trails",
+                "qfit_unresolved": [
+                    {"property": "filter"},
+                    {"property": "paint.line-opacity"},
+                ],
+            },
+            {
+                "id": "poi-label",
+                "group": "pois/labels",
+                "qfit_unresolved": [
+                    {"property": "filter"},
+                    {"property": "layout.icon-image"},
+                    {"property": "layout.text-font"},
+                ],
+            },
+            {
+                "id": "building",
+                "group": "boundaries/buildings",
+                "qfit_unresolved": [{"property": "fill-opacity"}],
+            },
+        ]
+
+        self.assertEqual(
+            mapbox_outdoors_style_audit._warning_layer_unresolved_property_summaries(
+                [
+                    "road-primary: Skipping unsupported expression",
+                    "poi-label: Could not retrieve sprite 'marker'",
+                    "Could not find sprite sheet",
+                ],
+                layers,
+                exclude_properties={"filter"},
+            ),
+            {
+                "by_property": [
+                    {"property": "layout.icon-image", "count": 1},
+                    {"property": "layout.text-font", "count": 1},
+                    {"property": "paint.line-opacity", "count": 1},
+                ],
+                "by_layer_group_and_property": [
+                    {"group": "pois/labels", "property": "layout.icon-image", "count": 1},
+                    {"group": "pois/labels", "property": "layout.text-font", "count": 1},
+                    {"group": "roads/trails", "property": "paint.line-opacity", "count": 1},
+                ],
+            },
         )
 
     def test_filter_expression_signature_group_summary_keeps_examples(self):
@@ -726,6 +798,16 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         {"group": "pois/labels", "raw_count": 2, "qfit_count": 1, "reduced_count": 1}
                     ],
                 },
+                "remaining_warning_layers_by_unresolved_property": {
+                    "by_property": [
+                        {"property": "layout.icon-image", "count": 1},
+                        {"property": "layout.text-font", "count": 1},
+                    ],
+                    "by_layer_group_and_property": [
+                        {"group": "pois/labels", "property": "layout.icon-image", "count": 1},
+                        {"group": "pois/labels", "property": "layout.text-font", "count": 1},
+                    ],
+                },
             },
         }
         layers = {layer["id"]: layer for layer in audit["layers"]}
@@ -783,6 +865,10 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )
         self.assertIn("##### Remaining probe warnings by layer", markdown)
         self.assertIn("| `poi-label` | 1 |", markdown)
+        self.assertIn("##### Remaining probe warning layers by unresolved qfit property", markdown)
+        self.assertIn("| `layout.icon-image` | 1 |", markdown)
+        self.assertIn("##### Remaining probe warning layers by layer group and unresolved qfit property", markdown)
+        self.assertIn("| `pois/labels` | `layout.text-font` | 1 |", markdown)
         self.assertIn("QGIS converter warnings: 2", markdown)
         self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)
 

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -619,6 +619,49 @@ def _annotate_warning_summary_groups(
     )
 
 
+def _warning_layer_unresolved_property_summaries(
+    warnings: list[str],
+    layers: list[dict[str, object]],
+    *,
+    exclude_properties: set[str] | None = None,
+) -> dict[str, list[dict[str, object]]]:
+    excluded = exclude_properties or set()
+    warning_layer_ids = {
+        layer
+        for warning in warnings
+        for layer, separator, _message in [warning.partition(": ")]
+        if separator and layer
+    }
+    property_counts: Counter[str] = Counter()
+    group_property_counts: Counter[tuple[str, str]] = Counter()
+    for layer in layers:
+        layer_id = str(layer.get("id") or "")
+        if layer_id not in warning_layer_ids:
+            continue
+        group = str(layer.get("group") or "other")
+        for property_name in _iter_property_names(layer, "qfit_unresolved"):
+            if property_name in excluded:
+                continue
+            property_counts[property_name] += 1
+            group_property_counts[(group, property_name)] += 1
+    return {
+        "by_property": [
+            {"property": property_name, "count": count}
+            for property_name, count in sorted(
+                property_counts.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ],
+        "by_layer_group_and_property": [
+            {"group": group, "property": property_name, "count": count}
+            for (group, property_name), count in sorted(
+                group_property_counts.items(),
+                key=lambda item: (-item[1], item[0][0], item[0][1]),
+            )
+        ],
+    }
+
+
 def _annotate_qgis_warning_group_summaries(
     layers: list[dict[str, object]],
     warning_report: dict[str, object],
@@ -650,6 +693,15 @@ def _annotate_qgis_warning_group_summaries(
         else {}
     )
     _annotate_warning_summary_groups(filterless_summary, layer_groups)
+    filterless_warnings = filterless_summary.get("warnings")
+    if isinstance(filterless_warnings, list):
+        filterless_probe["remaining_warning_layers_by_unresolved_property"] = (
+            _warning_layer_unresolved_property_summaries(
+                [str(warning) for warning in filterless_warnings],
+                layers,
+                exclude_properties={"filter"},
+            )
+        )
     reduced_from_qfit = filterless_probe.setdefault("reduced_from_qfit", {})
     if isinstance(reduced_from_qfit, dict):
         reduced_from_qfit["by_layer_group"] = _warning_reduction_summary(
@@ -1037,6 +1089,11 @@ def _markdown_filterless_probe(probe: object) -> list[str]:
         return []
     summary = probe.get("summary") if isinstance(probe.get("summary"), dict) else {}
     reduced = probe.get("reduced_from_qfit") if isinstance(probe.get("reduced_from_qfit"), dict) else {}
+    unresolved_property_summary = (
+        probe.get("remaining_warning_layers_by_unresolved_property")
+        if isinstance(probe.get("remaining_warning_layers_by_unresolved_property"), dict)
+        else {}
+    )
     lines = [
         "#### Diagnostic filter-removal probe",
         "",
@@ -1054,6 +1111,8 @@ def _markdown_filterless_probe(probe: object) -> list[str]:
     remaining_by_group = list(summary.get("by_layer_group") or [])
     remaining_by_group_message = list(summary.get("by_layer_group_and_message") or [])
     remaining_by_layer = list(summary.get("by_layer") or [])
+    unresolved_by_property = list(unresolved_property_summary.get("by_property") or [])
+    unresolved_by_group_property = list(unresolved_property_summary.get("by_layer_group_and_property") or [])
     if by_message:
         lines.extend(
             [
@@ -1108,6 +1167,12 @@ def _markdown_filterless_probe(probe: object) -> list[str]:
                 key="layer",
                 label=_MARKDOWN_LAYER_LABEL,
             ),
+            "##### Remaining probe warning layers by unresolved qfit property",
+            "",
+            *_markdown_count_table(unresolved_by_property),
+            "##### Remaining probe warning layers by layer group and unresolved qfit property",
+            "",
+            *_markdown_group_count_table(unresolved_by_group_property),
         ]
     )
     return lines


### PR DESCRIPTION
## Summary
- summarize diagnostic filter-removal probe residual warning layers by non-filter qfit unresolved property
- surface the same property/group breakdown in the audit Markdown
- document the extra residual-cue table in the Mapbox Outdoors comparison harness docs

## Evidence
- Live audit with local QGIS profile Mapbox token, token not printed:
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T000521Z/audit.json`
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T000522Z/audit.md`
- Filterless probe remains at 65 warnings; top residual non-filter cues:
  - `layout.text-font`: 24 warning layers
  - `layout.icon-image`: 20 warning layers
  - `paint.line-opacity`: 13 warning layers
  - top group/property: `roads/trails / paint.line-opacity`: 12 warning layers

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
