### PR TITLE
Snapshot minor road filters

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -307,6 +307,9 @@ _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "tunnel-minor": 14.0,
     "tunnel-minor-case": 14.0,
 }
+assert set(_FILTER_NORMALIZATION_ZOOM_OVERRIDES).issubset(_ZOOM_NORMALIZED_LINE_FILTER_LAYER_IDS), (
+    "Filter zoom overrides must also be present in the line filter normalization allowlist."
+)
 
 
 def _is_literal_color(value: object) -> bool:

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -375,8 +375,7 @@ def _numeric_zoom_bound(value: object) -> float | None:
     return float(value)
 
 
-def _representative_zoom_in_layer_range(minzoom: object, maxzoom: object) -> float | None:
-    target_zoom = _REPRESENTATIVE_STYLE_ZOOM
+def _zoom_in_layer_range(target_zoom: float, minzoom: object, maxzoom: object) -> float | None:
     minimum_zoom = _numeric_zoom_bound(minzoom)
     maximum_zoom = _numeric_zoom_bound(maxzoom)
     if minimum_zoom is not None and maximum_zoom is not None and minimum_zoom >= maximum_zoom:
@@ -388,6 +387,10 @@ def _representative_zoom_in_layer_range(minzoom: object, maxzoom: object) -> flo
     if minimum_zoom is not None and target_zoom < minimum_zoom:
         return None
     return target_zoom
+
+
+def _representative_zoom_in_layer_range(minzoom: object, maxzoom: object) -> float | None:
+    return _zoom_in_layer_range(_REPRESENTATIVE_STYLE_ZOOM, minzoom, maxzoom)
 
 
 def _has_valid_zoom_step_thresholds(expr: list[object]) -> bool:
@@ -1081,7 +1084,12 @@ def _zoom_normalized_filter_expression_for_qgis(layer: dict[str, object], value:
     # Some Mapbox Outdoors road layers begin just below their high-detail filter
     # branch. Snapshot those layers at the branch threshold instead of the layer
     # minzoom so QGIS keeps service-road detail in high-zoom renders.
-    target_zoom = _FILTER_NORMALIZATION_ZOOM_OVERRIDES.get(str(layer.get("id") or ""))
+    override_zoom = _FILTER_NORMALIZATION_ZOOM_OVERRIDES.get(str(layer.get("id") or ""))
+    target_zoom = (
+        _zoom_in_layer_range(override_zoom, layer.get("minzoom"), layer.get("maxzoom"))
+        if override_zoom is not None
+        else None
+    )
     if target_zoom is None:
         target_zoom = _representative_zoom_in_layer_range(layer.get("minzoom"), layer.get("maxzoom"))
     if target_zoom is None:

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -290,8 +290,22 @@ _ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS = {
     "landuse",
 }
 _ZOOM_NORMALIZED_LINE_FILTER_LAYER_IDS = {
+    "bridge-minor",
+    "bridge-minor-case",
     "road-motorway-trunk",
     "road-motorway-trunk-case",
+    "road-minor",
+    "road-minor-case",
+    "tunnel-minor",
+    "tunnel-minor-case",
+}
+_FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
+    "bridge-minor": 14.0,
+    "bridge-minor-case": 14.0,
+    "road-minor": 14.0,
+    "road-minor-case": 14.0,
+    "tunnel-minor": 14.0,
+    "tunnel-minor-case": 14.0,
 }
 
 
@@ -1061,7 +1075,12 @@ def _filter_expression_value_at_zoom(value: object, zoom: float) -> object:
 
 
 def _zoom_normalized_filter_expression_for_qgis(layer: dict[str, object], value: object) -> object:
-    target_zoom = _representative_zoom_in_layer_range(layer.get("minzoom"), layer.get("maxzoom"))
+    # Some Mapbox Outdoors road layers begin just below their high-detail filter
+    # branch. Snapshot those layers at the branch threshold instead of the layer
+    # minzoom so QGIS keeps service-road detail in high-zoom renders.
+    target_zoom = _FILTER_NORMALIZATION_ZOOM_OVERRIDES.get(str(layer.get("id") or ""))
+    if target_zoom is None:
+        target_zoom = _representative_zoom_in_layer_range(layer.get("minzoom"), layer.get("maxzoom"))
     if target_zoom is None:
         target_zoom = _REPRESENTATIVE_STYLE_ZOOM
     return _filter_expression_value_at_zoom(value, target_zoom)
@@ -1072,15 +1091,15 @@ def _should_zoom_normalize_filter_for_qgis(layer: dict[str, object]) -> bool:
     # zoom snapshots to the high-signal label layers from #949 visual audits:
     # repeated road labels, pedestrian path label noise, ferry/transit label
     # leakage, road shields/one-way arrows, terrain/landcover layers, and the
