### PR TITLE
Simplify Mapbox transit label layout matches

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -60,6 +60,7 @@ DEFAULT_MAPBOX_MIN_ZOOM = 0
 DEFAULT_MAPBOX_MAX_ZOOM = 22
 QGIS_TEXT_FONT_FALLBACK = "Noto Sans"
 _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE = object()
+_LAYOUT_SIMPLIFICATION_NOT_AVAILABLE = object()
 _ICON_IMAGE_EMPTY_MATCH_FALLBACKS_BY_LAYER = {
     "gate-label": "gate",
 }
@@ -194,6 +195,22 @@ _POI_LABEL_MAKI_ICON_VALUES = (
 _ROAD_NUMBER_SHIELD_LAYER_ID = "road-number-shield"
 _ROAD_EXIT_SHIELD_LAYER_ID = "road-exit-shield"
 _ROAD_EXIT_SHIELD_ICON_IMAGE = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
+_TRANSIT_LABEL_LAYER_ID = "transit-label"
+_TRANSIT_LABEL_STOP_TYPE_EXCLUSION = ["!=", ["get", "stop_type"], "entrance"]
+_TRANSIT_LABEL_ENTRANCE_TEXT_ANCHOR = ["match", ["get", "stop_type"], "entrance", "left", "top"]
+_TRANSIT_LABEL_ENTRANCE_TEXT_JUSTIFY = ["match", ["get", "stop_type"], "entrance", "left", "center"]
+_TRANSIT_LABEL_ENTRANCE_TEXT_OFFSET = [
+    "match",
+    ["get", "stop_type"],
+    "entrance",
+    ["literal", [1, 0]],
+    ["literal", [0, 0.8]],
+]
+_TRANSIT_LABEL_NON_ENTRANCE_LAYOUT_VALUES = {
+    "text-anchor": (_TRANSIT_LABEL_ENTRANCE_TEXT_ANCHOR, "top"),
+    "text-justify": (_TRANSIT_LABEL_ENTRANCE_TEXT_JUSTIFY, "center"),
+    "text-offset": (_TRANSIT_LABEL_ENTRANCE_TEXT_OFFSET, [0, 0.8]),
+}
 _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN = {
     2: (
         "al-motorway",
@@ -875,6 +892,31 @@ def _with_additional_filter_clauses(filter_value: object, *clauses: object) -> o
     if isinstance(filter_copy, list):
         return ["all", filter_copy, *(copy.deepcopy(clause) for clause in clauses)]
     return ["all", *(copy.deepcopy(clause) for clause in clauses)]
+
+
+def _filter_contains_clause(filter_value: object, clause: object) -> bool:
+    if filter_value == clause:
+        return True
+    if isinstance(filter_value, list) and filter_value[:1] == ["all"]:
+        return any(_filter_contains_clause(child, clause) for child in filter_value[1:])
+    return False
+
+
+def _transit_label_non_entrance_layout_value(
+    prop: str,
+    value: object,
+    filter_value: object,
+) -> object:
+    """Collapse transit-label entrance layout matches when entrances are filtered out."""
+    if not _filter_contains_clause(filter_value, _TRANSIT_LABEL_STOP_TYPE_EXCLUSION):
+        return _LAYOUT_SIMPLIFICATION_NOT_AVAILABLE
+    expected = _TRANSIT_LABEL_NON_ENTRANCE_LAYOUT_VALUES.get(prop)
+    if expected is None:
+        return _LAYOUT_SIMPLIFICATION_NOT_AVAILABLE
+    expression, literal_value = expected
+    if value != expression:
+        return _LAYOUT_SIMPLIFICATION_NOT_AVAILABLE
+    return copy.deepcopy(literal_value)
 
 
 def _is_path_type_low_zoom_filter(value: object) -> bool:
@@ -2482,6 +2524,15 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                     icon_image = _road_exit_shield_icon_fallback(layer_id, val)
                     if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
                         props[prop] = icon_image
+                        continue
+                if section == "layout" and base_layer_id == _TRANSIT_LABEL_LAYER_ID:
+                    layout_value = _transit_label_non_entrance_layout_value(
+                        prop,
+                        val,
+                        layer.get("filter"),
+                    )
+                    if layout_value is not _LAYOUT_SIMPLIFICATION_NOT_AVAILABLE:
+                        props[prop] = layout_value
                         continue
                 if not isinstance(val, list):
                     continue

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1027,6 +1027,54 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertEqual(result["layers"][1]["layout"]["icon-image"], network_icon)
 
+    def test_transit_label_non_entrance_layout_is_literalized(self):
+        text_anchor = ["match", ["get", "stop_type"], "entrance", "left", "top"]
+        text_justify = ["match", ["get", "stop_type"], "entrance", "left", "center"]
+        text_offset = [
+            "match",
+            ["get", "stop_type"],
+            "entrance",
+            ["literal", [1, 0]],
+            ["literal", [0, 0.8]],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "transit-label",
+                    "filter": ["all", ["!=", ["get", "stop_type"], "entrance"]],
+                    "layout": {
+                        "text-anchor": text_anchor,
+                        "text-justify": text_justify,
+                        "text-offset": text_offset,
+                    },
+                },
+                {
+                    "id": "transit-label",
+                    "layout": {
+                        "text-anchor": copy.deepcopy(text_anchor),
+                        "text-justify": copy.deepcopy(text_justify),
+                        "text-offset": copy.deepcopy(text_offset),
+                    },
+                },
+                {
+                    "id": "poi-label",
+                    "filter": ["all", ["!=", ["get", "stop_type"], "entrance"]],
+                    "layout": {"text-anchor": copy.deepcopy(text_anchor)},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        transit_layout = result["layers"][0]["layout"]
+        self.assertEqual(transit_layout["text-anchor"], "top")
+        self.assertEqual(transit_layout["text-justify"], "center")
+        self.assertEqual(transit_layout["text-offset"], [0, 0.8])
+        self.assertEqual(result["layers"][1]["layout"]["text-anchor"], text_anchor)
+        self.assertEqual(result["layers"][1]["layout"]["text-justify"], text_justify)
+        self.assertEqual(result["layers"][1]["layout"]["text-offset"], text_offset)
+        self.assertEqual(result["layers"][2]["layout"]["text-anchor"], text_anchor)
+
     def test_road_exit_shield_concat_icon_uses_reflen_sprite_match_fallback(self):
         exit_icon = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
         other_concat_icon = ["concat", "motorway-exit-", ["get", "reflen"]]


### PR DESCRIPTION
## Summary

Part of #949.

This PR takes a small QGIS-safety slice for Mapbox Outdoors transit labels:

- when qfit's existing transit-label filter normalization excludes `stop_type=entrance`, collapse the remaining entrance/non-entrance layout matches to their literal non-entrance values
- convert `layout.text-anchor`, `layout.text-justify`, and `layout.text-offset` to QGIS-friendly literals for the simplified transit label layer
- leave the Mapbox expressions unchanged when the layer filter does not prove entrances are excluded, and leave other layers untouched

## Why

The live style audit showed `transit-label` as the only route overlay candidate still carrying QGIS-dependent text anchor/justify/offset expressions after preprocessing. Since qfit already normalizes the visible filter to exclude entrances at the representative z12 transit-label range, the entrance-specific layout branch is unreachable in the processed layer.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 107 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2016 passed, 163 skipped, 135 subtests passed
- `git diff --check` passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T054335Z/audit.md`
  - Raw style warnings: 159
  - After qfit preprocessing: 624
  - QGIS parser probe: 205 accepted / 0 rejected
  - Warnings with sprite context: 0
  - `transit-label` now reports qfit substitutions for `layout.text-anchor`, `layout.text-justify`, and `layout.text-offset`; remaining route-overlay QGIS-dependent control is `layout.icon-image`
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T054402Z/summary.md`
  - z5 Switzerland Alps: 0.1059 / 0.1457
  - z8 Valais/Geneva: 0.1098 / 0.1400
  - z10 Lausanne/Lavaux: 0.0765 / 0.1125
  - z14 Geneva airport: 0.0896 / 0.1308
  - z14 Chamonix trails: 0.1329 / 0.1726
  - z18 Zermatt trails: 0.0330 / 0.0882
