### PR TITLE
Split contour line opacity fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -759,6 +759,25 @@ _ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float
     ("z16-to-z17", 16.0, 17.0),
     ("z17-plus", 17.0, None),
 )
+_CONTOUR_LINE_LAYER_ID = "contour-line"
+_CONTOUR_LINE_OPACITY_EXPRESSION = [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    11,
+    ["match", ["get", "index"], [1, 2], 0.15, 0.3],
+    13,
+    ["match", ["get", "index"], [1, 2], 0.3, 0.5],
+]
+_CONTOUR_LINE_OPACITY_VARIANTS: tuple[
+    tuple[str, object, float | None, float | None, float],
+    ...,
+] = (
+    ("index-major-z11-to-z13", ["match", ["get", "index"], [1, 2], True, False], 11.0, 13.0, 0.225),
+    ("index-major-z13-plus", ["match", ["get", "index"], [1, 2], True, False], 13.0, None, 0.3),
+    ("index-other-z11-to-z13", ["match", ["get", "index"], [1, 2], False, True], 11.0, 13.0, 0.4),
+    ("index-other-z13-plus", ["match", ["get", "index"], [1, 2], False, True], 13.0, None, 0.5),
+)
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
     "bridge-minor-case": 14.0,
@@ -1909,6 +1928,44 @@ def _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(layers: 
     return expanded_layers
 
 
+def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited contour index opacity expressions into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    paint = layer.get("paint")
+    if layer_id != _CONTOUR_LINE_LAYER_ID or layer.get("type") != "line" or not isinstance(paint, dict):
+        return None
+    if paint.get("line-opacity") != _CONTOUR_LINE_OPACITY_EXPRESSION:
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, index_filter, band_minzoom, band_maxzoom, line_opacity in _CONTOUR_LINE_OPACITY_VARIANTS:
+        if _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom) is None:
+            continue
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), index_filter)
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["line-opacity"] = line_opacity
+        variants.append(variant)
+    return variants or None
+
+
+def _split_contour_line_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _contour_line_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _has_label_icon_visibility_expression(layer: dict[str, object]) -> bool:
     base_layer_id = base_mapbox_style_layer_id_for_qfit(layer.get("id"))
     layout = layer.get("layout")
@@ -3007,6 +3064,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_wetland_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_contour_line_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -773,10 +773,12 @@ _CONTOUR_LINE_OPACITY_VARIANTS: tuple[
     tuple[str, object, float | None, float | None, float],
     ...,
 ] = (
-    ("index-major-z11-to-z13", ["match", ["get", "index"], [1, 2], True, False], 11.0, 13.0, 0.225),
-    ("index-major-z13-plus", ["match", ["get", "index"], [1, 2], True, False], 13.0, None, 0.3),
-    ("index-other-z11-to-z13", ["match", ["get", "index"], [1, 2], False, True], 11.0, 13.0, 0.4),
-    ("index-other-z13-plus", ["match", ["get", "index"], [1, 2], False, True], 13.0, None, 0.5),
+    ("index-minor-below-z11", ["match", ["get", "index"], [1, 2], True, False], None, 11.0, 0.15),
+    ("index-minor-z11-to-z13", ["match", ["get", "index"], [1, 2], True, False], 11.0, 13.0, 0.225),
+    ("index-minor-z13-plus", ["match", ["get", "index"], [1, 2], True, False], 13.0, None, 0.3),
+    ("index-major-below-z11", ["match", ["get", "index"], [1, 2], False, True], None, 11.0, 0.3),
+    ("index-major-z11-to-z13", ["match", ["get", "index"], [1, 2], False, True], 11.0, 13.0, 0.4),
+    ("index-major-z13-plus", ["match", ["get", "index"], [1, 2], False, True], 13.0, None, 0.5),
 )
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2173,6 +2173,99 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "road-pedestrian-polygon-pattern-z16-to-z17")
         self.assertEqual(result[2]["id"], "road-pedestrian-polygon-pattern-z17-plus")
 
