### PR TITLE
Split wetland fill opacity fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -742,6 +742,15 @@ _NATIONAL_PARK_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | N
     ("z9-to-z12", 9.0, 12.0),
     ("z12-plus", 12.0, None),
 )
+_WETLAND_LAYER_ID = "wetland"
+_WETLAND_FILL_OPACITY_EXPRESSIONS = {
+    _WETLAND_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 10, 0.25, 10.5, 0.15],
+}
+_WETLAND_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("below-z10", None, 10.0),
+    ("z10-to-z10_5", 10.0, 10.5),
+    ("z10_5-plus", 10.5, None),
+)
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
     "bridge-minor-case": 14.0,
@@ -1842,6 +1851,30 @@ def _split_national_park_fill_opacity_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _wetland_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited wetland fill opacity fade into static QGIS zoom bands."""
+    return _zoom_expression_opacity_layer_variants(
+        layer,
+        layer_type="fill",
+        paint_property="fill-opacity",
+        expressions_by_layer_id=_WETLAND_FILL_OPACITY_EXPRESSIONS,
+        zoom_bands=_WETLAND_FILL_OPACITY_ZOOM_BANDS,
+    )
+
+
+def _split_wetland_fill_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _wetland_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _has_label_icon_visibility_expression(layer: dict[str, object]) -> bool:
     base_layer_id = base_mapbox_style_layer_id_for_qfit(layer.get("id"))
     layout = layer.get("layout")
@@ -2938,6 +2971,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_building_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landcover_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_wetland_fill_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2045,6 +2045,72 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[3]["id"], "national-park-z9-to-z12")
         self.assertEqual(result[4]["id"], "national-park-z12-plus")
 
+    def _wetland_layer(self, fill_opacity=None):
+        if fill_opacity is None:
+            fill_opacity = ["interpolate", ["linear"], ["zoom"], 10, 0.25, 10.5, 0.15]
+        return {
+            "id": "wetland",
+            "type": "fill",
+            "minzoom": 5,
+            "source-layer": "landuse_overlay",
+            "filter": ["match", ["get", "class"], ["wetland", "wetland_noveg"], True, False],
+            "paint": {
+                "fill-color": "hsla(175, 53%, 73%, 0.28)",
+                "fill-opacity": fill_opacity,
+            },
+        }
+
+    def test_wetland_fill_opacity_splits_to_static_zoom_bands(self):
+        style = {"layers": [self._wetland_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 3)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_layer = by_id["wetland-below-z10"]
+        mid_layer = by_id["wetland-z10-to-z10_5"]
+        high_layer = by_id["wetland-z10_5-plus"]
+        self.assertEqual(low_layer["minzoom"], 5)
+        self.assertEqual(low_layer["maxzoom"], 10.0)
+        self.assertEqual(mid_layer["minzoom"], 10.0)
+        self.assertEqual(mid_layer["maxzoom"], 10.5)
+        self.assertEqual(high_layer["minzoom"], 10.5)
+        self.assertNotIn("maxzoom", high_layer)
+        self.assertAlmostEqual(low_layer["paint"]["fill-opacity"], 0.25)
+        self.assertAlmostEqual(mid_layer["paint"]["fill-opacity"], 0.2)
+        self.assertAlmostEqual(high_layer["paint"]["fill-opacity"], 0.15)
+        for layer in result["layers"]:
+            self.assertEqual(layer["paint"]["fill-color"], "hsla(175, 53%, 73%, 0.28)")
+            self.assertEqual(
+                layer["filter"],
+                ["match", ["get", "class"], ["wetland", "wetland_noveg"], True, False],
+            )
+
+    def test_wetland_fill_opacity_is_not_split_when_shape_changes(self):
+        fill_opacity = ["get", "opacity"]
+        style = {"layers": [self._wetland_layer(fill_opacity=fill_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "wetland")
+        self.assertEqual(result["layers"][0]["paint"]["fill-opacity"], fill_opacity)
+
+    def test_wetland_fill_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._wetland_layer()]
+
+        self.assertIs(
+            mapbox_config._split_wetland_fill_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_wetland_fill_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "wetland-below-z10")
+        self.assertEqual(result[2]["id"], "wetland-z10-to-z10_5")
+        self.assertEqual(result[3]["id"], "wetland-z10_5-plus")
+
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [
             "all",


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `wetland` fill-opacity z10→z10.5 fade into static QGIS zoom-band layers
- keep the slice exact-shape gated to the live `wetland` expression so upstream style changes pass through safely
- preserve the existing wetland fill color and filter on each generated variant

Refs #949.

## Evidence / validation
- Live preprocessing inspection: `wetland-below-z10` opacity `0.25`, `wetland-z10-to-z10_5` opacity `0.2`, `wetland-z10_5-plus` opacity `0.15`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T100511Z/audit.md` — `wetland` now reports `paint.fill-opacity` as qfit-simplified; terrain/landcover unresolved `paint.fill-opacity` drops from 2 to 1; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T100558Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1078/0.1384`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1726`, z18 Zermatt `0.0323/0.0878`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 132 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2042 passed, 163 skipped, 135 subtests passed
- `git diff --check`
