### PR TITLE
fix: preserve settlement label English fallback

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2609,7 +2609,17 @@ def _settlement_dot_icon_layer_variants(layer: dict[str, object]) -> list[dict[s
         _set_settlement_high_zoom_text_layout(text_layer)
         variants.append(text_layer)
 
-    return variants or None
+    if not variants:
+        return None
+    field_variants: list[dict[str, object]] = []
+    for variant in variants:
+        field_variants.extend(
+            _name_en_fallback_text_field_variants(
+                variant,
+                fallback_layer_id=base_layer_id,
+            )
+        )
+    return field_variants
 
 
 def _split_settlement_dot_icon_layers_for_qgis(layers: object) -> object:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2130,6 +2130,78 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertNotIn("symbol-sort-key", by_id["settlement-minor-label-z8-plus"]["layout"])
         self.assertEqual(by_id["settlement-minor-label-z8-plus"]["filter"][-1], town_filter)
 
+    def test_filter_simplification_splits_settlement_label_name_en_fallbacks(self):
+        base_filter = ["<=", ["get", "filterrank"], 3]
+        text_field = ["coalesce", ["get", "name_en"], ["get", "name"]]
+        style = {
+            "layers": [
+                {
+                    "id": "settlement-major-label",
+                    "type": "symbol",
+                    "minzoom": 8,
+                    "maxzoom": 9,
+                    "filter": base_filter,
+                    "layout": {
+                        **self._settlement_dot_icon_layout(),
+                        "text-field": copy.deepcopy(text_field),
+                    },
+                },
+                {
+                    "id": "settlement-minor-label",
+                    "type": "symbol",
+                    "minzoom": 8,
+                    "maxzoom": 9,
+                    "filter": base_filter,
+                    "layout": {
+                        **self._settlement_dot_icon_layout(),
+                        "text-field": copy.deepcopy(text_field),
+                    },
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            list(by_id),
+            [
+                "settlement-major-label-z8-plus-name-en",
+                "settlement-major-label-z8-plus-name",
+                "settlement-minor-label-z8-plus-name-en",
+                "settlement-minor-label-z8-plus-name",
+            ],
+        )
+        city_filter = ["match", ["get", "type"], ["city"], True, False]
+        town_filter = ["match", ["get", "type"], ["town"], True, False]
+        for base_id, settlement_filter in (
+            ("settlement-major-label-z8-plus", city_filter),
+            ("settlement-minor-label-z8-plus", town_filter),
+        ):
+            name_en_layer = by_id[f"{base_id}-name-en"]
+            name_layer = by_id[f"{base_id}-name"]
+            self.assertEqual(name_en_layer["layout"]["text-field"], ["get", "name_en"])
+            self.assertEqual(name_layer["layout"]["text-field"], ["get", "name"])
+            self.assertNotIn("icon-image", name_en_layer["layout"])
+            self.assertEqual(name_en_layer["layout"]["text-anchor"], "center")
+            self.assertEqual(name_en_layer["layout"]["text-radial-offset"], 0)
+            self.assertEqual(name_en_layer["filter"][1][-1], ["has", "name_en"])
+            self.assertEqual(name_layer["filter"][1][-1], ["!", ["has", "name_en"]])
+            self.assertEqual(name_en_layer["filter"][-1], settlement_filter)
+            self.assertEqual(name_layer["filter"][-1], settlement_filter)
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                "settlement-major-label-z8-plus-name-en"
+            ),
+            "settlement-major-label",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                "settlement-minor-label-z8-plus-name"
+            ),
+            "settlement-minor-label",
+        )
+
     def test_settlement_symbol_sort_key_removal_is_exact_shape_gated(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

- split existing settlement-major and settlement-minor QGIS variants into `name_en` and fallback `name` branches when the live Mapbox text field is `coalesce(name_en, name)`
- keep the generic text-field simplifier unchanged for other label families
- add regression coverage for generated settlement ids, filters, text fields, z8+ layout values, and base-layer mapping

## Evidence

This follows the remaining post-#1094 settlement locale gap where Mapbox GL shows `Geneva` while QGIS still rendered the local-name label.

Focused live validation:
- `debug/mapbox-outdoors-comparison/valais-geneva-outdoors/20260517T055659Z/`
- `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260517T055607Z/`

Visual read:
- `Geneve` -> `Geneva`, matching Mapbox's visible English label
- `Aosta - Aoste` -> `Aosta`; Mapbox still differs with `Aosta - Quart`, but the branch removes the bilingual local-name expansion
- visible settlement labels such as `Lausanne`, `Bern`, `Annecy`, `Biella`, and `Novara` remain present
- no obvious duplicate settlement-label pairs in the focused comparisons
- z5/z18 visual spot-check did not show meaningful settlement-label loss or duplicate labels; z5 `Roma` -> `Rome` moves closer to the Mapbox reference

Full live matrix:
- `debug/mapbox-outdoors-comparison/all-cameras/20260517T055822Z/summary.md`

Style audit:
- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T055759Z/audit.md`

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `scripts/run_plugin_security_scan.py --allow-findings` (`detect-secrets` clean; existing allowed packaged-scan findings remain)

Closes part of #949.

