### PR TITLE
feat: summarize sprite-context residual audit cues

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -989,6 +989,52 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(probe["warning_count_delta_from_qfit"], 0)
         self.assertIsNone(fake_converter.converted_contexts[5].sprites)
 
+    def test_build_style_audit_summarizes_sprite_context_residual_unresolved_properties(self):
+        warning_report = {
+            "raw": {"count": 0, "warnings": []},
+            "qfit_preprocessed": {"count": 1, "warnings": ["poi-label: Skipping unsupported expression"]},
+            "reduced_by_qfit": {},
+            "with_sprite_context_probe": {
+                "sprite_definition_count": 1,
+                "sprite_image_loaded": True,
+                "summary": {
+                    "count": 2,
+                    "warnings": [
+                        "poi-label: Skipping unsupported expression",
+                        "road-path: Skipping unsupported expression",
+                    ],
+                },
+                "reduced_from_qfit": {},
+            },
+        }
+
+        with patch.object(
+            mapbox_outdoors_style_audit,
+            "_qgis_converter_warning_report",
+            return_value=warning_report,
+        ):
+            audit = build_style_audit(
+                SAMPLE_STYLE,
+                config=StyleAuditConfig(include_qgis_converter_warnings=True),
+            )
+
+        sprite_probe = audit["qgis_converter_warnings"]["with_sprite_context_probe"]
+        self.assertEqual(
+            sprite_probe["remaining_warning_layers_by_unresolved_property"],
+            {
+                "by_property": [
+                    {"property": "filter", "count": 1},
+                    {"property": "layout.icon-image", "count": 1},
+                    {"property": "paint.line-dasharray", "count": 1},
+                ],
+                "by_layer_group_and_property": [
+                    {"group": "pois/labels", "property": "filter", "count": 1},
+                    {"group": "pois/labels", "property": "layout.icon-image", "count": 1},
+                    {"group": "roads/trails", "property": "paint.line-dasharray", "count": 1},
+                ],
+            },
+        )
+
     def test_markdown_summarizes_source_filter_preserved_and_unresolved_cues(self):
         audit = build_style_audit(SAMPLE_STYLE)
         markdown = build_audit_markdown(audit)
@@ -1188,6 +1234,16 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         {"group": "pois/labels", "raw_count": 2, "qfit_count": 1, "reduced_count": 1}
                     ],
                 },
+                "remaining_warning_layers_by_unresolved_property": {
+                    "by_property": [
+                        {"property": "filter", "count": 1},
+                        {"property": "layout.icon-image", "count": 1},
+                    ],
+                    "by_layer_group_and_property": [
+                        {"group": "pois/labels", "property": "filter", "count": 1},
+                        {"group": "pois/labels", "property": "layout.icon-image", "count": 1},
+                    ],
+                },
             },
         }
         layers = {layer["id"]: layer for layer in audit["layers"]}
@@ -1269,6 +1325,13 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("##### Sprite context reductions by layer group", markdown)
         self.assertIn("##### Remaining sprite-context warnings by message", markdown)
         self.assertIn("##### Remaining sprite-context warnings by layer", markdown)
+        self.assertIn("##### Remaining sprite-context warning layers by unresolved qfit property", markdown)
+        self.assertIn("| `filter` | 1 |", markdown)
+        self.assertIn(
+            "##### Remaining sprite-context warning layers by layer group and unresolved qfit property",
+            markdown,
+        )
+        self.assertIn("| `pois/labels` | `layout.icon-image` | 1 |", markdown)
         self.assertIn("#### Diagnostic line-opacity scalarization probe", markdown)
         self.assertIn("Line opacity expressions replaced in probe: 2", markdown)
         self.assertIn("Warnings after scalar line opacity: 1", markdown)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -699,6 +699,22 @@ def _warning_layer_unresolved_property_summaries(
     }
 
 
