### PR TITLE
feat: add Mapbox line dasharray warning probe

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -769,6 +769,21 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 },
                 {"id": "literal", "paint": {"line-dasharray": [5, 2]}},
                 {"id": "literal-expression", "paint": {"line-dasharray": ["literal", [2, 1]]}},
+                {
+                    "id": "malformed-match",
+                    "paint": {"line-dasharray": ["match", ["get", "class"], "primary", ["literal", [9, 9]]]},
+                },
+                {
+                    "id": "case-literal-condition",
+                    "paint": {
+                        "line-dasharray": [
+                            "case",
+                            ["literal", [9, 9]],
+                            ["get", "dash"],
+                            ["get", "fallbackDash"],
+                        ]
+                    },
+                },
                 {"id": "data-only", "paint": {"line-dasharray": ["get", "dash"]}},
             ]
         }
@@ -781,7 +796,12 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(result["layers"][2]["paint"]["line-dasharray"], [2, 2])
         self.assertEqual(result["layers"][3]["paint"]["line-dasharray"], [5, 2])
         self.assertEqual(result["layers"][4]["paint"]["line-dasharray"], [2, 1])
-        self.assertEqual(result["layers"][5]["paint"]["line-dasharray"], ["get", "dash"])
+        self.assertEqual(result["layers"][5]["paint"]["line-dasharray"], ["match", ["get", "class"], "primary", ["literal", [9, 9]]])
+        self.assertEqual(
+            result["layers"][6]["paint"]["line-dasharray"],
+            ["case", ["literal", [9, 9]], ["get", "dash"], ["get", "fallbackDash"]],
+        )
+        self.assertEqual(result["layers"][7]["paint"]["line-dasharray"], ["get", "dash"])
         self.assertEqual(style["layers"][0]["paint"]["line-dasharray"][0], "step")
 
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -733,6 +733,57 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(result["layers"][6]["paint"]["line-opacity"], 0.2)
         self.assertIsInstance(style["layers"][0]["paint"]["line-opacity"], list)
 
+    def test_style_with_literal_line_dasharray_replaces_supported_expressions_without_mutating_original(self):
+        style = {
+            "layers": [
+                {
+                    "id": "path",
+                    "paint": {
+                        "line-dasharray": ["step", ["zoom"], ["literal", [3, 3]], 12, ["literal", [4, 4]]]
+                    },
+                },
+                {
+                    "id": "rail",
+                    "paint": {
+                        "line-dasharray": [
+                            "interpolate",
+                            ["linear"],
+                            ["zoom"],
+                            10,
+                            ["literal", [1, 2]],
+                            14,
+                            ["literal", [2, 4]],
+                        ]
+                    },
+                },
+                {
+                    "id": "fence",
+                    "paint": {
+                        "line-dasharray": [
+                            "case",
+                            ["==", ["get", "class"], "gate"],
+                            ["literal", [1, 1]],
+                            ["literal", [2, 2]],
+                        ]
+                    },
+                },
+                {"id": "literal", "paint": {"line-dasharray": [5, 2]}},
+                {"id": "literal-expression", "paint": {"line-dasharray": ["literal", [2, 1]]}},
+                {"id": "data-only", "paint": {"line-dasharray": ["get", "dash"]}},
+            ]
+        }
+
+        result, replaced_count = mapbox_outdoors_style_audit._style_with_literal_line_dasharray(style)
+
+        self.assertEqual(replaced_count, 4)
+        self.assertEqual(result["layers"][0]["paint"]["line-dasharray"], [4, 4])
+        self.assertEqual(result["layers"][1]["paint"]["line-dasharray"], [1, 2])
+        self.assertEqual(result["layers"][2]["paint"]["line-dasharray"], [2, 2])
+        self.assertEqual(result["layers"][3]["paint"]["line-dasharray"], [5, 2])
+        self.assertEqual(result["layers"][4]["paint"]["line-dasharray"], [2, 1])
+        self.assertEqual(result["layers"][5]["paint"]["line-dasharray"], ["get", "dash"])
+        self.assertEqual(style["layers"][0]["paint"]["line-dasharray"][0], "step")
+
     def test_qgis_converter_warning_report_initializes_and_closes_qgis_app(self):
         raw_style = {"layers": []}
         qfit_style = {
@@ -757,6 +808,10 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ],
                 ["poi-label: Could not retrieve sprite 'park'"],
                 ["poi-label: Skipping unsupported expression"],
