### PR TITLE
Split Mapbox major link widths

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2039,37 +2039,64 @@ def _major_link_width_mm(expr: object, target_zoom: float) -> float | None:
     return max(0.1, min(size * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM))
 
 
-def _major_link_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
-    """Split audited z12+ motorway/trunk link widths into static QGIS zoom bands."""
+def _has_major_link_width_expression(layer: dict[str, object]) -> bool:
     layer_id = str(layer.get("id") or "")
     if layer_id not in _MAJOR_LINK_WIDTH_LAYER_IDS or layer.get("type") != "line":
-        return None
+        return False
     paint = layer.get("paint")
-    if not isinstance(paint, dict) or not any(
+    return isinstance(paint, dict) and any(
         isinstance(paint.get(prop), list) for prop in _MAJOR_LINK_WIDTH_PROPS
-    ):
+    )
+
+
+def _apply_major_link_width_values_for_qgis(paint: dict[str, object], target_zoom: float) -> bool:
+    changed = False
+    for prop in _MAJOR_LINK_WIDTH_PROPS:
+        width_mm = _major_link_width_mm(paint.get(prop), target_zoom)
+        if width_mm is not None:
+            paint[prop] = width_mm
+            changed = True
+    return changed
+
+
+def _major_link_width_layer_variant(
+    layer: dict[str, object],
+    layer_id: str,
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band: tuple[str, float | None, float | None, float],
+) -> dict[str, object] | None:
+    suffix, band_minzoom, band_maxzoom, target_zoom = band
+    zoom_band = _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom)
+    if zoom_band is None:
+        return None
+    variant = copy.deepcopy(layer)
+    variant["id"] = f"{layer_id}-{suffix}"
+    _set_zoom_bounds(variant, *zoom_band)
+    variant_paint = variant.get("paint")
+    if not isinstance(variant_paint, dict):
+        return None
+    return variant if _apply_major_link_width_values_for_qgis(variant_paint, target_zoom) else None
+
+
+def _major_link_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited z12+ motorway/trunk link widths into static QGIS zoom bands."""
+    if not _has_major_link_width_expression(layer):
         return None
 
+    layer_id = str(layer.get("id") or "")
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
     variants: list[dict[str, object]] = []
-    for suffix, band_minzoom, band_maxzoom, target_zoom in _MAJOR_LINK_WIDTH_BANDS:
-        zoom_band = _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom)
-        if zoom_band is None:
-            continue
-        variant = copy.deepcopy(layer)
-        variant["id"] = f"{layer_id}-{suffix}"
-        _set_zoom_bounds(variant, *zoom_band)
-        variant_paint = variant.get("paint")
-        if not isinstance(variant_paint, dict):
-            continue
-        changed = False
-        for prop in _MAJOR_LINK_WIDTH_PROPS:
-            width_mm = _major_link_width_mm(variant_paint.get(prop), target_zoom)
-            if width_mm is not None:
-                variant_paint[prop] = width_mm
-                changed = True
-        if changed:
+    for band in _MAJOR_LINK_WIDTH_BANDS:
+        variant = _major_link_width_layer_variant(
+            layer,
+            layer_id,
+            existing_minzoom,
+            existing_maxzoom,
+            band,
+        )
+        if variant is not None:
             variants.append(variant)
     return variants or None
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -534,6 +534,21 @@ _REGIONAL_CORE_ROAD_WIDTH_LAYER_IDS = {
     "road-primary",
     "road-primary-case",
 }
+_MAJOR_LINK_WIDTH_LAYER_IDS = {
+    "bridge-major-link",
+    "bridge-major-link-2",
+    "bridge-major-link-2-case",
+    "bridge-major-link-case",
+    "road-major-link",
+    "road-major-link-case",
+    "tunnel-major-link",
+    "tunnel-major-link-case",
+}
+_MAJOR_LINK_WIDTH_PROPS = {"line-width", "line-gap-width"}
+_MAJOR_LINK_WIDTH_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
+    ("z12-to-z16", 12.0, 16.0, 14.0),
+    ("z16-plus", 16.0, None, 16.0),
+)
 _REGIONAL_MAJOR_ROAD_WIDTH_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
     ("z3-to-z5", None, 5.0),
     ("z5-to-z6", 5.0, 6.0),
@@ -1827,6 +1842,17 @@ def _regional_major_road_width_base_layer_id(layer_id: object) -> str | None:
     return None
 
 
+def _major_link_width_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    for suffix, _band_minzoom, _band_maxzoom, _target_zoom in _MAJOR_LINK_WIDTH_BANDS:
+        band_suffix = f"-{suffix}"
+        if normalized.endswith(band_suffix):
+            base_layer_id = normalized[: -len(band_suffix)]
+            if base_layer_id in _MAJOR_LINK_WIDTH_LAYER_IDS:
+                return base_layer_id
+    return None
+
+
 def _water_label_typography_base_layer_id(layer_id: object) -> str | None:
     normalized = str(layer_id or "")
     for base_layer_id in _WATER_LABEL_TYPOGRAPHY_LAYER_IDS:
@@ -1840,6 +1866,7 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     for resolved_layer_id in (
         _water_label_typography_base_layer_id(layer_id),
         _regional_major_road_width_base_layer_id(layer_id),
+        _major_link_width_base_layer_id(layer_id),
         _landcover_fill_opacity_base_layer_id(layer_id),
         _landuse_fill_opacity_base_layer_id(layer_id),
         _path_background_line_color_base_layer_id(layer_id),
@@ -1983,6 +2010,79 @@ def _split_regional_major_road_width_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _regional_major_road_width_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _extract_zoom_scalar_size_at_zoom(expr: object, target_zoom: float) -> float | None:
+    if isinstance(expr, bool):
+        return None
+    if isinstance(expr, (int, float)):
+        return float(expr)
+    if not isinstance(expr, list) or len(expr) < 4:
+        return None
+    if expr[0] == "step" and expr[1] == ["zoom"]:
+        outputs = _step_outputs(expr)
+        if all(_numeric_expression_value(output) is not None for output in outputs):
+            return _numeric_expression_value(_step_zoom_value(expr, target_zoom=target_zoom))
+    if expr[0] == "interpolate" and len(expr) >= 5 and expr[2] == ["zoom"]:
+        outputs = [expr[index] for index in range(4, len(expr), 2)]
+        if all(_numeric_expression_value(output) is not None for output in outputs):
+            return _numeric_expression_value(_interpolate_filter_value_at_zoom(expr, target_zoom))
+    return None
+
+
+def _major_link_width_mm(expr: object, target_zoom: float) -> float | None:
+    size = _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
+    if size is None:
+        return None
+    return max(0.1, min(size * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM))
+
+
+def _major_link_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited z12+ motorway/trunk link widths into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    if layer_id not in _MAJOR_LINK_WIDTH_LAYER_IDS or layer.get("type") != "line":
+        return None
+    paint = layer.get("paint")
+    if not isinstance(paint, dict) or not any(
+        isinstance(paint.get(prop), list) for prop in _MAJOR_LINK_WIDTH_PROPS
+    ):
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, band_minzoom, band_maxzoom, target_zoom in _MAJOR_LINK_WIDTH_BANDS:
+        zoom_band = _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom)
+        if zoom_band is None:
+            continue
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        _set_zoom_bounds(variant, *zoom_band)
+        variant_paint = variant.get("paint")
+        if not isinstance(variant_paint, dict):
+            continue
+        changed = False
+        for prop in _MAJOR_LINK_WIDTH_PROPS:
+            width_mm = _major_link_width_mm(variant_paint.get(prop), target_zoom)
+            if width_mm is not None:
+                variant_paint[prop] = width_mm
+                changed = True
+        if changed:
+            variants.append(variant)
+    return variants or None
+
+
+def _split_major_link_width_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _major_link_width_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -3382,20 +3482,10 @@ def _extract_zoom_scalar_size(expr: object, *, minzoom: object = None, maxzoom: 
     Keep data-driven sizes intact; QGIS may be able to apply them in contexts
     where a static snapshot would lose feature-specific emphasis.
     """
