### PR TITLE
Split water label class typography for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -887,6 +887,53 @@ _WATERWAY_LABEL_SYMBOL_SPACING_ZOOM_BANDS: tuple[tuple[str, float | None, float 
     ("z15-to-z17", 15.0, 17.0),
     ("z17-plus", 17.0, None),
 )
+_WATER_LINE_LABEL_LAYER_ID = "water-line-label"
+_WATER_POINT_LABEL_LAYER_ID = "water-point-label"
+_WATER_LABEL_TYPOGRAPHY_LAYER_IDS = (
+    _WATER_LINE_LABEL_LAYER_ID,
+    _WATER_POINT_LABEL_LAYER_ID,
+)
+_WATER_LINE_LABEL_TEXT_LETTER_SPACING_EXPRESSION = [
+    "match",
+    ["get", "class"],
+    "ocean",
+    0.25,
+    ["sea", "bay"],
+    0.15,
+    0,
+]
+_WATER_POINT_LABEL_TEXT_LETTER_SPACING_EXPRESSION = [
+    "match",
+    ["get", "class"],
+    "ocean",
+    0.25,
+    ["bay", "sea"],
+    0.15,
+    0.01,
+]
+_WATER_POINT_LABEL_TEXT_MAX_WIDTH_EXPRESSION = [
+    "match",
+    ["get", "class"],
+    "ocean",
+    4,
+    "sea",
+    5,
+    ["bay", "water"],
+    7,
+    10,
+]
+_WATER_LINE_LABEL_TYPOGRAPHY_VARIANTS: tuple[tuple[str, object, float], ...] = (
+    ("ocean", ["match", ["get", "class"], ["ocean"], True, False], 0.25),
+    ("sea-bay", ["match", ["get", "class"], ["sea", "bay"], True, False], 0.15),
+    ("other", ["match", ["get", "class"], ["ocean", "sea", "bay"], False, True], 0.0),
+)
+_WATER_POINT_LABEL_TYPOGRAPHY_VARIANTS: tuple[tuple[str, object, float, float], ...] = (
+    ("ocean", ["match", ["get", "class"], ["ocean"], True, False], 0.25, 4.0),
+    ("sea", ["match", ["get", "class"], ["sea"], True, False], 0.15, 5.0),
+    ("bay", ["match", ["get", "class"], ["bay"], True, False], 0.15, 7.0),
+    ("water", ["match", ["get", "class"], ["water"], True, False], 0.01, 7.0),
+    ("other", ["match", ["get", "class"], ["ocean", "sea", "bay", "water"], False, True], 0.01, 10.0),
+)
 _CONTOUR_LINE_LAYER_ID = "contour-line"
 _CONTOUR_LINE_OPACITY_EXPRESSION = [
     "interpolate",
@@ -1460,10 +1507,21 @@ def _regional_major_road_width_base_layer_id(layer_id: object) -> str | None:
     return None
 
 
+def _water_label_typography_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    for base_layer_id in _WATER_LABEL_TYPOGRAPHY_LAYER_IDS:
+        if normalized == base_layer_id or normalized.startswith(f"{base_layer_id}-"):
+            return base_layer_id
+    return None
+
+
 def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     """Return the original Mapbox layer id for qfit-created layer variants."""
     if _is_waterway_label_layer_id(layer_id):
         return _WATERWAY_LABEL_LAYER_ID
+    water_label_layer_id = _water_label_typography_base_layer_id(layer_id)
+    if water_label_layer_id is not None:
+        return water_label_layer_id
     regional_road_layer_id = _regional_major_road_width_base_layer_id(layer_id)
     if regional_road_layer_id is not None:
         return regional_road_layer_id
@@ -2506,6 +2564,71 @@ def _split_waterway_label_symbol_spacing_layers_for_qgis(layers: object) -> obje
             expanded_layers.append(layer)
             continue
         variants = _waterway_label_symbol_spacing_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _water_line_label_typography_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited water line label class spacing into static QGIS layers."""
+    if str(layer.get("id") or "") != _WATER_LINE_LABEL_LAYER_ID or layer.get("type") != "symbol":
+        return None
+    layout = layer.get("layout")
+    if not isinstance(layout, dict):
+        return None
+    if layout.get("text-letter-spacing") != _WATER_LINE_LABEL_TEXT_LETTER_SPACING_EXPRESSION:
+        return None
+
+    variants: list[dict[str, object]] = []
+    for suffix, class_filter, text_letter_spacing in _WATER_LINE_LABEL_TYPOGRAPHY_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{_WATER_LINE_LABEL_LAYER_ID}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), class_filter)
+        variant_layout = variant["layout"]
+        assert isinstance(variant_layout, dict)
+        variant_layout["text-letter-spacing"] = text_letter_spacing
+        variants.append(variant)
+    return variants
+
+
+def _water_point_label_typography_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited water point label class typography into static QGIS layers."""
+    if str(layer.get("id") or "") != _WATER_POINT_LABEL_LAYER_ID or layer.get("type") != "symbol":
+        return None
+    layout = layer.get("layout")
+    if not isinstance(layout, dict):
+        return None
+    if (
+        layout.get("text-letter-spacing") != _WATER_POINT_LABEL_TEXT_LETTER_SPACING_EXPRESSION
+        or layout.get("text-max-width") != _WATER_POINT_LABEL_TEXT_MAX_WIDTH_EXPRESSION
+    ):
+        return None
+
+    variants: list[dict[str, object]] = []
+    for suffix, class_filter, text_letter_spacing, text_max_width in _WATER_POINT_LABEL_TYPOGRAPHY_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{_WATER_POINT_LABEL_LAYER_ID}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), class_filter)
+        variant_layout = variant["layout"]
+        assert isinstance(variant_layout, dict)
+        variant_layout["text-letter-spacing"] = text_letter_spacing
+        variant_layout["text-max-width"] = text_max_width
+        variants.append(variant)
+    return variants
+
+
+def _water_label_typography_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    return _water_line_label_typography_layer_variants(layer) or _water_point_label_typography_layer_variants(layer)
+
+
+def _split_water_label_typography_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _water_label_typography_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -3652,6 +3775,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_water_shadow_translate_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_turning_feature_circle_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_waterway_label_symbol_spacing_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_water_label_typography_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_contour_line_opacity_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2617,7 +2617,10 @@ def _water_point_label_typography_layer_variants(layer: dict[str, object]) -> li
 
 
 def _water_label_typography_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
