### PR TITLE
feat: provide Mapbox sprites to QGIS style conversion

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from urllib.parse import quote, unquote
+from urllib.parse import parse_qsl, quote, urlencode, unquote, urlparse, urlunparse
 from urllib.request import urlopen
 
 
@@ -730,28 +730,68 @@ def build_mapbox_sprite_url(
     )
 
 
+def build_mapbox_sprite_file_url(
+    access_token: str,
+    sprite_url: str,
+    *,
+    file_type: str,
+    retina: bool = False,
+) -> str:
+    """Return a concrete sprite JSON or PNG URL from a style JSON sprite base URL."""
+    token = access_token.strip()
+    sprite_base_url = sprite_url.strip()
+    if not token:
+        raise MapboxConfigError("Enter a Mapbox access token to load the selected background map.")
+    if not sprite_base_url:
+        raise MapboxConfigError("Mapbox style JSON does not define a sprite URL.")
+    if file_type not in {"json", "png"}:
+        raise MapboxConfigError("Mapbox sprite file_type must be 'json' or 'png'.")
+
+    if sprite_base_url.startswith("mapbox://sprites/"):
+        sprite_path = sprite_base_url.removeprefix("mapbox://sprites/")
+        owner, _, resolved_style_id = sprite_path.partition("/")
+        if not owner or not resolved_style_id:
+            raise MapboxConfigError("Mapbox sprite URL must include an owner and style ID.")
+        return build_mapbox_sprite_url(
+            token,
+            unquote(owner),
+            unquote(resolved_style_id),
+            file_type=file_type,
+            retina=retina,
+        )
+
+    parsed = urlparse(sprite_base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise MapboxConfigError("Mapbox sprite URL must be a mapbox://, http://, or https:// URL.")
+
+    retina_suffix = "@2x" if retina else ""
+    query = parse_qsl(parsed.query, keep_blank_values=True)
+    if parsed.netloc.endswith("mapbox.com") and not any(key == "access_token" for key, _ in query):
+        query.append(("access_token", token))
+    return urlunparse(
+        parsed._replace(
+            path=f"{parsed.path}{retina_suffix}.{file_type}",
+            query=urlencode(query),
+        )
+    )
+
+
 def fetch_mapbox_sprite_resources(
     access_token: str,
     style_owner: str,
     style_id: str,
     *,
+    sprite_url: str | None = None,
     retina: bool = False,
 ) -> MapboxSpriteResources:
     """Fetch Mapbox sprite definitions and image bytes for a style."""
-    definitions_url = build_mapbox_sprite_url(
-        access_token,
-        style_owner,
-        style_id,
-        file_type="json",
-        retina=retina,
-    )
-    image_url = build_mapbox_sprite_url(
-        access_token,
-        style_owner,
-        style_id,
-        file_type="png",
-        retina=retina,
-    )
+    url_builder = build_mapbox_sprite_url
+    url_args = (access_token, style_owner, style_id)
+    if sprite_url:
+        url_builder = build_mapbox_sprite_file_url
+        url_args = (access_token, sprite_url)
+    definitions_url = url_builder(*url_args, file_type="json", retina=retina)
+    image_url = url_builder(*url_args, file_type="png", retina=retina)
     with urlopen(definitions_url, timeout=20) as response:  # noqa: S310
         definitions = json.loads(response.read().decode("utf-8"))
     if not isinstance(definitions, dict):

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -24,6 +24,30 @@ def _is_mapbox_hostname(hostname: str | None) -> bool:
     return hostname.lower().split(".")[-2:] == ["mapbox", "com"]
 
 
+def _format_mapbox_sprite_url(
+    token: str,
+    owner: str,
+    style_id: str,
+    sprite_path_segments: tuple[str, ...],
+    *,
+    file_type: str,
+    retina: bool,
+) -> str:
+    retina_suffix = "@2x" if retina else ""
+    extra_sprite_path = "".join(f"/{quote(segment, safe='')}" for segment in sprite_path_segments)
+    return (
+        "https://api.mapbox.com/styles/v1/{owner}/{style_id}{extra}/sprite{retina}.{file_type}"
+        "?access_token={token}"
+    ).format(
+        owner=quote(owner, safe=""),
+        style_id=quote(style_id, safe=""),
+        extra=extra_sprite_path,
+        retina=retina_suffix,
+        file_type=file_type,
+        token=quote(token, safe=""),
+    )
+
+
 BACKGROUND_LAYER_PREFIX = "qfit background"
 DEFAULT_BACKGROUND_PRESET = "Outdoor"
 DEFAULT_MAPBOX_TILE_SIZE = 512
@@ -723,16 +747,13 @@ def build_mapbox_sprite_url(
     token, owner, resolved_style_id = _validated_mapbox_style_parts(access_token, style_owner, style_id)
     if file_type not in {"json", "png"}:
         raise MapboxConfigError("Mapbox sprite file_type must be 'json' or 'png'.")
-    retina_suffix = "@2x" if retina else ""
-    return (
-        "https://api.mapbox.com/styles/v1/{owner}/{style_id}/sprite{retina}.{file_type}"
-        "?access_token={token}"
-    ).format(
-        owner=quote(owner, safe=""),
-        style_id=quote(resolved_style_id, safe=""),
-        retina=retina_suffix,
+    return _format_mapbox_sprite_url(
+        token,
+        owner,
+        resolved_style_id,
+        (),
         file_type=file_type,
-        token=quote(token, safe=""),
+        retina=retina,
     )
 
 
@@ -755,13 +776,16 @@ def build_mapbox_sprite_file_url(
 
     if sprite_base_url.startswith("mapbox://sprites/"):
         sprite_path = sprite_base_url.removeprefix("mapbox://sprites/")
-        owner, _, resolved_style_id = sprite_path.partition("/")
-        if not owner or not resolved_style_id:
+        path_segments = tuple(unquote(segment) for segment in sprite_path.split("/"))
+        if len(path_segments) < 2 or not path_segments[0] or not path_segments[1] or any(
+            not segment for segment in path_segments[2:]
+        ):
             raise MapboxConfigError("Mapbox sprite URL must include an owner and style ID.")
-        return build_mapbox_sprite_url(
+        return _format_mapbox_sprite_url(
             token,
-            unquote(owner),
-            unquote(resolved_style_id),
+            path_segments[0],
+            path_segments[1],
+            path_segments[2:],
             file_type=file_type,
             retina=retina,
         )

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -18,6 +18,12 @@ class MapboxSpriteResources:
     image_bytes: bytes
 
 
+def _is_mapbox_hostname(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    return hostname.lower().split(".")[-2:] == ["mapbox", "com"]
+
+
 BACKGROUND_LAYER_PREFIX = "qfit background"
 DEFAULT_BACKGROUND_PRESET = "Outdoor"
 DEFAULT_MAPBOX_TILE_SIZE = 512
@@ -766,7 +772,7 @@ def build_mapbox_sprite_file_url(
 
     retina_suffix = "@2x" if retina else ""
     query = parse_qsl(parsed.query, keep_blank_values=True)
-    if parsed.netloc.endswith("mapbox.com") and not any(key == "access_token" for key, _ in query):
+    if _is_mapbox_hostname(parsed.hostname) and not any(key == "access_token" for key, _ in query):
         query.append(("access_token", token))
     return urlunparse(
         parsed._replace(

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from urllib.parse import quote, unquote
 from urllib.request import urlopen
 
 
 class MapboxConfigError(ValueError):
     """Raised when the configured Mapbox background settings are incomplete."""
+
+
+@dataclass(frozen=True)
+class MapboxSpriteResources:
+    """Mapbox sprite sheet resources for QGIS Mapbox GL style conversion."""
+
+    definitions: dict[str, object]
+    image_bytes: bytes
 
 
 BACKGROUND_LAYER_PREFIX = "qfit background"
@@ -694,6 +703,62 @@ def build_mapbox_style_json_url(
         style_id=quote(resolved_style_id, safe=""),
         token=quote(token, safe=""),
     )
+
+
+def build_mapbox_sprite_url(
+    access_token: str,
+    style_owner: str,
+    style_id: str,
+    *,
+    file_type: str,
+    retina: bool = False,
+) -> str:
+    """Return a Mapbox sprite JSON or PNG URL for a style."""
+    token, owner, resolved_style_id = _validated_mapbox_style_parts(access_token, style_owner, style_id)
+    if file_type not in {"json", "png"}:
+        raise MapboxConfigError("Mapbox sprite file_type must be 'json' or 'png'.")
+    retina_suffix = "@2x" if retina else ""
+    return (
+        "https://api.mapbox.com/styles/v1/{owner}/{style_id}/sprite{retina}.{file_type}"
+        "?access_token={token}"
+    ).format(
+        owner=quote(owner, safe=""),
+        style_id=quote(resolved_style_id, safe=""),
+        retina=retina_suffix,
+        file_type=file_type,
+        token=quote(token, safe=""),
+    )
+
+
+def fetch_mapbox_sprite_resources(
+    access_token: str,
+    style_owner: str,
+    style_id: str,
+    *,
+    retina: bool = False,
+) -> MapboxSpriteResources:
+    """Fetch Mapbox sprite definitions and image bytes for a style."""
+    definitions_url = build_mapbox_sprite_url(
+        access_token,
+        style_owner,
+        style_id,
+        file_type="json",
+        retina=retina,
+    )
+    image_url = build_mapbox_sprite_url(
+        access_token,
+        style_owner,
+        style_id,
+        file_type="png",
+        retina=retina,
+    )
+    with urlopen(definitions_url, timeout=20) as response:  # noqa: S310
+        definitions = json.loads(response.read().decode("utf-8"))
+    if not isinstance(definitions, dict):
+        raise MapboxConfigError("Mapbox sprite definitions response must be a JSON object.")
+    with urlopen(image_url, timeout=20) as response:  # noqa: S310
+        image_bytes = response.read()
+    return MapboxSpriteResources(definitions=definitions, image_bytes=image_bytes)
 
 
 def build_vector_tile_layer_uri(

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -406,7 +406,9 @@ class EnsureBackgroundLayerMockTests(unittest.TestCase):
         vector_layer.isValid.return_value = True
         sprite_resources = SimpleNamespace(definitions={"marker": {"x": 0}}, image_bytes=b"png")
 
-        with patch.object(_mock_bms_mod, "fetch_mapbox_style_definition", return_value={"sources": {}}) as style_fetch, \
+        style_definition = {"sources": {}, "sprite": "mapbox://sprites/shared-owner/shared-style"}
+
+        with patch.object(_mock_bms_mod, "fetch_mapbox_style_definition", return_value=style_definition) as style_fetch, \
              patch.object(_mock_bms_mod, "simplify_mapbox_style_expressions", return_value={"layers": []}), \
              patch.object(_mock_bms_mod, "fetch_mapbox_sprite_resources", return_value=sprite_resources) as sprite_fetch, \
              patch.object(_mock_bms_mod, "extract_mapbox_vector_source_ids", return_value=["mapbox.mapbox-streets-v8"]), \
@@ -422,7 +424,12 @@ class EnsureBackgroundLayerMockTests(unittest.TestCase):
 
         self.assertIs(result, vector_layer)
         style_fetch.assert_called_once_with("tok", "mapbox", "outdoors-v12")
-        sprite_fetch.assert_called_once_with("tok", "mapbox", "outdoors-v12")
+        sprite_fetch.assert_called_once_with(
+            "tok",
+            "mapbox",
+            "outdoors-v12",
+            sprite_url="mapbox://sprites/shared-owner/shared-style",
+        )
         uri_builder.assert_called_once()
         apply_style.assert_called_once_with(vector_layer, {"layers": []}, sprite_resources=sprite_resources)
 
@@ -430,7 +437,7 @@ class EnsureBackgroundLayerMockTests(unittest.TestCase):
         vector_layer = MagicMock()
         vector_layer.isValid.return_value = True
 
-        with patch.object(_mock_bms_mod, "fetch_mapbox_style_definition", return_value={"sources": {}}), \
+        with patch.object(_mock_bms_mod, "fetch_mapbox_style_definition", return_value={"sources": {}, "sprite": "mapbox://sprites/shared-owner/shared-style"}), \
              patch.object(_mock_bms_mod, "simplify_mapbox_style_expressions", return_value={"layers": []}), \
              patch.object(_mock_bms_mod, "fetch_mapbox_sprite_resources", side_effect=OSError("offline")), \
              patch.object(_mock_bms_mod, "extract_mapbox_vector_source_ids", return_value=["mapbox.mapbox-streets-v8"]), \

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -401,6 +401,52 @@ class EnsureBackgroundLayerMockTests(unittest.TestCase):
                     tile_mode="Raster",
                 )
 
+    def test_enabled_vector_passes_sprite_resources_to_style_conversion(self):
+        vector_layer = MagicMock()
+        vector_layer.isValid.return_value = True
+        sprite_resources = SimpleNamespace(definitions={"marker": {"x": 0}}, image_bytes=b"png")
+
+        with patch.object(_mock_bms_mod, "fetch_mapbox_style_definition", return_value={"sources": {}}) as style_fetch, \
+             patch.object(_mock_bms_mod, "simplify_mapbox_style_expressions", return_value={"layers": []}), \
+             patch.object(_mock_bms_mod, "fetch_mapbox_sprite_resources", return_value=sprite_resources) as sprite_fetch, \
+             patch.object(_mock_bms_mod, "extract_mapbox_vector_source_ids", return_value=["mapbox.mapbox-streets-v8"]), \
+             patch.object(_mock_bms_mod, "build_vector_tile_layer_uri", return_value="vector://style") as uri_builder, \
+             patch.object(_mock_bms_mod, "QgsVectorTileLayer", return_value=vector_layer), \
+             patch.object(self.service, "_apply_mapbox_gl_style") as apply_style:
+            result = self.service.ensure_background_layer(
+                enabled=True,
+                preset_name="Outdoor",
+                access_token="tok",
+                tile_mode="Vector",
+            )
+
+        self.assertIs(result, vector_layer)
+        style_fetch.assert_called_once_with("tok", "mapbox", "outdoors-v12")
+        sprite_fetch.assert_called_once_with("tok", "mapbox", "outdoors-v12")
+        uri_builder.assert_called_once()
+        apply_style.assert_called_once_with(vector_layer, {"layers": []}, sprite_resources=sprite_resources)
+
+    def test_enabled_vector_continues_without_unavailable_sprite_resources(self):
+        vector_layer = MagicMock()
+        vector_layer.isValid.return_value = True
+
+        with patch.object(_mock_bms_mod, "fetch_mapbox_style_definition", return_value={"sources": {}}), \
+             patch.object(_mock_bms_mod, "simplify_mapbox_style_expressions", return_value={"layers": []}), \
+             patch.object(_mock_bms_mod, "fetch_mapbox_sprite_resources", side_effect=OSError("offline")), \
+             patch.object(_mock_bms_mod, "extract_mapbox_vector_source_ids", return_value=["mapbox.mapbox-streets-v8"]), \
+             patch.object(_mock_bms_mod, "build_vector_tile_layer_uri", return_value="vector://style"), \
+             patch.object(_mock_bms_mod, "QgsVectorTileLayer", return_value=vector_layer), \
+             patch.object(self.service, "_apply_mapbox_gl_style") as apply_style:
+            result = self.service.ensure_background_layer(
+                enabled=True,
+                preset_name="Outdoor",
+                access_token="tok",
+                tile_mode="Vector",
+            )
+
+        self.assertIs(result, vector_layer)
+        apply_style.assert_called_once_with(vector_layer, {"layers": []}, sprite_resources=None)
+
 
 @unittest.skipIf(QGIS_AVAILABLE, SKIP_MOCK)
 @unittest.skipIf(_mock_bms_cls is None, SKIP_MOCK_LOAD)
@@ -684,6 +730,17 @@ class ApplyMapboxGlStyleMockTests(unittest.TestCase):
             self.service._apply_sprite_resources_to_context(ctx, sprite_resources)
 
         sprite_image.loadFromData.assert_called_once_with(b"not-an-image")
+        ctx.setSprites.assert_not_called()
+
+    def test_sprite_resources_skip_qimage_errors(self):
+        ctx = MagicMock()
+        fake_qt_gui = types.ModuleType("qgis.PyQt.QtGui")
+        fake_qt_gui.QImage = MagicMock(side_effect=RuntimeError("qt image unavailable"))
+        sprite_resources = SimpleNamespace(definitions={"marker": {"x": 0}}, image_bytes=b"png-bytes")
+
+        with patch.dict(sys.modules, {"qgis.PyQt.QtGui": fake_qt_gui}):
+            self.service._apply_sprite_resources_to_context(ctx, sprite_resources)
+
         ctx.setSprites.assert_not_called()
 
     def test_skips_when_renderer_is_none(self):

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -12,7 +12,9 @@ import importlib
 import importlib.util
 import os
 import sys
+import types
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
@@ -75,7 +77,7 @@ def _load_service_with_mock_qgis():
 
     qstub.QgsRasterLayer = _QgsRasterLayer
 
-    _QGIS_MODS = ["qgis", "qgis.core", "qgis.PyQt", "qgis.PyQt.QtCore"]
+    _QGIS_MODS = ["qgis", "qgis.core", "qgis.PyQt", "qgis.PyQt.QtCore", "qgis.PyQt.QtGui"]
 
     saved_qgis = {m: sys.modules.get(m) for m in _QGIS_MODS}
     saved_bms = sys.modules.get("qfit.visualization.infrastructure.background_map_service")
@@ -339,7 +341,13 @@ class EnsureBackgroundLayerMockTests(unittest.TestCase):
 
     def setUp(self):
         self._sys_patch = patch.dict(
-            "sys.modules", {"qgis": _qstub, "qgis.core": _qstub}
+            "sys.modules",
+            {
+                "qgis": _qstub,
+                "qgis.core": _qstub,
+                "qgis.PyQt": _qstub,
+                "qgis.PyQt.QtGui": _qstub,
+            },
         )
         self._sys_patch.start()
         self.service = _mock_bms_cls()
@@ -644,6 +652,39 @@ class ApplyMapboxGlStyleMockTests(unittest.TestCase):
         layer.setRenderer.assert_called_once()
         layer.setLabeling.assert_called_once()
         layer.setLabelsEnabled.assert_called_once_with(True)
+
+    def test_applies_sprite_resources_to_conversion_context(self):
+        layer = MagicMock()
+        sprite_image = MagicMock()
+        sprite_image.loadFromData.return_value = True
+        converted_image = MagicMock()
+        sprite_image.convertToFormat.return_value = converted_image
+        fake_qt_gui = types.ModuleType("qgis.PyQt.QtGui")
+        fake_qt_gui.QImage = MagicMock(return_value=sprite_image)
+        fake_qt_gui.QImage.Format_ARGB32 = "argb32"
+        sprite_resources = SimpleNamespace(definitions={"marker": {"x": 0}}, image_bytes=b"png-bytes")
+
+        with patch.dict(sys.modules, {"qgis.PyQt.QtGui": fake_qt_gui}):
+            self.service._apply_mapbox_gl_style(layer, {"layers": []}, sprite_resources=sprite_resources)
+
+        ctx = _qstub.QgsMapBoxGlStyleConversionContext.return_value
+        sprite_image.loadFromData.assert_called_once_with(b"png-bytes")
+        sprite_image.convertToFormat.assert_called_once_with("argb32")
+        ctx.setSprites.assert_called_once_with(converted_image, {"marker": {"x": 0}})
+
+    def test_sprite_resources_skip_invalid_images(self):
+        ctx = MagicMock()
+        sprite_image = MagicMock()
+        sprite_image.loadFromData.return_value = False
+        fake_qt_gui = types.ModuleType("qgis.PyQt.QtGui")
+        fake_qt_gui.QImage = MagicMock(return_value=sprite_image)
+        sprite_resources = SimpleNamespace(definitions={"marker": {"x": 0}}, image_bytes=b"not-an-image")
+
+        with patch.dict(sys.modules, {"qgis.PyQt.QtGui": fake_qt_gui}):
+            self.service._apply_sprite_resources_to_context(ctx, sprite_resources)
+
+        sprite_image.loadFromData.assert_called_once_with(b"not-an-image")
+        ctx.setSprites.assert_not_called()
 
     def test_skips_when_renderer_is_none(self):
         _qstub.QgsMapBoxGlStyleConverter.return_value.renderer.return_value = None

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import tests._path  # noqa: F401,E402
 
@@ -12,11 +13,13 @@ from mapbox_config import (  # noqa: E402
     TILE_MODES,
     MapboxConfigError,
     build_background_layer_name,
+    build_mapbox_sprite_url,
     build_mapbox_style_json_url,
     build_mapbox_tiles_url,
     build_mapbox_vector_tiles_url,
     build_vector_tile_layer_uri,
     extract_mapbox_vector_source_ids,
+    fetch_mapbox_sprite_resources,
     nearest_native_web_mercator_zoom_level,
     native_web_mercator_resolution_for_zoom,
     simplify_mapbox_style_expressions,
@@ -26,6 +29,20 @@ from mapbox_config import (  # noqa: E402
     resolve_background_style,
     snap_web_mercator_bounds_to_native_zoom,
 )
+
+
+class _FakeUrlResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return self.payload
 
 
 class MapboxConfigTests(unittest.TestCase):
@@ -137,6 +154,35 @@ class MapboxConfigTests(unittest.TestCase):
         url = build_mapbox_style_json_url("pk.token", "mapbox", "outdoors-v12")
         self.assertIn("api.mapbox.com/styles/v1/mapbox/outdoors-v12", url)
         self.assertIn("access_token=pk.token", url)
+
+    def test_sprite_url_uses_styles_endpoint(self):
+        url = build_mapbox_sprite_url(
+            "pk.test token",
+            "my user",
+            "style/id",
+            file_type="png",
+            retina=True,
+        )
+
+        self.assertIn("api.mapbox.com/styles/v1/my%20user/style%2Fid/sprite@2x.png", url)
+        self.assertIn("access_token=pk.test%20token", url)
+
+    def test_sprite_url_rejects_unknown_file_type(self):
+        with self.assertRaises(MapboxConfigError):
+            build_mapbox_sprite_url("pk.token", "mapbox", "outdoors-v12", file_type="svg")
+
+    def test_fetch_sprite_resources_fetches_definitions_and_image(self):
+        responses = [
+            _FakeUrlResponse(b'{"marker":{"x":0,"y":0,"width":12,"height":12}}'),
+            _FakeUrlResponse(b"png-bytes"),
+        ]
+
+        with patch("mapbox_config.urlopen", side_effect=responses) as urlopen_mock:
+            resources = fetch_mapbox_sprite_resources("pk.token", "mapbox", "outdoors-v12")
+
+        self.assertEqual(resources.definitions, {"marker": {"x": 0, "y": 0, "width": 12, "height": 12}})
+        self.assertEqual(resources.image_bytes, b"png-bytes")
+        self.assertEqual(urlopen_mock.call_count, 2)
 
     def test_vector_tile_layer_uri_contains_both_urls(self):
         uri = build_vector_tile_layer_uri("pk.token", "mapbox", "outdoors-v12")

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -13,6 +13,7 @@ from mapbox_config import (  # noqa: E402
     TILE_MODES,
     MapboxConfigError,
     build_background_layer_name,
+    build_mapbox_sprite_file_url,
     build_mapbox_sprite_url,
     build_mapbox_style_json_url,
     build_mapbox_tiles_url,
@@ -171,6 +172,46 @@ class MapboxConfigTests(unittest.TestCase):
         with self.assertRaises(MapboxConfigError):
             build_mapbox_sprite_url("pk.token", "mapbox", "outdoors-v12", file_type="svg")
 
+    def test_sprite_file_url_uses_style_json_mapbox_sprite_reference(self):
+        url = build_mapbox_sprite_file_url(
+            "pk.token",
+            "mapbox://sprites/shared-owner/shared-style",
+            file_type="json",
+            retina=True,
+        )
+
+        self.assertIn("api.mapbox.com/styles/v1/shared-owner/shared-style/sprite@2x.json", url)
+        self.assertIn("access_token=pk.token", url)
+
+    def test_sprite_file_url_appends_file_type_and_token_to_mapbox_https_url(self):
+        url = build_mapbox_sprite_file_url(
+            "pk.test token",
+            "https://api.mapbox.com/styles/v1/shared-owner/shared-style/sprite?fresh=true",
+            file_type="png",
+        )
+
+        self.assertEqual(
+            url,
+            "https://api.mapbox.com/styles/v1/shared-owner/shared-style/sprite.png"
+            "?fresh=true&access_token=pk.test+token",
+        )
+
+    def test_sprite_file_url_preserves_existing_token(self):
+        url = build_mapbox_sprite_file_url(
+            "pk.replacement",
+            "https://api.mapbox.com/styles/v1/shared-owner/shared-style/sprite?access_token=pk.embedded",
+            file_type="json",
+        )
+
+        self.assertEqual(
+            url,
+            "https://api.mapbox.com/styles/v1/shared-owner/shared-style/sprite.json?access_token=pk.embedded",
+        )
+
+    def test_sprite_file_url_rejects_unknown_url_scheme(self):
+        with self.assertRaises(MapboxConfigError):
+            build_mapbox_sprite_file_url("pk.token", "ftp://example.test/sprite", file_type="json")
+
     def test_fetch_sprite_resources_fetches_definitions_and_image(self):
         responses = [
             _FakeUrlResponse(b'{"marker":{"x":0,"y":0,"width":12,"height":12}}'),
@@ -178,11 +219,17 @@ class MapboxConfigTests(unittest.TestCase):
         ]
 
         with patch("mapbox_config.urlopen", side_effect=responses) as urlopen_mock:
-            resources = fetch_mapbox_sprite_resources("pk.token", "mapbox", "outdoors-v12")
+            resources = fetch_mapbox_sprite_resources(
+                "pk.token",
+                "mapbox",
+                "outdoors-v12",
+                sprite_url="mapbox://sprites/shared-owner/shared-style",
+            )
 
         self.assertEqual(resources.definitions, {"marker": {"x": 0, "y": 0, "width": 12, "height": 12}})
         self.assertEqual(resources.image_bytes, b"png-bytes")
         self.assertEqual(urlopen_mock.call_count, 2)
+        self.assertIn("shared-owner/shared-style/sprite.json", urlopen_mock.call_args_list[0].args[0])
 
     def test_vector_tile_layer_uri_contains_both_urls(self):
         uri = build_vector_tile_layer_uri("pk.token", "mapbox", "outdoors-v12")

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -208,6 +208,18 @@ class MapboxConfigTests(unittest.TestCase):
             "https://api.mapbox.com/styles/v1/shared-owner/shared-style/sprite.json?access_token=pk.embedded",
         )
 
+    def test_sprite_file_url_does_not_append_token_to_lookalike_hosts(self):
+        url = build_mapbox_sprite_file_url(
+            "pk.secret",
+            "https://evilmapbox.com/styles/v1/shared-owner/shared-style/sprite",
+            file_type="json",
+        )
+
+        self.assertEqual(
+            url,
+            "https://evilmapbox.com/styles/v1/shared-owner/shared-style/sprite.json",
+        )
+
     def test_sprite_file_url_rejects_unknown_url_scheme(self):
         with self.assertRaises(MapboxConfigError):
             build_mapbox_sprite_file_url("pk.token", "ftp://example.test/sprite", file_type="json")

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -183,6 +183,19 @@ class MapboxConfigTests(unittest.TestCase):
         self.assertIn("api.mapbox.com/styles/v1/shared-owner/shared-style/sprite@2x.json", url)
         self.assertIn("access_token=pk.token", url)
 
+    def test_sprite_file_url_preserves_immutable_mapbox_sprite_id(self):
+        url = build_mapbox_sprite_file_url(
+            "pk.token",
+            "mapbox://sprites/shared-owner/shared-style/immutable-sprite-id",
+            file_type="png",
+        )
+
+        self.assertIn(
+            "api.mapbox.com/styles/v1/shared-owner/shared-style/immutable-sprite-id/sprite.png",
+            url,
+        )
+        self.assertIn("access_token=pk.token", url)
+
     def test_sprite_file_url_appends_file_type_and_token_to_mapbox_https_url(self):
         url = build_mapbox_sprite_file_url(
             "pk.test token",

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -327,7 +327,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         fake_mapbox_config.simplify_mapbox_style_expressions = lambda style: style
         fake_mapbox_config.extract_mapbox_vector_source_ids = lambda _style: ["mapbox.mapbox-streets-v8"]
         fake_mapbox_config.build_vector_tile_layer_uri = lambda *_args, **_kwargs: "vector://style"
-        fake_mapbox_config.fetch_mapbox_sprite_resources = lambda *_args: "sprite-resources"
+        fake_mapbox_config.fetch_mapbox_sprite_resources = lambda *_args, **_kwargs: "sprite-resources"
 
         fake_background_service = types.ModuleType("qfit.visualization.infrastructure.background_map_service")
         fake_background_service.BackgroundMapService = FakeBackgroundMapService

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -301,8 +301,9 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 return FakeRenderedImage()
 
         class FakeBackgroundMapService:
-            def _apply_mapbox_gl_style(self, layer, style_definition):
+            def _apply_mapbox_gl_style(self, layer, style_definition, *, sprite_resources=None):
                 layer.applied_style = style_definition
+                layer.sprite_resources = sprite_resources
 
         fake_core = types.ModuleType("qgis.core")
         fake_core.QgsApplication = FakeQgsApplication
@@ -326,6 +327,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         fake_mapbox_config.simplify_mapbox_style_expressions = lambda style: style
         fake_mapbox_config.extract_mapbox_vector_source_ids = lambda _style: ["mapbox.mapbox-streets-v8"]
         fake_mapbox_config.build_vector_tile_layer_uri = lambda *_args, **_kwargs: "vector://style"
+        fake_mapbox_config.fetch_mapbox_sprite_resources = lambda *_args: "sprite-resources"
 
         fake_background_service = types.ModuleType("qfit.visualization.infrastructure.background_map_service")
         fake_background_service.BackgroundMapService = FakeBackgroundMapService

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -493,9 +493,14 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
         simplified_style = simplify_mapbox_style_expressions(resolved_style_definition)
         sprite_resources = None
         try:
-            sprite_resources = fetch_mapbox_sprite_resources(token, camera.style_owner, camera.style_id)
+            sprite_resources = fetch_mapbox_sprite_resources(
+                token,
+                camera.style_owner,
+                camera.style_id,
+                sprite_url=resolved_style_definition.get("sprite"),
+            )
         except (RuntimeError, KeyError, ValueError, OSError):
-            sprite_resources = None
+            pass
         tileset_ids = extract_mapbox_vector_source_ids(resolved_style_definition)
         layer_uri = build_vector_tile_layer_uri(
             token,

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -473,6 +473,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
         build_vector_tile_layer_uri,
         extract_mapbox_vector_source_ids,
         fetch_mapbox_style_definition,
+        fetch_mapbox_sprite_resources,
         simplify_mapbox_style_expressions,
     )
     from qfit.visualization.infrastructure.background_map_service import BackgroundMapService
@@ -490,6 +491,11 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
             else fetch_mapbox_style_definition(token, camera.style_owner, camera.style_id)
         )
         simplified_style = simplify_mapbox_style_expressions(resolved_style_definition)
+        sprite_resources = None
+        try:
+            sprite_resources = fetch_mapbox_sprite_resources(token, camera.style_owner, camera.style_id)
+        except (RuntimeError, KeyError, ValueError, OSError):
+            sprite_resources = None
         tileset_ids = extract_mapbox_vector_source_ids(resolved_style_definition)
         layer_uri = build_vector_tile_layer_uri(
             token,
@@ -501,7 +507,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
         layer = QgsVectorTileLayer(layer_uri, f"qfit comparison {camera.style_owner}/{camera.style_id}")
         if not is_valid_qgis_vector_tile_layer(layer=layer, vector_tile_layer_type=QgsVectorTileLayer):
             raise RuntimeError("QGIS did not create a valid Mapbox vector tile layer.")
-        BackgroundMapService()._apply_mapbox_gl_style(layer, simplified_style)
+        BackgroundMapService()._apply_mapbox_gl_style(layer, simplified_style, sprite_resources=sprite_resources)
 
         destination_crs = QgsCoordinateReferenceSystem("EPSG:3857")
         settings = QgsMapSettings()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -18,6 +18,7 @@ from ...mapbox_config import (
     build_xyz_layer_uri,
     extract_mapbox_vector_source_ids,
     fetch_mapbox_style_definition,
+    fetch_mapbox_sprite_resources,
     resolve_background_style,
     simplify_mapbox_style_expressions,
     snap_web_mercator_bounds_to_native_zoom,
@@ -60,6 +61,11 @@ class BackgroundMapService:
             try:
                 style_definition = fetch_mapbox_style_definition(access_token, resolved_owner, resolved_style_id)
                 simplified_style = simplify_mapbox_style_expressions(style_definition)
+                sprite_resources = None
+                try:
+                    sprite_resources = fetch_mapbox_sprite_resources(access_token, resolved_owner, resolved_style_id)
+                except (RuntimeError, KeyError, ValueError, OSError):
+                    logger.debug("Mapbox sprite sheet unavailable for vector style conversion", exc_info=True)
                 tileset_ids = extract_mapbox_vector_source_ids(style_definition)
                 uri = build_vector_tile_layer_uri(
                     access_token,
@@ -72,7 +78,7 @@ class BackgroundMapService:
                 if not layer.isValid():
                     layer = None
                 else:
-                    self._apply_mapbox_gl_style(layer, simplified_style)
+                    self._apply_mapbox_gl_style(layer, simplified_style, sprite_resources=sprite_resources)
             except (RuntimeError, KeyError, ValueError, OSError):
                 logger.warning("Vector tile layer creation failed, falling back to raster", exc_info=True)
                 layer = None
@@ -184,7 +190,22 @@ class BackgroundMapService:
         except (RuntimeError, AttributeError):
             logger.debug("Mapbox GL style application skipped", exc_info=True)
 
-    def _apply_mapbox_gl_style(self, layer: QgsVectorTileLayer, style_definition: dict) -> None:
+    def _apply_sprite_resources_to_context(self, ctx, sprite_resources) -> None:
+        if sprite_resources is None:
+            return
+        try:
+            from qgis.PyQt.QtGui import QImage  # noqa: PLC0415
+
+            sprite_image = QImage()
+            if sprite_image.loadFromData(sprite_resources.image_bytes):
+                argb_format = getattr(QImage, "Format_ARGB32", None)
+                if argb_format is not None:
+                    sprite_image = sprite_image.convertToFormat(argb_format)
+                ctx.setSprites(sprite_image, sprite_resources.definitions)
+        except (RuntimeError, ImportError, AttributeError, TypeError):
+            logger.debug("Mapbox sprite sheet skipped for vector style conversion", exc_info=True)
+
+    def _apply_mapbox_gl_style(self, layer: QgsVectorTileLayer, style_definition: dict, *, sprite_resources=None) -> None:
         try:
             from qgis.core import (  # noqa: PLC0415
                 QgsMapBoxGlStyleConversionContext,
@@ -195,6 +216,7 @@ class BackgroundMapService:
             ctx = QgsMapBoxGlStyleConversionContext()
             ctx.setTargetUnit(Qgis.RenderUnit.Millimeters)
             ctx.setPixelSizeConversionFactor(25.4 / 96.0)
+            self._apply_sprite_resources_to_context(ctx, sprite_resources)
             converter = QgsMapBoxGlStyleConverter()
             result = converter.convert(style_definition, ctx)
             if result == QgsMapBoxGlStyleConverter.Success:

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -203,13 +203,13 @@ class BackgroundMapService:
             from qgis.PyQt.QtGui import QImage  # noqa: PLC0415
 
             sprite_image = QImage()
-            if sprite_image.loadFromData(sprite_resources.image_bytes):
-                argb_format = getattr(QImage, "Format_ARGB32", None)
-                if argb_format is not None:
-                    sprite_image = sprite_image.convertToFormat(argb_format)
-                ctx.setSprites(sprite_image, sprite_resources.definitions)
-            else:
+            if not sprite_image.loadFromData(sprite_resources.image_bytes):
                 logger.debug("Mapbox sprite sheet image could not be decoded for vector style conversion")
+                return
+            argb_format = getattr(QImage, "Format_ARGB32", None)
+            if argb_format is not None:
+                sprite_image = sprite_image.convertToFormat(argb_format)
+            ctx.setSprites(sprite_image, sprite_resources.definitions)
         except (RuntimeError, ImportError, AttributeError, TypeError):
             logger.debug("Mapbox sprite sheet skipped for vector style conversion", exc_info=True)
 

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -13,6 +13,7 @@ from ...mapbox_config import (
     BACKGROUND_LAYER_PREFIX,
     TILE_MODE_RASTER,
     TILE_MODE_VECTOR,
+    MapboxSpriteResources,
     build_background_layer_name,
     build_vector_tile_layer_uri,
     build_xyz_layer_uri,
@@ -63,7 +64,12 @@ class BackgroundMapService:
                 simplified_style = simplify_mapbox_style_expressions(style_definition)
                 sprite_resources = None
                 try:
-                    sprite_resources = fetch_mapbox_sprite_resources(access_token, resolved_owner, resolved_style_id)
+                    sprite_resources = fetch_mapbox_sprite_resources(
+                        access_token,
+                        resolved_owner,
+                        resolved_style_id,
+                        sprite_url=style_definition.get("sprite"),
+                    )
                 except (RuntimeError, KeyError, ValueError, OSError):
                     logger.debug("Mapbox sprite sheet unavailable for vector style conversion", exc_info=True)
                 tileset_ids = extract_mapbox_vector_source_ids(style_definition)
@@ -190,7 +196,7 @@ class BackgroundMapService:
         except (RuntimeError, AttributeError):
             logger.debug("Mapbox GL style application skipped", exc_info=True)
 
-    def _apply_sprite_resources_to_context(self, ctx, sprite_resources) -> None:
+    def _apply_sprite_resources_to_context(self, ctx: object, sprite_resources: MapboxSpriteResources | None) -> None:
         if sprite_resources is None:
             return
         try:
@@ -202,10 +208,18 @@ class BackgroundMapService:
                 if argb_format is not None:
                     sprite_image = sprite_image.convertToFormat(argb_format)
                 ctx.setSprites(sprite_image, sprite_resources.definitions)
+            else:
+                logger.debug("Mapbox sprite sheet image could not be decoded for vector style conversion")
         except (RuntimeError, ImportError, AttributeError, TypeError):
             logger.debug("Mapbox sprite sheet skipped for vector style conversion", exc_info=True)
 
-    def _apply_mapbox_gl_style(self, layer: QgsVectorTileLayer, style_definition: dict, *, sprite_resources=None) -> None:
+    def _apply_mapbox_gl_style(
+        self,
+        layer: QgsVectorTileLayer,
+        style_definition: dict,
+        *,
+        sprite_resources: MapboxSpriteResources | None = None,
+    ) -> None:
         try:
             from qgis.core import (  # noqa: PLC0415
                 QgsMapBoxGlStyleConversionContext,


### PR DESCRIPTION
## Summary
- fetch Mapbox sprite JSON/PNG resources for vector-tile styles
- resolve sprites from the style JSON `sprite` URL when present, instead of assuming the owner/style-id default endpoint
- pass sprite resources into QGIS `QgsMapBoxGlStyleConversionContext.setSprites`
- use the same sprite-aware styling path in the Mapbox Outdoors comparison harness

Refs #949.

## Evidence
- Live Mapbox Outdoors/QGIS converter probe using the style JSON sprite URL: qfit-preprocessed warnings dropped from 96 to 86; 440 sprite definitions loaded and sprite image decoded.
  - `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T013113Z-sprite-url-probe/sprite-url-probe.json`
- Visual spot checks, one QGIS process per camera:
  - `zermatt-trails-z18-outdoors`: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260512T012133Z/metrics.json`
  - `chamonix-trails-z14-outdoors`: `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260512T012211Z/metrics.json`
- Visual review: sprite context did not introduce broad visual regressions; differences were localized around icon/symbol handling.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py tests/test_background_map_service.py tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
