### PR TITLE
Split building fill opacity fades for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -715,6 +715,14 @@ _CLIFF_LINE_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ..
     ("z15-to-z15_25", 15.0, 15.25),
     ("z15_25-plus", 15.25, None),
 )
+_BUILDING_FILL_OPACITY_EXPRESSIONS = {
+    "building": ["interpolate", ["linear"], ["zoom"], 15, 0, 16, 1],
+    "building-underground": ["interpolate", ["linear"], ["zoom"], 15, 0, 16, 0.5],
+}
+_BUILDING_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z15-to-z16", 15.0, 16.0),
+    ("z16-plus", 16.0, None),
+)
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
     "bridge-minor-case": 14.0,
@@ -1698,6 +1706,54 @@ def _split_cliff_line_pattern_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _cliff_line_pattern_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _building_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited building fill opacity fades into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    expected_expression = _BUILDING_FILL_OPACITY_EXPRESSIONS.get(layer_id)
+    paint = layer.get("paint")
+    if layer.get("type") != "fill" or expected_expression is None or not isinstance(paint, dict):
+        return None
+    if paint.get("fill-opacity") != expected_expression:
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, band_minzoom, band_maxzoom in _BUILDING_FILL_OPACITY_ZOOM_BANDS:
+        effective_zoom_band = _effective_zoom_band(
+            existing_minzoom,
+            existing_maxzoom,
+            band_minzoom,
+            band_maxzoom,
+        )
+        if effective_zoom_band is None:
+            continue
+        representative_zoom = _zoom_band_representative_zoom(*effective_zoom_band)
+        fill_opacity = _clamp_opacity_value(_interpolate_filter_value_at_zoom(expected_expression, representative_zoom))
+        if fill_opacity is None:
+            continue
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["fill-opacity"] = fill_opacity
+        variants.append(variant)
+    return variants or None
+
+
+def _split_building_fill_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _building_fill_opacity_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -2795,6 +2851,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_country_label_layout_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_continent_label_text_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_cliff_line_pattern_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_building_fill_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1847,6 +1847,72 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "cliff")
         self.assertEqual(result[1]["paint"]["line-pattern"], "other-pattern")
 
