### PR TITLE
Default comparison QGIS capture to offscreen Qt

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -63,7 +63,7 @@ export MAPBOX_ACCESS_TOKEN="***"
 python3 validation/mapbox_outdoors_comparison.py valais-geneva-outdoors
 ```
 
-The command prints only artifact paths. It does not print the token, and `manifest.json` intentionally excludes token values. The QGIS capture builds a temporary vector-tile layer for rendering and does not clear the active QGIS project.
+The command prints only artifact paths. It does not print the token, and `manifest.json` intentionally excludes token values. The QGIS capture builds a temporary vector-tile layer for rendering, defaults Qt to the `offscreen` platform for headless validation unless `QT_QPA_PLATFORM` is already set, and does not clear the active QGIS project.
 
 To compare against a pinned/downloaded style snapshot instead of fetching live style metadata, pass `--style-json`. The browser reference uses the same style object and the QGIS render uses it for qfit's style preprocessing; Mapbox vector tiles, glyphs, and sprites still require a token.
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -334,7 +334,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         fake_background_service = types.ModuleType("qfit.visualization.infrastructure.background_map_service")
         fake_background_service.BackgroundMapService = FakeBackgroundMapService
 
-        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {}, clear=False), patch.dict(
             sys.modules,
             {
                 "qgis": types.ModuleType("qgis"),
@@ -356,6 +356,35 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             )
 
             self.assertEqual(output_path.read_bytes(), PNG_PLACEHOLDER)
+
+    def test_headless_qt_platform_defaults_to_offscreen_without_overriding_callers(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        empty_env = {}
+        mapbox_outdoors_comparison._ensure_headless_qt_platform(empty_env)
+
+        custom_env = {"QT_QPA_PLATFORM": "minimal"}
+        mapbox_outdoors_comparison._ensure_headless_qt_platform(custom_env)
+
+        self.assertEqual(empty_env["QT_QPA_PLATFORM"], "offscreen")
+        self.assertEqual(custom_env["QT_QPA_PLATFORM"], "minimal")
+
+    def test_all_camera_child_environment_defaults_qgis_to_offscreen(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with patch.dict(os.environ, {}, clear=True):
+            env = mapbox_outdoors_comparison._single_camera_subprocess_environment(token="test-mapbox-token")
+
+        self.assertEqual(env["MAPBOX_ACCESS_TOKEN"], "test-mapbox-token")
+        self.assertEqual(env["QT_QPA_PLATFORM"], "offscreen")
+
+    def test_all_camera_child_environment_preserves_qt_platform_override(self):
+        from qfit.validation import mapbox_outdoors_comparison
+
+        with patch.dict(os.environ, {"QT_QPA_PLATFORM": "minimal"}, clear=True):
+            env = mapbox_outdoors_comparison._single_camera_subprocess_environment(token="test-mapbox-token")
+
+        self.assertEqual(env["QT_QPA_PLATFORM"], "minimal")
 
     def test_build_image_diff_writes_enhanced_diff_and_metrics_for_same_size_images(self):
         try:

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable, TypeAlias
@@ -21,6 +22,7 @@ DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-comparison"
 DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
 DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 DEFAULT_MAPBOX_STYLE_URL = f"mapbox://styles/{DEFAULT_MAPBOX_STYLE_OWNER}/{DEFAULT_MAPBOX_STYLE_ID}"
+DEFAULT_QT_QPA_PLATFORM = "offscreen"
 WEB_MERCATOR_HALF_WORLD = 20037508.342789244
 WEB_MERCATOR_TILE_SIZE = 512
 ImageMetrics: TypeAlias = dict[str, object]
@@ -454,6 +456,12 @@ def _ensure_package_parent_on_path() -> None:  # pragma: no cover - exercised on
         sys.path.insert(0, package_parent_text)
 
 
+def _ensure_headless_qt_platform(environ: MutableMapping[str, str] | None = None) -> None:
+    """Default QGIS validation captures to Qt's offscreen platform unless callers override it."""
+    target = os.environ if environ is None else environ
+    target.setdefault("QT_QPA_PLATFORM", DEFAULT_QT_QPA_PLATFORM)
+
+
 def is_valid_qgis_vector_tile_layer(*, layer: object, vector_tile_layer_type: type) -> bool:
     return isinstance(layer, vector_tile_layer_type) and bool(layer.isValid())
 
@@ -466,6 +474,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     style_definition: dict[str, object] | None = None,
 ) -> None:
     _ensure_package_parent_on_path()
+    _ensure_headless_qt_platform()
     try:
         from qgis.PyQt.QtCore import QSize  # type: ignore[import-not-found]
         from qgis.PyQt.QtGui import QColor  # type: ignore[import-not-found]
@@ -822,6 +831,7 @@ def _camera_subprocess_timeout_seconds(args: argparse.Namespace) -> float:
 
 def _single_camera_subprocess_environment(*, token: str) -> dict[str, str]:
     env = os.environ.copy()
+    _ensure_headless_qt_platform(env)
     env["MAPBOX_ACCESS_TOKEN"] = token
     return env
 


### PR DESCRIPTION
## Summary
- default the Mapbox Outdoors comparison harness QGIS/Qt capture path to `QT_QPA_PLATFORM=offscreen`
- preserve any caller-provided `QT_QPA_PLATFORM` override
- apply the default before PyQGIS imports and in all-camera child process environments
- document the headless Qt default

## Live evidence
- Before this change, a live all-camera run with the local QGIS profile Mapbox token and no display failed every camera with Qt `xcb` initialization errors; failure summary: `debug/mapbox-outdoors-comparison/all-cameras/20260512T215758Z/summary.md`
- With this branch and `QT_QPA_PLATFORM` intentionally unset in the parent environment, the same live all-camera run completed all five browser/QGIS/diff captures: `debug/mapbox-outdoors-comparison/all-cameras/20260512T220050Z/summary.md`
- The passing summary reports `metrics_available` for all cameras, with changed ratios 0.9980–0.9999 and manifests for each camera run

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q` → 38 passed
- `coverage run -m unittest tests.test_mapbox_outdoors_comparison -v && coverage report -m validation/mapbox_outdoors_comparison.py` → 38 tests passed, 94% coverage for `validation/mapbox_outdoors_comparison.py`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check` → 1956 passed, 163 skipped, 135 subtests passed

Refs #949
