### PR TITLE
fix: split gate label icon sprites

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1506,6 +1506,11 @@ def _is_poi_label_layer_id(layer_id: object) -> bool:
     return normalized == _POI_LABEL_LAYER_ID or normalized.startswith(f"{_POI_LABEL_LAYER_ID}-")
 
 
+def _is_gate_label_layer_id(layer_id: object) -> bool:
+    normalized = str(layer_id or "")
+    return normalized == _GATE_LABEL_LAYER_ID or normalized.startswith(f"{_GATE_LABEL_LAYER_ID}-")
+
+
 def _is_natural_point_label_layer_id(layer_id: object) -> bool:
     normalized = str(layer_id or "")
     return normalized == _NATURAL_POINT_LABEL_LAYER_ID or normalized.startswith(f"{_NATURAL_POINT_LABEL_LAYER_ID}-")
@@ -1582,6 +1587,8 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
         return _ROAD_NUMBER_SHIELD_LAYER_ID
     if _is_poi_label_layer_id(layer_id):
         return _POI_LABEL_LAYER_ID
+    if _is_gate_label_layer_id(layer_id):
+        return _GATE_LABEL_LAYER_ID
     if _is_natural_point_label_layer_id(layer_id):
         return _NATURAL_POINT_LABEL_LAYER_ID
     if _is_continent_label_layer_id(layer_id):
@@ -2922,7 +2929,10 @@ def _gate_label_icon_image_layer_variants(layer: dict[str, object]) -> list[dict
     for suffix, filter_clause, icon_image in _GATE_LABEL_ICON_IMAGE_VARIANTS:
         variant = copy.deepcopy(layer)
         variant["id"] = f"{layer_id}-{suffix}"
-        variant["filter"] = _with_additional_filter_clauses(variant.get("filter"), filter_clause)
+        if variant.get("filter") is False:
+            variant["filter"] = False
+        else:
+            variant["filter"] = _with_additional_filter_clauses(variant.get("filter"), filter_clause)
         variant_layout = variant.get("layout")
         if isinstance(variant_layout, dict):
             variant_layout["icon-image"] = icon_image

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -565,10 +565,16 @@ _PATH_TYPE_FILTER_LOW_ZOOM_SIMPLIFIED_MATCH = [
 _PATH_TYPE_FILTER_SPLIT_ZOOM = 16.0
 _NATURAL_POINT_LABEL_LAYER_ID = "natural-point-label"
 _POI_LABEL_LAYER_ID = "poi-label"
+_GATE_LABEL_LAYER_ID = "gate-label"
 _CONTINENT_LABEL_LAYER_ID = "continent-label"
 _COUNTRY_LABEL_LAYER_ID = "country-label"
 _SETTLEMENT_MAJOR_LABEL_LAYER_ID = "settlement-major-label"
 _SETTLEMENT_MINOR_LABEL_LAYER_ID = "settlement-minor-label"
+_GATE_LABEL_ICON_IMAGE_EXPRESSION = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]
+_GATE_LABEL_ICON_IMAGE_VARIANTS: tuple[tuple[str, object, str], ...] = (
+    ("gate", ["==", ["get", "type"], "gate"], "gate"),
+    ("lift-gate", ["==", ["get", "type"], "lift_gate"], "lift-gate"),
+)
 _POI_FILTER_RANK_ZOOM_STEP = ["step", ["zoom"], 0, 16, 1, 17, 2]
 _POI_FILTER_RANK_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("below-z16", None, 16.0, 0.0),
@@ -2901,6 +2907,42 @@ def _split_label_icon_visibility_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _gate_label_icon_image_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    layout = layer.get("layout")
+    if (
+        base_mapbox_style_layer_id_for_qfit(layer.get("id")) != _GATE_LABEL_LAYER_ID
+        or layer.get("type") != "symbol"
+        or not isinstance(layout, dict)
+        or layout.get("icon-image") != _GATE_LABEL_ICON_IMAGE_EXPRESSION
+    ):
+        return None
+
+    layer_id = str(layer.get("id") or _GATE_LABEL_LAYER_ID)
+    variants: list[dict[str, object]] = []
+    for suffix, filter_clause, icon_image in _GATE_LABEL_ICON_IMAGE_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(variant.get("filter"), filter_clause)
+        variant_layout = variant.get("layout")
+        if isinstance(variant_layout, dict):
+            variant_layout["icon-image"] = icon_image
+        variants.append(variant)
+    return variants
+
+
+def _split_gate_label_icon_image_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _gate_label_icon_image_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _expand_road_number_shield_layers_for_qgis(layers: object) -> object:
     if not isinstance(layers, list):
         return layers
@@ -3869,6 +3911,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_gate_label_icon_image_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_settlement_dot_icon_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_country_label_layout_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_continent_label_text_opacity_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -974,6 +974,39 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][1]["layout"]["icon-image"], generic_empty_fallback)
         self.assertEqual(result["layers"][2]["layout"]["icon-image"], mixed_output_fallback)
 
