### PR TITLE
fix: split settlement major label justification

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -630,12 +630,15 @@ _SETTLEMENT_DOT_TEXT_RADIAL_OFFSET_EXPRESSION = [
     _SETTLEMENT_DOT_ICON_SPLIT_ZOOM,
     0,
 ]
+_SETTLEMENT_DOT_LEFT_TEXT_ANCHORS = ["left", "bottom-left", "top-left"]
+_SETTLEMENT_DOT_RIGHT_TEXT_ANCHORS = ["right", "bottom-right", "top-right"]
+_SETTLEMENT_DOT_SIDE_TEXT_ANCHORS = [*_SETTLEMENT_DOT_LEFT_TEXT_ANCHORS, *_SETTLEMENT_DOT_RIGHT_TEXT_ANCHORS]
 _SETTLEMENT_DOT_TEXT_JUSTIFY_LOW_ZOOM = [
     "match",
     ["get", "text_anchor"],
-    ["left", "bottom-left", "top-left"],
+    _SETTLEMENT_DOT_LEFT_TEXT_ANCHORS,
     "left",
-    ["right", "bottom-right", "top-right"],
+    _SETTLEMENT_DOT_RIGHT_TEXT_ANCHORS,
     "right",
     "center",
 ]
@@ -661,6 +664,23 @@ _SETTLEMENT_DOT_ICON_VARIANTS: tuple[tuple[str, object, str, float], ...] = (
         0.55,
     ),
     ("dot-9", ["all", ["!=", ["get", "capital"], 2], [">=", ["get", "symbolrank"], 11]], "dot-9", 0.55),
+)
+_SETTLEMENT_MAJOR_LOW_ZOOM_TEXT_JUSTIFY_VARIANTS: tuple[tuple[str, object, str], ...] = (
+    (
+        "left",
+        ["match", ["get", "text_anchor"], _SETTLEMENT_DOT_LEFT_TEXT_ANCHORS, True, False],
+        "left",
+    ),
+    (
+        "right",
+        ["match", ["get", "text_anchor"], _SETTLEMENT_DOT_RIGHT_TEXT_ANCHORS, True, False],
+        "right",
+    ),
+    (
+        "center",
+        ["match", ["get", "text_anchor"], _SETTLEMENT_DOT_SIDE_TEXT_ANCHORS, False, True],
+        "center",
+    ),
 )
 _COUNTRY_LABEL_LEFT_TEXT_ANCHORS = ["left", "bottom-left", "top-left"]
 _COUNTRY_LABEL_RIGHT_TEXT_ANCHORS = ["right", "bottom-right", "top-right"]
@@ -1734,13 +1754,31 @@ def _set_settlement_high_zoom_text_layout(layer: dict[str, object]) -> None:
         layout["text-justify"] = "center"
 
 
+def _settlement_major_low_zoom_text_justify_variants(layer: dict[str, object]) -> list[dict[str, object]]:
+    layout = layer.get("layout")
+    if not isinstance(layout, dict) or layout.get("text-justify") != _SETTLEMENT_DOT_TEXT_JUSTIFY_LOW_ZOOM:
+        return [layer]
+    layer_id = str(layer.get("id") or _SETTLEMENT_MAJOR_LABEL_LAYER_ID)
+    variants: list[dict[str, object]] = []
+    for suffix, filter_clause, text_justify in _SETTLEMENT_MAJOR_LOW_ZOOM_TEXT_JUSTIFY_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(variant.get("filter"), filter_clause)
+        variant_layout = variant.get("layout")
+        if isinstance(variant_layout, dict):
+            variant_layout["text-justify"] = text_justify
+        variants.append(variant)
+    return variants
+
+
 def _settlement_dot_icon_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split Mapbox's low-zoom settlement dot icons from z8+ centered labels."""
     if not _has_settlement_dot_icon_expression(layer):
         return None
+    base_layer_id = base_mapbox_style_layer_id_for_qfit(layer.get("id"))
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
-    layer_id = str(layer.get("id") or base_mapbox_style_layer_id_for_qfit(layer.get("id")))
+    layer_id = str(layer.get("id") or base_layer_id)
     variants: list[dict[str, object]] = []
 
     for zoom_suffix, band_minzoom, band_maxzoom in _SETTLEMENT_DOT_ICON_ZOOM_BANDS:
@@ -1755,7 +1793,10 @@ def _settlement_dot_icon_layer_variants(layer: dict[str, object]) -> list[dict[s
                 icon_image=icon_image,
                 text_radial_offset=text_radial_offset,
             )
-            variants.append(icon_layer)
+            if base_layer_id == _SETTLEMENT_MAJOR_LABEL_LAYER_ID:
+                variants.extend(_settlement_major_low_zoom_text_justify_variants(icon_layer))
+            else:
+                variants.append(icon_layer)
 
     if _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, _SETTLEMENT_DOT_ICON_SPLIT_ZOOM, None):
         text_layer = _apply_zoom_band_bounds(layer, _SETTLEMENT_DOT_ICON_SPLIT_ZOOM, None)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1528,11 +1528,21 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 17)
