### PR TITLE
fix: preserve low-zoom settlement dot icons

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -516,6 +516,8 @@ _PATH_TYPE_FILTER_LOW_ZOOM_SIMPLIFIED_MATCH = [
 _PATH_TYPE_FILTER_SPLIT_ZOOM = 16.0
 _NATURAL_POINT_LABEL_LAYER_ID = "natural-point-label"
 _POI_LABEL_LAYER_ID = "poi-label"
+_SETTLEMENT_MAJOR_LABEL_LAYER_ID = "settlement-major-label"
+_SETTLEMENT_MINOR_LABEL_LAYER_ID = "settlement-minor-label"
 _POI_FILTER_RANK_ZOOM_STEP = ["step", ["zoom"], 0, 16, 1, 17, 2]
 _POI_FILTER_RANK_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("below-z16", None, 16.0, 0.0),
@@ -549,6 +551,65 @@ _LABEL_ICON_TEXT_OFFSET_EXPRESSION = [
 _LABEL_ICON_VISIBILITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("below-z17", None, _LABEL_ICON_VISIBILITY_SPLIT_ZOOM, _LABEL_ICON_LOW_ZOOM_SIZERANK_THRESHOLD),
     ("z17-plus", _LABEL_ICON_VISIBILITY_SPLIT_ZOOM, None, _LABEL_ICON_HIGH_ZOOM_SIZERANK_THRESHOLD),
+)
+_SETTLEMENT_DOT_ICON_SPLIT_ZOOM = 8.0
+_SETTLEMENT_DOT_ICON_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z2-to-z4", 2.0, 4.0),
+    ("z4-to-z6", 4.0, 6.0),
+    ("z6-to-z7", 6.0, 7.0),
+    ("z7-to-z8", 7.0, _SETTLEMENT_DOT_ICON_SPLIT_ZOOM),
+)
+_SETTLEMENT_DOT_ICON_IMAGE_EXPRESSION = [
+    "step",
+    ["zoom"],
+    [
+        "case",
+        ["==", ["get", "capital"], 2],
+        "border-dot-13",
+        ["step", ["get", "symbolrank"], "dot-11", 9, "dot-10", 11, "dot-9"],
+    ],
+    _SETTLEMENT_DOT_ICON_SPLIT_ZOOM,
+    "",
+]
+_SETTLEMENT_DOT_TEXT_ANCHOR_EXPRESSION = ["step", ["zoom"], ["get", "text_anchor"], _SETTLEMENT_DOT_ICON_SPLIT_ZOOM, "center"]
+_SETTLEMENT_DOT_TEXT_RADIAL_OFFSET_EXPRESSION = [
+    "step",
+    ["zoom"],
+    ["match", ["get", "capital"], 2, 0.6, 0.55],
+    _SETTLEMENT_DOT_ICON_SPLIT_ZOOM,
+    0,
+]
+_SETTLEMENT_DOT_TEXT_JUSTIFY_LOW_ZOOM = [
+    "match",
+    ["get", "text_anchor"],
+    ["left", "bottom-left", "top-left"],
+    "left",
+    ["right", "bottom-right", "top-right"],
+    "right",
+    "center",
+]
+_SETTLEMENT_DOT_TEXT_JUSTIFY_EXPRESSION = [
+    "step",
+    ["zoom"],
+    _SETTLEMENT_DOT_TEXT_JUSTIFY_LOW_ZOOM,
+    _SETTLEMENT_DOT_ICON_SPLIT_ZOOM,
+    "center",
+]
+_SETTLEMENT_DOT_ICON_VARIANTS: tuple[tuple[str, object, str, float], ...] = (
+    ("capital-border-dot", ["==", ["get", "capital"], 2], "border-dot-13", 0.6),
+    (
+        "dot-11",
+        ["all", ["!=", ["get", "capital"], 2], ["<", ["get", "symbolrank"], 9]],
+        "dot-11",
+        0.55,
+    ),
+    (
+        "dot-10",
+        ["all", ["!=", ["get", "capital"], 2], [">=", ["get", "symbolrank"], 9], ["<", ["get", "symbolrank"], 11]],
+        "dot-10",
+        0.55,
+    ),
+    ("dot-9", ["all", ["!=", ["get", "capital"], 2], [">=", ["get", "symbolrank"], 11]], "dot-9", 0.55),
 )
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
@@ -1031,6 +1092,16 @@ def _is_natural_point_label_layer_id(layer_id: object) -> bool:
     return normalized == _NATURAL_POINT_LABEL_LAYER_ID or normalized.startswith(f"{_NATURAL_POINT_LABEL_LAYER_ID}-")
 
 
