### PR TITLE
Prefer Mapbox airport names over short refs in QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -195,6 +195,7 @@ _POI_LABEL_MAKI_ICON_VALUES = (
 _ROAD_NUMBER_SHIELD_LAYER_ID = "road-number-shield"
 _ROAD_EXIT_SHIELD_LAYER_ID = "road-exit-shield"
 _ROAD_EXIT_SHIELD_ICON_IMAGE = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
+_AIRPORT_LABEL_LAYER_ID = "airport-label"
 _TRANSIT_LABEL_LAYER_ID = "transit-label"
 _TRANSIT_LABEL_STOP_TYPE_EXCLUSION = ["!=", ["get", "stop_type"], "entrance"]
 _TRANSIT_LABEL_ENTRANCE_TEXT_ANCHOR = ["match", ["get", "stop_type"], "entrance", "left", "top"]
@@ -2268,6 +2269,29 @@ def _prefer_generic_name_reference(references: list[object]) -> object | None:
     return references[0] if references else None
 
 
+def _prefer_airport_name_reference(references: list[object]) -> object | None:
+    for reference in references:
+        if _text_field_reference_name(reference) == "name":
+            return reference
+    for reference in references:
+        if _is_localized_name_reference(reference):
+            return reference
+    return None
+
+
+def _all_simple_text_field_references(expr: object) -> list[object]:
+    if isinstance(expr, dict):
+        return []
+    if _is_simple_text_field_reference(expr):
+        return [expr]
+    if not isinstance(expr, list):
+        return []
+    references: list[object] = []
+    for child in expr[1:]:
+        references.extend(_all_simple_text_field_references(child))
+    return references
+
+
 def _text_field_references_from_children(
     children: list[object],
     *,
@@ -2391,6 +2415,24 @@ def _simplify_text_field(expr: object) -> object:
             if isinstance(item, str) and item:
                 return item
     return expr
+
+
+def _simplify_airport_label_text_field(base_layer_id: str, expr: object) -> object | None:
+    """Keep airport labels name-first instead of collapsing to the short ref code."""
+    if (
+        base_layer_id != _AIRPORT_LABEL_LAYER_ID
+        or not isinstance(expr, list)
+        or len(expr) < 3
+        or expr[0] != "step"
+        or expr[1] != ["get", "sizerank"]
+    ):
+        return None
+    references: list[object] = []
+    for output in _text_field_output_candidates(expr):
+        references.extend(_all_simple_text_field_references(output))
+    if not any(_text_field_reference_name(reference) == "ref" for reference in references):
+        return None
+    return copy.deepcopy(_prefer_airport_name_reference(references))
 
 
 def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> dict[str, object]:
@@ -2582,7 +2624,8 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                     if opacity is not None and opacity > _FULL_OPACITY - _FULL_OPACITY_EPSILON:
                         props[prop] = _FULL_OPACITY
                 elif prop == "text-field":
-                    props[prop] = _simplify_text_field(val)
+                    airport_text_field = _simplify_airport_label_text_field(base_layer_id, val)
+                    props[prop] = airport_text_field if airport_text_field is not None else _simplify_text_field(val)
                 elif prop == "text-font" and _is_text_font_stack(val):
                     props[prop] = [QGIS_TEXT_FONT_FALLBACK]
                 elif prop == "text-size":

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2627,6 +2627,38 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "ref"])
 
+    def test_airport_label_text_field_prefers_name_over_ref_code(self):
+        airport_text_field = [
+            "step",
+            ["get", "sizerank"],
+            [
+                "case",
+                ["has", "ref"],
+                ["concat", ["get", "ref"], " -\n", ["coalesce", ["get", "name_en"], ["get", "name"]]],
+                ["coalesce", ["get", "name_en"], ["get", "name"]],
+            ],
+            15,
+            ["get", "ref"],
+        ]
+        updated_threshold_text_field = copy.deepcopy(airport_text_field)
+        updated_threshold_text_field[3] = 16
+        ref_only_text_field = ["step", ["get", "sizerank"], ["get", "ref"], 15, ["get", "ref"]]
+        style = {
+            "layers": [
+                {"id": "airport-label", "layout": {"text-field": airport_text_field}},
+                {"id": "airport-label", "layout": {"text-field": updated_threshold_text_field}},
+                {"id": "airport-label", "layout": {"text-field": ref_only_text_field}},
+                {"id": "poi-label", "layout": {"text-field": copy.deepcopy(airport_text_field)}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "name"])
+        self.assertEqual(result["layers"][1]["layout"]["text-field"], ["get", "name"])
+        self.assertEqual(result["layers"][2]["layout"]["text-field"], ["get", "ref"])
+        self.assertEqual(result["layers"][3]["layout"]["text-field"], ["get", "ref"])
+
     def test_case_text_field_expression_uses_label_output_not_condition(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

Part of #949.

This PR takes a small visual-parity slice for Mapbox Outdoors airport labels:

- recognize `airport-label` `sizerank` text-field expressions that include both a short `ref` branch and a name branch
- keep QGIS airport labels name-first by simplifying that expression to the best available airport name field instead of the generic simplifier's `ref` fallback
- keep the generic text-field simplification behavior unchanged for other layers and for airport expressions that do not expose an airport name branch

## Why

The Geneva airport z14 comparison showed Mapbox GL rendering the airport as a named airport label (`GVA` / `Geneva International Airport`) while the QGIS approximation had been vulnerable to collapsing the airport text-field to the short `ref` code. Since QGIS cannot preserve the full Mapbox `step/case/concat/coalesce` text expression safely, this layer-specific fallback keeps the label as a readable airport name rather than only the code.

## Review follow-up

- Greptile noted the first version matched the exact live expression too rigidly. The helper now detects the airport `sizerank`/`ref`/name shape instead of requiring byte-for-byte equality, so minor Mapbox threshold/fallback changes still use the name branch.
- Added regression coverage for both a changed threshold and an airport-label expression with only `ref` output, which must still fall back through the generic simplifier.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 108 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2017 passed, 163 skipped, 135 subtests passed
- `git diff --check` passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T062144Z/audit.md`
  - Raw style warnings: 159
  - After qfit preprocessing: 624
  - QGIS parser probe: 205 accepted / 0 rejected
  - Warnings with sprite context: 0
  - `airport-label` now reports `layout.text-field`: Mapbox `step/case/concat/coalesce` expression → `["get", "name"]` instead of `["get", "ref"]`
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T062210Z/summary.md`
  - z5 Switzerland Alps: 0.1059 / 0.1457
  - z8 Valais/Geneva: 0.1098 / 0.1400
  - z10 Lausanne/Lavaux: 0.0765 / 0.1125
  - z14 Geneva airport: 0.0896 / 0.1308
  - z14 Chamonix trails: 0.1329 / 0.1726
  - z18 Zermatt trails: 0.0330 / 0.0882
- Visual check: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260515T062159Z/qgis-vector-render.png` now shows a full airport name rather than relying on only a short airport code/ref; remaining differences include placement/localization and missing runway/airport styling parity.
