### PR TITLE
fix: preserve minor settlement label zoom filter

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -705,6 +705,29 @@ _NAME_EN_FALLBACK_TEXT_FIELD_EXPRESSION = [
 ]
 _SETTLEMENT_MAJOR_LABEL_LAYER_ID = "settlement-major-label"
 _SETTLEMENT_MINOR_LABEL_LAYER_ID = "settlement-minor-label"
+_SETTLEMENT_MINOR_SYMBOLRANK_FILTER_ZOOM_STEP = [
+    "step",
+    ["zoom"],
+    [">", ["get", "symbolrank"], 6],
+    4,
+    [">=", ["get", "symbolrank"], 7],
+    6,
+    [">=", ["get", "symbolrank"], 8],
+    7,
+    [">=", ["get", "symbolrank"], 10],
+    10,
+    [">=", ["get", "symbolrank"], 11],
+    11,
+    [">=", ["get", "symbolrank"], 13],
+    12,
+    [">=", ["get", "symbolrank"], 15],
+]
+_SETTLEMENT_MINOR_TEXT_FILTER_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, object], ...] = (
+    ("z8-to-z10", 8.0, 10.0, [">=", ["get", "symbolrank"], 10]),
+    ("z10-to-z11", 10.0, 11.0, [">=", ["get", "symbolrank"], 11]),
+    ("z11-to-z12", 11.0, 12.0, [">=", ["get", "symbolrank"], 13]),
+    ("z12-plus", 12.0, None, [">=", ["get", "symbolrank"], 15]),
+)
 _GATE_LABEL_ICON_IMAGE_EXPRESSION = ["match", ["get", "type"], "gate", "gate", "lift_gate", "lift-gate", ""]
 _GATE_LABEL_ICON_IMAGE_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ("gate", ["==", ["get", "type"], "gate"], "gate"),
@@ -2677,6 +2700,44 @@ def _set_settlement_high_zoom_text_layout(layer: dict[str, object]) -> None:
         layout["text-justify"] = "center"
 
 
+def _settlement_minor_symbolrank_step_filter_clause_index(filter_value: object) -> int | None:
+    if not isinstance(filter_value, list) or filter_value[:1] != ["all"]:
+        return None
+    for index, clause in enumerate(filter_value[1:], start=1):
+        if clause == _SETTLEMENT_MINOR_SYMBOLRANK_FILTER_ZOOM_STEP:
+            return index
+    return None
+
+
+def _settlement_minor_text_filter_zoom_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    if base_mapbox_style_layer_id_for_qfit(layer.get("id")) != _SETTLEMENT_MINOR_LABEL_LAYER_ID:
+        return None
+    if layer.get("type") != "symbol":
+        return None
+    layout = layer.get("layout")
+    if not isinstance(layout, dict) or "icon-image" in layout:
+        return None
+    clause_index = _settlement_minor_symbolrank_step_filter_clause_index(layer.get("filter"))
+    if clause_index is None:
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, band_minzoom, band_maxzoom, symbolrank_filter in _SETTLEMENT_MINOR_TEXT_FILTER_ZOOM_BANDS:
+        if not _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom):
+            continue
+        variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
+        variant["id"] = f"{_SETTLEMENT_MINOR_LABEL_LAYER_ID}-{suffix}"
+        variant["filter"] = _filter_with_replaced_clause(
+            variant.get("filter"),
+            clause_index,
+            symbolrank_filter,
+        )
+        variants.append(variant)
+    return variants or None
+
+
 def _settlement_major_low_zoom_text_justify_variants(layer: dict[str, object]) -> list[dict[str, object]]:
     layout = layer.get("layout")
     if not isinstance(layout, dict) or layout.get("text-justify") != _SETTLEMENT_DOT_TEXT_JUSTIFY_LOW_ZOOM:
