### PR TITLE
Split turning feature circle sizes for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2320,8 +2320,7 @@ def _turning_feature_circle_size_for_zoom_band(
     return _circle_size_value(_interpolate_filter_value_at_zoom(expression, representative_zoom))
 
 
-def _turning_feature_circle_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
-    """Split audited turning circle radii/strokes into static QGIS zoom bands."""
+def _turning_feature_circle_layer_match(layer: dict[str, object]) -> tuple[str, bool] | None:
     layer_id = str(layer.get("id") or "")
     if layer_id not in {_TURNING_FEATURE_LAYER_ID, _TURNING_FEATURE_OUTLINE_LAYER_ID} or layer.get("type") != "circle":
         return None
@@ -2331,6 +2330,30 @@ def _turning_feature_circle_layer_variants(layer: dict[str, object]) -> list[dic
     has_stroke_width = layer_id == _TURNING_FEATURE_OUTLINE_LAYER_ID
     if has_stroke_width and paint.get("circle-stroke-width") != _TURNING_FEATURE_CIRCLE_STROKE_WIDTH_EXPRESSION:
         return None
+    return layer_id, has_stroke_width
+
+
+def _turning_feature_circle_stroke_width_for_zoom_band(
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+) -> float | None:
+    return _turning_feature_circle_size_for_zoom_band(
+        _TURNING_FEATURE_CIRCLE_STROKE_WIDTH_EXPRESSION,
+        existing_minzoom,
+        existing_maxzoom,
+        band_minzoom,
+        band_maxzoom,
+    )
+
+
+def _turning_feature_circle_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited turning circle radii/strokes into static QGIS zoom bands."""
+    layer_match = _turning_feature_circle_layer_match(layer)
+    if layer_match is None:
+        return None
+    layer_id, has_stroke_width = layer_match
 
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
@@ -2351,8 +2374,7 @@ def _turning_feature_circle_layer_variants(layer: dict[str, object]) -> list[dic
         assert isinstance(variant_paint, dict)
         variant_paint["circle-radius"] = circle_radius
         if has_stroke_width:
-            circle_stroke_width = _turning_feature_circle_size_for_zoom_band(
-                _TURNING_FEATURE_CIRCLE_STROKE_WIDTH_EXPRESSION,
+            circle_stroke_width = _turning_feature_circle_stroke_width_for_zoom_band(
                 existing_minzoom,
                 existing_maxzoom,
                 band_minzoom,

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -850,6 +850,28 @@ _WATER_SHADOW_TRANSLATE_ZOOM_BANDS: tuple[tuple[str, float | None, float | None]
     ("z13-to-z16", 13.0, 16.0),
     ("z16-plus", 16.0, None),
 )
+_TURNING_FEATURE_LAYER_ID = "turning-feature"
+_TURNING_FEATURE_OUTLINE_LAYER_ID = "turning-feature-outline"
+_TURNING_FEATURE_CIRCLE_RADIUS_EXPRESSION = [
+    "interpolate",
+    ["exponential", 1.5],
+    ["zoom"],
+    15,
+    4.5,
+    16,
+    8,
+    18,
+    20,
+    22,
+    200,
+]
+_TURNING_FEATURE_CIRCLE_STROKE_WIDTH_EXPRESSION = ["interpolate", ["linear"], ["zoom"], 15, 0.8, 16, 1.2, 18, 2]
+_TURNING_FEATURE_CIRCLE_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z15-to-z16", 15.0, 16.0),
+    ("z16-to-z18", 16.0, 18.0),
+    ("z18-to-z22", 18.0, 22.0),
+    ("z22-plus", 22.0, None),
+)
 _CONTOUR_LINE_LAYER_ID = "contour-line"
 _CONTOUR_LINE_OPACITY_EXPRESSION = [
     "interpolate",
@@ -2273,6 +2295,89 @@ def _split_water_shadow_translate_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _circle_size_value(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        return None
+    return float(value)
+
+
+def _turning_feature_circle_size_for_zoom_band(
+    expression: list[object],
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+) -> float | None:
+    effective_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        band_minzoom,
+        band_maxzoom,
+    )
+    if effective_zoom_band is None:
+        return None
+    representative_zoom = _zoom_band_representative_zoom(*effective_zoom_band)
+    return _circle_size_value(_interpolate_filter_value_at_zoom(expression, representative_zoom))
+
+
+def _turning_feature_circle_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited turning circle radii/strokes into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    if layer_id not in {_TURNING_FEATURE_LAYER_ID, _TURNING_FEATURE_OUTLINE_LAYER_ID} or layer.get("type") != "circle":
+        return None
+    paint = layer.get("paint")
+    if not isinstance(paint, dict) or paint.get("circle-radius") != _TURNING_FEATURE_CIRCLE_RADIUS_EXPRESSION:
+        return None
+    has_stroke_width = layer_id == _TURNING_FEATURE_OUTLINE_LAYER_ID
+    if has_stroke_width and paint.get("circle-stroke-width") != _TURNING_FEATURE_CIRCLE_STROKE_WIDTH_EXPRESSION:
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, band_minzoom, band_maxzoom in _TURNING_FEATURE_CIRCLE_ZOOM_BANDS:
+        circle_radius = _turning_feature_circle_size_for_zoom_band(
+            _TURNING_FEATURE_CIRCLE_RADIUS_EXPRESSION,
+            existing_minzoom,
+            existing_maxzoom,
+            band_minzoom,
+            band_maxzoom,
+        )
+        if circle_radius is None:
+            continue
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["circle-radius"] = circle_radius
+        if has_stroke_width:
+            circle_stroke_width = _turning_feature_circle_size_for_zoom_band(
+                _TURNING_FEATURE_CIRCLE_STROKE_WIDTH_EXPRESSION,
+                existing_minzoom,
+                existing_maxzoom,
+                band_minzoom,
+                band_maxzoom,
+            )
+            if circle_stroke_width is None:
+                return None
+            variant_paint["circle-stroke-width"] = circle_stroke_width
+        variants.append(variant)
+    return variants or None
+
+
+def _split_turning_feature_circle_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _turning_feature_circle_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited contour index opacity expressions into static QGIS zoom bands."""
     layer_id = str(layer.get("id") or "")
@@ -3413,6 +3518,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_rail_track_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_gate_fence_hedge_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_water_shadow_translate_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_turning_feature_circle_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_contour_line_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2564,6 +2564,104 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "water-shadow-z13-to-z16")
         self.assertEqual(result[3]["id"], "water-shadow-z16-plus")
 
+    def _turning_feature_circle_radius_expression(self):
+        return ["interpolate", ["exponential", 1.5], ["zoom"], 15, 4.5, 16, 8, 18, 20, 22, 200]
+
+    def _turning_feature_circle_stroke_width_expression(self):
+        return ["interpolate", ["linear"], ["zoom"], 15, 0.8, 16, 1.2, 18, 2]
+
+    def _turning_feature_outline_layer(self, circle_radius=None, circle_stroke_width=None):
+        if circle_radius is None:
+            circle_radius = self._turning_feature_circle_radius_expression()
+        if circle_stroke_width is None:
+            circle_stroke_width = self._turning_feature_circle_stroke_width_expression()
+        return {
+            "id": "turning-feature-outline",
+            "type": "circle",
+            "minzoom": 15,
+            "source-layer": "road",
+            "filter": ["all", ["match", ["get", "class"], ["turning_circle", "turning_loop"], True, False]],
+            "paint": {
+                "circle-radius": circle_radius,
+                "circle-color": "hsl(0, 0%, 95%)",
+                "circle-stroke-width": circle_stroke_width,
+                "circle-stroke-color": "hsl(60, 10%, 70%)",
+                "circle-pitch-alignment": "map",
+            },
+        }
+
+    def _turning_feature_layer(self, circle_radius=None):
+        if circle_radius is None:
+            circle_radius = self._turning_feature_circle_radius_expression()
+        return {
+            "id": "turning-feature",
+            "type": "circle",
+            "minzoom": 15,
+            "source-layer": "road",
+            "filter": ["all", ["match", ["get", "class"], ["turning_circle", "turning_loop"], True, False]],
+            "paint": {
+                "circle-radius": circle_radius,
+                "circle-color": "hsl(0, 0%, 95%)",
+                "circle-pitch-alignment": "map",
+            },
+        }
+
+    def test_turning_feature_circle_properties_split_to_static_zoom_bands(self):
+        style = {"layers": [self._turning_feature_outline_layer(), self._turning_feature_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 8)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        for layer_prefix in ("turning-feature-outline", "turning-feature"):
+            low_layer = by_id[f"{layer_prefix}-z15-to-z16"]
+            mid_layer = by_id[f"{layer_prefix}-z16-to-z18"]
+            high_layer = by_id[f"{layer_prefix}-z18-to-z22"]
+            top_layer = by_id[f"{layer_prefix}-z22-plus"]
+            self.assertEqual(low_layer["minzoom"], 15)
+            self.assertEqual(low_layer["maxzoom"], 16.0)
+            self.assertEqual(mid_layer["minzoom"], 16.0)
+            self.assertEqual(mid_layer["maxzoom"], 18.0)
+            self.assertEqual(high_layer["minzoom"], 18.0)
+            self.assertEqual(high_layer["maxzoom"], 22.0)
+            self.assertEqual(top_layer["minzoom"], 22.0)
+            self.assertNotIn("maxzoom", top_layer)
+            self.assertAlmostEqual(low_layer["paint"]["circle-radius"], 6.073214099741122)
+            self.assertAlmostEqual(mid_layer["paint"]["circle-radius"], 12.8)
+            self.assertAlmostEqual(high_layer["paint"]["circle-radius"], 75.38461538461539)
+            self.assertEqual(top_layer["paint"]["circle-radius"], 200.0)
+        outline_prefix = "turning-feature-outline"
+        self.assertEqual(by_id[f"{outline_prefix}-z15-to-z16"]["paint"]["circle-stroke-width"], 1.0)
+        self.assertEqual(by_id[f"{outline_prefix}-z16-to-z18"]["paint"]["circle-stroke-width"], 1.6)
+        self.assertEqual(by_id[f"{outline_prefix}-z18-to-z22"]["paint"]["circle-stroke-width"], 2.0)
+        self.assertEqual(by_id[f"{outline_prefix}-z22-plus"]["paint"]["circle-stroke-width"], 2.0)
+
+    def test_turning_feature_circle_split_is_exact_shape_gated(self):
+        circle_radius = ["interpolate", ["linear"], ["zoom"], 15, 5, 16, 8]
+        style = {"layers": [self._turning_feature_layer(circle_radius=circle_radius)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "turning-feature")
+        self.assertEqual(result["layers"][0]["paint"]["circle-radius"], circle_radius)
+
+    def test_turning_feature_circle_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._turning_feature_layer()]
+
+        self.assertIs(
+            mapbox_config._split_turning_feature_circle_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_turning_feature_circle_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "turning-feature-z15-to-z16")
+        self.assertEqual(result[2]["id"], "turning-feature-z16-to-z18")
+        self.assertEqual(result[3]["id"], "turning-feature-z18-to-z22")
+        self.assertEqual(result[4]["id"], "turning-feature-z22-plus")
+
     def _contour_line_layer(self, line_opacity=None, minzoom=11):
         if line_opacity is None:
             line_opacity = [


### PR DESCRIPTION
## Summary
- split the audited Mapbox Outdoors `turning-feature-outline` / `turning-feature` circle radius fade into static QGIS zoom-band variants
- scalarize the matching outline `circle-stroke-width` fade in the same bands
- keep the split exact-expression gated so future or unrelated circle expressions pass through unchanged

Refs #949.

## Evidence / validation
- Live preprocessing inspection: generated `turning-feature*` z15–z16, z16–z18, z18–z22, and z22+ variants with static radii `6.073214099741122`, `12.8`, `75.38461538461539`, and `200.0`; outline stroke widths `1.0`, `1.6`, `2.0`, and `2.0`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T120434Z/audit.md` — `paint.circle-radius` and `paint.circle-stroke-width` are no longer listed under QGIS-dependent/unresolved; turning-feature layers now report circle size properties under qfit simplifications; sprite-context probe remains 0 warnings
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T120458Z/summary.md` — all cameras passed; z5 `0.1007/0.1410`, z8 `0.1062/0.1362`, z10 `0.0708/0.1097`, z14 Geneva `0.0896/0.1308`, z14 Chamonix `0.1329/0.1725`, z18 Zermatt `0.0321/0.0873`
- `python3 -m pytest tests/test_mapbox_config.py -q` — 157 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2067 passed, 163 skipped, 135 subtests passed
- `git diff --check`
