### PR TITLE
fix: split low zoom country label justification

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -681,8 +681,9 @@ _COUNTRY_LABEL_LAYOUT_TEXT_JUSTIFY_EXPRESSION = [
     "auto",
 ]
 _COUNTRY_LABEL_LAYOUT_TEXT_RADIAL_OFFSET_EXPRESSION = ["step", ["zoom"], 0.6, 8, 0]
+_COUNTRY_LABEL_BELOW_Z7_BAND_SUFFIX = "below-z7"
 _COUNTRY_LABEL_LAYOUT_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, str | None, float | None], ...] = (
-    ("below-z7", None, 7.0, None, 0.6),
+    (_COUNTRY_LABEL_BELOW_Z7_BAND_SUFFIX, None, 7.0, None, 0.6),
     ("z7-to-z8", 7.0, 8.0, "auto", 0.6),
     ("z8-plus", 8.0, None, "auto", 0.0),
 )
@@ -1838,7 +1839,7 @@ def _country_label_layout_layer_variants(layer: dict[str, object]) -> list[dict[
             continue
         variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
         variant["id"] = f"{layer_id}-{suffix}"
-        if suffix == "below-z7" and text_justify is None:
+        if suffix == _COUNTRY_LABEL_BELOW_Z7_BAND_SUFFIX and text_justify is None:
             variants.extend(
                 _country_label_low_zoom_text_justify_variants(
                     variant,

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -662,15 +662,18 @@ _SETTLEMENT_DOT_ICON_VARIANTS: tuple[tuple[str, object, str, float], ...] = (
     ),
     ("dot-9", ["all", ["!=", ["get", "capital"], 2], [">=", ["get", "symbolrank"], 11]], "dot-9", 0.55),
 )
+_COUNTRY_LABEL_LEFT_TEXT_ANCHORS = ["left", "bottom-left", "top-left"]
+_COUNTRY_LABEL_RIGHT_TEXT_ANCHORS = ["right", "bottom-right", "top-right"]
+_COUNTRY_LABEL_SIDE_TEXT_ANCHORS = [*_COUNTRY_LABEL_LEFT_TEXT_ANCHORS, *_COUNTRY_LABEL_RIGHT_TEXT_ANCHORS]
 _COUNTRY_LABEL_LAYOUT_TEXT_JUSTIFY_EXPRESSION = [
     "step",
     ["zoom"],
     [
         "match",
         ["get", "text_anchor"],
-        ["left", "bottom-left", "top-left"],
+        _COUNTRY_LABEL_LEFT_TEXT_ANCHORS,
         "left",
-        ["right", "bottom-right", "top-right"],
+        _COUNTRY_LABEL_RIGHT_TEXT_ANCHORS,
         "right",
         "center",
     ],
@@ -682,6 +685,23 @@ _COUNTRY_LABEL_LAYOUT_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, s
     ("below-z7", None, 7.0, None, 0.6),
     ("z7-to-z8", 7.0, 8.0, "auto", 0.6),
     ("z8-plus", 8.0, None, "auto", 0.0),
+)
+_COUNTRY_LABEL_LOW_ZOOM_TEXT_JUSTIFY_VARIANTS: tuple[tuple[str, object, str], ...] = (
+    (
+        "left",
+        ["match", ["get", "text_anchor"], _COUNTRY_LABEL_LEFT_TEXT_ANCHORS, True, False],
+        "left",
+    ),
+    (
+        "right",
+        ["match", ["get", "text_anchor"], _COUNTRY_LABEL_RIGHT_TEXT_ANCHORS, True, False],
+        "right",
+    ),
+    (
+        "center",
+        ["match", ["get", "text_anchor"], _COUNTRY_LABEL_SIDE_TEXT_ANCHORS, False, True],
+        "center",
+    ),
 )
 _CONTINENT_LABEL_TEXT_OPACITY_EXPRESSION = [
     "interpolate",
@@ -1784,8 +1804,28 @@ def _set_country_label_static_layout(
         layout["text-radial-offset"] = text_radial_offset
 
 
+def _country_label_low_zoom_text_justify_variants(
+    layer: dict[str, object],
+    *,
+    layer_id: str,
+    text_radial_offset: float | None,
+) -> list[dict[str, object]]:
+    variants: list[dict[str, object]] = []
+    for suffix, filter_clause, text_justify in _COUNTRY_LABEL_LOW_ZOOM_TEXT_JUSTIFY_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(variant.get("filter"), filter_clause)
+        _set_country_label_static_layout(
+            variant,
+            text_justify=text_justify,
+            text_radial_offset=text_radial_offset,
+        )
+        variants.append(variant)
+    return variants
+
+
 def _country_label_layout_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
-    """Split country labels where zoom-only layout ramps become literal at z7+."""
+    """Split audited country-label zoom/layout expressions into QGIS-safe static variants."""
     if not _has_country_label_layout_expression(layer):
         return None
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
@@ -1798,6 +1838,16 @@ def _country_label_layout_layer_variants(layer: dict[str, object]) -> list[dict[
             continue
         variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
         variant["id"] = f"{layer_id}-{suffix}"
+        if suffix == "below-z7" and text_justify is None:
+            variants.extend(
+                _country_label_low_zoom_text_justify_variants(
+                    variant,
+                    layer_id=str(variant["id"]),
+                    text_radial_offset=text_radial_offset,
+                )
+            )
+            has_static_variant = True
+            continue
         if text_justify is not None or text_radial_offset is not None:
             _set_country_label_static_layout(
                 variant,

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1639,6 +1639,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         }
 
     def test_country_label_layout_splits_zoom_only_justification_and_offset(self):
+        country_filter = ["==", ["get", "class"], "country"]
         style = {
             "layers": [
                 {
@@ -1646,6 +1647,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     "type": "symbol",
                     "minzoom": 1,
                     "maxzoom": 10,
+                    "filter": country_filter,
                     "layout": self._country_label_layout(),
                 }
             ]
@@ -1653,24 +1655,50 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 3)
+        self.assertEqual(len(result["layers"]), 5)
         by_id = {layer["id"]: layer for layer in result["layers"]}
-        low_layer = by_id["country-label-below-z7"]
+        low_left_layer = by_id["country-label-below-z7-left"]
+        low_right_layer = by_id["country-label-below-z7-right"]
+        low_center_layer = by_id["country-label-below-z7-center"]
         mid_layer = by_id["country-label-z7-to-z8"]
         high_layer = by_id["country-label-z8-plus"]
-        self.assertEqual(low_layer["minzoom"], 1)
-        self.assertEqual(low_layer["maxzoom"], 7.0)
+        for low_layer, text_justify, text_anchor_filter in (
+            (
+                low_left_layer,
+                "left",
+                ["match", ["get", "text_anchor"], ["left", "bottom-left", "top-left"], True, False],
+            ),
+            (
+                low_right_layer,
+                "right",
+                ["match", ["get", "text_anchor"], ["right", "bottom-right", "top-right"], True, False],
+            ),
+            (
+                low_center_layer,
+                "center",
+                [
+                    "match",
+                    ["get", "text_anchor"],
+                    ["left", "bottom-left", "top-left", "right", "bottom-right", "top-right"],
+                    False,
+                    True,
+                ],
+            ),
+        ):
+            self.assertEqual(low_layer["minzoom"], 1)
+            self.assertEqual(low_layer["maxzoom"], 7.0)
+            self.assertEqual(low_layer["filter"], ["all", country_filter, text_anchor_filter])
+            self.assertEqual(low_layer["layout"]["text-justify"], text_justify)
+            self.assertEqual(low_layer["layout"]["text-radial-offset"], 0.6)
+            self.assertNotIn("icon-image", low_layer["layout"])
         self.assertEqual(mid_layer["minzoom"], 7.0)
         self.assertEqual(mid_layer["maxzoom"], 8.0)
         self.assertEqual(high_layer["minzoom"], 8.0)
         self.assertEqual(high_layer["maxzoom"], 10)
-        self.assertEqual(low_layer["layout"]["text-justify"], self._country_label_layout()["text-justify"])
-        self.assertEqual(low_layer["layout"]["text-radial-offset"], 0.6)
         self.assertEqual(mid_layer["layout"]["text-justify"], "auto")
         self.assertEqual(mid_layer["layout"]["text-radial-offset"], 0.6)
         self.assertEqual(high_layer["layout"]["text-justify"], "auto")
         self.assertEqual(high_layer["layout"]["text-radial-offset"], 0.0)
-        self.assertNotIn("icon-image", low_layer["layout"])
         self.assertEqual({layer["layout"]["text-size"] for layer in result["layers"]}, {16.0})
 
     def test_country_label_layout_is_not_split_when_shape_changes(self):


### PR DESCRIPTION
## Summary

- split the low-zoom `country-label` band into static left/right/center text-justify variants keyed by `text_anchor`
- keep the existing z7+ `auto` variants and low-zoom radial offset literalization intact
- extend the country-label regression test to cover the new filters and static layout values

## Evidence

The live Mapbox Outdoors style uses `['step', ['zoom'], ['match', ['get', 'text_anchor'], ...], 7, 'auto']` for `country-label` `layout.text-justify`. qfit already isolates the below-z7 band, where this expression reduces exactly to the `text_anchor` match. The new variants preserve that behavior with disjoint filters for left/right/default-center anchors.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` → 163 passed
- `python3 -m pytest tests/ -x -q --tb=short` → 2073 passed, 163 skipped, 135 subtests passed
- live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T134700Z/audit.md`
- all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T134725Z/summary.md`

Refs #949