+                [
+                    "poi-label: Skipping unsupported expression",
+                    "poi-label: Could not retrieve sprite 'park'",
+                ],
                 [
                     "poi-label: Skipping unsupported expression",
                     "poi-label: Could not retrieve sprite 'park'",
@@ -818,6 +873,13 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(report["with_scalar_line_opacity_probe"]["summary"]["count"], 2)
         self.assertEqual(report["with_scalar_line_opacity_probe"]["warning_count_delta_from_qfit"], 0)
         self.assertEqual(report["with_scalar_line_opacity_probe"]["reduced_from_qfit"], {"by_message": [], "by_layer": []})
+        self.assertEqual(report["with_literal_line_dasharray_probe"]["line_dasharray_expression_count_replaced"], 0)
+        self.assertEqual(report["with_literal_line_dasharray_probe"]["summary"]["count"], 2)
+        self.assertEqual(report["with_literal_line_dasharray_probe"]["warning_count_delta_from_qfit"], 0)
+        self.assertEqual(
+            report["with_literal_line_dasharray_probe"]["reduced_from_qfit"],
+            {"by_message": [], "by_layer": []},
+        )
         self.assertEqual(
             report["reduced_by_qfit"],
             {
@@ -844,6 +906,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             {"layers": [{"id": "poi-label", "filter": ["==", ["get", "maki"], "park"], "layout": {}}]},
         )
         self.assertEqual(fake_converter.converted_styles[4], qfit_style)
+        self.assertEqual(fake_converter.converted_styles[5], qfit_style)
         self.assertIn("filter", qfit_style["layers"][0])
         self.assertIn("icon-image", qfit_style["layers"][0]["layout"])
         self.assertEqual(len(fake_app.created), 1)
@@ -855,7 +918,14 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
     def test_qgis_converter_warning_report_reuses_existing_qgis_app(self):
         existing_app = object()
         fake_qgis, fake_core, fake_app, _fake_converter = _fake_qgis_modules(
-            [["raw warning"], ["qfit warning"], ["filterless warning"], ["iconless warning"], ["line opacity warning"]],
+            [
+                ["raw warning"],
+                ["qfit warning"],
+                ["filterless warning"],
+                ["iconless warning"],
+                ["line opacity warning"],
+                ["line dasharray warning"],
+            ],
             existing_app=existing_app,
         )
 
@@ -870,6 +940,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(report["without_filters_probe"]["summary"]["warnings"], ["filterless warning"])
         self.assertEqual(report["without_icon_images_probe"]["summary"]["warnings"], ["iconless warning"])
         self.assertEqual(report["with_scalar_line_opacity_probe"]["summary"]["warnings"], ["line opacity warning"])
+        self.assertEqual(report["with_literal_line_dasharray_probe"]["summary"]["warnings"], ["line dasharray warning"])
         self.assertEqual(fake_app.created, [])
 
     def test_qgis_converter_warning_report_can_include_sprite_context_probe(self):
@@ -898,6 +969,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ["filterless warning"],
                 ["iconless warning"],
                 ["line opacity warning"],
+                ["line dasharray warning"],
                 ["poi-label: Skipping unsupported expression"],
             ]
         )
@@ -934,7 +1006,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 }
             ],
         )
-        sprite_context = fake_converter.converted_contexts[5]
+        sprite_context = fake_converter.converted_contexts[6]
         self.assertEqual(sprite_context.target_unit, "millimeters")
         self.assertAlmostEqual(sprite_context.pixel_size_conversion_factor, 25.4 / 96.0)
         image, definitions = sprite_context.sprites
@@ -963,6 +1035,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 ["filterless warning"],
                 ["iconless warning"],
                 ["line opacity warning"],
+                ["line dasharray warning"],
                 ["poi-label: Could not retrieve sprite 'park'"],
             ]
         )
@@ -987,7 +1060,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(probe["sprite_definition_count"], 1)
         self.assertFalse(probe["sprite_image_loaded"])
         self.assertEqual(probe["warning_count_delta_from_qfit"], 0)
