### PR TITLE
Split rail track line opacity fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -817,11 +817,10 @@ _ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float
     ("z17-plus", 17.0, None),
 )
 _RAIL_TRACK_LINE_OPACITY_EXPRESSION = ["interpolate", ["linear"], ["zoom"], 13.75, 0, 14, 1]
-_RAIL_TRACK_LINE_OPACITY_LAYER_IDS = ("road-rail-tracks", "bridge-rail-tracks")
-_RAIL_TRACK_LINE_OPACITY_EXPRESSIONS = dict.fromkeys(
-    _RAIL_TRACK_LINE_OPACITY_LAYER_IDS,
-    _RAIL_TRACK_LINE_OPACITY_EXPRESSION,
-)
+_RAIL_TRACK_LINE_OPACITY_EXPRESSIONS = {
+    "road-rail-tracks": copy.deepcopy(_RAIL_TRACK_LINE_OPACITY_EXPRESSION),
+    "bridge-rail-tracks": copy.deepcopy(_RAIL_TRACK_LINE_OPACITY_EXPRESSION),
+}
 _RAIL_TRACK_LINE_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
     ("below-z13_75", None, 13.75),
     ("z13_75-to-z14", 13.75, 14.0),

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -816,6 +816,17 @@ _ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float
     ("z16-to-z17", 16.0, 17.0),
     ("z17-plus", 17.0, None),
 )
+_RAIL_TRACK_LINE_OPACITY_EXPRESSION = ["interpolate", ["linear"], ["zoom"], 13.75, 0, 14, 1]
+_RAIL_TRACK_LINE_OPACITY_LAYER_IDS = ("road-rail-tracks", "bridge-rail-tracks")
+_RAIL_TRACK_LINE_OPACITY_EXPRESSIONS = {
+    layer_id: _RAIL_TRACK_LINE_OPACITY_EXPRESSION
+    for layer_id in _RAIL_TRACK_LINE_OPACITY_LAYER_IDS
+}
+_RAIL_TRACK_LINE_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("below-z13_75", None, 13.75),
+    ("z13_75-to-z14", 13.75, 14.0),
+    ("z14-plus", 14.0, None),
+)
 _CONTOUR_LINE_LAYER_ID = "contour-line"
 _CONTOUR_LINE_OPACITY_EXPRESSION = [
     "interpolate",
@@ -2078,6 +2089,30 @@ def _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(layers: 
     return expanded_layers
 
 
+def _rail_track_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited rail track opacity fade into static QGIS zoom bands."""
+    return _zoom_expression_opacity_layer_variants(
+        layer,
+        layer_type="line",
+        paint_property="line-opacity",
+        expressions_by_layer_id=_RAIL_TRACK_LINE_OPACITY_EXPRESSIONS,
+        zoom_bands=_RAIL_TRACK_LINE_OPACITY_ZOOM_BANDS,
+    )
+
+
+def _split_rail_track_line_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _rail_track_line_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited contour index opacity expressions into static QGIS zoom bands."""
     layer_id = str(layer.get("id") or "")
@@ -3215,6 +3250,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_wetland_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_rail_track_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_contour_line_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -818,10 +818,10 @@ _ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float
 )
 _RAIL_TRACK_LINE_OPACITY_EXPRESSION = ["interpolate", ["linear"], ["zoom"], 13.75, 0, 14, 1]
 _RAIL_TRACK_LINE_OPACITY_LAYER_IDS = ("road-rail-tracks", "bridge-rail-tracks")
-_RAIL_TRACK_LINE_OPACITY_EXPRESSIONS = {
-    layer_id: _RAIL_TRACK_LINE_OPACITY_EXPRESSION
-    for layer_id in _RAIL_TRACK_LINE_OPACITY_LAYER_IDS
-}
+_RAIL_TRACK_LINE_OPACITY_EXPRESSIONS = dict.fromkeys(
+    _RAIL_TRACK_LINE_OPACITY_LAYER_IDS,
+    _RAIL_TRACK_LINE_OPACITY_EXPRESSION,
+)
 _RAIL_TRACK_LINE_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
     ("below-z13_75", None, 13.75),
     ("z13_75-to-z14", 13.75, 14.0),

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2305,6 +2305,80 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "road-pedestrian-polygon-pattern-z16-to-z17")
         self.assertEqual(result[2]["id"], "road-pedestrian-polygon-pattern-z17-plus")
 
