### PR TITLE
[codex] Split low zoom hillshade colors

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -837,6 +837,32 @@ _BUILDING_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None],
     ("z15-to-z16", 15.0, 16.0),
     ("z16-plus", 16.0, None),
 )
+_HILLSHADE_LAYER_ID = "hillshade"
+_HILLSHADE_SHADOW_FILL_COLOR = "hsla(66, 38%, 17%, 0.08)"
+_HILLSHADE_HIGHLIGHT_FILL_COLOR = "hsla(60, 20%, 95%, 0.14)"
+_HILLSHADE_HIGHLIGHT_MIN_ZOOM = 11.0
+_HILLSHADE_CLASS_SPLIT_MAX_ZOOM = 13.0
+_HILLSHADE_FILL_COLOR_EXPRESSION = [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    14,
+    [
+        "match",
+        ["get", "class"],
+        "shadow",
+        _HILLSHADE_SHADOW_FILL_COLOR,
+        _HILLSHADE_HIGHLIGHT_FILL_COLOR,
+    ],
+    16,
+    [
+        "match",
+        ["get", "class"],
+        "shadow",
+        "hsla(66, 38%, 17%, 0)",
+        "hsla(60, 20%, 95%, 0)",
+    ],
+]
 _LANDCOVER_LAYER_ID = "landcover"
 _LANDCOVER_FILL_OPACITY_EXPRESSIONS = {
     _LANDCOVER_LAYER_ID: ["interpolate", ["exponential", 1.5], ["zoom"], 8, 0.8, 12, 0],
@@ -1875,6 +1901,18 @@ def _major_link_width_base_layer_id(layer_id: object) -> str | None:
     return None
 
 
+def _hillshade_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    if normalized in {
+        _HILLSHADE_LAYER_ID,
+        f"{_HILLSHADE_LAYER_ID}-shadow",
+        f"{_HILLSHADE_LAYER_ID}-highlight",
+        f"{_HILLSHADE_LAYER_ID}-z13-plus",
+    }:
+        return _HILLSHADE_LAYER_ID
+    return None
+
+
 def _water_label_typography_base_layer_id(layer_id: object) -> str | None:
     normalized = str(layer_id or "")
     for base_layer_id in _WATER_LABEL_TYPOGRAPHY_LAYER_IDS:
@@ -1887,6 +1925,7 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     """Return the original Mapbox layer id for qfit-created layer variants."""
     for resolved_layer_id in (
         _road_class_line_color_base_layer_id(layer_id),
+        _hillshade_base_layer_id(layer_id),
         _water_label_typography_base_layer_id(layer_id),
         _regional_major_road_width_base_layer_id(layer_id),
         _major_link_width_base_layer_id(layer_id),
@@ -2692,6 +2731,90 @@ def _split_building_fill_opacity_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _building_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _hillshade_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split Mapbox hillshade shadows and highlights into static QGIS layers."""
+    paint = layer.get("paint")
+    if (
+        str(layer.get("id") or "") != _HILLSHADE_LAYER_ID
+        or layer.get("type") != "fill"
+        or not isinstance(paint, dict)
+        or paint.get("fill-color") != _HILLSHADE_FILL_COLOR_EXPRESSION
+    ):
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+
+    split_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        None,
+        _HILLSHADE_CLASS_SPLIT_MAX_ZOOM,
+    )
+    if split_zoom_band is not None:
+        shadow_layer = copy.deepcopy(layer)
+        shadow_layer["id"] = f"{_HILLSHADE_LAYER_ID}-shadow"
+        _set_zoom_bounds(shadow_layer, *split_zoom_band)
+        shadow_layer["filter"] = _with_additional_filter_clauses(
+            layer.get("filter"),
+            ["==", ["get", "class"], "shadow"],
+        )
+        shadow_paint = shadow_layer["paint"]
+        assert isinstance(shadow_paint, dict)
+        shadow_paint["fill-color"] = _HILLSHADE_SHADOW_FILL_COLOR
+        variants.append(shadow_layer)
+
+    highlight_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        _HILLSHADE_HIGHLIGHT_MIN_ZOOM,
+        _HILLSHADE_CLASS_SPLIT_MAX_ZOOM,
+    )
+    if highlight_zoom_band is not None:
+        highlight_layer = copy.deepcopy(layer)
+        highlight_layer["id"] = f"{_HILLSHADE_LAYER_ID}-highlight"
+        _set_zoom_bounds(highlight_layer, *highlight_zoom_band)
+        highlight_layer["filter"] = _with_additional_filter_clauses(
+            layer.get("filter"),
+            ["!=", ["get", "class"], "shadow"],
+        )
+        highlight_paint = highlight_layer["paint"]
+        assert isinstance(highlight_paint, dict)
+        highlight_paint["fill-color"] = _HILLSHADE_HIGHLIGHT_FILL_COLOR
+        variants.append(highlight_layer)
+
+    high_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        _HILLSHADE_CLASS_SPLIT_MAX_ZOOM,
+        None,
+    )
+    if high_zoom_band is not None:
+        high_zoom_layer = copy.deepcopy(layer)
+        high_zoom_layer["id"] = f"{_HILLSHADE_LAYER_ID}-z13-plus"
+        _set_zoom_bounds(high_zoom_layer, *high_zoom_band)
+        high_zoom_paint = high_zoom_layer["paint"]
+        assert isinstance(high_zoom_paint, dict)
+        high_zoom_paint["fill-color"] = _HILLSHADE_HIGHLIGHT_FILL_COLOR
+        variants.append(high_zoom_layer)
+
+    return variants or None
+
+
+def _split_hillshade_fill_color_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _hillshade_fill_color_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -4511,8 +4634,9 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     literalizes simple ``line-dasharray`` expressions so dashed routes and paths
     survive QGIS conversion, rewrites a few semantics-preserving filter shapes,
     snapshots selected zoom-dependent filters at a representative layer zoom that
-    QGIS can parse, splits visible landcover, landuse, path background, and road
-    class colors into static class layers, and collapses Mapbox font stacks to a QGIS-safe local fallback to avoid
+    QGIS can parse, splits visible hillshade, landcover, landuse, path
+    background, and road class colors into static class layers, and collapses
+    Mapbox font stacks to a QGIS-safe local fallback to avoid
     warning spam from proprietary Mapbox font
     family names.
 
@@ -4534,6 +4658,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_continent_label_text_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_cliff_line_pattern_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_building_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_hillshade_fill_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landcover_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landcover_class_fill_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_landuse_fill_opacity_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2396,6 +2396,89 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "building-z15-to-z16")
         self.assertEqual(result[2]["id"], "building-z16-plus")
 
+    def _hillshade_layer(self, fill_color=None, maxzoom=16):
+        if fill_color is None:
+            fill_color = copy.deepcopy(mapbox_config._HILLSHADE_FILL_COLOR_EXPRESSION)
+        return {
+            "id": "hillshade",
+            "type": "fill",
+            "minzoom": 0,
+            "maxzoom": maxzoom,
+            "source-layer": "hillshade",
+            "filter": [
+                "all",
+                ["step", ["zoom"], ["==", ["get", "class"], "shadow"], 11, True],
+                ["match", ["get", "level"], 89, True, 78, ["step", ["zoom"], False, 5, True], False],
+            ],
+            "paint": {
+                "fill-antialias": False,
+                "fill-color": fill_color,
+            },
+        }
+
+    def test_hillshade_fill_color_splits_shadow_and_highlight_layers(self):
+        style = {"layers": [self._hillshade_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            ["hillshade-shadow", "hillshade-highlight", "hillshade-z13-plus"],
+        )
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        shadow = by_id["hillshade-shadow"]
+        highlight = by_id["hillshade-highlight"]
+        high_zoom = by_id["hillshade-z13-plus"]
+        self.assertEqual(shadow["minzoom"], 0)
+        self.assertEqual(shadow["maxzoom"], 13.0)
+        self.assertEqual(highlight["minzoom"], 11.0)
+        self.assertEqual(highlight["maxzoom"], 13.0)
+        self.assertEqual(high_zoom["minzoom"], 13.0)
+        self.assertEqual(high_zoom["maxzoom"], 16)
+        self.assertEqual(shadow["paint"]["fill-color"], "hsla(66, 38%, 17%, 0.08)")
+        self.assertEqual(highlight["paint"]["fill-color"], "hsla(60, 20%, 95%, 0.14)")
+        self.assertEqual(high_zoom["paint"]["fill-color"], "hsla(60, 20%, 95%, 0.14)")
+        self.assertIn(["==", ["get", "class"], "shadow"], shadow["filter"])
+        self.assertIn(["!=", ["get", "class"], "shadow"], highlight["filter"])
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("hillshade-z13-plus"),
+            "hillshade",
+        )
+
+    def test_hillshade_fill_color_skips_highlight_when_not_visible(self):
+        style = {"layers": [self._hillshade_layer(maxzoom=10)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual([layer["id"] for layer in result["layers"]], ["hillshade-shadow"])
+        self.assertEqual(result["layers"][0]["maxzoom"], 10)
+
+    def test_hillshade_fill_color_is_not_split_when_shape_changes(self):
+        fill_color = ["get", "color"]
+        style = {"layers": [self._hillshade_layer(fill_color=fill_color)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "hillshade")
+        self.assertEqual(result["layers"][0]["paint"]["fill-color"], fill_color)
+
+    def test_hillshade_fill_color_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", {"id": "hillshade", "type": "fill"}, self._hillshade_layer()]
+
+        self.assertIs(
+            mapbox_config._split_hillshade_fill_color_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_hillshade_fill_color_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "hillshade")
+        self.assertEqual(result[2]["id"], "hillshade-shadow")
+        self.assertEqual(result[3]["id"], "hillshade-highlight")
+        self.assertEqual(result[4]["id"], "hillshade-z13-plus")
+
     def _landcover_layer(self, fill_opacity=None):
         if fill_opacity is None:
             fill_opacity = ["interpolate", ["exponential", 1.5], ["zoom"], 8, 0.8, 12, 0]


### PR DESCRIPTION
## Summary

- Split the audited Mapbox Outdoors hillshade fill-color expression into QGIS-static shadow/highlight layers only below z13.
- Preserve the existing z13+ highlight fallback after the broader z0-z16 split improved low zoom terrain but darkened Chamonix z14 trails and labels.
- Map the generated hillshade variants back to the original `hillshade` layer id for qfit audit/accounting helpers.

Closes part of #949.

## Evidence

Live Mapbox/QGIS comparison used the local QGIS-profile token source without printing or storing the token.

| Camera | Changed pixels delta | Mean error delta | RMS error delta |
| --- | ---: | ---: | ---: |
| switzerland-alps-z5-outdoors | -0.000312 | -0.004995 | -0.004346 |
| valais-geneva-outdoors | -0.000034 | -0.075272 | -0.076526 |
| lausanne-lavaux-z10-outdoors | +0.000004 | -0.021527 | -0.030595 |
| geneva-airport-motorway-z14-outdoors | +0.000000 | +0.000000 | +0.000000 |
| chamonix-trails-z14-outdoors | +0.000000 | +0.000000 | +0.000000 |
| zermatt-trails-z18-outdoors | +0.000009 | -0.000019 | -0.000065 |

Comparison artifacts:

- Post-#1081 baseline: `debug/mapbox-outdoors-comparison/all-cameras/20260516T223236Z/summary.md`
- Full z0-z16 hillshade split, not promoted: `debug/mapbox-outdoors-comparison/all-cameras/20260516T224739Z/summary.md`
- Narrowed branch comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260516T225015Z/summary.md`
- Fresh style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260516T225320Z/audit.md`

Visual review: the narrowed split restores terrain definition at Switzerland z5 and Valais z8, keeps Geneva and Chamonix z14 visually unchanged from the post-#1081 baseline, and avoids the high-zoom murkiness seen in the full split. Remaining risk is that low/mid zoom alpine hillshade can read slightly contrasty or patchy in places.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short` - 2093 passed, 163 skipped, 135 subtests passed
- `git diff --check`
- Live all-camera Mapbox/QGIS comparison
- Live Mapbox Outdoors style audit with QGIS converter/filter checks
