### PR TITLE
[codex] Split high zoom road class colors

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -549,6 +549,24 @@ _MAJOR_LINK_WIDTH_MINIMUM_MM_BY_PROP = {
     "line-width": 0.1,
     "line-gap-width": 0.0,
 }
+_ROAD_CLASS_LINE_COLOR_VARIANTS_BY_LAYER_ID = {
+    "bridge-major-link": (("motorway_link", "motorway-link"), ("trunk_link", "trunk-link")),
+    "bridge-major-link-2": (("motorway_link", "motorway-link"), ("trunk_link", "trunk-link")),
+    "bridge-motorway-trunk": (("motorway", "motorway"), ("trunk", "trunk")),
+    "bridge-motorway-trunk-2": (("motorway", "motorway"), ("trunk", "trunk")),
+    "road-major-link": (("motorway_link", "motorway-link"), ("trunk_link", "trunk-link")),
+    "road-motorway-trunk": (("motorway", "motorway"), ("trunk", "trunk")),
+    "tunnel-major-link": (("motorway_link", "motorway-link"), ("trunk_link", "trunk-link")),
+    "tunnel-motorway-trunk": (("motorway", "motorway"), ("trunk", "trunk")),
+}
+_ROAD_CLASS_LINE_COLOR_SUFFIXES = tuple(
+    sorted(
+        {suffix for variants in _ROAD_CLASS_LINE_COLOR_VARIANTS_BY_LAYER_ID.values() for _class_value, suffix in variants},
+        key=len,
+        reverse=True,
+    )
+)
+_ROAD_CLASS_LINE_COLOR_MIN_ZOOM = 12.0
 _MAJOR_LINK_WIDTH_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("z12-to-z16", 12.0, 16.0, 14.0),
     ("z16-plus", 16.0, None, 16.0),
