### PR TITLE
feat: add Mapbox line opacity warning probe

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -660,6 +660,43 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
         self.assertIn("icon-image", style["layers"][0]["layout"])
 
+    def test_style_with_scalar_line_opacity_replaces_supported_expressions_without_mutating_original(self):
+        style = {
+            "layers": [
+                {
+                    "id": "waterway",
+                    "paint": {"line-opacity": ["interpolate", ["linear"], ["zoom"], 8, 0, 14, 1]},
+                },
+                {"id": "road", "paint": {"line-opacity": ["step", ["zoom"], 0, 11, 1]}},
+                {
+                    "id": "contour",
+                    "paint": {
+                        "line-opacity": [
+                            "interpolate",
+                            ["linear"],
+                            ["zoom"],
+                            11,
+                            ["match", ["get", "index"], [1, 2], 0.15, 0.3],
+                            13,
+                            ["match", ["get", "index"], [1, 2], 0.3, 0.5],
+                        ]
+                    },
+                },
+                {"id": "literal", "paint": {"line-opacity": 0.2}},
+                {"id": "data-only", "paint": {"line-opacity": ["get", "opacity"]}},
+            ]
+        }
+
+        result, replaced_count = mapbox_outdoors_style_audit._style_with_scalar_line_opacity(style)
+
+        self.assertEqual(replaced_count, 3)
+        self.assertEqual(result["layers"][0]["paint"]["line-opacity"], 1.0)
+        self.assertEqual(result["layers"][1]["paint"]["line-opacity"], 1.0)
+        self.assertEqual(result["layers"][2]["paint"]["line-opacity"], 0.3)
+        self.assertEqual(result["layers"][3]["paint"]["line-opacity"], 0.2)
+        self.assertEqual(result["layers"][4]["paint"]["line-opacity"], ["get", "opacity"])
+        self.assertIsInstance(style["layers"][0]["paint"]["line-opacity"], list)
+
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):
         raw_style = {"layers": []}
         qfit_style = {
@@ -684,6 +721,10 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ],
                 ["poi-label: Could not retrieve sprite 'park'"],
                 ["poi-label: Skipping unsupported expression"],
+                [
+                    "poi-label: Skipping unsupported expression",
+                    "poi-label: Could not retrieve sprite 'park'",
+                ],
             ]
         )
 
@@ -737,6 +778,10 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ],
             },
         )
+        self.assertEqual(report["with_scalar_line_opacity_probe"]["line_opacity_expression_count_replaced"], 0)
+        self.assertEqual(report["with_scalar_line_opacity_probe"]["summary"]["count"], 2)
+        self.assertEqual(report["with_scalar_line_opacity_probe"]["warning_count_delta_from_qfit"], 0)
+        self.assertEqual(report["with_scalar_line_opacity_probe"]["reduced_from_qfit"], {"by_message": [], "by_layer": []})
         self.assertEqual(
             report["reduced_by_qfit"],
             {
@@ -762,6 +807,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             fake_converter.converted_styles[3],
             {"layers": [{"id": "poi-label", "filter": ["==", ["get", "maki"], "park"], "layout": {}}]},
         )
+        self.assertEqual(fake_converter.converted_styles[4], qfit_style)
         self.assertIn("filter", qfit_style["layers"][0])
         self.assertIn("icon-image", qfit_style["layers"][0]["layout"])
         self.assertEqual(len(fake_app.created), 1)
@@ -773,7 +819,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
     def test_qgis_converter_warning_report_reuses_existing_qgis_app(self):
         existing_app = object()
         fake_qgis, fake_core, fake_app, _fake_converter = _fake_qgis_modules(
-            [["raw warning"], ["qfit warning"], ["filterless warning"], ["iconless warning"]],
+            [["raw warning"], ["qfit warning"], ["filterless warning"], ["iconless warning"], ["line opacity warning"]],
             existing_app=existing_app,
         )
 
@@ -787,6 +833,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(report["qfit_preprocessed"]["warnings"], ["qfit warning"])
         self.assertEqual(report["without_filters_probe"]["summary"]["warnings"], ["filterless warning"])
         self.assertEqual(report["without_icon_images_probe"]["summary"]["warnings"], ["iconless warning"])
+        self.assertEqual(report["with_scalar_line_opacity_probe"]["summary"]["warnings"], ["line opacity warning"])
         self.assertEqual(fake_app.created, [])
 
     def test_markdown_summarizes_source_filter_preserved_and_unresolved_cues(self):
@@ -936,6 +983,32 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                     ],
                 },
             },