+        self.assertEqual(len(result["layers"]), 49)
         by_id = {layer["id"]: layer for layer in result["layers"]}
         city_filter = ["match", ["get", "type"], ["city"], True, False]
-        capital_layer = by_id["settlement-major-label-z2-to-z4-capital-border-dot"]
-        dot_layer = by_id["settlement-major-label-z7-to-z8-dot-10"]
+        left_anchor_filter = ["match", ["get", "text_anchor"], ["left", "bottom-left", "top-left"], True, False]
+        right_anchor_filter = ["match", ["get", "text_anchor"], ["right", "bottom-right", "top-right"], True, False]
+        center_anchor_filter = [
+            "match",
+            ["get", "text_anchor"],
+            ["left", "bottom-left", "top-left", "right", "bottom-right", "top-right"],
+            False,
+            True,
+        ]
+        capital_layer = by_id["settlement-major-label-z2-to-z4-capital-border-dot-left"]
+        dot_layer = by_id["settlement-major-label-z7-to-z8-dot-10-right"]
+        center_layer = by_id["settlement-major-label-z2-to-z4-dot-11-center"]
         text_layer = by_id["settlement-major-label-z8-plus"]
         self.assertEqual(capital_layer["minzoom"], 2)
         self.assertEqual(capital_layer["maxzoom"], 4.0)
@@ -1545,10 +1555,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(capital_layer["layout"]["text-anchor"], ["get", "text_anchor"])
         self.assertEqual(capital_layer["layout"]["text-radial-offset"], 0.6)
         self.assertEqual(dot_layer["layout"]["text-radial-offset"], 0.55)
-        self.assertEqual(capital_layer["layout"]["text-justify"], self._settlement_dot_icon_layout()["text-justify"][2])
+        self.assertEqual(capital_layer["layout"]["text-justify"], "left")
+        self.assertEqual(dot_layer["layout"]["text-justify"], "right")
+        self.assertEqual(center_layer["layout"]["text-justify"], "center")
         self.assertEqual(
             capital_layer["filter"],
-            ["all", ["all", base_filter, ["<=", ["get", "symbolrank"], 6], ["==", ["get", "capital"], 2]], city_filter],
+            [
+                "all",
+                ["all", base_filter, ["<=", ["get", "symbolrank"], 6], ["==", ["get", "capital"], 2], left_anchor_filter],
+                city_filter,
+            ],
         )
         self.assertEqual(
             dot_layer["filter"],
@@ -1559,10 +1575,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     base_filter,
                     ["<", ["get", "symbolrank"], 10],
                     ["all", ["!=", ["get", "capital"], 2], [">=", ["get", "symbolrank"], 9], ["<", ["get", "symbolrank"], 11]],
+                    right_anchor_filter,
                 ],
                 city_filter,
             ],
         )
+        self.assertEqual(center_layer["filter"][1][-1], center_anchor_filter)
         self.assertNotIn("icon-image", text_layer["layout"])
         self.assertEqual(text_layer["layout"]["text-anchor"], "center")
         self.assertEqual(text_layer["layout"]["text-radial-offset"], 0)


### PR DESCRIPTION
## Summary

Split Mapbox Outdoors `settlement-major-label` low-zoom text justification into static left/right/center QGIS layers while preserving the existing dot icon and zoom/rank splits.

## Evidence

- Latest live audit before this slice still had one unresolved `layout.text-justify` expression under settlements/places (`settlement-major-label`).
- New live audit removes `layout.text-justify` from unresolved expression operators: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T140738Z/audit.md`.
- All-camera comparison stayed stable: `debug/mapbox-outdoors-comparison/all-cameras/20260515T140806Z/summary.md`.

## Changes

- Share settlement dot left/right/side anchor constants with the audited Mapbox expression shape.
- Expand only low-zoom `settlement-major-label` dot variants into disjoint `left`, `right`, and `center` `text_anchor` filters.
- Keep z8+ centered settlement text and minor settlement label behavior unchanged.

## Testing

- `python3 -m pytest tests/test_mapbox_config.py -q` — 163 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2073 passed, 163 skipped, 135 subtests passed
- Live Mapbox Outdoors style audit using local QGIS profile token — generated `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T140738Z/audit.md`
- Live all-camera comparison using local QGIS profile token — generated `debug/mapbox-outdoors-comparison/all-cameras/20260515T140806Z/summary.md`

Refs #949
