### PR TITLE
Drop empty Mapbox step icons

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -59,6 +59,7 @@ WEB_MERCATOR_WORLD_WIDTH_M = 40075016.685578488
 DEFAULT_MAPBOX_MIN_ZOOM = 0
 DEFAULT_MAPBOX_MAX_ZOOM = 22
 QGIS_TEXT_FONT_FALLBACK = "Noto Sans"
+_ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE = object()
 
 _BACKGROUND_PRESETS = {
     "Outdoor": {
@@ -356,25 +357,46 @@ def _representative_zoom_in_layer_range(minzoom: object, maxzoom: object) -> flo
     return target_zoom
 
 
-def _literal_step_icon_image(expr: object, *, minzoom: object = None, maxzoom: object = None) -> str | None:
+def _has_valid_zoom_step_thresholds(expr: list[object]) -> bool:
+    return all(
+        not isinstance(expr[index], bool) and isinstance(expr[index], (int, float))
+        for index in range(3, len(expr) - 1, 2)
+    )
+
+
+def _step_outputs(expr: list[object]) -> list[object]:
+    return [expr[2], *(expr[index + 1] for index in range(3, len(expr) - 1, 2))]
+
+
+def _step_has_only_non_empty_literal_outputs(expr: list[object]) -> bool:
+    return all(isinstance(output, str) and output for output in _step_outputs(expr))
+
+
+def _step_has_future_icon_outputs(expr: list[object], target_zoom: float) -> bool:
+    return any(
+        float(expr[index]) > target_zoom and expr[index + 1] != ""
+        for index in range(3, len(expr) - 1, 2)
+    )
+
+
+def _literal_step_icon_image(expr: object, *, minzoom: object = None, maxzoom: object = None) -> object:
     if not isinstance(expr, list) or len(expr) < 3 or expr[0] != "step" or expr[1] != ["zoom"]:
-        return None
-    if not isinstance(expr[2], str) or not expr[2]:
-        return None
-    for index in range(3, len(expr) - 1, 2):
-        threshold = expr[index]
-        output = expr[index + 1]
-        if isinstance(threshold, bool) or not isinstance(threshold, (int, float)):
-            return None
-        if not isinstance(output, str) or not output:
-            return None
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+    if not _has_valid_zoom_step_thresholds(expr):
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
     target_zoom = _representative_zoom_in_layer_range(minzoom, maxzoom)
     if target_zoom is None:
-        return None
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
     representative = _step_zoom_value(expr, target_zoom=target_zoom)
-    if isinstance(representative, str) and representative:
+    if not isinstance(representative, str):
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+    if not representative:
+        if _step_has_future_icon_outputs(expr, target_zoom):
+            return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
         return representative
-    return None
+    if _step_has_only_non_empty_literal_outputs(expr):
+        return representative
+    return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
 
 
 def _extract_fallback_color(expr: object) -> str | None:
@@ -1283,8 +1305,11 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         minzoom=layer.get("minzoom"),
                         maxzoom=layer.get("maxzoom"),
                     )
-                    if icon_image is not None:
-                        props[prop] = icon_image
+                    if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
+                        if icon_image:
+                            props[prop] = icon_image
+                        else:
+                            del props[prop]
                         continue
                 if not isinstance(val, list):
                     continue

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -609,11 +609,26 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
     def test_icon_image_placeholders_and_literal_zoom_steps_are_simplified(self):
         empty_output_step = ["step", ["zoom"], "dot-11", 8, ""]
+        empty_representative_step = ["step", ["zoom"], ["case", ["==", ["get", "capital"], 2], "dot-11", "dot-9"], 8, ""]
         data_driven_step = [
             "step",
             ["zoom"],
             "shield-small",
             12,
+            ["concat", ["get", "shield"], "-", ["to-string", ["get", "reflen"]]],
+        ]
+        data_driven_high_zoom_step = [
+            "step",
+            ["zoom"],
+            "shield-small",
+            13,
+            ["concat", ["get", "shield"], "-", ["to-string", ["get", "reflen"]]],
+        ]
+        empty_then_data_driven_high_zoom_step = [
+            "step",
+            ["zoom"],
+            "",
+            13,
             ["concat", ["get", "shield"], "-", ["to-string", ["get", "reflen"]]],
         ]
         style = {
@@ -625,7 +640,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 {"minzoom": 14, "layout": {"icon-image": ["step", ["zoom"], "oneway-small", 13, "oneway-large"]}},
                 {"maxzoom": 11, "layout": {"icon-image": ["step", ["zoom"], "zoom-low", 10, "zoom-mid", 12, "zoom-high"]}},
                 {"layout": {"icon-image": empty_output_step}},
+                {"layout": {"icon-image": empty_representative_step}},
                 {"layout": {"icon-image": data_driven_step}},
+                {"layout": {"icon-image": data_driven_high_zoom_step}},
+                {"layout": {"icon-image": empty_then_data_driven_high_zoom_step}},
             ]
         }
 
@@ -638,8 +656,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][3]["layout"]["icon-image"], "oneway-small")
         self.assertEqual(result["layers"][4]["layout"]["icon-image"], "oneway-large")
         self.assertEqual(result["layers"][5]["layout"]["icon-image"], "zoom-mid")
-        self.assertEqual(result["layers"][6]["layout"]["icon-image"], empty_output_step)
-        self.assertEqual(result["layers"][7]["layout"]["icon-image"], data_driven_step)
+        self.assertNotIn("icon-image", result["layers"][6]["layout"])
+        self.assertNotIn("icon-image", result["layers"][7]["layout"])
+        self.assertEqual(result["layers"][8]["layout"]["icon-image"], data_driven_step)
+        self.assertEqual(result["layers"][9]["layout"]["icon-image"], data_driven_high_zoom_step)
+        self.assertEqual(result["layers"][10]["layout"]["icon-image"], empty_then_data_driven_high_zoom_step)
 
     def test_line_dasharray_expressions_resolve_to_literal_arrays(self):
         style = {


### PR DESCRIPTION
## Summary
- drop `icon-image` when a zoom-step expression resolves to an empty sprite at qfit's representative style zoom
- keep non-representative/data-driven icon branches intact instead of collapsing mixed-output steps to a literal or deleting future icon branches
- add regression coverage for empty step outputs and mixed data-driven branches

## Evidence
- Latest baseline audit after #1029: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T053603Z/audit.json` had 66 qfit-preprocessed warnings.
- New live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T061537Z/audit.json` has 64 qfit-preprocessed warnings; the remaining warning table no longer includes `Could not interpret sprite value list with method step`.
- New all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T061558Z/summary.md`; all 5 cameras passed, with metrics effectively unchanged from the prior baseline.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.
