### PR TITLE
Split Mapbox path filters by zoom band

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -380,6 +380,24 @@ _ZOOM_NORMALIZED_LINE_FILTER_LAYER_IDS = {
     "tunnel-minor",
     "tunnel-minor-case",
 }
+_PATH_TYPE_FILTER_SPLIT_LAYER_IDS = {
+    "bridge-path-bg",
+    "road-path",
+    "road-path-bg",
+}
+_PATH_TYPE_FILTER_LOW_ZOOM_TYPES = ["steps", "sidewalk", "crossing"]
+_PATH_TYPE_FILTER_LOW_ZOOM_INVERTED_MATCH = [
+    "!",
+    ["match", ["get", "type"], _PATH_TYPE_FILTER_LOW_ZOOM_TYPES, True, False],
+]
+_PATH_TYPE_FILTER_LOW_ZOOM_SIMPLIFIED_MATCH = [
+    "match",
+    ["get", "type"],
+    _PATH_TYPE_FILTER_LOW_ZOOM_TYPES,
+    False,
+    True,
+]
+_PATH_TYPE_FILTER_SPLIT_ZOOM = 16.0
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
     "bridge-minor-case": 14.0,
@@ -604,6 +622,98 @@ def _with_additional_filter_clauses(filter_value: object, *clauses: object) -> o
     if isinstance(filter_copy, list):
         return ["all", filter_copy, *(copy.deepcopy(clause) for clause in clauses)]
     return ["all", *(copy.deepcopy(clause) for clause in clauses)]
+
+
+def _is_path_type_low_zoom_filter(value: object) -> bool:
+    return value in (_PATH_TYPE_FILTER_LOW_ZOOM_INVERTED_MATCH, _PATH_TYPE_FILTER_LOW_ZOOM_SIMPLIFIED_MATCH)
+
+
+def _is_path_type_high_zoom_filter(value: object) -> bool:
+    return value == ["!=", ["get", "type"], "steps"]
+
+
+def _path_type_zoom_step_filter_clause(value: object) -> tuple[float, object, object] | None:
+    if not isinstance(value, list) or len(value) != 5 or value[0] != "step" or value[1] != ["zoom"]:
+        return None
+    threshold = _numeric_zoom_bound(value[3])
+    if threshold is None or abs(threshold - _PATH_TYPE_FILTER_SPLIT_ZOOM) > _ZOOM_BOUND_EPSILON:
+        return None
+    low_zoom_filter = value[2]
+    high_zoom_filter = value[4]
+    if not _is_path_type_low_zoom_filter(low_zoom_filter) or not _is_path_type_high_zoom_filter(high_zoom_filter):
+        return None
+    return threshold, low_zoom_filter, high_zoom_filter
+
+
+def _filter_with_replaced_clause(filter_value: object, clause_index: int, replacement: object) -> object:
+    filter_copy = copy.deepcopy(filter_value)
+    if isinstance(filter_copy, list) and filter_copy[:1] == ["all"] and 0 < clause_index < len(filter_copy):
+        filter_copy[clause_index] = copy.deepcopy(replacement)
+        return filter_copy
+    return copy.deepcopy(replacement)
+
+
+def _zoom_band_label(zoom: float) -> str:
+    return str(int(zoom)) if zoom.is_integer() else str(zoom).replace(".", "_")
+
+
+def _path_type_filter_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited path filters at their Mapbox zoom threshold for QGIS.
+
+    QGIS cannot parse the Mapbox ``step(['zoom'], ...)`` filter clause used by
+    the Outdoors path layers.  A single representative snapshot either hides
+    sidewalks/crossings at high zoom or renders them too early at mid zoom, so
+    preserve the Mapbox behavior by emitting two static zoom-band layers.
+    """
+    layer_id = str(layer.get("id") or "")
+    if layer_id not in _PATH_TYPE_FILTER_SPLIT_LAYER_IDS or layer.get("type") != "line":
+        return None
+    filter_value = layer.get("filter")
+    if not isinstance(filter_value, list) or filter_value[:1] != ["all"]:
+        return None
+
+    for clause_index, clause in enumerate(filter_value[1:], start=1):
+        path_type_clause = _path_type_zoom_step_filter_clause(clause)
+        if path_type_clause is None:
+            continue
+
+        threshold, low_zoom_filter, high_zoom_filter = path_type_clause
+        existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+        existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+        if existing_maxzoom is not None and existing_maxzoom <= threshold:
+            low_layer = copy.deepcopy(layer)
+            low_layer["filter"] = _filter_with_replaced_clause(filter_value, clause_index, low_zoom_filter)
+            return [low_layer]
+        if existing_minzoom is not None and existing_minzoom >= threshold:
+            high_layer = copy.deepcopy(layer)
+            high_layer["filter"] = _filter_with_replaced_clause(filter_value, clause_index, high_zoom_filter)
+            return [high_layer]
+
+        zoom_label = _zoom_band_label(threshold)
+        low_layer = copy.deepcopy(layer)
+        low_layer["id"] = f"{layer_id}-below-z{zoom_label}"
+        low_layer["filter"] = _filter_with_replaced_clause(filter_value, clause_index, low_zoom_filter)
+        low_layer["maxzoom"] = threshold
+
+        high_layer = copy.deepcopy(layer)
+        high_layer["id"] = f"{layer_id}-z{zoom_label}-plus"
+        high_layer["filter"] = _filter_with_replaced_clause(filter_value, clause_index, high_zoom_filter)
+        high_layer["minzoom"] = threshold
+        return [low_layer, high_layer]
+    return None
+
+
+def _split_path_type_filter_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _path_type_filter_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
 
 
 def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
@@ -1532,6 +1642,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     """
     style = copy.deepcopy(style_definition)
     style["layers"] = _expand_road_number_shield_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1265,6 +1265,115 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         for layer in style["layers"]:
             self.assertEqual(layer["filter"], original_minor_filter)
 
