### PR TITLE
fix: preserve country label English fallback

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -659,6 +659,11 @@ _POI_LABEL_LAYER_ID = "poi-label"
 _GATE_LABEL_LAYER_ID = "gate-label"
 _CONTINENT_LABEL_LAYER_ID = "continent-label"
 _COUNTRY_LABEL_LAYER_ID = "country-label"
+_NAME_EN_FALLBACK_TEXT_FIELD_EXPRESSION = [
+    "coalesce",
+    ["get", "name_en"],
+    ["get", "name"],
+]
 _SETTLEMENT_MAJOR_LABEL_LAYER_ID = "settlement-major-label"
 _SETTLEMENT_MINOR_LABEL_LAYER_ID = "settlement-minor-label"
 _GATE_LABEL_ICON_IMAGE_EXPRESSION = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]
@@ -2666,6 +2671,38 @@ def _country_label_low_zoom_text_justify_variants(
     return variants
 
 
+def _country_label_name_field_variants(
+    layer: dict[str, object],
+) -> list[dict[str, object]]:
+    layout = layer.get("layout")
+    if not isinstance(layout, dict):
+        return [layer]
+    if layout.get("text-field") != _NAME_EN_FALLBACK_TEXT_FIELD_EXPRESSION:
+        return [layer]
+
+    layer_id = str(layer.get("id") or _COUNTRY_LABEL_LAYER_ID)
+    name_en_layer = copy.deepcopy(layer)
+    name_en_layer["id"] = f"{layer_id}-name-en"
+    name_en_layer["filter"] = _with_additional_filter_clauses(
+        layer.get("filter"),
+        ["has", "name_en"],
+    )
+    name_en_layout = name_en_layer.get("layout")
+    if isinstance(name_en_layout, dict):
+        name_en_layout["text-field"] = ["get", "name_en"]
+
+    name_layer = copy.deepcopy(layer)
+    name_layer["id"] = f"{layer_id}-name"
+    name_layer["filter"] = _with_additional_filter_clauses(
+        layer.get("filter"),
+        ["!", ["has", "name_en"]],
+    )
+    name_layout = name_layer.get("layout")
+    if isinstance(name_layout, dict):
+        name_layout["text-field"] = ["get", "name"]
+    return [name_en_layer, name_layer]
+
+
 def _country_label_layout_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited country-label zoom/layout expressions into QGIS-safe static variants."""
     if not _has_country_label_layout_expression(layer):
@@ -2698,7 +2735,12 @@ def _country_label_layout_layer_variants(layer: dict[str, object]) -> list[dict[
             )
             has_static_variant = True
         variants.append(variant)
-    return variants if has_static_variant else None
+    if not has_static_variant:
+        return None
+    field_variants: list[dict[str, object]] = []
+    for variant in variants:
+        field_variants.extend(_country_label_name_field_variants(variant))
+    return field_variants
 
 
 def _split_country_label_layout_layers_for_qgis(layers: object) -> object:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2191,51 +2191,88 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 5)
+        self.assertEqual(len(result["layers"]), 10)
         by_id = {layer["id"]: layer for layer in result["layers"]}
-        low_left_layer = by_id["country-label-below-z7-left"]
-        low_right_layer = by_id["country-label-below-z7-right"]
-        low_center_layer = by_id["country-label-below-z7-center"]
-        mid_layer = by_id["country-label-z7-to-z8"]
-        high_layer = by_id["country-label-z8-plus"]
-        for low_layer, text_justify, text_anchor_filter in (
-            (
-                low_left_layer,
-                "left",
-                ["match", ["get", "text_anchor"], ["left", "bottom-left", "top-left"], True, False],
-            ),
-            (
-                low_right_layer,
-                "right",
-                ["match", ["get", "text_anchor"], ["right", "bottom-right", "top-right"], True, False],
-            ),
-            (
-                low_center_layer,
-                "center",
-                [
-                    "match",
-                    ["get", "text_anchor"],
-                    ["left", "bottom-left", "top-left", "right", "bottom-right", "top-right"],
-                    False,
-                    True,
-                ],
-            ),
+        for name_suffix, text_field, name_filter in (
+            ("name-en", ["get", "name_en"], ["has", "name_en"]),
+            ("name", ["get", "name"], ["!", ["has", "name_en"]]),
         ):
-            self.assertEqual(low_layer["minzoom"], 1)
-            self.assertEqual(low_layer["maxzoom"], 7.0)
-            self.assertEqual(low_layer["filter"], ["all", country_filter, text_anchor_filter])
-            self.assertEqual(low_layer["layout"]["text-justify"], text_justify)
-            self.assertEqual(low_layer["layout"]["text-radial-offset"], 0.6)
-            self.assertNotIn("icon-image", low_layer["layout"])
-        self.assertEqual(mid_layer["minzoom"], 7.0)
-        self.assertEqual(mid_layer["maxzoom"], 8.0)
-        self.assertEqual(high_layer["minzoom"], 8.0)
-        self.assertEqual(high_layer["maxzoom"], 10)
-        self.assertEqual(mid_layer["layout"]["text-justify"], "auto")
-        self.assertEqual(mid_layer["layout"]["text-radial-offset"], 0.6)
-        self.assertEqual(high_layer["layout"]["text-justify"], "auto")
-        self.assertEqual(high_layer["layout"]["text-radial-offset"], 0.0)
+            low_left_layer = by_id[f"country-label-below-z7-left-{name_suffix}"]
+            low_right_layer = by_id[f"country-label-below-z7-right-{name_suffix}"]
+            low_center_layer = by_id[f"country-label-below-z7-center-{name_suffix}"]
+            mid_layer = by_id[f"country-label-z7-to-z8-{name_suffix}"]
+            high_layer = by_id[f"country-label-z8-plus-{name_suffix}"]
+            for low_layer, text_justify, text_anchor_filter in (
+                (
+                    low_left_layer,
+                    "left",
+                    [
+                        "match",
+                        ["get", "text_anchor"],
+                        ["left", "bottom-left", "top-left"],
+                        True,
+                        False,
+                    ],
+                ),
+                (
+                    low_right_layer,
+                    "right",
+                    [
+                        "match",
+                        ["get", "text_anchor"],
+                        ["right", "bottom-right", "top-right"],
+                        True,
+                        False,
+                    ],
+                ),
+                (
+                    low_center_layer,
+                    "center",
+                    [
+                        "match",
+                        ["get", "text_anchor"],
+                        [
+                            "left",
+                            "bottom-left",
+                            "top-left",
+                            "right",
+                            "bottom-right",
+                            "top-right",
+                        ],
+                        False,
+                        True,
+                    ],
+                ),
+            ):
+                self.assertEqual(low_layer["minzoom"], 1)
+                self.assertEqual(low_layer["maxzoom"], 7.0)
+                self.assertEqual(
+                    low_layer["filter"],
+                    ["all", country_filter, text_anchor_filter, name_filter],
+                )
+                self.assertEqual(low_layer["layout"]["text-field"], text_field)
+                self.assertEqual(low_layer["layout"]["text-justify"], text_justify)
+                self.assertEqual(low_layer["layout"]["text-radial-offset"], 0.6)
+                self.assertNotIn("icon-image", low_layer["layout"])
+            self.assertEqual(mid_layer["minzoom"], 7.0)
+            self.assertEqual(mid_layer["maxzoom"], 8.0)
+            self.assertEqual(mid_layer["filter"], ["all", country_filter, name_filter])
+            self.assertEqual(high_layer["minzoom"], 8.0)
+            self.assertEqual(high_layer["maxzoom"], 10)
+            self.assertEqual(high_layer["filter"], ["all", country_filter, name_filter])
+            self.assertEqual(mid_layer["layout"]["text-field"], text_field)
+            self.assertEqual(high_layer["layout"]["text-field"], text_field)
+            self.assertEqual(mid_layer["layout"]["text-justify"], "auto")
+            self.assertEqual(mid_layer["layout"]["text-radial-offset"], 0.6)
+            self.assertEqual(high_layer["layout"]["text-justify"], "auto")
+            self.assertEqual(high_layer["layout"]["text-radial-offset"], 0.0)
         self.assertEqual({layer["layout"]["text-size"] for layer in result["layers"]}, {16.0})
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                "country-label-below-z7-left-name-en"
+            ),
+            "country-label",
+        )
 
     def test_country_label_layout_is_not_split_when_shape_changes(self):
         style = {


### PR DESCRIPTION
## Summary

- split the audited Mapbox Outdoors `country-label` QGIS variants into English-name and fallback-name branches
- keep the existing generic text-field simplifier unchanged for other label layers
- add regression coverage for the generated country-label ids, filters, text fields, and base-layer mapping

## Evidence

This follows the post-#1092 visual/audit evidence that low-zoom country labels were falling back to local names in QGIS while Mapbox GL preferred `name_en`.

Focused live validation:
- `debug/mapbox-outdoors-comparison/switzerland-alps-z5-outdoors/20260517T052625Z/`

Visual read from that run:
- `Deutschland` -> `Germany`
- `Belgique / Belgie / Belgien` -> `Belgium`
- `Osterreich` -> `Austria`
- `Italia` -> `Italy`
- `Hrvatska` -> `Croatia`
- no obvious country-label loss or duplicate labels in the focused z5 view

Full live matrix:
- `debug/mapbox-outdoors-comparison/all-cameras/20260517T052808Z/summary.md`

Style audit:
- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T052813Z/audit.md`

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `scripts/run_plugin_security_scan.py --allow-findings` (`detect-secrets` clean; existing allowed packaged-scan findings remain)

Closes part of #949.

