### PR TITLE
Split continent label opacity fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -563,6 +563,7 @@ _PATH_TYPE_FILTER_LOW_ZOOM_SIMPLIFIED_MATCH = [
 _PATH_TYPE_FILTER_SPLIT_ZOOM = 16.0
 _NATURAL_POINT_LABEL_LAYER_ID = "natural-point-label"
 _POI_LABEL_LAYER_ID = "poi-label"
+_CONTINENT_LABEL_LAYER_ID = "continent-label"
 _COUNTRY_LABEL_LAYER_ID = "country-label"
 _SETTLEMENT_MAJOR_LABEL_LAYER_ID = "settlement-major-label"
 _SETTLEMENT_MINOR_LABEL_LAYER_ID = "settlement-minor-label"
@@ -679,6 +680,22 @@ _COUNTRY_LABEL_LAYOUT_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, f
     ("below-z7", None, 7.0, None),
     ("z7-to-z8", 7.0, 8.0, 0.6),
     ("z8-plus", 8.0, None, 0.0),
+)
+_CONTINENT_LABEL_TEXT_OPACITY_EXPRESSION = [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    0,
+    0.8,
+    1.5,
+    0.5,
+    2.5,
+    0,
+]
+_CONTINENT_LABEL_TEXT_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("below-z1_5", None, 1.5),
+    ("z1_5-to-z2_5", 1.5, 2.5),
+    ("z2_5-plus", 2.5, None),
 )
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
@@ -1186,6 +1203,11 @@ def _is_natural_point_label_layer_id(layer_id: object) -> bool:
     return normalized == _NATURAL_POINT_LABEL_LAYER_ID or normalized.startswith(f"{_NATURAL_POINT_LABEL_LAYER_ID}-")
 
 
+def _is_continent_label_layer_id(layer_id: object) -> bool:
+    normalized = str(layer_id or "")
+    return normalized == _CONTINENT_LABEL_LAYER_ID or normalized.startswith(f"{_CONTINENT_LABEL_LAYER_ID}-")
+
+
 def _is_country_label_layer_id(layer_id: object) -> bool:
     normalized = str(layer_id or "")
     return normalized == _COUNTRY_LABEL_LAYER_ID or normalized.startswith(f"{_COUNTRY_LABEL_LAYER_ID}-")
@@ -1223,6 +1245,8 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
         return _POI_LABEL_LAYER_ID
     if _is_natural_point_label_layer_id(layer_id):
         return _NATURAL_POINT_LABEL_LAYER_ID
+    if _is_continent_label_layer_id(layer_id):
+        return _CONTINENT_LABEL_LAYER_ID
     if _is_country_label_layer_id(layer_id):
         return _COUNTRY_LABEL_LAYER_ID
     if _is_settlement_major_label_layer_id(layer_id):