+    def _building_layer(self, layer_id="building", fill_opacity=None):
+        if fill_opacity is None:
+            fill_opacity = ["interpolate", ["linear"], ["zoom"], 15, 0, 16, 1]
+        return {
+            "id": layer_id,
+            "type": "fill",
+            "minzoom": 15,
+            "filter": ["all", ["!=", ["get", "type"], "building:part"], ["==", ["get", "underground"], "false"]],
+            "paint": {
+                "fill-color": "hsl(50, 15%, 75%)",
+                "fill-opacity": fill_opacity,
+                "fill-outline-color": "hsl(60, 10%, 65%)",
+            },
+        }
+
+    def test_building_fill_opacity_splits_to_static_zoom_bands(self):
+        underground = self._building_layer(
+            layer_id="building-underground",
+            fill_opacity=["interpolate", ["linear"], ["zoom"], 15, 0, 16, 0.5],
+        )
+        style = {"layers": [self._building_layer(), underground]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 4)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        building_fade = by_id["building-z15-to-z16"]
+        building_full = by_id["building-z16-plus"]
+        underground_fade = by_id["building-underground-z15-to-z16"]
+        underground_full = by_id["building-underground-z16-plus"]
+        self.assertEqual(building_fade["minzoom"], 15)
+        self.assertEqual(building_fade["maxzoom"], 16.0)
+        self.assertEqual(building_full["minzoom"], 16.0)
+        self.assertNotIn("maxzoom", building_full)
+        self.assertAlmostEqual(building_fade["paint"]["fill-opacity"], 0.5)
+        self.assertAlmostEqual(building_full["paint"]["fill-opacity"], 1.0)
+        self.assertAlmostEqual(underground_fade["paint"]["fill-opacity"], 0.25)
+        self.assertAlmostEqual(underground_full["paint"]["fill-opacity"], 0.5)
+        for layer in result["layers"]:
+            self.assertEqual(layer["paint"]["fill-color"], "hsl(50, 15%, 75%)")
+            self.assertEqual(layer["filter"], self._building_layer()["filter"])
+
+    def test_building_fill_opacity_is_not_split_when_shape_changes(self):
+        fill_opacity = ["get", "opacity"]
+        style = {"layers": [self._building_layer(fill_opacity=fill_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "building")
+        self.assertEqual(result["layers"][0]["paint"]["fill-opacity"], fill_opacity)
+
+    def test_building_fill_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._building_layer()]
+
+        self.assertIs(
+            mapbox_config._split_building_fill_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_building_fill_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "building-z15-to-z16")
+        self.assertEqual(result[2]["id"], "building-z16-plus")
+
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [
             "all",

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -311,6 +311,38 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             [{"property": "layout.text-font", "count": 1}],
         )
 
+    def test_build_style_audit_maps_split_building_layers_to_original_ids(self):
+        audit = build_style_audit(
+            {
+                "version": 8,
+                "layers": [
+                    {
+                        "id": "building",
+                        "type": "fill",
+                        "source-layer": "building",
+                        "minzoom": 15,
+                        "filter": [
+                            "all",
+                            ["!=", ["get", "type"], "building:part"],
+                            ["==", ["get", "underground"], "false"],
+                        ],
+                        "paint": {
+                            "fill-color": "hsl(50, 15%, 75%)",
+                            "fill-opacity": ["interpolate", ["linear"], ["zoom"], 15, 0, 16, 1],
+                        },
+                    }
+                ],
+            }
+        )
+
+        layer = audit["layers"][0]
+        self.assertIn("paint.fill-opacity", {change["property"] for change in layer["qfit_simplifies"]})
+        self.assertNotIn("paint.fill-opacity", {item["property"] for item in layer["qfit_unresolved"]})
+        self.assertEqual(
+            audit["summary"]["qfit_simplifies_by_property"],
+            [{"property": "paint.fill-opacity", "count": 1}],
+        )
+
     def test_build_style_audit_reports_visible_label_density_candidates(self):
         audit = build_style_audit(
             {

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -585,6 +585,36 @@ def _unresolved_cues(layer: dict[str, object], simplified_layer: dict[str, objec
     return unresolved
 
 
+def _simplified_layers_by_original_id_for_audit(
+    original_layers: list[dict[str, object]],
+    simplified_layers: list[dict[str, object]],
+) -> dict[str, dict[str, object]]:
+    """Map qfit-split layer variants back to their original Mapbox layer ids.
+
+    Several qfit preprocessors replace one Mapbox layer with suffixed zoom-band
+    variants. The audit compares raw layers against the simplified style, so it
+    must treat the first generated variant as the representative simplified
+    layer instead of reporting the original expression as still unresolved.
+    """
+    original_ids = [str(layer.get("id") or "") for layer in original_layers]
+    original_ids = [layer_id for layer_id in original_ids if layer_id]
+    original_ids_by_specificity = sorted(original_ids, key=len, reverse=True)
+
+    by_original_id: dict[str, dict[str, object]] = {}
+    for layer in simplified_layers:
+        simplified_id = str(layer.get("id") or "")
+        if not simplified_id:
+            continue
+        if simplified_id in original_ids:
+            by_original_id[simplified_id] = layer
+            continue
+        for original_id in original_ids_by_specificity:
+            if simplified_id.startswith(f"{original_id}-"):
+                by_original_id.setdefault(original_id, layer)
+                break
+    return by_original_id
+
+
 def build_layer_audit(
     *,
     layer: dict[str, object],
@@ -2873,15 +2903,26 @@ def build_style_audit(
     resolved_config = config or StyleAuditConfig()
     style_copy = copy.deepcopy(style_definition)
     simplified_style = simplify_mapbox_style_expressions(style_copy)
-    simplified_layers = {
-        str(layer.get("id") or ""): layer
-        for layer in simplified_style.get("layers", [])
-        if isinstance(layer, dict)
-    }
-    layers = [
-        build_layer_audit(layer=layer, simplified_layer=simplified_layers.get(str(layer.get("id") or "")))
+    original_layers = [
+        layer
         for layer in style_definition.get("layers", [])
         if isinstance(layer, dict)
+    ]
+    simplified_layers = [
+        layer
+        for layer in simplified_style.get("layers", [])
+        if isinstance(layer, dict)
+    ]
+    simplified_layers_by_original_id = _simplified_layers_by_original_id_for_audit(
+        original_layers,
+        simplified_layers,
+    )
+    layers = [
+        build_layer_audit(
+            layer=layer,
+            simplified_layer=simplified_layers_by_original_id.get(str(layer.get("id") or "")),
+        )
+        for layer in original_layers
     ]
     label_density_candidates = _label_density_candidate_rows(layers)
     road_trail_hierarchy_candidates = _road_trail_hierarchy_candidate_rows(layers)


### PR DESCRIPTION
## Summary
- split Mapbox Outdoors `building` and `building-underground` z15→z16 fill-opacity fades into static QGIS zoom-band layers
- sample each opacity band at its effective midpoint so the z15 fade remains visible without handing QGIS unsupported zoom opacity expressions
- map split building variants back to their original layer ids in the audit, so #949 evidence no longer reports the converted fill-opacity as stale unresolved debt

Refs #949.

## Evidence / validation
- Live style preprocessing inspection: `building-z15-to-z16` opacity `0.5`, `building-z16-plus` opacity `1.0`, `building-underground-z15-to-z16` opacity `0.25`, `building-underground-z16-plus` opacity `0.5`
- Initial style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T091002Z/audit.md` (rendering conversion unchanged; sprite-context probe 0 warnings)
- Final style audit after Codex feedback: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T091925Z/audit.md` — building layers now show `paint.fill-opacity` converted to static scalars in the audit
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T091043Z/summary.md`
- `python3 -m pytest tests/test_mapbox_config.py tests/test_mapbox_outdoors_style_audit.py -q` — 190 passed, 11 subtests passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2033 passed, 163 skipped, 135 subtests passed
- `git diff --check`
