### PR TITLE
Snapshot settlement label zoom filters

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -278,6 +278,8 @@ _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS = {
     "path-pedestrian-label",
     "road-label",
     "road-number-shield",
+    "settlement-major-label",
+    "settlement-minor-label",
     "transit-label",
 }
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -851,6 +851,45 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertEqual(style["layers"][0]["filter"], filter_expression)
 
+    def test_filter_simplification_snapshots_settlement_label_filters(self):
+        major_filter = [
+            "all",
+            ["<=", ["get", "filterrank"], 3],
+            ["step", ["zoom"], False, 12, ["<", ["get", "symbolrank"], 15]],
+        ]
+        minor_filter = [
+            "all",
+            ["<=", ["get", "filterrank"], 3],
+            ["step", ["zoom"], [">", ["get", "symbolrank"], 6], 12, [">=", ["get", "symbolrank"], 15]],
+        ]
+        style = {
+            "layers": [
+                {"id": "settlement-major-label", "type": "symbol", "filter": major_filter},
+                {"id": "settlement-minor-label", "type": "symbol", "filter": minor_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["filter"],
+            [
+                "all",
+                ["all", ["<=", ["get", "filterrank"], 3], ["<", ["get", "symbolrank"], 15]],
+                ["match", ["get", "type"], ["city"], True, False],
+            ],
+        )
+        self.assertEqual(
+            result["layers"][1]["filter"],
+            [
+                "all",
+                ["all", ["<=", ["get", "filterrank"], 3], [">=", ["get", "symbolrank"], 15]],
+                ["match", ["get", "type"], ["town"], True, False],
+            ],
+        )
+        self.assertEqual(style["layers"][0]["filter"], major_filter)
+        self.assertEqual(style["layers"][1]["filter"], minor_filter)
+
     def test_filter_simplification_normalizes_nested_zoom_arithmetic(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary
- include `settlement-major-label` and `settlement-minor-label` in the small allowlist of symbol filters snapshotted at a representative zoom for QGIS
- keep existing settlement type filters intact while making the zoom-dependent rank filters parser-friendly
- add regression coverage for the settlement label filter snapshots and immutability

## Evidence
- Baseline after #1032: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T070734Z/audit.json` had 64 qfit-preprocessed warnings and 47 runtime sprite-context warnings, including 6 settlement/places `Skipping unsupported expression` warnings.
- The filter parse support probe showed the zoom-normalized settlement filters are supported by QGIS' parser.
- New live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T072105Z/audit.json` improves qfit-preprocessed warnings to 58 and runtime sprite-context warnings to 41; settlement/places unsupported-expression warnings are gone.
- New all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T072128Z/summary.md`; all 5 cameras passed, with improved deltas on the low/mid-zoom settlement cameras.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.