+            "with_scalar_line_opacity_probe": {
+                "line_opacity_expression_count_replaced": 2,
+                "summary": {
+                    "count": 1,
+                    "by_message": [{"message": "Could not retrieve sprite 'park'", "count": 1}],
+                    "by_layer_group": [{"group": "pois/labels", "count": 1}],
+                    "by_layer_group_and_message": [
+                        {"group": "pois/labels", "message": "Could not retrieve sprite 'park'", "count": 1}
+                    ],
+                    "by_layer": [{"layer": "poi-label", "count": 1}],
+                },
+                "warning_count_delta_from_qfit": 1,
+                "reduced_from_qfit": {
+                    "by_message": [
+                        {
+                            "message": "Skipping unsupported expression",
+                            "raw_count": 2,
+                            "qfit_count": 1,
+                            "reduced_count": 1,
+                        }
+                    ],
+                    "by_layer_group": [
+                        {"group": "pois/labels", "raw_count": 2, "qfit_count": 1, "reduced_count": 1}
+                    ],
+                },
+            },
         }
         layers = {layer["id"]: layer for layer in audit["layers"]}
         layers["poi-label"]["qgis_converter_warnings"] = {
@@ -1006,6 +1079,14 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("| Layer group | Before icon probe | Without icon-image | Reduced |", markdown)
         self.assertIn("##### Remaining icon probe warnings by message", markdown)
         self.assertIn("##### Remaining icon probe warnings by layer", markdown)
+        self.assertIn("#### Diagnostic line-opacity scalarization probe", markdown)
+        self.assertIn("Line opacity expressions replaced in probe: 2", markdown)
+        self.assertIn("Warnings after scalar line opacity: 1", markdown)
+        self.assertIn("##### Line-opacity probe reductions by message", markdown)
+        self.assertIn("| Message | Before line-opacity probe | Scalar line-opacity | Reduced |", markdown)
+        self.assertIn("##### Line-opacity probe reductions by layer group", markdown)
+        self.assertIn("##### Remaining line-opacity probe warnings by message", markdown)
+        self.assertIn("##### Remaining line-opacity probe warnings by layer", markdown)
         self.assertIn("QGIS converter warnings: 2", markdown)
         self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)
 

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -688,7 +688,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 {
                     "id": "data-interpolate",
                     "paint": {
-                        "line-opacity": ["interpolate", ["linear"], ["get", "altitude"], 0, 0.0, 3000, 1.0]
+                        "line-opacity": ["interpolate", ["linear"], ["get", "altitude"], 0, 0.2, 3000, 1.0]
                     },
                 },
             ]
@@ -696,17 +696,14 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
 
         result, replaced_count = mapbox_outdoors_style_audit._style_with_scalar_line_opacity(style)
 
-        self.assertEqual(replaced_count, 4)
+        self.assertEqual(replaced_count, 5)
         self.assertEqual(result["layers"][0]["paint"]["line-opacity"], 1.0)
         self.assertEqual(result["layers"][1]["paint"]["line-opacity"], 1.0)
         self.assertEqual(result["layers"][2]["paint"]["line-opacity"], 0.3)
         self.assertEqual(result["layers"][3]["paint"]["line-opacity"], 0.2)
         self.assertEqual(result["layers"][4]["paint"]["line-opacity"], ["get", "opacity"])
         self.assertEqual(result["layers"][5]["paint"]["line-opacity"], 0.2)
