### PR TITLE
fix: preserve natural landuse colors

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1051,6 +1051,12 @@ _LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS = {
     if not residential and suffix not in _LANDUSE_CLASS_FILL_COLOR_EXCLUDED_OPACITY_SUFFIXES
 }
 _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
+    ("wood", ["match", ["get", "class"], "wood", True, False], _LANDUSE_WOOD_FILL_COLOR),
+    ("scrub", ["match", ["get", "class"], "scrub", True, False], _LANDUSE_SCRUB_FILL_COLOR),
+    ("agriculture", ["match", ["get", "class"], "agriculture", True, False], _LANDUSE_AGRICULTURE_FILL_COLOR),
+    ("grass", ["match", ["get", "class"], "grass", True, False], _LANDUSE_AGRICULTURE_FILL_COLOR),
+    ("glacier", ["match", ["get", "class"], "glacier", True, False], _LANDUSE_GLACIER_FILL_COLOR),
+    ("sand", ["match", ["get", "class"], "sand", True, False], _LANDUSE_SAND_FILL_COLOR),
     (
         "park-special",
         [
@@ -1070,7 +1076,17 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
         _LANDUSE_PARK_FILL_COLOR,
     ),
     ("airport", ["match", ["get", "class"], "airport", True, False], _LANDUSE_AIRPORT_FILL_COLOR),
-    ("remaining", ["match", ["get", "class"], ["park", "airport"], False, True], _LANDUSE_FALLBACK_FILL_COLOR),
+    (
+        "remaining",
+        [
+            "match",
+            ["get", "class"],
+            ["wood", "scrub", "agriculture", "grass", "glacier", "sand", "park", "airport"],
+            False,
+            True,
+        ],
+        _LANDUSE_FALLBACK_FILL_COLOR,
+    ),
 )
 _LANDCOVER_CROP_FILL_COLOR = "hsla(68, 55%, 70%, 0.6)"
 _LANDCOVER_FALLBACK_FILL_COLOR = "hsl(98, 48%, 67%)"

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2681,7 +2681,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             )
             self.assertEqual(layer["paint"]["fill-color"], "hsl(60, 22%, 72%)")
 
-    def test_landuse_fill_color_splits_visible_park_and_airport_classes(self):
+    def test_landuse_fill_color_splits_visible_natural_park_and_airport_classes(self):
         layer = self._landuse_layer()
         layer["paint"]["fill-color"] = copy.deepcopy(mapbox_config._LANDUSE_FILL_COLOR_EXPRESSION)
         style = {"layers": [layer]}
@@ -2693,9 +2693,17 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS,
             {"landuse-other-z8-to-z10", "landuse-other-z10-plus"},
         )
-        self.assertEqual(len(result["layers"]), 12)
+        self.assertEqual(len(result["layers"]), 24)
         self.assertIn("landuse-other-below-z8", by_id)
         self.assertNotIn("landuse-other-below-z8-park", by_id)
+        natural_colors = {
+            "wood": mapbox_config._LANDUSE_WOOD_FILL_COLOR,
+            "scrub": mapbox_config._LANDUSE_SCRUB_FILL_COLOR,
+            "agriculture": mapbox_config._LANDUSE_AGRICULTURE_FILL_COLOR,
+            "grass": mapbox_config._LANDUSE_AGRICULTURE_FILL_COLOR,
+            "glacier": mapbox_config._LANDUSE_GLACIER_FILL_COLOR,
+            "sand": mapbox_config._LANDUSE_SAND_FILL_COLOR,
+        }
         park_special_mid = by_id["landuse-other-z8-to-z10-park-special"]
         park_mid = by_id["landuse-other-z8-to-z10-park"]
         airport_mid = by_id["landuse-other-z8-to-z10-airport"]
@@ -2704,6 +2712,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         park_high = by_id["landuse-other-z10-plus-park"]
         airport_high = by_id["landuse-other-z10-plus-airport"]
         remaining_high = by_id["landuse-other-z10-plus-remaining"]
