### PR TITLE
Simplify Mapbox line blur expressions for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -58,6 +58,8 @@ DEFAULT_MAPBOX_TILE_PIXEL_RATIO = 2
 WEB_MERCATOR_WORLD_WIDTH_M = 40075016.685578488
 DEFAULT_MAPBOX_MIN_ZOOM = 0
 DEFAULT_MAPBOX_MAX_ZOOM = 22
+_MAPBOX_PIXEL_TO_MM = 25.4 / 96.0
+_MAX_LINE_WIDTH_MM = 3.0  # ~11px at 96 DPI — sane max for cartographic lines and blur widths
 QGIS_TEXT_FONT_FALLBACK = "Noto Sans"
 _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE = object()
 _LAYOUT_SIMPLIFICATION_NOT_AVAILABLE = object()
@@ -2446,6 +2448,14 @@ def _drop_icon_opacity_without_icon_image(layer: dict[str, object]) -> None:
     del paint["icon-opacity"]
 
 
+def _line_blur_width_mm(expr: object, *, minzoom: object = None, maxzoom: object = None) -> float | None:
+    """Return a representative QGIS line-blur width in millimetres."""
+    blur_px = _extract_zoom_scalar_size(expr, minzoom=minzoom, maxzoom=maxzoom)
+    if blur_px is None:
+        return None
+    return max(0.0, min(blur_px * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM))
+
+
 def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> dict[str, object]:
     """Return a copy of a Mapbox style with expression-based colors replaced by
     literal fallback colors so QGIS' converter does not render them as black.
@@ -2479,7 +2489,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     # QGIS may pick a large stop and produce QPen::setWidthF warnings.
     # We extract a z12-representative value and cap to a sane maximum.
     _WIDTH_PROPS = {"line-width", "line-gap-width", "line-offset"}
-    _MAX_LINE_WIDTH_MM = 3.0  # ~11px at 96 DPI — sane max for cartographic lines
+    _LINE_BLUR_PROPS = {"line-blur"}
     _LINE_LAYOUT_CHOICES = {
         "line-cap": {"butt", "round", "square"},
         "line-join": {"bevel", "round", "miter"},
@@ -2611,10 +2621,18 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         if is_regional_road_width_variant:
                             width *= _regional_major_road_width_scale(layer_id)
                         # Convert px → mm (96 DPI) and clamp to sane range
-                        width_mm = width * 25.4 / 96.0
+                        width_mm = width * _MAPBOX_PIXEL_TO_MM
                         if is_regional_road_width_variant and prop == "line-width":
                             width_mm = max(width_mm, _regional_major_road_min_width_mm(layer_id))
                         props[prop] = max(0.1, min(width_mm, _MAX_LINE_WIDTH_MM))
+                elif prop in _LINE_BLUR_PROPS:
+                    blur_width_mm = _line_blur_width_mm(
+                        val,
+                        minzoom=layer.get("minzoom"),
+                        maxzoom=layer.get("maxzoom"),
+                    )
+                    if blur_width_mm is not None:
+                        props[prop] = blur_width_mm
                 elif prop == "line-dasharray":
                     dasharray = _extract_line_dasharray_literal(val)
                     if dasharray is not None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -840,6 +840,26 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][2]["paint"]["fill-opacity"], partial_case)
         self.assertEqual(result["layers"][3]["paint"]["fill-opacity"], property_expression)
 
+    def test_line_blur_zoom_expression_uses_representative_mm_width(self):
+        blur_expression = ["interpolate", ["linear"], ["zoom"], 3, 0, 12, 3]
+        data_driven_blur = ["get", "blur"]
+        mixed_data_blur = ["interpolate", ["linear"], ["zoom"], 3, ["get", "blur"], 12, 3]
+        style = {
+            "layers": [
+                {"minzoom": 7, "paint": {"line-blur": blur_expression}},
+                {"paint": {"line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 12, 20]}},
+                {"paint": {"line-blur": data_driven_blur}},
+                {"paint": {"line-blur": mixed_data_blur}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertAlmostEqual(result["layers"][0]["paint"]["line-blur"], 3 * 25.4 / 96.0)
+        self.assertEqual(result["layers"][1]["paint"]["line-blur"], 3.0)
+        self.assertEqual(result["layers"][2]["paint"]["line-blur"], data_driven_blur)
+        self.assertEqual(result["layers"][3]["paint"]["line-blur"], mixed_data_blur)
+
     def test_icon_image_placeholders_and_literal_zoom_steps_are_simplified(self):
         empty_output_step = ["step", ["zoom"], "dot-11", 8, ""]
         empty_representative_step = ["step", ["zoom"], ["case", ["==", ["get", "capital"], 2], "dot-11", "dot-9"], 8, ""]


### PR DESCRIPTION
## Summary

Part of #949.

This PR takes a small audit-backed Mapbox Outdoors style simplification slice:

- collapse zoom-only `paint.line-blur` expressions to representative scalar QGIS widths
- use the same Mapbox px → QGIS mm conversion and shared max-width cap already used for line widths
- keep data-driven and mixed data-driven `line-blur` expressions unchanged
- add regression coverage for representative conversion, clamping, data-driven fallback, and mixed data-driven fallback

## Why

The live style audit still showed three zoom-only `paint.line-blur` expressions being handed to QGIS after qfit preprocessing: `national-park_tint-band`, `admin-1-boundary-bg`, and `admin-0-boundary-bg`. These are simple zoom ramps and can be safely reduced to scalar QGIS values for the representative layer zoom, avoiding unsupported expression handling without changing filters or layer structure.

## Review follow-up

- Codex noted that the first version's fallback could collapse mixed data-driven expressions if a later zoom stop was numeric. The helper now only simplifies expressions accepted by `_extract_zoom_scalar_size`, which requires zoom-only numeric outputs, and the test covers a mixed `['get', 'blur']`/numeric expression staying unchanged.
- Greptile noted the line-blur cap duplicated the local line-width cap. The max line width/blur cap is now a shared module-level constant used by both paths.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 110 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2019 passed, 163 skipped, 135 subtests passed
- `git diff --check` passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T065318Z/audit.md`
  - Raw style warnings: 159
  - After qfit preprocessing: 624
  - QGIS parser probe: 205 accepted / 0 rejected
  - Warnings with sprite context: 0
  - `national-park_tint-band` `paint.line-blur`: Mapbox zoom interpolate → `0.931684439178515`
  - `admin-1-boundary-bg` `paint.line-blur`: Mapbox zoom interpolate → `0.79375`
  - `admin-0-boundary-bg` `paint.line-blur`: Mapbox zoom interpolate → `0.5291666666666667`
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T065341Z/summary.md`
  - z5 Switzerland Alps: 0.1059 / 0.1457
  - z8 Valais/Geneva: 0.1098 / 0.1400
  - z10 Lausanne/Lavaux: 0.0765 / 0.1125
  - z14 Geneva airport: 0.0896 / 0.1308
  - z14 Chamonix trails: 0.1329 / 0.1726
  - z18 Zermatt trails: 0.0330 / 0.0882
