### PR TITLE
Simplify boundary background opacity for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -197,6 +197,7 @@ _POI_LABEL_MAKI_ICON_VALUES = (
 _ROAD_NUMBER_SHIELD_LAYER_ID = "road-number-shield"
 _ROAD_EXIT_SHIELD_LAYER_ID = "road-exit-shield"
 _ROAD_EXIT_SHIELD_ICON_IMAGE = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
+_BOUNDARY_BG_LINE_OPACITY_LAYER_IDS = {"admin-0-boundary-bg", "admin-1-boundary-bg"}
 _AIRPORT_LABEL_LAYER_ID = "airport-label"
 _TRANSIT_LABEL_LAYER_ID = "transit-label"
 _TRANSIT_LABEL_STOP_TYPE_EXCLUSION = ["!=", ["get", "stop_type"], "entrance"]
@@ -2456,6 +2457,21 @@ def _line_blur_width_mm(expr: object, *, minzoom: object = None, maxzoom: object
     return max(0.0, min(blur_px * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM))
 
 
+def _boundary_bg_line_opacity(
+    base_layer_id: str,
+    prop: str,
+    expr: object,
+    *,
+    minzoom: object = None,
+    maxzoom: object = None,
+) -> float | None:
+    """Return a representative scalar opacity for admin boundary background lines."""
+    if base_layer_id not in _BOUNDARY_BG_LINE_OPACITY_LAYER_IDS or prop != "line-opacity":
+        return None
+    opacity = _extract_zoom_scalar_size(expr, minzoom=minzoom, maxzoom=maxzoom)
+    return _clamp_opacity_value(opacity)
+
+
 def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> dict[str, object]:
     """Return a copy of a Mapbox style with expression-based colors replaced by
     literal fallback colors so QGIS' converter does not render them as black.
@@ -2638,6 +2654,16 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                     if dasharray is not None:
                         props[prop] = dasharray
                 elif prop in _FULL_OPACITY_PROPS:
+                    boundary_bg_opacity = _boundary_bg_line_opacity(
+                        base_layer_id,
+                        prop,
+                        val,
+                        minzoom=layer.get("minzoom"),
+                        maxzoom=layer.get("maxzoom"),
+                    )
+                    if boundary_bg_opacity is not None:
+                        props[prop] = boundary_bg_opacity
+                        continue
                     visibility_minzoom = _zoom_step_full_opacity_minzoom(
                         val,
                         minzoom=layer.get("minzoom"),

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -840,6 +840,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][2]["paint"]["fill-opacity"], partial_case)
         self.assertEqual(result["layers"][3]["paint"]["fill-opacity"], property_expression)
 
+    def test_boundary_bg_line_opacity_zoom_expression_uses_scalar(self):
+        boundary_opacity = ["interpolate", ["linear"], ["zoom"], 7, 0, 8, 0.5]
+        mixed_opacity = ["interpolate", ["linear"], ["zoom"], 7, ["get", "opacity"], 8, 0.5]
+        style = {
+            "layers": [
+                {"id": "admin-1-boundary-bg", "minzoom": 7, "paint": {"line-opacity": boundary_opacity}},
+                {"id": "admin-0-boundary-bg", "paint": {"line-opacity": ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.5]}},
+                {"id": "admin-1-boundary", "minzoom": 7, "paint": {"line-opacity": copy.deepcopy(boundary_opacity)}},
+                {"id": "admin-1-boundary-bg", "minzoom": 7, "paint": {"line-opacity": mixed_opacity}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["paint"]["line-opacity"], 0.5)
+        self.assertEqual(result["layers"][1]["paint"]["line-opacity"], 0.5)
+        self.assertEqual(result["layers"][2]["paint"]["line-opacity"], boundary_opacity)
+        self.assertEqual(result["layers"][3]["paint"]["line-opacity"], mixed_opacity)
+
     def test_line_blur_zoom_expression_uses_representative_mm_width(self):
         blur_expression = ["interpolate", ["linear"], ["zoom"], 3, 0, 12, 3]
         data_driven_blur = ["get", "blur"]


### PR DESCRIPTION
## Summary

Part of #949.

This PR takes a small audit-backed Mapbox Outdoors style simplification slice:

- collapse zoom-only `paint.line-opacity` ramps on `admin-0-boundary-bg` and `admin-1-boundary-bg` to representative scalar QGIS opacities
- limit the behavior to boundary background layers, where the audit shows simple zoom-only fade-in ramps
- leave foreground boundary opacity and mixed/data-driven opacity expressions unchanged
- add regression coverage for both simplified boundary background ramps and the guarded unchanged cases

## Why

After the line-blur slice, the live audit still showed the boundary background line opacity ramps being handed to QGIS as Mapbox expressions. These two background layers use simple zoom-only fade-ins that are already fully visible at the representative rendering zoom, so scalarizing them to `0.5` removes unsupported expression handling without changing filters, layer structure, or foreground boundary semantics.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 111 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2020 passed, 163 skipped, 135 subtests passed
- `git diff --check` passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T070327Z/audit.md`
  - Raw style warnings: 159
  - After qfit preprocessing: 624
  - QGIS parser probe: 205 accepted / 0 rejected
  - Warnings with sprite context: 0
  - `admin-1-boundary-bg` `paint.line-opacity`: Mapbox zoom interpolate → `0.5`
  - `admin-0-boundary-bg` `paint.line-opacity`: Mapbox zoom interpolate → `0.5`
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T070353Z/summary.md`
  - z5 Switzerland Alps: 0.1059 / 0.1457
  - z8 Valais/Geneva: 0.1098 / 0.1400
  - z10 Lausanne/Lavaux: 0.0765 / 0.1125
  - z14 Geneva airport: 0.0896 / 0.1308
  - z14 Chamonix trails: 0.1329 / 0.1726
  - z18 Zermatt trails: 0.0330 / 0.0882
