### PR TITLE
feat: isolate Mapbox all-camera comparison captures

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -83,7 +83,7 @@ python3 validation/mapbox_outdoors_comparison.py \
 
 `--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.
 Do not pass a positional camera name with `--all-cameras`; use one mode or the other.
-Each camera is captured in its own child Python process so a local Chromium/PyQGIS crash in one camera does not kill the whole matrix runner or expose token values on the command line. If any camera fails, the runner continues with the remaining cameras and exits non-zero with the failed camera names.
+Each camera is captured in its own child Python process so a local Chromium/PyQGIS crash in one camera does not kill the whole matrix runner or expose token values on the command line. If any camera fails or times out, the runner continues with the remaining cameras and exits non-zero with the failed camera names.
 
 ## Partial captures
 

--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -83,6 +83,7 @@ python3 validation/mapbox_outdoors_comparison.py \
 
 `--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.
 Do not pass a positional camera name with `--all-cameras`; use one mode or the other.
+Each camera is captured in its own child Python process so a local Chromium/PyQGIS crash in one camera does not kill the whole matrix runner or expose token values on the command line. If any camera fails, the runner continues with the remaining cameras and exits non-zero with the failed camera names.
 
 ## Partial captures
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -520,32 +520,40 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
     def test_main_all_cameras_runs_full_inspection_matrix(self):
         from qfit.validation import mapbox_outdoors_comparison
 
-        captured_camera_names = []
+        calls = []
 
-        def fake_run_comparison(config):
-            captured_camera_names.append(config.camera.name)
-            paths = mapbox_outdoors_comparison.build_comparison_paths(
-                run_dir=Path("/tmp/qfit-mapbox") / config.camera.name / "20260511T130000Z"
-            )
-            return mapbox_outdoors_comparison.ComparisonResult(
-                paths=paths,
-                browser_captured=False,
-                qgis_captured=False,
-                diff_captured=False,
-            )
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return types.SimpleNamespace(returncode=0, stdout=f"Camera: {command[2]}\n", stderr="")
 
-        with patch.dict("os.environ", {"MAPBOX_ACCESS_TOKEN": "test-mapbox-token"}, clear=True):
-            with patch("qfit.validation.mapbox_outdoors_comparison.run_comparison", side_effect=fake_run_comparison):
-                with patch("builtins.print"):
-                    result = mapbox_outdoors_comparison.main([
-                        "--all-cameras",
-                        "--skip-browser",
-                        "--skip-qgis",
-                        "--skip-diff",
-                    ])
+        with patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run):
+            with patch("builtins.print"):
+                result = mapbox_outdoors_comparison.main([
+                    "--all-cameras",
+                    "--mapbox-token",
+                    "test-mapbox-token",
+                    "--style-json",
+                    "/tmp/mapbox-outdoors-v12.json",
+                    "--output-root",
+                    "/tmp/qfit-mapbox",
+                    "--skip-browser",
+                    "--skip-diff",
+                    "--browser-timeout-ms",
+                    "5000",
+                ])
 
         self.assertEqual(result, 0)
-        self.assertEqual(captured_camera_names, list(CAMERAS))
+        self.assertEqual([command[2] for command, _kwargs in calls], list(CAMERAS))
+        for command, kwargs in calls:
+            self.assertNotIn("test-mapbox-token", command)
+            self.assertNotIn("--mapbox-token", command)
+            self.assertNotIn("--all-cameras", command)
+            self.assertIn("--style-json", command)
+            self.assertIn("/tmp/mapbox-outdoors-v12.json", command)
+            self.assertIn("--skip-browser", command)
+            self.assertIn("--skip-diff", command)
+            self.assertEqual(kwargs["env"]["MAPBOX_ACCESS_TOKEN"], "test-mapbox-token")
+            self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)
 
     def test_main_rejects_single_camera_with_all_cameras(self):
         from qfit.validation import mapbox_outdoors_comparison
@@ -565,39 +573,35 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
     def test_main_all_cameras_prints_finished_camera_before_later_failure(self):
         from qfit.validation import mapbox_outdoors_comparison
 
-        captured_camera_names = []
+        calls = []
 
