### PR TITLE
Probe unsupported Mapbox filter parts

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -1635,6 +1635,43 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             ["step", ["zoom"], False, 12, True],
         )
 
+    def test_iter_direct_filter_parts_skips_non_boolean_and_non_list_parts(self):
+        self.assertEqual(list(mapbox_outdoors_style_audit._iter_direct_filter_parts([])), [])
+        self.assertEqual(
+            list(mapbox_outdoors_style_audit._iter_direct_filter_parts(["==", ["get", "class"], "park"])),
+            [],
+        )
+        self.assertEqual(
+            list(
+                mapbox_outdoors_style_audit._iter_direct_filter_parts(
+                    ["all", True, ["==", ["get", "class"], "park"], False, ["has", "name"]]
+                )
+            ),
+            [
+                (2, "all", ["==", ["get", "class"], "park"]),
+                (4, "all", ["has", "name"]),
+            ],
+        )
+
+    def test_filter_part_probe_style_uses_direct_part_filter(self):
+        layer = {
+            "id": "poi-label",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "poi_label",
+            "filter": ["all", ["==", ["get", "class"], "park"], ["has", "name"]],
+        }
+        filter_part = ["==", ["get", "class"], "park"]
+
+        style = mapbox_outdoors_style_audit._filter_part_probe_style(
+            {"version": 8, "sources": {"composite": {"type": "vector"}}}, layer, filter_part
+        )
+
+        self.assertEqual(style["layers"][0]["filter"], ["==", ["get", "class"], "park"])
+        self.assertNotEqual(style["layers"][0]["filter"], layer["filter"])
+        filter_part[1][1] = "mutated"
+        self.assertEqual(style["layers"][0]["filter"], ["==", ["get", "class"], "park"])
+
     def test_qgis_converter_warning_report_can_include_sprite_context_probe(self):
         class FakeQImage:
             Format_ARGB32 = "argb32"

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -1581,6 +1581,60 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             "!has, !in, none",
         )
 
+    def test_filter_parse_support_report_summarizes_unsupported_direct_filter_parts(self):
+        style = {
+            "version": 8,
+            "sources": {"composite": {"type": "vector"}},
+            "layers": [
+                {
+                    "id": "poi-label",
+                    "type": "symbol",
+                    "source": "composite",
+                    "source-layer": "poi_label",
+                    "filter": [
+                        "all",
+                        ["==", ["get", "class"], "park"],
+                        ["step", ["zoom"], False, 12, True],
+                    ],
+                }
+            ],
+        }
+
+        with patch.object(
+            mapbox_outdoors_style_audit,
+            "_collect_qgis_converter_warnings",
+            side_effect=[
+                ["poi-label: Skipping unsupported expression"],
+                [],
+                ["poi-label: Skipping unsupported expression"],
+            ],
+        ) as collect_warnings:
+            report = mapbox_outdoors_style_audit._qgis_filter_parse_support_report(style)
+
+        self.assertEqual(report["direct_filter_part_count"], 2)
+        self.assertEqual(report["qgis_parser_supported_part_count"], 1)
+        self.assertEqual(report["qgis_parser_unsupported_part_count"], 1)
+        self.assertEqual(
+            report["unsupported_parts_by_layer_group_and_operator_signature"],
+            [
+                {
+                    "group": "pois/labels",
+                    "operator_signature": "step, zoom",
+                    "count": 1,
+                    "example_layers": ["poi-label"],
+                }
+            ],
+        )
+        self.assertEqual(len(report["unsupported_parts"]), 1)
+        self.assertEqual(report["unsupported_parts"][0]["layer"], "poi-label")
+        self.assertEqual(report["unsupported_parts"][0]["parent_operator"], "all")
+        self.assertEqual(report["unsupported_parts"][0]["part_index"], 2)
+        self.assertEqual(report["unsupported_parts"][0]["operator_signature"], "step, zoom")
+        self.assertEqual(
+            collect_warnings.call_args_list[2].args[0]["layers"][0]["filter"],
+            ["step", ["zoom"], False, 12, True],
+        )
+
     def test_qgis_converter_warning_report_can_include_sprite_context_probe(self):
         class FakeQImage:
             Format_ARGB32 = "argb32"
@@ -1999,6 +2053,9 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                 "filter_expression_count": 2,
                 "qgis_parser_supported_count": 1,
                 "qgis_parser_unsupported_count": 1,
