### PR TITLE
Improve Mapbox regional road widths in QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -496,6 +496,32 @@ _ZOOM_NORMALIZED_LINE_FILTER_LAYER_IDS = {
     "tunnel-minor",
     "tunnel-minor-case",
 }
+_REGIONAL_MAJOR_ROAD_WIDTH_LAYER_IDS = {
+    "road-motorway-trunk",
+    "road-motorway-trunk-case",
+    "road-primary",
+    "road-primary-case",
+    "road-secondary-tertiary",
+    "road-secondary-tertiary-case",
+}
+_REGIONAL_MAJOR_ROAD_STROKE_WIDTH_PROPS = {"line-width", "line-gap-width"}
+_REGIONAL_CORE_ROAD_WIDTH_LAYER_IDS = {
+    "road-motorway-trunk",
+    "road-motorway-trunk-case",
+    "road-primary",
+    "road-primary-case",
+}
+_REGIONAL_MAJOR_ROAD_WIDTH_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z3-to-z5", None, 5.0),
+    ("z5-to-z6", 5.0, 6.0),
+    ("z6-to-z9", 6.0, 9.0),
+    ("z9-to-z12", 9.0, 12.0),
+)
+_REGIONAL_MAJOR_ROAD_WIDTH_HIGH_ZOOM_MIN = 12.0
+_REGIONAL_MAJOR_ROAD_WIDTH_QGIS_SCALE = 1.3
+_REGIONAL_MAJOR_ROAD_MIN_WIDTH_MM = 0.32
+_REGIONAL_CORE_ROAD_WIDTH_QGIS_SCALE = 2.1
+_REGIONAL_CORE_ROAD_MIN_WIDTH_MM = 0.60
 _PATH_TYPE_FILTER_SPLIT_LAYER_IDS = {
     "bridge-path-bg",
     "road-path",
@@ -1102,8 +1128,22 @@ def _is_settlement_minor_label_layer_id(layer_id: object) -> bool:
     return normalized == _SETTLEMENT_MINOR_LABEL_LAYER_ID or normalized.startswith(f"{_SETTLEMENT_MINOR_LABEL_LAYER_ID}-")
 
 
+def _regional_major_road_width_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    for suffix, _band_minzoom, _band_maxzoom in _REGIONAL_MAJOR_ROAD_WIDTH_BANDS:
+        band_suffix = f"-{suffix}"
+        if normalized.endswith(band_suffix):
+            base_layer_id = normalized[: -len(band_suffix)]
+            if base_layer_id in _REGIONAL_MAJOR_ROAD_WIDTH_LAYER_IDS:
+                return base_layer_id
+    return None
+
+
 def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     """Return the original Mapbox layer id for qfit-created layer variants."""
+    regional_road_layer_id = _regional_major_road_width_base_layer_id(layer_id)
+    if regional_road_layer_id is not None:
+        return regional_road_layer_id
     if _is_road_number_shield_layer_id(layer_id):
         return _ROAD_NUMBER_SHIELD_LAYER_ID
     if _is_poi_label_layer_id(layer_id):
@@ -1115,6 +1155,123 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     if _is_settlement_minor_label_layer_id(layer_id):
         return _SETTLEMENT_MINOR_LABEL_LAYER_ID
     return str(layer_id or "")
+
+
+def _is_regional_major_road_width_variant(layer_id: object) -> bool:
+    return _regional_major_road_width_base_layer_id(layer_id) is not None
+
+
+def _regional_major_road_width_scale(layer_id: object) -> float:
+    base_layer_id = base_mapbox_style_layer_id_for_qfit(layer_id)
+    if base_layer_id in _REGIONAL_CORE_ROAD_WIDTH_LAYER_IDS:
+        return _REGIONAL_CORE_ROAD_WIDTH_QGIS_SCALE
+    return _REGIONAL_MAJOR_ROAD_WIDTH_QGIS_SCALE
+
+
+def _regional_major_road_min_width_mm(layer_id: object) -> float:
+    base_layer_id = base_mapbox_style_layer_id_for_qfit(layer_id)
+    if base_layer_id in _REGIONAL_CORE_ROAD_WIDTH_LAYER_IDS:
+        return _REGIONAL_CORE_ROAD_MIN_WIDTH_MM
+    return _REGIONAL_MAJOR_ROAD_MIN_WIDTH_MM
+
+
+def _effective_zoom_band(
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+) -> tuple[float | None, float | None] | None:
+    effective_minzoom = existing_minzoom
+    if band_minzoom is not None:
+        effective_minzoom = (
+            max(existing_minzoom, band_minzoom)
+            if existing_minzoom is not None
+            else band_minzoom
+        )
+
+    effective_maxzoom = existing_maxzoom
+    if band_maxzoom is not None:
+        effective_maxzoom = (
+            min(existing_maxzoom, band_maxzoom)
+            if existing_maxzoom is not None
+            else band_maxzoom
+        )
+
+    if effective_minzoom is not None and effective_maxzoom is not None and effective_minzoom >= effective_maxzoom:
+        return None
+    return effective_minzoom, effective_maxzoom
+
+
+def _set_zoom_bounds(layer: dict[str, object], minzoom: float | None, maxzoom: float | None) -> None:
+    if minzoom is None:
+        layer.pop("minzoom", None)
+    else:
+        layer["minzoom"] = minzoom
+    if maxzoom is None:
+        layer.pop("maxzoom", None)
+    else:
+        layer["maxzoom"] = maxzoom
+
+
+def _regional_major_road_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split z3-z12 major road strokes so regional views keep Mapbox widths."""
+    base_layer_id = base_mapbox_style_layer_id_for_qfit(layer.get("id"))
+    if base_layer_id not in _REGIONAL_MAJOR_ROAD_WIDTH_LAYER_IDS or layer.get("type") != "line":
+        return None
+    paint = layer.get("paint")
+    if not isinstance(paint, dict) or not any(
+        isinstance(paint.get(prop), list) for prop in _REGIONAL_MAJOR_ROAD_STROKE_WIDTH_PROPS
+    ):
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    if existing_minzoom is not None and existing_minzoom >= _REGIONAL_MAJOR_ROAD_WIDTH_HIGH_ZOOM_MIN:
+        return None
+    if (
+        existing_minzoom is not None
+        and existing_maxzoom is not None
+        and existing_maxzoom <= existing_minzoom
+    ):
+        return None
+
+    variants: list[dict[str, object]] = []
+    layer_id = str(layer.get("id") or base_layer_id)
+    for suffix, band_minzoom, band_maxzoom in _REGIONAL_MAJOR_ROAD_WIDTH_BANDS:
+        zoom_band = _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom)
+        if zoom_band is None:
+            continue
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        _set_zoom_bounds(variant, *zoom_band)
+        variants.append(variant)
+
+    high_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        _REGIONAL_MAJOR_ROAD_WIDTH_HIGH_ZOOM_MIN,
+        None,
+    )
+    if not variants:
+        return None
+    if high_zoom_band is not None:
+        high_zoom_variant = copy.deepcopy(layer)
+        _set_zoom_bounds(high_zoom_variant, *high_zoom_band)
+        variants.append(high_zoom_variant)
+    return variants
+
+
+def _split_regional_major_road_width_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _regional_major_road_width_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
 
 
 def _has_settlement_dot_icon_expression(layer: dict[str, object]) -> bool:
@@ -2211,6 +2368,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     simplified.  Literal strings (``hsl(...)``, ``#rrggbb``) are kept as-is.
     """
     style = copy.deepcopy(style_definition)
+    style["layers"] = _split_regional_major_road_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _expand_road_number_shield_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
@@ -2332,10 +2490,26 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                     if fallback is not None:
                         props[prop] = fallback
                 elif prop in _WIDTH_PROPS:
-                    width = _extract_midrange_size(val)
+                    width = None
+                    is_regional_road_width_variant = (
+                        prop in _REGIONAL_MAJOR_ROAD_STROKE_WIDTH_PROPS
+                        and _is_regional_major_road_width_variant(layer_id)
+                    )
+                    if is_regional_road_width_variant:
+                        width = _extract_zoom_scalar_size(
+                            val,
+                            minzoom=layer.get("minzoom"),
+                            maxzoom=layer.get("maxzoom"),
+                        )
+                    if width is None:
+                        width = _extract_midrange_size(val)
                     if width is not None:
+                        if is_regional_road_width_variant:
+                            width *= _regional_major_road_width_scale(layer_id)
                         # Convert px → mm (96 DPI) and clamp to sane range
                         width_mm = width * 25.4 / 96.0
+                        if is_regional_road_width_variant and prop == "line-width":
+                            width_mm = max(width_mm, _regional_major_road_min_width_mm(layer_id))
                         props[prop] = max(0.1, min(width_mm, _MAX_LINE_WIDTH_MM))
                 elif prop == "line-dasharray":
                     dasharray = _extract_line_dasharray_literal(val)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -451,6 +451,238 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         width = result["layers"][0]["paint"]["line-width"]
         self.assertEqual(width, 3.0)
 
+    def test_regional_major_road_widths_are_split_by_zoom_band(self):
+        zoom_width = ["interpolate", ["linear"], ["zoom"], 3, 1, 5, 3, 6, 4, 12, 10]
+        zoom_filter = [
+            "step",
+            ["zoom"],
+            ["==", ["get", "class"], "motorway"],
+            5,
+            ["all", ["==", ["get", "class"], "motorway"], ["==", ["get", "structure"], "none"]],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "road-motorway-trunk",
+                    "type": "line",
+                    "minzoom": 3,
+                    "filter": zoom_filter,
+                    "paint": {"line-width": zoom_width},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layers = result["layers"]
+        self.assertEqual(
+            [layer["id"] for layer in layers],
+            [
+                "road-motorway-trunk-z3-to-z5",
+                "road-motorway-trunk-z5-to-z6",
+                "road-motorway-trunk-z6-to-z9",
+                "road-motorway-trunk-z9-to-z12",
+                "road-motorway-trunk",
+            ],
+        )
+        self.assertEqual((layers[0]["minzoom"], layers[0]["maxzoom"]), (3.0, 5.0))
+        self.assertEqual((layers[1]["minzoom"], layers[1]["maxzoom"]), (5.0, 6.0))
+        self.assertEqual((layers[2]["minzoom"], layers[2]["maxzoom"]), (6.0, 9.0))
+        self.assertEqual((layers[3]["minzoom"], layers[3]["maxzoom"]), (9.0, 12.0))
+        self.assertEqual(layers[4]["minzoom"], 12.0)
+        self.assertNotIn("maxzoom", layers[4])
+        self.assertAlmostEqual(layers[0]["paint"]["line-width"], 3 * 2.1 * 25.4 / 96.0)
+        self.assertAlmostEqual(layers[1]["paint"]["line-width"], 4 * 2.1 * 25.4 / 96.0)
+        self.assertEqual(layers[2]["paint"]["line-width"], 3.0)
+        self.assertEqual(layers[3]["paint"]["line-width"], 3.0)
+        self.assertAlmostEqual(layers[4]["paint"]["line-width"], 10 * 25.4 / 96.0)
+        self.assertEqual(layers[0]["filter"], ["==", ["get", "class"], "motorway"])
+        self.assertEqual(
+            layers[1]["filter"],
+            ["all", ["==", ["get", "class"], "motorway"], ["==", ["get", "structure"], "none"]],
+        )
+        for layer in layers[2:]:
+            self.assertEqual(layer["filter"], layers[1]["filter"])
+
+    def test_regional_primary_road_width_is_split_from_layer_minzoom(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-primary",
+                    "type": "line",
+                    "minzoom": 6,
+                    "paint": {"line-width": ["interpolate", ["linear"], ["zoom"], 6, 2, 9, 5, 12, 8]},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layers = result["layers"]
+        self.assertEqual(
+            [layer["id"] for layer in layers],
+            ["road-primary-z6-to-z9", "road-primary-z9-to-z12", "road-primary"],
+        )
+        self.assertEqual((layers[0]["minzoom"], layers[0]["maxzoom"]), (6.0, 9.0))
+        self.assertEqual((layers[1]["minzoom"], layers[1]["maxzoom"]), (9.0, 12.0))
+        self.assertEqual(layers[2]["minzoom"], 12.0)
+        self.assertAlmostEqual(layers[0]["paint"]["line-width"], 5 * 2.1 * 25.4 / 96.0)
+        self.assertEqual(layers[1]["paint"]["line-width"], 3.0)
+        self.assertAlmostEqual(layers[2]["paint"]["line-width"], 8 * 25.4 / 96.0)
+
+    def test_regional_secondary_road_width_uses_lower_qgis_scale(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-secondary-tertiary",
+                    "type": "line",
+                    "minzoom": 9,
+                    "paint": {"line-width": ["interpolate", ["linear"], ["zoom"], 9, 2, 12, 4]},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layers = result["layers"]
+        self.assertEqual(
+            [layer["id"] for layer in layers],
+            ["road-secondary-tertiary-z9-to-z12", "road-secondary-tertiary"],
+        )
+        self.assertAlmostEqual(layers[0]["paint"]["line-width"], 4 * 1.3 * 25.4 / 96.0)
+        self.assertAlmostEqual(layers[1]["paint"]["line-width"], 4 * 25.4 / 96.0)
+
+    def test_regional_road_width_split_preserves_layers_that_end_before_z12(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-primary",
+                    "type": "line",
+                    "minzoom": 6,
+                    "maxzoom": 10,
+                    "paint": {"line-width": ["interpolate", ["linear"], ["zoom"], 6, 2, 9, 5, 12, 8]},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layers = result["layers"]
+        self.assertEqual(
+            [layer["id"] for layer in layers],
+            ["road-primary-z6-to-z9", "road-primary-z9-to-z12"],
+        )
+        self.assertEqual((layers[0]["minzoom"], layers[0]["maxzoom"]), (6.0, 9.0))
+        self.assertEqual((layers[1]["minzoom"], layers[1]["maxzoom"]), (9.0, 10.0))
+        self.assertAlmostEqual(layers[0]["paint"]["line-width"], 5 * 2.1 * 25.4 / 96.0)
+        self.assertEqual(layers[1]["paint"]["line-width"], 3.0)
+
+    def test_regional_road_width_split_treats_missing_minzoom_as_open_lower_bound(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-motorway-trunk",
+                    "type": "line",
+                    "paint": {"line-width": ["interpolate", ["linear"], ["zoom"], 0, 1, 5, 3, 12, 10]},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layers = result["layers"]
+        self.assertEqual(
+            [layer["id"] for layer in layers],
+            [
+                "road-motorway-trunk-z3-to-z5",
+                "road-motorway-trunk-z5-to-z6",
+                "road-motorway-trunk-z6-to-z9",
+                "road-motorway-trunk-z9-to-z12",
+                "road-motorway-trunk",
+            ],
+        )
+        self.assertNotIn("minzoom", layers[0])
+        self.assertEqual(layers[0]["maxzoom"], 5.0)
+        self.assertAlmostEqual(layers[0]["paint"]["line-width"], 3 * 2.1 * 25.4 / 96.0)
+
+    def test_regional_road_width_split_does_not_floor_line_offset(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-primary",
+                    "type": "line",
+                    "minzoom": 6,
+                    "paint": {
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 6, 2, 12, 4],
+                        "line-offset": ["interpolate", ["linear"], ["zoom"], 6, 0, 12, 0],
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layers = result["layers"]
+        self.assertAlmostEqual(layers[0]["paint"]["line-width"], 3 * 2.1 * 25.4 / 96.0)
+        self.assertEqual(layers[0]["paint"]["line-offset"], 0.1)
+
+    def test_regional_road_width_split_does_not_floor_line_gap_width(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-motorway-trunk-case",
+                    "type": "line",
+                    "minzoom": 3,
+                    "paint": {
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 1, 12, 4],
+                        "line-gap-width": ["interpolate", ["linear"], ["zoom"], 3, 0, 5, 1, 12, 4],
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layers = result["layers"]
+        self.assertGreater(layers[0]["paint"]["line-width"], 0.6)
+        self.assertAlmostEqual(layers[0]["paint"]["line-gap-width"], 1 * 2.1 * 25.4 / 96.0)
+
+    def test_regional_major_road_case_gap_width_uses_split_zoom_band(self):
+        style = {
+            "layers": [
+                {
+                    "id": "road-motorway-trunk-case",
+                    "type": "line",
+                    "minzoom": 3,
+                    "paint": {
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 14, 1, 22, 2],
+                        "line-gap-width": ["interpolate", ["linear"], ["zoom"], 3, 1, 6, 4, 12, 10],
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layers = result["layers"]
+        self.assertEqual(
+            [layer["id"] for layer in layers],
+            [
+                "road-motorway-trunk-case-z3-to-z5",
+                "road-motorway-trunk-case-z5-to-z6",
+                "road-motorway-trunk-case-z6-to-z9",
+                "road-motorway-trunk-case-z9-to-z12",
+                "road-motorway-trunk-case",
+            ],
+        )
+        self.assertAlmostEqual(layers[0]["paint"]["line-gap-width"], 3 * 2.1 * 25.4 / 96.0)
+        self.assertAlmostEqual(layers[1]["paint"]["line-gap-width"], 4 * 2.1 * 25.4 / 96.0)
+        self.assertEqual(layers[2]["paint"]["line-gap-width"], 3.0)
+        self.assertEqual(layers[3]["paint"]["line-gap-width"], 3.0)
+        self.assertAlmostEqual(layers[4]["paint"]["line-gap-width"], 10 * 25.4 / 96.0)
+        for layer in layers[:4]:
+            self.assertEqual(layer["paint"]["line-width"], 0.6)
+
     def test_full_line_opacity_expressions_simplify_to_scalar_default(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

Part of #949.

This PR keeps Mapbox Outdoors regional road widths zoom-aware in QGIS instead of collapsing major road strokes to the z12-style scalar at low and regional zooms.

- split `road-motorway-trunk`, `road-primary`, and `road-secondary-tertiary` stroke/casing layers into z3–z5, z5–z6, z6–z9, z9–z12, and z12+ variants
- resolve zoom-only `line-width` / `line-gap-width` expressions against each variant's zoom range, including layers whose source `maxzoom` ends before z12 or whose `minzoom` is omitted
- preserve stronger motorway/trunk/primary hierarchy while keeping secondary/tertiary roads thinner to reduce the z8–z10 white-road mesh
- avoid applying the regional width scale/minimum to `line-offset`, and avoid applying the minimum floor to `line-gap-width`, so split variants do not introduce spurious displacement or artificial casing gaps
- keep the high-zoom z12+ behavior unchanged

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 106 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2015 passed, 163 skipped, 135 subtests passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T052908Z/audit.md`
  - Raw style warnings: 159
  - After qfit preprocessing: 624
  - QGIS parser probe: 205 accepted / 0 rejected
  - Sprite context warnings: 0
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T052932Z/summary.md`
- Before/after visual contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260515T052932Z/regional-road-widths-before-after-qgis.jpg`

## Visual notes

Compared with the #1047 baseline (`20260515T042514Z`), the live comparison improved the road-heavy regional cameras without changing z14/z18 metrics:

| Camera | Baseline Mean Δ / RMS Δ | This PR Mean Δ / RMS Δ |
| --- | ---: | ---: |
| z5 Switzerland Alps | 0.1080 / 0.1480 | 0.1059 / 0.1457 |
| z8 Valais/Geneva | 0.1111 / 0.1424 | 0.1098 / 0.1400 |
| z10 Lausanne/Lavaux | 0.0791 / 0.1167 | 0.0765 / 0.1125 |

Manual visual QA on the contact sheet: the z8–z10 road web is noticeably less dominant while motorway/trunk/primary routes remain distinguishable. Low-zoom roads are still a bit subdued versus Mapbox GL, but there was no obvious regression severe enough to block this focused slice.

## Review follow-up

- Addressed Codex/Greptile P2 by returning accumulated regional variants even when a source layer has no z12+ high-zoom tail.
- Addressed Greptile P2 by limiting the regional scale/minimum to `line-width` and `line-gap-width`, not `line-offset`.
- Addressed Codex P2 by treating omitted `minzoom` as an open lower bound for targeted road splits, while avoiding splits for layers without width/gap expressions.
- Addressed Codex P2 by applying the regional minimum floor only to actual `line-width`, not `line-gap-width`.
