### PR TITLE
fix: preserve low-zoom road shield points

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -195,6 +195,27 @@ _POI_LABEL_MAKI_ICON_VALUES = (
 )
 
 _ROAD_NUMBER_SHIELD_LAYER_ID = "road-number-shield"
+_ROAD_NUMBER_SHIELD_POINT_TO_LINE_ZOOM = 11.0
+_ROAD_NUMBER_SHIELD_SYMBOL_PLACEMENT_EXPRESSION = [
+    "step",
+    ["zoom"],
+    "point",
+    11,
+    "line",
+]
+_ROAD_NUMBER_SHIELD_POINT_TO_LINE_FILTER_EXPRESSION = [
+    "step",
+    ["zoom"],
+    ["==", ["geometry-type"], "Point"],
+    11,
+    [">", ["get", "len"], 5000],
+    12,
+    [">", ["get", "len"], 2500],
+    13,
+    [">", ["get", "len"], 1000],
+    14,
+    True,
+]
 _ROAD_EXIT_SHIELD_LAYER_ID = "road-exit-shield"
 _ROAD_EXIT_SHIELD_ICON_IMAGE = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
 _BOUNDARY_BG_LINE_OPACITY_LAYER_IDS = {"admin-0-boundary-bg", "admin-1-boundary-bg"}
@@ -1890,6 +1911,62 @@ def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[st
         shield_layer["layout"]["icon-image"] = _road_shield_icon_match("shield", reflen)
         variants.append(shield_layer)
     return variants
+
+
+def _road_number_shield_zoom_layer_variants(
+    layer: dict[str, object],
+) -> list[dict[str, object]] | None:
+    if (
+        not _is_road_number_shield_layer_id(layer.get("id"))
+        or layer.get("type") != "symbol"
+    ):
+        return None
+    layout = layer.get("layout")
+    if not isinstance(layout, dict):
+        return None
+    if (
+        layout.get("symbol-placement")
+        != _ROAD_NUMBER_SHIELD_SYMBOL_PLACEMENT_EXPRESSION
+    ):
+        return None
+    filter_value = layer.get("filter")
+    if not _filter_contains_clause(
+        filter_value,
+        _ROAD_NUMBER_SHIELD_POINT_TO_LINE_FILTER_EXPRESSION,
+    ):
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    split_zoom = _ROAD_NUMBER_SHIELD_POINT_TO_LINE_ZOOM
+    if existing_maxzoom is not None and existing_maxzoom <= split_zoom:
+        return None
+    if existing_minzoom is not None and existing_minzoom >= split_zoom:
+        return None
+
+    zoom_label = _zoom_band_label(split_zoom)
+    layer_id = str(layer.get("id") or _ROAD_NUMBER_SHIELD_LAYER_ID)
+    low_layer = copy.deepcopy(layer)
+    low_layer["id"] = f"{layer_id}-below-z{zoom_label}"
+    low_layer["maxzoom"] = split_zoom
+
+    high_layer = copy.deepcopy(layer)
+    high_layer["id"] = f"{layer_id}-z{zoom_label}-plus"
+    high_layer["minzoom"] = split_zoom
+    return [low_layer, high_layer]
+
+
+def _split_road_number_shield_zoom_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _road_number_shield_zoom_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
 
 
 def _is_road_number_shield_layer_id(layer_id: object) -> bool:
@@ -4963,6 +5040,9 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_major_link_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_class_line_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _expand_road_number_shield_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_road_number_shield_zoom_layers_for_qgis(
+        style.get("layers")
+    )
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_background_line_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1584,17 +1584,37 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][1]["layout"]["icon-image"], exit_icon)
         self.assertEqual(result["layers"][2]["layout"]["icon-image"], other_concat_icon)
 