@@ -1868,6 +1886,7 @@ def _water_label_typography_base_layer_id(layer_id: object) -> str | None:
 def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     """Return the original Mapbox layer id for qfit-created layer variants."""
     for resolved_layer_id in (
+        _road_class_line_color_base_layer_id(layer_id),
         _water_label_typography_base_layer_id(layer_id),
         _regional_major_road_width_base_layer_id(layer_id),
         _major_link_width_base_layer_id(layer_id),
@@ -1955,6 +1974,103 @@ def _set_zoom_bounds(layer: dict[str, object], minzoom: float | None, maxzoom: f
         layer.pop("maxzoom", None)
     else:
         layer["maxzoom"] = maxzoom
+
+
+def _match_output_for_value(expr: object, value: object) -> object | None:
+    if not isinstance(expr, list) or len(expr) < 5 or expr[0] != "match" or (len(expr) - 3) % 2 != 0:
+        return None
+    for index in range(2, len(expr) - 1, 2):
+        candidate = expr[index]
+        if candidate == value or (isinstance(candidate, list) and value in candidate):
+            return expr[index + 1]
+    return expr[-1]
+
+
+def _line_color_for_road_class(expr: object, class_value: str, target_zoom: float) -> str | None:
+    if _is_literal_color(expr):
+        return str(expr)
+    if not isinstance(expr, list) or not expr:
+        return None
+    if expr[0] == "step" and expr[1:2] == [["zoom"]]:
+        return _line_color_for_road_class(_step_zoom_value(expr, target_zoom=target_zoom), class_value, target_zoom)
+    if expr[0] != "match" or expr[1] != ["get", "class"]:
+        return None
+    output = _match_output_for_value(expr, class_value)
+    return str(output) if _is_literal_color(output) else None
+
+
+def _road_class_line_color_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    for suffix in _ROAD_CLASS_LINE_COLOR_SUFFIXES:
+        color_suffix = f"-{suffix}"
+        if not normalized.endswith(color_suffix):
+            continue
+        candidate = normalized[: -len(color_suffix)]
+        for base_layer_id in (
+            _regional_major_road_width_base_layer_id(candidate),
+            _major_link_width_base_layer_id(candidate),
+            candidate,
+        ):
+            if base_layer_id in _ROAD_CLASS_LINE_COLOR_VARIANTS_BY_LAYER_ID:
+                return base_layer_id
+    return None
+
+
+def _road_class_line_color_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited motorway/trunk class colors into static QGIS layers."""
+    base_layer_id = base_mapbox_style_layer_id_for_qfit(layer.get("id"))
+    variants = _ROAD_CLASS_LINE_COLOR_VARIANTS_BY_LAYER_ID.get(base_layer_id)
+    paint = layer.get("paint")
+    if variants is None or layer.get("type") != "line" or not isinstance(paint, dict):
+        return None
+    line_color = paint.get("line-color")
+    if not isinstance(line_color, list):
+        return None
+
+    target_zoom = _representative_zoom_in_layer_range(layer.get("minzoom"), layer.get("maxzoom"))
+    if target_zoom is None:
+        return None
+    minimum_zoom = _numeric_zoom_bound(layer.get("minzoom"))
+    if minimum_zoom is None or minimum_zoom < _ROAD_CLASS_LINE_COLOR_MIN_ZOOM:
+        return None
+
+    resolved_variants: list[tuple[str, str, str]] = []
+    for class_value, suffix in variants:
+        color = _line_color_for_road_class(line_color, class_value, target_zoom)
+        if color is None:
+            return None
+        resolved_variants.append((class_value, suffix, color))
+
+    if len({color for _class_value, _suffix, color in resolved_variants}) <= 1:
+        return None
+
+    layer_id = str(layer.get("id") or base_layer_id)
+    class_layers: list[dict[str, object]] = []
+    for class_value, suffix, color in resolved_variants:
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _with_additional_filter_clauses(
+            layer.get("filter"),
+            ["==", ["get", "class"], class_value],
+        )
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        variant_paint["line-color"] = color
+        class_layers.append(variant)
+    return class_layers
+
+
+def _split_road_class_line_color_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _road_class_line_color_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
 
 
 def _regional_major_road_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
@@ -4395,8 +4511,8 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     literalizes simple ``line-dasharray`` expressions so dashed routes and paths
     survive QGIS conversion, rewrites a few semantics-preserving filter shapes,
     snapshots selected zoom-dependent filters at a representative layer zoom that
-    QGIS can parse, splits visible landcover, landuse, and path background class
-    colors into static class layers, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
+    QGIS can parse, splits visible landcover, landuse, path background, and road
+    class colors into static class layers, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
     warning spam from proprietary Mapbox font
     family names.
 
@@ -4406,6 +4522,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style = copy.deepcopy(style_definition)
     style["layers"] = _split_regional_major_road_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_major_link_width_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_road_class_line_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _expand_road_number_shield_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_background_line_color_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -879,6 +879,153 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "road-major-link-z12-to-z16")
         self.assertEqual(result[3]["id"], "road-major-link-z16-plus")
 
+    def test_motorway_trunk_line_color_splits_only_at_high_zoom(self):
+        line_color = [
+            "step",
+            ["zoom"],
+            [
+                "match",
+                ["get", "class"],
+                "motorway",
+                "hsl(15, 88%, 69%)",
+                "trunk",
+                "hsl(35, 81%, 59%)",
+                "hsl(60, 18%, 85%)",
+            ],
+            9,
+            [
+                "match",
+                ["get", "class"],
+                "motorway",
+                "hsl(15, 100%, 75%)",
+                "hsl(35, 89%, 75%)",
+            ],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "road-motorway-trunk",
+                    "type": "line",
+                    "minzoom": 3,
+                    "filter": ["==", ["geometry-type"], "LineString"],
+                    "paint": {
+                        "line-color": line_color,
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 1, 12, 10],
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [
+                "road-motorway-trunk-z3-to-z5",
+                "road-motorway-trunk-z5-to-z6",
+                "road-motorway-trunk-z6-to-z9",
+                "road-motorway-trunk-z9-to-z12",
+                "road-motorway-trunk-motorway",
+                "road-motorway-trunk-trunk",
+            ],
+        )
+        self.assertEqual(
+            by_id["road-motorway-trunk-z6-to-z9"]["paint"]["line-color"],
+            "hsl(35, 89%, 75%)",
+        )
+        self.assertEqual(
+            by_id["road-motorway-trunk-motorway"]["paint"]["line-color"],
+            "hsl(15, 100%, 75%)",
+        )
+        self.assertEqual(
+            by_id["road-motorway-trunk-trunk"]["paint"]["line-color"],
+            "hsl(35, 89%, 75%)",
+        )
+        self.assertIn(["==", ["get", "class"], "motorway"], by_id["road-motorway-trunk-motorway"]["filter"])
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-motorway-trunk-motorway"),
+            "road-motorway-trunk",
+        )
+
+    def test_major_link_line_color_splits_after_width_bands(self):
+        link_width = ["interpolate", ["linear"], ["zoom"], 12, 0.8, 16, 4]
+        style = {
+            "layers": [
+                {
+                    "id": "road-major-link",
+                    "type": "line",
+                    "minzoom": 12,
+                    "filter": ["==", ["geometry-type"], "LineString"],
+                    "paint": {
+                        "line-color": [
+                            "match",
+                            ["get", "class"],
+                            "motorway_link",
+                            "hsl(15, 100%, 75%)",
+                            "hsl(35, 89%, 75%)",
+                        ],
+                        "line-width": link_width,
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [
+                "road-major-link-z12-to-z16-motorway-link",
+                "road-major-link-z12-to-z16-trunk-link",
+                "road-major-link-z16-plus-motorway-link",
+                "road-major-link-z16-plus-trunk-link",
+            ],
+        )
+        self.assertEqual(
+            by_id["road-major-link-z12-to-z16-motorway-link"]["paint"]["line-color"],
+            "hsl(15, 100%, 75%)",
+        )
+        self.assertEqual(
+            by_id["road-major-link-z12-to-z16-trunk-link"]["paint"]["line-color"],
+            "hsl(35, 89%, 75%)",
+        )
+        self.assertIn(
+            ["==", ["get", "class"], "motorway_link"],
+            by_id["road-major-link-z12-to-z16-motorway-link"]["filter"],
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-major-link-z12-to-z16-motorway-link"),
+            "road-major-link",
+        )
+
+    def test_road_class_line_color_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = [
+            "not-a-layer",
+            {
+                "id": "road-major-link",
+                "type": "symbol",
+                "paint": {"line-color": ["match", ["get", "class"], "motorway_link", "red", "blue"]},
+            },
+            {
+                "id": "road-major-link",
+                "type": "line",
+                "paint": {"line-color": ["get", "color"]},
+            },
+        ]
+
+        self.assertIs(
+            mapbox_config._split_road_class_line_color_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_road_class_line_color_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["type"], "symbol")
+        self.assertEqual(result[2]["id"], "road-major-link")
+
     def test_full_line_opacity_expressions_simplify_to_scalar_default(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

- Split high-zoom Mapbox Outdoors motorway/trunk and major-link line colors into static class-filtered QGIS layers.
- Keep the split at z12+ only after the broader low-zoom version visibly over-emphasized country-scale roads.
- Preserve the existing width zoom-band behavior and base-layer mapping for qfit-created variants.

## Issue

Part of #949.

## Evidence

- Live audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260516T223347Z/audit.md`
- Baseline all-camera comparison after #1080: `debug/mapbox-outdoors-comparison/all-cameras/20260516T215514Z/summary.md`
- This branch all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260516T223236Z/summary.md`

Metric deltas versus the baseline:

| Camera | Changed ratio delta | Mean delta | RMS delta |
| --- | ---: | ---: | ---: |
| `switzerland-alps-z5-outdoors` | +0.000000 | +0.000000 | +0.000000 |
| `valais-geneva-outdoors` | +0.000000 | +0.000000 | +0.000000 |
| `lausanne-lavaux-z10-outdoors` | +0.000000 | +0.000000 | +0.000000 |
| `geneva-airport-motorway-z14-outdoors` | +0.000047 | -0.000288 | -0.000053 |
| `chamonix-trails-z14-outdoors` | +0.000000 | +0.000000 | +0.000000 |
| `zermatt-trails-z18-outdoors` | +0.000000 | +0.000000 | +0.000000 |

Manual visual review: the narrowed z12+ split improves the Geneva motorway/trunk/link color hierarchy without reintroducing the earlier z5 road-clutter regression.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check`
- Live Mapbox/QGIS all-camera comparison using the local QGIS-profile token source without printing or storing the token.
