### PR TITLE
Split national park fill opacity fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -732,6 +732,16 @@ _LANDCOVER_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None]
     ("z8-to-z10", 8.0, 10.0),
     ("z10-to-z12", 10.0, 12.0),
 )
+_NATIONAL_PARK_LAYER_ID = "national-park"
+_NATIONAL_PARK_FILL_OPACITY_EXPRESSIONS = {
+    _NATIONAL_PARK_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 5, 0, 6, 0.6, 12, 0.2],
+}
+_NATIONAL_PARK_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z5-to-z6", 5.0, 6.0),
+    ("z6-to-z9", 6.0, 9.0),
+    ("z9-to-z12", 9.0, 12.0),
+    ("z12-plus", 12.0, None),
+)
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
     "bridge-minor-case": 14.0,
@@ -1804,6 +1814,30 @@ def _split_landcover_fill_opacity_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _landcover_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _national_park_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited national-park fill opacity fade into static QGIS zoom bands."""
+    return _zoom_expression_opacity_layer_variants(
+        layer,
+        layer_type="fill",
+        paint_property="fill-opacity",
+        expressions_by_layer_id=_NATIONAL_PARK_FILL_OPACITY_EXPRESSIONS,
+        zoom_bands=_NATIONAL_PARK_FILL_OPACITY_ZOOM_BANDS,
+    )
+
+
+def _split_national_park_fill_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _national_park_fill_opacity_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -2903,6 +2937,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_cliff_line_pattern_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_building_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landcover_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1977,6 +1977,74 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "landcover-z8-to-z10")
         self.assertEqual(result[3]["id"], "landcover-z10-to-z12")
 
+    def _national_park_layer(self, fill_opacity=None):
+        if fill_opacity is None:
+            fill_opacity = ["interpolate", ["linear"], ["zoom"], 5, 0, 6, 0.6, 12, 0.2]
+        return {
+            "id": "national-park",
+            "type": "fill",
+            "minzoom": 5,
+            "source-layer": "landuse_overlay",
+            "filter": ["==", ["get", "class"], "national_park"],
+            "paint": {
+                "fill-color": "hsla(100, 58%, 76%, 0.4)",
+                "fill-opacity": fill_opacity,
+            },
+        }
+
+    def test_national_park_fill_opacity_splits_to_static_zoom_bands(self):
+        style = {"layers": [self._national_park_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 4)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        first_layer = by_id["national-park-z5-to-z6"]
+        second_layer = by_id["national-park-z6-to-z9"]
+        third_layer = by_id["national-park-z9-to-z12"]
+        final_layer = by_id["national-park-z12-plus"]
+        self.assertEqual(first_layer["minzoom"], 5)
+        self.assertEqual(first_layer["maxzoom"], 6.0)
+        self.assertEqual(second_layer["minzoom"], 6.0)
+        self.assertEqual(second_layer["maxzoom"], 9.0)
+        self.assertEqual(third_layer["minzoom"], 9.0)
+        self.assertEqual(third_layer["maxzoom"], 12.0)
+        self.assertEqual(final_layer["minzoom"], 12.0)
+        self.assertNotIn("maxzoom", final_layer)
+        self.assertAlmostEqual(first_layer["paint"]["fill-opacity"], 0.3)
+        self.assertAlmostEqual(second_layer["paint"]["fill-opacity"], 0.5)
+        self.assertAlmostEqual(third_layer["paint"]["fill-opacity"], 0.3)
+        self.assertAlmostEqual(final_layer["paint"]["fill-opacity"], 0.2)
+        for layer in result["layers"]:
+            self.assertEqual(layer["paint"]["fill-color"], "hsla(100, 58%, 76%, 0.4)")
+            self.assertEqual(layer["filter"], ["==", ["get", "class"], "national_park"])
+
+    def test_national_park_fill_opacity_is_not_split_when_shape_changes(self):
+        fill_opacity = ["get", "opacity"]
+        style = {"layers": [self._national_park_layer(fill_opacity=fill_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "national-park")
+        self.assertEqual(result["layers"][0]["paint"]["fill-opacity"], fill_opacity)
+
+    def test_national_park_fill_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._national_park_layer()]
+
+        self.assertIs(
+            mapbox_config._split_national_park_fill_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_national_park_fill_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "national-park-z5-to-z6")
+        self.assertEqual(result[2]["id"], "national-park-z6-to-z9")
+        self.assertEqual(result[3]["id"], "national-park-z9-to-z12")
+        self.assertEqual(result[4]["id"], "national-park-z12-plus")
+
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [
             "all",


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `national-park` fill-opacity z5→z12 fade into static QGIS zoom-band layers
- keep the slice exact-shape gated to the live `national-park` expression so upstream style changes pass through safely
- preserve the existing national-park fill color and filter on each generated variant

Refs #949.

## Evidence / validation
- Live preprocessing inspection: `national-park-z5-to-z6` opacity `0.3`, `national-park-z6-to-z9` opacity `0.5`, `national-park-z9-to-z12` opacity `0.3`, `national-park-z12-plus` opacity `0.2`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T094609Z/audit.md` — `national-park` now reports `paint.fill-opacity` as qfit-simplified; terrain/landcover unresolved `paint.fill-opacity` drops from 3 to 2; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T094653Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1078/0.1384`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1726`, z18 Zermatt `0.0323/0.0878`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 129 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2039 passed, 163 skipped, 135 subtests passed
- `git diff --check`