@@ -1483,6 +1507,84 @@ def _split_country_label_layout_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _country_label_layout_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _has_continent_label_text_opacity_expression(layer: dict[str, object]) -> bool:
+    paint = layer.get("paint")
+    return (
+        base_mapbox_style_layer_id_for_qfit(layer.get("id")) == _CONTINENT_LABEL_LAYER_ID
+        and layer.get("type") == "symbol"
+        and isinstance(paint, dict)
+        and paint.get("text-opacity") == _CONTINENT_LABEL_TEXT_OPACITY_EXPRESSION
+    )
+
+
+def _zoom_band_representative_zoom(minzoom: float | None, maxzoom: float | None) -> float:
+    if minzoom is not None and maxzoom is not None:
+        return (minzoom + maxzoom) / 2.0
+    if minzoom is not None:
+        return minzoom
+    if maxzoom is not None:
+        return max(0.0, maxzoom - _ZOOM_BOUND_EPSILON)
+    return _REPRESENTATIVE_STYLE_ZOOM
+
+
+def _continent_label_text_opacity_for_zoom_band(
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+) -> float | None:
+    effective_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        band_minzoom,
+        band_maxzoom,
+    )
+    if effective_zoom_band is None:
+        return None
+    representative_zoom = _zoom_band_representative_zoom(*effective_zoom_band)
+    opacity = _interpolate_filter_value_at_zoom(_CONTINENT_LABEL_TEXT_OPACITY_EXPRESSION, representative_zoom)
+    return _clamp_opacity_value(opacity)
+
+
+def _continent_label_text_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split continent-label opacity fade into static zoom bands for QGIS."""
+    if not _has_continent_label_text_opacity_expression(layer):
+        return None
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    layer_id = str(layer.get("id") or _CONTINENT_LABEL_LAYER_ID)
+    variants: list[dict[str, object]] = []
+    for suffix, band_minzoom, band_maxzoom in _CONTINENT_LABEL_TEXT_OPACITY_ZOOM_BANDS:
+        text_opacity = _continent_label_text_opacity_for_zoom_band(
+            existing_minzoom,
+            existing_maxzoom,
+            band_minzoom,
+            band_maxzoom,
+        )
+        if text_opacity is None:
+            continue
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["text-opacity"] = text_opacity
+        variants.append(variant)
+    return variants or None
+
+
+def _split_continent_label_text_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _continent_label_text_opacity_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -2578,6 +2680,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_settlement_dot_icon_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_country_label_layout_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_continent_label_text_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import tests._path  # noqa: F401,E402
 
+import mapbox_config  # noqa: E402
 from mapbox_config import (  # noqa: E402
     DEFAULT_MAPBOX_RETINA,
     DEFAULT_MAPBOX_TILE_PIXEL_RATIO,
@@ -1687,6 +1688,93 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(len(result["layers"]), 1)
         self.assertEqual(result["layers"][0]["id"], "country-label")
         self.assertEqual(result["layers"][0]["layout"]["text-radial-offset"], ["get", "offset"])
+
+    def _continent_label_layer(self, text_opacity=None):
+        if text_opacity is None:
+            text_opacity = ["interpolate", ["linear"], ["zoom"], 0, 0.8, 1.5, 0.5, 2.5, 0]
+        return {
+            "id": "continent-label",
+            "type": "symbol",
+            "minzoom": 0.75,
+            "maxzoom": 3,
+            "filter": ["==", ["get", "class"], "continent"],
+            "layout": {
+                "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+                "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+                "text-size": ["interpolate", ["exponential", 0.5], ["zoom"], 0, 10, 2.5, 15],
+            },
+            "paint": {
+                "text-color": "hsl(230, 29%, 0%)",
+                "text-opacity": text_opacity,
+            },
+        }
+
+    def test_continent_label_text_opacity_splits_to_static_zoom_bands(self):
+        style = {"layers": [self._continent_label_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 3)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_layer = by_id["continent-label-below-z1_5"]
+        mid_layer = by_id["continent-label-z1_5-to-z2_5"]
+        high_layer = by_id["continent-label-z2_5-plus"]
+        self.assertEqual(low_layer["minzoom"], 0.75)
+        self.assertEqual(low_layer["maxzoom"], 1.5)
+        self.assertEqual(mid_layer["minzoom"], 1.5)
+        self.assertEqual(mid_layer["maxzoom"], 2.5)
+        self.assertEqual(high_layer["minzoom"], 2.5)
+        self.assertEqual(high_layer["maxzoom"], 3)
+        self.assertAlmostEqual(low_layer["paint"]["text-opacity"], 0.575)
+        self.assertAlmostEqual(mid_layer["paint"]["text-opacity"], 0.25)
+        self.assertAlmostEqual(high_layer["paint"]["text-opacity"], 0.0)
+        self.assertEqual({layer["layout"]["text-size"] for layer in result["layers"]}, {16.0})
+
+    def test_continent_label_text_opacity_uses_effective_open_zoom_bounds(self):
+        max_only_layer = self._continent_label_layer()
+        max_only_layer.pop("minzoom")
+        max_only_layer["maxzoom"] = 1.0
+        min_only_layer = self._continent_label_layer()
+        min_only_layer["id"] = "continent-label-min-only"
+        min_only_layer["minzoom"] = 2.75
+        min_only_layer.pop("maxzoom")
+        style = {"layers": [max_only_layer, min_only_layer]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        max_only_variant = by_id["continent-label-below-z1_5"]
+        min_only_variant = by_id["continent-label-min-only-z2_5-plus"]
+        self.assertNotIn("minzoom", max_only_variant)
+        self.assertEqual(max_only_variant["maxzoom"], 1.0)
+        self.assertAlmostEqual(max_only_variant["paint"]["text-opacity"], 0.6)
+        self.assertEqual(min_only_variant["minzoom"], 2.75)
+        self.assertNotIn("maxzoom", min_only_variant)
+        self.assertAlmostEqual(min_only_variant["paint"]["text-opacity"], 0.0)
+
+    def test_continent_label_text_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._continent_label_layer()]
+
+        self.assertEqual(mapbox_config._zoom_band_representative_zoom(None, None), 12.0)
+        self.assertIs(
+            mapbox_config._split_continent_label_text_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_continent_label_text_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "continent-label-below-z1_5")
+
+    def test_continent_label_text_opacity_is_not_split_when_shape_changes(self):
+        text_opacity = ["get", "opacity"]
+        style = {"layers": [self._continent_label_layer(text_opacity=text_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "continent-label")
+        self.assertEqual(result["layers"][0]["paint"]["text-opacity"], text_opacity)
 
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [


### PR DESCRIPTION
## Summary

Part of #949.

This PR takes one small Mapbox Outdoors style-parity slice:

- split the audited `continent-label` zoom-only `paint.text-opacity` fade into QGIS-safe zoom-band variants
- compute each static opacity from the midpoint of the effective zoom band instead of hard-coding a whole-layer snapshot
- preserve the existing `continent-label` text-size override for qfit-created variants
- add regression coverage for the split, open-bound zoom bands, passthrough inputs, and a shape-guard fallback when the upstream expression changes

## Why

The live Outdoors audit still showed `continent-label`'s zoom-interpolated `paint.text-opacity` as QGIS-dependent. Mapbox fades continent labels across z0–z2.5, while QGIS is safer with literal paint values. Splitting only this layer and deriving per-band scalar opacities keeps the approximation small and reviewable.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 117 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2026 passed, 163 skipped, 135 subtests passed
- `git diff --check` passed
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T074724Z/audit.md`
  - Raw style warnings: 159
  - After qfit preprocessing: 624
  - QGIS parser probe: 209 accepted / 0 rejected
  - Warnings with sprite context: 0
  - `continent-label` converter warnings reduced 2 → 0 in the live audit
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T074747Z/summary.md`
  - z5 Switzerland Alps: 0.1059 / 0.1457
  - z8 Valais/Geneva: 0.1098 / 0.1400
  - z10 Lausanne/Lavaux: 0.0765 / 0.1125
  - z14 Geneva airport: 0.0896 / 0.1308
  - z14 Chamonix trails: 0.1329 / 0.1726
  - z18 Zermatt trails: 0.0330 / 0.0882