-        def fake_run_comparison(config):
-            captured_camera_names.append(config.camera.name)
-            if len(captured_camera_names) > 1:
-                raise RuntimeError("qgis setup failed")
-            paths = mapbox_outdoors_comparison.build_comparison_paths(
-                run_dir=Path("/tmp/qfit-mapbox") / config.camera.name / "20260511T130000Z"
-            )
-            return mapbox_outdoors_comparison.ComparisonResult(
-                paths=paths,
-                browser_captured=False,
-                qgis_captured=False,
-                diff_captured=False,
-            )
+        def fake_run(command, **_kwargs):
+            calls.append(command)
+            if len(calls) == 2:
+                return types.SimpleNamespace(returncode=-11, stdout="", stderr="crashed for test-mapbox-token\n")
+            return types.SimpleNamespace(returncode=0, stdout=f"Camera: {command[2]}\n", stderr="")
 
-        with patch.dict("os.environ", {"MAPBOX_ACCESS_TOKEN": "test-mapbox-token"}, clear=True):
-            with patch("qfit.validation.mapbox_outdoors_comparison.run_comparison", side_effect=fake_run_comparison):
-                with patch("builtins.print") as print_mock:
-                    with patch("sys.stderr"):
-                        result = mapbox_outdoors_comparison.main([
-                            "--all-cameras",
-                            "--skip-browser",
-                            "--skip-qgis",
-                            "--skip-diff",
-                        ])
+        with patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run):
+            with patch("builtins.print") as print_mock:
+                with patch("sys.stderr") as stderr_mock:
+                    result = mapbox_outdoors_comparison.main([
+                        "--all-cameras",
+                        "--mapbox-token",
+                        "test-mapbox-token",
+                        "--skip-browser",
+                        "--skip-qgis",
+                        "--skip-diff",
+                    ])
 
         self.assertEqual(result, 2)
-        self.assertEqual(captured_camera_names[:2], list(CAMERAS)[:2])
-        print_mock.assert_any_call("Camera: switzerland-alps-z5-outdoors")
-        print_mock.assert_any_call(
-            "Manifest: /tmp/qfit-mapbox/switzerland-alps-z5-outdoors/20260511T130000Z/manifest.json"
+        self.assertEqual([command[2] for command in calls], list(CAMERAS))
+        print_mock.assert_any_call("Camera: switzerland-alps-z5-outdoors\n", end="")
+        stderr_text = "".join(
+            call.args[0] for call in print_mock.call_args_list if call.kwargs.get("file") is stderr_mock
         )
+        self.assertIn("camera valais-geneva-outdoors failed with exit code -11", stderr_text)
+        self.assertIn("comparison capture failed for: valais-geneva-outdoors (exit -11)", stderr_text)
+        self.assertNotIn("test-mapbox-token", stderr_text)
 
     def test_redact_sensitive_text_removes_token_from_errors(self):
         self.assertEqual(

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -1,6 +1,8 @@
 import base64
 import datetime as dt
 import json
+import os
+import subprocess
 import sys
 import tempfile
 import types
@@ -554,6 +556,41 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertIn("--skip-diff", command)
             self.assertEqual(kwargs["env"]["MAPBOX_ACCESS_TOKEN"], "test-mapbox-token")
             self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)
+            self.assertEqual(kwargs["timeout"], 65)
+
+    def test_main_all_cameras_resolves_relative_style_json_before_spawning_children(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        original_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            style_json = Path(tmpdir) / "snapshots" / "mapbox-outdoors-v12.json"
+            expected_style_json = style_json.resolve()
+            os.chdir(tmpdir)
+            try:
+                with patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run):
+                    result = mapbox_outdoors_comparison.main([
+                        "--all-cameras",
+                        "--mapbox-token",
+                        "test-mapbox-token",
+                        "--style-json",
+                        "snapshots/mapbox-outdoors-v12.json",
+                        "--skip-browser",
+                        "--skip-qgis",
+                        "--skip-diff",
+                    ])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(result, 0)
+        for command, kwargs in calls:
+            self.assertIn(str(expected_style_json), command)
+            self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)
 
     def test_main_rejects_single_camera_with_all_cameras(self):
         from qfit.validation import mapbox_outdoors_comparison
@@ -601,6 +638,49 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         )
         self.assertIn("camera valais-geneva-outdoors failed with exit code -11", stderr_text)
         self.assertIn("comparison capture failed for: valais-geneva-outdoors (exit -11)", stderr_text)
