### PR TITLE
[codex] Split Mapbox waterway widths

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1165,6 +1165,26 @@ _WATER_SHADOW_TRANSLATE_ZOOM_BANDS: tuple[tuple[str, float | None, float | None]
     ("z13-to-z16", 13.0, 16.0),
     ("z16-plus", 16.0, None),
 )
+_WATERWAY_LAYER_ID = "waterway"
+_WATERWAY_SHADOW_LAYER_ID = "waterway-shadow"
+_WATERWAY_LINE_WIDTH_EXPRESSION = [
+    "interpolate",
+    ["exponential", 1.3],
+    ["zoom"],
+    9,
+    ["match", ["get", "class"], ["canal", "river"], 0.1, 0],
+    20,
+    ["match", ["get", "class"], ["canal", "river"], 8, 3],
+]
+_WATERWAY_LINE_WIDTH_CLASS_VARIANTS: tuple[tuple[str, object, float, float], ...] = (
+    ("canal-river", ["match", ["get", "class"], ["canal", "river"], True, False], 0.1, 8.0),
+    ("other", ["match", ["get", "class"], ["canal", "river"], False, True], 0.0, 3.0),
+)
+_WATERWAY_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z8-to-z13", 8.0, 13.0),
+    ("z13-to-z16", 13.0, 16.0),
+    ("z16-plus", 16.0, None),
+)
 _TURNING_FEATURE_LAYER_ID = "turning-feature"
 _TURNING_FEATURE_OUTLINE_LAYER_ID = "turning-feature-outline"
 _TURNING_FEATURE_CIRCLE_RADIUS_EXPRESSION = [
@@ -1921,11 +1941,23 @@ def _water_label_typography_base_layer_id(layer_id: object) -> str | None:
     return None
 
 
+def _waterway_line_width_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    if normalized == _WATERWAY_LAYER_ID or normalized.startswith(f"{_WATERWAY_LAYER_ID}-canal-river-"):
+        return _WATERWAY_LAYER_ID
+    if normalized.startswith(f"{_WATERWAY_LAYER_ID}-other-"):
+        return _WATERWAY_LAYER_ID
+    if normalized == _WATERWAY_SHADOW_LAYER_ID or normalized.startswith(f"{_WATERWAY_SHADOW_LAYER_ID}-"):
+        return _WATERWAY_SHADOW_LAYER_ID
+    return None
+
+
 def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     """Return the original Mapbox layer id for qfit-created layer variants."""
     for resolved_layer_id in (
         _road_class_line_color_base_layer_id(layer_id),
         _hillshade_base_layer_id(layer_id),
+        _waterway_line_width_base_layer_id(layer_id),
         _water_label_typography_base_layer_id(layer_id),
         _regional_major_road_width_base_layer_id(layer_id),
         _major_link_width_base_layer_id(layer_id),
@@ -3228,6 +3260,99 @@ def _split_water_shadow_translate_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _water_shadow_translate_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _waterway_line_width_px_at_zoom(target_zoom: float, lower_width: float, upper_width: float) -> float | None:
+    if target_zoom <= 9.0:
+        return lower_width
+    if target_zoom >= 20.0:
+        return upper_width
+    factor = _interpolate_filter_factor(["exponential", 1.3], target_zoom, 9.0, 20.0)
+    if factor is None:
+        return None
+    return lower_width + ((upper_width - lower_width) * factor)
+
+
+def _waterway_line_width_mm_for_zoom_band(
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+    lower_width: float,
+    upper_width: float,
+) -> tuple[float, float | None, float | None] | None:
+    effective_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        band_minzoom,
+        band_maxzoom,
+    )
+    if effective_zoom_band is None:
+        return None
+    representative_zoom = _zoom_band_representative_zoom(*effective_zoom_band)
+    width_px = _waterway_line_width_px_at_zoom(representative_zoom, lower_width, upper_width)
+    if width_px is None:
+        return None
+    return min(max(width_px * _MAPBOX_PIXEL_TO_MM, 0.0), _MAX_LINE_WIDTH_MM), *effective_zoom_band
+
+
+def _waterway_line_width_layer_id(layer_id: str, class_suffix: str, band_suffix: str) -> str:
+    if layer_id.startswith(f"{_WATERWAY_SHADOW_LAYER_ID}-"):
+        return f"{layer_id}-{class_suffix}"
+    return f"{layer_id}-{class_suffix}-{band_suffix}"
+
+
+def _waterway_line_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split Mapbox waterway width classes into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    base_layer_id = _waterway_line_width_base_layer_id(layer_id)
+    paint = layer.get("paint")
+    if (
+        base_layer_id not in {_WATERWAY_LAYER_ID, _WATERWAY_SHADOW_LAYER_ID}
+        or layer.get("type") != "line"
+        or not isinstance(paint, dict)
+        or paint.get("line-width") != _WATERWAY_LINE_WIDTH_EXPRESSION
+    ):
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for band_suffix, band_minzoom, band_maxzoom in _WATERWAY_LINE_WIDTH_ZOOM_BANDS:
+        for class_suffix, class_filter, lower_width, upper_width in _WATERWAY_LINE_WIDTH_CLASS_VARIANTS:
+            width = _waterway_line_width_mm_for_zoom_band(
+                existing_minzoom,
+                existing_maxzoom,
+                band_minzoom,
+                band_maxzoom,
+                lower_width,
+                upper_width,
+            )
+            if width is None:
+                continue
+            line_width, effective_minzoom, effective_maxzoom = width
+            variant = copy.deepcopy(layer)
+            variant["id"] = _waterway_line_width_layer_id(layer_id, class_suffix, band_suffix)
+            _set_zoom_bounds(variant, effective_minzoom, effective_maxzoom)
+            variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), class_filter)
+            variant_paint = variant["paint"]
+            assert isinstance(variant_paint, dict)
+            variant_paint["line-width"] = line_width
+            variants.append(variant)
+    return variants or None
+
+
+def _split_waterway_line_width_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _waterway_line_width_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -4634,8 +4759,8 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     literalizes simple ``line-dasharray`` expressions so dashed routes and paths
     survive QGIS conversion, rewrites a few semantics-preserving filter shapes,
     snapshots selected zoom-dependent filters at a representative layer zoom that
