### PR TITLE
fix: split Mapbox aeroway line widths

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1205,6 +1205,25 @@ _WATER_SHADOW_TRANSLATE_ZOOM_BANDS: tuple[tuple[str, float | None, float | None]
     ("z13-to-z16", 13.0, 16.0),
     ("z16-plus", 16.0, None),
 )
+_AEROWAY_LINE_LAYER_ID = "aeroway-line"
+_AEROWAY_LINE_WIDTH_EXPRESSION = [
+    "interpolate",
+    ["exponential", 1.5],
+    ["zoom"],
+    9,
+    ["match", ["get", "type"], "runway", 1, 0.5],
+    18,
+    ["match", ["get", "type"], "runway", 80, 20],
+]
+_AEROWAY_LINE_WIDTH_TYPE_VARIANTS: tuple[tuple[str, object, float, float], ...] = (
+    ("runway", ["match", ["get", "type"], "runway", True, False], 1.0, 80.0),
+    ("other", ["match", ["get", "type"], "runway", False, True], 0.5, 20.0),
+)
+_AEROWAY_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z9-to-z14", 9.0, 14.0),
+    ("z14-to-z16", 14.0, 16.0),
+    ("z16-plus", 16.0, None),
+)
 _WATERWAY_LAYER_ID = "waterway"
 _WATERWAY_SHADOW_LAYER_ID = "waterway-shadow"
 _WATERWAY_LINE_WIDTH_EXPRESSION = [
@@ -1992,11 +2011,22 @@ def _waterway_line_width_base_layer_id(layer_id: object) -> str | None:
     return None
 
 
+def _aeroway_line_width_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    if normalized == _AEROWAY_LINE_LAYER_ID:
+        return _AEROWAY_LINE_LAYER_ID
+    for type_suffix, _class_filter, _lower_width, _upper_width in _AEROWAY_LINE_WIDTH_TYPE_VARIANTS:
+        if normalized.startswith(f"{_AEROWAY_LINE_LAYER_ID}-{type_suffix}-"):
+            return _AEROWAY_LINE_LAYER_ID
+    return None
+
+
 def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     """Return the original Mapbox layer id for qfit-created layer variants."""
     for resolved_layer_id in (
         _road_class_line_color_base_layer_id(layer_id),
         _hillshade_base_layer_id(layer_id),
+        _aeroway_line_width_base_layer_id(layer_id),
         _waterway_line_width_base_layer_id(layer_id),
         _water_label_typography_base_layer_id(layer_id),
         _regional_major_road_width_base_layer_id(layer_id),
@@ -3300,6 +3330,92 @@ def _split_water_shadow_translate_layers_for_qgis(layers: object) -> object:
             expanded_layers.append(layer)
             continue
         variants = _water_shadow_translate_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
+def _aeroway_line_width_px_at_zoom(target_zoom: float, lower_width: float, upper_width: float) -> float | None:
+    if target_zoom <= 9.0:
+        return lower_width
+    if target_zoom >= 18.0:
+        return upper_width
+    factor = _interpolate_filter_factor(["exponential", 1.5], target_zoom, 9.0, 18.0)
+    if factor is None:
+        return None
+    return lower_width + ((upper_width - lower_width) * factor)
+
+
+def _aeroway_line_width_mm_for_zoom_band(
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+    band_minzoom: float | None,
+    band_maxzoom: float | None,
+    lower_width: float,
+    upper_width: float,
+) -> tuple[float, float | None, float | None] | None:
+    effective_zoom_band = _effective_zoom_band(
+        existing_minzoom,
+        existing_maxzoom,
+        band_minzoom,
+        band_maxzoom,
+    )
+    if effective_zoom_band is None:
+        return None
+    representative_zoom = _zoom_band_representative_zoom(*effective_zoom_band)
+    width_px = _aeroway_line_width_px_at_zoom(representative_zoom, lower_width, upper_width)
+    if width_px is None:
+        return None
+    return min(max(width_px * _MAPBOX_PIXEL_TO_MM, 0.0), _MAX_LINE_WIDTH_MM), *effective_zoom_band
+
+
+def _aeroway_line_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split Mapbox aeroway runway widths into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    paint = layer.get("paint")
+    if (
+        layer_id != _AEROWAY_LINE_LAYER_ID
+        or layer.get("type") != "line"
+        or not isinstance(paint, dict)
+        or paint.get("line-width") != _AEROWAY_LINE_WIDTH_EXPRESSION
+    ):
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for band_suffix, band_minzoom, band_maxzoom in _AEROWAY_LINE_WIDTH_ZOOM_BANDS:
+        for type_suffix, type_filter, lower_width, upper_width in _AEROWAY_LINE_WIDTH_TYPE_VARIANTS:
+            width = _aeroway_line_width_mm_for_zoom_band(
+                existing_minzoom,
+                existing_maxzoom,
+                band_minzoom,
+                band_maxzoom,
+                lower_width,
+                upper_width,
+            )
+            if width is None:
+                continue
+            line_width, effective_minzoom, effective_maxzoom = width
+            variant = copy.deepcopy(layer)
+            variant["id"] = f"{layer_id}-{type_suffix}-{band_suffix}"
+            _set_zoom_bounds(variant, effective_minzoom, effective_maxzoom)
+            variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), type_filter)
+            variant_paint = variant["paint"]
+            assert isinstance(variant_paint, dict)
+            variant_paint["line-width"] = line_width
+            variants.append(variant)
+    return variants or None
+
+
+def _split_aeroway_line_width_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _aeroway_line_width_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -4834,6 +4950,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_rail_track_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_gate_fence_hedge_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_water_shadow_translate_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_aeroway_line_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_waterway_line_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_turning_feature_circle_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_waterway_label_symbol_spacing_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3364,6 +3364,88 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "water-shadow-z13-to-z16")
         self.assertEqual(result[3]["id"], "water-shadow-z16-plus")
 
