### PR TITLE
Split landuse fill opacity fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -743,7 +743,7 @@ _LANDUSE_FILL_OPACITY_EXPRESSION = [
     ["match", ["get", "class"], "residential", 0, 1],
 ]
 _LANDUSE_FILL_OPACITY_VARIANTS: tuple[
-    tuple[str, object, float | None, float | None, float],
+    tuple[str, object, float | None, float | None, bool],
     ...,
 ] = (
     (
@@ -751,42 +751,42 @@ _LANDUSE_FILL_OPACITY_VARIANTS: tuple[
         ["match", ["get", "class"], "residential", True, False],
         None,
         8.0,
-        0.8,
+        True,
     ),
     (
         "residential-z8-to-z10",
         ["match", ["get", "class"], "residential", True, False],
         8.0,
         10.0,
-        0.4,
+        True,
     ),
     (
         "residential-z10-plus",
         ["match", ["get", "class"], "residential", True, False],
         10.0,
         None,
-        0.0,
+        True,
     ),
     (
         "other-below-z8",
         ["match", ["get", "class"], "residential", False, True],
         None,
         8.0,
-        0.2,
+        False,
     ),
     (
         "other-z8-to-z10",
         ["match", ["get", "class"], "residential", False, True],
         8.0,
         10.0,
-        0.6,
+        False,
     ),
     (
         "other-z10-plus",
         ["match", ["get", "class"], "residential", False, True],
         10.0,
         None,
-        1.0,
+        False,
     ),
 )
 _NATIONAL_PARK_LAYER_ID = "national-park"
@@ -1926,6 +1926,39 @@ def _split_landcover_fill_opacity_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _landuse_fill_opacity_at_zoom(zoom: float, *, residential: bool) -> float | None:
+    lower_opacity = 0.8 if residential else 0.2
+    upper_opacity = 0.0 if residential else 1.0
+    if zoom <= 8.0:
+        return lower_opacity
+    if zoom >= 10.0:
+        return upper_opacity
+    factor = _interpolate_filter_factor(["linear"], zoom, 8.0, 10.0)
+    if factor is None:
+        return None
+    return _clamp_opacity_value(lower_opacity + ((upper_opacity - lower_opacity) * factor))
+
+
+def _landuse_fill_opacity_for_zoom_band(
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+    *,
+    residential: bool,
+) -> float | None:
+    effective_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        band_minzoom,
+        band_maxzoom,
+    )
+    if effective_zoom_band is None:
+        return None
+    representative_zoom = _zoom_band_representative_zoom(*effective_zoom_band)
+    return _landuse_fill_opacity_at_zoom(representative_zoom, residential=residential)
+
+
 def _landuse_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited landuse opacity class fade into static QGIS zoom/class bands."""
     layer_id = str(layer.get("id") or "")
@@ -1938,9 +1971,15 @@ def _landuse_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
     variants: list[dict[str, object]] = []
-    for suffix, class_filter, band_minzoom, band_maxzoom, fill_opacity in _LANDUSE_FILL_OPACITY_VARIANTS:
-        effective_zoom_band = _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom)
-        if effective_zoom_band is None:
+    for suffix, class_filter, band_minzoom, band_maxzoom, residential in _LANDUSE_FILL_OPACITY_VARIANTS:
+        fill_opacity = _landuse_fill_opacity_for_zoom_band(
+            existing_minzoom,
+            existing_maxzoom,
+            band_minzoom,
+            band_maxzoom,
+            residential=residential,
+        )
+        if fill_opacity is None:
             continue
         variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
         variant["id"] = f"{layer_id}-{suffix}"

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -732,6 +732,63 @@ _LANDCOVER_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None]
     ("z8-to-z10", 8.0, 10.0),
     ("z10-to-z12", 10.0, 12.0),
 )
+_LANDUSE_LAYER_ID = "landuse"
+_LANDUSE_FILL_OPACITY_EXPRESSION = [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    8,
+    ["match", ["get", "class"], "residential", 0.8, 0.2],
+    10,
+    ["match", ["get", "class"], "residential", 0, 1],
+]
+_LANDUSE_FILL_OPACITY_VARIANTS: tuple[
+    tuple[str, object, float | None, float | None, float],
+    ...,
+] = (
+    (
+        "residential-below-z8",
+        ["match", ["get", "class"], "residential", True, False],
+        None,
+        8.0,
+        0.8,
+    ),
+    (
+        "residential-z8-to-z10",
+        ["match", ["get", "class"], "residential", True, False],
+        8.0,
+        10.0,
+        0.4,
+    ),
+    (
+        "residential-z10-plus",
+        ["match", ["get", "class"], "residential", True, False],
+        10.0,
+        None,
+        0.0,
+    ),
+    (
+        "other-below-z8",
+        ["match", ["get", "class"], "residential", False, True],
+        None,
+        8.0,
+        0.2,
+    ),
+    (
+        "other-z8-to-z10",
+        ["match", ["get", "class"], "residential", False, True],
+        8.0,
+        10.0,
+        0.6,
+    ),
+    (
+        "other-z10-plus",
+        ["match", ["get", "class"], "residential", False, True],
+        10.0,
+        None,
+        1.0,
+    ),
+)
 _NATIONAL_PARK_LAYER_ID = "national-park"
 _NATIONAL_PARK_FILL_OPACITY_EXPRESSIONS = {
     _NATIONAL_PARK_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 5, 0, 6, 0.6, 12, 0.2],
@@ -1311,6 +1368,16 @@ def _is_settlement_minor_label_layer_id(layer_id: object) -> bool:
     return normalized == _SETTLEMENT_MINOR_LABEL_LAYER_ID or normalized.startswith(f"{_SETTLEMENT_MINOR_LABEL_LAYER_ID}-")
 
 
+def _landuse_fill_opacity_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    if normalized == _LANDUSE_LAYER_ID:
+        return _LANDUSE_LAYER_ID
+    for suffix, _class_filter, _band_minzoom, _band_maxzoom, _fill_opacity in _LANDUSE_FILL_OPACITY_VARIANTS:
+        if normalized == f"{_LANDUSE_LAYER_ID}-{suffix}":
+            return _LANDUSE_LAYER_ID
+    return None
+
+
 def _regional_major_road_width_base_layer_id(layer_id: object) -> str | None:
     normalized = str(layer_id or "")
     for suffix, _band_minzoom, _band_maxzoom in _REGIONAL_MAJOR_ROAD_WIDTH_BANDS:
@@ -1327,6 +1394,9 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     regional_road_layer_id = _regional_major_road_width_base_layer_id(layer_id)
     if regional_road_layer_id is not None:
         return regional_road_layer_id
+    landuse_layer_id = _landuse_fill_opacity_base_layer_id(layer_id)
+    if landuse_layer_id is not None:
+        return landuse_layer_id
     if _is_road_number_shield_layer_id(layer_id):
         return _ROAD_NUMBER_SHIELD_LAYER_ID
     if _is_poi_label_layer_id(layer_id):
@@ -1852,6 +1922,45 @@ def _split_landcover_fill_opacity_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _landcover_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _landuse_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited landuse opacity class fade into static QGIS zoom/class bands."""
+    layer_id = str(layer.get("id") or "")
+    paint = layer.get("paint")
+    if layer_id != _LANDUSE_LAYER_ID or layer.get("type") != "fill" or not isinstance(paint, dict):
+        return None
+    if paint.get("fill-opacity") != _LANDUSE_FILL_OPACITY_EXPRESSION:
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, class_filter, band_minzoom, band_maxzoom, fill_opacity in _LANDUSE_FILL_OPACITY_VARIANTS:
+        effective_zoom_band = _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom)
+        if effective_zoom_band is None:
+            continue
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), class_filter)
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["fill-opacity"] = fill_opacity
+        variants.append(variant)
+    return variants or None
+
+
+def _split_landuse_fill_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _landuse_fill_opacity_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -3063,6 +3172,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_cliff_line_pattern_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_building_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landcover_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_landuse_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_wetland_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import unittest
 from unittest.mock import patch
 
