### PR TITLE
Simplify high-zoom country label layout for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -563,6 +563,7 @@ _PATH_TYPE_FILTER_LOW_ZOOM_SIMPLIFIED_MATCH = [
 _PATH_TYPE_FILTER_SPLIT_ZOOM = 16.0
 _NATURAL_POINT_LABEL_LAYER_ID = "natural-point-label"
 _POI_LABEL_LAYER_ID = "poi-label"
+_COUNTRY_LABEL_LAYER_ID = "country-label"
 _SETTLEMENT_MAJOR_LABEL_LAYER_ID = "settlement-major-label"
 _SETTLEMENT_MINOR_LABEL_LAYER_ID = "settlement-minor-label"
 _POI_FILTER_RANK_ZOOM_STEP = ["step", ["zoom"], 0, 16, 1, 17, 2]
@@ -657,6 +658,27 @@ _SETTLEMENT_DOT_ICON_VARIANTS: tuple[tuple[str, object, str, float], ...] = (
         0.55,
     ),
     ("dot-9", ["all", ["!=", ["get", "capital"], 2], [">=", ["get", "symbolrank"], 11]], "dot-9", 0.55),
+)
+_COUNTRY_LABEL_LAYOUT_TEXT_JUSTIFY_EXPRESSION = [
+    "step",
+    ["zoom"],
+    [
+        "match",
+        ["get", "text_anchor"],
+        ["left", "bottom-left", "top-left"],
+        "left",
+        ["right", "bottom-right", "top-right"],
+        "right",
+        "center",
+    ],
+    7,
+    "auto",
+]
+_COUNTRY_LABEL_LAYOUT_TEXT_RADIAL_OFFSET_EXPRESSION = ["step", ["zoom"], 0.6, 8, 0]
+_COUNTRY_LABEL_LAYOUT_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float | None], ...] = (
+    ("below-z7", None, 7.0, None),
+    ("z7-to-z8", 7.0, 8.0, 0.6),
+    ("z8-plus", 8.0, None, 0.0),
 )
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
@@ -1164,6 +1186,11 @@ def _is_natural_point_label_layer_id(layer_id: object) -> bool:
     return normalized == _NATURAL_POINT_LABEL_LAYER_ID or normalized.startswith(f"{_NATURAL_POINT_LABEL_LAYER_ID}-")
 
 
+def _is_country_label_layer_id(layer_id: object) -> bool:
+    normalized = str(layer_id or "")
+    return normalized == _COUNTRY_LABEL_LAYER_ID or normalized.startswith(f"{_COUNTRY_LABEL_LAYER_ID}-")
+
+
 def _is_settlement_major_label_layer_id(layer_id: object) -> bool:
     normalized = str(layer_id or "")
     return normalized == _SETTLEMENT_MAJOR_LABEL_LAYER_ID or normalized.startswith(f"{_SETTLEMENT_MAJOR_LABEL_LAYER_ID}-")
@@ -1196,6 +1223,8 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
         return _POI_LABEL_LAYER_ID
     if _is_natural_point_label_layer_id(layer_id):
         return _NATURAL_POINT_LABEL_LAYER_ID
+    if _is_country_label_layer_id(layer_id):
+        return _COUNTRY_LABEL_LAYER_ID
     if _is_settlement_major_label_layer_id(layer_id):
         return _SETTLEMENT_MAJOR_LABEL_LAYER_ID
     if _is_settlement_minor_label_layer_id(layer_id):
