### PR TITLE
fix: preserve high-zoom path background colors (#949)

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1726,12 +1726,6 @@ def _path_background_line_color_layer_variants(layer: dict[str, object]) -> list
         or paint.get("line-color") != _PATH_BACKGROUND_LINE_COLOR_EXPRESSION
     ):
         return None
-    maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
-    # Keep z16+ path backgrounds on the conservative fallback until QGIS can
-    # approximate Mapbox's high-zoom pedestrian/path casing stack more fully.
-    if maxzoom is None or maxzoom > _PATH_TYPE_FILTER_SPLIT_ZOOM:
-        return None
-
     layer_id = str(layer.get("id") or base_layer_id)
     variants: list[dict[str, object]] = []
     for suffix, type_filter, line_color in _PATH_BACKGROUND_LINE_COLOR_VARIANTS:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4306,21 +4306,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-path-bg-below-z16-piste",
                 "road-path-bg-below-z16-outdoor",
                 "road-path-bg-below-z16-remaining",
-                "road-path-bg-z16-plus",
+                "road-path-bg-z16-plus-piste",
+                "road-path-bg-z16-plus-outdoor",
+                "road-path-bg-z16-plus-remaining",
                 "bridge-path-bg-below-z16-piste",
                 "bridge-path-bg-below-z16-outdoor",
                 "bridge-path-bg-below-z16-remaining",
-                "bridge-path-bg-z16-plus",
+                "bridge-path-bg-z16-plus-piste",
+                "bridge-path-bg-z16-plus-outdoor",
+                "bridge-path-bg-z16-plus-remaining",
             ],
         )
         by_id = {layer["id"]: layer for layer in result["layers"]}
         for layer_id in ("road-path-bg", "bridge-path-bg"):
+            for band in ("below-z16", "z16-plus"):
+                self.assertEqual(by_id[f"{layer_id}-{band}-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
+                self.assertEqual(by_id[f"{layer_id}-{band}-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
+                self.assertEqual(by_id[f"{layer_id}-{band}-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
             self.assertEqual(by_id[f"{layer_id}-below-z16-piste"]["maxzoom"], 16.0)
-            self.assertEqual(by_id[f"{layer_id}-z16-plus"]["minzoom"], 16.0)
-            self.assertEqual(by_id[f"{layer_id}-below-z16-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
-            self.assertEqual(by_id[f"{layer_id}-below-z16-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
-            self.assertEqual(by_id[f"{layer_id}-below-z16-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
-            self.assertEqual(by_id[f"{layer_id}-z16-plus"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
+            self.assertEqual(by_id[f"{layer_id}-z16-plus-piste"]["minzoom"], 16.0)
         self.assertEqual(by_id["road-path-bg-below-z16-piste"]["minzoom"], 12)
         self.assertEqual(by_id["bridge-path-bg-below-z16-piste"]["minzoom"], 14)
         self.assertEqual(

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4323,34 +4323,55 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 self.assertEqual(by_id[f"{layer_id}-{band}-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
                 self.assertEqual(by_id[f"{layer_id}-{band}-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
                 self.assertEqual(by_id[f"{layer_id}-{band}-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
-            self.assertEqual(by_id[f"{layer_id}-below-z16-piste"]["maxzoom"], 16.0)
-            self.assertEqual(by_id[f"{layer_id}-z16-plus-piste"]["minzoom"], 16.0)
+            for suffix in ("piste", "outdoor", "remaining"):
+                self.assertEqual(by_id[f"{layer_id}-below-z16-{suffix}"]["maxzoom"], 16.0)
+                self.assertEqual(by_id[f"{layer_id}-z16-plus-{suffix}"]["minzoom"], 16.0)
         self.assertEqual(by_id["road-path-bg-below-z16-piste"]["minzoom"], 12)
         self.assertEqual(by_id["bridge-path-bg-below-z16-piste"]["minzoom"], 14)
+        expected_below_z16_outdoor_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], False, True],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ["==", ["geometry-type"], "LineString"],
+            [
+                "match",
+                ["get", "type"],
+                ["mountain_bike", "hiking", "trail", "cycleway", "footway", "path", "bridleway"],
+                True,
+                False,
+            ],
+        ]
+        expected_z16_plus_outdoor_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            ["!=", ["get", "type"], "steps"],
+            ["match", ["get", "structure"], ["none", "ford"], True, False],
+            ["==", ["geometry-type"], "LineString"],
+            [
+                "match",
+                ["get", "type"],
+                ["mountain_bike", "hiking", "trail", "cycleway", "footway", "path", "bridleway"],
+                True,
+                False,
+            ],
+        ]
         self.assertEqual(
             by_id["road-path-bg-below-z16-outdoor"]["filter"],
-            [
-                "all",
-                ["==", ["get", "class"], "path"],
-                ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], False, True],
-                ["match", ["get", "structure"], ["none", "ford"], True, False],
-                ["==", ["geometry-type"], "LineString"],
-                [
-                    "match",
-                    ["get", "type"],
-                    ["mountain_bike", "hiking", "trail", "cycleway", "footway", "path", "bridleway"],
-                    True,
-                    False,
-                ],
-            ],
+            expected_below_z16_outdoor_filter,
         )
+        self.assertEqual(by_id["road-path-bg-z16-plus-outdoor"]["filter"], expected_z16_plus_outdoor_filter)
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-bg-below-z16-outdoor"),
             "road-path-bg",
         )
         self.assertEqual(
             by_id["bridge-path-bg-below-z16-outdoor"]["filter"],
-            by_id["road-path-bg-below-z16-outdoor"]["filter"],
+            expected_below_z16_outdoor_filter,
+        )
+        self.assertEqual(
+            by_id["bridge-path-bg-z16-plus-outdoor"]["filter"],
+            expected_z16_plus_outdoor_filter,
         )
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("bridge-path-bg-below-z16-outdoor"),


### PR DESCRIPTION
## Summary

- extend the existing Mapbox path background type-color split to the z16+ path and bridge background layers
- keep piste, outdoor path, and remaining path background variants consistent across low and high zoom bands
- update the converter regression test so the high-zoom split is locked in

## Evidence

This is a small #949 road/trail hierarchy slice. The focused Zermatt z18 visual comparison showed the branch makes the high-zoom path/trail network more discoverable in QGIS, closer to Mapbox Outdoors' pedestrian/path emphasis, without a major clutter regression.

Live validation artifacts:

- Focused Zermatt comparison: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260517T034538Z/`
- All-camera summary: `debug/mapbox-outdoors-comparison/all-cameras/20260517T034655Z/summary.md`
- Style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T034749Z/audit.md`

Live Mapbox checks used the local QGIS profile token source without printing or storing the token.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check`
- `coverage run -m unittest tests.test_mapbox_config -v && coverage report -m mapbox_config.py`
- live focused Zermatt Mapbox/QGIS comparison
- live all-camera Mapbox/QGIS comparison
- live Mapbox Outdoors style audit
