### PR TITLE
fix: drop handled settlement sort key

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -3964,13 +3964,14 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                 continue
             for prop in list(props.keys()):
                 val = props[prop]
-                if section == "layout" and prop == "symbol-sort-key":
-                    if (
-                        base_layer_id in {_SETTLEMENT_MAJOR_LABEL_LAYER_ID, _SETTLEMENT_MINOR_LABEL_LAYER_ID}
-                        and val == _SETTLEMENT_SYMBOL_SORT_KEY_EXPRESSION
-                    ):
-                        del props[prop]
-                        continue
+                if (
+                    section == "layout"
+                    and prop == "symbol-sort-key"
+                    and base_layer_id in {_SETTLEMENT_MAJOR_LABEL_LAYER_ID, _SETTLEMENT_MINOR_LABEL_LAYER_ID}
+                    and val == _SETTLEMENT_SYMBOL_SORT_KEY_EXPRESSION
+                ):
+                    del props[prop]
+                    continue
                 if section == "layout" and prop == "icon-image":
                     if val == "":
                         del props[prop]

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -604,6 +604,7 @@ _LABEL_ICON_VISIBILITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, 
     ("z17-plus", _LABEL_ICON_VISIBILITY_SPLIT_ZOOM, None, _LABEL_ICON_HIGH_ZOOM_SIZERANK_THRESHOLD),
 )
 _SETTLEMENT_DOT_ICON_SPLIT_ZOOM = 8.0
+_SETTLEMENT_SYMBOL_SORT_KEY_EXPRESSION = ["get", "symbolrank"]
 _SETTLEMENT_DOT_ICON_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
     ("z2-to-z4", 2.0, 4.0),
     ("z4-to-z6", 4.0, 6.0),
@@ -3963,6 +3964,13 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                 continue
             for prop in list(props.keys()):
                 val = props[prop]
+                if section == "layout" and prop == "symbol-sort-key":
+                    if (
+                        base_layer_id in {_SETTLEMENT_MAJOR_LABEL_LAYER_ID, _SETTLEMENT_MINOR_LABEL_LAYER_ID}
+                        and val == _SETTLEMENT_SYMBOL_SORT_KEY_EXPRESSION
+                    ):
+                        del props[prop]
+                        continue
                 if section == "layout" and prop == "icon-image":
                     if val == "":
                         del props[prop]

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1462,6 +1462,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
     def _settlement_dot_icon_layout(self):
         return {
+            "symbol-sort-key": ["get", "symbolrank"],
             "icon-image": [
                 "step",
                 ["zoom"],
@@ -1558,6 +1559,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(capital_layer["layout"]["text-justify"], "left")
         self.assertEqual(dot_layer["layout"]["text-justify"], "right")
         self.assertEqual(center_layer["layout"]["text-justify"], "center")
+        self.assertNotIn("symbol-sort-key", capital_layer["layout"])
+        self.assertNotIn("symbol-sort-key", dot_layer["layout"])
+        self.assertNotIn("symbol-sort-key", text_layer["layout"])
         self.assertEqual(
             capital_layer["filter"],
             [
@@ -1627,11 +1631,34 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         ):
             layer = by_id[f"settlement-minor-label-z2-to-z4-{suffix}"]
             self.assertEqual(layer["layout"]["icon-image"], icon_name)
+            self.assertNotIn("symbol-sort-key", layer["layout"])
             self.assertEqual(layer["filter"][-1], town_filter)
         self.assertEqual(by_id["settlement-minor-label-z2-to-z4-dot-11"]["filter"][1][2], [">", ["get", "symbolrank"], 6])
         self.assertEqual(by_id["settlement-minor-label-z7-to-z8-dot-11"]["filter"][1][2], [">=", ["get", "symbolrank"], 10])
         self.assertNotIn("icon-image", by_id["settlement-minor-label-z8-plus"]["layout"])
+        self.assertNotIn("symbol-sort-key", by_id["settlement-minor-label-z8-plus"]["layout"])
         self.assertEqual(by_id["settlement-minor-label-z8-plus"]["filter"][-1], town_filter)
+
+    def test_settlement_symbol_sort_key_removal_is_exact_shape_gated(self):
+        style = {
+            "layers": [
+                {
+                    "id": "settlement-major-label",
+                    "type": "symbol",
+                    "layout": {"symbol-sort-key": ["get", "other_rank"]},
+                },
+                {
+                    "id": "state-label",
+                    "type": "symbol",
+                    "layout": {"symbol-sort-key": ["get", "symbolrank"]},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"]["symbol-sort-key"], ["get", "other_rank"])
+        self.assertEqual(result["layers"][1]["layout"]["symbol-sort-key"], ["get", "symbolrank"])
 
     def _country_label_layout(self):
         return {


### PR DESCRIPTION
## Summary

Remove the Mapbox Outdoors settlement `layout.symbol-sort-key: ["get", "symbolrank"]` expression from the QGIS-converted style after #1074 moved settlement label ordering into qfit's QGIS label-priority post-processing.

## Evidence

- Live Mapbox Outdoors uses this exact `symbolrank` sort-key expression on `settlement-major-label` and `settlement-minor-label`.
- qfit now applies a QGIS data-defined settlement label priority from `symbolrank` with a `sizerank` fallback, so passing the same expression through the QGIS Mapbox converter is redundant.
- New audit removes `layout.symbol-sort-key` from unresolved expression operators: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T144550Z/audit.md`.
- All-camera comparison stayed stable: `debug/mapbox-outdoors-comparison/all-cameras/20260515T144615Z/summary.md`.

## Changes

- Add an exact-shape settlement `symbol-sort-key` simplification for `settlement-major-label` and `settlement-minor-label` only.
- Leave non-settlement sort keys and non-`symbolrank` settlement sort-key expressions untouched.
- Extend Mapbox config tests for major/minor settlement split outputs and exact-shape gating.

## Testing

- `python3 -m pytest tests/test_mapbox_config.py -q` — 164 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2074 passed, 163 skipped, 135 subtests passed
- Live Mapbox Outdoors style audit using the local QGIS profile token — generated `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T144550Z/audit.md`
- Live all-camera comparison using the local QGIS profile token — generated `debug/mapbox-outdoors-comparison/all-cameras/20260515T144615Z/summary.md`

Refs #949
