### PR TITLE
Avoid empty Mapbox gate icon fallback

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -60,6 +60,9 @@ DEFAULT_MAPBOX_MIN_ZOOM = 0
 DEFAULT_MAPBOX_MAX_ZOOM = 22
 QGIS_TEXT_FONT_FALLBACK = "Noto Sans"
 _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE = object()
+_ICON_IMAGE_EMPTY_MATCH_FALLBACKS_BY_LAYER = {
+    "gate-label": "gate",
+}
 
 _BACKGROUND_PRESETS = {
     "Outdoor": {
@@ -396,6 +399,26 @@ def _literal_step_icon_image(expr: object, *, minzoom: object = None, maxzoom: o
         return representative
     if _step_has_only_non_empty_literal_outputs(expr):
         return representative
+    return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+
+
+def _icon_image_empty_match_fallback(layer_id: object, expr: object) -> object:
+    """Replace known empty icon-image match fallbacks with existing sprites.
+
+    Mapbox uses an empty fallback on the Outdoors gate-label layer, but QGIS'
+    converter still tries to retrieve a sprite named ``""``. Limit this to
+    audited layers whose other match outputs are literal sprite names.
+    """
+    fallback = _ICON_IMAGE_EMPTY_MATCH_FALLBACKS_BY_LAYER.get(str(layer_id or ""))
+    if fallback is None or not isinstance(expr, list) or len(expr) < 5 or expr[0] != "match":
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+    if expr[-1] != "":
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+    outputs = [expr[index] for index in range(3, len(expr) - 1, 2)]
+    if outputs and all(isinstance(output, str) and output for output in outputs):
+        updated = copy.deepcopy(expr)
+        updated[-1] = fallback
+        return updated
     return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
 
 
@@ -1332,6 +1355,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                             props[prop] = icon_image
                         else:
                             del props[prop]
+                        continue
+                    icon_image = _icon_image_empty_match_fallback(layer_id, val)
+                    if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
+                        props[prop] = icon_image
                         continue
                 if not isinstance(val, list):
                     continue

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -662,6 +662,27 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][9]["layout"]["icon-image"], data_driven_high_zoom_step)
         self.assertEqual(result["layers"][10]["layout"]["icon-image"], empty_then_data_driven_high_zoom_step)
 
+    def test_gate_label_icon_match_uses_existing_sprite_fallback(self):
+        gate_icon = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]
+        generic_empty_fallback = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]
+        mixed_output_fallback = ["match", ["get", "type"], "gate", ["get", "maki"], "lift_gate", "lift-gate", ""]
+        style = {
+            "layers": [
+                {"id": "gate-label", "layout": {"icon-image": gate_icon}},
+                {"id": "other-label", "layout": {"icon-image": generic_empty_fallback}},
+                {"id": "gate-label", "layout": {"icon-image": mixed_output_fallback}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["layout"]["icon-image"],
+            ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", "gate"],
+        )
+        self.assertEqual(result["layers"][1]["layout"]["icon-image"], generic_empty_fallback)
+        self.assertEqual(result["layers"][2]["layout"]["icon-image"], mixed_output_fallback)
+
     def test_zoom_only_icon_size_expressions_resolve_to_scalars(self):
         zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 10, 0.5, 14, 1.5]
         single_stop_zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 14, 1.25]


### PR DESCRIPTION
## Summary
- replace the audited `gate-label` empty `icon-image` match fallback with the existing `gate` sprite
- keep the rewrite allowlisted to the `gate-label` layer and literal sprite-output matches
- add regression coverage for the gate fallback plus non-allowlisted/data-driven preservation

## Evidence
- Baseline after #1031: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T065822Z/audit.json` had 48 warnings in the runtime sprite-context probe, including the remaining `gate-label: Could not retrieve sprite ''` warning.
- New live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T070734Z/audit.json` improves the runtime sprite-context probe to 47 warnings and removes all `gate-label` sprite warnings with runtime sprite resources.
- New all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T070754Z/summary.md`; all 5 cameras passed, with metrics effectively unchanged from the prior baseline.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.
