### PR TITLE
feat: summarize Mapbox comparison matrix runs

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -84,6 +84,7 @@ python3 validation/mapbox_outdoors_comparison.py \
 `--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.
 Do not pass a positional camera name with `--all-cameras`; use one mode or the other.
 Each camera is captured in its own child Python process so a local Chromium/PyQGIS crash in one camera does not kill the whole matrix runner or expose token values on the command line. If any camera fails or times out, the runner continues with the remaining cameras and exits non-zero with the failed camera names.
+The parent run also writes token-free aggregate `summary.json` and `summary.md` files under `debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/` with per-camera status, manifest paths, and the main diff metrics.
 
 ## Partial captures
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -596,7 +596,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         from qfit.validation import mapbox_outdoors_comparison
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_root = Path(tmpdir)
+            output_root = Path(tmpdir) / "test-mapbox-token-output"
 
             def fake_run(command, **_kwargs):
                 camera_name = command[2]
@@ -636,7 +636,8 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                         "--skip-diff",
                     ])
 
-            summary_json = next((output_root / "all-cameras").glob("*/summary.json"))
+            summary_json = next((output_root / "all-cameras").glob("*/summary.json"), None)
+            self.assertIsNotNone(summary_json, "all-cameras summary.json should be written")
             summary_markdown = summary_json.with_name("summary.md")
             summary_json_text = summary_json.read_text(encoding="utf-8")
             summary = json.loads(summary_json_text)
@@ -649,6 +650,9 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertIn("| `switzerland-alps-z5-outdoors` | passed | 5.35 | 0.1000 |", summary_text)
         self.assertNotIn("test-mapbox-token", summary_json_text)
         self.assertNotIn("test-mapbox-token", summary_text)
+        for call in print_mock.call_args_list:
+            if call.args:
+                self.assertNotIn("test-mapbox-token", call.args[0])
         self.assertTrue(any(call.args[0].startswith("Matrix summary:") for call in print_mock.call_args_list))
 
     def test_main_rejects_single_camera_with_all_cameras(self):

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -592,6 +592,65 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertIn(str(expected_style_json), command)
             self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)
 
+    def test_main_all_cameras_writes_matrix_summary_with_manifest_metrics(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_root = Path(tmpdir)
+
+            def fake_run(command, **_kwargs):
+                camera_name = command[2]
+                camera_index = list(CAMERAS).index(camera_name)
+                run_dir = output_root / camera_name / "20260512T030000Z"
+                run_dir.mkdir(parents=True)
+                manifest_path = run_dir / "manifest.json"
+                manifest_path.write_text(
+                    json.dumps(
+                        {
+                            "metrics": {
+                                "changed_pixel_ratio": 0.1 + camera_index / 10,
+                                "normalized_mean_absolute_channel_delta": 0.01 + camera_index / 100,
+                                "normalized_rms_channel_delta": 0.02 + camera_index / 100,
+                                "ssim_status": "unavailable",
+                            }
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                return types.SimpleNamespace(
+                    returncode=0,
+                    stdout=f"Camera: {camera_name}\nManifest: {manifest_path}\n",
+                    stderr="",
+                )
+
+            with patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run):
+                with patch("builtins.print") as print_mock:
+                    result = mapbox_outdoors_comparison.main([
+                        "--all-cameras",
+                        "--mapbox-token",
+                        "test-mapbox-token",
+                        "--output-root",
+                        str(output_root),
+                        "--skip-browser",
+                        "--skip-qgis",
+                        "--skip-diff",
+                    ])
+
+            summary_json = next((output_root / "all-cameras").glob("*/summary.json"))
+            summary_markdown = summary_json.with_name("summary.md")
+            summary_json_text = summary_json.read_text(encoding="utf-8")
+            summary = json.loads(summary_json_text)
+            summary_text = summary_markdown.read_text(encoding="utf-8")
+
+        self.assertEqual(result, 0)
+        self.assertEqual(summary["counts"], {"passed": len(CAMERAS), "failed": 0, "timeout": 0})
+        self.assertEqual([entry["camera"] for entry in summary["cameras"]], list(CAMERAS))
+        self.assertEqual(summary["cameras"][0]["metrics"]["changed_pixel_ratio"], 0.1)
+        self.assertIn("| `switzerland-alps-z5-outdoors` | passed | 5.35 | 0.1000 |", summary_text)
+        self.assertNotIn("test-mapbox-token", summary_json_text)
+        self.assertNotIn("test-mapbox-token", summary_text)
+        self.assertTrue(any(call.args[0].startswith("Matrix summary:") for call in print_mock.call_args_list))
+
     def test_main_rejects_single_camera_with_all_cameras(self):
         from qfit.validation import mapbox_outdoors_comparison
 

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -20,6 +20,7 @@ PACKAGE_PARENT = REPO_ROOT.parent
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-comparison"
 DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
 DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
+DEFAULT_MAPBOX_STYLE_URL = f"mapbox://styles/{DEFAULT_MAPBOX_STYLE_OWNER}/{DEFAULT_MAPBOX_STYLE_ID}"
 WEB_MERCATOR_HALF_WORLD = 20037508.342789244
 WEB_MERCATOR_TILE_SIZE = 512
 ImageMetrics: TypeAlias = dict[str, object]
@@ -868,6 +869,7 @@ def _all_camera_summary_entry(
     returncode: int | None,
     timeout_seconds: float,
     manifest_path: Path | None,
+    token: str,
 ) -> dict[str, object]:
     return {
         "camera": camera.name,
@@ -876,7 +878,7 @@ def _all_camera_summary_entry(
         "status": status,
         "returncode": returncode,
         "timeout_seconds": timeout_seconds,
-        "manifest": str(manifest_path) if manifest_path is not None else None,
+        "manifest": redact_sensitive_text(str(manifest_path), token) if manifest_path is not None else None,
         "metrics": _metric_summary_from_manifest(manifest_path),
     }
 
@@ -929,6 +931,7 @@ def _write_all_cameras_summary(
     args: argparse.Namespace,
     output_root: Path,
     entries: list[dict[str, object]],
+    token: str,
 ) -> tuple[Path, Path]:
     generated_at = _utc_timestamp()
     run_dir = output_root / "all-cameras" / generated_at
@@ -939,9 +942,13 @@ def _write_all_cameras_summary(
     }
     summary: dict[str, object] = {
         "generated_at": generated_at,
-        "style_url": None if args.style_json is not None else CAMERAS["valais-geneva-outdoors"].style_url,
-        "style_json_path": str(args.style_json.expanduser().resolve()) if args.style_json is not None else None,
-        "output_root": str(output_root),
+        "style_url": None if args.style_json is not None else DEFAULT_MAPBOX_STYLE_URL,
+        "style_json_path": (
+            redact_sensitive_text(str(args.style_json.expanduser().resolve()), token)
+            if args.style_json is not None
+            else None
+        ),
+        "output_root": redact_sensitive_text(str(output_root), token),
         "counts": counts,
         "cameras": entries,
         "notes": [
@@ -990,6 +997,7 @@ def _run_all_cameras_in_subprocesses(
                     returncode=None,
                     timeout_seconds=timeout_seconds,
                     manifest_path=None,
+                    token=token,
                 )
             )
             failures.append(f"{camera.name} (timeout after {timeout_seconds:g}s)")
@@ -1007,6 +1015,7 @@ def _run_all_cameras_in_subprocesses(
                 returncode=completed.returncode,
                 timeout_seconds=timeout_seconds,
                 manifest_path=manifest_path,
+                token=token,
             )
         )
         if completed.returncode != 0:
@@ -1015,9 +1024,14 @@ def _run_all_cameras_in_subprocesses(
                 f"error: camera {camera.name} failed with exit code {completed.returncode}; continuing.",
                 file=sys.stderr,
             )
-    summary_json, summary_markdown = _write_all_cameras_summary(args=args, output_root=output_root, entries=summary_entries)
-    print(f"Matrix summary: {summary_json}")
-    print(f"Matrix report: {summary_markdown}")
+    summary_json, summary_markdown = _write_all_cameras_summary(
+        args=args,
+        output_root=output_root,
+        entries=summary_entries,
+        token=token,
+    )
+    print(f"Matrix summary: {redact_sensitive_text(str(summary_json), token)}")
+    print(f"Matrix report: {redact_sensitive_text(str(summary_markdown), token)}")
     if failures:
         raise ComparisonCaptureError(f"comparison capture failed for: {', '.join(failures)}")
 

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -23,6 +23,12 @@ DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 WEB_MERCATOR_HALF_WORLD = 20037508.342789244
 WEB_MERCATOR_TILE_SIZE = 512
 ImageMetrics: TypeAlias = dict[str, object]
+MATRIX_SUMMARY_METRIC_KEYS = (
+    "changed_pixel_ratio",
+    "normalized_mean_absolute_channel_delta",
+    "normalized_rms_channel_delta",
+    "ssim_status",
+)
 
 
 class ComparisonCaptureError(RuntimeError):
@@ -832,6 +838,124 @@ def _timeout_output_text(value: bytes | str | None) -> str:
     return value
 
 
+def _manifest_path_from_child_stdout(stdout: str) -> Path | None:
+    manifest_path: Path | None = None
+    for line in stdout.splitlines():
+        if line.startswith("Manifest: "):
+            manifest_text = line.removeprefix("Manifest: ").strip()
+            if manifest_text:
+                manifest_path = Path(manifest_text)
+    return manifest_path
+
+
+def _metric_summary_from_manifest(manifest_path: Path | None) -> dict[str, object]:
+    if manifest_path is None:
+        return {}
+    try:
+        loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    metrics = loaded.get("metrics") if isinstance(loaded, dict) else None
+    if not isinstance(metrics, dict):
+        return {}
+    return {key: metrics[key] for key in MATRIX_SUMMARY_METRIC_KEYS if key in metrics}
+
+
+def _all_camera_summary_entry(
+    *,
+    camera: MapboxComparisonCamera,
+    status: str,
+    returncode: int | None,
+    timeout_seconds: float,
+    manifest_path: Path | None,
+) -> dict[str, object]:
+    return {
+        "camera": camera.name,
+        "description": camera.description,
+        "zoom": camera.zoom,
+        "status": status,
+        "returncode": returncode,
+        "timeout_seconds": timeout_seconds,
+        "manifest": str(manifest_path) if manifest_path is not None else None,
+        "metrics": _metric_summary_from_manifest(manifest_path),
+    }
+
+
+def _format_summary_metric(metrics: dict[str, object], key: str) -> str:
+    value = metrics.get(key)
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+def _all_cameras_summary_markdown(summary: dict[str, object]) -> str:
+    lines = [
+        "# Mapbox Outdoors all-camera comparison summary",
+        "",
+        f"Generated: `{summary['generated_at']}`",
+        "",
+        "| Camera | Status | z | Changed ratio | Mean Δ | RMS Δ | SSIM | Manifest |",
+        "| --- | --- | ---: | ---: | ---: | ---: | --- | --- |",
+    ]
+    for entry in summary["cameras"]:
+        metrics = entry["metrics"] if isinstance(entry.get("metrics"), dict) else {}
+        manifest = entry.get("manifest") or "—"
+        lines.append(
+            "| "
+            f"`{entry['camera']}` | "
+            f"{entry['status']} | "
+            f"{entry['zoom']:g} | "
+            f"{_format_summary_metric(metrics, 'changed_pixel_ratio')} | "
+            f"{_format_summary_metric(metrics, 'normalized_mean_absolute_channel_delta')} | "
+            f"{_format_summary_metric(metrics, 'normalized_rms_channel_delta')} | "
+            f"{_format_summary_metric(metrics, 'ssim_status')} | "
+            f"`{manifest}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "Notes:",
+            "- Mapbox tokens are intentionally excluded from this summary.",
+            "- This is a manual visual QA aid, not a CI gate.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _write_all_cameras_summary(
+    *,
+    args: argparse.Namespace,
+    output_root: Path,
+    entries: list[dict[str, object]],
+) -> tuple[Path, Path]:
+    generated_at = _utc_timestamp()
+    run_dir = output_root / "all-cameras" / generated_at
+    _ensure_output_directory(run_dir)
+    counts = {
+        status: sum(1 for entry in entries if entry["status"] == status)
+        for status in ("passed", "failed", "timeout")
+    }
+    summary: dict[str, object] = {
+        "generated_at": generated_at,
+        "style_url": None if args.style_json is not None else CAMERAS["valais-geneva-outdoors"].style_url,
+        "style_json_path": str(args.style_json.expanduser().resolve()) if args.style_json is not None else None,
+        "output_root": str(output_root),
+        "counts": counts,
+        "cameras": entries,
+        "notes": [
+            "Mapbox tokens are intentionally excluded from this summary.",
+            "This is a manual visual QA aid, not a CI gate.",
+        ],
+    }
+    summary_json = run_dir / "summary.json"
+    summary_markdown = run_dir / "summary.md"
+    summary_json.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    summary_markdown.write_text(_all_cameras_summary_markdown(summary), encoding="utf-8")
+    return summary_json, summary_markdown
+
+
 def _run_all_cameras_in_subprocesses(
     *,
     args: argparse.Namespace,
@@ -840,6 +964,7 @@ def _run_all_cameras_in_subprocesses(
     output_root: Path,
 ) -> None:
     failures: list[str] = []
+    summary_entries: list[dict[str, object]] = []
     for camera in cameras:
         timeout_seconds = _camera_subprocess_timeout_seconds(args)
         try:
@@ -858,6 +983,15 @@ def _run_all_cameras_in_subprocesses(
                 stderr=_timeout_output_text(exc.stderr),
                 token=token,
             )
+            summary_entries.append(
+                _all_camera_summary_entry(
+                    camera=camera,
+                    status="timeout",
+                    returncode=None,
+                    timeout_seconds=timeout_seconds,
+                    manifest_path=None,
+                )
+            )
             failures.append(f"{camera.name} (timeout after {timeout_seconds:g}s)")
             print(
                 f"error: camera {camera.name} timed out after {timeout_seconds:g}s; continuing.",
@@ -865,12 +999,25 @@ def _run_all_cameras_in_subprocesses(
             )
             continue
         _write_child_output(stdout=completed.stdout, stderr=completed.stderr, token=token)
+        manifest_path = _manifest_path_from_child_stdout(completed.stdout)
+        summary_entries.append(
+            _all_camera_summary_entry(
+                camera=camera,
+                status="passed" if completed.returncode == 0 else "failed",
+                returncode=completed.returncode,
+                timeout_seconds=timeout_seconds,
+                manifest_path=manifest_path,
+            )
+        )
         if completed.returncode != 0:
             failures.append(f"{camera.name} (exit {completed.returncode})")
             print(
                 f"error: camera {camera.name} failed with exit code {completed.returncode}; continuing.",
                 file=sys.stderr,
             )
+    summary_json, summary_markdown = _write_all_cameras_summary(args=args, output_root=output_root, entries=summary_entries)
+    print(f"Matrix summary: {summary_json}")
+    print(f"Matrix report: {summary_markdown}")
     if failures:
         raise ComparisonCaptureError(f"comparison capture failed for: {', '.join(failures)}")
 


### PR DESCRIPTION
## Summary
- write token-free aggregate `summary.json` and `summary.md` artifacts for `--all-cameras` comparison runs
- include per-camera pass/fail/timeout status, manifest path, zoom, and core diff metrics
- keep matrix evidence under `debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/` so #949 visual comparisons are easier to inspect across cameras

## Evidence
- Live all-camera run completed with the local QGIS-profile Mapbox token without printing it.
- New aggregate report produced at:
  - `debug/mapbox-outdoors-comparison/all-cameras/20260512T032459Z/summary.md`
- The report captured all five cameras as passed and summarized the main diff metrics:
  - z5 Switzerland-Alps: changed ratio 0.9999, mean Δ 0.1274
  - z8 Valais-Geneva: changed ratio 0.9997, mean Δ 0.1410
  - z10 Lausanne-Lavaux: changed ratio 0.9987, mean Δ 0.1074
  - z14 Chamonix trails: changed ratio 0.9980, mean Δ 0.1413
  - z18 Zermatt trails: changed ratio 0.9995, mean Δ 0.0477

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949