-    # motorway/trunk line filters whose normalized branch is stable at the
-    # representative zoom. Applying the same approximation broadly can hide
-    # high-zoom road/path geometry or over-suppress POIs/places, so keep this
-    # deliberately small.
+    # road line filters whose normalized branches improved #949 visual audits.
+    # Applying the same approximation broadly can hide high-zoom path geometry
+    # or over-suppress POIs/places, so keep this deliberately small.
     layer_id = layer.get("id")
+    layer_type = layer.get("type")
     return (
-        layer.get("type") == "symbol" and layer_id in _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS
-    ) or (layer.get("type") == "fill" and layer_id in _ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS) or (
-        layer.get("type") == "line" and layer_id in _ZOOM_NORMALIZED_LINE_FILTER_LAYER_IDS
+        (layer_type == "symbol" and layer_id in _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS)
+        or (layer_type == "fill" and layer_id in _ZOOM_NORMALIZED_FILL_FILTER_LAYER_IDS)
+        or (layer_type == "line" and layer_id in _ZOOM_NORMALIZED_LINE_FILTER_LAYER_IDS)
     )
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1040,6 +1040,49 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         for layer in style["layers"]:
             self.assertEqual(layer["filter"], original_motorway_filter)
 
+    def test_filter_simplification_snapshots_minor_line_filters_at_service_zoom(self):
+        minor_filter = [
+            "all",
+            [
+                "match",
+                ["get", "class"],
+                ["track"],
+                True,
+                "service",
+                ["step", ["zoom"], False, 14, True],
+                False,
+            ],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        original_minor_filter = copy.deepcopy(minor_filter)
+        style = {
+            "layers": [
+                {"id": "road-minor", "type": "line", "minzoom": 13, "filter": minor_filter},
+                {"id": "road-minor-case", "type": "line", "minzoom": 13, "filter": minor_filter},
+                {"id": "bridge-minor", "type": "line", "minzoom": 13, "filter": minor_filter},
+                {"id": "bridge-minor-case", "type": "line", "minzoom": 13, "filter": minor_filter},
+                {"id": "tunnel-minor", "type": "line", "minzoom": 13, "filter": minor_filter},
+                {"id": "tunnel-minor-case", "type": "line", "minzoom": 13, "filter": minor_filter},
+                {"id": "road-path", "type": "line", "minzoom": 13, "filter": minor_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        expected_filter = [
+            "all",
+            ["match", ["get", "class"], ["track"], True, "service", True, False],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        for layer in result["layers"][:-1]:
+            self.assertEqual(layer["filter"], expected_filter)
+        self.assertEqual(result["layers"][-1]["filter"], original_minor_filter)
+        self.assertEqual(minor_filter, original_minor_filter)
+        for layer in style["layers"]:
+            self.assertEqual(layer["filter"], original_minor_filter)
+
     def test_filter_simplification_normalizes_nested_zoom_arithmetic(self):
         style = {
             "layers": [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1083,6 +1083,29 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         for layer in style["layers"]:
             self.assertEqual(layer["filter"], original_minor_filter)
 
+    def test_filter_simplification_clamps_minor_line_zoom_override_to_layer_bounds(self):
+        minor_filter = [
+            "match",
+            ["get", "class"],
+            ["track"],
+            True,
+            "service",
+            ["step", ["zoom"], False, 14, True],
+            False,
+        ]
+        style = {
+            "layers": [
+                {"id": "road-minor", "type": "line", "minzoom": 13, "maxzoom": 14, "filter": minor_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["filter"],
+            ["match", ["get", "class"], ["track"], True, "service", False, False],
+        )
+
     def test_filter_simplification_normalizes_nested_zoom_arithmetic(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary
- add a small line-layer allowlist for `road-minor`, `bridge-minor`, and `tunnel-minor` filter snapshots
- snapshot those minor-road filters at zoom 14 so the QGIS import keeps the Mapbox high-detail `service` branch instead of freezing the lower-detail branch
- keep `road-path`/`bridge-path` filters unchanged because prior audits showed path geometry normalization can be risky
- add regression coverage for the minor-road filter snapshots, service-branch zoom override, non-allowlisted path preservation, and input immutability

## Evidence
- Baseline after #1036: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T082719Z/audit.json` had 36 qfit-preprocessed warnings and 19 runtime sprite-context warnings, including 6 `*-minor*` road/trail filter `Skipping unsupported expression` warnings.
- New live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T085539Z/audit.json` improves qfit-preprocessed warnings to 30 and runtime sprite-context warnings to 13; the `road-minor`/`bridge-minor`/`tunnel-minor` filter warnings are gone.
- New all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T085557Z/summary.md`; all 5 cameras passed. The three lower-zoom QGIS renders were byte-identical to the #1036 baseline; high-zoom Chamonix/Zermatt changed only in road/trail detail.
- Manual visual check of Chamonix z14 and Zermatt z18 triplets found the candidate closer/neutral: Chamonix restores more hillside minor-track visibility, while Zermatt is essentially unchanged and keeps service-road detail.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.
