### PR TITLE
Split water shadow translate fade for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2182,15 +2182,26 @@ def _literal_translate_vector(value: object) -> list[float] | None:
 
 
 def _water_shadow_translate_at_zoom(zoom: float) -> list[float] | None:
-    lower_translate = _literal_translate_vector(_WATER_SHADOW_TRANSLATE_EXPRESSION[4])
-    upper_translate = _literal_translate_vector(_WATER_SHADOW_TRANSLATE_EXPRESSION[6])
+    expr = _WATER_SHADOW_TRANSLATE_EXPRESSION
+    if len(expr) < 7:
+        return None
+    lower_stop = expr[3]
+    lower_translate = _literal_translate_vector(expr[4])
+    upper_stop = expr[5]
+    upper_translate = _literal_translate_vector(expr[6])
+    if not isinstance(lower_stop, (int, float)) or isinstance(lower_stop, bool):
+        return None
+    if not isinstance(upper_stop, (int, float)) or isinstance(upper_stop, bool):
+        return None
     if lower_translate is None or upper_translate is None:
         return None
-    if zoom <= 7.0:
+    lower_zoom = float(lower_stop)
+    upper_zoom = float(upper_stop)
+    if zoom <= lower_zoom:
         return lower_translate
-    if zoom >= 16.0:
+    if zoom >= upper_zoom:
         return upper_translate
-    factor = _interpolate_filter_factor(["exponential", 1.2], zoom, 7.0, 16.0)
+    factor = _interpolate_filter_factor(expr[1], zoom, lower_zoom, upper_zoom)
     if factor is None:
         return None
     return [

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -832,6 +832,24 @@ _GATE_FENCE_HEDGE_LINE_OPACITY_VARIANTS: tuple[tuple[str, object, float], ...] =
     ("gate", ["match", ["get", "class"], "gate", True, False], 0.5),
     ("fence-hedge", ["match", ["get", "class"], "gate", False, True], 1.0),
 )
