### PR TITLE
List all-camera comparison image artifacts

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -51,7 +51,7 @@ For a complete browser + QGIS + diff run, install or run from an environment wit
   - for example, run from a QGIS Python shell, OSGeo/QGIS environment, or another shell where `import qgis` works
 - Pillow for the diff image
   - already available in the qfit development environment; if missing, install it in a virtual environment rather than using system `sudo pip`
-- `QT_QPA_PLATFORM=offscreen` when running headlessly, if your QGIS environment requires it
+- QGIS/Qt support for the `offscreen` platform when running headlessly; the harness sets `QT_QPA_PLATFORM=offscreen` by default unless you provide a different value
 - `xvfb-run` or another virtual display when your local Chromium/QGIS build cannot render headlessly without an X server
 
 Keep tokens out of shell history where practical by exporting an environment variable instead of passing `--mapbox-token` directly.
@@ -84,7 +84,7 @@ python3 validation/mapbox_outdoors_comparison.py \
 `--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.
 Do not pass a positional camera name with `--all-cameras`; use one mode or the other.
 Each camera is captured in its own child Python process so a local Chromium/PyQGIS crash in one camera does not kill the whole matrix runner or expose token values on the command line. If any camera fails or times out, the runner continues with the remaining cameras and exits non-zero with the failed camera names.
-The parent run also writes token-free aggregate `summary.json` and `summary.md` files under `debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/` with per-camera subprocess status, artifact status, manifest paths, and the main diff metrics. Treat rows with missing manifests or unavailable metrics as operational smoke-test output, not visual parity evidence.
+The parent run also writes token-free aggregate `summary.json` and `summary.md` files under `debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/` with per-camera subprocess status, artifact status, manifest paths, captured image artifact paths, and the main diff metrics. Treat rows with missing manifests or unavailable metrics as operational smoke-test output, not visual parity evidence.
 
 ## Partial captures
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -633,9 +633,22 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 run_dir = output_root / camera_name / "20260512T030000Z"
                 run_dir.mkdir(parents=True)
                 manifest_path = run_dir / "manifest.json"
+                browser_png = run_dir / "mapbox-gl-reference.png"
+                qgis_png = run_dir / "qgis-vector-render.png"
+                diff_png = run_dir / "mapbox-gl-vs-qgis-diff.png"
                 manifest_path.write_text(
                     json.dumps(
                         {
+                            "outputs": {
+                                "browser_reference": str(browser_png),
+                                "qgis_vector_render": str(qgis_png),
+                                "diff": str(diff_png),
+                            },
+                            "captured": {
+                                "browser_reference": True,
+                                "qgis_vector_render": True,
+                                "diff": True,
+                            },
                             "metrics": {
                                 "changed_pixel_ratio": 0.1 + camera_index / 10,
                                 "normalized_mean_absolute_channel_delta": 0.01 + camera_index / 100,
@@ -677,10 +690,17 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual([entry["camera"] for entry in summary["cameras"]], list(CAMERAS))
         self.assertEqual(summary["cameras"][0]["artifact_status"], "metrics_available")
         self.assertEqual(summary["cameras"][0]["metrics"]["changed_pixel_ratio"], 0.1)
+        self.assertTrue(summary["cameras"][0]["outputs"]["browser_reference"].endswith("mapbox-gl-reference.png"))
+        self.assertTrue(summary["cameras"][0]["outputs"]["qgis_vector_render"].endswith("qgis-vector-render.png"))
+        self.assertTrue(summary["cameras"][0]["outputs"]["diff"].endswith("mapbox-gl-vs-qgis-diff.png"))
         self.assertIn(
             "| `switzerland-alps-z5-outdoors` | passed | `metrics_available` | 5.35 | 0.1000 |",
             summary_text,
         )
+        self.assertIn("## Image artifacts", summary_text)
+        self.assertIn("mapbox-gl-reference.png", summary_text)
+        self.assertIn("qgis-vector-render.png", summary_text)
+        self.assertIn("mapbox-gl-vs-qgis-diff.png", summary_text)
         self.assertNotIn("test-mapbox-token", summary_json_text)
         self.assertNotIn("test-mapbox-token", summary_text)
         for call in print_mock.call_args_list:
@@ -718,7 +738,9 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(summary["cameras"][0]["status"], "passed")
         self.assertEqual(summary["cameras"][0]["artifact_status"], "manifest_missing")
         self.assertEqual(summary["cameras"][0]["metrics"], {})
+        self.assertEqual(summary["cameras"][0]["outputs"], {})
         self.assertIn("| `switzerland-alps-z5-outdoors` | passed | `manifest_missing` |", summary_text)
+        self.assertIn("| `switzerland-alps-z5-outdoors` | `—` | `—` | `—` |", summary_text)
         self.assertIn("The Artifacts column distinguishes subprocess success", summary_text)
 
     def test_manifest_artifact_status_distinguishes_unreadable_and_metricless_manifests(self):
@@ -729,7 +751,17 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             invalid_manifest = tmp_path / "invalid.json"
             invalid_manifest.write_text("{", encoding="utf-8")
             metricless_manifest = tmp_path / "metricless.json"
-            metricless_manifest.write_text(json.dumps({"metrics": {}}), encoding="utf-8")
+            diff_path = tmp_path / "mapbox-gl-vs-qgis-diff.png"
+            metricless_manifest.write_text(
+                json.dumps(
+                    {
+                        "outputs": {"diff": str(diff_path), "browser_reference": str(tmp_path / "missing.png")},
+                        "captured": {"diff": True, "browser_reference": False},
+                        "metrics": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
 
             unreadable_status, unreadable_metrics = mapbox_outdoors_comparison._manifest_artifact_status_and_metrics(
                 invalid_manifest
@@ -737,11 +769,16 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             metricless_status, metricless_metrics = mapbox_outdoors_comparison._manifest_artifact_status_and_metrics(
                 metricless_manifest
             )
+            metricless_full = mapbox_outdoors_comparison._manifest_artifact_status_metrics_and_outputs(
+                metricless_manifest,
+                token="",
+            )
 
         self.assertEqual(unreadable_status, "manifest_unreadable")
         self.assertEqual(unreadable_metrics, {})
         self.assertEqual(metricless_status, "metrics_unavailable")
         self.assertEqual(metricless_metrics, {})
+        self.assertEqual(metricless_full[2], {"diff": str(diff_path)})
 
     def test_main_rejects_single_camera_with_all_cameras(self):
         from qfit.validation import mapbox_outdoors_comparison

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -32,6 +32,7 @@ MATRIX_SUMMARY_METRIC_KEYS = (
     "normalized_rms_channel_delta",
     "ssim_status",
 )
+MATRIX_SUMMARY_OUTPUT_KEYS = ("browser_reference", "qgis_vector_render", "diff")
 MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE = "metrics_available"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING = "manifest_missing"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE = "manifest_unreadable"
@@ -863,20 +864,43 @@ def _manifest_path_from_child_stdout(stdout: str) -> Path | None:
     return manifest_path
 
 
-def _manifest_artifact_status_and_metrics(manifest_path: Path | None) -> tuple[str, dict[str, object]]:
+def _manifest_visual_outputs(manifest: dict[str, object], *, token: str) -> dict[str, str]:
+    outputs = manifest.get("outputs")
+    captured = manifest.get("captured")
+    if not isinstance(outputs, dict) or not isinstance(captured, dict):
+        return {}
+    visual_outputs: dict[str, str] = {}
+    for key in MATRIX_SUMMARY_OUTPUT_KEYS:
+        output_path = outputs.get(key)
+        if captured.get(key) is True and output_path:
+            visual_outputs[key] = redact_sensitive_text(str(output_path), token)
+    return visual_outputs
+
+
+def _manifest_artifact_status_metrics_and_outputs(
+    manifest_path: Path | None,
+    *,
+    token: str,
+) -> tuple[str, dict[str, object], dict[str, str]]:
     if manifest_path is None:
-        return MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING, {}
+        return MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING, {}, {}
     try:
         loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE, {}
+        return MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE, {}, {}
     metrics = loaded.get("metrics") if isinstance(loaded, dict) else None
+    outputs = _manifest_visual_outputs(loaded, token=token) if isinstance(loaded, dict) else {}
     if not isinstance(metrics, dict):
-        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}
+        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}, outputs
     metric_summary = {key: metrics[key] for key in MATRIX_SUMMARY_METRIC_KEYS if key in metrics}
     if not metric_summary:
-        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}
-    return MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE, metric_summary
+        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}, outputs
+    return MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE, metric_summary, outputs
+
+
+def _manifest_artifact_status_and_metrics(manifest_path: Path | None) -> tuple[str, dict[str, object]]:
+    status, metrics, _outputs = _manifest_artifact_status_metrics_and_outputs(manifest_path, token="")
+    return status, metrics
 
 
 def _all_camera_summary_entry(
@@ -888,7 +912,7 @@ def _all_camera_summary_entry(
     manifest_path: Path | None,
     token: str,
 ) -> dict[str, object]:
-    artifact_status, metrics = _manifest_artifact_status_and_metrics(manifest_path)
+    artifact_status, metrics, outputs = _manifest_artifact_status_metrics_and_outputs(manifest_path, token=token)
     return {
         "camera": camera.name,
         "description": camera.description,
@@ -899,6 +923,7 @@ def _all_camera_summary_entry(
         "timeout_seconds": timeout_seconds,
         "manifest": redact_sensitive_text(str(manifest_path), token) if manifest_path is not None else None,
         "metrics": metrics,
+        "outputs": outputs,
     }
 
 
@@ -939,10 +964,29 @@ def _all_cameras_summary_markdown(summary: dict[str, object]) -> str:
     lines.extend(
         [
             "",
+            "## Image artifacts",
+            "",
+            "| Camera | Mapbox GL reference | QGIS vector render | Diff |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for entry in summary["cameras"]:
+        outputs = entry["outputs"] if isinstance(entry.get("outputs"), dict) else {}
+        lines.append(
+            "| "
+            f"`{entry['camera']}` | "
+            f"`{outputs.get('browser_reference') or '—'}` | "
+            f"`{outputs.get('qgis_vector_render') or '—'}` | "
+            f"`{outputs.get('diff') or '—'}` |"
+        )
+    lines.extend(
+        [
+            "",
             "Notes:",
             "- Mapbox tokens are intentionally excluded from this summary.",
             "- This is a manual visual QA aid, not a CI gate.",
             "- The Artifacts column distinguishes subprocess success from manifest/metric availability.",
+            "- Image artifact paths are listed only for outputs captured by each child camera run.",
         ]
     )
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add captured Mapbox GL, QGIS vector, and diff image artifact paths to all-camera `summary.json`
- add a dedicated image-artifacts table to all-camera `summary.md`
- preserve subprocess status/metric semantics while keeping token redaction on manifest-derived paths
- document that aggregate summaries include captured image artifact paths

## Evidence
- #949 visual work now depends on repeatedly inspecting browser/QGIS/diff outputs across the z5-z18 matrix.
- The live all-camera summary previously surfaced manifest paths and metrics only, so visual review required opening each manifest before reaching the images.
- This branch ran the live matrix with the local QGIS profile Mapbox token without printing it; the new aggregate report directly lists all captured image paths: `debug/mapbox-outdoors-comparison/all-cameras/20260512T221414Z/summary.md`.
- The live run passed all five cameras with `metrics_available` and direct Mapbox GL/QGIS/diff image paths for each camera.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q` → 38 passed
- `coverage run -m unittest tests.test_mapbox_outdoors_comparison -v && coverage report -m validation/mapbox_outdoors_comparison.py` → 38 tests passed, 94% coverage for `validation/mapbox_outdoors_comparison.py`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check` → 1956 passed, 163 skipped, 135 subtests passed

Refs #949
