### PR TITLE
Snapshot selected Mapbox label filters for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -856,17 +856,48 @@ def _interpolate_filter_factor(
     linear_factor = (input_value - lower_stop) / (upper_stop - lower_stop)
     if interpolation_type == ["linear"]:
         return linear_factor
-    if isinstance(interpolation_type, list) and len(interpolation_type) == 2 and interpolation_type[0] == "exponential":
+    if (
+        isinstance(interpolation_type, list)
+        and len(interpolation_type) == 2
+        and interpolation_type[0] == "exponential"
+    ):
         base = _numeric_expression_value(interpolation_type[1])
         if base is None or base <= 0:
             return None
         if abs(base - 1.0) <= _ZOOM_BOUND_EPSILON:
             return linear_factor
-        denominator = (base ** (upper_stop - lower_stop)) - 1.0
+        denominator = base - 1.0
         if denominator == 0:
             return None
-        return ((base ** (input_value - lower_stop)) - 1.0) / denominator
+        return ((base**linear_factor) - 1.0) / denominator
     return None
+
+
+def _interpolate_filter_stops(expression: list[object], zoom: float) -> list[tuple[float, object]]:
+    stops: list[tuple[float, object]] = []
+    for index in range(3, len(expression) - 1, 2):
+        stop = _numeric_expression_value(expression[index])
+        if stop is not None:
+            stops.append((stop, _filter_expression_value_at_zoom(expression[index + 1], zoom)))
+    return stops
+
+
+def _interpolate_filter_output_between_stops(
+    interpolation_type: object,
+    input_value: float,
+    lower_stop: float,
+    lower_value: object,
+    upper_stop: float,
+    upper_value: object,
+) -> object | None:
+    lower_numeric = _numeric_expression_value(lower_value)
+    upper_numeric = _numeric_expression_value(upper_value)
+    if lower_numeric is None or upper_numeric is None:
+        return lower_value
+    fraction = _interpolate_filter_factor(interpolation_type, input_value, lower_stop, upper_stop)
+    if fraction is None:
+        return None
+    return lower_numeric + ((upper_numeric - lower_numeric) * fraction)
 
 
 def _interpolate_filter_value_at_zoom(expression: list[object], zoom: float) -> object | None:
@@ -875,26 +906,32 @@ def _interpolate_filter_value_at_zoom(expression: list[object], zoom: float) -> 
     input_value = _numeric_expression_value(_filter_expression_value_at_zoom(expression[2], zoom))
     if input_value is None:
         return None
-    stops: list[tuple[float, object]] = []
-    for index in range(3, len(expression) - 1, 2):
-        stop = _numeric_expression_value(expression[index])
-        if stop is not None:
-            stops.append((stop, _filter_expression_value_at_zoom(expression[index + 1], zoom)))
+    stops = _interpolate_filter_stops(expression, zoom)
     if not stops:
         return None
     if input_value <= stops[0][0]:
         return stops[0][1]
     for (lower_stop, lower_value), (upper_stop, upper_value) in zip(stops, stops[1:]):
         if input_value <= upper_stop:
-            lower_numeric = _numeric_expression_value(lower_value)
-            upper_numeric = _numeric_expression_value(upper_value)
-            if lower_numeric is not None and upper_numeric is not None:
-                fraction = _interpolate_filter_factor(expression[1], input_value, lower_stop, upper_stop)
-                if fraction is None:
-                    return None
-                return lower_numeric + ((upper_numeric - lower_numeric) * fraction)
-            return lower_value
+            return _interpolate_filter_output_between_stops(
+                expression[1], input_value, lower_stop, lower_value, upper_stop, upper_value
+            )
     return stops[-1][1]
+
+
+def _match_filter_value_at_zoom(expression: list[object], zoom: float) -> object:
+    if len(expression) < 5 or (len(expression) - 3) % 2 != 0:
+        return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+    normalized = ["match", _filter_expression_value_at_zoom(expression[1], zoom)]
+    for label_index in range(2, len(expression) - 1, 2):
+        normalized.extend(
+            [
+                copy.deepcopy(expression[label_index]),
+                _filter_expression_value_at_zoom(expression[label_index + 1], zoom),
+            ]
+        )
+    normalized.append(_filter_expression_value_at_zoom(expression[-1], zoom))
+    return normalized
 
 
 def _filter_expression_value_at_zoom(value: object, zoom: float) -> object:
@@ -916,6 +953,10 @@ def _filter_expression_value_at_zoom(value: object, zoom: float) -> object:
         if interpolate_value is not None:
             return interpolate_value
         return value
+    if operator == "match":
+        match_value = _match_filter_value_at_zoom(value, zoom)
+        if match_value is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
+            return match_value
     if isinstance(operator, str) and operator in {"+", "-", "*", "/"} and _filter_expression_depends_on_zoom(value):
         arithmetic_value = _arithmetic_filter_value_at_zoom(
             operator,

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 from dataclasses import dataclass
+from typing import Iterable
 from urllib.parse import parse_qsl, quote, urlencode, unquote, urlparse, urlunparse
 from urllib.request import urlopen
 
@@ -269,6 +270,12 @@ _ZOOM_BOUND_EPSILON = 1e-9
 _FULL_OPACITY = 1.0
 _FULL_OPACITY_EPSILON = 1e-9
 _FULL_OPACITY_PROPS = {"fill-opacity", "line-opacity"}
+_ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS = {
+    "path-pedestrian-label",
+    "road-label",
+    "road-number-shield",
+    "transit-label",
+}
 
 
 def _is_literal_color(value: object) -> bool:
@@ -776,6 +783,166 @@ def _simplify_filter_expression_for_qgis(value: object, *, root: bool = True) ->
     return [operator, *[_simplify_filter_expression_for_qgis(item, root=False) for item in value[1:]]]
 
 
+def _numeric_expression_value(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _filter_expression_depends_on_zoom(value: object) -> bool:
+    if not isinstance(value, list) or not value:
+        return False
+    operator = value[0]
+    if operator == "zoom" and len(value) == 1:
+        return True
+    children: Iterable[object]
+    if operator == "literal":
+        children = []
+    elif operator == "match":
+        children = []
+        if len(value) > 1:
+            children = [value[1]]
+        match_outputs = [value[index] for index in range(3, len(value) - 1, 2)]
+        if len(value) > 2:
+            match_outputs.append(value[-1])
+        children = [*children, *match_outputs]
+    else:
+        children = value[1:]
+    return any(_filter_expression_depends_on_zoom(child) for child in children)
+
+
+def _arithmetic_filter_value_at_zoom(operator: str, values: list[object]) -> object | None:
+    numeric_values = [_numeric_expression_value(value) for value in values]
+    if not numeric_values or any(value is None for value in numeric_values):
+        return None
+    numbers = [value for value in numeric_values if value is not None]
+    if operator == "+":
+        return sum(numbers)
+    if operator == "-":
+        return -numbers[0] if len(numbers) == 1 else numbers[0] - sum(numbers[1:])
+    if operator == "*":
+        result = 1.0
+        for number in numbers:
+            result *= number
+        return result
+    if operator == "/" and len(numbers) == 2 and numbers[1] != 0:
+        return numbers[0] / numbers[1]
+    return None
+
+
+def _step_filter_value_at_zoom(expression: list[object], zoom: float) -> object | None:
+    if len(expression) < 4:
+        return None
+    input_value = _numeric_expression_value(_filter_expression_value_at_zoom(expression[1], zoom))
+    if input_value is None:
+        return None
+    selected_value = expression[2]
+    for index in range(3, len(expression) - 1, 2):
+        stop = _numeric_expression_value(expression[index])
+        if stop is None or input_value < stop:
+            break
+        selected_value = expression[index + 1]
+    return _filter_expression_value_at_zoom(selected_value, zoom)
+
+
+def _interpolate_filter_factor(
+    interpolation_type: object,
+    input_value: float,
+    lower_stop: float,
+    upper_stop: float,
+) -> float | None:
+    if upper_stop == lower_stop:
+        return None
+    linear_factor = (input_value - lower_stop) / (upper_stop - lower_stop)
+    if interpolation_type == ["linear"]:
+        return linear_factor
+    if isinstance(interpolation_type, list) and len(interpolation_type) == 2 and interpolation_type[0] == "exponential":
+        base = _numeric_expression_value(interpolation_type[1])
+        if base is None or base <= 0:
+            return None
+        if abs(base - 1.0) <= _ZOOM_BOUND_EPSILON:
+            return linear_factor
+        denominator = (base ** (upper_stop - lower_stop)) - 1.0
+        if denominator == 0:
+            return None
+        return ((base ** (input_value - lower_stop)) - 1.0) / denominator
+    return None
+
+
+def _interpolate_filter_value_at_zoom(expression: list[object], zoom: float) -> object | None:
+    if len(expression) < 5:
+        return None
+    input_value = _numeric_expression_value(_filter_expression_value_at_zoom(expression[2], zoom))
+    if input_value is None:
+        return None
+    stops: list[tuple[float, object]] = []
+    for index in range(3, len(expression) - 1, 2):
+        stop = _numeric_expression_value(expression[index])
+        if stop is not None:
+            stops.append((stop, _filter_expression_value_at_zoom(expression[index + 1], zoom)))
+    if not stops:
+        return None
+    if input_value <= stops[0][0]:
+        return stops[0][1]
+    for (lower_stop, lower_value), (upper_stop, upper_value) in zip(stops, stops[1:]):
+        if input_value <= upper_stop:
+            lower_numeric = _numeric_expression_value(lower_value)
+            upper_numeric = _numeric_expression_value(upper_value)
+            if lower_numeric is not None and upper_numeric is not None:
+                fraction = _interpolate_filter_factor(expression[1], input_value, lower_stop, upper_stop)
+                if fraction is None:
+                    return None
+                return lower_numeric + ((upper_numeric - lower_numeric) * fraction)
+            return lower_value
+    return stops[-1][1]
+
+
+def _filter_expression_value_at_zoom(value: object, zoom: float) -> object:
+    """Collapse Mapbox filter zoom expressions to a QGIS-parser-friendly snapshot."""
+    if not isinstance(value, list) or not value:
+        return value
+    operator = value[0]
+    if operator == "literal":
+        return value
+    if operator == "zoom" and len(value) == 1:
+        return zoom
+    if operator == "step":
+        step_value = _step_filter_value_at_zoom(value, zoom)
+        if step_value is not None:
+            return step_value
+        return value
+    if operator == "interpolate":
+        interpolate_value = _interpolate_filter_value_at_zoom(value, zoom)
+        if interpolate_value is not None:
+            return interpolate_value
+        return value
+    if isinstance(operator, str) and operator in {"+", "-", "*", "/"} and _filter_expression_depends_on_zoom(value):
+        arithmetic_value = _arithmetic_filter_value_at_zoom(
+            operator,
+            [_filter_expression_value_at_zoom(item, zoom) for item in value[1:]],
+        )
+        if arithmetic_value is not None:
+            return arithmetic_value
+    return [_filter_expression_value_at_zoom(item, zoom) for item in value]
+
+
+def _zoom_normalized_filter_expression_for_qgis(layer: dict[str, object], value: object) -> object:
+    target_zoom = _representative_zoom_in_layer_range(layer.get("minzoom"), layer.get("maxzoom"))
+    if target_zoom is None:
+        target_zoom = _REPRESENTATIVE_STYLE_ZOOM
+    return _filter_expression_value_at_zoom(value, target_zoom)
+
+
+def _should_zoom_normalize_filter_for_qgis(layer: dict[str, object]) -> bool:
+    # QGIS' Mapbox converter rejects zoom-dependent filters. Restrict static
+    # zoom snapshots to the high-signal label layers from #949 visual audits:
+    # repeated road labels, pedestrian path label noise, ferry/transit label
+    # leakage, and road shields. Applying the same approximation broadly can hide
+    # high-zoom road/path geometry or over-suppress POIs/places, so keep this
+    # deliberately small.
+    return layer.get("type") == "symbol" and layer.get("id") in _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS
+
+
 def _line_layout_choice(expr: object, choices: set[str]) -> str | None:
     if not isinstance(expr, list) or len(expr) < 3 or expr[0] != "step" or expr[1] != ["zoom"]:
         return None
@@ -966,9 +1133,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     Also simplifies ``text-field`` coalesce expressions to their first simple
     ``['get', field]`` reference so QGIS can resolve the label field name,
     literalizes simple ``line-dasharray`` expressions so dashed routes and paths
-    survive QGIS conversion, rewrites a few semantics-preserving filter shapes
-    that QGIS parses more reliably, and collapses Mapbox font stacks to a
-    QGIS-safe local fallback to avoid warning spam from proprietary Mapbox font
+    survive QGIS conversion, rewrites a few semantics-preserving filter shapes,
+    snapshots selected zoom-dependent filters at a representative layer zoom that
+    QGIS can parse, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
+    warning spam from proprietary Mapbox font
     family names.
 
     Only color properties whose values are Mapbox expressions (lists) are
@@ -1042,6 +1210,8 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
 
         filter_value = layer.get("filter")
         if isinstance(filter_value, (bool, list)):
+            if _should_zoom_normalize_filter_for_qgis(layer):
+                filter_value = _zoom_normalized_filter_expression_for_qgis(layer, filter_value)
             layer["filter"] = _simplify_filter_expression_for_qgis(filter_value)
 
         for section in ("paint", "layout"):

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -934,6 +934,34 @@ def _match_filter_value_at_zoom(expression: list[object], zoom: float) -> object
     return normalized
 
 
+def _operator_filter_value_at_zoom(operator: object, expression: list[object], zoom: float) -> object:
+    if operator == "zoom" and len(expression) == 1:
+        return zoom
+    if operator == "step":
+        step_value = _step_filter_value_at_zoom(expression, zoom)
+        return step_value if step_value is not None else expression
+    if operator == "interpolate":
+        interpolate_value = _interpolate_filter_value_at_zoom(expression, zoom)
+        return interpolate_value if interpolate_value is not None else expression
+    if operator == "match":
+        return _match_filter_value_at_zoom(expression, zoom)
+    return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+
+
+def _arithmetic_filter_expression_value_at_zoom(operator: object, expression: list[object], zoom: float) -> object:
+    if not isinstance(operator, str) or operator not in {"+", "-", "*", "/"}:
+        return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+    if not _filter_expression_depends_on_zoom(expression):
+        return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+    arithmetic_value = _arithmetic_filter_value_at_zoom(
+        operator,
+        [_filter_expression_value_at_zoom(item, zoom) for item in expression[1:]],
+    )
+    if arithmetic_value is None:
+        return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+    return arithmetic_value
+
+
 def _filter_expression_value_at_zoom(value: object, zoom: float) -> object:
     """Collapse Mapbox filter zoom expressions to a QGIS-parser-friendly snapshot."""
     if not isinstance(value, list) or not value:
@@ -941,29 +969,12 @@ def _filter_expression_value_at_zoom(value: object, zoom: float) -> object:
     operator = value[0]
     if operator == "literal":
         return value
-    if operator == "zoom" and len(value) == 1:
-        return zoom
-    if operator == "step":
-        step_value = _step_filter_value_at_zoom(value, zoom)
-        if step_value is not None:
-            return step_value
-        return value
-    if operator == "interpolate":
-        interpolate_value = _interpolate_filter_value_at_zoom(value, zoom)
-        if interpolate_value is not None:
-            return interpolate_value
-        return value
-    if operator == "match":
-        match_value = _match_filter_value_at_zoom(value, zoom)
-        if match_value is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
-            return match_value
-    if isinstance(operator, str) and operator in {"+", "-", "*", "/"} and _filter_expression_depends_on_zoom(value):
-        arithmetic_value = _arithmetic_filter_value_at_zoom(
-            operator,
-            [_filter_expression_value_at_zoom(item, zoom) for item in value[1:]],
-        )
-        if arithmetic_value is not None:
-            return arithmetic_value
+    operator_value = _operator_filter_value_at_zoom(operator, value, zoom)
+    if operator_value is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
+        return operator_value
+    arithmetic_value = _arithmetic_filter_expression_value_at_zoom(operator, value, zoom)
+    if arithmetic_value is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
+        return arithmetic_value
     return [_filter_expression_value_at_zoom(item, zoom) for item in value]
 
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -866,10 +866,12 @@ def _interpolate_filter_factor(
             return None
         if abs(base - 1.0) <= _ZOOM_BOUND_EPSILON:
             return linear_factor
-        denominator = base - 1.0
+        # Match Mapbox GL JS' exponentialInterpolation: the exponent uses raw
+        # stop distance, not the normalized 0..1 progress fraction.
+        denominator = (base ** (upper_stop - lower_stop)) - 1.0
         if denominator == 0:
             return None
-        return ((base**linear_factor) - 1.0) / denominator
+        return ((base ** (input_value - lower_stop)) - 1.0) / denominator
     return None
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -767,19 +767,213 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][5]["filter"], ["==", 1, 1])
         self.assertEqual(style["layers"][0]["filter"][0], "!")
 
-    def test_filter_simplification_preserves_zoom_dependent_filters(self):
+    def test_filter_simplification_snapshots_zoom_dependent_filters(self):
         filter_expression = [
             "step",
             ["zoom"],
             ["match", ["get", "class"], ["primary", "secondary"], True, False],
             14,
-            True,
+            ["match", ["get", "class"], ["primary", "secondary", "service"], True, False],
         ]
-        style = {"layers": [{"filter": filter_expression}]}
+        style = {"layers": [{"id": "road-label", "type": "symbol", "minzoom": 16, "filter": filter_expression}]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["filter"],
+            ["match", ["get", "class"], ["primary", "secondary", "service"], True, False],
+        )
+        self.assertEqual(style["layers"][0]["filter"], filter_expression)
+
+    def test_filter_simplification_normalizes_nested_zoom_arithmetic(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-number-shield",
+                    "type": "symbol",
+                    "filter": [
+                        "<=",
+                        ["-", ["to-number", ["get", "sizerank"]], ["interpolate", ["linear"], ["zoom"], 12, 0, 18, 14]],
+                        14,
+                    ]
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["filter"],
+            ["<=", ["to-number", ["get", "sizerank"]], 14],
+        )
+
+    def test_filter_simplification_normalizes_zoom_arithmetic_operators(self):
+        style = {
+            "layers": [
+                {"id": "road-label", "type": "symbol", "filter": ["==", ["+", ["zoom"], 2], 14]},
+                {"id": "road-label", "type": "symbol", "filter": ["==", ["-", ["zoom"], 2], 10]},
+                {"id": "road-label", "type": "symbol", "filter": ["==", ["*", ["zoom"], 2], 24]},
+                {"id": "road-label", "type": "symbol", "filter": ["==", ["/", ["zoom"], 2], 6]},
+                {"id": "road-label", "type": "symbol", "filter": ["==", ["/", ["zoom"], 0], 0]},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["filter"], ["==", 14.0, 14])
+        self.assertEqual(result["layers"][1]["filter"], ["==", 10.0, 10])
+        self.assertEqual(result["layers"][2]["filter"], ["==", 24.0, 24])
+        self.assertEqual(result["layers"][3]["filter"], ["==", 6.0, 6])
+        self.assertEqual(result["layers"][4]["filter"], ["==", ["/", 12.0, 0], 0])
+
+    def test_filter_simplification_normalizes_zoom_inside_literal_and_match_outputs(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "filter": ["==", ["+", ["literal", [["zoom"]]], 2], 0],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "filter": ["==", ["+", ["match", ["get", "class"], "primary", ["zoom"], 0], 2], 14],
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["filter"], ["==", ["+", ["literal", [["zoom"]]], 2], 0])
+        self.assertEqual(
+            result["layers"][1]["filter"],
+            ["==", ["+", ["match", ["get", "class"], "primary", 12.0, 0], 2], 14],
+        )
+
+    def test_filter_simplification_handles_unsupported_zoom_step_shapes(self):
+        style = {
+            "layers": [
+                {"id": "road-label", "type": "symbol", "filter": ["==", ["step", ["zoom"], "low"], "low"]},
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "filter": ["==", ["step", ["get", "rank"], "low", 14, "high"], "low"],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "filter": ["==", ["step", ["zoom"], "low", 14, "high"], "low"],
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["filter"], ["==", ["step", ["zoom"], "low"], "low"])
+        self.assertEqual(
+            result["layers"][1]["filter"],
+            ["==", ["step", ["get", "rank"], "low", 14, "high"], "low"],
+        )
+        self.assertEqual(result["layers"][2]["filter"], ["==", "low", "low"])
+
+    def test_filter_simplification_handles_zoom_interpolate_edge_cases(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "filter": ["==", ["interpolate", ["linear"], ["zoom"], 12, 0], 0],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "filter": ["==", ["interpolate", ["linear"], ["get", "rank"], 0, 0, 10, 10], 0],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "filter": ["==", ["interpolate", ["linear"], ["zoom"], "low", 0, "high", 10], 0],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "minzoom": 15,
+                    "filter": ["==", ["interpolate", ["linear"], ["zoom"], 12, 0, 18, 12], 6],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "minzoom": 15,
+                    "filter": ["==", ["interpolate", ["linear"], ["zoom"], 12, "low", 18, "high"], "low"],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "minzoom": 20,
+                    "filter": ["==", ["interpolate", ["linear"], ["zoom"], 12, 0, 18, 12], 12],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "minzoom": 15,
+                    "filter": ["==", ["interpolate", ["exponential", 2], ["zoom"], 12, 0, 18, 12], 0],
+                },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "minzoom": 15,
+                    "filter": ["==", ["interpolate", ["cubic-bezier", 0, 0, 1, 1], ["zoom"], 12, 0, 18, 12], 0],
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["filter"], ["==", 0, 0])
+        self.assertEqual(
+            result["layers"][1]["filter"],
+            ["==", ["interpolate", ["linear"], ["get", "rank"], 0, 0, 10, 10], 0],
+        )
+        self.assertEqual(
+            result["layers"][2]["filter"],
+            ["==", ["interpolate", ["linear"], ["zoom"], "low", 0, "high", 10], 0],
+        )
+        self.assertEqual(result["layers"][3]["filter"], ["==", 6.0, 6])
+        self.assertEqual(result["layers"][4]["filter"], ["==", "low", "low"])
+        self.assertEqual(result["layers"][5]["filter"], ["==", 12, 12])
+        self.assertEqual(result["layers"][6]["filter"][0], "==")
+        self.assertAlmostEqual(result["layers"][6]["filter"][1], 1.3333333333333333)
+        self.assertEqual(result["layers"][6]["filter"][2], 0)
+        self.assertEqual(
+            result["layers"][7]["filter"],
+            ["==", ["interpolate", ["cubic-bezier", 0, 0, 1, 1], ["zoom"], 12, 0, 18, 12], 0],
+        )
+
+    def test_filter_simplification_preserves_zoom_dependent_geometry_filters(self):
+        filter_expression = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            ["step", ["zoom"], ["match", ["get", "type"], ["steps", "sidewalk"], False, True], 16, True],
+        ]
+        style = {"layers": [{"type": "line", "filter": filter_expression}]}
 
         result = simplify_mapbox_style_expressions(style)
 
         self.assertEqual(result["layers"][0]["filter"], filter_expression)
+
+    def test_filter_simplification_preserves_non_target_symbol_zoom_filters(self):
+        filter_expression = ["<=", ["get", "filterrank"], ["step", ["zoom"], 0, 16, 2]]
+        style = {
+            "layers": [
+                {"id": "poi-label", "type": "symbol", "filter": filter_expression},
+                {"id": "natural-point-label", "type": "symbol", "filter": filter_expression},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["filter"], filter_expression)
+        self.assertEqual(result["layers"][1]["filter"], filter_expression)
 
     def test_line_cap_step_expression_uses_high_zoom_choice(self):
         style = {

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -957,7 +957,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][4]["filter"], ["==", "low", "low"])
         self.assertEqual(result["layers"][5]["filter"], ["==", 12, 12])
         self.assertEqual(result["layers"][6]["filter"][0], "==")
-        self.assertAlmostEqual(result["layers"][6]["filter"][1], 4.970562748477143)
+        self.assertAlmostEqual(result["layers"][6]["filter"][1], 1.3333333333333333)
         self.assertEqual(result["layers"][6]["filter"][2], 0)
         self.assertEqual(
             result["layers"][7]["filter"],

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -839,6 +839,17 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     "type": "symbol",
                     "filter": ["==", ["+", ["match", ["get", "class"], "primary", ["zoom"], 0], 2], 14],
                 },
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "filter": [
+                        "match",
+                        ["get", "class"],
+                        ["zoom"],
+                        ["==", ["step", ["zoom"], "low", 14, "high"], "low"],
+                        False,
+                    ],
+                },
             ]
         }
 
