### PR TITLE
Split Mapbox landcover class colors

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -982,6 +982,38 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ("airport", ["match", ["get", "class"], "airport", True, False], _LANDUSE_AIRPORT_FILL_COLOR),
     ("remaining", ["match", ["get", "class"], ["park", "airport"], False, True], _LANDUSE_FALLBACK_FILL_COLOR),
 )
+_LANDCOVER_CROP_FILL_COLOR = "hsla(68, 55%, 70%, 0.6)"
+_LANDCOVER_FALLBACK_FILL_COLOR = "hsl(98, 48%, 67%)"
+_LANDCOVER_FILL_COLOR_EXPRESSION = [
+    "match",
+    ["get", "class"],
+    "wood",
+    _LANDUSE_WOOD_FILL_COLOR,
+    "scrub",
+    _LANDUSE_SCRUB_FILL_COLOR,
+    "crop",
+    _LANDCOVER_CROP_FILL_COLOR,
+    "grass",
+    _LANDUSE_AGRICULTURE_FILL_COLOR,
+    "snow",
+    _LANDUSE_GLACIER_FILL_COLOR,
+    _LANDCOVER_FALLBACK_FILL_COLOR,
+]
+_LANDCOVER_CLASS_FILL_COLOR_SPLIT_LAYER_IDS = {
+    f"{_LANDCOVER_LAYER_ID}-{suffix}" for suffix, _band_minzoom, _band_maxzoom in _LANDCOVER_FILL_OPACITY_ZOOM_BANDS
+}
+_LANDCOVER_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
+    ("wood", ["match", ["get", "class"], "wood", True, False], _LANDUSE_WOOD_FILL_COLOR),
+    ("scrub", ["match", ["get", "class"], "scrub", True, False], _LANDUSE_SCRUB_FILL_COLOR),
+    ("crop", ["match", ["get", "class"], "crop", True, False], _LANDCOVER_CROP_FILL_COLOR),
+    ("grass", ["match", ["get", "class"], "grass", True, False], _LANDUSE_AGRICULTURE_FILL_COLOR),
+    ("snow", ["match", ["get", "class"], "snow", True, False], _LANDUSE_GLACIER_FILL_COLOR),
+    (
+        "remaining",
+        ["match", ["get", "class"], ["wood", "scrub", "crop", "grass", "snow"], False, True],
+        _LANDCOVER_FALLBACK_FILL_COLOR,
+    ),
+)
 _NATIONAL_PARK_LAYER_ID = "national-park"
 _NATIONAL_PARK_FILL_OPACITY_EXPRESSIONS = {
     _NATIONAL_PARK_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 5, 0, 6, 0.6, 12, 0.2],
@@ -1684,6 +1716,17 @@ def _is_settlement_minor_label_layer_id(layer_id: object) -> bool:
     return normalized == _SETTLEMENT_MINOR_LABEL_LAYER_ID or normalized.startswith(f"{_SETTLEMENT_MINOR_LABEL_LAYER_ID}-")
 
 
+def _landcover_fill_opacity_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    if normalized == _LANDCOVER_LAYER_ID:
+        return _LANDCOVER_LAYER_ID
+    for suffix, _band_minzoom, _band_maxzoom in _LANDCOVER_FILL_OPACITY_ZOOM_BANDS:
+        opacity_variant_id = f"{_LANDCOVER_LAYER_ID}-{suffix}"
+        if normalized == opacity_variant_id or normalized.startswith(f"{opacity_variant_id}-"):
+            return _LANDCOVER_LAYER_ID
+    return None
+
+
 def _landuse_fill_opacity_base_layer_id(layer_id: object) -> str | None:
     normalized = str(layer_id or "")
     if normalized == _LANDUSE_LAYER_ID:
@@ -1724,6 +1767,9 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     regional_road_layer_id = _regional_major_road_width_base_layer_id(layer_id)
     if regional_road_layer_id is not None:
         return regional_road_layer_id
