### PR TITLE
Drop Mapbox icon opacity when icons are removed

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2435,6 +2435,17 @@ def _simplify_airport_label_text_field(base_layer_id: str, expr: object) -> obje
     return copy.deepcopy(_prefer_airport_name_reference(references))
 
 
+def _drop_icon_opacity_without_icon_image(layer: dict[str, object]) -> None:
+    """Remove no-op icon opacity expressions after qfit drops an empty icon-image."""
+    paint = layer.get("paint")
+    if not isinstance(paint, dict) or "icon-opacity" not in paint:
+        return
+    layout = layer.get("layout")
+    if isinstance(layout, dict) and "icon-image" in layout:
+        return
+    del paint["icon-opacity"]
+
+
 def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> dict[str, object]:
     """Return a copy of a Mapbox style with expression-based colors replaced by
     literal fallback colors so QGIS' converter does not render them as black.
@@ -2665,6 +2676,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                     choice = _line_layout_choice(val, _LINE_LAYOUT_CHOICES[prop])
                     if choice is not None:
                         props[prop] = choice
+        _drop_icon_opacity_without_icon_image(layer)
     return style
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -895,6 +895,23 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][9]["layout"]["icon-image"], data_driven_high_zoom_step)
         self.assertEqual(result["layers"][10]["layout"]["icon-image"], empty_then_data_driven_high_zoom_step)
 
+    def test_icon_opacity_is_removed_when_icon_image_is_absent(self):
+        icon_opacity = ["step", ["zoom"], ["case", ["has", "text_anchor"], 1, 0], 7, 0]
+        style = {
+            "layers": [
+                {"layout": {"icon-image": ""}, "paint": {"icon-opacity": icon_opacity}},
+                {"layout": {"icon-image": "marker"}, "paint": {"icon-opacity": copy.deepcopy(icon_opacity)}},
+                {"paint": {"icon-opacity": copy.deepcopy(icon_opacity)}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertNotIn("icon-image", result["layers"][0]["layout"])
+        self.assertNotIn("icon-opacity", result["layers"][0]["paint"])
+        self.assertEqual(result["layers"][1]["paint"]["icon-opacity"], icon_opacity)
+        self.assertNotIn("icon-opacity", result["layers"][2]["paint"])
+
     def test_gate_label_icon_match_uses_existing_sprite_fallback(self):
         gate_icon = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]
         generic_empty_fallback = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]


### PR DESCRIPTION
## Summary

Part of #949.

This PR takes a small audit-backed cleanup for Mapbox Outdoors symbol layers:

- after qfit removes an empty `layout.icon-image`, also remove `paint.icon-opacity`
- keep `paint.icon-opacity` unchanged when a layer still has an icon image
- add regression coverage for both paths

## Why

The live audit showed `country-label` still handing QGIS a data-driven `paint.icon-opacity` expression even though qfit had already removed its empty `layout.icon-image`. Since `icon-opacity` only affects icons, keeping it after the icon image is absent is a no-op that leaves QGIS with unnecessary unsupported expression work.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 109 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2018 passed, 163 skipped, 135 subtests passed
- `git diff --check` passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T063120Z/audit.md`
  - Raw style warnings: 159
  - After qfit preprocessing: 624
  - QGIS parser probe: 205 accepted / 0 rejected
  - Warnings with sprite context: 0
  - `country-label` now reports `paint.icon-opacity`: Mapbox `step/case` expression → absent, alongside the existing `layout.icon-image`: `""` → absent
  - Remaining `paint.icon-opacity` warnings are for layers that still have icon images (`natural-point-label`, `poi-label`)
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T063143Z/summary.md`
  - z5 Switzerland Alps: 0.1059 / 0.1457
  - z8 Valais/Geneva: 0.1098 / 0.1400
  - z10 Lausanne/Lavaux: 0.0765 / 0.1125
  - z14 Geneva airport: 0.0896 / 0.1308
  - z14 Chamonix trails: 0.1329 / 0.1726
  - z18 Zermatt trails: 0.0330 / 0.0882