-        self.assertIsNone(fake_converter.converted_contexts[5].sprites)
+        self.assertIsNone(fake_converter.converted_contexts[6].sprites)
 
     def test_build_style_audit_summarizes_sprite_context_residual_unresolved_properties(self):
         warning_report = {
@@ -1031,6 +1104,52 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                     {"group": "pois/labels", "property": "filter", "count": 1},
                     {"group": "pois/labels", "property": "layout.icon-image", "count": 1},
                     {"group": "roads/trails", "property": "paint.line-dasharray", "count": 1},
+                ],
+            },
+        )
+
+    def test_build_style_audit_summarizes_line_dasharray_probe_residual_unresolved_properties(self):
+        warning_report = {
+            "raw": {"count": 0, "warnings": []},
+            "qfit_preprocessed": {
+                "count": 2,
+                "warnings": [
+                    "road-path: Skipping unsupported expression",
+                    "poi-label: Skipping unsupported expression",
+                ],
+            },
+            "reduced_by_qfit": {},
+            "with_literal_line_dasharray_probe": {
+                "line_dasharray_expression_count_replaced": 1,
+                "summary": {
+                    "count": 1,
+                    "warnings": ["poi-label: Skipping unsupported expression"],
+                },
+                "reduced_from_qfit": {},
+            },
+        }
+
+        with patch.object(
+            mapbox_outdoors_style_audit,
+            "_qgis_converter_warning_report",
+            return_value=warning_report,
+        ):
+            audit = build_style_audit(
+                SAMPLE_STYLE,
+                config=StyleAuditConfig(include_qgis_converter_warnings=True),
+            )
+
+        dasharray_probe = audit["qgis_converter_warnings"]["with_literal_line_dasharray_probe"]
+        self.assertEqual(
+            dasharray_probe["remaining_warning_layers_by_unresolved_property"],
+            {
+                "by_property": [
+                    {"property": "filter", "count": 1},
+                    {"property": "layout.icon-image", "count": 1},
+                ],
+                "by_layer_group_and_property": [
+                    {"group": "pois/labels", "property": "filter", "count": 1},
+                    {"group": "pois/labels", "property": "layout.icon-image", "count": 1},
                 ],
             },
         )
@@ -1208,6 +1327,40 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                     ],
                 },
             },
