### PR TITLE
fix: align settlement priority with symbolrank

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -658,6 +658,11 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         expression_arg = _qstub.QgsProperty.fromExpression.call_args[0][0]
         self.assertIn('to_int("symbolrank")', expression_arg)
         self.assertIn('to_int("sizerank")', expression_arg)
+        self.assertLess(
+            expression_arg.index('to_int("symbolrank")'),
+            expression_arg.index('to_int("sizerank")'),
+            "symbolrank must appear before sizerank in the coalesce expression",
+        )
 
     def test_unknown_layer_is_skipped(self):
         labeling = MagicMock()

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -655,6 +655,9 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         dd_props.setProperty.assert_called_once()
         args = dd_props.setProperty.call_args[0]
         self.assertEqual(args[0], 87)  # QgsPalLayerSettings.Priority
+        expression_arg = _qstub.QgsProperty.fromExpression.call_args[0][0]
+        self.assertIn('to_int("symbolrank")', expression_arg)
+        self.assertIn('to_int("sizerank")', expression_arg)
 
     def test_unknown_layer_is_skipped(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -189,7 +189,7 @@ class BackgroundMapService:
                     dd_props.setProperty(
                         87,
                         QgsProperty.fromExpression(
-                            "greatest(1, least(10, 10 - coalesce(to_int(\"sizerank\"), 8) + 1))"
+                            "greatest(1, least(10, 10 - coalesce(to_int(\"symbolrank\"), to_int(\"sizerank\"), 8) + 1))"
                         ),
                     )
                     settings.setDataDefinedProperties(dd_props)


### PR DESCRIPTION
## Summary

Align qfit's QGIS settlement label priority workaround with the live Mapbox Outdoors settlement label sort key by deriving priority from `symbolrank` before falling back to `sizerank`.

## Evidence

- Live Mapbox Outdoors style uses `layout.symbol-sort-key: ["get", "symbolrank"]` for both `settlement-major-label` and `settlement-minor-label`.
- qfit already applies a QGIS post-conversion data-defined label priority for settlement labels, but it was using `sizerank` instead of the audited `symbolrank` field.
- Live validation artifacts after the change:
  - Audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T142634Z/audit.md`
  - All-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260515T142659Z/summary.md`

## Changes

- Use `symbolrank` first when computing settlement label priority in `BackgroundMapService._apply_label_priority`.
- Keep `sizerank` as a fallback for compatibility with any converted styles/data that lack `symbolrank`.
- Extend the mock QGIS background map service test to assert both fields appear in the data-defined priority expression.

## Testing

- `python3 -m pytest tests/test_background_map_service.py -q` — 12 passed, 26 skipped
- `python3 -m pytest tests/ -x -q --tb=short` — 2073 passed, 163 skipped, 135 subtests passed
- Live Mapbox Outdoors style audit using the local QGIS profile token — generated `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T142634Z/audit.md`
- Live all-camera comparison using the local QGIS profile token — generated `debug/mapbox-outdoors-comparison/all-cameras/20260515T142659Z/summary.md`

Refs #949