+        self.assertNotIn("test-mapbox-token", stderr_text)
+
+    def test_main_all_cameras_continues_after_timed_out_camera(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            if len(calls) == 1:
+                raise subprocess.TimeoutExpired(
+                    command,
+                    timeout=kwargs["timeout"],
+                    output="partial output for test-mapbox-token\n",
+                    stderr="partial error for test-mapbox-token\n",
+                )
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run):
+            with patch("builtins.print") as print_mock:
+                with patch("sys.stderr") as stderr_mock:
+                    result = mapbox_outdoors_comparison.main([
+                        "--all-cameras",
+                        "--mapbox-token",
+                        "test-mapbox-token",
+                        "--skip-browser",
+                        "--skip-qgis",
+                        "--skip-diff",
+                        "--browser-timeout-ms",
+                        "5000",
+                    ])
+
+        self.assertEqual(result, 2)
+        self.assertEqual([command[2] for command in calls], list(CAMERAS))
+        stderr_text = "".join(
+            call.args[0] for call in print_mock.call_args_list if call.kwargs.get("file") is stderr_mock
+        )
+        self.assertIn("camera switzerland-alps-z5-outdoors timed out after 65s", stderr_text)
+        self.assertIn(
+            "comparison capture failed for: switzerland-alps-z5-outdoors (timeout after 65s)",
+            stderr_text,
+        )
+        self.assertIn("partial error for <redacted>", stderr_text)
         self.assertNotIn("test-mapbox-token", stderr_text)
 
     def test_redact_sensitive_text_removes_token_from_errors(self):

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -793,7 +793,7 @@ def _single_camera_subprocess_command(
 ) -> list[str]:
     command = [sys.executable, str(Path(__file__).resolve()), camera.name]
     if args.style_json is not None:
-        command.extend(["--style-json", str(args.style_json)])
+        command.extend(["--style-json", str(args.style_json.expanduser().resolve())])
     command.extend(["--output-root", str(output_root)])
     if args.skip_browser:
         command.append("--skip-browser")