+def _is_settlement_major_label_layer_id(layer_id: object) -> bool:
+    normalized = str(layer_id or "")
+    return normalized == _SETTLEMENT_MAJOR_LABEL_LAYER_ID or normalized.startswith(f"{_SETTLEMENT_MAJOR_LABEL_LAYER_ID}-")
+
+
+def _is_settlement_minor_label_layer_id(layer_id: object) -> bool:
+    normalized = str(layer_id or "")
+    return normalized == _SETTLEMENT_MINOR_LABEL_LAYER_ID or normalized.startswith(f"{_SETTLEMENT_MINOR_LABEL_LAYER_ID}-")
+
+
 def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     """Return the original Mapbox layer id for qfit-created layer variants."""
     if _is_road_number_shield_layer_id(layer_id):
@@ -1039,7 +1110,96 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
         return _POI_LABEL_LAYER_ID
     if _is_natural_point_label_layer_id(layer_id):
         return _NATURAL_POINT_LABEL_LAYER_ID
+    if _is_settlement_major_label_layer_id(layer_id):
+        return _SETTLEMENT_MAJOR_LABEL_LAYER_ID
+    if _is_settlement_minor_label_layer_id(layer_id):
+        return _SETTLEMENT_MINOR_LABEL_LAYER_ID
     return str(layer_id or "")
+
+
+def _has_settlement_dot_icon_expression(layer: dict[str, object]) -> bool:
+    base_layer_id = base_mapbox_style_layer_id_for_qfit(layer.get("id"))
+    layout = layer.get("layout")
+    return (
+        base_layer_id in {_SETTLEMENT_MAJOR_LABEL_LAYER_ID, _SETTLEMENT_MINOR_LABEL_LAYER_ID}
+        and layer.get("type") == "symbol"
+        and isinstance(layout, dict)
+        and layout.get("icon-image") == _SETTLEMENT_DOT_ICON_IMAGE_EXPRESSION
+        and layout.get("text-anchor") == _SETTLEMENT_DOT_TEXT_ANCHOR_EXPRESSION
+        and layout.get("text-radial-offset") == _SETTLEMENT_DOT_TEXT_RADIAL_OFFSET_EXPRESSION
+    )
+
+
+def _set_settlement_low_zoom_dot_label_layout(
+    layer: dict[str, object],
+    *,
+    icon_image: str,
+    text_radial_offset: float,
+) -> None:
+    layout = layer.get("layout")
+    if not isinstance(layout, dict):
+        return
+    layout["icon-image"] = icon_image
+    layout["text-anchor"] = ["get", "text_anchor"]
+    layout["text-radial-offset"] = text_radial_offset
+    if layout.get("text-justify") == _SETTLEMENT_DOT_TEXT_JUSTIFY_EXPRESSION:
+        layout["text-justify"] = copy.deepcopy(_SETTLEMENT_DOT_TEXT_JUSTIFY_LOW_ZOOM)
+
+
+def _set_settlement_high_zoom_text_layout(layer: dict[str, object]) -> None:
+    layout = layer.get("layout")
+    if not isinstance(layout, dict):
+        return
+    layout.pop("icon-image", None)
+    layout["text-anchor"] = "center"
+    layout["text-radial-offset"] = 0
+    if layout.get("text-justify") == _SETTLEMENT_DOT_TEXT_JUSTIFY_EXPRESSION:
+        layout["text-justify"] = "center"
+
+
+def _settlement_dot_icon_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split Mapbox's low-zoom settlement dot icons from z8+ centered labels."""
+    if not _has_settlement_dot_icon_expression(layer):
+        return None
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    layer_id = str(layer.get("id") or base_mapbox_style_layer_id_for_qfit(layer.get("id")))
+    variants: list[dict[str, object]] = []
+
+    for zoom_suffix, band_minzoom, band_maxzoom in _SETTLEMENT_DOT_ICON_ZOOM_BANDS:
+        if not _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom):
+            continue
+        for suffix, icon_filter, icon_image, text_radial_offset in _SETTLEMENT_DOT_ICON_VARIANTS:
+            icon_layer = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+            icon_layer["id"] = f"{layer_id}-{zoom_suffix}-{suffix}"
+            icon_layer["filter"] = _with_additional_filter_clauses(layer.get("filter"), icon_filter)
+            _set_settlement_low_zoom_dot_label_layout(
+                icon_layer,
+                icon_image=icon_image,
+                text_radial_offset=text_radial_offset,
+            )
+            variants.append(icon_layer)
+
+    if _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, _SETTLEMENT_DOT_ICON_SPLIT_ZOOM, None):
+        text_layer = _apply_zoom_band_bounds(layer, _SETTLEMENT_DOT_ICON_SPLIT_ZOOM, None)
+        text_layer["id"] = f"{layer_id}-z8-plus"
+        _set_settlement_high_zoom_text_layout(text_layer)
+        variants.append(text_layer)
+
+    return variants or None
+
+
+def _split_settlement_dot_icon_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _settlement_dot_icon_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
 
 
 def _has_label_icon_visibility_expression(layer: dict[str, object]) -> bool:
