### PR TITLE
Split Mapbox landuse class colors

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -845,6 +845,9 @@ _LANDUSE_LOW_ZOOM_FILL_COLORS = [
     _LANDUSE_INDUSTRIAL_FILL_COLOR,
     _LANDUSE_FALLBACK_FILL_COLOR,
 ]
+# This intentionally mirrors the live Mapbox Outdoors z16 stop. Residential is
+# absent in Mapbox's expression here, and qfit's residential z10+ opacity band is
+# fully transparent.
 _LANDUSE_HIGH_ZOOM_FILL_COLORS = [
     "match",
     ["get", "class"],
@@ -951,9 +954,11 @@ _LANDUSE_FILL_OPACITY_VARIANTS: tuple[
         False,
     ),
 )
+_LANDUSE_CLASS_FILL_COLOR_EXCLUDED_OPACITY_SUFFIXES = {"other-below-z8"}
 _LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS = {
-    "landuse-other-z8-to-z10",
-    "landuse-other-z10-plus",
+    f"{_LANDUSE_LAYER_ID}-{suffix}"
+    for suffix, _class_filter, _band_minzoom, _band_maxzoom, residential in _LANDUSE_FILL_OPACITY_VARIANTS
+    if not residential and suffix not in _LANDUSE_CLASS_FILL_COLOR_EXCLUDED_OPACITY_SUFFIXES
 }
 _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     (

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -783,6 +783,118 @@ _LANDCOVER_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None]
     ("z10-to-z12", 10.0, 12.0),
 )
 _LANDUSE_LAYER_ID = "landuse"
