### PR TITLE
Fix Mapbox road-exit shield fallback

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -76,6 +76,8 @@ _ICON_IMAGE_GET_MATCH_FALLBACKS_BY_LAYER_FIELD = {
 }
 
 _ROAD_NUMBER_SHIELD_LAYER_ID = "road-number-shield"
+_ROAD_EXIT_SHIELD_LAYER_ID = "road-exit-shield"
+_ROAD_EXIT_SHIELD_ICON_IMAGE = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
 _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN = {
     2: (
         "al-motorway",
@@ -545,6 +547,23 @@ def _icon_image_get_fallback(layer_id: object, expr: object) -> object:
     fallback = match_fallback["fallback"]
     input_expr = match_fallback.get("input", expr)
     return ["match", copy.deepcopy(input_expr), *(item for value in values for item in (value, value)), fallback]
+
+
+def _road_exit_shield_icon_fallback(layer_id: object, expr: object) -> object:
+    """Replace Mapbox Outdoors road-exit shield concat sprites with a finite match."""
+    if str(layer_id or "") != _ROAD_EXIT_SHIELD_LAYER_ID or expr != _ROAD_EXIT_SHIELD_ICON_IMAGE:
+        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
+    # QGIS validates the match fallback against the loaded sprite sheet up front,
+    # even though audited road-exit features use reflen values in the 1..9 range.
+    # Keep the fallback on an existing sprite instead of a missing sentinel so this
+    # replacement does not reintroduce a sprite-retrieval warning. Malformed or
+    # out-of-range reflen values therefore fall back to the one-character shield.
+    return [
+        "match",
+        ["get", "reflen"],
+        *(item for reflen in range(1, 10) for item in (reflen, f"motorway-exit-{reflen}")),
+        "motorway-exit-1",
+    ]
 
 
 def _expression_references_get_field(expr: object, field_name: str) -> bool:
@@ -1610,6 +1629,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         props[prop] = icon_image
                         continue
                     icon_image = _icon_image_get_fallback(layer_id, val)
+                    if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
+                        props[prop] = icon_image
+                        continue
+                    icon_image = _road_exit_shield_icon_fallback(layer_id, val)
                     if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
                         props[prop] = icon_image
                         continue

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -751,6 +751,48 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertEqual(result["layers"][1]["layout"]["icon-image"], network_icon)
 
+    def test_road_exit_shield_concat_icon_uses_reflen_sprite_match_fallback(self):
+        exit_icon = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
+        other_concat_icon = ["concat", "motorway-exit-", ["get", "reflen"]]
+        style = {
+            "layers": [
+                {"id": "road-exit-shield", "layout": {"icon-image": exit_icon}},
+                {"id": "road-number-shield", "layout": {"icon-image": exit_icon}},
+                {"id": "road-exit-shield", "layout": {"icon-image": other_concat_icon}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            result["layers"][0]["layout"]["icon-image"],
+            [
+                "match",
+                ["get", "reflen"],
+                1,
+                "motorway-exit-1",
+                2,
+                "motorway-exit-2",
+                3,
+                "motorway-exit-3",
+                4,
+                "motorway-exit-4",
+                5,
+                "motorway-exit-5",
+                6,
+                "motorway-exit-6",
+                7,
+                "motorway-exit-7",
+                8,
+                "motorway-exit-8",
+                9,
+                "motorway-exit-9",
+                "motorway-exit-1",
+            ],
+        )
+        self.assertEqual(result["layers"][1]["layout"]["icon-image"], exit_icon)
+        self.assertEqual(result["layers"][2]["layout"]["icon-image"], other_concat_icon)
+
     def test_road_number_shield_icon_case_expands_to_reflen_sprite_matches(self):
         shield_icon = [
             "case",


### PR DESCRIPTION
## Summary

- Replace the Mapbox Outdoors `road-exit-shield` `icon-image` concat expression with a finite QGIS-friendly `match` over `reflen`.
- Preserve the existing `motorway-exit-1` through `motorway-exit-9` sprite names instead of collapsing exit shields to a generic marker.
- Add a regression test that keeps the fallback scoped to the audited road-exit expression/layer.

## Evidence

- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260514T123025Z/audit.json`
  - sprite-context warnings: `10 -> 9`
  - removed `road-exit-shield: Could not interpret sprite value list with method concat`
  - no road-exit sprite retrieval warnings remain when the Mapbox sprite context is loaded
  - no-sprite converter warnings increase because the generated literal exit shield sprite names require the Mapbox sprite sheet; the sprite-context probe is the relevant runtime check for this slice.
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260514T123051Z/summary.md`
  - all six cameras passed
  - baseline-vs-candidate QGIS changes: Switzerland `0.000000`, Valais `0.000000`, Lausanne `0.000000`, Geneva motorway `0.003606`, Chamonix `0.005212`, Zermatt `0.000000`
  - visual review: the new Geneva motorway camera is closer because the candidate restores exit/junction shields such as `6`, `5`, `4-5`, and `4` around the A1/Geneva Airport interchange; Chamonix only gains sparse localized `31` shields with minor risk, not major clutter.

## Tests

- `python3 -m pytest tests/test_mapbox_config.py -q` → `89 passed`
- `python3 -m pytest tests/ -x -q --tb=short` → `1997 passed, 163 skipped, 135 subtests passed`
- `git diff --check`

Fixes part of #949.