@@ -848,6 +859,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(
             result["layers"][1]["filter"],
             ["==", ["+", ["match", ["get", "class"], "primary", 12.0, 0], 2], 14],
+        )
+        self.assertEqual(
+            result["layers"][2]["filter"],
+            ["match", ["get", "class"], ["zoom"], ["==", "low", "low"], False],
         )
 
     def test_filter_simplification_handles_unsupported_zoom_step_shapes(self):
@@ -942,7 +957,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][4]["filter"], ["==", "low", "low"])
         self.assertEqual(result["layers"][5]["filter"], ["==", 12, 12])
         self.assertEqual(result["layers"][6]["filter"][0], "==")
-        self.assertAlmostEqual(result["layers"][6]["filter"][1], 1.3333333333333333)
+        self.assertAlmostEqual(result["layers"][6]["filter"][1], 4.970562748477143)
         self.assertEqual(result["layers"][6]["filter"][2], 0)
         self.assertEqual(
             result["layers"][7]["filter"],


### PR DESCRIPTION
## Summary
- snapshot zoom-dependent filters only for the high-signal Mapbox Outdoors symbol label layers QGIS struggles to parse (`road-label`, `path-pedestrian-label`, `road-number-shield`, `transit-label`)
- keep road/path geometry filters, POI labels, and settlement labels untouched after visual QA showed broader normalization can over-suppress geometry or places
- address Codex/Greptile/SonarCloud feedback by preserving `match` label arrays as literals, matching Mapbox GL JS exponential interpolation, and splitting helper complexity
- add regression coverage for targeted symbol normalization, nested zoom arithmetic, Mapbox interpolation curves, literal `match` labels, and non-target layer preservation

Refs #949

## Evidence
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T053603Z/audit.json`
  - raw QGIS warnings: 159
  - qfit-preprocessed warnings: 66 (previous active baseline was 73)
  - unsupported filter parser count: 19/140 remaining; all 19 have parser-friendly equivalents in the audit probe
- All-camera visual/metric comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T053636Z/summary.md`
  - all 5 cameras passed with metrics available
  - mean Δ: z5 `0.1280`, z8 `0.1423`, z10 `0.1067`, z14 `0.1400`, z18 `0.0474`

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