+def _annotate_probe_remaining_warning_unresolved_properties(
+    probe: dict[str, object],
+    layers: list[dict[str, object]],
+    *,
+    exclude_properties: set[str] | None = None,
+) -> None:
+    summary = probe.get("summary") if isinstance(probe.get("summary"), dict) else {}
+    warnings = summary.get("warnings")
+    if isinstance(warnings, list):
+        probe["remaining_warning_layers_by_unresolved_property"] = _warning_layer_unresolved_property_summaries(
+            [str(warning) for warning in warnings],
+            layers,
+            exclude_properties=exclude_properties,
+        )
+
+
 def _annotate_qgis_warning_group_summaries(
     layers: list[dict[str, object]],
     warning_report: dict[str, object],
@@ -724,16 +740,12 @@ def _annotate_qgis_warning_group_summaries(
         if isinstance(warning_report.get("without_filters_probe"), dict)
         else {}
     )
-    filterless_summary = _annotate_probe_warning_groups(filterless_probe, qfit_summary, layer_groups)
-    filterless_warnings = filterless_summary.get("warnings")
-    if isinstance(filterless_warnings, list):
-        filterless_probe["remaining_warning_layers_by_unresolved_property"] = (
-            _warning_layer_unresolved_property_summaries(
-                [str(warning) for warning in filterless_warnings],
-                layers,
-                exclude_properties={"filter"},
-            )
-        )
+    _annotate_probe_warning_groups(filterless_probe, qfit_summary, layer_groups)
+    _annotate_probe_remaining_warning_unresolved_properties(
+        filterless_probe,
+        layers,
+        exclude_properties={"filter"},
+    )
     icon_image_probe = (
         warning_report.get("without_icon_images_probe")
         if isinstance(warning_report.get("without_icon_images_probe"), dict)
@@ -752,6 +764,7 @@ def _annotate_qgis_warning_group_summaries(
         else {}
     )
     _annotate_probe_warning_groups(sprite_context_probe, qfit_summary, layer_groups)
+    _annotate_probe_remaining_warning_unresolved_properties(sprite_context_probe, layers)
 
 
 def _annotate_layers_with_qgis_warnings(
@@ -1557,6 +1570,11 @@ def _markdown_sprite_context_probe(probe: object) -> list[str]:
         return []
     summary = probe.get("summary") if isinstance(probe.get("summary"), dict) else {}
     reduced = probe.get("reduced_from_qfit") if isinstance(probe.get("reduced_from_qfit"), dict) else {}
+    unresolved_property_summary = (
+        probe.get("remaining_warning_layers_by_unresolved_property")
+        if isinstance(probe.get("remaining_warning_layers_by_unresolved_property"), dict)
+        else {}
+    )
     lines = [
         "#### Runtime sprite context probe",
         "",
@@ -1571,6 +1589,8 @@ def _markdown_sprite_context_probe(probe: object) -> list[str]:
     ]
     by_message = list(reduced.get("by_message") or [])
     by_group = list(reduced.get("by_layer_group") or [])
+    unresolved_by_property = list(unresolved_property_summary.get("by_property") or [])
+    unresolved_by_group_property = list(unresolved_property_summary.get("by_layer_group_and_property") or [])
     if by_message:
         lines.extend(
             [
@@ -1625,6 +1645,12 @@ def _markdown_sprite_context_probe(probe: object) -> list[str]:
                 key="layer",
                 label=_MARKDOWN_LAYER_LABEL,
             ),
+            "##### Remaining sprite-context warning layers by unresolved qfit property",
+            "",
+            *_markdown_count_table(unresolved_by_property),
+            "##### Remaining sprite-context warning layers by layer group and unresolved qfit property",
+            "",
+            *_markdown_group_count_table(unresolved_by_group_property),
         ]
     )
     return lines

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -643,7 +643,7 @@ def _annotate_probe_warning_groups(
     probe: dict[str, object],
     qfit_summary: dict[str, object],
     layer_groups: dict[str, str],
-) -> dict[str, object]:
+) -> None:
     summary = probe.get("summary") if isinstance(probe.get("summary"), dict) else {}
     _annotate_warning_summary_groups(summary, layer_groups)
     reduced_from_qfit = probe.setdefault("reduced_from_qfit", {})
@@ -653,7 +653,6 @@ def _annotate_probe_warning_groups(
             list(summary.get("by_layer_group") or []),
             key="group",
         )
-    return summary
 
 
 def _warning_layer_unresolved_property_summaries(


### PR DESCRIPTION
## Summary
- add unresolved-property summaries for remaining sprite-context converter warnings
- render those residual cues in the Mapbox Outdoors audit Markdown
- cover the sprite-context residual property grouping with unit tests

Refs #949.

## Evidence
- Live audit JSON: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T020646Z/audit.json`
  - sprite-context warnings: 86
  - top remaining unresolved-property cues: `filter` 47 layers, `layout.icon-image` 16, `paint.line-opacity` 14
  - top remaining group/property cue: `roads/trails` + `filter` 36 layers
- Live audit Markdown: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T020647Z/audit.md`

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
