### PR TITLE
Tune Mapbox aeroway polygon contrast

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1211,6 +1211,9 @@ _WATER_SHADOW_TRANSLATE_ZOOM_BANDS: tuple[tuple[str, float | None, float | None]
     ("z13-to-z16", 13.0, 16.0),
     ("z16-plus", 16.0, None),
 )
+_AEROWAY_POLYGON_LAYER_ID = "aeroway-polygon"
+_AEROWAY_POLYGON_FILL_COLOR = "hsl(230, 36%, 74%)"
+_AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR = "hsl(230, 36%, 70%)"
 _AEROWAY_LINE_LAYER_ID = "aeroway-line"
 _AEROWAY_LINE_WIDTH_EXPRESSION = [
     "interpolate",
@@ -5036,6 +5039,13 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
             if _should_zoom_normalize_filter_for_qgis(layer):
                 filter_value = _zoom_normalized_filter_expression_for_qgis(layer, filter_value)
             layer["filter"] = _simplify_filter_expression_for_qgis(filter_value)
+
+        if base_layer_id == _AEROWAY_POLYGON_LAYER_ID and layer.get("type") == "fill":
+            paint = layer.get("paint")
+            if isinstance(paint, dict) and paint.get("fill-color") == _AEROWAY_POLYGON_FILL_COLOR:
+                # QGIS renders Mapbox's airport aeroway fill too close to the
+                # surrounding airport landuse in the Geneva z14 comparison.
+                paint["fill-color"] = _AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR
 
         for section in ("paint", "layout"):
             props = layer.get(section)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3452,6 +3452,36 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "aeroway-line-runway-z9-to-z14")
         self.assertEqual(result[2]["id"], "aeroway-line-other-z9-to-z14")
 
+    def test_aeroway_polygon_fill_uses_qgis_contrast_color(self):
+        style = {
+            "layers": [
+                {
+                    "id": "aeroway-polygon",
+                    "type": "fill",
+                    "minzoom": 11,
+                    "source-layer": "aeroway",
+                    "filter": [
+                        "all",
+                        ["match", ["get", "type"], ["runway", "taxiway", "helipad"], True, False],
+                        ["==", ["geometry-type"], "Polygon"],
+                    ],
+                    "paint": {
+                        "fill-color": mapbox_config._AEROWAY_POLYGON_FILL_COLOR,
+                        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 10, 0, 11, 1],
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        aeroway_polygon = result["layers"][0]
+        self.assertEqual(
+            aeroway_polygon["paint"]["fill-color"],
+            mapbox_config._AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR,
+        )
+        self.assertAlmostEqual(aeroway_polygon["paint"]["fill-opacity"], 1.0)
+
     def test_waterway_line_width_splits_classes_and_zoom_bands(self):
         style = {
             "layers": [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3482,6 +3482,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertAlmostEqual(aeroway_polygon["paint"]["fill-opacity"], 1.0)
 
+    def test_aeroway_polygon_fill_leaves_non_matching_color_unchanged(self):
+        style = {
+            "layers": [
+                {
+                    "id": "aeroway-polygon",
+                    "type": "fill",
+                    "source-layer": "aeroway",
+                    "paint": {
+                        "fill-color": "hsl(230, 36%, 72%)",
+                        "fill-opacity": 1.0,
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["paint"]["fill-color"], "hsl(230, 36%, 72%)")
+
     def test_waterway_line_width_splits_classes_and_zoom_bands(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

- darken only the qfit-preprocessed Mapbox Outdoors `aeroway-polygon` fill from `hsl(230, 36%, 74%)` to `hsl(230, 36%, 70%)`
- keep airport landuse opacity, aeroway line widths, airport labels, and non-airport layers unchanged
- add regression coverage for the generated QGIS contrast fill

## Evidence

Focused Geneva airport comparison:

- Baseline after #1088: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T023420Z/`
- Final branch run: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T025824Z/`

Metric deltas versus the baseline:

| Camera | Changed ratio delta | Mean delta | RMS delta |
| --- | ---: | ---: | ---: |
| `geneva-airport-motorway-z14-outdoors` | -0.000006 | +0.000000 | -0.000003 |

Visual read: the darker aeroway polygon fill makes the runway/taxiway/helipad geometry read slightly closer to Mapbox GL without making the surrounding roads, labels, parks, buildings, or airport landuse feel heavier. A line-only contrast probe was rejected because the improvement was too small and the focused metrics moved slightly worse.

Broader validation:

- All-camera comparison summary: `debug/mapbox-outdoors-comparison/all-cameras/20260517T030004Z/summary.md`
- Fresh style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T030049Z/audit.md`

The all-camera matrix stayed effectively unchanged outside tiny Geneva/Chamonix render-noise movement below rounded summary precision.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `coverage run -m unittest tests.test_mapbox_config -v`
- `coverage report -m mapbox_config.py`
- live focused Geneva comparison using the local token source without printing or storing the token
- live all-camera comparison using the local token source without printing or storing the token
- live Mapbox Outdoors style audit using the local token source without printing or storing the token

Fixes part of #949.