-    QGIS can parse, splits visible hillshade, landcover, landuse, path
-    background, and road class colors into static class layers, and collapses
+    QGIS can parse, splits visible hillshade, landcover, landuse, waterway,
+    path background, and road class colors into static class layers, and collapses
     Mapbox font stacks to a QGIS-safe local fallback to avoid
     warning spam from proprietary Mapbox font
     family names.
@@ -4669,6 +4794,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_rail_track_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_gate_fence_hedge_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_water_shadow_translate_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_waterway_line_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_turning_feature_circle_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_waterway_label_symbol_spacing_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_water_label_typography_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3194,7 +3194,34 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             },
         }
 
-    def _waterway_shadow_layer(self, translate=None):
+    def _waterway_line_width_expression(self):
+        return [
+            "interpolate",
+            ["exponential", 1.3],
+            ["zoom"],
+            9,
+            ["match", ["get", "class"], ["canal", "river"], 0.1, 0],
+            20,
+            ["match", ["get", "class"], ["canal", "river"], 8, 3],
+        ]
+
+    def _waterway_layer(self, line_width=None):
+        if line_width is None:
+            line_width = self._waterway_line_width_expression()
+        return {
+            "id": "waterway",
+            "type": "line",
+            "minzoom": 8,
+            "source-layer": "waterway",
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-color": "hsl(205, 56%, 73%)",
+                "line-opacity": ["interpolate", ["linear"], ["zoom"], 8, 0, 8.5, 1],
+                "line-width": line_width,
+            },
+        }
+
+    def _waterway_shadow_layer(self, translate=None, line_width=0.1):
         if translate is None:
             translate = self._water_shadow_translate_expression()
         return {
@@ -3207,7 +3234,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "line-color": "hsl(224, 79%, 69%)",
                 "line-translate": translate,
                 "line-translate-anchor": "viewport",
-                "line-width": 0.1,
+                "line-width": line_width,
             },
         }
 
@@ -3278,6 +3305,83 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "water-shadow-z10-to-z13")
         self.assertEqual(result[2]["id"], "water-shadow-z13-to-z16")
         self.assertEqual(result[3]["id"], "water-shadow-z16-plus")
