### PR TITLE
fix: split Mapbox POI filters by zoom band

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -862,6 +862,20 @@ def _is_road_number_shield_layer_id(layer_id: object) -> bool:
     return normalized == _ROAD_NUMBER_SHIELD_LAYER_ID or normalized.startswith(f"{_ROAD_NUMBER_SHIELD_LAYER_ID}-")
 
 
+def _is_poi_label_layer_id(layer_id: object) -> bool:
+    normalized = str(layer_id or "")
+    return normalized == _POI_LABEL_LAYER_ID or normalized.startswith(f"{_POI_LABEL_LAYER_ID}-")
+
+
+def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
+    """Return the original Mapbox layer id for qfit-created layer variants."""
+    if _is_road_number_shield_layer_id(layer_id):
+        return _ROAD_NUMBER_SHIELD_LAYER_ID
+    if _is_poi_label_layer_id(layer_id):
+        return _POI_LABEL_LAYER_ID
+    return str(layer_id or "")
+
+
 def _expand_road_number_shield_layers_for_qgis(layers: object) -> object:
     if not isinstance(layers, list):
         return layers
@@ -1525,8 +1539,7 @@ def _should_zoom_normalize_filter_for_qgis(layer: dict[str, object]) -> bool:
     # road line filters whose normalized branches improved #949 visual audits.
     # Applying the same approximation broadly can hide high-zoom path geometry
     # or over-suppress POIs/places, so keep this deliberately small.
-    layer_id = layer.get("id")
-    normalized_layer_id = _ROAD_NUMBER_SHIELD_LAYER_ID if _is_road_number_shield_layer_id(layer_id) else layer_id
+    normalized_layer_id = base_mapbox_style_layer_id_for_qfit(layer.get("id"))
     layer_type = layer.get("type")
     return (
         (layer_type == "symbol" and normalized_layer_id in _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS)
@@ -1805,6 +1818,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
 
     for layer in style.get("layers", []):
         layer_id = layer.get("id", "")
+        base_layer_id = base_mapbox_style_layer_id_for_qfit(layer_id)
 
         # Suppress or filter settlement label layers
         settlement_filter = _SETTLEMENT_FILTERS.get(layer_id, "NOTSET")
@@ -1894,7 +1908,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                 elif prop == "text-font" and _is_text_font_stack(val):
                     props[prop] = [QGIS_TEXT_FONT_FALLBACK]
                 elif prop == "text-size":
-                    override = _TEXT_SIZE_OVERRIDES.get(layer_id)
+                    override = _TEXT_SIZE_OVERRIDES.get(base_layer_id)
                     if override is not None:
                         props[prop] = override
                     else:

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -398,6 +398,13 @@ _PATH_TYPE_FILTER_LOW_ZOOM_SIMPLIFIED_MATCH = [
     True,
 ]
 _PATH_TYPE_FILTER_SPLIT_ZOOM = 16.0
+_POI_LABEL_LAYER_ID = "poi-label"
+_POI_FILTER_RANK_ZOOM_STEP = ["step", ["zoom"], 0, 16, 1, 17, 2]
+_POI_FILTER_RANK_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
+    ("below-z16", None, 16.0, 0.0),
+    ("z16-to-z17", 16.0, 17.0, 1.0),
+    ("z17-plus", 17.0, None, 2.0),
+)
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
     "bridge-minor-case": 14.0,