-        self.assertEqual(
-            result["layers"][6]["paint"]["line-opacity"],
-            ["interpolate", ["linear"], ["get", "altitude"], 0, 0.0, 3000, 1.0],
-        )
+        self.assertEqual(result["layers"][6]["paint"]["line-opacity"], 0.2)
         self.assertIsInstance(style["layers"][0]["paint"]["line-opacity"], list)
 
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -684,17 +684,29 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 },
                 {"id": "literal", "paint": {"line-opacity": 0.2}},
                 {"id": "data-only", "paint": {"line-opacity": ["get", "opacity"]}},
+                {"id": "data-step", "paint": {"line-opacity": ["step", ["get", "rank"], 0.2, 10, 0.8]}},
+                {
+                    "id": "data-interpolate",
+                    "paint": {
+                        "line-opacity": ["interpolate", ["linear"], ["get", "altitude"], 0, 0.0, 3000, 1.0]
+                    },
+                },
             ]
         }
 
         result, replaced_count = mapbox_outdoors_style_audit._style_with_scalar_line_opacity(style)
 
-        self.assertEqual(replaced_count, 3)
+        self.assertEqual(replaced_count, 4)
         self.assertEqual(result["layers"][0]["paint"]["line-opacity"], 1.0)
         self.assertEqual(result["layers"][1]["paint"]["line-opacity"], 1.0)
         self.assertEqual(result["layers"][2]["paint"]["line-opacity"], 0.3)
         self.assertEqual(result["layers"][3]["paint"]["line-opacity"], 0.2)
         self.assertEqual(result["layers"][4]["paint"]["line-opacity"], ["get", "opacity"])
+        self.assertEqual(result["layers"][5]["paint"]["line-opacity"], 0.2)
+        self.assertEqual(
+            result["layers"][6]["paint"]["line-opacity"],
+            ["interpolate", ["linear"], ["get", "altitude"], 0, 0.0, 3000, 1.0],
+        )
         self.assertIsInstance(style["layers"][0]["paint"]["line-opacity"], list)
 
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -837,8 +837,10 @@ def _clamp_opacity_value(value: object) -> float | None:
 
 
 def _representative_interpolate_output(expr: list[object]) -> object | None:
-    if len(expr) < 3 or expr[2] != ["zoom"]:
+    if len(expr) < 5:
         return None
+    if expr[2] != ["zoom"]:
+        return expr[4]
     stops: list[tuple[float, object]] = []
     for index in range(3, len(expr) - 1, 2):
         stop = expr[index]

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -837,6 +837,8 @@ def _clamp_opacity_value(value: object) -> float | None:
 
 
 def _representative_interpolate_output(expr: list[object]) -> object | None:
+    if len(expr) < 3 or expr[2] != ["zoom"]:
+        return None
     stops: list[tuple[float, object]] = []
     for index in range(3, len(expr) - 1, 2):
         stop = expr[index]
@@ -849,8 +851,10 @@ def _representative_interpolate_output(expr: list[object]) -> object | None:
 
 
 def _representative_step_output(expr: list[object]) -> object | None:
-    if len(expr) < 3 or expr[1] != ["zoom"]:
+    if len(expr) < 3:
         return None
+    if expr[1] != ["zoom"]:
+        return expr[2]
     value = expr[2]
     for index in range(3, len(expr) - 1, 2):
         stop = expr[index]

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -21,6 +21,10 @@ _MARKDOWN_THREE_COLUMN_COUNT_SEPARATOR = "| --- | --- | ---: |"
 _MARKDOWN_LAYER_GROUP_LABEL = "Layer group"
 _MARKDOWN_MESSAGE_LABEL = "Message"
 _MARKDOWN_LAYER_LABEL = "Layer"
+_MARKDOWN_WARNING_DELTA_FROM_QFIT_LABEL = "Warning count delta from qfit preprocessing"
+_LINE_OPACITY_PROBE_ZOOM = 12.0
+_SCALAR_LINE_OPACITY_PROBE_KEY = "with_scalar_line_opacity_probe"
+_LINE_OPACITY_EXPRESSION_COUNT_KEY = "line_opacity_expression_count_replaced"
 
 if str(PACKAGE_PARENT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_PARENT))