+
+    def test_waterway_line_width_splits_classes_and_zoom_bands(self):
+        style = {
+            "layers": [
+                self._waterway_layer(),
+                self._waterway_shadow_layer(line_width=self._waterway_line_width_expression()),
+            ],
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            list(by_id),
+            [
+                "waterway-canal-river-z8-to-z13",
+                "waterway-other-z8-to-z13",
+                "waterway-canal-river-z13-to-z16",
+                "waterway-other-z13-to-z16",
+                "waterway-canal-river-z16-plus",
+                "waterway-other-z16-plus",
+                "waterway-shadow-z10-to-z13-canal-river",
+                "waterway-shadow-z10-to-z13-other",
+                "waterway-shadow-z13-to-z16-canal-river",
+                "waterway-shadow-z13-to-z16-other",
+                "waterway-shadow-z16-plus-canal-river",
+                "waterway-shadow-z16-plus-other",
+            ],
+        )
+        low_major = by_id["waterway-canal-river-z8-to-z13"]
+        low_other = by_id["waterway-other-z8-to-z13"]
+        mid_major = by_id["waterway-canal-river-z13-to-z16"]
+        high_major = by_id["waterway-canal-river-z16-plus"]
+        shadow_low_major = by_id["waterway-shadow-z10-to-z13-canal-river"]
+        self.assertEqual(low_major["minzoom"], 8)
+        self.assertEqual(low_major["maxzoom"], 13.0)
+        self.assertEqual(mid_major["minzoom"], 13.0)
+        self.assertEqual(mid_major["maxzoom"], 16.0)
+        self.assertEqual(high_major["minzoom"], 16.0)
+        self.assertNotIn("maxzoom", high_major)
+        self.assertEqual(shadow_low_major["minzoom"], 10)
+        self.assertEqual(shadow_low_major["maxzoom"], 13.0)
+        self.assertIn(["match", ["get", "class"], ["canal", "river"], True, False], low_major["filter"])
+        self.assertIn(["match", ["get", "class"], ["canal", "river"], False, True], low_other["filter"])
+        self.assertAlmostEqual(low_major["paint"]["line-width"], 0.08602461899537378)
+        self.assertAlmostEqual(low_other["paint"]["line-width"], 0.022620108479255864)
+        self.assertAlmostEqual(mid_major["paint"]["line-width"], 0.42585675726411115)
+        self.assertAlmostEqual(high_major["paint"]["line-width"], 0.6780241671213343)
+        self.assertAlmostEqual(shadow_low_major["paint"]["line-width"], 0.14095142330582108)
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("waterway-shadow-z16-plus-other"),
+            "waterway-shadow",
+        )
+
+    def test_waterway_line_width_is_not_split_when_shape_changes(self):
+        line_width = ["interpolate", ["linear"], ["zoom"], 9, 0.1, 20, 8]
+        layers = [self._waterway_layer(line_width=line_width)]
+
+        result = mapbox_config._split_waterway_line_width_layers_for_qgis(layers)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "waterway")
+        self.assertEqual(result[0]["paint"]["line-width"], line_width)
+
+    def test_waterway_line_width_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._waterway_layer()]
+
+        self.assertIs(
+            mapbox_config._split_waterway_line_width_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_waterway_line_width_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "waterway-canal-river-z8-to-z13")
+        self.assertEqual(result[2]["id"], "waterway-other-z8-to-z13")
 
     def _turning_feature_circle_radius_expression(self):
         return ["interpolate", ["exponential", 1.5], ["zoom"], 15, 4.5, 16, 8, 18, 20, 22, 200]


### PR DESCRIPTION
## Summary

- Split the live Mapbox Outdoors `waterway` and `waterway-shadow` line-width expression into static QGIS layers by waterway class and zoom band.
- Preserve Mapbox's wider canal/river treatment separately from smaller stream/other waterway classes instead of collapsing every waterway to the same `0.1mm` fallback.
- Keep the split exact-shape gated so it no-ops if the live Mapbox expression changes.

Closes part of #949.

## Evidence

Live Mapbox/QGIS comparison used the local QGIS-profile token source without printing or storing the token.

| Camera | Changed ratio delta | Mean error delta | RMS error delta |
| --- | ---: | ---: | ---: |
| switzerland-alps-z5-outdoors | +0.000000 | +0.000000 | +0.000000 |
| valais-geneva-outdoors | +0.000003 | +0.000002 | +0.000004 |
| lausanne-lavaux-z10-outdoors | +0.000002 | -0.000019 | -0.000033 |
| geneva-airport-motorway-z14-outdoors | -0.000116 | -0.000104 | -0.000287 |
| chamonix-trails-z14-outdoors | -0.000128 | -0.000101 | -0.000106 |
| zermatt-trails-z18-outdoors | +0.000000 | -0.000036 | -0.000093 |

Comparison artifacts:

- Post-#1082 baseline: `debug/mapbox-outdoors-comparison/all-cameras/20260516T225015Z/summary.md`
- Waterway-width branch comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260516T231945Z/summary.md`
- Visual contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260516T231945Z/waterway-width-contact-sheet.jpg`
- Fresh style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260516T232137Z/audit.md`

Visual review: the change is essentially neutral in the sampled cameras, with no added clutter or readability regression in Lausanne, Geneva, Chamonix, or Zermatt. Metrics move slightly closer at z10/z14/z18, z5 is unchanged, and z8 has only a microscopic negative delta.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` - 186 passed
- `python3 -m pytest tests/ -x -q --tb=short` - 2096 passed, 163 skipped, 135 subtests passed
- `git diff --check`
- Live all-camera Mapbox/QGIS comparison
- Live Mapbox Outdoors style audit with QGIS converter/filter checks