@@ -1976,6 +1977,122 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "landcover-below-z8")
         self.assertEqual(result[2]["id"], "landcover-z8-to-z10")
         self.assertEqual(result[3]["id"], "landcover-z10-to-z12")
+
+    def _landuse_layer(self, fill_opacity=None, filter_value=None):
+        if fill_opacity is None:
+            fill_opacity = [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                8,
+                ["match", ["get", "class"], "residential", 0.8, 0.2],
+                10,
+                ["match", ["get", "class"], "residential", 0, 1],
+            ]
+        if filter_value is None:
+            filter_value = ["==", ["get", "source"], "test"]
+        return {
+            "id": "landuse",
+            "type": "fill",
+            "minzoom": 5,
+            "source-layer": "landuse",
+            "filter": filter_value,
+            "paint": {
+                "fill-color": "hsl(60, 22%, 72%)",
+                "fill-opacity": fill_opacity,
+            },
+        }
+
+    def test_landuse_fill_opacity_splits_to_class_and_zoom_bands(self):
+        style = {"layers": [self._landuse_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 6)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        residential_low = by_id["landuse-residential-below-z8"]
+        residential_mid = by_id["landuse-residential-z8-to-z10"]
+        residential_high = by_id["landuse-residential-z10-plus"]
+        other_low = by_id["landuse-other-below-z8"]
+        other_mid = by_id["landuse-other-z8-to-z10"]
+        other_high = by_id["landuse-other-z10-plus"]
+        self.assertEqual(residential_low["minzoom"], 5)
+        self.assertEqual(residential_low["maxzoom"], 8.0)
+        self.assertEqual(residential_mid["minzoom"], 8.0)
+        self.assertEqual(residential_mid["maxzoom"], 10.0)
+        self.assertEqual(residential_high["minzoom"], 10.0)
+        self.assertNotIn("maxzoom", residential_high)
+        self.assertEqual(other_low["minzoom"], 5)
+        self.assertEqual(other_low["maxzoom"], 8.0)
+        self.assertEqual(other_mid["minzoom"], 8.0)
+        self.assertEqual(other_mid["maxzoom"], 10.0)
+        self.assertEqual(other_high["minzoom"], 10.0)
+        self.assertNotIn("maxzoom", other_high)
+        self.assertAlmostEqual(residential_low["paint"]["fill-opacity"], 0.8)
+        self.assertAlmostEqual(residential_mid["paint"]["fill-opacity"], 0.4)
+        self.assertAlmostEqual(residential_high["paint"]["fill-opacity"], 0.0)
+        self.assertAlmostEqual(other_low["paint"]["fill-opacity"], 0.2)
+        self.assertAlmostEqual(other_mid["paint"]["fill-opacity"], 0.6)
+        self.assertAlmostEqual(other_high["paint"]["fill-opacity"], 1.0)
+        for layer in (residential_low, residential_mid, residential_high):
+            self.assertEqual(
+                layer["filter"],
+                [
+                    "all",
+                    ["==", ["get", "source"], "test"],
+                    ["match", ["get", "class"], "residential", True, False],
+                ],
+            )
+            self.assertEqual(layer["paint"]["fill-color"], "hsl(60, 22%, 72%)")
+        for layer in (other_low, other_mid, other_high):
+            self.assertEqual(
+                layer["filter"],
+                [
+                    "all",
+                    ["==", ["get", "source"], "test"],
+                    ["match", ["get", "class"], "residential", False, True],
+                ],
+            )
+            self.assertEqual(layer["paint"]["fill-color"], "hsl(60, 22%, 72%)")
+
+    def test_landuse_fill_opacity_variants_keep_filter_normalization(self):
+        style = {"layers": [self._landuse_layer(filter_value=["step", ["zoom"], False, 8, True])]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-residential-z8-to-z10"),
+            "landuse",
+        )
+        self.assertNotIn('"zoom"', json.dumps([layer["filter"] for layer in result["layers"]]))
+
+    def test_landuse_fill_opacity_is_not_split_when_shape_changes(self):
+        fill_opacity = ["get", "opacity"]
+        style = {"layers": [self._landuse_layer(fill_opacity=fill_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "landuse")
+        self.assertEqual(result["layers"][0]["paint"]["fill-opacity"], fill_opacity)
+
+    def test_landuse_fill_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._landuse_layer()]
+
+        self.assertIs(
+            mapbox_config._split_landuse_fill_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_landuse_fill_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "landuse-residential-below-z8")
+        self.assertEqual(result[2]["id"], "landuse-residential-z8-to-z10")
+        self.assertEqual(result[3]["id"], "landuse-residential-z10-plus")
+        self.assertEqual(result[4]["id"], "landuse-other-below-z8")
+        self.assertEqual(result[5]["id"], "landuse-other-z8-to-z10")
+        self.assertEqual(result[6]["id"], "landuse-other-z10-plus")
 
     def _national_park_layer(self, fill_opacity=None):
         if fill_opacity is None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2055,6 +2055,21 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             )
             self.assertEqual(layer["paint"]["fill-color"], "hsl(60, 22%, 72%)")
 
+    def test_landuse_fill_opacity_uses_effective_zoom_band_midpoints(self):
+        layer = self._landuse_layer()
+        layer["minzoom"] = 9.5
+        style = {"layers": [layer]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertNotIn("landuse-residential-below-z8", by_id)
+        self.assertNotIn("landuse-other-below-z8", by_id)
+        self.assertAlmostEqual(by_id["landuse-residential-z8-to-z10"]["paint"]["fill-opacity"], 0.1)
+        self.assertAlmostEqual(by_id["landuse-other-z8-to-z10"]["paint"]["fill-opacity"], 0.9)
+        self.assertAlmostEqual(by_id["landuse-residential-z10-plus"]["paint"]["fill-opacity"], 0.0)
+        self.assertAlmostEqual(by_id["landuse-other-z10-plus"]["paint"]["fill-opacity"], 1.0)
+
     def test_landuse_fill_opacity_variants_keep_filter_normalization(self):
         style = {"layers": [self._landuse_layer(filter_value=["step", ["zoom"], False, 8, True])]}
 


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `landuse` fill-opacity class/zoom expression into static QGIS zoom/class variants
- keep the split exact-shape gated to the live expression so upstream style changes pass through safely
- compute each static opacity from the effective zoom-band midpoint after intersecting with existing layer zoom bounds, and map generated `landuse-*` variants back to `landuse` so filter normalization still runs

Refs #949.

## Evidence / validation
- Addressed Codex P2 feedback: narrowed `minzoom`/`maxzoom` landuse layers now compute opacity from the intersected effective band midpoint; regression test covers `minzoom: 9.5` producing residential `0.1` / other `0.9` for the z8-z10 band
- Live preprocessing inspection: generated `landuse-residential-below-z8` opacity `0.8`, `landuse-residential-z8-to-z10` opacity `0.4`, `landuse-residential-z10-plus` opacity `0.0`, `landuse-other-below-z8` opacity `0.2`, `landuse-other-z8-to-z10` opacity `0.6`, and `landuse-other-z10-plus` opacity `1.0`; all variants retain landuse filter normalization and add the matching class filter
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T110812Z/audit.md` — `paint.fill-opacity` is no longer listed as QGIS-dependent/unresolved; `landuse` now reports `paint.fill-opacity` under qfit simplifications; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T110833Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1062/0.1362`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1726`, z18 Zermatt `0.0323/0.0878`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 144 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2054 passed, 163 skipped, 135 subtests passed
- `git diff --check`