+_WATER_SHADOW_TRANSLATE_EXPRESSION = [
+    "interpolate",
+    ["exponential", 1.2],
+    ["zoom"],
+    7,
+    ["literal", [0, 0]],
+    16,
+    ["literal", [-1, -1]],
+]
+_WATER_SHADOW_TRANSLATE_LAYERS: dict[str, tuple[str, str]] = {
+    "water-shadow": ("fill", "fill-translate"),
+    "waterway-shadow": ("line", "line-translate"),
+}
+_WATER_SHADOW_TRANSLATE_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z10-to-z13", 10.0, 13.0),
+    ("z13-to-z16", 13.0, 16.0),
+    ("z16-plus", 16.0, None),
+)
 _CONTOUR_LINE_LAYER_ID = "contour-line"
 _CONTOUR_LINE_OPACITY_EXPRESSION = [
     "interpolate",
@@ -2152,6 +2170,98 @@ def _split_gate_fence_hedge_line_opacity_layers_for_qgis(layers: object) -> obje
     return expanded_layers
 
 
+def _literal_translate_vector(value: object) -> list[float] | None:
+    vector = value
+    if isinstance(value, list) and len(value) == 2 and value[0] == "literal":
+        vector = value[1]
+    if not isinstance(vector, list) or len(vector) != 2:
+        return None
+    if any(isinstance(item, bool) or not isinstance(item, (int, float)) for item in vector):
+        return None
+    return [float(vector[0]), float(vector[1])]
+
+
+def _water_shadow_translate_at_zoom(zoom: float) -> list[float] | None:
+    lower_translate = _literal_translate_vector(_WATER_SHADOW_TRANSLATE_EXPRESSION[4])
+    upper_translate = _literal_translate_vector(_WATER_SHADOW_TRANSLATE_EXPRESSION[6])
+    if lower_translate is None or upper_translate is None:
+        return None
+    if zoom <= 7.0:
+        return lower_translate
+    if zoom >= 16.0:
+        return upper_translate
+    factor = _interpolate_filter_factor(["exponential", 1.2], zoom, 7.0, 16.0)
+    if factor is None:
+        return None
+    return [
+        lower_value + ((upper_value - lower_value) * factor)
+        for lower_value, upper_value in zip(lower_translate, upper_translate)
+    ]
+
+
+def _water_shadow_translate_for_zoom_band(
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+) -> list[float] | None:
+    effective_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        band_minzoom,
+        band_maxzoom,
+    )
+    if effective_zoom_band is None:
+        return None
+    representative_zoom = _zoom_band_representative_zoom(*effective_zoom_band)
+    return _water_shadow_translate_at_zoom(representative_zoom)
+
+
+def _water_shadow_translate_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited water shadow translate fade into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    expected = _WATER_SHADOW_TRANSLATE_LAYERS.get(layer_id)
+    paint = layer.get("paint")
+    if expected is None or not isinstance(paint, dict):
+        return None
+    layer_type, paint_property = expected
+    if layer.get("type") != layer_type or paint.get(paint_property) != _WATER_SHADOW_TRANSLATE_EXPRESSION:
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, band_minzoom, band_maxzoom in _WATER_SHADOW_TRANSLATE_ZOOM_BANDS:
+        translate = _water_shadow_translate_for_zoom_band(
+            existing_minzoom,
+            existing_maxzoom,
+            band_minzoom,
+            band_maxzoom,
+        )
+        if translate is None:
+            continue
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint[paint_property] = translate
+        variants.append(variant)
+    return variants or None
+
+
+def _split_water_shadow_translate_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _water_shadow_translate_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited contour index opacity expressions into static QGIS zoom bands."""
     layer_id = str(layer.get("id") or "")
@@ -3291,6 +3401,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_rail_track_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_gate_fence_hedge_line_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_water_shadow_translate_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_contour_line_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2522,6 +2522,23 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             self.assertAlmostEqual(mid_layer["paint"][paint_property][1], -0.7032048944969905)
             self.assertEqual(high_layer["paint"][paint_property], [-1.0, -1.0])
 
+    def test_water_shadow_translate_uses_expression_stops_and_base(self):
+        expression = [
+            "interpolate",
+            ["exponential", 2],
+            ["zoom"],
+            8,
+            ["literal", [0, 0]],
+            12,
+            ["literal", [-4, -8]],
+        ]
+
+        with patch.object(mapbox_config, "_WATER_SHADOW_TRANSLATE_EXPRESSION", expression):
+            translate = mapbox_config._water_shadow_translate_at_zoom(10)
+
+        self.assertAlmostEqual(translate[0], -0.8)
+        self.assertAlmostEqual(translate[1], -1.6)
+
     def test_water_shadow_translate_is_not_split_when_shape_changes(self):
         translate = ["literal", [0, -1]]
         style = {"layers": [self._water_shadow_layer(translate=translate)]}

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2453,6 +2453,100 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "gate-fence-hedge-gate")
         self.assertEqual(result[2]["id"], "gate-fence-hedge-fence-hedge")
 
+    def _water_shadow_translate_expression(self):
+        return [
+            "interpolate",
+            ["exponential", 1.2],
+            ["zoom"],
+            7,
+            ["literal", [0, 0]],
+            16,
+            ["literal", [-1, -1]],
+        ]
+
+    def _water_shadow_layer(self, translate=None):
+        if translate is None:
+            translate = self._water_shadow_translate_expression()
+        return {
+            "id": "water-shadow",
+            "type": "fill",
+            "minzoom": 10,
+            "source-layer": "water",
+            "paint": {
+                "fill-color": "hsl(224, 79%, 69%)",
+                "fill-translate": translate,
+                "fill-translate-anchor": "viewport",
+            },
+        }
+
+    def _waterway_shadow_layer(self, translate=None):
+        if translate is None:
+            translate = self._water_shadow_translate_expression()
+        return {
+            "id": "waterway-shadow",
+            "type": "line",
+            "minzoom": 10,
+            "source-layer": "waterway",
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-color": "hsl(224, 79%, 69%)",
+                "line-translate": translate,
+                "line-translate-anchor": "viewport",
+                "line-width": 0.1,
+            },
+        }
+
+    def test_water_shadow_translate_splits_to_static_zoom_bands(self):
+        style = {"layers": [self._water_shadow_layer(), self._waterway_shadow_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 6)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        for layer_prefix, paint_property in (
+            ("water-shadow", "fill-translate"),
+            ("waterway-shadow", "line-translate"),
+        ):
+            low_layer = by_id[f"{layer_prefix}-z10-to-z13"]
+            mid_layer = by_id[f"{layer_prefix}-z13-to-z16"]
+            high_layer = by_id[f"{layer_prefix}-z16-plus"]
+            self.assertEqual(low_layer["minzoom"], 10)
+            self.assertEqual(low_layer["maxzoom"], 13.0)
+            self.assertEqual(mid_layer["minzoom"], 13.0)
+            self.assertEqual(mid_layer["maxzoom"], 16.0)
+            self.assertEqual(high_layer["minzoom"], 16.0)
+            self.assertNotIn("maxzoom", high_layer)
+            self.assertAlmostEqual(low_layer["paint"][paint_property][0], -0.3056687812552621)
+            self.assertAlmostEqual(low_layer["paint"][paint_property][1], -0.3056687812552621)
+            self.assertAlmostEqual(mid_layer["paint"][paint_property][0], -0.7032048944969905)
+            self.assertAlmostEqual(mid_layer["paint"][paint_property][1], -0.7032048944969905)
+            self.assertEqual(high_layer["paint"][paint_property], [-1.0, -1.0])
+
+    def test_water_shadow_translate_is_not_split_when_shape_changes(self):
+        translate = ["literal", [0, -1]]
+        style = {"layers": [self._water_shadow_layer(translate=translate)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "water-shadow")
+        self.assertEqual(result["layers"][0]["paint"]["fill-translate"], translate)
+
+    def test_water_shadow_translate_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._water_shadow_layer()]
+
+        self.assertIs(
+            mapbox_config._split_water_shadow_translate_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_water_shadow_translate_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "water-shadow-z10-to-z13")
+        self.assertEqual(result[2]["id"], "water-shadow-z13-to-z16")
+        self.assertEqual(result[3]["id"], "water-shadow-z16-plus")
+
     def _contour_line_layer(self, line_opacity=None, minzoom=11):
         if line_opacity is None:
             line_opacity = [


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors water shadow translate fade into static QGIS zoom-band variants
- cover both `water-shadow` (`paint.fill-translate`) and `waterway-shadow` (`paint.line-translate`) with exact expression-shape gating
- keep the exponential offset approximation per effective zoom band while preserving anchors and existing color/line simplifications

Refs #949.

## Evidence / validation
- Live preprocessing inspection: generated `water-shadow-*` and `waterway-shadow-*` z10–z13, z13–z16, and z16+ variants with static translate vectors `[-0.3056687812552621, -0.3056687812552621]`, `[-0.7032048944969905, -0.7032048944969905]`, and `[-1.0, -1.0]`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T114725Z/audit.md` — `paint.fill-translate` and `paint.line-translate` are no longer listed as QGIS-dependent/unresolved; water shadow layers now report translate under qfit simplifications; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T114753Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1062/0.1362`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1725`, z18 Zermatt `0.0321/0.0874`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 153 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2063 passed, 163 skipped, 135 subtests passed
- `git diff --check`