-    if not isinstance(expr, list) or len(expr) < 4:
-        return None
     target_zoom = _representative_zoom_in_layer_range(minzoom, maxzoom)
     if target_zoom is None:
         return None
-    if expr[0] == "step" and expr[1] == ["zoom"]:
-        outputs = _step_outputs(expr)
-        if all(_numeric_expression_value(output) is not None for output in outputs):
-            return _numeric_expression_value(_step_zoom_value(expr, target_zoom=target_zoom))
-    if expr[0] == "interpolate" and len(expr) >= 5 and expr[2] == ["zoom"]:
-        outputs = [expr[index] for index in range(4, len(expr), 2)]
-        if all(_numeric_expression_value(output) is not None for output in outputs):
-            return _numeric_expression_value(_interpolate_filter_value_at_zoom(expr, target_zoom))
-    return None
+    return _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
 
 
 def _clamp_opacity_value(value: object) -> float | None:
@@ -4253,6 +4343,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     """
     style = copy.deepcopy(style_definition)
     style["layers"] = _split_regional_major_road_width_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_major_link_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _expand_road_number_shield_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_background_line_color_layers_for_qgis(style.get("layers"))

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -545,6 +545,10 @@ _MAJOR_LINK_WIDTH_LAYER_IDS = {
     "tunnel-major-link-case",
 }
 _MAJOR_LINK_WIDTH_PROPS = {"line-width", "line-gap-width"}
+_MAJOR_LINK_WIDTH_MINIMUM_MM_BY_PROP = {
+    "line-width": 0.1,
+    "line-gap-width": 0.0,
+}
 _MAJOR_LINK_WIDTH_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("z12-to-z16", 12.0, 16.0, 14.0),
     ("z16-plus", 16.0, None, 16.0),
@@ -2032,11 +2036,11 @@ def _extract_zoom_scalar_size_at_zoom(expr: object, target_zoom: float) -> float
     return None
 
 
-def _major_link_width_mm(expr: object, target_zoom: float) -> float | None:
+def _major_link_width_mm(expr: object, target_zoom: float, *, minimum_mm: float) -> float | None:
     size = _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
     if size is None:
         return None
-    return max(0.1, min(size * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM))
+    return max(minimum_mm, min(size * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM))
 
 
 def _has_major_link_width_expression(layer: dict[str, object]) -> bool:
@@ -2052,7 +2056,8 @@ def _has_major_link_width_expression(layer: dict[str, object]) -> bool:
 def _apply_major_link_width_values_for_qgis(paint: dict[str, object], target_zoom: float) -> bool:
     changed = False
     for prop in _MAJOR_LINK_WIDTH_PROPS:
-        width_mm = _major_link_width_mm(paint.get(prop), target_zoom)
+        minimum_mm = _MAJOR_LINK_WIDTH_MINIMUM_MM_BY_PROP[prop]
+        width_mm = _major_link_width_mm(paint.get(prop), target_zoom, minimum_mm=minimum_mm)
         if width_mm is not None:
             paint[prop] = width_mm
             changed = True

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2075,6 +2075,9 @@ def _major_link_width_layer_variant(
     zoom_band = _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom)
     if zoom_band is None:
         return None
+    target_zoom = _zoom_in_layer_range(target_zoom, *zoom_band)
+    if target_zoom is None:
+        return None
     variant = copy.deepcopy(layer)
     variant["id"] = f"{layer_id}-{suffix}"
     _set_zoom_bounds(variant, *zoom_band)
@@ -2082,6 +2085,22 @@ def _major_link_width_layer_variant(
     if not isinstance(variant_paint, dict):
         return None
     return variant if _apply_major_link_width_values_for_qgis(variant_paint, target_zoom) else None
+
+
+def _major_link_width_passthrough_layer_variant(
+    layer: dict[str, object],
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+) -> dict[str, object] | None:
+    first_split_minzoom = _MAJOR_LINK_WIDTH_BANDS[0][1]
+    if first_split_minzoom is None:
+        return None
+    zoom_band = _effective_zoom_band(existing_minzoom, existing_maxzoom, None, first_split_minzoom)
+    if zoom_band is None:
+        return None
+    variant = copy.deepcopy(layer)
+    _set_zoom_bounds(variant, *zoom_band)
+    return variant
 
 
 def _major_link_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
@@ -2092,7 +2111,7 @@ def _major_link_width_layer_variants(layer: dict[str, object]) -> list[dict[str,
     layer_id = str(layer.get("id") or "")
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
-    variants: list[dict[str, object]] = []
+    split_variants: list[dict[str, object]] = []
     for band in _MAJOR_LINK_WIDTH_BANDS:
         variant = _major_link_width_layer_variant(
             layer,
@@ -2102,8 +2121,19 @@ def _major_link_width_layer_variants(layer: dict[str, object]) -> list[dict[str,
             band,
         )
         if variant is not None:
-            variants.append(variant)
-    return variants or None
+            split_variants.append(variant)
+    if not split_variants:
+        return None
+    variants: list[dict[str, object]] = []
+    passthrough_variant = _major_link_width_passthrough_layer_variant(
+        layer,
+        existing_minzoom,
+        existing_maxzoom,
+    )
+    if passthrough_variant is not None:
+        variants.append(passthrough_variant)
+    variants.extend(split_variants)
+    return variants
 
 
 def _split_major_link_width_layers_for_qgis(layers: object) -> object:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -685,6 +685,93 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         for layer in layers[:4]:
             self.assertEqual(layer["paint"]["line-width"], 0.6)
 
+    def test_major_link_widths_are_split_by_zoom_band(self):
+        link_width = ["interpolate", ["exponential", 1.5], ["zoom"], 12, 0.8, 18, 20, 22, 200]
+        case_width = ["interpolate", ["exponential", 1.5], ["zoom"], 14, 0.8, 22, 2]
+        style = {
+            "layers": [
+                {
+                    "id": "road-major-link",
+                    "type": "line",
+                    "minzoom": 12,
+                    "filter": ["==", ["get", "class"], "motorway_link"],
+                    "paint": {"line-color": "hsl(15, 100%, 75%)", "line-width": link_width},
+                },
+                {
+                    "id": "bridge-major-link-case",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {"line-width": case_width, "line-gap-width": copy.deepcopy(link_width)},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [
+                "road-major-link-z12-to-z16",
+                "road-major-link-z16-plus",
+                "bridge-major-link-case-z12-to-z16",
+                "bridge-major-link-case-z16-plus",
+            ],
+        )
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            (
+                by_id["road-major-link-z12-to-z16"]["minzoom"],
+                by_id["road-major-link-z12-to-z16"]["maxzoom"],
+            ),
+            (12.0, 16.0),
+        )
+        self.assertEqual(by_id["road-major-link-z16-plus"]["minzoom"], 16.0)
+        self.assertAlmostEqual(
+            by_id["road-major-link-z12-to-z16"]["paint"]["line-width"],
+            mapbox_config._interpolate_filter_value_at_zoom(link_width, 14.0) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
+        self.assertAlmostEqual(
+            by_id["road-major-link-z16-plus"]["paint"]["line-width"],
+            mapbox_config._interpolate_filter_value_at_zoom(link_width, 16.0) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-major-link-case-z12-to-z16"]["paint"]["line-width"],
+            mapbox_config._interpolate_filter_value_at_zoom(case_width, 14.0) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-major-link-case-z12-to-z16"]["paint"]["line-gap-width"],
+            mapbox_config._interpolate_filter_value_at_zoom(link_width, 14.0) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("bridge-major-link-case-z12-to-z16"),
+            "bridge-major-link-case",
+        )
+        self.assertEqual(style["layers"][0]["paint"]["line-width"], link_width)
+
+    def test_major_link_width_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        link_width = ["interpolate", ["exponential", 1.5], ["zoom"], 12, 0.8, 18, 20, 22, 200]
+        mixed_layers = [
+            "not-a-layer",
+            {
+                "id": "road-major-link",
+                "type": "symbol",
+                "paint": {"line-width": copy.deepcopy(link_width)},
+            },
+            {"id": "road-major-link", "type": "line", "paint": {"line-width": copy.deepcopy(link_width)}},
+        ]
+
+        self.assertIs(
+            mapbox_config._split_major_link_width_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_major_link_width_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["type"], "symbol")
+        self.assertEqual(result[2]["id"], "road-major-link-z12-to-z16")
+        self.assertEqual(result[3]["id"], "road-major-link-z16-plus")
+
     def test_full_line_opacity_expressions_simplify_to_scalar_default(self):
         style = {
             "layers": [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -766,6 +766,90 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertEqual(style["layers"][0]["paint"]["line-width"], link_width)
 
+    def test_major_link_width_split_preserves_pre_z12_visibility(self):
+        link_width = ["interpolate", ["linear"], ["zoom"], 10, 0.2, 12, 0.8, 16, 6]
+        style = {
+            "layers": [
+                {
+                    "id": "road-major-link",
+                    "type": "line",
+                    "minzoom": 10,
+                    "paint": {"line-width": copy.deepcopy(link_width)},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            ["road-major-link", "road-major-link-z12-to-z16", "road-major-link-z16-plus"],
+        )
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            (by_id["road-major-link"]["minzoom"], by_id["road-major-link"]["maxzoom"]),
+            (10.0, 12.0),
+        )
+        self.assertEqual(by_id["road-major-link-z12-to-z16"]["minzoom"], 12.0)
+        self.assertEqual(by_id["road-major-link-z16-plus"]["minzoom"], 16.0)
+
+    def test_major_link_widths_sample_within_effective_zoom_band(self):
+        link_width = ["interpolate", ["linear"], ["zoom"], 12, 1.0, 16, 9.0]
+        layers = [
+            {
+                "id": "road-major-link",
+                "type": "line",
+                "minzoom": 15,
+                "maxzoom": 15.5,
+                "paint": {"line-width": copy.deepcopy(link_width)},
+            },
+            {
+                "id": "bridge-major-link",
+                "type": "line",
+                "minzoom": 12,
+                "maxzoom": 13,
+                "paint": {"line-width": copy.deepcopy(link_width)},
+            },
+        ]
+
+        result = mapbox_config._split_major_link_width_layers_for_qgis(layers)
+
+        self.assertEqual(
+            [layer["id"] for layer in result],
+            ["road-major-link-z12-to-z16", "bridge-major-link-z12-to-z16"],
+        )
+        by_id = {layer["id"]: layer for layer in result}
+        width_mm = lambda zoom: max(
+            0.1,
+            min(
+                mapbox_config._interpolate_filter_value_at_zoom(link_width, zoom)
+                * mapbox_config._MAPBOX_PIXEL_TO_MM,
+                mapbox_config._MAX_LINE_WIDTH_MM,
+            ),
+        )
+        self.assertEqual(
+            (
+                by_id["road-major-link-z12-to-z16"]["minzoom"],
+                by_id["road-major-link-z12-to-z16"]["maxzoom"],
+            ),
+            (15.0, 15.5),
+        )
+        self.assertAlmostEqual(
+            by_id["road-major-link-z12-to-z16"]["paint"]["line-width"],
+            width_mm(15.0),
+        )
+        self.assertEqual(
+            (
+                by_id["bridge-major-link-z12-to-z16"]["minzoom"],
+                by_id["bridge-major-link-z12-to-z16"]["maxzoom"],
+            ),
+            (12.0, 13.0),
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-major-link-z12-to-z16"]["paint"]["line-width"],
+            width_mm(13.0 - mapbox_config._ZOOM_BOUND_EPSILON),
+        )
+
     def test_major_link_width_helpers_keep_passthrough_inputs(self):
         unchanged_layers = "not-a-layer-list"
         link_width = ["interpolate", ["exponential", 1.5], ["zoom"], 12, 0.8, 18, 20, 22, 200]
@@ -776,7 +860,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "type": "symbol",
                 "paint": {"line-width": copy.deepcopy(link_width)},
             },
-            {"id": "road-major-link", "type": "line", "paint": {"line-width": copy.deepcopy(link_width)}},
+            {
+                "id": "road-major-link",
+                "type": "line",
+                "minzoom": 12,
+                "paint": {"line-width": copy.deepcopy(link_width)},
+            },
         ]
 
         self.assertIs(

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -688,6 +688,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
     def test_major_link_widths_are_split_by_zoom_band(self):
         link_width = ["interpolate", ["exponential", 1.5], ["zoom"], 12, 0.8, 18, 20, 22, 200]
         case_width = ["interpolate", ["exponential", 1.5], ["zoom"], 14, 0.8, 22, 2]
+        zero_gap_width = ["interpolate", ["linear"], ["zoom"], 12, 0, 18, 0]
         style = {
             "layers": [
                 {
@@ -703,6 +704,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     "minzoom": 12,
                     "paint": {"line-width": case_width, "line-gap-width": copy.deepcopy(link_width)},
                 },
+                {
+                    "id": "tunnel-major-link-case",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {"line-width": copy.deepcopy(case_width), "line-gap-width": zero_gap_width},
+                },
             ]
         }
 
@@ -715,9 +722,18 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-major-link-z16-plus",
                 "bridge-major-link-case-z12-to-z16",
                 "bridge-major-link-case-z16-plus",
+                "tunnel-major-link-case-z12-to-z16",
+                "tunnel-major-link-case-z16-plus",
             ],
         )
         by_id = {layer["id"]: layer for layer in result["layers"]}
+        width_mm = lambda expr, zoom, minimum: max(
+            minimum,
+            min(
+                mapbox_config._interpolate_filter_value_at_zoom(expr, zoom) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+                mapbox_config._MAX_LINE_WIDTH_MM,
+            ),
+        )
         self.assertEqual(
             (
                 by_id["road-major-link-z12-to-z16"]["minzoom"],
@@ -728,20 +744,22 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(by_id["road-major-link-z16-plus"]["minzoom"], 16.0)
         self.assertAlmostEqual(
             by_id["road-major-link-z12-to-z16"]["paint"]["line-width"],
-            mapbox_config._interpolate_filter_value_at_zoom(link_width, 14.0) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+            width_mm(link_width, 14.0, 0.1),
         )
         self.assertAlmostEqual(
             by_id["road-major-link-z16-plus"]["paint"]["line-width"],
-            mapbox_config._interpolate_filter_value_at_zoom(link_width, 16.0) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+            width_mm(link_width, 16.0, 0.1),
         )
         self.assertAlmostEqual(
             by_id["bridge-major-link-case-z12-to-z16"]["paint"]["line-width"],
-            mapbox_config._interpolate_filter_value_at_zoom(case_width, 14.0) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+            width_mm(case_width, 14.0, 0.1),
         )
         self.assertAlmostEqual(
             by_id["bridge-major-link-case-z12-to-z16"]["paint"]["line-gap-width"],
-            mapbox_config._interpolate_filter_value_at_zoom(link_width, 14.0) * mapbox_config._MAPBOX_PIXEL_TO_MM,
+            width_mm(link_width, 14.0, 0.0),
         )
+        self.assertEqual(by_id["tunnel-major-link-case-z12-to-z16"]["paint"]["line-gap-width"], 0.0)
+        self.assertEqual(by_id["tunnel-major-link-case-z16-plus"]["paint"]["line-gap-width"], 0.0)
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("bridge-major-link-case-z12-to-z16"),
             "bridge-major-link-case",


### PR DESCRIPTION
## Summary

- split audited Mapbox Outdoors motorway/trunk major-link layers into z12-z16 and z16+ static-width variants for QGIS
- evaluate `line-width` and `line-gap-width` at representative Mapbox zooms instead of collapsing z12+ ramp links to the z12 value
- add regression coverage for the public style simplification pipeline and helper passthrough behavior

## Evidence

- Live style inspection showed all major-link ramp layers were collapsing to `0.2117 mm` at z12+, while the Mapbox expression is about `0.8228 mm` at z14 and `2.1978 mm` at z16.
- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260516T211040Z/audit.md`
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260516T211127Z/summary.md`
- Geneva z14 improved slightly: mean delta `0.0738 -> 0.0736`, RMS `0.1234 -> 0.1230`.
- z5, z8, z10, and z18 metrics were unchanged; Chamonix z14 moved slightly better.
- Visual review found the Geneva airport ramps closer to Mapbox GL and not too heavy; Chamonix was neutral.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check`

Part of #949.