@@ -712,6 +719,109 @@ def _split_path_type_filter_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _path_type_filter_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _numeric_match_filter_with_offset(value: object, offset: float) -> object | None:
+    if not isinstance(value, list) or len(value) < 5 or value[0] != "match" or (len(value) - 3) % 2 != 0:
+        return None
+    adjusted = ["match", copy.deepcopy(value[1])]
+    for index in range(2, len(value) - 1, 2):
+        output_value = _numeric_expression_value(value[index + 1])
+        if output_value is None:
+            return None
+        adjusted.extend([copy.deepcopy(value[index]), output_value + offset])
+    fallback_value = _numeric_expression_value(value[-1])
+    if fallback_value is None:
+        return None
+    adjusted.append(fallback_value + offset)
+    return adjusted
+
+
+def _poi_filterrank_components(filter_value: object) -> tuple[object, object] | None:
+    if (
+        not isinstance(filter_value, list)
+        or len(filter_value) != 3
+        or filter_value[0] != "<="
+        or filter_value[1] != ["get", "filterrank"]
+    ):
+        return None
+    threshold = filter_value[2]
+    if not isinstance(threshold, list) or len(threshold) != 3 or threshold[0] != "+":
+        return None
+    left, right = threshold[1], threshold[2]
+    if left == _POI_FILTER_RANK_ZOOM_STEP:
+        return left, right
+    if right == _POI_FILTER_RANK_ZOOM_STEP:
+        return right, left
+    return None
+
+
+def _zoom_ranges_overlap(
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+) -> bool:
+    if existing_maxzoom is not None and band_minzoom is not None and existing_maxzoom <= band_minzoom:
+        return False
+    if existing_minzoom is not None and band_maxzoom is not None and existing_minzoom >= band_maxzoom:
+        return False
+    return True
+
+
+def _apply_zoom_band_bounds(
+    layer: dict[str, object],
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+) -> dict[str, object]:
+    bounded_layer = copy.deepcopy(layer)
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    if band_minzoom is not None and (existing_minzoom is None or existing_minzoom < band_minzoom):
+        bounded_layer["minzoom"] = band_minzoom
+    if band_maxzoom is not None and (existing_maxzoom is None or existing_maxzoom > band_maxzoom):
+        bounded_layer["maxzoom"] = band_maxzoom
+    return bounded_layer
+
+
+def _poi_label_filter_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split the audited Outdoors POI filterrank zoom bump into QGIS-safe bands."""
+    if str(layer.get("id") or "") != _POI_LABEL_LAYER_ID or layer.get("type") != "symbol":
+        return None
+    components = _poi_filterrank_components(layer.get("filter"))
+    if components is None:
+        return None
+    _, class_rank_match = components
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants_with_suffixes: list[tuple[str, dict[str, object]]] = []
+    for suffix, band_minzoom, band_maxzoom, rank_offset in _POI_FILTER_RANK_ZOOM_BANDS:
+        if not _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom):
+            continue
+        adjusted_rank_match = _numeric_match_filter_with_offset(class_rank_match, rank_offset)
+        if adjusted_rank_match is None:
+            return None
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["filter"] = ["<=", ["get", "filterrank"], adjusted_rank_match]
+        variants_with_suffixes.append((suffix, variant))
+    variants = [variant for _suffix, variant in variants_with_suffixes]
+    if len(variants) > 1:
+        for suffix, variant in variants_with_suffixes:
+            variant["id"] = f"{_POI_LABEL_LAYER_ID}-{suffix}"
+    return variants or None
+
+
+def _split_poi_label_filter_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _poi_label_filter_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -1643,6 +1753,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style = copy.deepcopy(style_definition)
     style["layers"] = _expand_road_number_shield_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -634,6 +634,16 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.assertEqual(settings.priority, 10)
         style.setLabelSettings.assert_called_once_with(settings)
 
+    def test_priority_set_for_split_poi_layer(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("poi-label-z17-plus")
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 2)
+        style.setLabelSettings.assert_called_once_with(settings)
+
     def test_data_defined_priority_for_settlement_layer(self):
         labeling = MagicMock()
         style, settings = self._make_style("settlement-major-label")

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1374,6 +1374,89 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ],
         )
 
+    def test_filter_simplification_splits_poi_filterrank_filter_by_zoom_band(self):
+        class_rank_match = [
+            "match",
+            ["get", "class"],
+            "food_and_drink_stores",
+            3,
+            "park_like",
+            4,
+            2,
+        ]
+        poi_filter = [
+            "<=",
+            ["get", "filterrank"],
+            ["+", ["step", ["zoom"], 0, 16, 1, 17, 2], class_rank_match],
+        ]
+        original_poi_filter = copy.deepcopy(poi_filter)
+        style = {
+            "layers": [
+                {"id": "poi-label", "type": "symbol", "minzoom": 6, "filter": poi_filter},
+                {"id": "natural-point-label", "type": "symbol", "minzoom": 6, "filter": poi_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            ["poi-label-below-z16", "poi-label-z16-to-z17", "poi-label-z17-plus", "natural-point-label"],
+        )
+        self.assertEqual(result["layers"][0]["minzoom"], 6)
+        self.assertEqual(result["layers"][0]["maxzoom"], 16.0)
+        self.assertEqual(result["layers"][1]["minzoom"], 16.0)
+        self.assertEqual(result["layers"][1]["maxzoom"], 17.0)
+        self.assertEqual(result["layers"][2]["minzoom"], 17.0)
+        self.assertNotIn("maxzoom", result["layers"][2])
+        self.assertEqual(
+            result["layers"][0]["filter"],
+            ["<=", ["get", "filterrank"], ["match", ["get", "class"], "food_and_drink_stores", 3.0, "park_like", 4.0, 2.0]],
+        )
+        self.assertEqual(
+            result["layers"][1]["filter"],
+            ["<=", ["get", "filterrank"], ["match", ["get", "class"], "food_and_drink_stores", 4.0, "park_like", 5.0, 3.0]],
+        )
+        self.assertEqual(
+            result["layers"][2]["filter"],
+            ["<=", ["get", "filterrank"], ["match", ["get", "class"], "food_and_drink_stores", 5.0, "park_like", 6.0, 4.0]],
+        )
+        self.assertEqual(result["layers"][3]["filter"], original_poi_filter)
+        self.assertEqual(poi_filter, original_poi_filter)
+        for layer in style["layers"]:
+            self.assertEqual(layer["filter"], original_poi_filter)
+
+    def test_filter_simplification_replaces_poi_filter_without_split_outside_thresholds(self):
+        class_rank_match = ["match", ["get", "class"], "historic", 3, 2]
+        poi_filter = [
+            "<=",
+            ["get", "filterrank"],
+            ["+", class_rank_match, ["step", ["zoom"], 0, 16, 1, 17, 2]],
+        ]
+        style = {
+            "layers": [
+                {"id": "poi-label", "type": "symbol", "minzoom": 6, "maxzoom": 16, "filter": poi_filter},
+                {"id": "poi-label", "type": "symbol", "minzoom": 16, "maxzoom": 17, "filter": poi_filter},
+                {"id": "poi-label", "type": "symbol", "minzoom": 17, "filter": poi_filter},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual([layer["id"] for layer in result["layers"]], ["poi-label", "poi-label", "poi-label"])
+        self.assertEqual(
+            result["layers"][0]["filter"],
+            ["<=", ["get", "filterrank"], ["match", ["get", "class"], "historic", 3.0, 2.0]],
+        )
+        self.assertEqual(
+            result["layers"][1]["filter"],
+            ["<=", ["get", "filterrank"], ["match", ["get", "class"], "historic", 4.0, 3.0]],
+        )
+        self.assertEqual(
+            result["layers"][2]["filter"],
+            ["<=", ["get", "filterrank"], ["match", ["get", "class"], "historic", 5.0, 4.0]],
+        )
+
     def test_filter_simplification_clamps_minor_line_zoom_override_to_layer_bounds(self):
         minor_filter = [
             "match",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1392,7 +1392,13 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         original_poi_filter = copy.deepcopy(poi_filter)
         style = {
             "layers": [
-                {"id": "poi-label", "type": "symbol", "minzoom": 6, "filter": poi_filter},
+                {
+                    "id": "poi-label",
+                    "type": "symbol",
+                    "minzoom": 6,
+                    "filter": poi_filter,
+                    "layout": {"text-size": ["interpolate", ["linear"], ["zoom"], 0, 4, 20, 24]},
+                },
                 {"id": "natural-point-label", "type": "symbol", "minzoom": 6, "filter": poi_filter},
             ]
         }
@@ -1409,6 +1415,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][1]["maxzoom"], 17.0)
         self.assertEqual(result["layers"][2]["minzoom"], 17.0)
         self.assertNotIn("maxzoom", result["layers"][2])
+        self.assertEqual(result["layers"][0]["layout"]["text-size"], 9.0)
+        self.assertEqual(result["layers"][1]["layout"]["text-size"], 9.0)
+        self.assertEqual(result["layers"][2]["layout"]["text-size"], 9.0)
         self.assertEqual(
             result["layers"][0]["filter"],
             ["<=", ["get", "filterrank"], ["match", ["get", "class"], "food_and_drink_stores", 3.0, "park_like", 4.0, 2.0]],

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -14,6 +14,7 @@ from ...mapbox_config import (
     TILE_MODE_RASTER,
     TILE_MODE_VECTOR,
     MapboxSpriteResources,
+    base_mapbox_style_layer_id_for_qfit,
     build_background_layer_name,
     build_vector_tile_layer_uri,
     build_xyz_layer_uri,
@@ -175,7 +176,7 @@ class BackgroundMapService:
             from qgis.core import QgsProperty  # noqa: PLC0415
 
             for style in labeling.styles():
-                layer_name = style.layerName()
+                layer_name = base_mapbox_style_layer_id_for_qfit(style.layerName())
                 priority = _LAYER_PRIORITIES.get(layer_name)
                 if priority is None:
                     continue


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `poi-label` filterrank zoom expression into QGIS-safe zoom-band layer variants
- preserve the Mapbox thresholds for `< z16`, `z16–z17`, and `>= z17` without feeding QGIS a zoom-dependent `step` filter
- preserve base `poi-label` text-size and QGIS label-priority overrides for the generated split variants
- add regression coverage for split, already-bounded POI filter, text-size override, and label-priority behavior

## Evidence
- Targeted tests: `python3 -m pytest tests/test_mapbox_config.py tests/test_background_map_service.py -q` → 105 passed, 26 skipped
- Full tests/coverage gate: `python3 -m pytest tests/ -x -q --tb=short` → 2002 passed, 163 skipped, 135 subtests passed
- Live style audit after Codex fix: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T023527Z/audit.md`
  - `Skipping unsupported expression`: raw 93 → after qfit preprocessing 0
  - QGIS filter parser probe: 154 tested / 154 accepted / 0 rejected
- All-camera comparison after Codex fix: `debug/mapbox-outdoors-comparison/all-cameras/20260515T023556Z/summary.md`
  - all six cameras passed with metrics available
- Initial visual QA contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260515T022624Z/poi-filter-before-after-qgis.jpg`
  - POI/label density improves at z8/z10/z14/z18
  - road/path styling appears unchanged

Refs #949