@@ -2725,7 +2786,7 @@ def _settlement_dot_icon_layer_variants(layer: dict[str, object]) -> list[dict[s
         text_layer = _apply_zoom_band_bounds(layer, _SETTLEMENT_DOT_ICON_SPLIT_ZOOM, None)
         text_layer["id"] = f"{layer_id}-z8-plus"
         _set_settlement_high_zoom_text_layout(text_layer)
-        variants.append(text_layer)
+        variants.extend(_settlement_minor_text_filter_zoom_variants(text_layer) or [text_layer])
 
     if not variants:
         return None

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2312,6 +2312,84 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             "settlement-minor-label",
         )
 
+    def test_filter_simplification_splits_minor_settlement_text_filter_by_zoom(self):
+        base_filter = ["<=", ["get", "filterrank"], 3]
+        symbolrank_step_filter = [
+            "step",
+            ["zoom"],
+            [">", ["get", "symbolrank"], 6],
+            4,
+            [">=", ["get", "symbolrank"], 7],
+            6,
+            [">=", ["get", "symbolrank"], 8],
+            7,
+            [">=", ["get", "symbolrank"], 10],
+            10,
+            [">=", ["get", "symbolrank"], 11],
+            11,
+            [">=", ["get", "symbolrank"], 13],
+            12,
+            [">=", ["get", "symbolrank"], 15],
+        ]
+        text_field = ["coalesce", ["get", "name_en"], ["get", "name"]]
+        style = {
+            "layers": [
+                {
+                    "id": "settlement-minor-label",
+                    "type": "symbol",
+                    "minzoom": 8,
+                    "maxzoom": 13,
+                    "filter": ["all", base_filter, symbolrank_step_filter],
+                    "layout": {
+                        **self._settlement_dot_icon_layout(),
+                        "text-field": copy.deepcopy(text_field),
+                    },
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            list(by_id),
+            [
+                "settlement-minor-label-z8-to-z10-name-en",
+                "settlement-minor-label-z8-to-z10-name",
+                "settlement-minor-label-z10-to-z11-name-en",
+                "settlement-minor-label-z10-to-z11-name",
+                "settlement-minor-label-z11-to-z12-name-en",
+                "settlement-minor-label-z11-to-z12-name",
+                "settlement-minor-label-z12-plus-name-en",
+                "settlement-minor-label-z12-plus-name",
+            ],
+        )
+        town_filter = ["match", ["get", "type"], ["town"], True, False]
+        expected_bands = {
+            "z8-to-z10": (8, 10.0, [">=", ["get", "symbolrank"], 10]),
+            "z10-to-z11": (10.0, 11.0, [">=", ["get", "symbolrank"], 11]),
+            "z11-to-z12": (11.0, 12.0, [">=", ["get", "symbolrank"], 13]),
+            "z12-plus": (12.0, 13, [">=", ["get", "symbolrank"], 15]),
+        }
+        for suffix, (minzoom, maxzoom, rank_filter) in expected_bands.items():
+            name_en_layer = by_id[f"settlement-minor-label-{suffix}-name-en"]
+            name_layer = by_id[f"settlement-minor-label-{suffix}-name"]
+            self.assertEqual(name_en_layer["minzoom"], minzoom)
+            self.assertEqual(name_en_layer["maxzoom"], maxzoom)
+            self.assertEqual(name_en_layer["filter"][1][2], rank_filter)
+            self.assertEqual(name_layer["filter"][1][2], rank_filter)
+            self.assertEqual(name_en_layer["filter"][1][-1], ["has", "name_en"])
+            self.assertEqual(name_layer["filter"][1][-1], ["!", ["has", "name_en"]])
+            self.assertEqual(name_en_layer["filter"][-1], town_filter)
+            self.assertEqual(name_layer["filter"][-1], town_filter)
+            self.assertEqual(name_en_layer["layout"]["text-field"], ["get", "name_en"])
+            self.assertEqual(name_layer["layout"]["text-field"], ["get", "name"])
+            self.assertNotIn("icon-image", name_en_layer["layout"])
+            self.assertEqual(
+                mapbox_config.base_mapbox_style_layer_id_for_qfit(name_en_layer["id"]),
+                "settlement-minor-label",
+            )
+
     def test_settlement_symbol_sort_key_removal_is_exact_shape_gated(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

- Split the audited Mapbox Outdoors `settlement-minor-label` high-zoom text filter into static QGIS-safe zoom bands.
- Preserve Mapbox's town symbolrank thresholds for z8-z10, z10-z11, z11-z12, and z12+ instead of using the z12 branch across the whole z8-z13 text layer.
- Keep the existing qfit town-only settlement policy and `name_en`/fallback text-field split unchanged.

## Evidence

Refs #949.

The fresh post-#1097 comparison showed QGIS under-labeling towns at the Lausanne/Lavaux z10 inspection scale while Chamonix/Zermatt/Geneva still had unrelated minor road/water label density issues. Live style inspection confirmed that qfit was flattening the `settlement-minor-label` zoom-dependent symbolrank filter to the z12 branch:

- before: z8-z13 text layer used `symbolrank >= 15`
- after: z8-z10 uses `>= 10`, z10-z11 uses `>= 11`, z11-z12 uses `>= 13`, z12+ keeps `>= 15`

Live validation artifacts generated with the local QGIS profile token source, without printing or storing the token:

- baseline all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260517T071444Z/summary.md`
- focused Lausanne probe: `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260517T072028Z/`
- full matrix after the patch: `debug/mapbox-outdoors-comparison/all-cameras/20260517T072156Z/summary.md`
- style audit after the patch: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T072303Z/audit.md`

Visual read:

- Lausanne z10 restored town labels visible in the Mapbox reference and missing in QGIS baseline, including Renens, Morges, Pully, Lutry, Montreux, Evian-les-Bains, Thonon-les-Bains, Aigle, and Bulle.
- Valais/Geneva z8 improved settlement coverage without obvious over-labeling.
- Chamonix z14 was visually neutral for settlement labels.

Metric deltas versus the 20260517T071444Z baseline were small and localized: z5 unchanged, z8/z10 changed mainly in mean/RMS due restored labels, z14/z18 essentially neutral.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short` — 2112 passed, 163 skipped, 135 subtests passed
- `scripts/run_plugin_security_scan.py --allow-findings` — detect-secrets clean; existing allowed Bandit/Flake8 findings only
