### PR TITLE
fix: preserve road label zoom filter

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -515,6 +515,7 @@ _ZOOM_BOUND_EPSILON = 1e-9
 _FULL_OPACITY = 1.0
 _FULL_OPACITY_EPSILON = 1e-9
 _FULL_OPACITY_PROPS = {"fill-opacity", "line-opacity"}
+_ROAD_LABEL_LAYER_ID = "road-label"
 _ZOOM_NORMALIZED_SYMBOL_FILTER_LAYER_IDS = {
     "bridge-oneway-arrow-blue",
     "path-pedestrian-label",
@@ -617,6 +618,44 @@ _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 18.0
 _PATH_BACKGROUND_LINE_COLOR_LAYER_IDS = {
     "bridge-path-bg",
     "road-path-bg",
+}
+_ROAD_LABEL_LOW_ZOOM_CLASS_FILTER = [
+    "match",
+    ["get", "class"],
+    ["motorway", "trunk", "primary", "secondary", "tertiary"],
+    True,
+    False,
+]
+_ROAD_LABEL_MID_ZOOM_CLASS_FILTER = [
+    "match",
+    ["get", "class"],
+    [
+        "motorway",
+        "trunk",
+        "primary",
+        "secondary",
+        "tertiary",
+        "street",
+        "street_limited",
+        "track",
+    ],
+    True,
+    False,
+]
+_ROAD_LABEL_HIGH_ZOOM_CLASS_FILTER = [
+    "match",
+    ["get", "class"],
+    ["path", "pedestrian", "golf", "ferry", "aerialway"],
+    False,
+    True,
+]
+_ROAD_LABEL_FILTER_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, object], ...] = (
+    ("below-z12", None, 12.0, _ROAD_LABEL_LOW_ZOOM_CLASS_FILTER),
+    ("z12-to-z15", 12.0, 15.0, _ROAD_LABEL_MID_ZOOM_CLASS_FILTER),
+    ("z15-plus", 15.0, None, _ROAD_LABEL_HIGH_ZOOM_CLASS_FILTER),
+)
+_ROAD_LABEL_FILTER_ZOOM_VARIANT_IDS = {
+    f"{_ROAD_LABEL_LAYER_ID}-{suffix}" for suffix, _band_minzoom, _band_maxzoom, _class_filter in _ROAD_LABEL_FILTER_ZOOM_BANDS
 }
 _PATH_BACKGROUND_LINE_COLOR_EXPRESSION = [
     "match",
@@ -1747,6 +1786,79 @@ def _split_path_type_filter_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _road_label_zoom_step_filter_clause(value: object) -> list[object] | None:
+    if (
+        not isinstance(value, list)
+        or len(value) != 7
+        or value[0] != "step"
+        or value[1] != ["zoom"]
+        or value[2] != _ROAD_LABEL_LOW_ZOOM_CLASS_FILTER
+        or value[4] != _ROAD_LABEL_MID_ZOOM_CLASS_FILTER
+        or value[6] != _ROAD_LABEL_HIGH_ZOOM_CLASS_FILTER
+    ):
+        return None
+    first_threshold = _numeric_zoom_bound(value[3])
+    second_threshold = _numeric_zoom_bound(value[5])
+    if first_threshold is None or second_threshold is None:
+        return None
+    if (
+        abs(first_threshold - 12.0) > _ZOOM_BOUND_EPSILON
+        or abs(second_threshold - 15.0) > _ZOOM_BOUND_EPSILON
+    ):
+        return None
+    return value
+
+
+def _road_label_filter_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split the audited road-label zoom filter into static QGIS zoom bands."""
+    if str(layer.get("id") or "") != _ROAD_LABEL_LAYER_ID or layer.get("type") != "symbol":
+        return None
+    filter_value = layer.get("filter")
+    if not isinstance(filter_value, list) or filter_value[:1] != ["all"]:
+        return None
+
+    for clause_index, clause in enumerate(filter_value[1:], start=1):
+        if _road_label_zoom_step_filter_clause(clause) is None:
+            continue
+
+        existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+        existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+        variants: list[dict[str, object]] = []
+        for suffix, band_minzoom, band_maxzoom, class_filter in _ROAD_LABEL_FILTER_ZOOM_BANDS:
+            zoom_band = _effective_zoom_band(
+                existing_minzoom,
+                existing_maxzoom,
+                band_minzoom,
+                band_maxzoom,
+            )
+            if zoom_band is None:
+                continue
+            variant = copy.deepcopy(layer)
+            variant["id"] = f"{_ROAD_LABEL_LAYER_ID}-{suffix}"
+            _set_zoom_bounds(variant, *zoom_band)
+            variant["filter"] = _filter_with_replaced_clause(
+                filter_value,
+                clause_index,
+                class_filter,
+            )
+            variants.append(variant)
+        return variants or None
+    return None
+
+
+def _split_road_label_filter_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _road_label_filter_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _path_background_line_color_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited path background casing colors into QGIS-safe type layers."""
     base_layer_id = _path_background_line_color_base_layer_id(layer.get("id"))
@@ -1989,6 +2101,11 @@ def _is_gate_label_layer_id(layer_id: object) -> bool:
     return normalized == _GATE_LABEL_LAYER_ID or normalized.startswith(f"{_GATE_LABEL_LAYER_ID}-")
 
 
+def _is_road_label_layer_id(layer_id: object) -> bool:
+    normalized = str(layer_id or "")
+    return normalized == _ROAD_LABEL_LAYER_ID or normalized in _ROAD_LABEL_FILTER_ZOOM_VARIANT_IDS
+
+
 def _is_natural_point_label_layer_id(layer_id: object) -> bool:
     normalized = str(layer_id or "")
     return normalized == _NATURAL_POINT_LABEL_LAYER_ID or normalized.startswith(f"{_NATURAL_POINT_LABEL_LAYER_ID}-")
@@ -2131,6 +2248,7 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     for matches_layer_id, base_layer_id in (
         (_is_waterway_label_layer_id, _WATERWAY_LABEL_LAYER_ID),
         (_is_road_number_shield_layer_id, _ROAD_NUMBER_SHIELD_LAYER_ID),
+        (_is_road_label_layer_id, _ROAD_LABEL_LAYER_ID),
         (_is_poi_label_layer_id, _POI_LABEL_LAYER_ID),
         (_is_gate_label_layer_id, _GATE_LABEL_LAYER_ID),
         (_is_natural_point_label_layer_id, _NATURAL_POINT_LABEL_LAYER_ID),
@@ -5119,6 +5237,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
         style.get("layers")
     )
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_road_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_background_line_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1912,6 +1912,116 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertEqual(style["layers"][0]["filter"], filter_expression)
 
+    def test_filter_simplification_splits_road_label_zoom_filter(self):
+        text_field = ["coalesce", ["get", "name_en"], ["get", "name"]]
+        low_zoom_filter = [
+            "match",
+            ["get", "class"],
+            ["motorway", "trunk", "primary", "secondary", "tertiary"],
+            True,
+            False,
+        ]
+        mid_zoom_filter = [
+            "match",
+            ["get", "class"],
+            [
+                "motorway",
+                "trunk",
+                "primary",
+                "secondary",
+                "tertiary",
+                "street",
+                "street_limited",
+                "track",
+            ],
+            True,
+            False,
+        ]
+        high_zoom_filter = [
+            "match",
+            ["get", "class"],
+            ["path", "pedestrian", "golf", "ferry", "aerialway"],
+            False,
+            True,
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "road-label",
+                    "type": "symbol",
+                    "minzoom": 10,
+                    "filter": [
+                        "all",
+                        ["has", "name"],
+                        [
+                            "step",
+                            ["zoom"],
+                            copy.deepcopy(low_zoom_filter),
+                            12,
+                            copy.deepcopy(mid_zoom_filter),
+                            15,
+                            copy.deepcopy(high_zoom_filter),
+                        ],
+                    ],
+                    "layout": {
+                        "symbol-placement": "line",
+                        "text-field": copy.deepcopy(text_field),
+                        "text-size": [
+                            "interpolate",
+                            ["linear"],
+                            ["zoom"],
+                            10,
+                            9,
+                            18,
+                            14,
+                        ],
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            list(by_id),
+            ["road-label-below-z12", "road-label-z12-to-z15", "road-label-z15-plus"],
+        )
+        self.assertEqual(by_id["road-label-below-z12"]["minzoom"], 10)
+        self.assertEqual(by_id["road-label-below-z12"]["maxzoom"], 12.0)
+        self.assertEqual(by_id["road-label-z12-to-z15"]["minzoom"], 12.0)
+        self.assertEqual(by_id["road-label-z12-to-z15"]["maxzoom"], 15.0)
+        self.assertEqual(by_id["road-label-z15-plus"]["minzoom"], 15.0)
+        self.assertNotIn("maxzoom", by_id["road-label-z15-plus"])
+        self.assertEqual(by_id["road-label-below-z12"]["filter"], ["all", ["has", "name"], low_zoom_filter])
+        self.assertEqual(by_id["road-label-z12-to-z15"]["filter"], ["all", ["has", "name"], mid_zoom_filter])
+        self.assertEqual(by_id["road-label-z15-plus"]["filter"], ["all", ["has", "name"], high_zoom_filter])
+        for layer in by_id.values():
+            self.assertEqual(layer["layout"]["text-field"], ["get", "name"])
+            self.assertEqual(layer["layout"]["text-size"], 10.0)
+        for layer_id in by_id:
+            self.assertEqual(
+                mapbox_config.base_mapbox_style_layer_id_for_qfit(layer_id),
+                "road-label",
+            )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-label-alt"),
+            "road-label-alt",
+        )
+
+        lower_bound_style = copy.deepcopy(style)
+        lower_bound_style["layers"][0]["minzoom"] = 8
+        lower_bound_style["layers"][0]["maxzoom"] = 11
+
+        lower_bound_result = simplify_mapbox_style_expressions(lower_bound_style)
+
+        self.assertEqual(len(lower_bound_result["layers"]), 1)
+        lower_bound_layer = lower_bound_result["layers"][0]
+        self.assertEqual(lower_bound_layer["id"], "road-label-below-z12")
+        self.assertEqual(lower_bound_layer["minzoom"], 8)
+        self.assertEqual(lower_bound_layer["maxzoom"], 11)
+        self.assertEqual(lower_bound_layer["filter"], ["all", ["has", "name"], low_zoom_filter])
+
     def test_filter_simplification_snapshots_settlement_label_filters(self):
         major_filter = [
             "all",


### PR DESCRIPTION
## Summary

- Split the audited Mapbox Outdoors `road-label` zoom-dependent class filter into static QGIS zoom-band layers.
- Preserve the source layer's lower bound through z12 for the major-road-only branch, plus the z12-z15 street/track branch and z15+ high-detail road-label branch, instead of flattening the filter at one representative zoom.
- Keep qfit-created road-label variants mapped back to the original Mapbox layer for existing text-size overrides and audit attribution.

## Evidence

- The live Outdoors style uses `road-label` with a `step(["zoom"], ...)` filter. Before this change qfit collapsed that filter to the z12 branch for the entire z10+ layer.
- Live preprocessing now emits:
  - `road-label-below-z12`
  - `road-label-z12-to-z15`
  - `road-label-z15-plus`
- Visual impact is intentionally small: z10 and z14 focused checks showed no visible regression, and the z10/Geneva metrics moved slightly closer to the Mapbox reference.

## Validation

- `git diff --check`
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `scripts/run_plugin_security_scan.py --allow-findings`
- Live focused comparison: `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260517T062152Z/`
- Live focused comparison: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260517T062240Z/`
- Live all-camera matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260517T062402Z/summary.md`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T062321Z/audit.md`

Refs #949