### PR TITLE
Split Mapbox path background colors

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -550,6 +550,33 @@ _PATH_TYPE_FILTER_SPLIT_LAYER_IDS = {
     "road-path",
     "road-path-bg",
 }
+_PATH_BACKGROUND_LINE_COLOR_LAYER_IDS = {
+    "bridge-path-bg",
+    "road-path-bg",
+}
+_PATH_BACKGROUND_LINE_COLOR_EXPRESSION = [
+    "match",
+    ["get", "type"],
+    "piste",
+    "hsl(215, 80%, 48%)",
+    ["mountain_bike", "hiking", "trail", "cycleway", "footway", "path", "bridleway"],
+    "hsl(35, 80%, 48%)",
+    "hsl(60, 1%, 64%)",
+]
+_PATH_BACKGROUND_OUTDOOR_TYPES = ["mountain_bike", "hiking", "trail", "cycleway", "footway", "path", "bridleway"]
+_PATH_BACKGROUND_LINE_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
+    ("piste", ["match", ["get", "type"], "piste", True, False], "hsl(215, 80%, 48%)"),
+    (
+        "outdoor",
+        ["match", ["get", "type"], _PATH_BACKGROUND_OUTDOOR_TYPES, True, False],
+        "hsl(35, 80%, 48%)",
+    ),
+    (
+        "remaining",
+        ["match", ["get", "type"], ["piste", *_PATH_BACKGROUND_OUTDOOR_TYPES], False, True],
+        "hsl(60, 1%, 64%)",
+    ),
+)
 _PATH_TYPE_FILTER_LOW_ZOOM_TYPES = ["steps", "sidewalk", "crossing"]
 _PATH_TYPE_FILTER_LOW_ZOOM_INVERTED_MATCH = [
     "!",
@@ -1537,6 +1564,49 @@ def _split_path_type_filter_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _path_background_line_color_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited path background casing colors into QGIS-safe type layers."""
+    base_layer_id = _path_background_line_color_base_layer_id(layer.get("id"))
+    paint = layer.get("paint")
+    if (
+        base_layer_id is None
+        or layer.get("type") != "line"
+        or not isinstance(paint, dict)
+        or paint.get("line-color") != _PATH_BACKGROUND_LINE_COLOR_EXPRESSION
+    ):
+        return None
+    maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    # Keep z16+ path backgrounds on the conservative fallback until QGIS can
+    # approximate Mapbox's high-zoom pedestrian/path casing stack more fully.
+    if maxzoom is None or maxzoom > _PATH_TYPE_FILTER_SPLIT_ZOOM:
+        return None
+
+    layer_id = str(layer.get("id") or base_layer_id)
+    variants: list[dict[str, object]] = []
+    for suffix, type_filter, line_color in _PATH_BACKGROUND_LINE_COLOR_VARIANTS:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), type_filter)
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["line-color"] = line_color
+        variants.append(variant)
+    return variants or None
+
+
+def _split_path_background_line_color_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _path_background_line_color_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _numeric_match_filter_with_offset(value: object, offset: float) -> object | None:
     if not isinstance(value, list) or len(value) < 5 or value[0] != "match" or (len(value) - 3) % 2 != 0:
         return None
@@ -1738,6 +1808,14 @@ def _landuse_fill_opacity_base_layer_id(layer_id: object) -> str | None:
     return None
 
 
+def _path_background_line_color_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    for base_layer_id in _PATH_BACKGROUND_LINE_COLOR_LAYER_IDS:
+        if normalized == base_layer_id or normalized.startswith(f"{base_layer_id}-"):
+            return base_layer_id
+    return None
+
+
 def _regional_major_road_width_base_layer_id(layer_id: object) -> str | None:
     normalized = str(layer_id or "")
     for suffix, _band_minzoom, _band_maxzoom in _REGIONAL_MAJOR_ROAD_WIDTH_BANDS:
@@ -1773,6 +1851,9 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     landuse_layer_id = _landuse_fill_opacity_base_layer_id(layer_id)
     if landuse_layer_id is not None:
         return landuse_layer_id
+    path_background_layer_id = _path_background_line_color_base_layer_id(layer_id)
+    if path_background_layer_id is not None:
+        return path_background_layer_id
     if _is_road_number_shield_layer_id(layer_id):
         return _ROAD_NUMBER_SHIELD_LAYER_ID
     if _is_poi_label_layer_id(layer_id):
@@ -4174,8 +4255,8 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     literalizes simple ``line-dasharray`` expressions so dashed routes and paths
     survive QGIS conversion, rewrites a few semantics-preserving filter shapes,
     snapshots selected zoom-dependent filters at a representative layer zoom that
-    QGIS can parse, splits visible landcover and landuse class colors into static
-    class layers, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
+    QGIS can parse, splits visible landcover, landuse, and path background class
+    colors into static class layers, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
     warning spam from proprietary Mapbox font
     family names.
 
@@ -4186,6 +4267,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_regional_major_road_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _expand_road_number_shield_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_path_background_line_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_gate_label_icon_image_layers_for_qgis(style.get("layers"))

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1837,41 +1837,29 @@ def _water_label_typography_base_layer_id(layer_id: object) -> str | None:
 
 def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     """Return the original Mapbox layer id for qfit-created layer variants."""
-    if _is_waterway_label_layer_id(layer_id):
-        return _WATERWAY_LABEL_LAYER_ID
-    water_label_layer_id = _water_label_typography_base_layer_id(layer_id)
-    if water_label_layer_id is not None:
-        return water_label_layer_id
-    regional_road_layer_id = _regional_major_road_width_base_layer_id(layer_id)
-    if regional_road_layer_id is not None:
-        return regional_road_layer_id
-    landcover_layer_id = _landcover_fill_opacity_base_layer_id(layer_id)
-    if landcover_layer_id is not None:
-        return landcover_layer_id
-    landuse_layer_id = _landuse_fill_opacity_base_layer_id(layer_id)
-    if landuse_layer_id is not None:
-        return landuse_layer_id
-    path_background_layer_id = _path_background_line_color_base_layer_id(layer_id)
-    if path_background_layer_id is not None:
-        return path_background_layer_id
-    if _is_road_number_shield_layer_id(layer_id):
-        return _ROAD_NUMBER_SHIELD_LAYER_ID
-    if _is_poi_label_layer_id(layer_id):
-        return _POI_LABEL_LAYER_ID
-    if _is_gate_label_layer_id(layer_id):
-        return _GATE_LABEL_LAYER_ID
-    if _is_natural_point_label_layer_id(layer_id):
-        return _NATURAL_POINT_LABEL_LAYER_ID
-    if _is_continent_label_layer_id(layer_id):
-        return _CONTINENT_LABEL_LAYER_ID
-    if _is_cliff_layer_id(layer_id):
-        return _CLIFF_LAYER_ID
-    if _is_country_label_layer_id(layer_id):
-        return _COUNTRY_LABEL_LAYER_ID
-    if _is_settlement_major_label_layer_id(layer_id):
-        return _SETTLEMENT_MAJOR_LABEL_LAYER_ID
-    if _is_settlement_minor_label_layer_id(layer_id):
-        return _SETTLEMENT_MINOR_LABEL_LAYER_ID
+    for resolved_layer_id in (
+        _water_label_typography_base_layer_id(layer_id),
+        _regional_major_road_width_base_layer_id(layer_id),
+        _landcover_fill_opacity_base_layer_id(layer_id),
+        _landuse_fill_opacity_base_layer_id(layer_id),
+        _path_background_line_color_base_layer_id(layer_id),
+    ):
+        if resolved_layer_id is not None:
+            return resolved_layer_id
+    for matches_layer_id, base_layer_id in (
+        (_is_waterway_label_layer_id, _WATERWAY_LABEL_LAYER_ID),
+        (_is_road_number_shield_layer_id, _ROAD_NUMBER_SHIELD_LAYER_ID),
+        (_is_poi_label_layer_id, _POI_LABEL_LAYER_ID),
+        (_is_gate_label_layer_id, _GATE_LABEL_LAYER_ID),
+        (_is_natural_point_label_layer_id, _NATURAL_POINT_LABEL_LAYER_ID),
+        (_is_continent_label_layer_id, _CONTINENT_LABEL_LAYER_ID),
+        (_is_cliff_layer_id, _CLIFF_LAYER_ID),
+        (_is_country_label_layer_id, _COUNTRY_LABEL_LAYER_ID),
+        (_is_settlement_major_label_layer_id, _SETTLEMENT_MAJOR_LABEL_LAYER_ID),
+        (_is_settlement_minor_label_layer_id, _SETTLEMENT_MINOR_LABEL_LAYER_ID),
+    ):
+        if matches_layer_id(layer_id):
+            return base_layer_id
     return str(layer_id or "")
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3542,6 +3542,94 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         for layer in style["layers"]:
             self.assertEqual(layer["filter"], original_path_filter)
 
+    def test_path_background_line_color_splits_type_colors_after_zoom_filter_split(self):
+        path_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            [
+                "step",
+                ["zoom"],
+                ["!", ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], True, False]],
+                16,
+                ["!=", ["get", "type"], "steps"],
+            ],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "road-path-bg",
+                    "type": "line",
+                    "minzoom": 12,
+                    "filter": path_filter,
+                    "paint": {"line-color": copy.deepcopy(mapbox_config._PATH_BACKGROUND_LINE_COLOR_EXPRESSION)},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [
+                "road-path-bg-below-z16-piste",
+                "road-path-bg-below-z16-outdoor",
+                "road-path-bg-below-z16-remaining",
+                "road-path-bg-z16-plus",
+            ],
+        )
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(by_id["road-path-bg-below-z16-piste"]["maxzoom"], 16.0)
+        self.assertEqual(by_id["road-path-bg-z16-plus"]["minzoom"], 16.0)
+        self.assertEqual(by_id["road-path-bg-below-z16-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
+        self.assertEqual(by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
+        self.assertEqual(by_id["road-path-bg-below-z16-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
+        self.assertEqual(by_id["road-path-bg-z16-plus"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
+        self.assertEqual(
+            by_id["road-path-bg-below-z16-outdoor"]["filter"],
+            [
+                "all",
+                ["==", ["get", "class"], "path"],
+                ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], False, True],
+                ["match", ["get", "structure"], ["none", "ford"], True, False],
+                ["==", ["geometry-type"], "LineString"],
+                [
+                    "match",
+                    ["get", "type"],
+                    ["mountain_bike", "hiking", "trail", "cycleway", "footway", "path", "bridleway"],
+                    True,
+                    False,
+                ],
+            ],
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-bg-below-z16-outdoor"),
+            "road-path-bg",
+        )
+
+    def test_path_background_line_color_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        split_layer = {
+            "id": "bridge-path-bg-below-z16",
+            "type": "line",
+            "maxzoom": 16.0,
+            "paint": {"line-color": copy.deepcopy(mapbox_config._PATH_BACKGROUND_LINE_COLOR_EXPRESSION)},
+        }
+        mixed_layers = ["not-a-layer", {"id": "road-path-bg", "type": "line"}, split_layer]
+
+        self.assertIs(
+            mapbox_config._split_path_background_line_color_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_path_background_line_color_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "road-path-bg")
+        self.assertEqual(result[2]["id"], "bridge-path-bg-below-z16-piste")
+        self.assertEqual(result[3]["id"], "bridge-path-bg-below-z16-outdoor")
+        self.assertEqual(result[4]["id"], "bridge-path-bg-below-z16-remaining")
+
     def test_filter_simplification_replaces_path_filter_without_split_outside_threshold(self):
         path_filter = [
             "all",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3562,9 +3562,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     "id": "road-path-bg",
                     "type": "line",
                     "minzoom": 12,
-                    "filter": path_filter,
+                    "filter": copy.deepcopy(path_filter),
                     "paint": {"line-color": copy.deepcopy(mapbox_config._PATH_BACKGROUND_LINE_COLOR_EXPRESSION)},
-                }
+                },
+                {
+                    "id": "bridge-path-bg",
+                    "type": "line",
+                    "minzoom": 14,
+                    "filter": copy.deepcopy(path_filter),
+                    "paint": {"line-color": copy.deepcopy(mapbox_config._PATH_BACKGROUND_LINE_COLOR_EXPRESSION)},
+                },
             ]
         }
 
@@ -3577,15 +3584,22 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-path-bg-below-z16-outdoor",
                 "road-path-bg-below-z16-remaining",
                 "road-path-bg-z16-plus",
+                "bridge-path-bg-below-z16-piste",
+                "bridge-path-bg-below-z16-outdoor",
+                "bridge-path-bg-below-z16-remaining",
+                "bridge-path-bg-z16-plus",
             ],
         )
         by_id = {layer["id"]: layer for layer in result["layers"]}
-        self.assertEqual(by_id["road-path-bg-below-z16-piste"]["maxzoom"], 16.0)
-        self.assertEqual(by_id["road-path-bg-z16-plus"]["minzoom"], 16.0)
-        self.assertEqual(by_id["road-path-bg-below-z16-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
-        self.assertEqual(by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
-        self.assertEqual(by_id["road-path-bg-below-z16-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
-        self.assertEqual(by_id["road-path-bg-z16-plus"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
+        for layer_id in ("road-path-bg", "bridge-path-bg"):
+            self.assertEqual(by_id[f"{layer_id}-below-z16-piste"]["maxzoom"], 16.0)
+            self.assertEqual(by_id[f"{layer_id}-z16-plus"]["minzoom"], 16.0)
+            self.assertEqual(by_id[f"{layer_id}-below-z16-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
+            self.assertEqual(by_id[f"{layer_id}-below-z16-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
+            self.assertEqual(by_id[f"{layer_id}-below-z16-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
+            self.assertEqual(by_id[f"{layer_id}-z16-plus"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
+        self.assertEqual(by_id["road-path-bg-below-z16-piste"]["minzoom"], 12)
+        self.assertEqual(by_id["bridge-path-bg-below-z16-piste"]["minzoom"], 14)
         self.assertEqual(
             by_id["road-path-bg-below-z16-outdoor"]["filter"],
             [
@@ -3606,6 +3620,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-bg-below-z16-outdoor"),
             "road-path-bg",
+        )
+        self.assertEqual(
+            by_id["bridge-path-bg-below-z16-outdoor"]["filter"],
+            by_id["road-path-bg-below-z16-outdoor"]["filter"],
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("bridge-path-bg-below-z16-outdoor"),
+            "bridge-path-bg",
         )
 
     def test_path_background_line_color_helpers_keep_passthrough_inputs(self):


### PR DESCRIPTION
Closes part of #949.

## Summary

- split Mapbox Outdoors `road-path-bg` and `bridge-path-bg` below-z16 path background colors into piste, outdoor-path, and remaining static QGIS layers
- keep z16+ path backgrounds on the conservative fallback until qfit can approximate Mapbox's high-zoom pedestrian/path casing stack more fully
- add regression coverage for the color split, zoom-filter interaction, passthrough behavior, and base-layer mapping

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check`
- live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260516T204136Z/audit.md`
- full live comparison matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260516T204201Z/summary.md`
- targeted visual review: Chamonix z14 is closer for orange trail/path color; Zermatt z18 is neutral because z16+ remains unchanged
