### PR TITLE
Add Mapbox motorway comparison camera

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -35,6 +35,7 @@ Recommended z5-z18 inspection matrix:
 | `switzerland-alps-z5-outdoors` | z5 | Country-wide Switzerland/Alps context: landcover, terrain/water balance, major roads, label density. |
 | `valais-geneva-outdoors` | z7-z8 | Regional qfit map context: terrain/outdoor features, main road hierarchy, settlement visibility. |
 | `lausanne-lavaux-z10-outdoors` | z9-z11 | Primary qfit activity-area target: road/trail hierarchy, labels, feature density, color/width balance. |
+| `geneva-airport-motorway-z14-outdoors` | z14 | Motorway/urban detail around Geneva airport: road-exit shields, junction labels, urban POIs, dense road hierarchy. |
 | `chamonix-trails-z14-outdoors` | z13-z14 | Local outdoor detail: paths/trails, minor roads, POIs, label emphasis. |
 | `zermatt-trails-z18-outdoors` | z18 | Street/trail-level stress test: casing, widths, local labels, POIs, high-detail symbols. |
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -70,6 +70,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(5.0 <= CAMERAS["switzerland-alps-z5-outdoors"].zoom <= 5.5)
         self.assertTrue(7.0 <= CAMERAS["valais-geneva-outdoors"].zoom <= 8.5)
         self.assertTrue(9.0 <= CAMERAS["lausanne-lavaux-z10-outdoors"].zoom <= 11.0)
+        self.assertTrue(14.0 <= CAMERAS["geneva-airport-motorway-z14-outdoors"].zoom <= 14.5)
         self.assertTrue(13.0 <= CAMERAS["chamonix-trails-z14-outdoors"].zoom <= 14.5)
         self.assertGreaterEqual(CAMERAS["zermatt-trails-z18-outdoors"].zoom, 18.0)
 

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -101,6 +101,18 @@ CAMERAS: dict[str, MapboxComparisonCamera] = {
         width=1280,
         height=900,
     ),
+    "geneva-airport-motorway-z14-outdoors": MapboxComparisonCamera(
+        name="geneva-airport-motorway-z14-outdoors",
+        description=(
+            "z14 motorway/urban detail around Geneva airport for road-exit shields, "
+            "motorway junction labels, urban POIs, and dense road hierarchy."
+        ),
+        longitude=6.103,
+        latitude=46.225,
+        zoom=14.25,
+        width=1280,
+        height=900,
+    ),
     "chamonix-trails-z14-outdoors": MapboxComparisonCamera(
         name="chamonix-trails-z14-outdoors",
         description=(


### PR DESCRIPTION
## Summary

- Add a Mapbox Outdoors comparison camera around Geneva airport at z14.25.
- Cover the current motorway/urban blind spot: road-exit shields, motorway junction labels, dense ramp/road hierarchy, and POIs.
- Document the new camera and extend the camera-matrix test.

## Evidence

- Live vector-tile probe found `motorway_junction` features around the Geneva airport/A1 interchange with exit refs including `1`, `3`, `4-5`, `5`, and `6`, so this camera exercises the remaining `road-exit-shield` warning in a way the existing five-camera matrix does not.
- Live all-camera comparison with the local QGIS-profile Mapbox token: `debug/mapbox-outdoors-comparison/all-cameras/20260514T121954Z/summary.md`
  - all six cameras passed
  - new camera artifact: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260514T121943Z/manifest.json`
  - new camera metrics: changed ratio `0.9918`, mean delta `0.0990`, RMS delta `0.1389`
- Visual review of the new triplet confirms it exercises motorway exit/junction shields, urban POIs, and dense road hierarchy. It also exposes useful remaining mismatches: airport landuse palette, motorway/ramp prominence, shield styling, and POI/label priority.

## Tests

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q` → `38 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1996 passed, 163 skipped, 135 subtests passed`
- `git diff --check`

Part of #949.