+    landcover_layer_id = _landcover_fill_opacity_base_layer_id(layer_id)
+    if landcover_layer_id is not None:
+        return landcover_layer_id
     landuse_layer_id = _landuse_fill_opacity_base_layer_id(layer_id)
     if landuse_layer_id is not None:
         return landuse_layer_id
@@ -2323,6 +2369,44 @@ def _split_landcover_fill_opacity_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _landcover_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _landcover_class_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split landcover opacity bands into QGIS-safe class colors."""
+    layer_id = str(layer.get("id") or "")
+    paint = layer.get("paint")
+    if (
+        layer_id not in _LANDCOVER_CLASS_FILL_COLOR_SPLIT_LAYER_IDS
+        or base_mapbox_style_layer_id_for_qfit(layer_id) != _LANDCOVER_LAYER_ID
+        or layer.get("type") != "fill"
+        or not isinstance(paint, dict)
+        or paint.get("fill-color") != _LANDCOVER_FILL_COLOR_EXPRESSION
+    ):
+        return None
+
+    variants: list[dict[str, object]] = []
+    for suffix, class_filter, fill_color in _LANDCOVER_CLASS_FILL_COLOR_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), class_filter)
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["fill-color"] = fill_color
+        variants.append(variant)
+    return variants or None
+
+
+def _split_landcover_class_fill_color_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _landcover_class_fill_color_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -4090,7 +4174,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     literalizes simple ``line-dasharray`` expressions so dashed routes and paths
     survive QGIS conversion, rewrites a few semantics-preserving filter shapes,
     snapshots selected zoom-dependent filters at a representative layer zoom that
-    QGIS can parse, splits visible landuse park/airport colors into static
+    QGIS can parse, splits visible landcover and landuse class colors into static
     class layers, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
     warning spam from proprietary Mapbox font
     family names.
@@ -4111,6 +4195,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_cliff_line_pattern_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_building_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landcover_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_landcover_class_fill_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landuse_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landuse_class_fill_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2094,6 +2094,45 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             self.assertEqual(layer["paint"]["fill-color"], "hsl(98, 48%, 67%)")
             self.assertFalse(layer["paint"]["fill-antialias"])
 
+    def test_landcover_fill_color_splits_class_colors_across_zoom_bands(self):
+        layer = self._landcover_layer()
+        layer["paint"]["fill-color"] = copy.deepcopy(mapbox_config._LANDCOVER_FILL_COLOR_EXPRESSION)
+        style = {"layers": [layer]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(len(result["layers"]), 18)
+        self.assertEqual(
+            mapbox_config._LANDCOVER_CLASS_FILL_COLOR_SPLIT_LAYER_IDS,
+            {"landcover-below-z8", "landcover-z8-to-z10", "landcover-z10-to-z12"},
+        )
+        wood_low = by_id["landcover-below-z8-wood"]
+        snow_mid = by_id["landcover-z8-to-z10-snow"]
+        remaining_high = by_id["landcover-z10-to-z12-remaining"]
+        self.assertEqual(wood_low["minzoom"], 0)
+        self.assertEqual(wood_low["maxzoom"], 8.0)
+        self.assertEqual(snow_mid["minzoom"], 8.0)
+        self.assertEqual(snow_mid["maxzoom"], 10.0)
+        self.assertEqual(remaining_high["minzoom"], 10.0)
+        self.assertEqual(remaining_high["maxzoom"], 12)
+        self.assertEqual(wood_low["paint"]["fill-color"], mapbox_config._LANDUSE_WOOD_FILL_COLOR)
+        self.assertEqual(snow_mid["paint"]["fill-color"], mapbox_config._LANDUSE_GLACIER_FILL_COLOR)
+        self.assertEqual(remaining_high["paint"]["fill-color"], mapbox_config._LANDCOVER_FALLBACK_FILL_COLOR)
+        self.assertAlmostEqual(wood_low["paint"]["fill-opacity"], 0.8)
+        self.assertAlmostEqual(snow_mid["paint"]["fill-opacity"], 0.7015384615384616)
+        self.assertAlmostEqual(remaining_high["paint"]["fill-opacity"], 0.3323076923076923)
+        self.assertEqual(wood_low["filter"], ["all", ["match", ["get", "class"], "wood", True, False]])
+        self.assertEqual(snow_mid["filter"], ["all", ["match", ["get", "class"], "snow", True, False]])
+        self.assertEqual(
+            remaining_high["filter"],
+            ["all", ["match", ["get", "class"], ["wood", "scrub", "crop", "grass", "snow"], False, True]],
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("landcover-z8-to-z10-snow"),
+            "landcover",
+        )
+
     def test_landcover_fill_opacity_is_not_split_when_shape_changes(self):
         fill_opacity = ["get", "opacity"]
         style = {"layers": [self._landcover_layer(fill_opacity=fill_opacity)]}
@@ -2118,6 +2157,28 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "landcover-below-z8")
         self.assertEqual(result[2]["id"], "landcover-z8-to-z10")
         self.assertEqual(result[3]["id"], "landcover-z10-to-z12")
+
+    def test_landcover_fill_color_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        split_layer = self._landcover_layer()
+        split_layer["id"] = "landcover-z8-to-z10"
+        split_layer["paint"]["fill-color"] = copy.deepcopy(mapbox_config._LANDCOVER_FILL_COLOR_EXPRESSION)
+        mixed_layers = ["not-a-layer", self._landcover_layer(), split_layer]
+
+        self.assertIs(
+            mapbox_config._split_landcover_class_fill_color_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_landcover_class_fill_color_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "landcover")
+        self.assertEqual(result[2]["id"], "landcover-z8-to-z10-wood")
+        self.assertEqual(result[3]["id"], "landcover-z8-to-z10-scrub")
+        self.assertEqual(result[4]["id"], "landcover-z8-to-z10-crop")
+        self.assertEqual(result[5]["id"], "landcover-z8-to-z10-grass")
+        self.assertEqual(result[6]["id"], "landcover-z8-to-z10-snow")
+        self.assertEqual(result[7]["id"], "landcover-z8-to-z10-remaining")
 
     def _landuse_layer(self, fill_opacity=None, filter_value=None):
         if fill_opacity is None:


### PR DESCRIPTION
## Summary

- split Mapbox Outdoors landcover opacity bands into wood, scrub, crop, grass, snow, and remaining class-color layers for QGIS
- keep the class colors aligned with the live Mapbox style instead of collapsing landcover to one fallback green
- add regression coverage for generated landcover color variants and base-layer mapping

## Why

The #949 live comparison still showed broad terrain/landcover drift after the landuse slice: low and regional zooms were too uniformly green, especially in alpine snow/rock areas. The live Mapbox landcover layer carries class-specific colors that QGIS could not preserve from the expression, so qfit now translates those into static per-class QGIS layers while preserving the existing opacity zoom bands.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check`
- Live style audit with QGIS warning/filter probes: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260516T200419Z/audit.md`
- Full live z5-z18 camera matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260516T195559Z/summary.md`

## Visual comparison

Compared against current `main` after #1077:

- z5 Switzerland improved materially: changed-pixel ratio `1.0000 -> 0.9438`, normalized mean delta `0.1007 -> 0.0759`.
- z8 Valais-Geneva gained stronger pale alpine snow/rock treatment; metrics changed mixed (`0.1063 -> 0.1162` mean delta), but manual review judged it closer to the Mapbox reference.
- z10 Lausanne moved slightly closer in mean delta (`0.0707 -> 0.0688`) with no obvious visual regression.
- z14 and z18 cameras were effectively unchanged apart from metric noise.
- Manual review: after images improve terrain/landcover parity and remain safe as a focused rendering slice; remaining Chamonix high-zoom forest/natural contrast still needs future #949 work.
