### PR TITLE
Fix Mapbox transit icon fallback

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -68,6 +68,11 @@ _ICON_IMAGE_GET_MATCH_FALLBACKS_BY_LAYER_FIELD = {
         "fallback": "airport",
         "values": ("airport", "airfield", "heliport", "rocket"),
     },
+    ("transit-label", "network"): {
+        "fallback": "rail",
+        "input": ["get", "maki"],
+        "values": ("bicycle-share", "bus", "entrance", "ferry", "rail", "rail-light", "rail-metro"),
+    },
 }
 
 _BACKGROUND_PRESETS = {
@@ -470,7 +475,8 @@ def _icon_image_get_fallback(layer_id: object, expr: object) -> object:
         return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
     values = match_fallback["values"]
     fallback = match_fallback["fallback"]
-    return ["match", copy.deepcopy(expr), *(item for value in values for item in (value, value)), fallback]
+    input_expr = match_fallback.get("input", expr)
+    return ["match", copy.deepcopy(input_expr), *(item for value in values for item in (value, value)), fallback]
 
 
 def _extract_fallback_color(expr: object) -> str | None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -716,6 +716,41 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][1]["layout"]["icon-image"], maki_icon)
         self.assertEqual(result["layers"][2]["layout"]["icon-image"], other_field_icon)
 
+    def test_transit_label_network_icon_get_uses_maki_sprite_match_fallback(self):
+        network_icon = ["get", "network"]
+        style = {
+            "layers": [
+                {"id": "transit-label", "layout": {"icon-image": network_icon}},
+                {"id": "road-label", "layout": {"icon-image": network_icon}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["layout"]["icon-image"],
+            [
+                "match",
+                ["get", "maki"],
+                "bicycle-share",
+                "bicycle-share",
+                "bus",
+                "bus",
+                "entrance",
+                "entrance",
+                "ferry",
+                "ferry",
+                "rail",
+                "rail",
+                "rail-light",
+                "rail-light",
+                "rail-metro",
+                "rail-metro",
+                "rail",
+            ],
+        )
+        self.assertEqual(result["layers"][1]["layout"]["icon-image"], network_icon)
+
     def test_zoom_only_icon_size_expressions_resolve_to_scalars(self):
         zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 10, 0.5, 14, 1.5]
         single_stop_zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 14, 1.25]


### PR DESCRIPTION
## Summary
- add an audited Mapbox Outdoors fallback for `transit-label` `icon-image: ["get", "network"]`
- render generic transit sprites through a QGIS-friendly `match` on `maki` so bicycle-share/bus/entrance/ferry/rail/rail-light/rail-metro icons survive without collapsing network-specific values to one literal
- add regression coverage for the transit fallback and non-allowlisted neighboring cases

Refs #949

## Evidence
- `python3 -m pytest tests/test_mapbox_config.py -q` → 87 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 1995 passed, 163 skipped, 135 subtests passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T104929Z/audit.json`
  - runtime sprite-context probe improves 12 → 11 warnings
  - `transit-label: Could not interpret sprite value list with method get` is gone with sprite context
  - no-sprite converter audit reports the literal sprite names as unavailable without sprite resources, so qfit-preprocessed warning count is 41 there; runtime style application provides sprite resources and remains the relevant check for this icon fallback
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T104948Z/summary.md`
  - all 5 recommended cameras passed
  - QGIS render is unchanged vs the latest merged baseline for 3/5 default cameras
  - Chamonix z14 changed ratio 0.000567, localized to transit symbols/labels
  - Zermatt z18 changed ratio 0.008802 after preserving `entrance`/`bicycle-share`; manual diff review found no significant new clutter/collision and only modest label/icon tweaks
- Manual visual review:
  - Chamonix z14 candidate is modestly closer because transit icons appear around Les Pélerins and central Chamonix, matching Mapbox GL's icon+label treatment better than the text-only baseline; remaining style/placement differences are still present.
  - Zermatt z18 is mixed/mostly unchanged for transit parity, with no major clutter regression.

## Review notes
- Addressed Codex feedback by including the remaining generic transit-stop `maki` values (`bicycle-share` and `entrance`) instead of letting them fall through to the `rail` default.

Mapbox token was only read locally for validation and is not included in artifacts, commits, or PR text.
