### PR TITLE
Keep Mapbox match labels out of filter signatures

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -523,6 +523,38 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             ],
         )
 
+    def test_filter_operator_signature_omits_match_label_arrays(self):
+        self.assertEqual(
+            mapbox_outdoors_style_audit._operator_signature(
+                [
+                    "match",
+                    ["get", "structure"],
+                    ["none", "ford"],
+                    True,
+                    False,
+                ]
+            ),
+            "get, match",
+        )
+        self.assertEqual(
+            mapbox_outdoors_style_audit._operator_signature(
+                ["none", ["!has", "reflen"], ["!in", "class", "path"]]
+            ),
+            "!has, !in, none",
+        )
+        self.assertEqual(
+            mapbox_outdoors_style_audit._operator_signature(
+                [
+                    "match",
+                    ["get", "class"],
+                    "road",
+                    ["case", ["has", "layer"], True, False],
+                    False,
+                ]
+            ),
+            "case, get, has, match",
+        )
+
     def test_property_removal_impact_probe_ranks_expression_property_warning_deltas(self):
         style = {
             "version": 8,

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -670,6 +670,23 @@ def _filter_probe_style(style_definition: dict[str, object], layer: dict[str, ob
     }
 
 
+def _match_expression_children(candidate: list[object]) -> Iterable[object]:
+    if len(candidate) > 1:
+        yield candidate[1]
+    for output_index in range(3, len(candidate) - 1, 2):
+        yield candidate[output_index]
+    if len(candidate) > 2:
+        yield candidate[-1]
+
+
+def _filter_operator_children(operator: str, candidate: list[object]) -> Iterable[object]:
+    if operator == "literal":
+        return []
+    if operator == "match":
+        return _match_expression_children(candidate)
+    return candidate[1:]
+
+
 def _filter_operator_names(value: object) -> list[str]:
     operators: set[str] = set()
 
@@ -679,7 +696,7 @@ def _filter_operator_names(value: object) -> list[str]:
         operator = candidate[0]
         if isinstance(operator, str) and operator in _MAPBOX_FILTER_OPERATORS:
             operators.add(operator)
-            children = [] if operator == "literal" else candidate[1:]
+            children = _filter_operator_children(operator, candidate)
         else:
             children = candidate
         for child in children:


### PR DESCRIPTION
## Summary
- avoid counting Mapbox `match` label arrays as filter operators in the #949 parser-support diagnostic signature
- keep true legacy filter roots such as `none`, `!has`, and `!in` counted
- add regression coverage for match labels and match output expressions

## Evidence
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T134517Z/audit.md`
- Filter parse support counts are unchanged: 140 filters tested, 113 accepted, 27 rejected
- The roads/trails rejected signatures no longer report `none` for `match` label arrays such as `['none', 'ford']`; the top roads/trails signature consolidates to `==, all, geometry-type, get, match, step, zoom` (8 filters)

## Review feedback addressed
- SonarCloud S3776: split match-expression child traversal out of `_filter_operator_names` to reduce complexity

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/test_mapbox_config.py tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`