### PR TITLE
Split pedestrian polygon opacity fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -751,6 +751,14 @@ _WETLAND_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], 
     ("z10-to-z10_5", 10.0, 10.5),
     ("z10_5-plus", 10.5, None),
 )
+_ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID = "road-pedestrian-polygon-pattern"
+_ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_EXPRESSIONS = {
+    _ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 16, 0, 17, 1],
+}
+_ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z16-to-z17", 16.0, 17.0),
+    ("z17-plus", 17.0, None),
+)
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
     "bridge-minor-case": 14.0,
@@ -1875,6 +1883,32 @@ def _split_wetland_fill_opacity_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _road_pedestrian_polygon_pattern_fill_opacity_layer_variants(
+    layer: dict[str, object],
+) -> list[dict[str, object]] | None:
+    """Split audited pedestrian polygon pattern opacity fade into static QGIS zoom bands."""
+    return _zoom_expression_opacity_layer_variants(
+        layer,
+        layer_type="fill",
+        paint_property="fill-opacity",
+        expressions_by_layer_id=_ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_EXPRESSIONS,
+        zoom_bands=_ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_ZOOM_BANDS,
+    )
+
+
+def _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _road_pedestrian_polygon_pattern_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _has_label_icon_visibility_expression(layer: dict[str, object]) -> bool:
     base_layer_id = base_mapbox_style_layer_id_for_qfit(layer.get("id"))
     layout = layer.get("layout")
@@ -2972,6 +3006,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_landcover_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_wetland_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2111,6 +2111,68 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "wetland-z10-to-z10_5")
         self.assertEqual(result[3]["id"], "wetland-z10_5-plus")
 
+    def _road_pedestrian_polygon_pattern_layer(self, fill_opacity=None):
+        if fill_opacity is None:
+            fill_opacity = ["interpolate", ["linear"], ["zoom"], 16, 0, 17, 1]
+        return {
+            "id": "road-pedestrian-polygon-pattern",
+            "type": "fill",
+            "minzoom": 16,
+            "source-layer": "road",
+            "filter": ["==", ["geometry-type"], "Polygon"],
+            "paint": {
+                "fill-pattern": "pedestrian-polygon",
+                "fill-opacity": fill_opacity,
+            },
+        }
+
+    def test_road_pedestrian_polygon_pattern_fill_opacity_splits_to_static_zoom_bands(self):
+        style = {"layers": [self._road_pedestrian_polygon_pattern_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 2)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        fade_layer = by_id["road-pedestrian-polygon-pattern-z16-to-z17"]
+        full_layer = by_id["road-pedestrian-polygon-pattern-z17-plus"]
+        self.assertEqual(fade_layer["minzoom"], 16)
+        self.assertEqual(fade_layer["maxzoom"], 17.0)
+        self.assertEqual(full_layer["minzoom"], 17.0)
+        self.assertNotIn("maxzoom", full_layer)
+        self.assertAlmostEqual(fade_layer["paint"]["fill-opacity"], 0.5)
+        self.assertAlmostEqual(full_layer["paint"]["fill-opacity"], 1.0)
+        for layer in result["layers"]:
+            self.assertEqual(layer["paint"]["fill-pattern"], "pedestrian-polygon")
+            self.assertEqual(layer["filter"], ["==", ["geometry-type"], "Polygon"])
+
+    def test_road_pedestrian_polygon_pattern_fill_opacity_is_not_split_when_shape_changes(self):
+        fill_opacity = ["get", "opacity"]
+        style = {"layers": [self._road_pedestrian_polygon_pattern_layer(fill_opacity=fill_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "road-pedestrian-polygon-pattern")
+        self.assertEqual(result["layers"][0]["paint"]["fill-opacity"], fill_opacity)
+
+    def test_road_pedestrian_polygon_pattern_fill_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._road_pedestrian_polygon_pattern_layer()]
+
+        self.assertIs(
+            mapbox_config._split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(
+                unchanged_layers
+            ),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(
+            mixed_layers
+        )
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "road-pedestrian-polygon-pattern-z16-to-z17")
+        self.assertEqual(result[2]["id"], "road-pedestrian-polygon-pattern-z17-plus")
+
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [
             "all",


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `road-pedestrian-polygon-pattern` fill-opacity z16→z17 fade into static QGIS zoom-band layers
- keep the slice exact-shape gated to the live expression so upstream style changes pass through safely
- preserve the pedestrian polygon sprite pattern and filter on both generated variants

Refs #949.

## Evidence / validation
- Live preprocessing inspection: `road-pedestrian-polygon-pattern-z16-to-z17` opacity `0.5`, `road-pedestrian-polygon-pattern-z17-plus` opacity `1.0`; both retain `fill-pattern: pedestrian-polygon`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T101516Z/audit.md` — `road-pedestrian-polygon-pattern` now reports `paint.fill-opacity` as qfit-simplified; unresolved `paint.fill-opacity` is down to the remaining `landuse` case; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T101605Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1078/0.1384`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1726`, z18 Zermatt `0.0323/0.0878`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 135 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2045 passed, 163 skipped, 135 subtests passed
- `git diff --check`
