### PR TITLE
Tune Mapbox airport landuse opacity

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1050,6 +1050,12 @@ _LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS = {
     for suffix, _class_filter, _band_minzoom, _band_maxzoom, residential in _LANDUSE_FILL_OPACITY_VARIANTS
     if not residential and suffix not in _LANDUSE_CLASS_FILL_COLOR_EXCLUDED_OPACITY_SUFFIXES
 }
+_LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY = 0.66
+# QGIS renders the full-opacity airport landuse wash too strongly over
+# aeroway polygons in the Geneva z14 comparison. Keep this override narrow.
+_LANDUSE_CLASS_FILL_OPACITY_OVERRIDES = {
+    (f"{_LANDUSE_LAYER_ID}-other-z10-plus", "airport"): _LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,
+}
 _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ("wood", ["match", ["get", "class"], "wood", True, False], _LANDUSE_WOOD_FILL_COLOR),
     ("scrub", ["match", ["get", "class"], "scrub", True, False], _LANDUSE_SCRUB_FILL_COLOR),
@@ -3082,6 +3088,9 @@ def _landuse_class_fill_color_layer_variants(layer: dict[str, object]) -> list[d
         variant_paint = variant["paint"]
         assert isinstance(variant_paint, dict)
         variant_paint["fill-color"] = fill_color
+        fill_opacity = _LANDUSE_CLASS_FILL_OPACITY_OVERRIDES.get((layer_id, suffix))
+        if fill_opacity is not None:
+            variant_paint["fill-opacity"] = fill_opacity
         variants.append(variant)
     return variants or None
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2733,7 +2733,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(park_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
         self.assertEqual(airport_high["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
         self.assertEqual(remaining_high["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
-        self.assertAlmostEqual(airport_mid["paint"]["fill-opacity"], 0.6000000000000001)
+        self.assertAlmostEqual(airport_mid["paint"]["fill-opacity"], 0.6)
         self.assertAlmostEqual(
             airport_high["paint"]["fill-opacity"],
             mapbox_config._LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2733,6 +2733,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(park_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
         self.assertEqual(airport_high["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
         self.assertEqual(remaining_high["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
+        self.assertAlmostEqual(airport_mid["paint"]["fill-opacity"], 0.6000000000000001)
+        self.assertAlmostEqual(
+            airport_high["paint"]["fill-opacity"],
+            mapbox_config._LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,
+        )
+        self.assertAlmostEqual(remaining_high["paint"]["fill-opacity"], 1.0)
         self.assertEqual(park_mid["minzoom"], 8.0)
         self.assertEqual(park_mid["maxzoom"], 10.0)
         self.assertEqual(airport_high["minzoom"], 10.0)


### PR DESCRIPTION
## Summary

- lower only the generated z10+ Mapbox Outdoors airport landuse fill opacity to reduce the QGIS airport wash around Geneva
- keep the existing landuse class/color split, lower zoom airport opacity, and non-airport classes unchanged
- add unit assertions for the airport-specific opacity override

## Visual comparison

- Baseline after #1087: `debug/mapbox-outdoors-comparison/all-cameras/20260517T020855Z/summary.md`
- Focused Geneva baseline: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T020731Z/`
- Tested opacity probes: `0.72`, `0.66`, and `0.60`
- Selected `0.66` because it improves runway/taxiway/apron readability without making the airport landuse wash too pale
- Final all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260517T023432Z/summary.md`
- Final style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T023515Z/audit.md`

Compared with the post-#1087 all-camera baseline, the final Geneva airport camera changed as expected: changed-pixel ratio `+0.058868`, normalized mean delta `+0.000425`, normalized RMS delta `-0.000968`. z5, z8, and z18 were unchanged; z10 and Chamonix showed only tiny render-noise movement.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check`
- `coverage run -m unittest tests.test_mapbox_config -v && coverage report -m mapbox_config.py`
- live focused Geneva comparison using the local Mapbox token source without printing or storing the token
- live all-camera comparison using the local Mapbox token source without printing or storing the token
- live Mapbox Outdoors style audit using the local Mapbox token source without printing or storing the token
