### PR TITLE
Flag all-camera artifact status

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -84,7 +84,7 @@ python3 validation/mapbox_outdoors_comparison.py \
 `--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.
 Do not pass a positional camera name with `--all-cameras`; use one mode or the other.
 Each camera is captured in its own child Python process so a local Chromium/PyQGIS crash in one camera does not kill the whole matrix runner or expose token values on the command line. If any camera fails or times out, the runner continues with the remaining cameras and exits non-zero with the failed camera names.
-The parent run also writes token-free aggregate `summary.json` and `summary.md` files under `debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/` with per-camera status, manifest paths, and the main diff metrics.
+The parent run also writes token-free aggregate `summary.json` and `summary.md` files under `debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/` with per-camera subprocess status, artifact status, manifest paths, and the main diff metrics. Treat rows with missing manifests or unavailable metrics as operational smoke-test output, not visual parity evidence.
 
 ## Partial captures
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -646,14 +646,73 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertEqual(summary["counts"], {"passed": len(CAMERAS), "failed": 0, "timeout": 0})
         self.assertEqual([entry["camera"] for entry in summary["cameras"]], list(CAMERAS))
+        self.assertEqual(summary["cameras"][0]["artifact_status"], "metrics_available")
         self.assertEqual(summary["cameras"][0]["metrics"]["changed_pixel_ratio"], 0.1)
-        self.assertIn("| `switzerland-alps-z5-outdoors` | passed | 5.35 | 0.1000 |", summary_text)
+        self.assertIn(
+            "| `switzerland-alps-z5-outdoors` | passed | `metrics_available` | 5.35 | 0.1000 |",
+            summary_text,
+        )
         self.assertNotIn("test-mapbox-token", summary_json_text)
         self.assertNotIn("test-mapbox-token", summary_text)
         for call in print_mock.call_args_list:
             if call.args:
                 self.assertNotIn("test-mapbox-token", call.args[0])
         self.assertTrue(any(call.args[0].startswith("Matrix summary:") for call in print_mock.call_args_list))
+
+    def test_main_all_cameras_flags_passed_camera_without_manifest_as_missing_artifacts(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_root = Path(tmpdir) / "test-mapbox-token-output"
+
+            def fake_run(command, **_kwargs):
+                return types.SimpleNamespace(returncode=0, stdout=f"Camera: {command[2]}\n", stderr="")
+
+            with patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run):
+                result = mapbox_outdoors_comparison.main([
+                    "--all-cameras",
+                    "--mapbox-token",
+                    "test-mapbox-token",
+                    "--output-root",
+                    str(output_root),
+                    "--skip-browser",
+                    "--skip-qgis",
+                    "--skip-diff",
+                ])
+
+            summary_json = next((output_root / "all-cameras").glob("*/summary.json"), None)
+            self.assertIsNotNone(summary_json, "all-cameras summary.json should be written")
+            summary = json.loads(summary_json.read_text(encoding="utf-8"))
+            summary_text = summary_json.with_name("summary.md").read_text(encoding="utf-8")
+
+        self.assertEqual(result, 0)
+        self.assertEqual(summary["cameras"][0]["status"], "passed")
+        self.assertEqual(summary["cameras"][0]["artifact_status"], "manifest_missing")
+        self.assertEqual(summary["cameras"][0]["metrics"], {})
+        self.assertIn("| `switzerland-alps-z5-outdoors` | passed | `manifest_missing` |", summary_text)
+        self.assertIn("The Artifacts column distinguishes subprocess success", summary_text)
+
+    def test_manifest_artifact_status_distinguishes_unreadable_and_metricless_manifests(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            invalid_manifest = tmp_path / "invalid.json"
+            invalid_manifest.write_text("{", encoding="utf-8")
+            metricless_manifest = tmp_path / "metricless.json"
+            metricless_manifest.write_text(json.dumps({"metrics": {}}), encoding="utf-8")
+
+            unreadable_status, unreadable_metrics = mapbox_outdoors_comparison._manifest_artifact_status_and_metrics(
+                invalid_manifest
+            )
+            metricless_status, metricless_metrics = mapbox_outdoors_comparison._manifest_artifact_status_and_metrics(
+                metricless_manifest
+            )
+
+        self.assertEqual(unreadable_status, "manifest_unreadable")
+        self.assertEqual(unreadable_metrics, {})
+        self.assertEqual(metricless_status, "metrics_unavailable")
+        self.assertEqual(metricless_metrics, {})
 
     def test_main_rejects_single_camera_with_all_cameras(self):
         from qfit.validation import mapbox_outdoors_comparison

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -30,6 +30,10 @@ MATRIX_SUMMARY_METRIC_KEYS = (
     "normalized_rms_channel_delta",
     "ssim_status",
 )
+MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE = "metrics_available"
+MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING = "manifest_missing"
+MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE = "manifest_unreadable"
+MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE = "metrics_unavailable"
 
 
 class ComparisonCaptureError(RuntimeError):
@@ -849,17 +853,20 @@ def _manifest_path_from_child_stdout(stdout: str) -> Path | None:
     return manifest_path
 
 
-def _metric_summary_from_manifest(manifest_path: Path | None) -> dict[str, object]:
+def _manifest_artifact_status_and_metrics(manifest_path: Path | None) -> tuple[str, dict[str, object]]:
     if manifest_path is None:
-        return {}
+        return MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING, {}
     try:
         loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return {}
+        return MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE, {}
     metrics = loaded.get("metrics") if isinstance(loaded, dict) else None
     if not isinstance(metrics, dict):
-        return {}
-    return {key: metrics[key] for key in MATRIX_SUMMARY_METRIC_KEYS if key in metrics}
+        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}
+    metric_summary = {key: metrics[key] for key in MATRIX_SUMMARY_METRIC_KEYS if key in metrics}
+    if not metric_summary:
+        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}
+    return MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE, metric_summary
 
 
 def _all_camera_summary_entry(
@@ -871,15 +878,17 @@ def _all_camera_summary_entry(
     manifest_path: Path | None,
     token: str,
 ) -> dict[str, object]:
+    artifact_status, metrics = _manifest_artifact_status_and_metrics(manifest_path)
     return {
         "camera": camera.name,
         "description": camera.description,
         "zoom": camera.zoom,
         "status": status,
+        "artifact_status": artifact_status,
         "returncode": returncode,
         "timeout_seconds": timeout_seconds,
         "manifest": redact_sensitive_text(str(manifest_path), token) if manifest_path is not None else None,
-        "metrics": _metric_summary_from_manifest(manifest_path),
+        "metrics": metrics,
     }
 
 
@@ -898,16 +907,18 @@ def _all_cameras_summary_markdown(summary: dict[str, object]) -> str:
         "",
         f"Generated: `{summary['generated_at']}`",
         "",
-        "| Camera | Status | z | Changed ratio | Mean Δ | RMS Δ | SSIM | Manifest |",
-        "| --- | --- | ---: | ---: | ---: | ---: | --- | --- |",
+        "| Camera | Status | Artifacts | z | Changed ratio | Mean Δ | RMS Δ | SSIM | Manifest |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |",
     ]
     for entry in summary["cameras"]:
         metrics = entry["metrics"] if isinstance(entry.get("metrics"), dict) else {}
         manifest = entry.get("manifest") or "—"
+        artifact_status = entry.get("artifact_status") or "unknown"
         lines.append(
             "| "
             f"`{entry['camera']}` | "
             f"{entry['status']} | "
+            f"`{artifact_status}` | "
             f"{entry['zoom']:g} | "
             f"{_format_summary_metric(metrics, 'changed_pixel_ratio')} | "
             f"{_format_summary_metric(metrics, 'normalized_mean_absolute_channel_delta')} | "
@@ -921,6 +932,7 @@ def _all_cameras_summary_markdown(summary: dict[str, object]) -> str:
             "Notes:",
             "- Mapbox tokens are intentionally excluded from this summary.",
             "- This is a manual visual QA aid, not a CI gate.",
+            "- The Artifacts column distinguishes subprocess success from manifest/metric availability.",
         ]
     )
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add an explicit all-camera `artifact_status` beside each subprocess status
- distinguish `metrics_available`, `manifest_missing`, `manifest_unreadable`, and `metrics_unavailable` rows in summary JSON/markdown
- document that missing manifests or unavailable metrics are operational smoke-test output, not visual parity evidence

## Evidence
- This targets #949 validation clarity after an all-camera run could show `passed` rows with no manifests/metrics, which should not be mistaken for visual parity evidence
- Token-free smoke validation: `python3 validation/mapbox_outdoors_comparison.py --all-cameras --mapbox-token dummy-mapbox-token --skip-browser --skip-qgis --skip-diff`
- Generated artifact-status summary: `debug/mapbox-outdoors-comparison/all-cameras/20260512T204955Z/summary.md`, showing passed rows with `metrics_unavailable`

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q` → 35 passed
- `coverage run -m unittest tests.test_mapbox_outdoors_comparison -v && coverage report -m validation/mapbox_outdoors_comparison.py` → 35 tests passed, 94% coverage for `validation/mapbox_outdoors_comparison.py`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check` → 1953 passed, 163 skipped, 135 subtests passed

Refs #949
