### PR TITLE
Scalarize Mapbox zoom icon sizes

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -486,10 +486,10 @@ def _extract_zoom_scalar_size(expr: object, *, minzoom: object = None, maxzoom: 
     if target_zoom is None:
         return None
     if expr[0] == "step" and expr[1] == ["zoom"]:
-        outputs = [expr[2], *(expr[index + 1] for index in range(3, len(expr) - 1, 2))]
+        outputs = _step_outputs(expr)
         if all(_numeric_expression_value(output) is not None for output in outputs):
             return _numeric_expression_value(_step_zoom_value(expr, target_zoom=target_zoom))
-    if expr[0] == "interpolate" and len(expr) >= 6 and expr[2] == ["zoom"]:
+    if expr[0] == "interpolate" and len(expr) >= 5 and expr[2] == ["zoom"]:
         outputs = [expr[index] for index in range(4, len(expr), 2)]
         if all(_numeric_expression_value(output) is not None for output in outputs):
             return _numeric_expression_value(_interpolate_filter_value_at_zoom(expr, target_zoom))

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -474,6 +474,28 @@ def _extract_midrange_size(expr: object) -> float | None:
     return None
 
 
+def _extract_zoom_scalar_size(expr: object, *, minzoom: object = None, maxzoom: object = None) -> float | None:
+    """Resolve zoom-only size expressions to a representative scalar for QGIS.
+
+    Keep data-driven sizes intact; QGIS may be able to apply them in contexts
+    where a static snapshot would lose feature-specific emphasis.
+    """
+    if not isinstance(expr, list) or len(expr) < 4:
+        return None
+    target_zoom = _representative_zoom_in_layer_range(minzoom, maxzoom)
+    if target_zoom is None:
+        return None
+    if expr[0] == "step" and expr[1] == ["zoom"]:
+        outputs = [expr[2], *(expr[index + 1] for index in range(3, len(expr) - 1, 2))]
+        if all(_numeric_expression_value(output) is not None for output in outputs):
+            return _numeric_expression_value(_step_zoom_value(expr, target_zoom=target_zoom))
+    if expr[0] == "interpolate" and len(expr) >= 6 and expr[2] == ["zoom"]:
+        outputs = [expr[index] for index in range(4, len(expr), 2)]
+        if all(_numeric_expression_value(output) is not None for output in outputs):
+            return _numeric_expression_value(_interpolate_filter_value_at_zoom(expr, target_zoom))
+    return None
+
+
 def _clamp_opacity_value(value: object) -> float | None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
@@ -1354,6 +1376,14 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         size = _extract_midrange_size(val)
                         if size is not None:
                             props[prop] = size
+                elif prop == "icon-size":
+                    size = _extract_zoom_scalar_size(
+                        val,
+                        minzoom=layer.get("minzoom"),
+                        maxzoom=layer.get("maxzoom"),
+                    )
+                    if size is not None:
+                        props[prop] = size
                 elif prop in _LINE_LAYOUT_CHOICES:
                     choice = _line_layout_choice(val, _LINE_LAYOUT_CHOICES[prop])
                     if choice is not None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -664,12 +664,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
     def test_zoom_only_icon_size_expressions_resolve_to_scalars(self):
         zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 10, 0.5, 14, 1.5]
+        single_stop_zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 14, 1.25]
         zoom_step = ["step", ["zoom"], 0.1, 18, 0.2, 20, 1.0]
         property_interpolate = ["interpolate", ["linear"], ["get", "rank"], 0, 0.5, 10, 1.5]
         data_driven_zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 10, ["get", "size"], 14, 1.5]
         style = {
             "layers": [
                 {"layout": {"icon-size": zoom_interpolate}},
+                {"layout": {"icon-size": single_stop_zoom_interpolate}},
                 {"minzoom": 18, "layout": {"icon-size": zoom_step}},
                 {"layout": {"icon-size": property_interpolate}},
                 {"layout": {"icon-size": data_driven_zoom_interpolate}},
@@ -679,9 +681,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         result = simplify_mapbox_style_expressions(style)
 
         self.assertAlmostEqual(result["layers"][0]["layout"]["icon-size"], 1.0)
-        self.assertAlmostEqual(result["layers"][1]["layout"]["icon-size"], 0.2)
-        self.assertEqual(result["layers"][2]["layout"]["icon-size"], property_interpolate)
-        self.assertEqual(result["layers"][3]["layout"]["icon-size"], data_driven_zoom_interpolate)
+        self.assertAlmostEqual(result["layers"][1]["layout"]["icon-size"], 1.25)
+        self.assertAlmostEqual(result["layers"][2]["layout"]["icon-size"], 0.2)
+        self.assertEqual(result["layers"][3]["layout"]["icon-size"], property_interpolate)
+        self.assertEqual(result["layers"][4]["layout"]["icon-size"], data_driven_zoom_interpolate)
 
     def test_line_dasharray_expressions_resolve_to_literal_arrays(self):
         style = {

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -662,6 +662,27 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][9]["layout"]["icon-image"], data_driven_high_zoom_step)
         self.assertEqual(result["layers"][10]["layout"]["icon-image"], empty_then_data_driven_high_zoom_step)
 
+    def test_zoom_only_icon_size_expressions_resolve_to_scalars(self):
+        zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 10, 0.5, 14, 1.5]
+        zoom_step = ["step", ["zoom"], 0.1, 18, 0.2, 20, 1.0]
+        property_interpolate = ["interpolate", ["linear"], ["get", "rank"], 0, 0.5, 10, 1.5]
+        data_driven_zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 10, ["get", "size"], 14, 1.5]
+        style = {
+            "layers": [
+                {"layout": {"icon-size": zoom_interpolate}},
+                {"minzoom": 18, "layout": {"icon-size": zoom_step}},
+                {"layout": {"icon-size": property_interpolate}},
+                {"layout": {"icon-size": data_driven_zoom_interpolate}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertAlmostEqual(result["layers"][0]["layout"]["icon-size"], 1.0)
+        self.assertAlmostEqual(result["layers"][1]["layout"]["icon-size"], 0.2)
+        self.assertEqual(result["layers"][2]["layout"]["icon-size"], property_interpolate)
+        self.assertEqual(result["layers"][3]["layout"]["icon-size"], data_driven_zoom_interpolate)
+
     def test_line_dasharray_expressions_resolve_to_literal_arrays(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary
- scalarize zoom-only Mapbox `icon-size` expressions for QGIS vector style conversion
- preserve data-driven icon-size expressions instead of snapshotting feature-dependent sizes
- add regression coverage for zoom interpolate/step icon sizes, single-stop zoom interpolation, and data-driven preservation

## Evidence
- Latest baseline after #1030: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T061537Z/audit.json` had 49 warnings in the runtime sprite-context probe, including `crosswalks: Skipping non-implemented icon-size type (QVariantList)`.
- New live audit after the review-fix commit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T065822Z/audit.json` keeps qfit-preprocessed warnings at 64 but improves the runtime sprite-context probe to 48 warnings; the crosswalk icon-size warning is gone.
- New all-camera comparison after the review-fix commit: `debug/mapbox-outdoors-comparison/all-cameras/20260514T065848Z/summary.md`; all 5 cameras passed, with metrics effectively unchanged from the prior baseline.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.