+            "with_literal_line_dasharray_probe": {
+                "line_dasharray_expression_count_replaced": 1,
+                "summary": {
+                    "count": 1,
+                    "by_message": [{"message": "Could not retrieve sprite 'park'", "count": 1}],
+                    "by_layer_group": [{"group": "pois/labels", "count": 1}],
+                    "by_layer_group_and_message": [
+                        {"group": "pois/labels", "message": "Could not retrieve sprite 'park'", "count": 1}
+                    ],
+                    "by_layer": [{"layer": "poi-label", "count": 1}],
+                },
+                "warning_count_delta_from_qfit": 1,
+                "reduced_from_qfit": {
+                    "by_message": [
+                        {
+                            "message": "Skipping unsupported expression",
+                            "raw_count": 2,
+                            "qfit_count": 1,
+                            "reduced_count": 1,
+                        }
+                    ],
+                    "by_layer_group": [
+                        {"group": "roads/trails", "raw_count": 2, "qfit_count": 1, "reduced_count": 1}
+                    ],
+                },
+                "remaining_warning_layers_by_unresolved_property": {
+                    "by_property": [
+                        {"property": "layout.icon-image", "count": 1},
+                    ],
+                    "by_layer_group_and_property": [
+                        {"group": "pois/labels", "property": "layout.icon-image", "count": 1},
+                    ],
+                },
+            },
             "with_sprite_context_probe": {
                 "sprite_definition_count": 2,
                 "sprite_image_loaded": True,
@@ -1340,6 +1493,15 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("##### Line-opacity probe reductions by layer group", markdown)
         self.assertIn("##### Remaining line-opacity probe warnings by message", markdown)
         self.assertIn("##### Remaining line-opacity probe warnings by layer", markdown)
+        self.assertIn("#### Diagnostic line-dasharray literalization probe", markdown)
+        self.assertIn("Line dasharray expressions replaced in probe: 1", markdown)
+        self.assertIn("Warnings after literal line dasharray: 1", markdown)
+        self.assertIn("##### Line-dasharray probe reductions by message", markdown)
+        self.assertIn("| Message | Before line-dasharray probe | Literal line-dasharray | Reduced |", markdown)
+        self.assertIn("##### Line-dasharray probe reductions by layer group", markdown)
+        self.assertIn("##### Remaining line-dasharray probe warnings by message", markdown)
+        self.assertIn("##### Remaining line-dasharray probe warnings by layer", markdown)
+        self.assertIn("##### Remaining line-dasharray probe warning layers by unresolved qfit property", markdown)
         self.assertIn("QGIS converter warnings: 2", markdown)
         self.assertIn("`Referenced font DIN Pro Medium is not available on system` (1)", markdown)
 

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -964,6 +964,20 @@ def _literal_line_dasharray(value: object) -> list[object] | None:
     return None
 
 
+def _first_line_dasharray_literal(candidates: Iterable[object]) -> list[object] | None:
+    for candidate in candidates:
+        literal_dasharray = _extract_line_dasharray_literal(candidate)
+        if literal_dasharray is not None:
+            return literal_dasharray
+    return None
+
+
+def _case_line_dasharray_output_candidates(expr: list[object]) -> list[object]:
+    if len(expr) < 4:
+        return []
+    return [expr[-1], *(expr[index] for index in range(len(expr) - 2, 1, -2))]
+
+
 def _extract_line_dasharray_literal(expr: object) -> list[object] | None:
     literal_dasharray = _literal_line_dasharray(expr)
     if literal_dasharray is not None:
@@ -979,17 +993,9 @@ def _extract_line_dasharray_literal(expr: object) -> list[object] | None:
     if op == "match":
         return _extract_line_dasharray_literal(expr[-1]) if len(expr) >= 5 else None
     if op == "case":
-        if len(expr) < 4:
-            return None
-        for index in [len(expr) - 1, *range(len(expr) - 2, 1, -2)]:
-            literal_dasharray = _extract_line_dasharray_literal(expr[index])
-            if literal_dasharray is not None:
-                return literal_dasharray
+        return _first_line_dasharray_literal(_case_line_dasharray_output_candidates(expr))
     if op == "coalesce":
-        for item in reversed(expr[1:]):
-            literal_dasharray = _extract_line_dasharray_literal(item)
-            if literal_dasharray is not None:
-                return literal_dasharray
+        return _first_line_dasharray_literal(reversed(expr[1:]))
     return None
 
 

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -977,8 +977,15 @@ def _extract_line_dasharray_literal(expr: object) -> list[object] | None:
     if op == "step":
         return _extract_line_dasharray_literal(_representative_step_output(expr))
     if op == "match":
-        return _extract_line_dasharray_literal(expr[-1]) if len(expr) >= 4 else None
-    if op in {"case", "coalesce"}:
+        return _extract_line_dasharray_literal(expr[-1]) if len(expr) >= 5 else None
+    if op == "case":
+        if len(expr) < 4:
+            return None
+        for index in [len(expr) - 1, *range(len(expr) - 2, 1, -2)]:
+            literal_dasharray = _extract_line_dasharray_literal(expr[index])
+            if literal_dasharray is not None:
+                return literal_dasharray
+    if op == "coalesce":
         for item in reversed(expr[1:]):
             literal_dasharray = _extract_line_dasharray_literal(item)
             if literal_dasharray is not None:

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -22,12 +22,14 @@ _MARKDOWN_LAYER_GROUP_LABEL = "Layer group"
 _MARKDOWN_MESSAGE_LABEL = "Message"
 _MARKDOWN_LAYER_LABEL = "Layer"
 _MARKDOWN_WARNING_DELTA_FROM_QFIT_LABEL = "Warning count delta from qfit preprocessing"
-_LINE_OPACITY_PROBE_ZOOM = 12.0
+_EXPRESSION_PROBE_ZOOM = 12.0
 _SPRITE_CONTEXT_PROBE_KEY = "with_sprite_context_probe"
 _SPRITE_CONTEXT_DEFINITION_COUNT_KEY = "sprite_definition_count"
 _SPRITE_CONTEXT_IMAGE_LOADED_KEY = "sprite_image_loaded"
 _SCALAR_LINE_OPACITY_PROBE_KEY = "with_scalar_line_opacity_probe"
 _LINE_OPACITY_EXPRESSION_COUNT_KEY = "line_opacity_expression_count_replaced"
+_LITERAL_LINE_DASHARRAY_PROBE_KEY = "with_literal_line_dasharray_probe"
+_LINE_DASHARRAY_EXPRESSION_COUNT_KEY = "line_dasharray_expression_count_replaced"
 
 if str(PACKAGE_PARENT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_PARENT))
