### PR TITLE
Snapshot terrain zoom filters

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -282,6 +282,10 @@ _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS = {
     "settlement-minor-label",
     "transit-label",
 }
+_ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS = {
+    "hillshade",
+    "landuse",
+}
 
 
 def _is_literal_color(value: object) -> bool:
@@ -1060,10 +1064,14 @@ def _should_zoom_normalize_filter_for_qgis(layer: dict[str, object]) -> bool:
     # QGIS' Mapbox converter rejects zoom-dependent filters. Restrict static
     # zoom snapshots to the high-signal label layers from #949 visual audits:
     # repeated road labels, pedestrian path label noise, ferry/transit label
-    # leakage, and road shields. Applying the same approximation broadly can hide
-    # high-zoom road/path geometry or over-suppress POIs/places, so keep this
-    # deliberately small.
-    return layer.get("type") == "symbol" and layer.get("id") in _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS
+    # leakage, road shields, and terrain/landcover layers whose normalized
+    # filters are QGIS-parser-friendly. Applying the same approximation broadly
+    # can hide high-zoom road/path geometry or over-suppress POIs/places, so keep
+    # this deliberately small.
+    layer_id = layer.get("id")
+    return (
+        layer.get("type") == "symbol" and layer_id in _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS
+    ) or (layer.get("type") == "fill" and layer_id in _ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS)
 
 
 def _line_layout_choice(expr: object, choices: set[str]) -> str | None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -890,6 +890,61 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(style["layers"][0]["filter"], major_filter)
         self.assertEqual(style["layers"][1]["filter"], minor_filter)
 
+    def test_filter_simplification_snapshots_terrain_fill_filters(self):
+        landuse_filter = [
+            "all",
+            [">=", ["to-number", ["get", "sizerank"]], 0],
+            [
+                "match",
+                ["get", "class"],
+                "residential",
+                ["step", ["zoom"], True, 10, False],
+                "park",
+                ["step", ["zoom"], False, 8, ["==", ["get", "sizerank"], 1], 10, True],
+                False,
+            ],
+            [
+                "<=",
+                [
+                    "-",
+                    ["to-number", ["get", "sizerank"]],
+                    ["interpolate", ["exponential", 1.5], ["zoom"], 12, 0, 18, 14],
+                ],
+                14,
+            ],
+        ]
+        hillshade_filter = [
+            "all",
+            ["step", ["zoom"], ["==", ["get", "class"], "shadow"], 11, True],
+            ["match", ["get", "level"], 89, True, 78, ["step", ["zoom"], False, 5, True], False],
+        ]
+        style = {
+            "layers": [
+                {"id": "landuse", "type": "fill", "filter": landuse_filter},
+                {"id": "hillshade", "type": "fill", "filter": hillshade_filter},
+                {"id": "water", "type": "fill", "filter": hillshade_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["filter"],
+            [
+                "all",
+                [">=", ["to-number", ["get", "sizerank"]], 0],
+                ["match", ["get", "class"], "residential", False, "park", True, False],
+                ["<=", ["to-number", ["get", "sizerank"]], 14],
+            ],
+        )
+        self.assertEqual(
+            result["layers"][1]["filter"],
+            ["all", True, ["match", ["get", "level"], 89, True, 78, True, False]],
+        )
+        self.assertEqual(result["layers"][2]["filter"], hillshade_filter)
+        self.assertEqual(style["layers"][0]["filter"], landuse_filter)
+        self.assertEqual(style["layers"][1]["filter"], hillshade_filter)
+
     def test_filter_simplification_normalizes_nested_zoom_arithmetic(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary
- add a small fill-layer allowlist so `landuse` and `hillshade` zoom-dependent filters are snapshotted before QGIS conversion
- keep the existing road/path and POI filters out of the broad normalization path
- add regression coverage for landuse/hillshade filter snapshots and non-allowlisted fill-layer preservation

## Evidence
- Baseline after #1033: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T072105Z/audit.json` had 58 qfit-preprocessed warnings and 41 runtime sprite-context warnings, including 12 terrain/landcover `Skipping unsupported expression` warnings from `landuse` and `hillshade` filters.
- The audit filter parse support probe showed the zoom-normalized `landuse`/`hillshade` filters are QGIS-parser-friendly, while the change avoids the known-risk broad road/path/POI normalization.
- New live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T074047Z/audit.json` improves qfit-preprocessed warnings to 46 and runtime sprite-context warnings to 29; terrain/landcover unsupported-expression warnings are gone.
- New all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T074111Z/summary.md`; all 5 cameras passed. Metrics are mostly unchanged or improved, with a small z5 mean/RMS increase and a notable z18 improvement.
- Manual visual check of the z5 and z18 triplets found no obvious terrain regression; z18 terrain/hillshade looked plausibly closer to the Mapbox reference.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.
