### PR TITLE
Split gate/fence/hedge opacity match for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -826,6 +826,12 @@ _RAIL_TRACK_LINE_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None
     ("z13_75-to-z14", 13.75, 14.0),
     ("z14-plus", 14.0, None),
 )
+_GATE_FENCE_HEDGE_LAYER_ID = "gate-fence-hedge"
+_GATE_FENCE_HEDGE_LINE_OPACITY_EXPRESSION = ["match", ["get", "class"], "gate", 0.5, 1]
+_GATE_FENCE_HEDGE_LINE_OPACITY_VARIANTS: tuple[tuple[str, object, float], ...] = (
+    ("gate", ["match", ["get", "class"], "gate", True, False], 0.5),
+    ("fence-hedge", ["match", ["get", "class"], "gate", False, True], 1.0),
+)
 _CONTOUR_LINE_LAYER_ID = "contour-line"
 _CONTOUR_LINE_OPACITY_EXPRESSION = [
     "interpolate",
@@ -2112,6 +2118,40 @@ def _split_rail_track_line_opacity_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _gate_fence_hedge_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited gate/fence/hedge opacity match into static QGIS class variants."""
+    layer_id = str(layer.get("id") or "")
+    paint = layer.get("paint")
+    if layer_id != _GATE_FENCE_HEDGE_LAYER_ID or layer.get("type") != "line" or not isinstance(paint, dict):
+        return None
+    if paint.get("line-opacity") != _GATE_FENCE_HEDGE_LINE_OPACITY_EXPRESSION:
+        return None
+
+    variants: list[dict[str, object]] = []
+    for suffix, class_filter, line_opacity in _GATE_FENCE_HEDGE_LINE_OPACITY_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), class_filter)
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["line-opacity"] = line_opacity
+        variants.append(variant)
+    return variants or None
+
+
+def _split_gate_fence_hedge_line_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _gate_fence_hedge_line_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited contour index opacity expressions into static QGIS zoom bands."""
     layer_id = str(layer.get("id") or "")
@@ -3250,6 +3290,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_wetland_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_rail_track_line_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_gate_fence_hedge_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_contour_line_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2379,6 +2379,80 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "road-rail-tracks-z13_75-to-z14")
         self.assertEqual(result[3]["id"], "road-rail-tracks-z14-plus")
 
+    def _gate_fence_hedge_layer(self, line_opacity=None, filter_value=None):
+        if line_opacity is None:
+            line_opacity = ["match", ["get", "class"], "gate", 0.5, 1]
+        if filter_value is None:
+            filter_value = ["match", ["get", "class"], ["gate", "fence", "hedge"], True, False]
+        return {
+            "id": "gate-fence-hedge",
+            "type": "line",
+            "minzoom": 16,
+            "source-layer": "structure",
+            "filter": filter_value,
+            "paint": {
+                "line-color": ["match", ["get", "class"], "hedge", "hsl(98, 32%, 56%)", "hsl(60, 25%, 63%)"],
+                "line-dasharray": [1, 2, 5, 2, 1, 2],
+                "line-opacity": line_opacity,
+            },
+        }
+
+    def test_gate_fence_hedge_line_opacity_splits_to_static_class_variants(self):
+        style = {"layers": [self._gate_fence_hedge_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 2)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        gate_layer = by_id["gate-fence-hedge-gate"]
+        fence_hedge_layer = by_id["gate-fence-hedge-fence-hedge"]
+        self.assertEqual(gate_layer["minzoom"], 16)
+        self.assertEqual(fence_hedge_layer["minzoom"], 16)
+        self.assertAlmostEqual(gate_layer["paint"]["line-opacity"], 0.5)
+        self.assertAlmostEqual(fence_hedge_layer["paint"]["line-opacity"], 1.0)
+        self.assertEqual(gate_layer["paint"]["line-dasharray"], [1, 2, 5, 2, 1, 2])
+        self.assertEqual(fence_hedge_layer["paint"]["line-dasharray"], [1, 2, 5, 2, 1, 2])
+        self.assertEqual(
+            gate_layer["filter"],
+            [
+                "all",
+                ["match", ["get", "class"], ["gate", "fence", "hedge"], True, False],
+                ["match", ["get", "class"], "gate", True, False],
+            ],
+        )
+        self.assertEqual(
+            fence_hedge_layer["filter"],
+            [
+                "all",
+                ["match", ["get", "class"], ["gate", "fence", "hedge"], True, False],
+                ["match", ["get", "class"], "gate", False, True],
+            ],
+        )
+
+    def test_gate_fence_hedge_line_opacity_is_not_split_when_shape_changes(self):
+        line_opacity = ["get", "opacity"]
+        style = {"layers": [self._gate_fence_hedge_layer(line_opacity=line_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "gate-fence-hedge")
+        self.assertEqual(result["layers"][0]["paint"]["line-opacity"], line_opacity)
+
+    def test_gate_fence_hedge_line_opacity_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._gate_fence_hedge_layer()]
+
+        self.assertIs(
+            mapbox_config._split_gate_fence_hedge_line_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_gate_fence_hedge_line_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "gate-fence-hedge-gate")
+        self.assertEqual(result[2]["id"], "gate-fence-hedge-fence-hedge")
+
     def _contour_line_layer(self, line_opacity=None, minzoom=11):
         if line_opacity is None:
             line_opacity = [


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `gate-fence-hedge` `line-opacity` class match into static QGIS class variants
- preserve the existing gate/fence/hedge source filter, dash pattern, color simplification, and width scalarization
- keep the split exact-shape gated so upstream style changes pass through safely

Refs #949.

## Evidence / validation
- Live preprocessing inspection: generated `gate-fence-hedge-gate` opacity `0.5` and `gate-fence-hedge-fence-hedge` opacity `1.0`, each with the original class filter plus the matching gate/non-gate class clause
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T113239Z/audit.md` — `paint.line-opacity` no longer appears in QGIS-dependent/unresolved properties; `gate-fence-hedge` now reports `paint.line-opacity` under qfit simplifications; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T113303Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1062/0.1362`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1726`, z18 Zermatt `0.0323/0.0878`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 150 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2060 passed, 163 skipped, 135 subtests passed
- `git diff --check`