@@ -757,6 +759,17 @@ def _annotate_qgis_warning_group_summaries(
         else {}
     )
     _annotate_probe_warning_groups(line_opacity_probe, qfit_summary, layer_groups)
+    line_dasharray_probe = (
+        warning_report.get(_LITERAL_LINE_DASHARRAY_PROBE_KEY)
+        if isinstance(warning_report.get(_LITERAL_LINE_DASHARRAY_PROBE_KEY), dict)
+        else {}
+    )
+    _annotate_probe_warning_groups(line_dasharray_probe, qfit_summary, layer_groups)
+    _annotate_probe_remaining_warning_unresolved_properties(
+        line_dasharray_probe,
+        layers,
+        exclude_properties={"paint.line-dasharray"},
+    )
     sprite_context_probe = (
         warning_report.get(_SPRITE_CONTEXT_PROBE_KEY)
         if isinstance(warning_report.get(_SPRITE_CONTEXT_PROBE_KEY), dict)
@@ -876,7 +889,7 @@ def _representative_interpolate_output(expr: list[object]) -> object | None:
         stops.append((float(stop), expr[index + 1]))
     if not stops:
         return None
-    return min(stops, key=lambda stop: abs(stop[0] - _LINE_OPACITY_PROBE_ZOOM))[1]
+    return min(stops, key=lambda stop: abs(stop[0] - _EXPRESSION_PROBE_ZOOM))[1]
 
 
 def _representative_step_output(expr: list[object]) -> object | None:
@@ -889,7 +902,7 @@ def _representative_step_output(expr: list[object]) -> object | None:
         stop = expr[index]
         if isinstance(stop, bool) or not isinstance(stop, (int, float)):
             continue
-        if _LINE_OPACITY_PROBE_ZOOM < float(stop):
+        if _EXPRESSION_PROBE_ZOOM < float(stop):
             break
         value = expr[index + 1]
     return value
@@ -939,6 +952,62 @@ def _style_with_scalar_line_opacity(style_definition: dict[str, object]) -> tupl
         paint["line-opacity"] = scalar_opacity
         replaced_count += 1
     return style_with_scalar_opacity, replaced_count
+
+
+def _literal_line_dasharray(value: object) -> list[object] | None:
+    if _is_literal_number_array(value):
+        return list(value)
+    if not isinstance(value, list) or not value:
+        return None
+    if value[0] == "literal" and len(value) == 2 and _is_literal_number_array(value[1]):
+        return list(value[1])
+    return None
+
+
+def _extract_line_dasharray_literal(expr: object) -> list[object] | None:
+    literal_dasharray = _literal_line_dasharray(expr)
+    if literal_dasharray is not None:
+        return literal_dasharray
+    if not isinstance(expr, list) or not expr:
+        return None
+
+    op = expr[0]
+    if op == "interpolate":
+        return _extract_line_dasharray_literal(_representative_interpolate_output(expr))
+    if op == "step":
+        return _extract_line_dasharray_literal(_representative_step_output(expr))
+    if op == "match":
+        return _extract_line_dasharray_literal(expr[-1]) if len(expr) >= 4 else None
+    if op in {"case", "coalesce"}:
+        for item in reversed(expr[1:]):
+            literal_dasharray = _extract_line_dasharray_literal(item)
+            if literal_dasharray is not None:
+                return literal_dasharray
+    return None
+
+
+def _style_with_literal_line_dasharray(style_definition: dict[str, object]) -> tuple[dict[str, object], int]:
+    """Return a copy with line-dasharray expressions literalized for converter diagnostics only."""
+    style_with_literal_dasharray = copy.deepcopy(style_definition)
+    replaced_count = 0
+    layers = style_with_literal_dasharray.get("layers")
+    if not isinstance(layers, list):
+        return style_with_literal_dasharray, replaced_count
+    for layer in layers:
+        if not isinstance(layer, dict):
+            continue
+        paint = layer.get("paint")
+        if not isinstance(paint, dict):
+            continue
+        line_dasharray = paint.get("line-dasharray")
+        if not isinstance(line_dasharray, list) or _is_literal_number_array(line_dasharray):
+            continue
+        literal_dasharray = _extract_line_dasharray_literal(line_dasharray)
+        if literal_dasharray is None:
+            continue
+        paint["line-dasharray"] = literal_dasharray
+        replaced_count += 1
+    return style_with_literal_dasharray, replaced_count
 
 
 def _qgis_conversion_context_with_sprites(sprite_resources: MapboxSpriteResources):
@@ -1009,6 +1078,10 @@ def _qgis_converter_warning_report(
             qfit_preprocessed_style
         )
         scalar_line_opacity_warnings = _collect_qgis_converter_warnings(scalar_line_opacity_style)
+        literal_line_dasharray_style, line_dasharray_expression_count_replaced = _style_with_literal_line_dasharray(
+            qfit_preprocessed_style
+        )
+        literal_line_dasharray_warnings = _collect_qgis_converter_warnings(literal_line_dasharray_style)
         sprite_image_loaded = None
         if sprite_resources is not None:
             sprite_context_warnings, sprite_image_loaded = _collect_qgis_converter_warnings_with_sprite_context(
@@ -1025,6 +1098,7 @@ def _qgis_converter_warning_report(
     filterless_summary = _qgis_warning_summary(filterless_warnings)
     iconless_summary = _qgis_warning_summary(iconless_warnings)
     scalar_line_opacity_summary = _qgis_warning_summary(scalar_line_opacity_warnings)
+    literal_line_dasharray_summary = _qgis_warning_summary(literal_line_dasharray_warnings)
     report = {
         "raw": raw_summary,
         "qfit_preprocessed": qfit_summary,
@@ -1047,6 +1121,12 @@ def _qgis_converter_warning_report(
             "summary": scalar_line_opacity_summary,
             "warning_count_delta_from_qfit": len(qfit_warnings) - len(scalar_line_opacity_warnings),
             "reduced_from_qfit": _qgis_warning_reduction_report(qfit_summary, scalar_line_opacity_summary),
+        },
+        _LITERAL_LINE_DASHARRAY_PROBE_KEY: {
+            _LINE_DASHARRAY_EXPRESSION_COUNT_KEY: line_dasharray_expression_count_replaced,
+            "summary": literal_line_dasharray_summary,
+            "warning_count_delta_from_qfit": len(qfit_warnings) - len(literal_line_dasharray_warnings),
+            "reduced_from_qfit": _qgis_warning_reduction_report(qfit_summary, literal_line_dasharray_summary),
         },
     }
     if sprite_context_warnings is not None:
@@ -1564,6 +1644,96 @@ def _markdown_line_opacity_probe(probe: object) -> list[str]:
     return lines
 
 
+def _markdown_line_dasharray_probe(probe: object) -> list[str]:
+    if not isinstance(probe, dict):
+        return []
+    summary = probe.get("summary") if isinstance(probe.get("summary"), dict) else {}
+    reduced = probe.get("reduced_from_qfit") if isinstance(probe.get("reduced_from_qfit"), dict) else {}
+    unresolved_property_summary = (
+        probe.get("remaining_warning_layers_by_unresolved_property")
+        if isinstance(probe.get("remaining_warning_layers_by_unresolved_property"), dict)
+        else {}
+    )
+    lines = [
+        "#### Diagnostic line-dasharray literalization probe",
+        "",
+        "This is not a rendering-safe qfit preprocessing mode; line dash arrays preserve zoom/data-driven cartographic distinctions.",
+        "Use it only to estimate how much converter warning debt is tied to Mapbox line-dasharray expressions.",
+        "",
+        f"Line dasharray expressions replaced in probe: {probe.get(_LINE_DASHARRAY_EXPRESSION_COUNT_KEY, 0)}",
+        f"Warnings after literal line dasharray: {summary.get('count', 0)}",
+        f"{_MARKDOWN_WARNING_DELTA_FROM_QFIT_LABEL}: {probe.get('warning_count_delta_from_qfit', 0)}",
+        "",
+    ]
+    by_message = list(reduced.get("by_message") or [])
+    by_group = list(reduced.get("by_layer_group") or [])
+    unresolved_by_property = list(unresolved_property_summary.get("by_property") or [])
+    unresolved_by_group_property = list(unresolved_property_summary.get("by_layer_group_and_property") or [])
+    if by_message:
+        lines.extend(
+            [
+                "##### Line-dasharray probe reductions by message",
+                "",
+                *_markdown_warning_reduction_table(
+                    by_message,
+                    key="message",
+                    label=_MARKDOWN_MESSAGE_LABEL,
+                    before_label="Before line-dasharray probe",
+                    after_label="Literal line-dasharray",
+                ),
+            ]
+        )
+    if by_group:
+        lines.extend(
+            [
+                "##### Line-dasharray probe reductions by layer group",
+                "",
+                *_markdown_warning_reduction_table(
+                    by_group,
+                    key="group",
+                    label=_MARKDOWN_LAYER_GROUP_LABEL,
+                    before_label="Before line-dasharray probe",
+                    after_label="Literal line-dasharray",
+                ),
+            ]
+        )
+    lines.extend(
+        [
+            "##### Remaining line-dasharray probe warnings by message",
+            "",
+            *_markdown_named_count_table(
+                list(summary.get("by_message") or []),
+                key="message",
+                label=_MARKDOWN_MESSAGE_LABEL,
+            ),
+            "##### Remaining line-dasharray probe warnings by layer group",
+            "",
+            *_markdown_named_count_table(
+                list(summary.get("by_layer_group") or []),
+                key="group",
+                label=_MARKDOWN_LAYER_GROUP_LABEL,
+            ),
+            "##### Remaining line-dasharray probe warnings by layer group and message",
+            "",
+            *_markdown_group_message_count_table(list(summary.get("by_layer_group_and_message") or [])),
+            "##### Remaining line-dasharray probe warnings by layer",
+            "",
+            *_markdown_named_count_table(
+                list(summary.get("by_layer") or []),
+                key="layer",
+                label=_MARKDOWN_LAYER_LABEL,
+            ),
+            "##### Remaining line-dasharray probe warning layers by unresolved qfit property",
+            "",
+            *_markdown_count_table(unresolved_by_property),
+            "##### Remaining line-dasharray probe warning layers by layer group and unresolved qfit property",
+            "",
+            *_markdown_group_count_table(unresolved_by_group_property),
+        ]
+    )
+    return lines
+
+
 def _markdown_sprite_context_probe(probe: object) -> list[str]:
     if not isinstance(probe, dict):
         return []
@@ -1667,6 +1837,7 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
     filterless_probe = report.get("without_filters_probe")
     icon_image_probe = report.get("without_icon_images_probe")
     line_opacity_probe = report.get(_SCALAR_LINE_OPACITY_PROBE_KEY)
+    line_dasharray_probe = report.get(_LITERAL_LINE_DASHARRAY_PROBE_KEY)
     sprite_context_probe = report.get(_SPRITE_CONTEXT_PROBE_KEY)
     lines = [
         "### QGIS converter warnings",
@@ -1742,6 +1913,7 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
             *_markdown_sprite_context_probe(sprite_context_probe),
             *_markdown_icon_image_probe(icon_image_probe),
             *_markdown_line_opacity_probe(line_opacity_probe),
+            *_markdown_line_dasharray_probe(line_dasharray_probe),
         ]
     )
     return lines


### PR DESCRIPTION
## Summary
- add a diagnostic Mapbox Outdoors audit probe that literalizes supported `paint.line-dasharray` expressions only for QGIS warning analysis
- include remaining-warning summaries after excluding `paint.line-dasharray` so follow-up work can see what warning debt remains
- cover the probe helper, QGIS converter report, residual summaries, and markdown output in tests

## Evidence
- Live Mapbox Outdoors/QGIS audit with local profile token (token not printed): `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T024555Z/audit.md`
- The new probe replaced 19 line-dasharray expressions and showed 0 warning-count reduction, so this stays diagnostic rather than becoming qfit preprocessing behavior.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
