### PR TITLE
Split landcover fill opacity fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -723,6 +723,15 @@ _BUILDING_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None],
     ("z15-to-z16", 15.0, 16.0),
     ("z16-plus", 16.0, None),
 )
+_LANDCOVER_LAYER_ID = "landcover"
+_LANDCOVER_FILL_OPACITY_EXPRESSIONS = {
+    _LANDCOVER_LAYER_ID: ["interpolate", ["exponential", 1.5], ["zoom"], 8, 0.8, 12, 0],
+}
+_LANDCOVER_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("below-z8", None, 8.0),
+    ("z8-to-z10", 8.0, 10.0),
+    ("z10-to-z12", 10.0, 12.0),
+)
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
     "bridge-minor-case": 14.0,
@@ -1710,20 +1719,26 @@ def _split_cliff_line_pattern_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
-def _building_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
-    """Split audited building fill opacity fades into static QGIS zoom bands."""
+def _zoom_expression_opacity_layer_variants(
+    layer: dict[str, object],
+    *,
+    layer_type: str,
+    paint_property: str,
+    expressions_by_layer_id: dict[str, list[object]],
+    zoom_bands: tuple[tuple[str, float | None, float | None], ...],
+) -> list[dict[str, object]] | None:
     layer_id = str(layer.get("id") or "")
-    expected_expression = _BUILDING_FILL_OPACITY_EXPRESSIONS.get(layer_id)
+    expected_expression = expressions_by_layer_id.get(layer_id)
     paint = layer.get("paint")
-    if layer.get("type") != "fill" or expected_expression is None or not isinstance(paint, dict):
+    if layer.get("type") != layer_type or expected_expression is None or not isinstance(paint, dict):
         return None
-    if paint.get("fill-opacity") != expected_expression:
+    if paint.get(paint_property) != expected_expression:
         return None
 
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
     variants: list[dict[str, object]] = []
-    for suffix, band_minzoom, band_maxzoom in _BUILDING_FILL_OPACITY_ZOOM_BANDS:
+    for suffix, band_minzoom, band_maxzoom in zoom_bands:
         effective_zoom_band = _effective_zoom_band(
             existing_minzoom,
             existing_maxzoom,
@@ -1740,9 +1755,20 @@ def _building_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict
         variant["id"] = f"{layer_id}-{suffix}"
         variant_paint = variant["paint"]
         assert isinstance(variant_paint, dict)
-        variant_paint["fill-opacity"] = fill_opacity
+        variant_paint[paint_property] = fill_opacity
         variants.append(variant)
     return variants or None
+
+
+def _building_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited building fill opacity fades into static QGIS zoom bands."""
+    return _zoom_expression_opacity_layer_variants(
+        layer,
+        layer_type="fill",
+        paint_property="fill-opacity",
+        expressions_by_layer_id=_BUILDING_FILL_OPACITY_EXPRESSIONS,
+        zoom_bands=_BUILDING_FILL_OPACITY_ZOOM_BANDS,
+    )
 
 
 def _split_building_fill_opacity_layers_for_qgis(layers: object) -> object:
@@ -1754,6 +1780,30 @@ def _split_building_fill_opacity_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _building_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _landcover_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited landcover fill opacity fade-out into static QGIS zoom bands."""
+    return _zoom_expression_opacity_layer_variants(
+        layer,
+        layer_type="fill",
+        paint_property="fill-opacity",
+        expressions_by_layer_id=_LANDCOVER_FILL_OPACITY_EXPRESSIONS,
+        zoom_bands=_LANDCOVER_FILL_OPACITY_ZOOM_BANDS,
+    )
+
+
+def _split_landcover_fill_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _landcover_fill_opacity_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -2852,6 +2902,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_continent_label_text_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_cliff_line_pattern_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_building_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_landcover_fill_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1913,6 +1913,70 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "building-z15-to-z16")
         self.assertEqual(result[2]["id"], "building-z16-plus")
 
+    def _landcover_layer(self, fill_opacity=None):
+        if fill_opacity is None:
+            fill_opacity = ["interpolate", ["exponential", 1.5], ["zoom"], 8, 0.8, 12, 0]
+        return {
+            "id": "landcover",
+            "type": "fill",
+            "minzoom": 0,
+            "maxzoom": 12,
+            "source-layer": "landcover",
+            "paint": {
+                "fill-antialias": False,
+                "fill-color": "hsl(98, 48%, 67%)",
+                "fill-opacity": fill_opacity,
+            },
+        }
+
+    def test_landcover_fill_opacity_splits_to_static_zoom_bands(self):
+        style = {"layers": [self._landcover_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 3)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_layer = by_id["landcover-below-z8"]
+        mid_layer = by_id["landcover-z8-to-z10"]
+        high_layer = by_id["landcover-z10-to-z12"]
+        self.assertEqual(low_layer["minzoom"], 0)
+        self.assertEqual(low_layer["maxzoom"], 8.0)
+        self.assertEqual(mid_layer["minzoom"], 8.0)
+        self.assertEqual(mid_layer["maxzoom"], 10.0)
+        self.assertEqual(high_layer["minzoom"], 10.0)
+        self.assertEqual(high_layer["maxzoom"], 12)
+        self.assertAlmostEqual(low_layer["paint"]["fill-opacity"], 0.8)
+        self.assertAlmostEqual(mid_layer["paint"]["fill-opacity"], 0.7015384615384616)
+        self.assertAlmostEqual(high_layer["paint"]["fill-opacity"], 0.3323076923076923)
+        for layer in result["layers"]:
+            self.assertEqual(layer["paint"]["fill-color"], "hsl(98, 48%, 67%)")
+            self.assertFalse(layer["paint"]["fill-antialias"])
+
+    def test_landcover_fill_opacity_is_not_split_when_shape_changes(self):
+        fill_opacity = ["get", "opacity"]
+        style = {"layers": [self._landcover_layer(fill_opacity=fill_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "landcover")
+        self.assertEqual(result["layers"][0]["paint"]["fill-opacity"], fill_opacity)
+
+    def test_landcover_fill_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._landcover_layer()]
+
+        self.assertIs(
+            mapbox_config._split_landcover_fill_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_landcover_fill_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "landcover-below-z8")
+        self.assertEqual(result[2]["id"], "landcover-z8-to-z10")
+        self.assertEqual(result[3]["id"], "landcover-z10-to-z12")
+
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [
             "all",


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `landcover` fill-opacity z8→z12 fade into static QGIS zoom-band layers
- reuse the zoom-band opacity splitter used by building layers, while keeping this slice gated to the exact live `landcover` expression shape
- preserve the existing landcover color fallback and antialias settings on each generated variant

Refs #949.

## Evidence / validation
- Live preprocessing inspection: `landcover-below-z8` opacity `0.8`, `landcover-z8-to-z10` opacity `0.7015384615384616`, `landcover-z10-to-z12` opacity `0.3323076923076923`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T092842Z/audit.md` — `landcover` now reports `paint.fill-opacity` as qfit-simplified instead of QGIS-dependent; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T093305Z/summary.md` — z5/z8/z10 mean/RMS deltas improved versus #1057 evidence (`0.1007/0.1411`, `0.1078/0.1384`, `0.0709/0.1097`)
- `python3 -m pytest tests/test_mapbox_config.py -q` — 126 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2036 passed, 163 skipped, 135 subtests passed
- `git diff --check`