+        for band in ("z8-to-z10", "z10-plus"):
+            for class_name, fill_color in natural_colors.items():
+                natural_layer = by_id[f"landuse-other-{band}-{class_name}"]
+                self.assertEqual(natural_layer["paint"]["fill-color"], fill_color)
         self.assertEqual(park_special_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_SPECIAL_FILL_COLOR)
         self.assertEqual(park_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
         self.assertEqual(airport_mid["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
@@ -2742,8 +2754,18 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ["match", ["get", "class"], "airport", True, False],
         )
         self.assertEqual(
+            by_id["landuse-other-z8-to-z10-wood"]["filter"][-1],
+            ["match", ["get", "class"], "wood", True, False],
+        )
+        self.assertEqual(
             remaining_mid["filter"][-1],
-            ["match", ["get", "class"], ["park", "airport"], False, True],
+            [
+                "match",
+                ["get", "class"],
+                ["wood", "scrub", "agriculture", "grass", "glacier", "sand", "park", "airport"],
+                False,
+                True,
+            ],
         )
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-airport"),
@@ -2817,12 +2839,23 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         result = mapbox_config._split_landuse_class_fill_color_layers_for_qgis(mixed_layers)
 
-        self.assertEqual(result[0], "not-a-layer")
-        self.assertEqual(result[1]["id"], "landuse")
-        self.assertEqual(result[2]["id"], "landuse-other-z10-plus-park-special")
-        self.assertEqual(result[3]["id"], "landuse-other-z10-plus-park")
-        self.assertEqual(result[4]["id"], "landuse-other-z10-plus-airport")
-        self.assertEqual(result[5]["id"], "landuse-other-z10-plus-remaining")
+        self.assertEqual(
+            [layer if isinstance(layer, str) else layer["id"] for layer in result],
+            [
+                "not-a-layer",
+                "landuse",
+                "landuse-other-z10-plus-wood",
+                "landuse-other-z10-plus-scrub",
+                "landuse-other-z10-plus-agriculture",
+                "landuse-other-z10-plus-grass",
+                "landuse-other-z10-plus-glacier",
+                "landuse-other-z10-plus-sand",
+                "landuse-other-z10-plus-park-special",
+                "landuse-other-z10-plus-park",
+                "landuse-other-z10-plus-airport",
+                "landuse-other-z10-plus-remaining",
+            ],
+        )
 
     def _national_park_layer(self, fill_opacity=None):
         if fill_opacity is None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2716,6 +2716,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             for class_name, fill_color in natural_colors.items():
                 natural_layer = by_id[f"landuse-other-{band}-{class_name}"]
                 self.assertEqual(natural_layer["paint"]["fill-color"], fill_color)
+                self.assertEqual(
+                    natural_layer["filter"][-1],
+                    ["match", ["get", "class"], class_name, True, False],
+                )
         self.assertEqual(park_special_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_SPECIAL_FILL_COLOR)
         self.assertEqual(park_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
         self.assertEqual(airport_mid["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
@@ -2752,10 +2756,6 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(
             airport_mid["filter"][-1],
             ["match", ["get", "class"], "airport", True, False],
-        )
-        self.assertEqual(
-            by_id["landuse-other-z8-to-z10-wood"]["filter"][-1],
-            ["match", ["get", "class"], "wood", True, False],
         )
         self.assertEqual(
             remaining_mid["filter"][-1],


### PR DESCRIPTION
## Summary

- split visible non-residential `landuse` fill-color bands for Mapbox Outdoors natural classes: `wood`, `scrub`, `agriculture`, `grass`, `glacier`, and `sand`
- keep existing park-special, park, airport, and remaining fallbacks intact
- update the focused Mapbox config tests for the expanded class-color variants and remaining filter

## Why

Post-#1083 visual review showed the QGIS render still collapsing several natural landuse classes into the beige fallback in z10/z14 views. These six classes use the same Mapbox color at the live low/high fill-color stops, so they can be scalarized into static QGIS class-filtered layers without adding a new zoom-band approximation.

Refs #949.

## Evidence

- Baseline comparison after #1083: `debug/mapbox-outdoors-comparison/all-cameras/20260516T231945Z/summary.md`
- Branch comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260516T234849Z/summary.md`
- Contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260516T234849Z/landuse-natural-colors-contact-sheet.jpg`
- Fresh style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260516T235039Z/audit.md`

Metric deltas versus the post-#1083 baseline:

| Camera | Changed ratio delta | Mean error delta | RMS error delta |
| --- | ---: | ---: | ---: |
| `switzerland-alps-z5-outdoors` | +0.000000 | +0.000000 | +0.000000 |
| `valais-geneva-outdoors` | +0.000000 | +0.000000 | +0.000000 |
| `lausanne-lavaux-z10-outdoors` | -0.000035 | -0.003556 | +0.000890 |
| `geneva-airport-motorway-z14-outdoors` | -0.002383 | -0.004007 | -0.001417 |
| `chamonix-trails-z14-outdoors` | -0.002537 | -0.040734 | -0.034663 |
| `zermatt-trails-z18-outdoors` | +0.000000 | +0.000000 | +0.000000 |

Visual review: Lausanne and Chamonix regain natural/forest coverage that is closer to the Mapbox GL reference, Geneva keeps road and label readability, and no sampled camera shows an obvious readability regression.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q` -> 186 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2096 passed, 163 skipped, 135 subtests passed
- `git diff --check`
- live all-camera Mapbox/QGIS comparison using the local profile token source without printing or storing the token
- live Mapbox Outdoors style audit with QGIS converter warnings and filter parser support
