### PR TITLE
fix: literalize transit label max width

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -210,10 +210,12 @@ _TRANSIT_LABEL_ENTRANCE_TEXT_OFFSET = [
     ["literal", [1, 0]],
     ["literal", [0, 0.8]],
 ]
+_TRANSIT_LABEL_ENTRANCE_TEXT_MAX_WIDTH = ["match", ["get", "stop_type"], "entrance", 15, 9]
 _TRANSIT_LABEL_NON_ENTRANCE_LAYOUT_VALUES = {
     "text-anchor": (_TRANSIT_LABEL_ENTRANCE_TEXT_ANCHOR, "top"),
     "text-justify": (_TRANSIT_LABEL_ENTRANCE_TEXT_JUSTIFY, "center"),
     "text-offset": (_TRANSIT_LABEL_ENTRANCE_TEXT_OFFSET, [0, 0.8]),
+    "text-max-width": (_TRANSIT_LABEL_ENTRANCE_TEXT_MAX_WIDTH, 9.0),
 }
 _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN = {
     2: (

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1095,6 +1095,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ["literal", [1, 0]],
             ["literal", [0, 0.8]],
         ]
+        text_max_width = ["match", ["get", "stop_type"], "entrance", 15, 9]
         style = {
             "layers": [
                 {
@@ -1104,6 +1105,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                         "text-anchor": text_anchor,
                         "text-justify": text_justify,
                         "text-offset": text_offset,
+                        "text-max-width": text_max_width,
                     },
                 },
                 {
@@ -1112,6 +1114,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                         "text-anchor": copy.deepcopy(text_anchor),
                         "text-justify": copy.deepcopy(text_justify),
                         "text-offset": copy.deepcopy(text_offset),
+                        "text-max-width": copy.deepcopy(text_max_width),
                     },
                 },
                 {
@@ -1128,9 +1131,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(transit_layout["text-anchor"], "top")
         self.assertEqual(transit_layout["text-justify"], "center")
         self.assertEqual(transit_layout["text-offset"], [0, 0.8])
+        self.assertEqual(transit_layout["text-max-width"], 9.0)
         self.assertEqual(result["layers"][1]["layout"]["text-anchor"], text_anchor)
         self.assertEqual(result["layers"][1]["layout"]["text-justify"], text_justify)
         self.assertEqual(result["layers"][1]["layout"]["text-offset"], text_offset)
+        self.assertEqual(result["layers"][1]["layout"]["text-max-width"], text_max_width)
         self.assertEqual(result["layers"][2]["layout"]["text-anchor"], text_anchor)
 
     def test_road_exit_shield_concat_icon_uses_reflen_sprite_match_fallback(self):


### PR DESCRIPTION
## Summary

- literalize the audited `transit-label` `layout.text-max-width` stop-type match when qfit has already reduced the layer filter to non-entrance stops
- extend the existing transit-label non-entrance layout regression test to cover max width

## Evidence

Live Mapbox Outdoors audit confirmed the source expression is `['match', ['get', 'stop_type'], 'entrance', 15, 9]` and qfit's simplified transit-label filter excludes entrances, so QGIS should receive the static non-entrance value `9.0`.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 163 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2073 passed, 163 skipped, 135 subtests passed
- live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T131644Z/audit.md`
- all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T131708Z/summary.md`

Refs #949
