### PR TITLE
Snapshot Mapbox oneway arrow filters

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -275,11 +275,14 @@ _FULL_OPACITY = 1.0
 _FULL_OPACITY_EPSILON = 1e-9
 _FULL_OPACITY_PROPS = {"fill-opacity", "line-opacity"}
 _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS = {
+    "bridge-oneway-arrow-blue",
     "path-pedestrian-label",
     "road-label",
     "road-number-shield",
+    "road-oneway-arrow-blue",
     "settlement-major-label",
     "settlement-minor-label",
+    "tunnel-oneway-arrow-blue",
     "transit-label",
 }
 _ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS = {
@@ -1064,10 +1067,10 @@ def _should_zoom_normalize_filter_for_qgis(layer: dict[str, object]) -> bool:
     # QGIS' Mapbox converter rejects zoom-dependent filters. Restrict static
     # zoom snapshots to the high-signal label layers from #949 visual audits:
     # repeated road labels, pedestrian path label noise, ferry/transit label
-    # leakage, road shields, and terrain/landcover layers whose normalized
-    # filters are QGIS-parser-friendly. Applying the same approximation broadly
-    # can hide high-zoom road/path geometry or over-suppress POIs/places, so keep
-    # this deliberately small.
+    # leakage, road shields/one-way arrows, and terrain/landcover layers whose
+    # normalized filters are QGIS-parser-friendly. Applying the same
+    # approximation broadly can hide high-zoom road/path geometry or
+    # over-suppress POIs/places, so keep this deliberately small.
     layer_id = layer.get("id")
     return (
         layer.get("type") == "symbol" and layer_id in _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from unittest.mock import patch
 
@@ -971,6 +972,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ],
             ["match", ["get", "structure"], ["none", "ford"], True, False],
         ]
+        original_arrow_filter = copy.deepcopy(arrow_filter)
         style = {
             "layers": [
                 {"id": "road-oneway-arrow-blue", "type": "symbol", "minzoom": 16, "filter": arrow_filter},
@@ -991,7 +993,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     ["match", ["get", "structure"], ["none", "ford"], True, False],
                 ],
             )
-        self.assertEqual(style["layers"][0]["filter"], arrow_filter)
+        self.assertEqual(arrow_filter, original_arrow_filter)
+        for layer in style["layers"]:
+            self.assertEqual(layer["filter"], original_arrow_filter)
 
     def test_filter_simplification_normalizes_nested_zoom_arithmetic(self):
         style = {

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -945,6 +945,54 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(style["layers"][0]["filter"], landuse_filter)
         self.assertEqual(style["layers"][1]["filter"], hillshade_filter)
 
+    def test_filter_simplification_snapshots_oneway_arrow_filters_at_minzoom(self):
+        low_zoom_classes = ["primary", "secondary", "tertiary", "street", "street_limited"]
+        high_zoom_classes = [
+            "primary",
+            "secondary",
+            "tertiary",
+            "street",
+            "street_limited",
+            "primary_link",
+            "secondary_link",
+            "tertiary_link",
+            "service",
+            "track",
+        ]
+        arrow_filter = [
+            "all",
+            ["==", ["get", "oneway"], "true"],
+            [
+                "step",
+                ["zoom"],
+                ["match", ["get", "class"], low_zoom_classes, True, False],
+                16,
+                ["match", ["get", "class"], high_zoom_classes, True, False],
+            ],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+        ]
+        style = {
+            "layers": [
+                {"id": "road-oneway-arrow-blue", "type": "symbol", "minzoom": 16, "filter": arrow_filter},
+                {"id": "bridge-oneway-arrow-blue", "type": "symbol", "minzoom": 16, "filter": arrow_filter},
+                {"id": "tunnel-oneway-arrow-blue", "type": "symbol", "minzoom": 16, "filter": arrow_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        for layer in result["layers"]:
+            self.assertEqual(
+                layer["filter"],
+                [
+                    "all",
+                    ["==", ["get", "oneway"], "true"],
+                    ["match", ["get", "class"], high_zoom_classes, True, False],
+                    ["match", ["get", "structure"], ["none", "ford"], True, False],
+                ],
+            )
+        self.assertEqual(style["layers"][0]["filter"], arrow_filter)
+
     def test_filter_simplification_normalizes_nested_zoom_arithmetic(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary
- add the three one-way arrow symbol layers to the narrow zoom-filter snapshot allowlist
- rely on each layer's `minzoom: 16`, so the high-zoom Mapbox branch is preserved instead of the generic z12 branch
- add regression coverage for road/bridge/tunnel one-way arrow filters and input immutability

## Evidence
- Baseline after #1034: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T074047Z/audit.json` had 46 qfit-preprocessed warnings and 29 runtime sprite-context warnings, including 6 `oneway-arrow-blue` filter `Skipping unsupported expression` warnings.
- The change avoids known-risk road/path line geometry filters; it only snapshots symbol arrow filters and uses the layers' minzoom to select the high-zoom class set.
- New live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T075433Z/audit.json` improves qfit-preprocessed warnings to 40 and runtime sprite-context warnings to 23; one-way arrow filter warnings are gone.
- New all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T075455Z/summary.md`; all 5 cameras passed. Four QGIS renders were byte-identical to the #1034 baseline; z18 changed slightly and improved mean/RMS (`0.0347/0.0913` → `0.0345/0.0907`).

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.