@@ -803,6 +803,10 @@ def _single_camera_subprocess_command(
         command.append("--skip-diff")
     command.extend(["--browser-timeout-ms", str(args.browser_timeout_ms)])
     return command
+
+
+def _camera_subprocess_timeout_seconds(args: argparse.Namespace) -> float:
+    return max(args.browser_timeout_ms / 1000 + 60, 1.0)
 
 
 def _single_camera_subprocess_environment(*, token: str) -> dict[str, str]:
@@ -820,6 +824,14 @@ def _write_child_output(*, stdout: str, stderr: str, token: str) -> None:
         print(safe_stderr, end="", file=sys.stderr)
 
 
+def _timeout_output_text(value: bytes | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def _run_all_cameras_in_subprocesses(
     *,
     args: argparse.Namespace,
@@ -829,14 +841,29 @@ def _run_all_cameras_in_subprocesses(
 ) -> None:
     failures: list[str] = []
     for camera in cameras:
-        completed = subprocess.run(  # noqa: S603 - command is built from this script and static camera names.
-            _single_camera_subprocess_command(args=args, camera=camera, output_root=output_root),
-            cwd=REPO_ROOT,
-            env=_single_camera_subprocess_environment(token=token),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        timeout_seconds = _camera_subprocess_timeout_seconds(args)
+        try:
+            completed = subprocess.run(  # noqa: S603 - command is built from this script and static camera names.
+                _single_camera_subprocess_command(args=args, camera=camera, output_root=output_root),
+                cwd=REPO_ROOT,
+                env=_single_camera_subprocess_environment(token=token),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            _write_child_output(
+                stdout=_timeout_output_text(exc.output),
+                stderr=_timeout_output_text(exc.stderr),
+                token=token,
+            )
+            failures.append(f"{camera.name} (timeout after {timeout_seconds:g}s)")
+            print(
+                f"error: camera {camera.name} timed out after {timeout_seconds:g}s; continuing.",
+                file=sys.stderr,
+            )
+            continue
         _write_child_output(stdout=completed.stdout, stderr=completed.stderr, token=token)
         if completed.returncode != 0:
             failures.append(f"{camera.name} (exit {completed.returncode})")

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -25,6 +25,10 @@ WEB_MERCATOR_TILE_SIZE = 512
 ImageMetrics: TypeAlias = dict[str, object]
 
 
+class ComparisonCaptureError(RuntimeError):
+    """Non-sensitive comparison harness failure safe to show on stderr."""
+
+
 @dataclass(frozen=True)
 class MapboxComparisonCamera:
     """Camera used by the manual Mapbox Outdoors comparison harness."""
@@ -765,6 +769,9 @@ def _run_and_print_configured_comparisons(args: argparse.Namespace) -> None:
     token = resolve_mapbox_token(provided_token=args.mapbox_token)
     output_root = Path(args.output_root).expanduser().resolve()
     cameras = _selected_cameras(args)
+    if args.all_cameras:
+        _run_all_cameras_in_subprocesses(args=args, cameras=cameras, token=token, output_root=output_root)
+        return
     multiple_results = len(cameras) > 1
     for camera in cameras:
         result = run_comparison(
@@ -776,6 +783,69 @@ def _run_and_print_configured_comparisons(args: argparse.Namespace) -> None:
             )
         )
         _print_result(result, camera_name=camera.name if multiple_results else None)
+
+
+def _single_camera_subprocess_command(
+    *,
+    args: argparse.Namespace,
+    camera: MapboxComparisonCamera,
+    output_root: Path,
+) -> list[str]:
+    command = [sys.executable, str(Path(__file__).resolve()), camera.name]
+    if args.style_json is not None:
+        command.extend(["--style-json", str(args.style_json)])
+    command.extend(["--output-root", str(output_root)])
+    if args.skip_browser:
+        command.append("--skip-browser")
+    if args.skip_qgis:
+        command.append("--skip-qgis")
+    if args.skip_diff:
+        command.append("--skip-diff")
+    command.extend(["--browser-timeout-ms", str(args.browser_timeout_ms)])
+    return command
+
+
+def _single_camera_subprocess_environment(*, token: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["MAPBOX_ACCESS_TOKEN"] = token
+    return env
+
+
+def _write_child_output(*, stdout: str, stderr: str, token: str) -> None:
+    safe_stdout = redact_sensitive_text(stdout, token)
+    safe_stderr = redact_sensitive_text(stderr, token)
+    if safe_stdout:
+        print(safe_stdout, end="")
+    if safe_stderr:
+        print(safe_stderr, end="", file=sys.stderr)
+
+
+def _run_all_cameras_in_subprocesses(
+    *,
+    args: argparse.Namespace,
+    cameras: list[MapboxComparisonCamera],
+    token: str,
+    output_root: Path,
+) -> None:
+    failures: list[str] = []
+    for camera in cameras:
+        completed = subprocess.run(  # noqa: S603 - command is built from this script and static camera names.
+            _single_camera_subprocess_command(args=args, camera=camera, output_root=output_root),
+            cwd=REPO_ROOT,
+            env=_single_camera_subprocess_environment(token=token),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        _write_child_output(stdout=completed.stdout, stderr=completed.stderr, token=token)
+        if completed.returncode != 0:
+            failures.append(f"{camera.name} (exit {completed.returncode})")
+            print(
+                f"error: camera {camera.name} failed with exit code {completed.returncode}; continuing.",
+                file=sys.stderr,
+            )
+    if failures:
+        raise ComparisonCaptureError(f"comparison capture failed for: {', '.join(failures)}")
 
 
 def _write_stdout_line(text: str) -> None:
@@ -800,6 +870,9 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 2
     except FileNotFoundError as exc:
         print(f"error: style JSON not found: {exc.filename}", file=sys.stderr)
+        return 2
+    except ComparisonCaptureError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return 2
     except (RuntimeError, OSError):
         print("error: comparison capture failed; use --skip-browser or --skip-qgis to isolate setup issues.", file=sys.stderr)


### PR DESCRIPTION
## Summary
- run each `--all-cameras` Mapbox Outdoors comparison capture in an isolated child Python process
- keep Mapbox tokens out of child command lines while redacting child stdout/stderr before replaying it
- continue the remaining camera matrix after a single camera process exits non-zero or times out, then exit non-zero with failed camera names
- resolve relative `--style-json` paths before spawning children so child `cwd=REPO_ROOT` does not change path semantics
- document the isolation behavior and update tests around all-camera execution/failure handling

## Evidence
- This slice came from a live full-matrix attempt that hit a PyQGIS SIGSEGV before this change.
- After the initial isolation change, the live z5-z18 matrix completed with the local profile token (token not printed):
  - `debug/mapbox-outdoors-comparison/switzerland-alps-z5-outdoors/20260512T031011Z/`
  - `debug/mapbox-outdoors-comparison/valais-geneva-outdoors/20260512T031018Z/`
  - `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260512T031023Z/`
  - `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260512T031027Z/`
  - `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260512T031031Z/`
- After addressing Codex/Greptile feedback, the live z5-z18 matrix completed again with the local profile token (token not printed):
  - `debug/mapbox-outdoors-comparison/switzerland-alps-z5-outdoors/20260512T031737Z/`
  - `debug/mapbox-outdoors-comparison/valais-geneva-outdoors/20260512T031742Z/`
  - `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260512T031747Z/`
  - `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260512T031751Z/`
  - `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260512T031755Z/`

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949