@@ -1401,6 +1430,59 @@ def _split_settlement_dot_icon_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _settlement_dot_icon_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _has_country_label_layout_expression(layer: dict[str, object]) -> bool:
+    layout = layer.get("layout")
+    return (
+        base_mapbox_style_layer_id_for_qfit(layer.get("id")) == _COUNTRY_LABEL_LAYER_ID
+        and layer.get("type") == "symbol"
+        and isinstance(layout, dict)
+        and layout.get("text-justify") == _COUNTRY_LABEL_LAYOUT_TEXT_JUSTIFY_EXPRESSION
+        and layout.get("text-radial-offset") == _COUNTRY_LABEL_LAYOUT_TEXT_RADIAL_OFFSET_EXPRESSION
+    )
+
+
+def _set_country_label_static_layout(layer: dict[str, object], *, text_radial_offset: float) -> None:
+    layout = layer.get("layout")
+    if not isinstance(layout, dict):
+        return
+    layout["text-justify"] = "auto"
+    layout["text-radial-offset"] = text_radial_offset
+
+
+def _country_label_layout_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split country labels where zoom-only layout ramps become literal at z7+."""
+    if not _has_country_label_layout_expression(layer):
+        return None
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    layer_id = str(layer.get("id") or _COUNTRY_LABEL_LAYER_ID)
+    variants: list[dict[str, object]] = []
+    has_static_variant = False
+    for suffix, band_minzoom, band_maxzoom, text_radial_offset in _COUNTRY_LABEL_LAYOUT_ZOOM_BANDS:
+        if not _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom):
+            continue
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["id"] = f"{layer_id}-{suffix}"
+        if text_radial_offset is not None:
+            _set_country_label_static_layout(variant, text_radial_offset=text_radial_offset)
+            has_static_variant = True
+        variants.append(variant)
+    return variants if has_static_variant else None
+
+
+def _split_country_label_layout_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _country_label_layout_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -2495,6 +2577,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_settlement_dot_icon_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_country_label_layout_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1608,6 +1608,86 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertNotIn("icon-image", by_id["settlement-minor-label-z8-plus"]["layout"])
         self.assertEqual(by_id["settlement-minor-label-z8-plus"]["filter"][-1], town_filter)
 
+    def _country_label_layout(self):
+        return {
+            "icon-image": "",
+            "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+            "text-justify": [
+                "step",
+                ["zoom"],
+                [
+                    "match",
+                    ["get", "text_anchor"],
+                    ["left", "bottom-left", "top-left"],
+                    "left",
+                    ["right", "bottom-right", "top-right"],
+                    "right",
+                    "center",
+                ],
+                7,
+                "auto",
+            ],
+            "text-radial-offset": ["step", ["zoom"], 0.6, 8, 0],
+            "text-size": ["interpolate", ["linear"], ["zoom"], 1, 11, 9, 22],
+        }
+
+    def test_country_label_layout_splits_zoom_only_justification_and_offset(self):
+        style = {
+            "layers": [
+                {
+                    "id": "country-label",
+                    "type": "symbol",
+                    "minzoom": 1,
+                    "maxzoom": 10,
+                    "layout": self._country_label_layout(),
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 3)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_layer = by_id["country-label-below-z7"]
+        mid_layer = by_id["country-label-z7-to-z8"]
+        high_layer = by_id["country-label-z8-plus"]
+        self.assertEqual(low_layer["minzoom"], 1)
+        self.assertEqual(low_layer["maxzoom"], 7.0)
+        self.assertEqual(mid_layer["minzoom"], 7.0)
+        self.assertEqual(mid_layer["maxzoom"], 8.0)
+        self.assertEqual(high_layer["minzoom"], 8.0)
+        self.assertEqual(high_layer["maxzoom"], 10)
+        self.assertEqual(low_layer["layout"]["text-justify"], self._country_label_layout()["text-justify"])
+        self.assertEqual(low_layer["layout"]["text-radial-offset"], self._country_label_layout()["text-radial-offset"])
+        self.assertEqual(mid_layer["layout"]["text-justify"], "auto")
+        self.assertEqual(mid_layer["layout"]["text-radial-offset"], 0.6)
+        self.assertEqual(high_layer["layout"]["text-justify"], "auto")
+        self.assertEqual(high_layer["layout"]["text-radial-offset"], 0.0)
+        self.assertNotIn("icon-image", low_layer["layout"])
+        self.assertEqual({layer["layout"]["text-size"] for layer in result["layers"]}, {16.0})
+
+    def test_country_label_layout_is_not_split_when_shape_changes(self):
+        style = {
+            "layers": [
+                {
+                    "id": "country-label",
+                    "type": "symbol",
+                    "minzoom": 1,
+                    "maxzoom": 10,
+                    "layout": {
+                        **self._country_label_layout(),
+                        "text-radial-offset": ["get", "offset"],
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "country-label")
+        self.assertEqual(result["layers"][0]["layout"]["text-radial-offset"], ["get", "offset"])
+
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [
             "all",


### PR DESCRIPTION
## Summary

Part of #949.

This PR takes a small audit-backed Mapbox Outdoors style simplification slice:

- split `country-label` at the zoom stops where its layout expressions become static
- keep the low-zoom data-driven `text_anchor` layout unchanged
- use literal QGIS-safe `text-justify` / `text-radial-offset` values for the z7–z8 and z8+ country-label bands
- preserve the existing country text-size override for the new layer variants
- add regression coverage for the split, static high-zoom values, and shape-guard fallback

## Why

The latest live audit still showed `country-label` layout expressions (`layout.text-justify` and `layout.text-radial-offset`) as QGIS-dependent controls. The live Mapbox style makes these expressions static at higher zooms:

- z7–z8: `text-justify: auto`, radial offset `0.6`
- z8+: `text-justify: auto`, radial offset `0`

Splitting only those bands removes unsupported layout-expression handling where the Mapbox value is already deterministic, while leaving the low-zoom feature-driven `text_anchor` behavior untouched.

## Review follow-up

- Codex noted that the first version used `center` for z7+ justification even though the Mapbox expression resolves to `auto`. The latest push keeps literal `auto` for z7+ and only scalarizes `text-radial-offset`.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 113 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2022 passed, 163 skipped, 135 subtests passed
- `git diff --check` passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T072701Z/audit.md`
  - Raw style warnings: 159
  - After qfit preprocessing: 624
  - QGIS parser probe: 207 accepted / 0 rejected
  - Warnings with sprite context: 0
  - `country-label` converter warnings reduced 4 → 0 in the live audit
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T072724Z/summary.md`
  - z5 Switzerland Alps: 0.1059 / 0.1457
  - z8 Valais/Geneva: 0.1098 / 0.1400
  - z10 Lausanne/Lavaux: 0.0765 / 0.1125
  - z14 Geneva airport: 0.0896 / 0.1308
  - z14 Chamonix trails: 0.1329 / 0.1726
  - z18 Zermatt trails: 0.0330 / 0.0882