+                "direct_filter_part_count": 2,
+                "qgis_parser_supported_part_count": 1,
+                "qgis_parser_unsupported_part_count": 1,
                 "unsupported_by_layer_group": [{"group": "pois/labels", "count": 1}],
                 "unsupported_by_warning_message": [{"message": "Skipping unsupported expression", "count": 1}],
                 "unsupported_by_layer_group_and_operator_signature": [
@@ -2007,6 +2064,31 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         "operator_signature": "==, case, get",
                         "count": 1,
                         "example_layers": ["poi-label"],
+                    }
+                ],
+                "unsupported_parts_by_layer_group_and_operator_signature": [
+                    {
+                        "group": "pois/labels",
+                        "operator_signature": "step, zoom",
+                        "count": 1,
+                        "example_layers": ["poi-label"],
+                    }
+                ],
+                "unsupported_parts": [
+                    {
+                        "layer": "poi-label",
+                        "group": "pois/labels",
+                        "type": "symbol",
+                        "source_layer": "poi_label",
+                        "parent_operator": "all",
+                        "part_index": 2,
+                        "operator_signature": "step, zoom",
+                        "unsupported_warning_count": 1,
+                        "unsupported_warning_messages": [
+                            {"message": "Skipping unsupported expression", "count": 1}
+                        ],
+                        "supported_by_qgis_parser": False,
+                        "filter": ["step", ["zoom"], False, 12, True],
                     }
                 ],
                 "unsupported_layers": [
@@ -2313,12 +2395,19 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("Filter expressions tested: 2", markdown)
         self.assertIn("Accepted by the QGIS parser probe: 1", markdown)
         self.assertIn("Rejected by the QGIS parser probe: 1", markdown)
+        self.assertIn("Direct parts tested from rejected boolean filters: 2", markdown)
+        self.assertIn("Rejected direct parts: 1", markdown)
         self.assertIn("##### Unsupported filter probes by layer group", markdown)
         self.assertIn("| `pois/labels` | 1 |", markdown)
         self.assertIn("##### Unsupported filter parser warnings by message", markdown)
         self.assertIn("| `Skipping unsupported expression` | 1 |", markdown)
         self.assertIn("##### Unsupported filter probes by layer group and operators", markdown)
         self.assertIn("| `pois/labels` | `==, case, get` | 1 | `poi-label` |", markdown)
+        self.assertIn("##### Unsupported direct filter parts by layer group and operators", markdown)
+        self.assertIn("| `pois/labels` | `step, zoom` | 1 | `poi-label` |", markdown)
+        self.assertIn("##### Unsupported direct filter parts", markdown)
+        self.assertIn("| `poi-label` | `all` | 2 | `step, zoom` | 1 |", markdown)
+        self.assertIn('<code>["step",["zoom"],false,12,true]</code>', markdown)
         self.assertIn("##### Unsupported filter probe layers", markdown)
         self.assertIn("| `poi-label` | `pois/labels` | `symbol / poi_label` | `==, case, get` | 1 |", markdown)
         self.assertIn('<code>["case",["==",["get","class"],"park"],true,false]</code>', markdown)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -634,12 +634,12 @@ def _filter_parse_unsupported_message_summary(warnings: list[str]) -> list[dict[
     ]
 
 
-def _minimal_filter_probe_layer(layer: dict[str, object]) -> dict[str, object]:
+def _minimal_filter_probe_layer(layer: dict[str, object], filter_value: object = _ABSENT) -> dict[str, object]:
     layer_type = str(layer.get("type") or "")
     probe_layer: dict[str, object] = {
         "id": str(layer.get("id") or "filter-probe"),
         "type": layer_type,
-        "filter": layer.get("filter"),
+        "filter": filter_value if filter_value is not _ABSENT else layer.get("filter"),
     }
     for key in ("source", "source-layer", "minzoom", "maxzoom"):
         if key in layer:
@@ -676,8 +676,7 @@ def _filter_part_probe_style(
     layer: dict[str, object],
     filter_part: list[object],
 ) -> dict[str, object]:
-    probe_layer = _minimal_filter_probe_layer(layer)
-    probe_layer["filter"] = copy.deepcopy(filter_part)
+    probe_layer = _minimal_filter_probe_layer(layer, copy.deepcopy(filter_part))
     return {
         "version": style_definition.get("version", 8),
         "sources": copy.deepcopy(style_definition.get("sources", {})),

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -43,6 +43,7 @@ _FILTER_PARSE_UNSUPPORTED_MESSAGE_ORDER = (
     _FILTER_PARSE_UNSUPPORTED_EXPRESSION_MESSAGE,
 )
 _FILTER_PARSE_UNSUPPORTED_MESSAGES = frozenset(_FILTER_PARSE_UNSUPPORTED_MESSAGE_ORDER)
+_FILTER_PARSE_PART_PARENT_OPERATORS = frozenset({"all", "any", "none"})
 _NO_OPERATOR_SIGNATURE = "(none)"
 
 if str(PACKAGE_PARENT) not in sys.path:
@@ -670,6 +671,31 @@ def _filter_probe_style(style_definition: dict[str, object], layer: dict[str, ob
     }
 
 
+def _filter_part_probe_style(
+    style_definition: dict[str, object],
+    layer: dict[str, object],
+    filter_part: list[object],
+) -> dict[str, object]:
+    probe_layer = _minimal_filter_probe_layer(layer)
+    probe_layer["filter"] = copy.deepcopy(filter_part)
+    return {
+        "version": style_definition.get("version", 8),
+        "sources": copy.deepcopy(style_definition.get("sources", {})),
+        "layers": [probe_layer],
+    }
+
+
+def _iter_direct_filter_parts(filter_value: list[object]) -> Iterable[tuple[int, str, list[object]]]:
+    if not filter_value:
+        return
+    parent_operator = filter_value[0]
+    if not isinstance(parent_operator, str) or parent_operator not in _FILTER_PARSE_PART_PARENT_OPERATORS:
+        return
+    for index, filter_part in enumerate(filter_value[1:], start=1):
+        if isinstance(filter_part, list):
+            yield index, parent_operator, filter_part
+
+
 def _match_expression_children(candidate: list[object]) -> Iterable[object]:
     if len(candidate) > 1:
         yield candidate[1]
@@ -791,20 +817,82 @@ def _filter_parse_support_row(
     }
 
 
-def _qgis_filter_parse_support_report(style_definition: dict[str, object]) -> dict[str, object]:
-    rows = [
-        _filter_parse_support_row(style_definition, layer, filter_value)
-        for layer, filter_value in _iter_filter_probe_layers(style_definition)
+def _filter_parse_part_support_row(
+    style_definition: dict[str, object],
+    layer: dict[str, object],
+    filter_part: list[object],
+    *,
+    parent_operator: str,
+    part_index: int,
+) -> dict[str, object]:
+    warnings = _collect_qgis_converter_warnings(_filter_part_probe_style(style_definition, layer, filter_part))
+    unsupported_warning_count = _filter_parse_unsupported_warning_count(warnings)
+    return {
+        "layer": str(layer.get("id") or ""),
+        "group": _layer_group(layer),
+        "type": str(layer.get("type") or ""),
+        "source_layer": str(layer.get("source-layer") or ""),
+        "parent_operator": parent_operator,
+        "part_index": part_index,
+        "operator_signature": _operator_signature(filter_part),
+        "unsupported_warning_count": unsupported_warning_count,
+        "unsupported_warning_messages": _filter_parse_unsupported_message_summary(warnings),
+        "supported_by_qgis_parser": unsupported_warning_count == 0,
+        "warnings": warnings,
+        "filter": filter_part,
+    }
+
+
+def _filter_parse_part_support_rows(
+    style_definition: dict[str, object],
+    layer: dict[str, object],
+    filter_value: list[object],
+) -> list[dict[str, object]]:
+    return [
+        _filter_parse_part_support_row(
+            style_definition,
+            layer,
+            filter_part,
+            parent_operator=parent_operator,
+            part_index=part_index,
+        )
+        for part_index, parent_operator, filter_part in _iter_direct_filter_parts(filter_value)
     ]
+
+
+def _qgis_filter_parse_support_report(style_definition: dict[str, object]) -> dict[str, object]:
+    rows: list[dict[str, object]] = []
+    part_rows: list[dict[str, object]] = []
+    for layer, filter_value in _iter_filter_probe_layers(style_definition):
+        row = _filter_parse_support_row(style_definition, layer, filter_value)
+        rows.append(row)
+        if int(row.get("unsupported_warning_count") or 0) > 0:
+            part_rows.extend(_filter_parse_part_support_rows(style_definition, layer, filter_value))
     unsupported_rows = [row for row in rows if int(row.get("unsupported_warning_count") or 0) > 0]
+    unsupported_part_rows = [row for row in part_rows if int(row.get("unsupported_warning_count") or 0) > 0]
     supported_count = len(rows) - len(unsupported_rows)
     return {
         "filter_expression_count": len(rows),
         "qgis_parser_supported_count": supported_count,
         "qgis_parser_unsupported_count": len(unsupported_rows),
+        "direct_filter_part_count": len(part_rows),
+        "qgis_parser_supported_part_count": len(part_rows) - len(unsupported_part_rows),
+        "qgis_parser_unsupported_part_count": len(unsupported_part_rows),
         "unsupported_by_layer_group": _count_rows_by_key(unsupported_rows, "group"),
         "unsupported_by_warning_message": _filter_parse_warning_message_summary(unsupported_rows),
         "unsupported_by_layer_group_and_operator_signature": _filter_parse_signature_summary(unsupported_rows),
+        "unsupported_parts_by_layer_group_and_operator_signature": _filter_parse_signature_summary(
+            unsupported_part_rows
+        ),
+        "unsupported_parts": sorted(
+            unsupported_part_rows,
+            key=lambda row: (
+                -int(row.get("unsupported_warning_count") or 0),
+                str(row.get("group") or ""),
+                str(row.get("layer") or ""),
+                int(row.get("part_index") or 0),
+            ),
+        ),
         "unsupported_layers": sorted(
             unsupported_rows,
             key=lambda row: (
@@ -2519,6 +2607,35 @@ def _markdown_filter_parse_unsupported_layer_table(
     return lines
 
 
+def _markdown_filter_parse_unsupported_part_table(
+    rows: list[dict[str, object]],
+    *,
+    limit: int = 25,
+) -> list[str]:
+    if not rows:
+        return ["—", ""]
+    shown_rows = rows[:limit]
+    lines = [
+        "| Layer | Parent | Part | Operators | Unsupported warnings | Filter part |",
+        "| --- | --- | ---: | --- | ---: | --- |",
+    ]
+    for row in shown_rows:
+        lines.append(
+            "| `{layer}` | `{parent}` | {part} | `{operators}` | {warnings} | {filter_value} |".format(
+                layer=row.get("layer", ""),
+                parent=row.get("parent_operator", ""),
+                part=row.get("part_index", 0),
+                operators=row.get("operator_signature", ""),
+                warnings=row.get("unsupported_warning_count", 0),
+                filter_value=_markdown_code_cell(_compact_json(row.get("filter"))),
+            )
+        )
+    if len(rows) > limit:
+        lines.append(f"| … | … | … | … | … | {len(rows) - limit} more unsupported filter parts omitted |")
+    lines.append("")
+    return lines
+
+
 def _markdown_filter_parse_warning_message_table(rows: list[dict[str, object]]) -> list[str]:
     return _markdown_named_count_table(rows, key="message", label=_MARKDOWN_MESSAGE_LABEL)
 
@@ -2527,6 +2644,7 @@ def _markdown_filter_parse_support_probe(probe: object) -> list[str]:
     if not isinstance(probe, dict):
         return []
     unsupported_rows = list(probe.get("unsupported_layers") or [])
+    unsupported_parts = list(probe.get("unsupported_parts") or [])
     return [
         "#### Diagnostic filter parser support probe",
         "",
@@ -2540,6 +2658,8 @@ def _markdown_filter_parse_support_probe(probe: object) -> list[str]:
         f"Filter expressions tested: {probe.get('filter_expression_count', 0)}",
         f"Accepted by the QGIS parser probe: {probe.get('qgis_parser_supported_count', 0)}",
         f"Rejected by the QGIS parser probe: {probe.get('qgis_parser_unsupported_count', 0)}",
+        f"Direct parts tested from rejected boolean filters: {probe.get('direct_filter_part_count', 0)}",
+        f"Rejected direct parts: {probe.get('qgis_parser_unsupported_part_count', 0)}",
         "",
         "##### Unsupported filter probes by layer group",
         "",
@@ -2557,6 +2677,15 @@ def _markdown_filter_parse_support_probe(probe: object) -> list[str]:
             list(probe.get("unsupported_by_layer_group_and_operator_signature") or []),
             count_label="Unsupported filters",
         ),
+        "##### Unsupported direct filter parts by layer group and operators",
+        "",
+        *_markdown_filter_signature_group_table(
+            list(probe.get("unsupported_parts_by_layer_group_and_operator_signature") or []),
+            count_label="Unsupported parts",
+        ),
+        "##### Unsupported direct filter parts",
+        "",
+        *_markdown_filter_parse_unsupported_part_table(unsupported_parts),
         "##### Unsupported filter probe layers",
         "",
         *_markdown_filter_parse_unsupported_layer_table(unsupported_rows),


### PR DESCRIPTION
## Summary
- extend the diagnostic QGIS filter parser probe to isolate direct child clauses from parser-rejected boolean filters
- summarize unsupported direct filter parts by layer group/operator signature and list examples in the audit markdown
- keep this diagnostic-only; it does not change qfit style preprocessing or rendering behavior

## Evidence
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260512T155129Z/audit.md`
- Full-filter probe remains stable: 140 filters tested, 113 accepted, 27 rejected
- New direct-part probe tested 76 direct child clauses from rejected boolean filters and found 28 rejected parts
- Top unsupported direct part signature is roads/trails `get, match, step, zoom` with 11 parts; `>=, case, get, has` follows with 5 road/trail parts

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/test_mapbox_config.py tests/test_mapbox_outdoors_style_audit.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
