### PR TITLE
fix: preserve water label English fallback

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2671,8 +2671,10 @@ def _country_label_low_zoom_text_justify_variants(
     return variants
 
 
-def _country_label_name_field_variants(
+def _name_en_fallback_text_field_variants(
     layer: dict[str, object],
+    *,
+    fallback_layer_id: str,
 ) -> list[dict[str, object]]:
     layout = layer.get("layout")
     if not isinstance(layout, dict):
@@ -2680,7 +2682,7 @@ def _country_label_name_field_variants(
     if layout.get("text-field") != _NAME_EN_FALLBACK_TEXT_FIELD_EXPRESSION:
         return [layer]
 
-    layer_id = str(layer.get("id") or _COUNTRY_LABEL_LAYER_ID)
+    layer_id = str(layer.get("id") or fallback_layer_id)
     name_en_layer = copy.deepcopy(layer)
     name_en_layer["id"] = f"{layer_id}-name-en"
     name_en_layer["filter"] = _with_additional_filter_clauses(
@@ -2739,7 +2741,12 @@ def _country_label_layout_layer_variants(layer: dict[str, object]) -> list[dict[
         return None
     field_variants: list[dict[str, object]] = []
     for variant in variants:
-        field_variants.extend(_country_label_name_field_variants(variant))
+        field_variants.extend(
+            _name_en_fallback_text_field_variants(
+                variant,
+                fallback_layer_id=_COUNTRY_LABEL_LAYER_ID,
+            )
+        )
     return field_variants
 
 
@@ -3876,7 +3883,15 @@ def _water_line_label_typography_layer_variants(layer: dict[str, object]) -> lis
         assert isinstance(variant_layout, dict)
         variant_layout["text-letter-spacing"] = text_letter_spacing
         variants.append(variant)
-    return variants
+    field_variants: list[dict[str, object]] = []
+    for variant in variants:
+        field_variants.extend(
+            _name_en_fallback_text_field_variants(
+                variant,
+                fallback_layer_id=_WATER_LINE_LABEL_LAYER_ID,
+            )
+        )
+    return field_variants
 
 
 def _water_point_label_typography_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
@@ -3902,7 +3917,15 @@ def _water_point_label_typography_layer_variants(layer: dict[str, object]) -> li
         variant_layout["text-letter-spacing"] = text_letter_spacing
         variant_layout["text-max-width"] = text_max_width
         variants.append(variant)
-    return variants
+    field_variants: list[dict[str, object]] = []
+    for variant in variants:
+        field_variants.extend(
+            _name_en_fallback_text_field_variants(
+                variant,
+                fallback_layer_id=_WATER_POINT_LABEL_LAYER_ID,
+            )
+        )
+    return field_variants
 
 
 def _water_label_typography_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3936,38 +3936,74 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         result = simplify_mapbox_style_expressions(style)
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
+        expected_base_ids = [
+            "water-line-label-ocean",
+            "water-line-label-sea-bay",
+            "water-line-label-other",
+            "water-point-label-ocean",
+            "water-point-label-sea",
+            "water-point-label-bay",
+            "water-point-label-water",
+            "water-point-label-other",
+        ]
         self.assertEqual(
             list(by_id),
             [
-                "water-line-label-ocean",
-                "water-line-label-sea-bay",
-                "water-line-label-other",
-                "water-point-label-ocean",
-                "water-point-label-sea",
-                "water-point-label-bay",
-                "water-point-label-water",
-                "water-point-label-other",
+                f"{base_id}-{name_suffix}"
+                for base_id in expected_base_ids
+                for name_suffix in ("name-en", "name")
             ],
         )
-        self.assertEqual(by_id["water-line-label-ocean"]["layout"]["text-letter-spacing"], 0.25)
-        self.assertEqual(by_id["water-line-label-sea-bay"]["layout"]["text-letter-spacing"], 0.15)
-        self.assertEqual(by_id["water-line-label-other"]["layout"]["text-letter-spacing"], 0.0)
-        self.assertEqual(by_id["water-point-label-ocean"]["layout"]["text-letter-spacing"], 0.25)
-        self.assertEqual(by_id["water-point-label-ocean"]["layout"]["text-max-width"], 4.0)
-        self.assertEqual(by_id["water-point-label-sea"]["layout"]["text-letter-spacing"], 0.15)
-        self.assertEqual(by_id["water-point-label-sea"]["layout"]["text-max-width"], 5.0)
-        self.assertEqual(by_id["water-point-label-bay"]["layout"]["text-letter-spacing"], 0.15)
-        self.assertEqual(by_id["water-point-label-bay"]["layout"]["text-max-width"], 7.0)
-        self.assertEqual(by_id["water-point-label-water"]["layout"]["text-letter-spacing"], 0.01)
-        self.assertEqual(by_id["water-point-label-water"]["layout"]["text-max-width"], 7.0)
-        self.assertEqual(by_id["water-point-label-other"]["layout"]["text-letter-spacing"], 0.01)
-        self.assertEqual(by_id["water-point-label-other"]["layout"]["text-max-width"], 10.0)
-        self.assertEqual(by_id["water-line-label-ocean"]["layout"]["text-size"], 11.0)
-        self.assertEqual(by_id["water-point-label-ocean"]["layout"]["text-size"], 12.0)
-        self.assertIn(["match", ["get", "class"], ["ocean"], True, False], by_id["water-point-label-ocean"]["filter"])
+
+        def assert_name_field_variants(base_id):
+            name_en_layer = by_id[f"{base_id}-name-en"]
+            name_layer = by_id[f"{base_id}-name"]
+            self.assertEqual(name_en_layer["layout"]["text-field"], ["get", "name_en"])
+            self.assertEqual(name_layer["layout"]["text-field"], ["get", "name"])
+            self.assertEqual(name_en_layer["filter"][:-1], name_layer["filter"][:-1])
+            self.assertEqual(name_en_layer["filter"][-1], ["has", "name_en"])
+            self.assertEqual(name_layer["filter"][-1], ["!", ["has", "name_en"]])
+            return name_en_layer
+
+        water_line_ocean = assert_name_field_variants("water-line-label-ocean")
+        water_line_sea_bay = assert_name_field_variants("water-line-label-sea-bay")
+        water_line_other = assert_name_field_variants("water-line-label-other")
+        water_point_ocean = assert_name_field_variants("water-point-label-ocean")
+        water_point_sea = assert_name_field_variants("water-point-label-sea")
+        water_point_bay = assert_name_field_variants("water-point-label-bay")
+        water_point_water = assert_name_field_variants("water-point-label-water")
+        water_point_other = assert_name_field_variants("water-point-label-other")
+
+        self.assertEqual(water_line_ocean["layout"]["text-letter-spacing"], 0.25)
+        self.assertEqual(water_line_sea_bay["layout"]["text-letter-spacing"], 0.15)
+        self.assertEqual(water_line_other["layout"]["text-letter-spacing"], 0.0)
+        self.assertEqual(water_point_ocean["layout"]["text-letter-spacing"], 0.25)
+        self.assertEqual(water_point_ocean["layout"]["text-max-width"], 4.0)
+        self.assertEqual(water_point_sea["layout"]["text-letter-spacing"], 0.15)
+        self.assertEqual(water_point_sea["layout"]["text-max-width"], 5.0)
+        self.assertEqual(water_point_bay["layout"]["text-letter-spacing"], 0.15)
+        self.assertEqual(water_point_bay["layout"]["text-max-width"], 7.0)
+        self.assertEqual(water_point_water["layout"]["text-letter-spacing"], 0.01)
+        self.assertEqual(water_point_water["layout"]["text-max-width"], 7.0)
+        self.assertEqual(water_point_other["layout"]["text-letter-spacing"], 0.01)
+        self.assertEqual(water_point_other["layout"]["text-max-width"], 10.0)
+        self.assertEqual(water_line_ocean["layout"]["text-size"], 11.0)
+        self.assertEqual(water_point_ocean["layout"]["text-size"], 12.0)
+        self.assertIn(
+            ["match", ["get", "class"], ["ocean"], True, False],
+            water_point_ocean["filter"],
+        )
         self.assertIn(
             ["match", ["get", "class"], ["ocean", "sea", "bay", "water"], False, True],
-            by_id["water-point-label-other"]["filter"],
+            water_point_other["filter"],
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("water-line-label-ocean-name-en"),
+            "water-line-label",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("water-point-label-water-name"),
+            "water-point-label",
         )
 
     def test_water_label_typography_split_is_exact_shape_gated(self):
@@ -3999,11 +4035,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         result = mapbox_config._split_water_label_typography_layers_for_qgis(mixed_layers)
 
         self.assertEqual(result[0], "not-a-layer")
-        self.assertEqual(result[1]["id"], "water-point-label-ocean")
-        self.assertEqual(result[2]["id"], "water-point-label-sea")
-        self.assertEqual(result[3]["id"], "water-point-label-bay")
-        self.assertEqual(result[4]["id"], "water-point-label-water")
-        self.assertEqual(result[5]["id"], "water-point-label-other")
+        self.assertEqual(result[1]["id"], "water-point-label-ocean-name-en")
+        self.assertEqual(result[2]["id"], "water-point-label-ocean-name")
+        self.assertEqual(result[3]["id"], "water-point-label-sea-name-en")
+        self.assertEqual(result[4]["id"], "water-point-label-sea-name")
+        self.assertEqual(result[5]["id"], "water-point-label-bay-name-en")
+        self.assertEqual(result[6]["id"], "water-point-label-bay-name")
+        self.assertEqual(result[7]["id"], "water-point-label-water-name-en")
+        self.assertEqual(result[8]["id"], "water-point-label-water-name")
+        self.assertEqual(result[9]["id"], "water-point-label-other-name-en")
+        self.assertEqual(result[10]["id"], "water-point-label-other-name")
 
     def _contour_line_layer(self, line_opacity=None, minzoom=11):
         if line_opacity is None:


### PR DESCRIPTION
## Summary

- split audited `water-line-label` and `water-point-label` typography variants into `name_en` and fallback `name` branches
- reuse the existing country-label fallback branching logic without changing the generic text-field simplifier
- add regression coverage for generated water-label ids, filters, text fields, typography values, and base-layer mapping

## Evidence

This follows the visible post-#1093 locale gap around Lake Geneva and Lake Neuchatel, where Mapbox GL uses English water names and QGIS was still rendering local names.

Focused live validation:
- `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260517T054211Z/`
- `debug/mapbox-outdoors-comparison/valais-geneva-outdoors/20260517T054310Z/`

Visual read from those runs:
- `Le Leman` -> `Lake Geneva`
- `Lac de Neuchatel` -> `Lake Neuchatel`
- `Lago Maggiore` -> `Lake Maggiore`
- no obvious water-label loss or duplicate local/English label pairs

Full live matrix:
- `debug/mapbox-outdoors-comparison/all-cameras/20260517T054431Z/summary.md`

Style audit:
- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T054441Z/audit.md`

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `scripts/run_plugin_security_scan.py --allow-findings` (`detect-secrets` clean; existing allowed packaged-scan findings remain)

Closes part of #949.

