### PR TITLE
Fix Mapbox airport label icon fallback

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -63,6 +63,12 @@ _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE = object()
 _ICON_IMAGE_EMPTY_MATCH_FALLBACKS_BY_LAYER = {
     "gate-label": "gate",
 }
+_ICON_IMAGE_GET_MATCH_FALLBACKS_BY_LAYER_FIELD = {
+    ("airport-label", "maki"): {
+        "fallback": "airport",
+        "values": ("airport", "airfield", "heliport", "rocket"),
+    },
+}
 
 _BACKGROUND_PRESETS = {
     "Outdoor": {
@@ -453,6 +459,18 @@ def _icon_image_empty_match_fallback(layer_id: object, expr: object) -> object:
         updated[-1] = fallback
         return updated
     return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+
+
+def _icon_image_get_fallback(layer_id: object, expr: object) -> object:
+    """Replace audited icon-image get expressions with literal sprite match fallbacks."""
+    if not isinstance(expr, list) or len(expr) != 2 or expr[0] != "get" or not isinstance(expr[1], str):
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+    match_fallback = _ICON_IMAGE_GET_MATCH_FALLBACKS_BY_LAYER_FIELD.get((str(layer_id or ""), expr[1]))
+    if match_fallback is None:
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+    values = match_fallback["values"]
+    fallback = match_fallback["fallback"]
+    return ["match", copy.deepcopy(expr), *(item for value in values for item in (value, value)), fallback]
 
 
 def _extract_fallback_color(expr: object) -> str | None:
@@ -1407,6 +1425,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                             del props[prop]
                         continue
                     icon_image = _icon_image_empty_match_fallback(layer_id, val)
+                    if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
+                        props[prop] = icon_image
+                        continue
+                    icon_image = _icon_image_get_fallback(layer_id, val)
                     if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
                         props[prop] = icon_image
                         continue

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -684,6 +684,38 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][1]["layout"]["icon-image"], generic_empty_fallback)
         self.assertEqual(result["layers"][2]["layout"]["icon-image"], mixed_output_fallback)
 
+    def test_airport_label_icon_get_uses_existing_sprite_match_fallback(self):
+        maki_icon = ["get", "maki"]
+        other_field_icon = ["get", "network"]
+        style = {
+            "layers": [
+                {"id": "airport-label", "layout": {"icon-image": maki_icon}},
+                {"id": "natural-point-label", "layout": {"icon-image": maki_icon}},
+                {"id": "airport-label", "layout": {"icon-image": other_field_icon}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["layout"]["icon-image"],
+            [
+                "match",
+                ["get", "maki"],
+                "airport",
+                "airport",
+                "airfield",
+                "airfield",
+                "heliport",
+                "heliport",
+                "rocket",
+                "rocket",
+                "airport",
+            ],
+        )
+        self.assertEqual(result["layers"][1]["layout"]["icon-image"], maki_icon)
+        self.assertEqual(result["layers"][2]["layout"]["icon-image"], other_field_icon)
+
     def test_zoom_only_icon_size_expressions_resolve_to_scalars(self):
         zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 10, 0.5, 14, 1.5]
         single_stop_zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 14, 1.25]


### PR DESCRIPTION
## Summary
- allowlist the Mapbox Outdoors `airport-label` `icon-image: ["get", "maki"]` expression to a literal sprite `match` that preserves known airport `maki` values (`airport`, `airfield`, `heliport`, `rocket`)
- keep other `icon-image` `get` expressions unchanged unless explicitly audited
- add regression coverage for the airport match fallback and neighboring non-allowlisted cases

Refs #949

## Evidence
- `python3 -m pytest tests/test_mapbox_config.py -q` → 86 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 1994 passed, 163 skipped, 135 subtests passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T100622Z/audit.json`
  - runtime sprite-context probe improves latest merged baseline 13 → 12 warnings
  - `airport-label: Could not interpret sprite value list with method get` is gone with sprite context
  - no-sprite converter audit reports the literal sprite names as unavailable without sprite resources, so qfit-preprocessed warning count is 34 there; runtime style application provides sprite resources and remains the relevant check for this icon fallback
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T100644Z/summary.md`
  - all 5 recommended cameras passed
  - QGIS render is unchanged vs the latest merged baseline for the default camera matrix
- Focused airport probes:
  - Zurich baseline `debug/mapbox-outdoors-comparison/airport-icon-probe/zurich-airport-z14-outdoors/20260514T095015Z/qgis-vector-render.png` vs candidate `debug/mapbox-outdoors-comparison/airport-icon-probe/zurich-airport-z14-outdoors/20260514T100820Z/qgis-vector-render.png`: changed ratio 0.000191, localized to the airport icon
  - Geneva baseline `debug/mapbox-outdoors-comparison/airport-icon-probe/geneva-airport-z14-outdoors/20260514T095223Z/qgis-vector-render.png` vs candidate `debug/mapbox-outdoors-comparison/airport-icon-probe/geneva-airport-z14-outdoors/20260514T100824Z/qgis-vector-render.png`: changed ratio 0.000192, localized to the airport icon
  - Manual visual review: candidate is modestly closer on both Zurich and Geneva because the airport symbol appears beside the airport label; broader label parity remains unchanged

## Review notes
- Addressed Codex feedback by preserving the non-`airport` airport-label `maki` variants instead of collapsing every feature to the `airport` sprite.

Mapbox token was only read locally for validation and is not included in artifacts, commits, or PR text.
