### PR TITLE
test: surface label placement audit controls

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -359,8 +359,12 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         "layout": {
                             "text-field": ["get", "name"],
                             "text-size": ["interpolate", ["linear"], ["zoom"], 10, 10, 14, 14],
+                            "symbol-avoid-edges": True,
+                            "symbol-placement": "line",
                             "symbol-sort-key": ["get", "rank"],
                             "symbol-spacing": ["step", ["zoom"], 150, 14, 250],
+                            "symbol-z-order": "source",
+                            "text-keep-upright": False,
                         },
                     },
                     {
@@ -400,7 +404,17 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(road_candidate["filter_operator_signature"], "==, all, get, has")
         self.assertEqual(
             road_candidate["label_control_properties"],
-            ["filter", "layout.symbol-sort-key", "layout.symbol-spacing", "layout.text-field", "layout.text-size"],
+            [
+                "filter",
+                "layout.symbol-avoid-edges",
+                "layout.symbol-placement",
+                "layout.symbol-sort-key",
+                "layout.symbol-spacing",
+                "layout.symbol-z-order",
+                "layout.text-field",
+                "layout.text-keep-upright",
+                "layout.text-size",
+            ],
         )
         self.assertEqual(
             road_candidate["qgis_dependent_control_properties"],
@@ -416,10 +430,36 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             audit["summary"]["label_density_candidates_by_layer_group"],
             [{"group": "roads/trails", "count": 1}, {"group": "settlements/places", "count": 1}],
         )
+        self.assertEqual(
+            audit["summary"]["label_density_controls_by_property"],
+            [
+                {"property": "filter", "count": 2},
+                {"property": "layout.text-field", "count": 2},
+                {"property": "layout.symbol-avoid-edges", "count": 1},
+                {"property": "layout.symbol-placement", "count": 1},
+                {"property": "layout.symbol-sort-key", "count": 1},
+                {"property": "layout.symbol-spacing", "count": 1},
+                {"property": "layout.symbol-z-order", "count": 1},
+                {"property": "layout.text-keep-upright", "count": 1},
+                {"property": "layout.text-size", "count": 1},
+            ],
+        )
+        self.assertEqual(
+            audit["summary"]["label_density_qgis_dependent_by_property"],
+            [
+                {"property": "filter", "count": 2},
+                {"property": "layout.symbol-sort-key", "count": 1},
+                {"property": "layout.symbol-spacing", "count": 1},
+            ],
+        )
 
         markdown = build_audit_markdown(audit)
         self.assertIn("### Label density candidates", markdown)
         self.assertIn("Visible symbol layers with text labels", markdown)
+        self.assertIn("#### Label density controls by property", markdown)
+        self.assertIn("| `layout.symbol-placement` | 1 |", markdown)
+        self.assertIn("#### Label density QGIS-dependent controls", markdown)
+        self.assertIn("| `layout.symbol-spacing` | 1 |", markdown)
         self.assertIn("| `roads/trails` | `road-label` | `road` | z≥10 | `==, all, get, has` |", markdown)
         self.assertIn("| `settlements/places` | `settlement-major-label` | `place_label` | all zooms | `get, match` |", markdown)
         self.assertNotIn("settlement-subdivision-label` |", markdown)
@@ -1316,7 +1356,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(aerialway_candidate["filter_operator_signature"], "get, match")
         self.assertEqual(
             aerialway_candidate["route_overlay_control_properties"],
-            ["filter", "layout.text-field", "layout.text-padding", "layout.symbol-placement", "paint.text-color"],
+            ["filter", "layout.symbol-placement", "layout.text-field", "layout.text-padding", "paint.text-color"],
         )
         self.assertEqual(aerialway_candidate["qfit_simplified_control_properties"], [])
         self.assertEqual(aerialway_candidate["qgis_dependent_control_properties"], ["filter"])

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -103,17 +103,23 @@ _NO_OPERATOR_SIGNATURE = "(none)"
 _ALL_ZOOMS_BAND = "all zooms"
 _LINE_DASHARRAY_PROPERTY = "paint.line-dasharray"
 _SYMBOL_SPACING_PROPERTY = "layout.symbol-spacing"
+_LABEL_DENSITY_CONTROLS_BY_PROPERTY_KEY = "label_density_controls_by_property"
+_LABEL_DENSITY_QGIS_DEPENDENT_BY_PROPERTY_KEY = "label_density_qgis_dependent_by_property"
 _LABEL_DENSITY_CONTROL_PROPERTIES = (
     "layout.icon-allow-overlap",
     "layout.icon-ignore-placement",
     "layout.icon-optional",
+    "layout.symbol-avoid-edges",
+    "layout.symbol-placement",
     "layout.symbol-sort-key",
     _SYMBOL_SPACING_PROPERTY,
+    "layout.symbol-z-order",
     "layout.text-allow-overlap",
     "layout.text-anchor",
     "layout.text-field",
     "layout.text-ignore-placement",
     "layout.text-justify",
+    "layout.text-keep-upright",
     "layout.text-max-angle",
     "layout.text-offset",
     "layout.text-optional",
@@ -3256,6 +3262,14 @@ def build_style_audit(
                 _filter_expression_signature_group_summary(layers)
             ),
             "label_density_candidates_by_layer_group": _count_rows_by_key(label_density_candidates, "group"),
+            _LABEL_DENSITY_CONTROLS_BY_PROPERTY_KEY: _count_row_values(
+                label_density_candidates,
+                "label_control_properties",
+            ),
+            _LABEL_DENSITY_QGIS_DEPENDENT_BY_PROPERTY_KEY: _count_row_values(
+                label_density_candidates,
+                _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY,
+            ),
             "label_density_candidates": label_density_candidates,
             _ROAD_TRAIL_HIERARCHY_CANDIDATES_BY_SOURCE_LAYER_KEY: _count_rows_by_key(
                 road_trail_hierarchy_candidates,
@@ -5049,6 +5063,20 @@ def _markdown_label_density_summary(summary: dict[str, object]) -> list[str]:
             _summary_rows(summary, "label_density_candidates_by_layer_group"),
             key="group",
             label=_MARKDOWN_LAYER_GROUP_LABEL,
+        ),
+        "#### Label density controls by property",
+        "",
+        *_markdown_named_count_table(
+            _summary_rows(summary, _LABEL_DENSITY_CONTROLS_BY_PROPERTY_KEY),
+            key="property",
+            label="Property",
+        ),
+        "#### Label density QGIS-dependent controls",
+        "",
+        *_markdown_named_count_table(
+            _summary_rows(summary, _LABEL_DENSITY_QGIS_DEPENDENT_BY_PROPERTY_KEY),
+            key="property",
+            label="Property",
         ),
         *_markdown_label_density_candidate_table(_summary_rows(summary, "label_density_candidates")),
     ]


### PR DESCRIPTION
## Summary

- Extend the Mapbox Outdoors label-density audit to include symbol placement/collision controls such as `layout.symbol-placement`, `layout.symbol-avoid-edges`, `layout.symbol-z-order`, and `layout.text-keep-upright`.
- Add label-density property count summaries so the audit highlights which placement and density controls are common across live text-label candidates.
- Keep this as a validation aid only; qfit rendering behavior is unchanged.

## Evidence

Refs #949.

The post-#1096 visual review showed QGIS is still often denser than the Mapbox GL reference, especially around road/trail/local labels, while a path-label filter split was not supported by screenshot evidence. A diagnostic slice is safer than tuning rendering behavior without a stronger signal.

Live audit generated with the local QGIS profile token source, without printing or storing the token:

- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T065922Z/audit.md`

That audit now reports live label-density control counts including:

- `layout.text-field`: 24
- `layout.text-size`: 24
- `filter`: 23
- `layout.symbol-placement`: 8
- `layout.text-max-angle`: 8

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q --tb=short`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short` — 2111 passed, 163 skipped, 135 subtests passed
- `scripts/run_plugin_security_scan.py --allow-findings` — detect-secrets clean; existing allowed Bandit/Flake8 findings only