+_LANDUSE_WOOD_FILL_COLOR = "hsla(103, 50%, 60%, 0.8)"
+_LANDUSE_SCRUB_FILL_COLOR = "hsla(98, 47%, 68%, 0.6)"
+_LANDUSE_AGRICULTURE_FILL_COLOR = "hsla(98, 50%, 74%, 0.6)"
+_LANDUSE_PARK_SPECIAL_FILL_COLOR = "hsl(98, 38%, 68%)"
+_LANDUSE_PARK_FILL_COLOR = "hsl(98, 55%, 70%)"
+_LANDUSE_AIRPORT_FILL_COLOR = "hsl(230, 40%, 82%)"
+_LANDUSE_CEMETERY_FILL_COLOR = "hsl(98, 45%, 75%)"
+_LANDUSE_GLACIER_FILL_COLOR = "hsl(205, 45%, 95%)"
+_LANDUSE_HOSPITAL_FILL_COLOR = "hsl(20, 45%, 82%)"
+_LANDUSE_PITCH_FILL_COLOR = "hsl(88, 65%, 75%)"
+_LANDUSE_SAND_FILL_COLOR = "hsl(69, 60%, 72%)"
+_LANDUSE_ROCK_FILL_COLOR = "hsl(60, 0%, 85%)"
+_LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR = "hsla(60, 0%, 85%, 0.5)"
+_LANDUSE_SCHOOL_FILL_COLOR = "hsl(40, 45%, 78%)"
+_LANDUSE_COMMERCIAL_AREA_FILL_COLOR = "hsl(55, 45%, 85%)"
+_LANDUSE_COMMERCIAL_AREA_HIGH_ZOOM_FILL_COLOR = "hsla(55, 45%, 85%, 0.5)"
+_LANDUSE_RESIDENTIAL_FILL_COLOR = "hsl(60, 7%, 87%)"
+_LANDUSE_INDUSTRIAL_FILL_COLOR = "hsl(230, 20%, 85%)"
+_LANDUSE_FALLBACK_FILL_COLOR = "hsl(60, 22%, 72%)"
+_LANDUSE_LOW_ZOOM_FILL_COLORS = [
+    "match",
+    ["get", "class"],
+    "wood",
+    _LANDUSE_WOOD_FILL_COLOR,
+    "scrub",
+    _LANDUSE_SCRUB_FILL_COLOR,
+    "agriculture",
+    _LANDUSE_AGRICULTURE_FILL_COLOR,
+    "park",
+    [
+        "match",
+        ["get", "type"],
+        ["garden", "playground", "zoo"],
+        _LANDUSE_PARK_SPECIAL_FILL_COLOR,
+        _LANDUSE_PARK_FILL_COLOR,
+    ],
+    "grass",
+    _LANDUSE_AGRICULTURE_FILL_COLOR,
+    "airport",
+    _LANDUSE_AIRPORT_FILL_COLOR,
+    "cemetery",
+    _LANDUSE_CEMETERY_FILL_COLOR,
+    "glacier",
+    _LANDUSE_GLACIER_FILL_COLOR,
+    "hospital",
+    _LANDUSE_HOSPITAL_FILL_COLOR,
+    "pitch",
+    _LANDUSE_PITCH_FILL_COLOR,
+    "sand",
+    _LANDUSE_SAND_FILL_COLOR,
+    "rock",
+    _LANDUSE_ROCK_FILL_COLOR,
+    "school",
+    _LANDUSE_SCHOOL_FILL_COLOR,
+    "commercial_area",
+    _LANDUSE_COMMERCIAL_AREA_FILL_COLOR,
+    "residential",
+    _LANDUSE_RESIDENTIAL_FILL_COLOR,
+    ["facility", "industrial"],
+    _LANDUSE_INDUSTRIAL_FILL_COLOR,
+    _LANDUSE_FALLBACK_FILL_COLOR,
+]
+_LANDUSE_HIGH_ZOOM_FILL_COLORS = [
+    "match",
+    ["get", "class"],
+    "wood",
+    _LANDUSE_WOOD_FILL_COLOR,
+    "scrub",
+    _LANDUSE_SCRUB_FILL_COLOR,
+    "agriculture",
+    _LANDUSE_AGRICULTURE_FILL_COLOR,
+    "park",
+    [
+        "match",
+        ["get", "type"],
+        ["garden", "playground", "zoo"],
+        _LANDUSE_PARK_SPECIAL_FILL_COLOR,
+        _LANDUSE_PARK_FILL_COLOR,
+    ],
+    "grass",
+    _LANDUSE_AGRICULTURE_FILL_COLOR,
+    "airport",
+    _LANDUSE_AIRPORT_FILL_COLOR,
+    "cemetery",
+    _LANDUSE_CEMETERY_FILL_COLOR,
+    "glacier",
+    _LANDUSE_GLACIER_FILL_COLOR,
+    "hospital",
+    _LANDUSE_HOSPITAL_FILL_COLOR,
+    "pitch",
+    _LANDUSE_PITCH_FILL_COLOR,
+    "sand",
+    _LANDUSE_SAND_FILL_COLOR,
+    "rock",
+    _LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR,
+    "school",
+    _LANDUSE_SCHOOL_FILL_COLOR,
+    "commercial_area",
+    _LANDUSE_COMMERCIAL_AREA_HIGH_ZOOM_FILL_COLOR,
+    ["facility", "industrial"],
+    _LANDUSE_INDUSTRIAL_FILL_COLOR,
+    _LANDUSE_FALLBACK_FILL_COLOR,
+]
+_LANDUSE_FILL_COLOR_EXPRESSION = [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    15,
+    _LANDUSE_LOW_ZOOM_FILL_COLORS,
+    16,
+    _LANDUSE_HIGH_ZOOM_FILL_COLORS,
+]
 _LANDUSE_FILL_OPACITY_EXPRESSION = [
     "interpolate",
     ["linear"],
@@ -838,6 +950,15 @@ _LANDUSE_FILL_OPACITY_VARIANTS: tuple[
         None,
         False,
     ),
+)
+_LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS = {
+    "landuse-other-z8-to-z10",
+    "landuse-other-z10-plus",
+}
+_LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
+    ("park", ["match", ["get", "class"], "park", True, False], _LANDUSE_PARK_FILL_COLOR),
+    ("airport", ["match", ["get", "class"], "airport", True, False], _LANDUSE_AIRPORT_FILL_COLOR),
+    ("remaining", ["match", ["get", "class"], ["park", "airport"], False, True], _LANDUSE_FALLBACK_FILL_COLOR),
 )
 _NATIONAL_PARK_LAYER_ID = "national-park"
 _NATIONAL_PARK_FILL_OPACITY_EXPRESSIONS = {
@@ -1546,7 +1667,8 @@ def _landuse_fill_opacity_base_layer_id(layer_id: object) -> str | None:
     if normalized == _LANDUSE_LAYER_ID:
         return _LANDUSE_LAYER_ID
     for suffix, _class_filter, _band_minzoom, _band_maxzoom, _fill_opacity in _LANDUSE_FILL_OPACITY_VARIANTS:
-        if normalized == f"{_LANDUSE_LAYER_ID}-{suffix}":
+        opacity_variant_id = f"{_LANDUSE_LAYER_ID}-{suffix}"
+        if normalized == opacity_variant_id or normalized.startswith(f"{opacity_variant_id}-"):
             return _LANDUSE_LAYER_ID
     return None
 
@@ -2257,6 +2379,44 @@ def _split_landuse_fill_opacity_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _landuse_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _landuse_class_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split visible non-residential landuse bands into QGIS-safe class colors."""
+    layer_id = str(layer.get("id") or "")
+    paint = layer.get("paint")
+    if (
+        layer_id not in _LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS
+        or base_mapbox_style_layer_id_for_qfit(layer_id) != _LANDUSE_LAYER_ID
+        or layer.get("type") != "fill"
+        or not isinstance(paint, dict)
+        or paint.get("fill-color") != _LANDUSE_FILL_COLOR_EXPRESSION
+    ):
+        return None
+
+    variants: list[dict[str, object]] = []
+    for suffix, class_filter, fill_color in _LANDUSE_CLASS_FILL_COLOR_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), class_filter)
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["fill-color"] = fill_color
+        variants.append(variant)
+    return variants or None
+
+
+def _split_landuse_class_fill_color_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _landuse_class_fill_color_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -3908,7 +4068,8 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     literalizes simple ``line-dasharray`` expressions so dashed routes and paths
     survive QGIS conversion, rewrites a few semantics-preserving filter shapes,
     snapshots selected zoom-dependent filters at a representative layer zoom that
-    QGIS can parse, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
+    QGIS can parse, splits visible landuse park/airport colors into static
+    class layers, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
     warning spam from proprietary Mapbox font
     family names.
 
@@ -3929,6 +4090,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_building_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landcover_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landuse_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_landuse_class_fill_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_wetland_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(style.get("layers"))

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -956,7 +956,24 @@ _LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS = {
     "landuse-other-z10-plus",
 }
 _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
-    ("park", ["match", ["get", "class"], "park", True, False], _LANDUSE_PARK_FILL_COLOR),
+    (
+        "park-special",
+        [
+            "all",
+            ["match", ["get", "class"], "park", True, False],
+            ["match", ["get", "type"], ["garden", "playground", "zoo"], True, False],
+        ],
+        _LANDUSE_PARK_SPECIAL_FILL_COLOR,
+    ),
+    (
+        "park",
+        [
+            "all",
+            ["match", ["get", "class"], "park", True, False],
+            ["match", ["get", "type"], ["garden", "playground", "zoo"], False, True],
+        ],
+        _LANDUSE_PARK_FILL_COLOR,
+    ),
     ("airport", ["match", ["get", "class"], "airport", True, False], _LANDUSE_AIRPORT_FILL_COLOR),
     ("remaining", ["match", ["get", "class"], ["park", "airport"], False, True], _LANDUSE_FALLBACK_FILL_COLOR),
 )

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2204,6 +2204,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         result = simplify_mapbox_style_expressions(style)
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            mapbox_config._LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS,
+            {"landuse-other-z8-to-z10", "landuse-other-z10-plus"},
+        )
         self.assertEqual(len(result["layers"]), 12)
         self.assertIn("landuse-other-below-z8", by_id)
         self.assertNotIn("landuse-other-below-z8-park", by_id)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2196,6 +2196,55 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             )
             self.assertEqual(layer["paint"]["fill-color"], "hsl(60, 22%, 72%)")
 
+    def test_landuse_fill_color_splits_visible_park_and_airport_classes(self):
+        layer = self._landuse_layer()
+        layer["paint"]["fill-color"] = copy.deepcopy(mapbox_config._LANDUSE_FILL_COLOR_EXPRESSION)
+        style = {"layers": [layer]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(len(result["layers"]), 10)
+        self.assertIn("landuse-other-below-z8", by_id)
+        self.assertNotIn("landuse-other-below-z8-park", by_id)
+        park_mid = by_id["landuse-other-z8-to-z10-park"]
+        airport_mid = by_id["landuse-other-z8-to-z10-airport"]
+        remaining_mid = by_id["landuse-other-z8-to-z10-remaining"]
+        park_high = by_id["landuse-other-z10-plus-park"]
+        airport_high = by_id["landuse-other-z10-plus-airport"]
+        remaining_high = by_id["landuse-other-z10-plus-remaining"]
+        self.assertEqual(park_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
+        self.assertEqual(airport_mid["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
+        self.assertEqual(remaining_mid["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
+        self.assertEqual(park_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
+        self.assertEqual(airport_high["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
+        self.assertEqual(remaining_high["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
+        self.assertEqual(park_mid["minzoom"], 8.0)
+        self.assertEqual(park_mid["maxzoom"], 10.0)
+        self.assertEqual(airport_high["minzoom"], 10.0)
+        self.assertNotIn("maxzoom", airport_high)
+        self.assertEqual(
+            park_mid["filter"],
+            [
+                "all",
+                ["==", ["get", "source"], "test"],
+                ["match", ["get", "class"], "residential", False, True],
+                ["match", ["get", "class"], "park", True, False],
+            ],
+        )
+        self.assertEqual(
+            airport_mid["filter"][-1],
+            ["match", ["get", "class"], "airport", True, False],
+        )
+        self.assertEqual(
+            remaining_mid["filter"][-1],
+            ["match", ["get", "class"], ["park", "airport"], False, True],
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-airport"),
+            "landuse",
+        )
+
     def test_landuse_fill_opacity_uses_effective_zoom_band_midpoints(self):
         layer = self._landuse_layer()
         layer["minzoom"] = 9.5
@@ -2249,6 +2298,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[4]["id"], "landuse-other-below-z8")
         self.assertEqual(result[5]["id"], "landuse-other-z8-to-z10")
         self.assertEqual(result[6]["id"], "landuse-other-z10-plus")
+
+    def test_landuse_fill_color_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        split_layer = self._landuse_layer()
+        split_layer["id"] = "landuse-other-z10-plus"
+        split_layer["paint"]["fill-color"] = copy.deepcopy(mapbox_config._LANDUSE_FILL_COLOR_EXPRESSION)
+        mixed_layers = ["not-a-layer", self._landuse_layer(), split_layer]
+
+        self.assertIs(
+            mapbox_config._split_landuse_class_fill_color_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_landuse_class_fill_color_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "landuse")
+        self.assertEqual(result[2]["id"], "landuse-other-z10-plus-park")
+        self.assertEqual(result[3]["id"], "landuse-other-z10-plus-airport")
+        self.assertEqual(result[4]["id"], "landuse-other-z10-plus-remaining")
 
     def _national_park_layer(self, fill_opacity=None):
         if fill_opacity is None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2204,18 +2204,22 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         result = simplify_mapbox_style_expressions(style)
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
-        self.assertEqual(len(result["layers"]), 10)
+        self.assertEqual(len(result["layers"]), 12)
         self.assertIn("landuse-other-below-z8", by_id)
         self.assertNotIn("landuse-other-below-z8-park", by_id)
+        park_special_mid = by_id["landuse-other-z8-to-z10-park-special"]
         park_mid = by_id["landuse-other-z8-to-z10-park"]
         airport_mid = by_id["landuse-other-z8-to-z10-airport"]
         remaining_mid = by_id["landuse-other-z8-to-z10-remaining"]
+        park_special_high = by_id["landuse-other-z10-plus-park-special"]
         park_high = by_id["landuse-other-z10-plus-park"]
         airport_high = by_id["landuse-other-z10-plus-airport"]
         remaining_high = by_id["landuse-other-z10-plus-remaining"]
+        self.assertEqual(park_special_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_SPECIAL_FILL_COLOR)
         self.assertEqual(park_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
         self.assertEqual(airport_mid["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
         self.assertEqual(remaining_mid["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
+        self.assertEqual(park_special_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_SPECIAL_FILL_COLOR)
         self.assertEqual(park_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
         self.assertEqual(airport_high["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
         self.assertEqual(remaining_high["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
@@ -2229,7 +2233,19 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "all",
                 ["==", ["get", "source"], "test"],
                 ["match", ["get", "class"], "residential", False, True],
+                [
+                    "all",
+                    ["match", ["get", "class"], "park", True, False],
+                    ["match", ["get", "type"], ["garden", "playground", "zoo"], False, True],
+                ],
+            ],
+        )
+        self.assertEqual(
+            park_special_mid["filter"][-1],
+            [
+                "all",
                 ["match", ["get", "class"], "park", True, False],
+                ["match", ["get", "type"], ["garden", "playground", "zoo"], True, False],
             ],
         )
         self.assertEqual(
@@ -2314,9 +2330,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result[0], "not-a-layer")
         self.assertEqual(result[1]["id"], "landuse")
-        self.assertEqual(result[2]["id"], "landuse-other-z10-plus-park")
-        self.assertEqual(result[3]["id"], "landuse-other-z10-plus-airport")
-        self.assertEqual(result[4]["id"], "landuse-other-z10-plus-remaining")
+        self.assertEqual(result[2]["id"], "landuse-other-z10-plus-park-special")
+        self.assertEqual(result[3]["id"], "landuse-other-z10-plus-park")
+        self.assertEqual(result[4]["id"], "landuse-other-z10-plus-airport")
+        self.assertEqual(result[5]["id"], "landuse-other-z10-plus-remaining")
 
     def _national_park_layer(self, fill_opacity=None):
         if fill_opacity is None:


### PR DESCRIPTION
## Summary

- split Mapbox Outdoors landuse z8+ non-residential QGIS variants into park-special, park, airport, and remaining class-color layers
- keep park, garden/playground/zoo, and airport fill colors aligned with the live Mapbox style instead of collapsing those classes to the generic landuse fallback color
- add regression coverage for the generated landuse color variants and base-layer mapping

## Why

The live #949 comparison matrix still showed Geneva airport and nearby parks collapsing into the generic olive/beige landuse fill in native QGIS vector rendering. The live Mapbox style uses distinct park green, garden/playground/zoo green, and airport blue landuse colors, but qfit previously reduced the whole non-residential landuse band to a single fallback color for QGIS.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check`
- Live style audit with QGIS warning/filter probes: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260516T194619Z/audit.md`
- Full live z5-z18 camera matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260516T194542Z/summary.md`

## Visual comparison

- Geneva airport z14 improved materially: changed-pixel ratio `0.9788 -> 0.8910`, normalized mean delta `0.0896 -> 0.0736`.
- Chamonix z14 moved slightly closer: changed-pixel ratio `0.9924 -> 0.9920`, normalized mean delta `0.1330 -> 0.1326`.
- z5, z8, z10, and z18 were effectively unchanged apart from tiny metric noise.
- Manual image review: Geneva regained the airport landuse tint and park greens without an obvious regression; Chamonix gained small green landuse areas but still needs broader forest/natural landcover work in a future #949 slice.
