### PR TITLE
fix: sample high-zoom path widths from z18 (#949)

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -587,6 +587,12 @@ _PATH_TYPE_FILTER_SPLIT_LAYER_IDS = {
     "road-path",
     "road-path-bg",
 }
+_PATH_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES = (
+    "road-path-z16-plus",
+    "road-path-bg-z16-plus",
+    "bridge-path-bg-z16-plus",
+)
+_PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 18.0
 _PATH_BACKGROUND_LINE_COLOR_LAYER_IDS = {
     "bridge-path-bg",
     "road-path-bg",
@@ -2066,6 +2072,19 @@ def _is_waterway_label_layer_id(layer_id: object) -> bool:
 
 def _is_regional_major_road_width_variant(layer_id: object) -> bool:
     return _regional_major_road_width_base_layer_id(layer_id) is not None
+
+
+def _should_sample_path_high_zoom_line_width(layer_id: object, prop: str, minzoom: object) -> bool:
+    if prop != "line-width":
+        return False
+    layer_minzoom = _numeric_zoom_bound(minzoom)
+    if layer_minzoom is None or layer_minzoom < _PATH_TYPE_FILTER_SPLIT_ZOOM:
+        return False
+    normalized = str(layer_id or "")
+    return any(
+        normalized == prefix or normalized.startswith(f"{prefix}-")
+        for prefix in _PATH_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES
+    )
 
 
 def _regional_major_road_width_scale(layer_id: object) -> float:
@@ -5103,6 +5122,11 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         props[prop] = fallback
                 elif prop in _WIDTH_PROPS:
                     width = None
+                    if _should_sample_path_high_zoom_line_width(layer_id, prop, layer.get("minzoom")):
+                        width = _extract_zoom_scalar_size_at_zoom(
+                            val,
+                            _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM,
+                        )
                     is_regional_road_width_variant = (
                         prop in _REGIONAL_MAJOR_ROAD_STROKE_WIDTH_PROPS
                         and _is_regional_major_road_width_variant(layer_id)

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2087,6 +2087,15 @@ def _should_sample_path_high_zoom_line_width(layer_id: object, prop: str, minzoo
     )
 
 
+def _path_high_zoom_line_width(expr: object, layer_id: object, prop: str, minzoom: object, maxzoom: object) -> float | None:
+    if not _should_sample_path_high_zoom_line_width(layer_id, prop, minzoom):
+        return None
+    target_zoom = _zoom_in_layer_range(_PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM, minzoom, maxzoom)
+    if target_zoom is None:
+        return None
+    return _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
+
+
 def _regional_major_road_width_scale(layer_id: object) -> float:
     base_layer_id = base_mapbox_style_layer_id_for_qfit(layer_id)
     if base_layer_id in _REGIONAL_CORE_ROAD_WIDTH_LAYER_IDS:
@@ -5122,11 +5131,13 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         props[prop] = fallback
                 elif prop in _WIDTH_PROPS:
                     width = None
-                    if _should_sample_path_high_zoom_line_width(layer_id, prop, layer.get("minzoom")):
-                        width = _extract_zoom_scalar_size_at_zoom(
-                            val,
-                            _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM,
-                        )
+                    width = _path_high_zoom_line_width(
+                        val,
+                        layer_id,
+                        prop,
+                        layer.get("minzoom"),
+                        layer.get("maxzoom"),
+                    )
                     is_regional_road_width_variant = (
                         prop in _REGIONAL_MAJOR_ROAD_STROKE_WIDTH_PROPS
                         and _is_regional_major_road_width_variant(layer_id)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4434,6 +4434,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     },
                 },
                 {
+                    "id": "bridge-path-bg",
+                    "type": "line",
+                    "minzoom": 14,
+                    "filter": copy.deepcopy(path_filter),
+                    "paint": {
+                        "line-width": copy.deepcopy(line_width),
+                        "line-color": copy.deepcopy(mapbox_config._PATH_BACKGROUND_LINE_COLOR_EXPRESSION),
+                    },
+                },
+                {
                     "id": "road-minor",
                     "type": "line",
                     "minzoom": 16,
@@ -4451,7 +4461,42 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(by_id["road-path-z16-plus"]["paint"]["line-width"], high_width_mm)
         self.assertAlmostEqual(by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"], low_width_mm)
         self.assertAlmostEqual(by_id["road-path-bg-z16-plus-outdoor"]["paint"]["line-width"], high_width_mm)
+        self.assertAlmostEqual(by_id["bridge-path-bg-z16-plus-outdoor"]["paint"]["line-width"], high_width_mm)
         self.assertAlmostEqual(by_id["road-minor"]["paint"]["line-width"], low_width_mm)
+
+    def test_high_zoom_path_line_width_clamps_to_split_layer_maxzoom(self):
+        path_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            [
+                "step",
+                ["zoom"],
+                ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], False, True],
+                16,
+                ["!=", ["get", "type"], "steps"],
+            ],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "road-path",
+                    "type": "line",
+                    "minzoom": 12,
+                    "maxzoom": 17,
+                    "filter": copy.deepcopy(path_filter),
+                    "paint": {"line-width": ["step", ["zoom"], 1, 16, 4, 18, 7]},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertAlmostEqual(
+            by_id["road-path-z16-plus"]["paint"]["line-width"],
+            4 * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
 
     def test_filter_simplification_replaces_path_filter_without_split_outside_threshold(self):
         path_filter = [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4400,6 +4400,59 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[3]["id"], "bridge-path-bg-below-z16-outdoor")
         self.assertEqual(result[4]["id"], "bridge-path-bg-below-z16-remaining")
 
+    def test_high_zoom_path_line_width_uses_split_zoom_band(self):
+        path_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            [
+                "step",
+                ["zoom"],
+                ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], False, True],
+                16,
+                ["!=", ["get", "type"], "steps"],
+            ],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        line_width = ["interpolate", ["linear"], ["zoom"], 12, 1, 16, 4, 18, 7]
+        style = {
+            "layers": [
+                {
+                    "id": "road-path",
+                    "type": "line",
+                    "minzoom": 12,
+                    "filter": copy.deepcopy(path_filter),
+                    "paint": {"line-width": copy.deepcopy(line_width)},
+                },
+                {
+                    "id": "road-path-bg",
+                    "type": "line",
+                    "minzoom": 12,
+                    "filter": copy.deepcopy(path_filter),
+                    "paint": {
+                        "line-width": copy.deepcopy(line_width),
+                        "line-color": copy.deepcopy(mapbox_config._PATH_BACKGROUND_LINE_COLOR_EXPRESSION),
+                    },
+                },
+                {
+                    "id": "road-minor",
+                    "type": "line",
+                    "minzoom": 16,
+                    "paint": {"line-width": copy.deepcopy(line_width)},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_width_mm = 1 * mapbox_config._MAPBOX_PIXEL_TO_MM
+        high_width_mm = 7 * mapbox_config._MAPBOX_PIXEL_TO_MM
+        self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], low_width_mm)
+        self.assertAlmostEqual(by_id["road-path-z16-plus"]["paint"]["line-width"], high_width_mm)
+        self.assertAlmostEqual(by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"], low_width_mm)
+        self.assertAlmostEqual(by_id["road-path-bg-z16-plus-outdoor"]["paint"]["line-width"], high_width_mm)
+        self.assertAlmostEqual(by_id["road-minor"]["paint"]["line-width"], low_width_mm)
+
     def test_filter_simplification_replaces_path_filter_without_split_outside_threshold(self):
         path_filter = [
             "all",


### PR DESCRIPTION
## Summary

- sample split z16+ path line widths from the high-detail z18 Mapbox stop instead of the generic low/mid representative zoom
- keep the override scoped to qfit-generated high-zoom road/path background and foreground variants
- add regression coverage so below-z16 path widths and unrelated road widths keep the existing representative sampler

## Evidence

This is a small #949 road/trail hierarchy slice. The baseline after PR #1090 still rendered high-zoom Zermatt paths too quietly versus Mapbox GL. The promoted z18-sampled variant makes the local path network more legible without visible label loss or orange casing clutter.

Validation artifacts:

- focused Zermatt comparison: debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260517T041506Z/
- all-camera summary: debug/mapbox-outdoors-comparison/all-cameras/20260517T041632Z/summary.md
- style audit: debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T041642Z/audit.md

The full camera matrix showed no metric movement for z5, z8, z10, or Chamonix z14. The visible change is concentrated in the intended Zermatt z18 guardrail camera.

Live Mapbox checks used the local QGIS profile token source without printing or storing the token.

## Validation

- python3 -m pytest tests/test_mapbox_config.py -q
- python3 -m pytest tests/ -x -q --tb=short && git diff --check
- coverage run -m unittest tests.test_mapbox_config -v && coverage report -m mapbox_config.py
- live focused Zermatt Mapbox/QGIS comparison
- live all-camera Mapbox/QGIS comparison
- live Mapbox Outdoors style audit