+    def _rail_track_layer(self, layer_id="road-rail-tracks", line_opacity=None):
+        if line_opacity is None:
+            line_opacity = ["interpolate", ["linear"], ["zoom"], 13.75, 0, 14, 1]
+        return {
+            "id": layer_id,
+            "type": "line",
+            "minzoom": 13,
+            "source-layer": "road",
+            "filter": ["match", ["get", "class"], ["major_rail", "minor_rail"], True, False],
+            "paint": {
+                "line-color": "hsl(75, 25%, 68%)",
+                "line-dasharray": [0.1, 15],
+                "line-opacity": line_opacity,
+            },
+        }
+
+    def test_rail_track_line_opacity_splits_to_static_zoom_bands(self):
+        style = {
+            "layers": [
+                self._rail_track_layer(),
+                self._rail_track_layer(layer_id="bridge-rail-tracks"),
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 6)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        for layer_prefix in ("road-rail-tracks", "bridge-rail-tracks"):
+            low_layer = by_id[f"{layer_prefix}-below-z13_75"]
+            mid_layer = by_id[f"{layer_prefix}-z13_75-to-z14"]
+            high_layer = by_id[f"{layer_prefix}-z14-plus"]
+            self.assertEqual(low_layer["minzoom"], 13)
+            self.assertEqual(low_layer["maxzoom"], 13.75)
+            self.assertEqual(mid_layer["minzoom"], 13.75)
+            self.assertEqual(mid_layer["maxzoom"], 14.0)
+            self.assertEqual(high_layer["minzoom"], 14.0)
+            self.assertNotIn("maxzoom", high_layer)
+            self.assertAlmostEqual(low_layer["paint"]["line-opacity"], 0.0)
+            self.assertAlmostEqual(mid_layer["paint"]["line-opacity"], 0.5)
+            self.assertAlmostEqual(high_layer["paint"]["line-opacity"], 1.0)
+            for layer in (low_layer, mid_layer, high_layer):
+                self.assertEqual(layer["paint"]["line-color"], "hsl(75, 25%, 68%)")
+                self.assertEqual(layer["paint"]["line-dasharray"], [0.1, 15])
+                self.assertEqual(
+                    layer["filter"],
+                    ["match", ["get", "class"], ["major_rail", "minor_rail"], True, False],
+                )
+
+    def test_rail_track_line_opacity_is_not_split_when_shape_changes(self):
+        line_opacity = ["get", "opacity"]
+        style = {"layers": [self._rail_track_layer(line_opacity=line_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "road-rail-tracks")
+        self.assertEqual(result["layers"][0]["paint"]["line-opacity"], line_opacity)
+
+    def test_rail_track_line_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._rail_track_layer()]
+
+        self.assertIs(
+            mapbox_config._split_rail_track_line_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_rail_track_line_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "road-rail-tracks-below-z13_75")
+        self.assertEqual(result[2]["id"], "road-rail-tracks-z13_75-to-z14")
+        self.assertEqual(result[3]["id"], "road-rail-tracks-z14-plus")
+
     def _contour_line_layer(self, line_opacity=None, minzoom=11):
         if line_opacity is None:
             line_opacity = [


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors rail-track `line-opacity` z13.75→z14 fade into static QGIS zoom-band variants
- cover both `road-rail-tracks` and `bridge-rail-tracks` with exact expression-shape gating
- preserve line color, dasharray, width processing, and filters while removing the remaining roads/trails line-opacity expression handed to QGIS

Refs #949.

## Evidence / validation
- Live preprocessing inspection: generated `road-rail-tracks-below-z13_75`/`bridge-rail-tracks-below-z13_75` opacity `0.0`, `*-z13_75-to-z14` opacity `0.5`, and `*-z14-plus` opacity `1.0`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T111920Z/audit.md` — `roads/trails` no longer has QGIS-dependent `paint.line-opacity`; total QGIS-dependent `paint.line-opacity` drops to one remaining `other` layer; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T111944Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1062/0.1362`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1726`, z18 Zermatt `0.0323/0.0878`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 147 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2057 passed, 163 skipped, 135 subtests passed
- `git diff --check`