+    def test_gate_label_icon_match_splits_to_static_sprites(self):
+        gate_icon = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]
+        style = {
+            "layers": [
+                {
+                    "id": "gate-label",
+                    "type": "symbol",
+                    "filter": ["==", ["get", "class"], "gate"],
+                    "layout": {"icon-image": gate_icon, "icon-size": 1},
+                },
+                {
+                    "id": "other-label",
+                    "type": "symbol",
+                    "filter": ["==", ["get", "class"], "gate"],
+                    "layout": {"icon-image": gate_icon},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            ["gate-label-gate", "gate-label-lift-gate", "other-label"],
+        )
+        self.assertEqual(by_id["gate-label-gate"]["layout"]["icon-image"], "gate")
+        self.assertEqual(by_id["gate-label-gate"]["layout"]["icon-size"], 1)
+        self.assertEqual(by_id["gate-label-gate"]["filter"][-1], ["==", ["get", "type"], "gate"])
+        self.assertEqual(by_id["gate-label-lift-gate"]["layout"]["icon-image"], "lift-gate")
+        self.assertEqual(by_id["gate-label-lift-gate"]["filter"][-1], ["==", ["get", "type"], "lift_gate"])
+        self.assertEqual(by_id["other-label"]["layout"]["icon-image"], gate_icon)
+
     def test_maki_icon_get_uses_existing_sprite_match_fallback(self):
         maki_icon = ["get", "maki"]
         other_field_icon = ["get", "network"]

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1005,7 +1005,37 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(by_id["gate-label-gate"]["filter"][-1], ["==", ["get", "type"], "gate"])
         self.assertEqual(by_id["gate-label-lift-gate"]["layout"]["icon-image"], "lift-gate")
         self.assertEqual(by_id["gate-label-lift-gate"]["filter"][-1], ["==", ["get", "type"], "lift_gate"])
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("gate-label-gate"),
+            "gate-label",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("gate-label-lift-gate"),
+            "gate-label",
+        )
         self.assertEqual(by_id["other-label"]["layout"]["icon-image"], gate_icon)
+
+    def test_gate_label_icon_split_preserves_disabled_filter(self):
+        gate_icon = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]
+        style = {
+            "layers": [
+                {
+                    "id": "gate-label",
+                    "type": "symbol",
+                    "filter": False,
+                    "layout": {"icon-image": gate_icon},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            ["gate-label-gate", "gate-label-lift-gate"],
+        )
+        self.assertEqual(result["layers"][0]["filter"], ["==", 1, 0])
+        self.assertEqual(result["layers"][1]["filter"], ["==", 1, 0])
 
     def test_maki_icon_get_uses_existing_sprite_match_fallback(self):
         maki_icon = ["get", "maki"]


### PR DESCRIPTION
## Summary

Split the Mapbox Outdoors `gate-label` sprite expression into two static QGIS layers: one for `type == gate` using the `gate` sprite and one for `type == lift_gate` using the `lift-gate` sprite.

## Evidence

- The live audit showed `gate-label` still passed a data-driven `layout.icon-image` match expression through QGIS: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T144550Z/audit.md`.
- The new audit reduces unresolved `layout.icon-image` expression operators from 5 `get` / 5 `match` layers to 4 `get` / 4 `match` layers and records the static `gate-label-gate` / `gate-label-lift-gate` outputs: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T150321Z/audit.md`.
- All-camera comparison stayed stable: `debug/mapbox-outdoors-comparison/all-cameras/20260515T150345Z/summary.md`.

## Changes

- Add an exact-shape gate-label icon split for the audited `['match', ['get', 'type'], 'gate', 'gate', 'lift_gate', 'lift-gate', '']` expression.
- Preserve non-gate layers and non-matching icon expressions unchanged.
- Add regression coverage for the split and exact layer gating.

## Testing

- `python3 -m pytest tests/test_mapbox_config.py -q` — 165 passed
- `python3 -m pytest tests/ -x -q --tb=short` — 2075 passed, 163 skipped, 135 subtests passed
- Live Mapbox Outdoors style audit using the local QGIS profile token — generated `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260515T150321Z/audit.md`
- Live all-camera comparison using the local QGIS profile token — generated `debug/mapbox-outdoors-comparison/all-cameras/20260515T150345Z/summary.md`

Refs #949