-    return _water_line_label_typography_layer_variants(layer) or _water_point_label_typography_layer_variants(layer)
+    variants = _water_line_label_typography_layer_variants(layer)
+    if variants is not None:
+        return variants
+    return _water_point_label_typography_layer_variants(layer)
 
 
 def _split_water_label_typography_layers_for_qgis(layers: object) -> object:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2733,6 +2733,140 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "waterway-label-z15-to-z17")
         self.assertEqual(result[3]["id"], "waterway-label-z17-plus")
 
+    def _water_label_filter(self, geometry_type="Point"):
+        return [
+            "all",
+            [
+                "match",
+                ["get", "class"],
+                [
+                    "bay",
+                    "ocean",
+                    "reservoir",
+                    "sea",
+                    "water",
+                    "disputed_bay",
+                    "disputed_ocean",
+                    "disputed_reservoir",
+                    "disputed_sea",
+                    "disputed_water",
+                ],
+                ["match", ["get", "worldview"], ["all", "US"], True, False],
+                False,
+            ],
+            ["==", ["geometry-type"], geometry_type],
+        ]
+
+    def _water_line_label_layer(self, text_letter_spacing=None):
+        if text_letter_spacing is None:
+            text_letter_spacing = ["match", ["get", "class"], "ocean", 0.25, ["sea", "bay"], 0.15, 0]
+        return {
+            "id": "water-line-label",
+            "type": "symbol",
+            "minzoom": 1,
+            "source-layer": "natural_label",
+            "filter": self._water_label_filter("LineString"),
+            "layout": {
+                "text-letter-spacing": text_letter_spacing,
+                "text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 22, 20],
+                "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+            },
+        }
+
+    def _water_point_label_layer(self, text_letter_spacing=None, text_max_width=None):
+        if text_letter_spacing is None:
+            text_letter_spacing = ["match", ["get", "class"], "ocean", 0.25, ["bay", "sea"], 0.15, 0.01]
+        if text_max_width is None:
+            text_max_width = ["match", ["get", "class"], "ocean", 4, "sea", 5, ["bay", "water"], 7, 10]
+        return {
+            "id": "water-point-label",
+            "type": "symbol",
+            "minzoom": 1,
+            "source-layer": "natural_label",
+            "filter": self._water_label_filter("Point"),
+            "layout": {
+                "text-letter-spacing": text_letter_spacing,
+                "text-max-width": text_max_width,
+                "text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 22, 20],
+                "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+            },
+        }
+
+    def test_water_label_typography_splits_class_variants(self):
+        style = {"layers": [self._water_line_label_layer(), self._water_point_label_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            list(by_id),
+            [
+                "water-line-label-ocean",
+                "water-line-label-sea-bay",
+                "water-line-label-other",
+                "water-point-label-ocean",
+                "water-point-label-sea",
+                "water-point-label-bay",
+                "water-point-label-water",
+                "water-point-label-other",
+            ],
+        )
+        self.assertEqual(by_id["water-line-label-ocean"]["layout"]["text-letter-spacing"], 0.25)
+        self.assertEqual(by_id["water-line-label-sea-bay"]["layout"]["text-letter-spacing"], 0.15)
+        self.assertEqual(by_id["water-line-label-other"]["layout"]["text-letter-spacing"], 0.0)
+        self.assertEqual(by_id["water-point-label-ocean"]["layout"]["text-letter-spacing"], 0.25)
+        self.assertEqual(by_id["water-point-label-ocean"]["layout"]["text-max-width"], 4.0)
+        self.assertEqual(by_id["water-point-label-sea"]["layout"]["text-letter-spacing"], 0.15)
+        self.assertEqual(by_id["water-point-label-sea"]["layout"]["text-max-width"], 5.0)
+        self.assertEqual(by_id["water-point-label-bay"]["layout"]["text-letter-spacing"], 0.15)
+        self.assertEqual(by_id["water-point-label-bay"]["layout"]["text-max-width"], 7.0)
+        self.assertEqual(by_id["water-point-label-water"]["layout"]["text-letter-spacing"], 0.01)
+        self.assertEqual(by_id["water-point-label-water"]["layout"]["text-max-width"], 7.0)
+        self.assertEqual(by_id["water-point-label-other"]["layout"]["text-letter-spacing"], 0.01)
+        self.assertEqual(by_id["water-point-label-other"]["layout"]["text-max-width"], 10.0)
+        self.assertEqual(by_id["water-line-label-ocean"]["layout"]["text-size"], 11.0)
+        self.assertEqual(by_id["water-point-label-ocean"]["layout"]["text-size"], 12.0)
+        self.assertIn(["match", ["get", "class"], ["ocean"], True, False], by_id["water-point-label-ocean"]["filter"])
+        self.assertIn(
+            ["match", ["get", "class"], ["ocean", "sea", "bay", "water"], False, True],
+            by_id["water-point-label-other"]["filter"],
+        )
+
+    def test_water_label_typography_split_is_exact_shape_gated(self):
+        text_letter_spacing = ["match", ["get", "class"], "ocean", 0.25, ["sea", "bay"], 0.2, 0]
+        text_max_width = ["match", ["get", "class"], "ocean", 4, "sea", 6, ["bay", "water"], 7, 10]
+        style = {
+            "layers": [
+                self._water_line_label_layer(text_letter_spacing=text_letter_spacing),
+                self._water_point_label_layer(text_max_width=text_max_width),
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 2)
+        self.assertEqual(result["layers"][0]["id"], "water-line-label")
+        self.assertEqual(result["layers"][0]["layout"]["text-letter-spacing"], text_letter_spacing)
+        self.assertEqual(result["layers"][1]["id"], "water-point-label")
+        self.assertEqual(result["layers"][1]["layout"]["text-max-width"], text_max_width)
+
+    def test_water_label_typography_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._water_point_label_layer()]
+
+        self.assertIs(
+            mapbox_config._split_water_label_typography_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_water_label_typography_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "water-point-label-ocean")
+        self.assertEqual(result[2]["id"], "water-point-label-sea")
+        self.assertEqual(result[3]["id"], "water-point-label-bay")
+        self.assertEqual(result[4]["id"], "water-point-label-water")
+        self.assertEqual(result[5]["id"], "water-point-label-other")
+
     def _contour_line_layer(self, line_opacity=None, minzoom=11):
         if line_opacity is None:
             line_opacity = [


### PR DESCRIPTION
## Summary
- split the audited `water-line-label` class-based `text-letter-spacing` expression into static class-filtered QGIS variants
- split the audited `water-point-label` class-based `text-letter-spacing` / `text-max-width` expressions into static class-filtered QGIS variants
- map generated water label variants back to their live Mapbox layers so existing qfit text-size policy and audit reporting stay aligned

Refs #949

## Validation
- `python3 -m pytest tests/test_mapbox_config.py -q` — 163 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2073 passed, 163 skipped, 135 subtests passed
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T124823Z/audit.md`
  - water `layout.text-letter-spacing` and water `layout.text-max-width` are no longer listed as QGIS-dependent unresolved properties
- All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T124847Z/summary.md`
  - z5 Alps mean/RMS: `0.1007 / 0.1410`
  - z8 Valais/Geneva mean/RMS: `0.1063 / 0.1362`
  - z10 Lausanne mean/RMS: `0.0708 / 0.1097`
  - z14 Geneva airport mean/RMS: `0.0897 / 0.1311`
  - z14 Chamonix mean/RMS: `0.1329 / 0.1726`
  - z18 Zermatt mean/RMS: `0.0321 / 0.0874`
