### PR TITLE
Snapshot motorway trunk filters

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -289,6 +289,10 @@ _ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS = {
     "hillshade",
     "landuse",
 }
+_ZOOM_NORMALIZED_LINE_FILTER_LAYER_IDS = {
+    "road-motorway-trunk",
+    "road-motorway-trunk-case",
+}
 
 
 def _is_literal_color(value: object) -> bool:
@@ -1067,14 +1071,17 @@ def _should_zoom_normalize_filter_for_qgis(layer: dict[str, object]) -> bool:
     # QGIS' Mapbox converter rejects zoom-dependent filters. Restrict static
     # zoom snapshots to the high-signal label layers from #949 visual audits:
     # repeated road labels, pedestrian path label noise, ferry/transit label
-    # leakage, road shields/one-way arrows, and terrain/landcover layers whose
-    # normalized filters are QGIS-parser-friendly. Applying the same
-    # approximation broadly can hide high-zoom road/path geometry or
-    # over-suppress POIs/places, so keep this deliberately small.
+    # leakage, road shields/one-way arrows, terrain/landcover layers, and the
+    # motorway/trunk line filters whose normalized branch is stable at the
+    # representative zoom. Applying the same approximation broadly can hide
+    # high-zoom road/path geometry or over-suppress POIs/places, so keep this
+    # deliberately small.
     layer_id = layer.get("id")
     return (
         layer.get("type") == "symbol" and layer_id in _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS
-    ) or (layer.get("type") == "fill" and layer_id in _ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS)
+    ) or (layer.get("type") == "fill" and layer_id in _ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS) or (
+        layer.get("type") == "line" and layer_id in _ZOOM_NORMALIZED_LINE_FILTER_LAYER_IDS
+    )
 
 
 def _line_layout_choice(expr: object, choices: set[str]) -> str | None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -997,6 +997,49 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         for layer in style["layers"]:
             self.assertEqual(layer["filter"], original_arrow_filter)
 
+    def test_filter_simplification_snapshots_motorway_trunk_line_filters(self):
+        motorway_filter = [
+            "all",
+            [
+                "step",
+                ["zoom"],
+                ["match", ["get", "class"], ["motorway", "trunk"], True, False],
+                5,
+                [
+                    "all",
+                    ["match", ["get", "class"], ["motorway", "trunk"], True, False],
+                    ["match", ["get", "structure"], ["none", "ford"], True, False],
+                ],
+            ],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        original_motorway_filter = copy.deepcopy(motorway_filter)
+        style = {
+            "layers": [
+                {"id": "road-motorway-trunk", "type": "line", "filter": motorway_filter},
+                {"id": "road-motorway-trunk-case", "type": "line", "filter": motorway_filter},
+                {"id": "road-primary", "type": "line", "filter": motorway_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        expected_filter = [
+            "all",
+            [
+                "all",
+                ["match", ["get", "class"], ["motorway", "trunk"], True, False],
+                ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        self.assertEqual(result["layers"][0]["filter"], expected_filter)
+        self.assertEqual(result["layers"][1]["filter"], expected_filter)
+        self.assertEqual(result["layers"][2]["filter"], original_motorway_filter)
+        self.assertEqual(motorway_filter, original_motorway_filter)
+        for layer in style["layers"]:
+            self.assertEqual(layer["filter"], original_motorway_filter)
+
     def test_filter_simplification_normalizes_nested_zoom_arithmetic(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary
- add a tiny line-layer allowlist for `road-motorway-trunk` and `road-motorway-trunk-case` zoom filter snapshots
- keep higher-risk path/minor-road geometry filters unchanged
- add regression coverage for motorway/trunk line filters, non-allowlisted line preservation, and input immutability

## Evidence
- Baseline after #1035: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T075433Z/audit.json` had 40 qfit-preprocessed warnings and 23 runtime sprite-context warnings, including 4 `road-motorway-trunk*` filter `Skipping unsupported expression` warnings.
- New live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T082719Z/audit.json` improves qfit-preprocessed warnings to 36 and runtime sprite-context warnings to 19; `road-motorway-trunk*` filter warnings are gone.
- New all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T082741Z/summary.md`; all 5 cameras passed, with mean/RMS improving on all cameras.
- Manual visual check of Valais/Geneva z8 and Lausanne/Lavaux z10 triplets found the candidate clearly closer to the Mapbox reference: the baseline over-rendered orange motorway/trunk roads, while the candidate restores road hierarchy without an obvious regression.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.