@@ -727,6 +731,12 @@ def _annotate_qgis_warning_group_summaries(
         else {}
     )
     _annotate_probe_warning_groups(icon_image_probe, qfit_summary, layer_groups)
+    line_opacity_probe = (
+        warning_report.get(_SCALAR_LINE_OPACITY_PROBE_KEY)
+        if isinstance(warning_report.get(_SCALAR_LINE_OPACITY_PROBE_KEY), dict)
+        else {}
+    )
+    _annotate_probe_warning_groups(line_opacity_probe, qfit_summary, layer_groups)
 
 
 def _annotate_layers_with_qgis_warnings(
@@ -820,6 +830,84 @@ def _style_without_icon_images(style_definition: dict[str, object]) -> tuple[dic
     return style_without_icons, removed_count
 
 
+def _clamp_opacity_value(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return max(0.0, min(float(value), 1.0))
+
+
+def _representative_interpolate_output(expr: list[object]) -> object | None:
+    stops: list[tuple[float, object]] = []
+    for index in range(3, len(expr) - 1, 2):
+        stop = expr[index]
+        if isinstance(stop, bool) or not isinstance(stop, (int, float)):
+            continue
+        stops.append((float(stop), expr[index + 1]))
+    if not stops:
+        return None
+    return min(stops, key=lambda stop: abs(stop[0] - _LINE_OPACITY_PROBE_ZOOM))[1]
+
+
+def _representative_step_output(expr: list[object]) -> object | None:
+    if len(expr) < 3 or expr[1] != ["zoom"]:
+        return None
+    value = expr[2]
+    for index in range(3, len(expr) - 1, 2):
+        stop = expr[index]
+        if isinstance(stop, bool) or not isinstance(stop, (int, float)):
+            continue
+        if _LINE_OPACITY_PROBE_ZOOM < float(stop):
+            break
+        value = expr[index + 1]
+    return value
+
+
+def _extract_line_opacity_scalar(expr: object) -> float | None:
+    scalar = _clamp_opacity_value(expr)
+    if scalar is not None:
+        return scalar
+    if not isinstance(expr, list) or not expr:
+        return None
+
+    op = expr[0]
+    if op == "interpolate":
+        return _extract_line_opacity_scalar(_representative_interpolate_output(expr))
+    if op == "step":
+        return _extract_line_opacity_scalar(_representative_step_output(expr))
+    if op == "match":
+        return _extract_line_opacity_scalar(expr[-1]) if len(expr) >= 4 else None
+    if op in {"case", "coalesce"}:
+        for item in reversed(expr[1:]):
+            scalar = _extract_line_opacity_scalar(item)
+            if scalar is not None:
+                return scalar
+    return None
+
+
+def _style_with_scalar_line_opacity(style_definition: dict[str, object]) -> tuple[dict[str, object], int]:
+    """Return a copy with line-opacity expressions scalarized for converter diagnostics only."""
+    style_with_scalar_opacity = copy.deepcopy(style_definition)
+    replaced_count = 0
+    layers = style_with_scalar_opacity.get("layers")
+    if not isinstance(layers, list):
+        return style_with_scalar_opacity, replaced_count
+    for layer in layers:
+        if not isinstance(layer, dict):
+            continue
+        paint = layer.get("paint")
+        if not isinstance(paint, dict):
+            continue
+        line_opacity = paint.get("line-opacity")
+        if not isinstance(line_opacity, list):
+            continue
+        scalar_opacity = _extract_line_opacity_scalar(line_opacity)
+        if scalar_opacity is None:
+            continue
+        paint["line-opacity"] = scalar_opacity
+        replaced_count += 1
+    return style_with_scalar_opacity, replaced_count
+
+
 def _collect_qgis_converter_warnings(style_definition: dict[str, object]) -> list[str]:
     from qgis.core import QgsMapBoxGlStyleConverter  # noqa: PLC0415
 
@@ -852,6 +940,10 @@ def _qgis_converter_warning_report(
         filterless_warnings = _collect_qgis_converter_warnings(filterless_style)
         iconless_style, icon_image_count_removed = _style_without_icon_images(qfit_preprocessed_style)
         iconless_warnings = _collect_qgis_converter_warnings(iconless_style)
+        scalar_line_opacity_style, line_opacity_expression_count_replaced = _style_with_scalar_line_opacity(
+            qfit_preprocessed_style
+        )
+        scalar_line_opacity_warnings = _collect_qgis_converter_warnings(scalar_line_opacity_style)
     finally:
         if created_app:
             app.exitQgis()
@@ -859,6 +951,7 @@ def _qgis_converter_warning_report(
     qfit_summary = _qgis_warning_summary(qfit_warnings)
     filterless_summary = _qgis_warning_summary(filterless_warnings)
     iconless_summary = _qgis_warning_summary(iconless_warnings)
+    scalar_line_opacity_summary = _qgis_warning_summary(scalar_line_opacity_warnings)
     return {
         "raw": raw_summary,
         "qfit_preprocessed": qfit_summary,
@@ -875,6 +968,12 @@ def _qgis_converter_warning_report(
             "summary": iconless_summary,
             "warning_count_delta_from_qfit": len(qfit_warnings) - len(iconless_warnings),
             "reduced_from_qfit": _qgis_warning_reduction_report(qfit_summary, iconless_summary),
+        },
+        _SCALAR_LINE_OPACITY_PROBE_KEY: {
+            _LINE_OPACITY_EXPRESSION_COUNT_KEY: line_opacity_expression_count_replaced,
+            "summary": scalar_line_opacity_summary,
+            "warning_count_delta_from_qfit": len(qfit_warnings) - len(scalar_line_opacity_warnings),
+            "reduced_from_qfit": _qgis_warning_reduction_report(qfit_summary, scalar_line_opacity_summary),
         },
     }
 
@@ -1147,7 +1246,7 @@ def _markdown_filterless_probe(probe: object) -> list[str]:
         "",
         f"Filters removed in probe: {probe.get('filter_count_removed', 0)}",
         f"Warnings after removing filters: {summary.get('count', 0)}",
-        f"Warning count delta from qfit preprocessing: {probe.get('warning_count_delta_from_qfit', 0)}",
+        f"{_MARKDOWN_WARNING_DELTA_FROM_QFIT_LABEL}: {probe.get('warning_count_delta_from_qfit', 0)}",
         "",
     ]
     by_message = list(reduced.get("by_message") or [])
@@ -1236,7 +1335,7 @@ def _markdown_icon_image_probe(probe: object) -> list[str]:
         "",
         f"Icon images removed in probe: {probe.get('icon_image_count_removed', 0)}",
         f"Warnings after removing icon images: {summary.get('count', 0)}",
-        f"Warning count delta from qfit preprocessing: {probe.get('warning_count_delta_from_qfit', 0)}",
+        f"{_MARKDOWN_WARNING_DELTA_FROM_QFIT_LABEL}: {probe.get('warning_count_delta_from_qfit', 0)}",
         "",
     ]
     by_message = list(reduced.get("by_message") or [])
@@ -1300,6 +1399,83 @@ def _markdown_icon_image_probe(probe: object) -> list[str]:
     return lines
 
 
+def _markdown_line_opacity_probe(probe: object) -> list[str]:
+    if not isinstance(probe, dict):
+        return []
+    summary = probe.get("summary") if isinstance(probe.get("summary"), dict) else {}
+    reduced = probe.get("reduced_from_qfit") if isinstance(probe.get("reduced_from_qfit"), dict) else {}
+    lines = [
+        "#### Diagnostic line-opacity scalarization probe",
+        "",
+        "This is not a rendering-safe qfit preprocessing mode; line opacity preserves zoom/data-driven cartographic emphasis.",
+        "Use it only to estimate how much converter warning debt is tied to Mapbox line-opacity expressions.",
+        "",
+        f"Line opacity expressions replaced in probe: {probe.get(_LINE_OPACITY_EXPRESSION_COUNT_KEY, 0)}",
+        f"Warnings after scalar line opacity: {summary.get('count', 0)}",
+        f"{_MARKDOWN_WARNING_DELTA_FROM_QFIT_LABEL}: {probe.get('warning_count_delta_from_qfit', 0)}",
+        "",
+    ]
+    by_message = list(reduced.get("by_message") or [])
+    by_group = list(reduced.get("by_layer_group") or [])
+    if by_message:
+        lines.extend(
+            [
+                "##### Line-opacity probe reductions by message",
+                "",
+                *_markdown_warning_reduction_table(
+                    by_message,
+                    key="message",
+                    label=_MARKDOWN_MESSAGE_LABEL,
+                    before_label="Before line-opacity probe",
+                    after_label="Scalar line-opacity",
+                ),
+            ]
+        )
+    if by_group:
+        lines.extend(
+            [
+                "##### Line-opacity probe reductions by layer group",
+                "",
+                *_markdown_warning_reduction_table(
+                    by_group,
+                    key="group",
+                    label=_MARKDOWN_LAYER_GROUP_LABEL,
+                    before_label="Before line-opacity probe",
+                    after_label="Scalar line-opacity",
+                ),
+            ]
+        )
+    lines.extend(
+        [
+            "##### Remaining line-opacity probe warnings by message",
+            "",
+            *_markdown_named_count_table(
+                list(summary.get("by_message") or []),
+                key="message",
+                label=_MARKDOWN_MESSAGE_LABEL,
+            ),
+            "##### Remaining line-opacity probe warnings by layer group",
+            "",
+            *_markdown_named_count_table(
+                list(summary.get("by_layer_group") or []),
+                key="group",
+                label=_MARKDOWN_LAYER_GROUP_LABEL,
+            ),
+            "##### Remaining line-opacity probe warnings by layer group and message",
+            "",
+            *_markdown_group_message_count_table(list(summary.get("by_layer_group_and_message") or [])),
+            "##### Remaining line-opacity probe warnings by layer",
+            "",
+            *_markdown_named_count_table(
+                list(summary.get("by_layer") or []),
+                key="layer",
+                label=_MARKDOWN_LAYER_LABEL,
+            ),
+        ]
+    )
+    return lines
+
+
 def _markdown_qgis_converter_warnings(report: object) -> list[str]:
     if not isinstance(report, dict):
         return []
@@ -1311,6 +1487,7 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
     reduced_by_group = list(reduced.get("by_layer_group") or [])
     filterless_probe = report.get("without_filters_probe")
     icon_image_probe = report.get("without_icon_images_probe")
+    line_opacity_probe = report.get(_SCALAR_LINE_OPACITY_PROBE_KEY)
     lines = [
         "### QGIS converter warnings",
         "",
@@ -1383,6 +1560,7 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
             ),
             *_markdown_filterless_probe(filterless_probe),
             *_markdown_icon_image_probe(icon_image_probe),
+            *_markdown_line_opacity_probe(line_opacity_probe),
         ]
     )
     return lines


### PR DESCRIPTION
## Summary

- add an audit-only diagnostic probe that scalarizes Mapbox `paint.line-opacity` expressions before running QGIS' Mapbox GL converter
- report warning reductions, remaining warnings, and layer-group summaries for the probe
- keep runtime Mapbox preprocessing unchanged because prior visual review showed scalar line opacity can regress Chamonix contour/trail linework
- handle review edge cases with deterministic diagnostic fallbacks for data-driven `step`/`interpolate` opacity expressions while avoiding zoom comparisons against property-domain stops

## Evidence for #949

Live QGIS converter audit using the local Mapbox token source:

- JSON: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T010335Z/audit.json`
- Markdown: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T010509Z/audit.md`

Observed warning counts:

- raw Mapbox style: 159
- qfit-preprocessed style: 96
- scalar line-opacity diagnostic probe: 84
- line-opacity expressions replaced in probe: 25
- delta from qfit preprocessing: 12 fewer warnings, all in `roads/trails`

This keeps line-opacity scalarization as evidence/research only, not a rendering behavior change.

## Tests

- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