+    def test_filter_simplification_splits_path_type_filters_by_zoom_band(self):
+        path_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            [
+                "step",
+                ["zoom"],
+                ["!", ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], True, False]],
+                16,
+                ["!=", ["get", "type"], "steps"],
+            ],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        original_path_filter = copy.deepcopy(path_filter)
+        style = {
+            "layers": [
+                {"id": "road-path-bg", "type": "line", "minzoom": 12, "filter": path_filter},
+                {"id": "road-path", "type": "line", "minzoom": 12, "filter": path_filter},
+                {"id": "bridge-path-bg", "type": "line", "minzoom": 14, "filter": path_filter},
+                {"id": "road-minor", "type": "line", "minzoom": 12, "filter": path_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [
+                "road-path-bg-below-z16",
+                "road-path-bg-z16-plus",
+                "road-path-below-z16",
+                "road-path-z16-plus",
+                "bridge-path-bg-below-z16",
+                "bridge-path-bg-z16-plus",
+                "road-minor",
+            ],
+        )
+        expected_low_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], False, True],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        expected_high_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            ["!=", ["get", "type"], "steps"],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        self.assertEqual(result["layers"][0]["filter"], expected_low_filter)
+        self.assertEqual(result["layers"][0]["minzoom"], 12)
+        self.assertEqual(result["layers"][0]["maxzoom"], 16.0)
+        self.assertEqual(result["layers"][1]["filter"], expected_high_filter)
+        self.assertEqual(result["layers"][1]["minzoom"], 16.0)
+        self.assertEqual(result["layers"][2]["filter"], expected_low_filter)
+        self.assertEqual(result["layers"][3]["filter"], expected_high_filter)
+        self.assertEqual(result["layers"][4]["minzoom"], 14)
+        self.assertEqual(result["layers"][4]["maxzoom"], 16.0)
+        self.assertEqual(result["layers"][5]["minzoom"], 16.0)
+        self.assertEqual(result["layers"][6]["filter"], expected_low_filter)
+        self.assertEqual(path_filter, original_path_filter)
+        for layer in style["layers"]:
+            self.assertEqual(layer["filter"], original_path_filter)
+
+    def test_filter_simplification_replaces_path_filter_without_split_outside_threshold(self):
+        path_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            [
+                "step",
+                ["zoom"],
+                ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], False, True],
+                16,
+                ["!=", ["get", "type"], "steps"],
+            ],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        style = {
+            "layers": [
+                {"id": "road-path", "type": "line", "minzoom": 12, "maxzoom": 15, "filter": path_filter},
+                {"id": "road-path-bg", "type": "line", "minzoom": 16, "filter": path_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual([layer["id"] for layer in result["layers"]], ["road-path", "road-path-bg"])
+        self.assertEqual(
+            result["layers"][0]["filter"],
+            [
+                "all",
+                ["==", ["get", "class"], "path"],
+                ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], False, True],
+                ["==", ["geometry-type"], "LineString"],
+            ],
+        )
+        self.assertEqual(
+            result["layers"][1]["filter"],
+            [
+                "all",
+                ["==", ["get", "class"], "path"],
+                ["!=", ["get", "type"], "steps"],
+                ["==", ["geometry-type"], "LineString"],
+            ],
+        )
+
     def test_filter_simplification_clamps_minor_line_zoom_override_to_layer_bounds(self):
         minor_filter = [
             "match",


### PR DESCRIPTION
## Summary
- Split the three audited Mapbox Outdoors path line filters (`road-path-bg`, `road-path`, `bridge-path-bg`) into below-z16 and z16+ QGIS layer variants.
- Preserve Mapbox's lower-zoom exclusion of steps/sidewalks/crossings while allowing the high-zoom non-steps filter without handing QGIS an unsupported zoom `step` filter.
- Add regression tests for the split and for layers whose zoom range already sits fully on one side of the threshold.

## Evidence
- Before this slice, the live audit at `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T020609Z/audit.md` showed 4 rejected filter probes and 7 `Skipping unsupported expression` warnings after qfit preprocessing; 3 rejected filters were the road/path filters.
- After this slice, the live audit at `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T021154Z/audit.md` shows 1 rejected filter probe and 1 `Skipping unsupported expression` warning after qfit preprocessing; the remaining rejected filter is `poi-label`, and roads/trails no longer contribute unsupported filter parser warnings.
- The all-camera visual comparison passed at `debug/mapbox-outdoors-comparison/all-cameras/20260515T021248Z/summary.md`. A before/after QGIS contact sheet at `debug/mapbox-outdoors-comparison/all-cameras/20260515T021248Z/path-filter-before-after-qgis.jpg` showed cleaner z14 path density with z18 detail still present.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py -q` → 91 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 1999 passed, 163 skipped, 135 subtests passed
- Live Mapbox audit and comparison commands were run using the local QGIS profile token source without printing or committing the token.

Refs #949