-    def test_road_number_shield_icon_case_expands_to_reflen_sprite_matches(self):
-        shield_icon = [
+    @staticmethod
+    def _road_number_shield_icon_case():
+        return [
             "case",
             ["has", "shield_beta"],
             [
                 "coalesce",
-                ["image", ["concat", ["get", "shield_beta"], "-", ["to-string", ["get", "reflen"]]]],
-                ["image", ["concat", "default-", ["to-string", ["get", "reflen"]]]],
+                [
+                    "image",
+                    [
+                        "concat",
+                        ["get", "shield_beta"],
+                        "-",
+                        ["to-string", ["get", "reflen"]],
+                    ],
+                ],
+                [
+                    "image",
+                    ["concat", "default-", ["to-string", ["get", "reflen"]]],
+                ],
             ],
-            ["concat", ["get", "shield"], "-", ["to-string", ["get", "reflen"]]],
+            [
+                "concat",
+                ["get", "shield"],
+                "-",
+                ["to-string", ["get", "reflen"]],
+            ],
         ]
+
+    def test_road_number_shield_icon_case_expands_to_reflen_sprite_matches(self):
+        shield_icon = self._road_number_shield_icon_case()
         style = {
             "layers": [
                 {"id": "before", "type": "background"},
@@ -1656,6 +1676,73 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(shield_layer["layout"]["icon-image"][:2], ["match", ["get", "shield"]])
         self.assertIn("rectangle-yellow-2", shield_layer["layout"]["icon-image"])
         self.assertEqual(result["layers"][-1]["layout"]["icon-image"], shield_icon)
+
+    def test_road_number_shield_point_layers_stay_visible_below_z11(self):
+        shield_icon = self._road_number_shield_icon_case()
+        point_to_line_filter = copy.deepcopy(
+            mapbox_config._ROAD_NUMBER_SHIELD_POINT_TO_LINE_FILTER_EXPRESSION
+        )
+        symbol_placement = copy.deepcopy(
+            mapbox_config._ROAD_NUMBER_SHIELD_SYMBOL_PLACEMENT_EXPRESSION
+        )
+        style = {
+            "layers": [
+                {
+                    "id": "road-number-shield",
+                    "type": "symbol",
+                    "minzoom": 6,
+                    "filter": [
+                        "all",
+                        ["has", "reflen"],
+                        ["<=", ["get", "reflen"], 6],
+                        point_to_line_filter,
+                    ],
+                    "layout": {
+                        "icon-image": shield_icon,
+                        "symbol-placement": symbol_placement,
+                        "symbol-spacing": [
+                            "interpolate",
+                            ["linear"],
+                            ["zoom"],
+                            11,
+                            400,
+                            14,
+                            600,
+                        ],
+                        "text-field": ["get", "ref"],
+                    },
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 20)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_layer = by_id["road-number-shield-2-beta-below-z11"]
+        self.assertEqual(low_layer["maxzoom"], 11.0)
+        self.assertEqual(low_layer["layout"]["symbol-placement"], "point")
+        self.assertAlmostEqual(low_layer["layout"]["symbol-spacing"], 400.0)
+        self.assertIn(["==", ["geometry-type"], "Point"], low_layer["filter"])
+        self.assertIn(["==", ["get", "reflen"], 2], low_layer["filter"])
+        self.assertIn(["has", "shield_beta"], low_layer["filter"])
+
+        high_layer = by_id["road-number-shield-2-beta-z11-plus"]
+        self.assertEqual(high_layer["minzoom"], 11.0)
+        self.assertEqual(high_layer["layout"]["symbol-placement"], "line")
+        self.assertAlmostEqual(
+            high_layer["layout"]["symbol-spacing"],
+            466.66666666666663,
+        )
+        self.assertIn([">", ["get", "len"], 2500], high_layer["filter"])
+        self.assertIn(["==", ["get", "reflen"], 2], high_layer["filter"])
+        self.assertIn(["has", "shield_beta"], high_layer["filter"])
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                "road-number-shield-2-beta-below-z11"
+            ),
+            "road-number-shield",
+        )
 
     def test_zoom_only_icon_size_expressions_resolve_to_scalars(self):
         zoom_interpolate = ["interpolate", ["linear"], ["zoom"], 10, 0.5, 14, 1.5]


### PR DESCRIPTION
## Summary

- Split generated Mapbox Outdoors `road-number-shield-*` QGIS variants at z11 when they use the audited Mapbox point-to-line shield filter and placement.
- Keep below-z11 shield variants as point symbols with the point-geometry filter; keep z11+ variants as line symbols with the Mapbox length threshold branch.
- Add a regression test covering the split, resolved placement/spacing/filter behavior, and base-layer mapping.

## Evidence

- Live style preprocessing now emits 20 road shield variants. For example, `road-number-shield-2-beta-below-z11` resolves to point placement, 400 spacing, and the point-geometry filter; `road-number-shield-2-beta-z11-plus` resolves to line placement, 466.6667 spacing, and `len > 2500`.
- Focused visual validation: `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260517T045808Z/`.
- All-camera validation: `debug/mapbox-outdoors-comparison/all-cameras/20260517T050011Z/summary.md`.
- Style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T050018Z/audit.md`.
- Visual read against the prior baseline: the branch restores low-zoom shields around Lausanne/Lavaux for the A1/1, 9, 12, 124/128/141/151/155/190, and French D1005/D902 corridors without obvious clutter.

## Tests

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Packaged plugin security scan via a temporary venv: `scripts/run_plugin_security_scan.py --allow-findings`
  - `detect-secrets`: clean
  - `bandit` / `flake8`: existing findings remain reported under `debug/plugin-security-scan/`

Closes part of #949.