+    def _aeroway_line_layer(self, line_width=None):
+        if line_width is None:
+            line_width = copy.deepcopy(mapbox_config._AEROWAY_LINE_WIDTH_EXPRESSION)
+        return {
+            "id": "aeroway-line",
+            "type": "line",
+            "minzoom": 9,
+            "source-layer": "aeroway",
+            "filter": ["==", ["geometry-type"], "LineString"],
+            "paint": {
+                "line-color": "hsl(230, 24%, 87%)",
+                "line-opacity": ["interpolate", ["linear"], ["zoom"], 10, 0, 11, 1],
+                "line-width": line_width,
+            },
+        }
+
+    def test_aeroway_line_width_splits_runway_and_zoom_bands(self):
+        style = {"layers": [self._aeroway_line_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            list(by_id),
+            [
+                "aeroway-line-runway-z9-to-z14",
+                "aeroway-line-other-z9-to-z14",
+                "aeroway-line-runway-z14-to-z16",
+                "aeroway-line-other-z14-to-z16",
+                "aeroway-line-runway-z16-plus",
+                "aeroway-line-other-z16-plus",
+            ],
+        )
+        low_runway = by_id["aeroway-line-runway-z9-to-z14"]
+        low_other = by_id["aeroway-line-other-z9-to-z14"]
+        mid_runway = by_id["aeroway-line-runway-z14-to-z16"]
+        mid_other = by_id["aeroway-line-other-z14-to-z16"]
+        high_runway = by_id["aeroway-line-runway-z16-plus"]
+        high_other = by_id["aeroway-line-other-z16-plus"]
+        self.assertEqual(low_runway["minzoom"], 9)
+        self.assertEqual(low_runway["maxzoom"], 14.0)
+        self.assertEqual(mid_runway["minzoom"], 14.0)
+        self.assertEqual(mid_runway["maxzoom"], 16.0)
+        self.assertEqual(high_runway["minzoom"], 16.0)
+        self.assertNotIn("maxzoom", high_runway)
+        self.assertIn(["match", ["get", "type"], "runway", True, False], low_runway["filter"])
+        self.assertIn(["match", ["get", "type"], "runway", False, True], low_other["filter"])
+        self.assertAlmostEqual(low_runway["paint"]["line-width"], 1.2446579272796943)
+        self.assertAlmostEqual(low_other["paint"]["line-width"], 0.3742088132736798)
+        self.assertAlmostEqual(mid_runway["paint"]["line-width"], 3.0)
+        self.assertAlmostEqual(mid_other["paint"]["line-width"], 1.5640310125536836)
+        self.assertAlmostEqual(high_runway["paint"]["line-width"], 3.0)
+        self.assertAlmostEqual(high_other["paint"]["line-width"], 2.3487964134195747)
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("aeroway-line-other-z16-plus"),
+            "aeroway-line",
+        )
+
+    def test_aeroway_line_width_is_not_split_when_shape_changes(self):
+        line_width = ["interpolate", ["linear"], ["zoom"], 9, 0.5, 18, 20]
+        layers = [self._aeroway_line_layer(line_width=line_width)]
+
+        result = mapbox_config._split_aeroway_line_width_layers_for_qgis(layers)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "aeroway-line")
+        self.assertEqual(result[0]["paint"]["line-width"], line_width)
+
+    def test_aeroway_line_width_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._aeroway_line_layer()]
+
+        self.assertIs(
+            mapbox_config._split_aeroway_line_width_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_aeroway_line_width_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "aeroway-line-runway-z9-to-z14")
+        self.assertEqual(result[2]["id"], "aeroway-line-other-z9-to-z14")
+
     def test_waterway_line_width_splits_classes_and_zoom_bands(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

- Split the Mapbox Outdoors `aeroway-line` width expression into QGIS-safe static runway/non-runway zoom-band layers.
- Keep the slice scoped to the audited `aeroway-line` layer; airport fills and labels are unchanged.
- Preserve qfit layer-base mapping for the generated aeroway variants.
- Add regression tests for split IDs, zoom bounds, runway/non-runway filters, sampled line widths, passthrough behavior, and base-layer mapping.

## Why

#949's latest airport/special-landuse audit isolated `aeroway-line` as a remaining Geneva airport mismatch: QGIS collapsed Mapbox's zoom/type width expression to a single 1px fallback, making runway and taxiway linework much weaker than Mapbox GL.

Visual inspection of the Geneva airport comparison showed the branch restores runway/taxiway structure without materially hurting nearby road readability. The airport polygon fill mismatch remains separate and intentionally out of scope.

## Evidence

- Focused Geneva comparison: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T020731Z/`
- All-camera comparison summary: `debug/mapbox-outdoors-comparison/all-cameras/20260517T020855Z/summary.md`
- Fresh style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T020939Z/audit.md`

Metric deltas versus the post-#1085 baseline `debug/mapbox-outdoors-comparison/all-cameras/20260517T000849Z/summary.json`:

| Camera | Changed ratio delta | Mean delta | RMS delta |
| --- | ---: | ---: | ---: |
| `switzerland-alps-z5-outdoors` | +0.000000 | +0.000000 | +0.000000 |
| `valais-geneva-outdoors` | +0.000000 | +0.000000 | +0.000000 |
| `lausanne-lavaux-z10-outdoors` | +0.000001 | +0.000004 | +0.000002 |
| `geneva-airport-motorway-z14-outdoors` | -0.000213 | -0.000454 | -0.000197 |
| `chamonix-trails-z14-outdoors` | -0.000129 | -0.000047 | -0.000066 |
| `zermatt-trails-z18-outdoors` | -0.000009 | +0.000019 | +0.000066 |

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `coverage run -m unittest tests.test_mapbox_config -v && coverage report -m mapbox_config.py`
- `git diff --check`
- Live focused Geneva comparison using the local token source
- Live all-camera comparison using the local token source
- Live Mapbox Outdoors style audit using the local token source