@@ -2055,6 +2215,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_settlement_dot_icon_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",
@@ -2109,7 +2270,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
         base_layer_id = base_mapbox_style_layer_id_for_qfit(layer_id)
 
         # Suppress or filter settlement label layers
-        settlement_filter = _SETTLEMENT_FILTERS.get(layer_id, "NOTSET")
+        settlement_filter = _SETTLEMENT_FILTERS.get(base_layer_id, "NOTSET")
         if settlement_filter != "NOTSET":
             if settlement_filter is None:
                 layer["layout"] = layer.get("layout", {})

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1117,6 +1117,161 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(style["layers"][0]["filter"], major_filter)
         self.assertEqual(style["layers"][1]["filter"], minor_filter)
 
+    def _settlement_dot_icon_layout(self):
+        return {
+            "icon-image": [
+                "step",
+                ["zoom"],
+                [
+                    "case",
+                    ["==", ["get", "capital"], 2],
+                    "border-dot-13",
+                    ["step", ["get", "symbolrank"], "dot-11", 9, "dot-10", 11, "dot-9"],
+                ],
+                8.0,
+                "",
+            ],
+            "text-anchor": ["step", ["zoom"], ["get", "text_anchor"], 8.0, "center"],
+            "text-radial-offset": ["step", ["zoom"], ["match", ["get", "capital"], 2, 0.6, 0.55], 8.0, 0],
+            "text-justify": [
+                "step",
+                ["zoom"],
+                [
+                    "match",
+                    ["get", "text_anchor"],
+                    ["left", "bottom-left", "top-left"],
+                    "left",
+                    ["right", "bottom-right", "top-right"],
+                    "right",
+                    "center",
+                ],
+                8.0,
+                "center",
+            ],
+        }
+
+    def test_filter_simplification_splits_major_settlement_dot_icons_by_zoom_and_rank(self):
+        base_filter = ["<=", ["get", "filterrank"], 3]
+        major_filter = [
+            "all",
+            base_filter,
+            [
+                "step",
+                ["zoom"],
+                False,
+                2,
+                ["<=", ["get", "symbolrank"], 6],
+                4,
+                ["<", ["get", "symbolrank"], 7],
+                6,
+                ["<", ["get", "symbolrank"], 8],
+                7,
+                ["<", ["get", "symbolrank"], 10],
+            ],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "settlement-major-label",
+                    "type": "symbol",
+                    "minzoom": 2,
+                    "maxzoom": 15,
+                    "filter": major_filter,
+                    "layout": self._settlement_dot_icon_layout(),
+                }
+            ]
+        }
+        original_icon_image = copy.deepcopy(style["layers"][0]["layout"]["icon-image"])
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 17)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        city_filter = ["match", ["get", "type"], ["city"], True, False]
+        capital_layer = by_id["settlement-major-label-z2-to-z4-capital-border-dot"]
+        dot_layer = by_id["settlement-major-label-z7-to-z8-dot-10"]
+        text_layer = by_id["settlement-major-label-z8-plus"]
+        self.assertEqual(capital_layer["minzoom"], 2)
+        self.assertEqual(capital_layer["maxzoom"], 4.0)
+        self.assertEqual(dot_layer["minzoom"], 7.0)
+        self.assertEqual(dot_layer["maxzoom"], 8.0)
+        self.assertEqual(text_layer["minzoom"], 8.0)
+        self.assertEqual(text_layer["maxzoom"], 15)
+        self.assertEqual(capital_layer["layout"]["icon-image"], "border-dot-13")
+        self.assertEqual(dot_layer["layout"]["icon-image"], "dot-10")
+        self.assertEqual(capital_layer["layout"]["text-anchor"], ["get", "text_anchor"])
+        self.assertEqual(capital_layer["layout"]["text-radial-offset"], 0.6)
+        self.assertEqual(dot_layer["layout"]["text-radial-offset"], 0.55)
+        self.assertEqual(capital_layer["layout"]["text-justify"], self._settlement_dot_icon_layout()["text-justify"][2])
+        self.assertEqual(
+            capital_layer["filter"],
+            ["all", ["all", base_filter, ["<=", ["get", "symbolrank"], 6], ["==", ["get", "capital"], 2]], city_filter],
+        )
+        self.assertEqual(
+            dot_layer["filter"],
+            [
+                "all",
+                [
+                    "all",
+                    base_filter,
+                    ["<", ["get", "symbolrank"], 10],
+                    ["all", ["!=", ["get", "capital"], 2], [">=", ["get", "symbolrank"], 9], ["<", ["get", "symbolrank"], 11]],
+                ],
+                city_filter,
+            ],
+        )
+        self.assertNotIn("icon-image", text_layer["layout"])
+        self.assertEqual(text_layer["layout"]["text-anchor"], "center")
+        self.assertEqual(text_layer["layout"]["text-radial-offset"], 0)
+        self.assertEqual(text_layer["layout"]["text-justify"], "center")
+        self.assertEqual(text_layer["filter"][-1], city_filter)
+        self.assertEqual(style["layers"][0]["layout"]["icon-image"], original_icon_image)
+
+    def test_filter_simplification_splits_minor_settlement_dot_icons_with_town_filter(self):
+        base_filter = ["<=", ["get", "filterrank"], 3]
+        minor_filter = [
+            "step",
+            ["zoom"],
+            [">", ["get", "symbolrank"], 6],
+            4,
+            [">=", ["get", "symbolrank"], 7],
+            6,
+            [">=", ["get", "symbolrank"], 8],
+            7,
+            [">=", ["get", "symbolrank"], 10],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "settlement-minor-label",
+                    "type": "symbol",
+                    "minzoom": 2,
+                    "maxzoom": 13,
+                    "filter": ["all", base_filter, minor_filter],
+                    "layout": self._settlement_dot_icon_layout(),
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 17)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        town_filter = ["match", ["get", "type"], ["town"], True, False]
+        for suffix, icon_name in (
+            ("capital-border-dot", "border-dot-13"),
+            ("dot-11", "dot-11"),
+            ("dot-10", "dot-10"),
+            ("dot-9", "dot-9"),
+        ):
+            layer = by_id[f"settlement-minor-label-z2-to-z4-{suffix}"]
+            self.assertEqual(layer["layout"]["icon-image"], icon_name)
+            self.assertEqual(layer["filter"][-1], town_filter)
+        self.assertEqual(by_id["settlement-minor-label-z2-to-z4-dot-11"]["filter"][1][2], [">", ["get", "symbolrank"], 6])
+        self.assertEqual(by_id["settlement-minor-label-z7-to-z8-dot-11"]["filter"][1][2], [">=", ["get", "symbolrank"], 10])
+        self.assertNotIn("icon-image", by_id["settlement-minor-label-z8-plus"]["layout"])
+        self.assertEqual(by_id["settlement-minor-label-z8-plus"]["filter"][-1], town_filter)
+
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [
             "all",


### PR DESCRIPTION
Refs #949.

## Summary
- split Mapbox Outdoors settlement major/minor label icon rules at z8 so low zoom keeps the original dot sprites while z8+ remains centered text-only
- preserve the low-zoom `capital`/`symbolrank` dot variants (`border-dot-13`, `dot-11`, `dot-10`, `dot-9`) as literal QGIS sprite layers
- preserve Mapbox's low-zoom settlement `symbolrank` thresholds in z2–z4, z4–z6, z6–z7, and z7–z8 bands
- keep existing city/town settlement filtering and text-size overrides applied to generated settlement variants

## Review follow-up
- addressed Codex P2 by splitting the low-zoom settlement layers into the original Mapbox zoom/rank bands instead of freezing one below-z8 threshold
- addressed Greptile P2 by adding `settlement-minor-label` coverage that verifies the town filter and low/high rank thresholds

## Evidence
- `python3 -m pytest tests/test_mapbox_config.py -q` → 98 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2007 passed, 163 skipped, 135 subtests passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T042437Z/audit.md`
  - QGIS filter parser probe: 192 accepted / 0 rejected
  - Runtime sprite context: 0 remaining warnings
- All-camera live comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T042514Z/summary.md`
  - all six cameras passed
- Visual QA contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260515T042514Z/settlement-dot-icons-review-fix-before-after-qgis.jpg`
  - intended low-zoom settlement dot/label changes are visible at z5; z8/z10 panels are unchanged; small z14/z18 diffs were reviewed as unrelated QGIS label/road-placement noise rather than settlement-dot regressions
