### PR TITLE
Skip Mapbox match labels in expression operator audit

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -889,6 +889,18 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             ["get", "match"],
         )
         self.assertEqual(
+            mapbox_outdoors_style_audit._expression_operator_names(
+                ["match", ["get", "worldview"], ["all", "US"], True, False]
+            ),
+            ["get", "match"],
+        )
+        self.assertEqual(
+            mapbox_outdoors_style_audit._expression_operator_names(
+                ["match", ["get", "class"], "road", ["case", ["has", "layer"], True, False], False]
+            ),
+            ["case", "get", "has", "match"],
+        )
+        self.assertEqual(
             mapbox_outdoors_style_audit._expression_operator_names(["DIN Pro Medium", "Arial Unicode MS Regular"]),
             [],
         )

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -355,7 +355,7 @@ def _expression_operator_names(value: object) -> list[str]:
         operator = candidate[0]
         if isinstance(operator, str) and operator in _MAPBOX_EXPRESSION_OPERATORS:
             operators.add(operator)
-            children = [] if operator == "literal" else candidate[1:]
+            children = _mapbox_operator_children(operator, candidate)
         else:
             children = candidate
         for child in children:
@@ -679,7 +679,7 @@ def _match_expression_children(candidate: list[object]) -> Iterable[object]:
         yield candidate[-1]
 
 
-def _filter_operator_children(operator: str, candidate: list[object]) -> Iterable[object]:
+def _mapbox_operator_children(operator: str, candidate: list[object]) -> Iterable[object]:
     if operator == "literal":
         return []
     if operator == "match":
@@ -696,7 +696,7 @@ def _filter_operator_names(value: object) -> list[str]:
         operator = candidate[0]
         if isinstance(operator, str) and operator in _MAPBOX_FILTER_OPERATORS:
             operators.add(operator)
-            children = _filter_operator_children(operator, candidate)
+            children = _mapbox_operator_children(operator, candidate)
         else:
             children = candidate
         for child in children:


### PR DESCRIPTION
## Summary
- reuse Mapbox `match`-aware child traversal for the general unresolved-expression operator audit
- avoid counting expression-shaped `match` label arrays such as `["all", "US"]` as operators
- keep real expressions in `match` output branches counted

## Evidence
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T145935Z/audit.md`
- The filter `all` operator count drops from 118 in the prior live audit to 115 after skipping `match` label arrays, while real `match` output expressions remain counted
- Filter parse support counts remain stable after the previous signature fix: 140 tested, 113 accepted, 27 rejected

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/test_mapbox_config.py tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