+    def _contour_line_layer(self, line_opacity=None):
+        if line_opacity is None:
+            line_opacity = [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                11,
+                ["match", ["get", "index"], [1, 2], 0.15, 0.3],
+                13,
+                ["match", ["get", "index"], [1, 2], 0.3, 0.5],
+            ]
+        return {
+            "id": "contour-line",
+            "type": "line",
+            "minzoom": 11,
+            "source-layer": "contour",
+            "filter": ["!=", ["get", "index"], -1],
+            "paint": {
+                "line-color": "hsl(33, 20%, 50%)",
+                "line-opacity": line_opacity,
+            },
+        }
+
+    def test_contour_line_opacity_splits_to_index_and_zoom_bands(self):
+        style = {"layers": [self._contour_line_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 4)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        major_fade = by_id["contour-line-index-major-z11-to-z13"]
+        major_full = by_id["contour-line-index-major-z13-plus"]
+        other_fade = by_id["contour-line-index-other-z11-to-z13"]
+        other_full = by_id["contour-line-index-other-z13-plus"]
+        self.assertEqual(major_fade["minzoom"], 11)
+        self.assertEqual(major_fade["maxzoom"], 13.0)
+        self.assertEqual(major_full["minzoom"], 13.0)
+        self.assertNotIn("maxzoom", major_full)
+        self.assertEqual(other_fade["minzoom"], 11)
+        self.assertEqual(other_fade["maxzoom"], 13.0)
+        self.assertEqual(other_full["minzoom"], 13.0)
+        self.assertNotIn("maxzoom", other_full)
+        self.assertAlmostEqual(major_fade["paint"]["line-opacity"], 0.225)
+        self.assertAlmostEqual(major_full["paint"]["line-opacity"], 0.3)
+        self.assertAlmostEqual(other_fade["paint"]["line-opacity"], 0.4)
+        self.assertAlmostEqual(other_full["paint"]["line-opacity"], 0.5)
+        for layer in (major_fade, major_full):
+            self.assertEqual(
+                layer["filter"],
+                [
+                    "all",
+                    ["!=", ["get", "index"], -1],
+                    ["match", ["get", "index"], [1, 2], True, False],
+                ],
+            )
+            self.assertEqual(layer["paint"]["line-color"], "hsl(33, 20%, 50%)")
+        for layer in (other_fade, other_full):
+            self.assertEqual(
+                layer["filter"],
+                [
+                    "all",
+                    ["!=", ["get", "index"], -1],
+                    ["match", ["get", "index"], [1, 2], False, True],
+                ],
+            )
+            self.assertEqual(layer["paint"]["line-color"], "hsl(33, 20%, 50%)")
+
+    def test_contour_line_opacity_is_not_split_when_shape_changes(self):
+        line_opacity = ["get", "opacity"]
+        style = {"layers": [self._contour_line_layer(line_opacity=line_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "contour-line")
+        self.assertEqual(result["layers"][0]["paint"]["line-opacity"], line_opacity)
+
+    def test_contour_line_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._contour_line_layer()]
+
+        self.assertIs(
+            mapbox_config._split_contour_line_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_contour_line_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "contour-line-index-major-z11-to-z13")
+        self.assertEqual(result[2]["id"], "contour-line-index-major-z13-plus")
+        self.assertEqual(result[3]["id"], "contour-line-index-other-z11-to-z13")
+        self.assertEqual(result[4]["id"], "contour-line-index-other-z13-plus")
+
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [
             "all",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2173,7 +2173,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "road-pedestrian-polygon-pattern-z16-to-z17")
         self.assertEqual(result[2]["id"], "road-pedestrian-polygon-pattern-z17-plus")
 
-    def _contour_line_layer(self, line_opacity=None):
+    def _contour_line_layer(self, line_opacity=None, minzoom=11):
         if line_opacity is None:
             line_opacity = [
                 "interpolate",
@@ -2187,7 +2187,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         return {
             "id": "contour-line",
             "type": "line",
-            "minzoom": 11,
+            "minzoom": minzoom,
             "source-layer": "contour",
             "filter": ["!=", ["get", "index"], -1],
             "paint": {
@@ -2203,23 +2203,23 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(len(result["layers"]), 4)
         by_id = {layer["id"]: layer for layer in result["layers"]}
+        minor_fade = by_id["contour-line-index-minor-z11-to-z13"]
+        minor_full = by_id["contour-line-index-minor-z13-plus"]
         major_fade = by_id["contour-line-index-major-z11-to-z13"]
         major_full = by_id["contour-line-index-major-z13-plus"]
-        other_fade = by_id["contour-line-index-other-z11-to-z13"]
-        other_full = by_id["contour-line-index-other-z13-plus"]
+        self.assertEqual(minor_fade["minzoom"], 11)
+        self.assertEqual(minor_fade["maxzoom"], 13.0)
+        self.assertEqual(minor_full["minzoom"], 13.0)
+        self.assertNotIn("maxzoom", minor_full)
         self.assertEqual(major_fade["minzoom"], 11)
         self.assertEqual(major_fade["maxzoom"], 13.0)
         self.assertEqual(major_full["minzoom"], 13.0)
         self.assertNotIn("maxzoom", major_full)
-        self.assertEqual(other_fade["minzoom"], 11)
-        self.assertEqual(other_fade["maxzoom"], 13.0)
-        self.assertEqual(other_full["minzoom"], 13.0)
-        self.assertNotIn("maxzoom", other_full)
-        self.assertAlmostEqual(major_fade["paint"]["line-opacity"], 0.225)
-        self.assertAlmostEqual(major_full["paint"]["line-opacity"], 0.3)
-        self.assertAlmostEqual(other_fade["paint"]["line-opacity"], 0.4)
-        self.assertAlmostEqual(other_full["paint"]["line-opacity"], 0.5)
-        for layer in (major_fade, major_full):
+        self.assertAlmostEqual(minor_fade["paint"]["line-opacity"], 0.225)
+        self.assertAlmostEqual(minor_full["paint"]["line-opacity"], 0.3)
+        self.assertAlmostEqual(major_fade["paint"]["line-opacity"], 0.4)
+        self.assertAlmostEqual(major_full["paint"]["line-opacity"], 0.5)
+        for layer in (minor_fade, minor_full):
             self.assertEqual(
                 layer["filter"],
                 [
@@ -2229,7 +2229,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 ],
             )
             self.assertEqual(layer["paint"]["line-color"], "hsl(33, 20%, 50%)")
-        for layer in (other_fade, other_full):
+        for layer in (major_fade, major_full):
             self.assertEqual(
                 layer["filter"],
                 [
@@ -2239,6 +2239,38 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 ],
             )
             self.assertEqual(layer["paint"]["line-color"], "hsl(33, 20%, 50%)")
+
+    def test_contour_line_opacity_preserves_visibility_below_z11_when_layer_allows_it(self):
+        style = {"layers": [self._contour_line_layer(minzoom=10)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 6)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        minor_below = by_id["contour-line-index-minor-below-z11"]
+        major_below = by_id["contour-line-index-major-below-z11"]
+        self.assertEqual(minor_below["minzoom"], 10)
+        self.assertEqual(minor_below["maxzoom"], 11.0)
+        self.assertEqual(major_below["minzoom"], 10)
+        self.assertEqual(major_below["maxzoom"], 11.0)
+        self.assertAlmostEqual(minor_below["paint"]["line-opacity"], 0.15)
+        self.assertAlmostEqual(major_below["paint"]["line-opacity"], 0.3)
+        self.assertEqual(
+            minor_below["filter"],
+            [
+                "all",
+                ["!=", ["get", "index"], -1],
+                ["match", ["get", "index"], [1, 2], True, False],
+            ],
+        )
+        self.assertEqual(
+            major_below["filter"],
+            [
+                "all",
+                ["!=", ["get", "index"], -1],
+                ["match", ["get", "index"], [1, 2], False, True],
+            ],
+        )
 
     def test_contour_line_opacity_is_not_split_when_shape_changes(self):
         line_opacity = ["get", "opacity"]
@@ -2261,10 +2293,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         result = mapbox_config._split_contour_line_opacity_layers_for_qgis(mixed_layers)
 
         self.assertEqual(result[0], "not-a-layer")
-        self.assertEqual(result[1]["id"], "contour-line-index-major-z11-to-z13")
-        self.assertEqual(result[2]["id"], "contour-line-index-major-z13-plus")
-        self.assertEqual(result[3]["id"], "contour-line-index-other-z11-to-z13")
-        self.assertEqual(result[4]["id"], "contour-line-index-other-z13-plus")
+        self.assertEqual(result[1]["id"], "contour-line-index-minor-z11-to-z13")
+        self.assertEqual(result[2]["id"], "contour-line-index-minor-z13-plus")
+        self.assertEqual(result[3]["id"], "contour-line-index-major-z11-to-z13")
+        self.assertEqual(result[4]["id"], "contour-line-index-major-z13-plus")
 
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `contour-line` index-dependent line-opacity expression into static QGIS zoom/index variants
- keep the conversion exact-shape gated to the live expression so upstream style changes pass through safely
- preserve the contour filter/line paint while adding index-specific filters for minor (`index` 1/2) and major contour groups
- preserve first-stop opacity coverage if a future live contour layer starts below z11

Refs #949.

## Evidence / validation
- Live preprocessing inspection: generated `contour-line-index-minor-z11-to-z13` opacity `0.225`, `contour-line-index-minor-z13-plus` opacity `0.3`, `contour-line-index-major-z11-to-z13` opacity `0.4`, and `contour-line-index-major-z13-plus` opacity `0.5`; each keeps the original contour filter plus the corresponding `index` match filter
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T103759Z/audit.md` — terrain/landcover `paint.line-opacity` moved from unresolved to qfit-simplified; total unresolved `paint.line-opacity` dropped from 4 to 3; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T103821Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1078/0.1384`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1726`, z18 Zermatt `0.0323/0.0878`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 139 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2049 passed, 163 skipped, 135 subtests passed
- `git diff --check`
