### PR TITLE
test: surface line label repetition audit

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -510,6 +510,18 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         },
                     },
                     {
+                        "id": "road-shield-low-zoom",
+                        "type": "symbol",
+                        "source-layer": "road",
+                        "maxzoom": 10,
+                        "filter": ["all", ["has", "reflen"], ["<=", ["get", "reflen"], 6]],
+                        "layout": {
+                            "symbol-placement": ["step", ["zoom"], "point", 11, "line"],
+                            "symbol-spacing": ["interpolate", ["linear"], ["zoom"], 10, 120, 16, 400],
+                            "text-field": ["get", "ref"],
+                        },
+                    },
+                    {
                         "id": "poi-label",
                         "type": "symbol",
                         "source-layer": "poi_label",
@@ -602,6 +614,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )[0]
         self.assertNotIn("poi-label` |", line_label_section)
         self.assertNotIn("hidden-line-label` |", line_label_section)
+        self.assertNotIn("road-shield-low-zoom` |", line_label_section)
 
     def test_symbol_placement_may_be_line_handles_expression_outputs(self):
         cases = [
@@ -610,6 +623,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             ("literal-expression", ["literal", "line"], True),
             ("step-line-output", ["step", ["zoom"], "point", 11, "line"], True),
             ("step-point-only", ["step", ["zoom"], "point", 11, "point"], False),
+            ("data-driven-step-line-output", ["step", ["get", "rank"], "point", 3, "line"], True),
             ("interpolate-line-output", ["interpolate", ["linear"], ["zoom"], 10, "point", 12, "line"], True),
             ("case-line-output", ["case", [">=", ["zoom"], 11], "line", "point"], True),
             ("case-line-default", ["case", [">=", ["zoom"], 11], "point", "line"], True),
@@ -623,6 +637,24 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         for label, value, expected in cases:
             with self.subTest(label=label):
                 self.assertIs(mapbox_outdoors_style_audit._symbol_placement_may_be_line(value), expected)
+
+        zoom_step_placement = ["step", ["zoom"], "point", 11, "line"]
+        self.assertIs(
+            mapbox_outdoors_style_audit._symbol_placement_may_be_line(
+                zoom_step_placement,
+                min_zoom=0,
+                max_zoom=10,
+            ),
+            False,
+        )
+        self.assertIs(
+            mapbox_outdoors_style_audit._symbol_placement_may_be_line(
+                zoom_step_placement,
+                min_zoom=10,
+                max_zoom=12,
+            ),
+            True,
+        )
 
     def test_build_style_audit_reports_road_trail_hierarchy_candidates(self):
         audit = build_style_audit(

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -603,6 +603,27 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertNotIn("poi-label` |", line_label_section)
         self.assertNotIn("hidden-line-label` |", line_label_section)
 
+    def test_symbol_placement_may_be_line_handles_expression_outputs(self):
+        cases = [
+            ("literal-line", "line", True),
+            ("literal-point", "point", False),
+            ("literal-expression", ["literal", "line"], True),
+            ("step-line-output", ["step", ["zoom"], "point", 11, "line"], True),
+            ("step-point-only", ["step", ["zoom"], "point", 11, "point"], False),
+            ("interpolate-line-output", ["interpolate", ["linear"], ["zoom"], 10, "point", 12, "line"], True),
+            ("case-line-output", ["case", [">=", ["zoom"], 11], "line", "point"], True),
+            ("case-line-default", ["case", [">=", ["zoom"], 11], "point", "line"], True),
+            ("match-line-output", ["match", ["get", "class"], "primary", "line", "point"], True),
+            ("match-line-default", ["match", ["get", "class"], "primary", "point", "line"], True),
+            ("coalesce-line-output", ["coalesce", ["get", "placement"], "line"], True),
+            ("let-line-output", ["let", "placement", "point", "line"], True),
+            ("get-expression", ["get", "placement"], False),
+        ]
+
+        for label, value, expected in cases:
+            with self.subTest(label=label):
+                self.assertIs(mapbox_outdoors_style_audit._symbol_placement_may_be_line(value), expected)
+
     def test_build_style_audit_reports_road_trail_hierarchy_candidates(self):
         audit = build_style_audit(
             {

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -498,6 +498,18 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         },
                     },
                     {
+                        "id": "road-shield",
+                        "type": "symbol",
+                        "source-layer": "road",
+                        "minzoom": 6,
+                        "filter": ["all", ["has", "reflen"], ["<=", ["get", "reflen"], 6]],
+                        "layout": {
+                            "symbol-placement": ["step", ["zoom"], "point", 11, "line"],
+                            "symbol-spacing": ["interpolate", ["linear"], ["zoom"], 10, 120, 16, 400],
+                            "text-field": ["get", "ref"],
+                        },
+                    },
+                    {
                         "id": "poi-label",
                         "type": "symbol",
                         "source-layer": "poi_label",
@@ -514,8 +526,11 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )
 
         candidates = audit["summary"]["line_label_repetition_candidates"]
-        self.assertEqual([candidate["layer"] for candidate in candidates], ["road-label", "waterway-label"])
-        road_candidate, waterway_candidate = candidates
+        self.assertEqual(
+            [candidate["layer"] for candidate in candidates],
+            ["road-label", "road-shield", "waterway-label"],
+        )
+        road_candidate, shield_candidate, waterway_candidate = candidates
         self.assertEqual(road_candidate["group"], "roads/trails")
         self.assertEqual(road_candidate["source_layer"], "road")
         self.assertEqual(road_candidate["zoom_band"], "z≥10")
@@ -526,21 +541,34 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )
         self.assertEqual(road_candidate["qfit_simplified_control_properties"], [])
         self.assertEqual(road_candidate["qgis_dependent_control_properties"], ["filter", "layout.symbol-spacing"])
+        self.assertEqual(shield_candidate["group"], "roads/trails")
+        self.assertEqual(shield_candidate["source_layer"], "road")
+        self.assertEqual(shield_candidate["zoom_band"], "z≥6")
+        self.assertEqual(shield_candidate["filter_operator_signature"], "<=, all, get, has")
+        self.assertEqual(
+            shield_candidate["line_label_control_properties"],
+            ["filter", "layout.symbol-placement", "layout.symbol-spacing", "layout.text-field"],
+        )
+        self.assertEqual(shield_candidate["qfit_simplified_control_properties"], [])
+        self.assertEqual(
+            shield_candidate["qgis_dependent_control_properties"],
+            ["filter", "layout.symbol-placement", "layout.symbol-spacing"],
+        )
         self.assertEqual(waterway_candidate["group"], "water")
         self.assertEqual(waterway_candidate["source_layer"], "natural_label")
         self.assertEqual(waterway_candidate["qfit_simplified_control_properties"], ["layout.symbol-spacing"])
         self.assertEqual(waterway_candidate["qgis_dependent_control_properties"], ["filter"])
         self.assertEqual(
             audit["summary"]["line_label_repetition_candidates_by_layer_group"],
-            [{"group": "roads/trails", "count": 1}, {"group": "water", "count": 1}],
+            [{"group": "roads/trails", "count": 2}, {"group": "water", "count": 1}],
         )
         self.assertEqual(
             audit["summary"]["line_label_repetition_controls_by_property"],
             [
-                {"property": "filter", "count": 2},
-                {"property": "layout.symbol-placement", "count": 2},
-                {"property": "layout.symbol-spacing", "count": 2},
-                {"property": "layout.text-field", "count": 2},
+                {"property": "filter", "count": 3},
+                {"property": "layout.symbol-placement", "count": 3},
+                {"property": "layout.symbol-spacing", "count": 3},
+                {"property": "layout.text-field", "count": 3},
                 {"property": "layout.text-size", "count": 2},
                 {"property": "layout.text-max-angle", "count": 1},
             ],
@@ -551,7 +579,11 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )
         self.assertEqual(
             audit["summary"]["line_label_repetition_qgis_dependent_by_property"],
-            [{"property": "filter", "count": 2}, {"property": "layout.symbol-spacing", "count": 1}],
+            [
+                {"property": "filter", "count": 3},
+                {"property": "layout.symbol-spacing", "count": 2},
+                {"property": "layout.symbol-placement", "count": 1},
+            ],
         )
 
         markdown = build_audit_markdown(audit)
@@ -561,6 +593,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("#### Line label repetition controls simplified/substituted by qfit", markdown)
         self.assertIn("#### Line label repetition QGIS-dependent controls", markdown)
         self.assertIn("| `roads/trails` | `road-label` | `road` | z≥10 | `==, all, get, has` |", markdown)
+        self.assertIn("| `roads/trails` | `road-shield` | `road` | z≥6 | `<=, all, get, has` |", markdown)
         self.assertIn("| `water` | `waterway-label` | `natural_label` | z≥13 | `==, get` |", markdown)
         self.assertIn("poi-label` |", markdown)
         line_label_section = markdown.split("### Line label repetition candidates", 1)[1].split(

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -465,6 +465,111 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertNotIn("settlement-subdivision-label` |", markdown)
         self.assertNotIn("hidden-label` |", markdown)
 
+    def test_build_style_audit_reports_line_label_repetition_candidates(self):
+        audit = build_style_audit(
+            {
+                "version": 8,
+                "layers": [
+                    {
+                        "id": "road-label",
+                        "type": "symbol",
+                        "source-layer": "road",
+                        "minzoom": 10,
+                        "filter": ["all", ["==", ["get", "class"], "primary"], ["has", "name"]],
+                        "layout": {
+                            "symbol-placement": "line",
+                            "symbol-spacing": ["step", ["zoom"], 150, 14, 250],
+                            "text-field": ["get", "name"],
+                            "text-size": 10,
+                        },
+                    },
+                    {
+                        "id": "waterway-label",
+                        "type": "symbol",
+                        "source-layer": "natural_label",
+                        "minzoom": 13,
+                        "filter": ["==", ["get", "class"], "river"],
+                        "layout": {
+                            "symbol-placement": "line",
+                            "symbol-spacing": ["interpolate", ["linear", 1], ["zoom"], 15, 250, 17, 400],
+                            "text-field": ["get", "name"],
+                            "text-max-angle": 30,
+                            "text-size": 10,
+                        },
+                    },
+                    {
+                        "id": "poi-label",
+                        "type": "symbol",
+                        "source-layer": "poi_label",
+                        "layout": {"text-field": ["get", "name"]},
+                    },
+                    {
+                        "id": "hidden-line-label",
+                        "type": "symbol",
+                        "source-layer": "road",
+                        "layout": {"symbol-placement": "line", "text-field": ["get", "name"], "visibility": "none"},
+                    },
+                ],
+            }
+        )
+
+        candidates = audit["summary"]["line_label_repetition_candidates"]
+        self.assertEqual([candidate["layer"] for candidate in candidates], ["road-label", "waterway-label"])
+        road_candidate, waterway_candidate = candidates
+        self.assertEqual(road_candidate["group"], "roads/trails")
+        self.assertEqual(road_candidate["source_layer"], "road")
+        self.assertEqual(road_candidate["zoom_band"], "z≥10")
+        self.assertEqual(road_candidate["filter_operator_signature"], "==, all, get, has")
+        self.assertEqual(
+            road_candidate["line_label_control_properties"],
+            ["filter", "layout.symbol-placement", "layout.symbol-spacing", "layout.text-field", "layout.text-size"],
+        )
+        self.assertEqual(road_candidate["qfit_simplified_control_properties"], [])
+        self.assertEqual(road_candidate["qgis_dependent_control_properties"], ["filter", "layout.symbol-spacing"])
+        self.assertEqual(waterway_candidate["group"], "water")
+        self.assertEqual(waterway_candidate["source_layer"], "natural_label")
+        self.assertEqual(waterway_candidate["qfit_simplified_control_properties"], ["layout.symbol-spacing"])
+        self.assertEqual(waterway_candidate["qgis_dependent_control_properties"], ["filter"])
+        self.assertEqual(
+            audit["summary"]["line_label_repetition_candidates_by_layer_group"],
+            [{"group": "roads/trails", "count": 1}, {"group": "water", "count": 1}],
+        )
+        self.assertEqual(
+            audit["summary"]["line_label_repetition_controls_by_property"],
+            [
+                {"property": "filter", "count": 2},
+                {"property": "layout.symbol-placement", "count": 2},
+                {"property": "layout.symbol-spacing", "count": 2},
+                {"property": "layout.text-field", "count": 2},
+                {"property": "layout.text-size", "count": 2},
+                {"property": "layout.text-max-angle", "count": 1},
+            ],
+        )
+        self.assertEqual(
+            audit["summary"]["line_label_repetition_simplified_by_property"],
+            [{"property": "layout.symbol-spacing", "count": 1}],
+        )
+        self.assertEqual(
+            audit["summary"]["line_label_repetition_qgis_dependent_by_property"],
+            [{"property": "filter", "count": 2}, {"property": "layout.symbol-spacing", "count": 1}],
+        )
+
+        markdown = build_audit_markdown(audit)
+        self.assertIn("### Line label repetition candidates", markdown)
+        self.assertIn("QGIS may repeat labels per feature segment", markdown)
+        self.assertIn("#### Line label repetition controls by property", markdown)
+        self.assertIn("#### Line label repetition controls simplified/substituted by qfit", markdown)
+        self.assertIn("#### Line label repetition QGIS-dependent controls", markdown)
+        self.assertIn("| `roads/trails` | `road-label` | `road` | z≥10 | `==, all, get, has` |", markdown)
+        self.assertIn("| `water` | `waterway-label` | `natural_label` | z≥13 | `==, get` |", markdown)
+        self.assertIn("poi-label` |", markdown)
+        line_label_section = markdown.split("### Line label repetition candidates", 1)[1].split(
+            "### Road/trail hierarchy candidates",
+            1,
+        )[0]
+        self.assertNotIn("poi-label` |", line_label_section)
+        self.assertNotIn("hidden-line-label` |", line_label_section)
+
     def test_build_style_audit_reports_road_trail_hierarchy_candidates(self):
         audit = build_style_audit(
             {

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -105,6 +105,11 @@ _LINE_DASHARRAY_PROPERTY = "paint.line-dasharray"
 _SYMBOL_SPACING_PROPERTY = "layout.symbol-spacing"
 _LABEL_DENSITY_CONTROLS_BY_PROPERTY_KEY = "label_density_controls_by_property"
 _LABEL_DENSITY_QGIS_DEPENDENT_BY_PROPERTY_KEY = "label_density_qgis_dependent_by_property"
+_LINE_LABEL_REPETITION_CANDIDATES_KEY = "line_label_repetition_candidates"
+_LINE_LABEL_REPETITION_CANDIDATES_BY_LAYER_GROUP_KEY = "line_label_repetition_candidates_by_layer_group"
+_LINE_LABEL_REPETITION_CONTROLS_BY_PROPERTY_KEY = "line_label_repetition_controls_by_property"
+_LINE_LABEL_REPETITION_SIMPLIFIED_BY_PROPERTY_KEY = "line_label_repetition_simplified_by_property"
+_LINE_LABEL_REPETITION_QGIS_DEPENDENT_BY_PROPERTY_KEY = "line_label_repetition_qgis_dependent_by_property"
 _LABEL_DENSITY_CONTROL_PROPERTIES = (
     "layout.icon-allow-overlap",
     "layout.icon-ignore-placement",
@@ -909,6 +914,15 @@ def _label_density_unresolved_controls(layer: dict[str, object]) -> list[str]:
     )
 
 
+def _is_line_label_repetition_candidate_layer(layer: dict[str, object]) -> bool:
+    layout = layer.get("layout")
+    return (
+        _is_label_density_candidate_layer(layer)
+        and isinstance(layout, dict)
+        and layout.get("symbol-placement") == "line"
+    )
+
+
 def _is_road_trail_hierarchy_candidate_layer(layer: dict[str, object]) -> bool:
     return (
         str(layer.get("group") or "") == "roads/trails"
@@ -1392,6 +1406,28 @@ def _label_density_candidate_rows(layers: list[dict[str, object]]) -> list[dict[
                 _FILTER_OPERATOR_SIGNATURE_KEY: _operator_signature(_qgis_filter_value(layer)),
                 "label_control_properties": _label_density_control_properties(layer),
                 _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY: _label_density_unresolved_controls(layer),
+            }
+        )
+    return sorted(rows, key=lambda row: (str(row["group"]), str(row["layer"])))
+
+
+def _line_label_repetition_candidate_rows(layers: list[dict[str, object]]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for layer in layers:
+        if not _is_line_label_repetition_candidate_layer(layer):
+            continue
+        controls = _label_density_control_properties(layer)
+        control_set = set(controls)
+        rows.append(
+            {
+                "layer": str(layer.get("id") or ""),
+                "group": str(layer.get("group") or "other"),
+                "source_layer": str(layer.get("source_layer") or ""),
+                "zoom_band": str(layer.get("zoom_band") or _ALL_ZOOMS_BAND),
+                _FILTER_OPERATOR_SIGNATURE_KEY: _operator_signature(_qgis_filter_value(layer)),
+                "line_label_control_properties": controls,
+                _QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY: _qfit_simplified_control_properties(layer, control_set),
+                _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY: _qgis_dependent_control_properties(layer, control_set),
             }
         )
     return sorted(rows, key=lambda row: (str(row["group"]), str(row["layer"])))
@@ -3209,6 +3245,7 @@ def build_style_audit(
         for layer in original_layers
     ]
     label_density_candidates = _label_density_candidate_rows(layers)
+    line_label_repetition_candidates = _line_label_repetition_candidate_rows(layers)
     road_trail_hierarchy_candidates = _road_trail_hierarchy_candidate_rows(layers)
     terrain_landcover_candidates = _terrain_landcover_candidate_rows(layers)
     water_flow_candidates = _water_flow_candidate_rows(layers)
@@ -3271,6 +3308,23 @@ def build_style_audit(
                 _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY,
             ),
             "label_density_candidates": label_density_candidates,
+            _LINE_LABEL_REPETITION_CANDIDATES_BY_LAYER_GROUP_KEY: _count_rows_by_key(
+                line_label_repetition_candidates,
+                "group",
+            ),
+            _LINE_LABEL_REPETITION_CONTROLS_BY_PROPERTY_KEY: _count_row_values(
+                line_label_repetition_candidates,
+                "line_label_control_properties",
+            ),
+            _LINE_LABEL_REPETITION_SIMPLIFIED_BY_PROPERTY_KEY: _count_row_values(
+                line_label_repetition_candidates,
+                _QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY,
+            ),
+            _LINE_LABEL_REPETITION_QGIS_DEPENDENT_BY_PROPERTY_KEY: _count_row_values(
+                line_label_repetition_candidates,
+                _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY,
+            ),
+            _LINE_LABEL_REPETITION_CANDIDATES_KEY: line_label_repetition_candidates,
             _ROAD_TRAIL_HIERARCHY_CANDIDATES_BY_SOURCE_LAYER_KEY: _count_rows_by_key(
                 road_trail_hierarchy_candidates,
                 "source_layer",
@@ -3558,6 +3612,40 @@ def _markdown_label_density_candidate_table(rows: list[dict[str, object]], *, em
                 zoom=row.get("zoom_band", _ALL_ZOOMS_BAND),
                 filter_operators=row.get(_FILTER_OPERATOR_SIGNATURE_KEY, _NO_OPERATOR_SIGNATURE),
                 controls=_markdown_list(list(row.get("label_control_properties") or [])),
+                unresolved=_markdown_list(list(row.get(_QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY) or [])),
+            )
+        )
+    lines.append("")
+    return lines
+
+
+def _markdown_line_label_repetition_candidate_table(
+    rows: list[dict[str, object]],
+    *,
+    empty: str = "—",
+) -> list[str]:
+    if not rows:
+        return [empty, ""]
+    lines = [
+        (
+            "| Layer group | Layer | Source layer | Zoom | Filter operators | Line-label controls | "
+            "Simplified/substituted by qfit | QGIS-dependent controls |"
+        ),
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            (
+                "| `{group}` | `{layer}` | `{source_layer}` | {zoom} | `{filter_operators}` | "
+                "{controls} | {simplified} | {unresolved} |"
+            ).format(
+                group=row.get("group", ""),
+                layer=row.get("layer", ""),
+                source_layer=row.get("source_layer", ""),
+                zoom=row.get("zoom_band", _ALL_ZOOMS_BAND),
+                filter_operators=row.get(_FILTER_OPERATOR_SIGNATURE_KEY, _NO_OPERATOR_SIGNATURE),
+                controls=_markdown_list(list(row.get("line_label_control_properties") or [])),
+                simplified=_markdown_list(list(row.get(_QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY) or [])),
                 unresolved=_markdown_list(list(row.get(_QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY) or [])),
             )
         )
@@ -5082,6 +5170,48 @@ def _markdown_label_density_summary(summary: dict[str, object]) -> list[str]:
     ]
 
 
+def _markdown_line_label_repetition_summary(summary: dict[str, object]) -> list[str]:
+    return [
+        "### Line label repetition candidates",
+        "",
+        (
+            "Visible line-placement text labels where QGIS may repeat labels per feature segment. Use this "
+            "diagnostic with live screenshots before changing road, path, waterway, contour, or natural-line "
+            "label spacing, filters, or placement."
+        ),
+        "",
+        *_markdown_named_count_table(
+            _summary_rows(summary, _LINE_LABEL_REPETITION_CANDIDATES_BY_LAYER_GROUP_KEY),
+            key="group",
+            label=_MARKDOWN_LAYER_GROUP_LABEL,
+        ),
+        "#### Line label repetition controls by property",
+        "",
+        *_markdown_named_count_table(
+            _summary_rows(summary, _LINE_LABEL_REPETITION_CONTROLS_BY_PROPERTY_KEY),
+            key="property",
+            label="Property",
+        ),
+        "#### Line label repetition controls simplified/substituted by qfit",
+        "",
+        *_markdown_named_count_table(
+            _summary_rows(summary, _LINE_LABEL_REPETITION_SIMPLIFIED_BY_PROPERTY_KEY),
+            key="property",
+            label="Property",
+        ),
+        "#### Line label repetition QGIS-dependent controls",
+        "",
+        *_markdown_named_count_table(
+            _summary_rows(summary, _LINE_LABEL_REPETITION_QGIS_DEPENDENT_BY_PROPERTY_KEY),
+            key="property",
+            label="Property",
+        ),
+        *_markdown_line_label_repetition_candidate_table(
+            _summary_rows(summary, _LINE_LABEL_REPETITION_CANDIDATES_KEY)
+        ),
+    ]
+
+
 def _markdown_road_trail_hierarchy_summary(summary: dict[str, object]) -> list[str]:
     return [
         "### Road/trail hierarchy candidates",
@@ -5305,6 +5435,7 @@ def _markdown_summary(summary: dict[str, object], qgis_converter_warnings: objec
             _summary_rows(summary, "qfit_unresolved_filter_expression_signatures_by_layer_group")
         ),
         *_markdown_label_density_summary(summary),
+        *_markdown_line_label_repetition_summary(summary),
         *_markdown_road_trail_hierarchy_summary(summary),
         *_markdown_terrain_landcover_summary(summary),
         *_markdown_water_flow_summary(summary),

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -683,6 +683,8 @@ def _qfit_split_variant_audit_layers_for_original_id(
                 "group": _layer_group(simplified_layer),
                 "source": str(simplified_layer.get("source") or ""),
                 "source_layer": str(simplified_layer.get("source-layer") or ""),
+                "minzoom": simplified_layer.get("minzoom"),
+                "maxzoom": simplified_layer.get("maxzoom"),
                 "zoom_band": _zoom_band(simplified_layer),
                 "filter": simplified_layer.get("filter"),
                 "qgis_filter": simplified_layer.get("filter"),
@@ -706,6 +708,8 @@ def build_layer_audit(
         "group": _layer_group(layer),
         "source": str(layer.get("source") or ""),
         "source_layer": str(layer.get("source-layer") or ""),
+        "minzoom": layer.get("minzoom"),
+        "maxzoom": layer.get("maxzoom"),
         "zoom_band": _zoom_band(layer),
         "filter": layer.get("filter"),
         "qgis_filter": (simplified_layer or layer).get("filter"),
@@ -914,15 +918,68 @@ def _label_density_unresolved_controls(layer: dict[str, object]) -> list[str]:
     )
 
 
-def _symbol_placement_may_be_line(value: object) -> bool:
+def _numeric_layer_zoom_bounds(layer: dict[str, object]) -> tuple[float, float]:
+    minzoom = layer.get("minzoom")
+    maxzoom = layer.get("maxzoom")
+    min_zoom = float(minzoom) if isinstance(minzoom, (int, float)) else 0.0
+    max_zoom = float(maxzoom) if isinstance(maxzoom, (int, float)) else float("inf")
+    return min_zoom, max_zoom
+
+
+def _zoom_expression(value: object) -> bool:
+    return isinstance(value, list) and value == ["zoom"]
+
+
+def _zoom_ranges_overlap(start: float, end: float, layer_min: float, layer_max: float) -> bool:
+    return start < layer_max and layer_min < end
+
+
+def _symbol_placement_zoom_step_may_be_line(
+    value: list[object],
+    *,
+    min_zoom: float,
+    max_zoom: float,
+) -> bool | None:
+    if len(value) < 3 or not _zoom_expression(value[1]):
+        return None
+    active_start = float("-inf")
+    active_value = value[2]
+    for index in range(3, len(value) - 1, 2):
+        stop = value[index]
+        if not isinstance(stop, (int, float)):
+            return None
+        active_end = float(stop)
+        if _zoom_ranges_overlap(active_start, active_end, min_zoom, max_zoom) and _symbol_placement_may_be_line(
+            active_value,
+            min_zoom=max(min_zoom, active_start),
+            max_zoom=min(max_zoom, active_end),
+        ):
+            return True
+        active_start = active_end
+        active_value = value[index + 1]
+    return _zoom_ranges_overlap(active_start, float("inf"), min_zoom, max_zoom) and _symbol_placement_may_be_line(
+        active_value,
+        min_zoom=max(min_zoom, active_start),
+        max_zoom=max_zoom,
+    )
+
+
+def _symbol_placement_may_be_line(value: object, *, min_zoom: float = 0.0, max_zoom: float = float("inf")) -> bool:
     if value == "line":
         return True
     if not isinstance(value, list) or not value:
         return False
     operator = value[0]
     if operator == "literal":
-        return len(value) == 2 and _symbol_placement_may_be_line(value[1])
+        return len(value) == 2 and _symbol_placement_may_be_line(
+            value[1],
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+        )
     if operator == "step":
+        step_result = _symbol_placement_zoom_step_may_be_line(value, min_zoom=min_zoom, max_zoom=max_zoom)
+        if step_result is not None:
+            return step_result
         output_indexes = range(2, len(value), 2)
     elif operator == "interpolate":
         output_indexes = range(4, len(value), 2)
@@ -936,15 +993,19 @@ def _symbol_placement_may_be_line(value: object) -> bool:
         output_indexes = [len(value) - 1]
     else:
         return False
-    return any(_symbol_placement_may_be_line(value[index]) for index in output_indexes)
+    return any(
+        _symbol_placement_may_be_line(value[index], min_zoom=min_zoom, max_zoom=max_zoom)
+        for index in output_indexes
+    )
 
 
 def _is_line_label_repetition_candidate_layer(layer: dict[str, object]) -> bool:
     layout = layer.get("layout")
+    min_zoom, max_zoom = _numeric_layer_zoom_bounds(layer)
     return (
         _is_label_density_candidate_layer(layer)
         and isinstance(layout, dict)
-        and _symbol_placement_may_be_line(layout.get("symbol-placement"))
+        and _symbol_placement_may_be_line(layout.get("symbol-placement"), min_zoom=min_zoom, max_zoom=max_zoom)
     )
 
 

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -914,12 +914,37 @@ def _label_density_unresolved_controls(layer: dict[str, object]) -> list[str]:
     )
 
 
+def _symbol_placement_may_be_line(value: object) -> bool:
+    if value == "line":
+        return True
+    if not isinstance(value, list) or not value:
+        return False
+    operator = value[0]
+    if operator == "literal":
+        return len(value) == 2 and _symbol_placement_may_be_line(value[1])
+    if operator == "step":
+        output_indexes = range(2, len(value), 2)
+    elif operator == "interpolate":
+        output_indexes = range(4, len(value), 2)
+    elif operator == "case":
+        output_indexes = [*range(2, len(value) - 1, 2), len(value) - 1]
+    elif operator == "match":
+        output_indexes = [*range(3, len(value) - 1, 2), len(value) - 1]
+    elif operator == "coalesce":
+        output_indexes = range(1, len(value))
+    elif operator == "let":
+        output_indexes = [len(value) - 1]
+    else:
+        return False
+    return any(_symbol_placement_may_be_line(value[index]) for index in output_indexes)
+
+
 def _is_line_label_repetition_candidate_layer(layer: dict[str, object]) -> bool:
     layout = layer.get("layout")
     return (
         _is_label_density_candidate_layer(layer)
         and isinstance(layout, dict)
-        and layout.get("symbol-placement") == "line"
+        and _symbol_placement_may_be_line(layout.get("symbol-placement"))
     )
 
 


### PR DESCRIPTION
Refs #949.

## Summary
- adds a diagnostic audit section for visible line-placement text labels where QGIS may repeat labels per feature segment
- treats literal and expression-resolved `symbol-placement: "line"` as repetition candidates
- respects layer `minzoom`/`maxzoom` when deciding whether zoom-expression line placement is reachable
- reports candidate counts by layer group, control properties, qfit simplifications, and QGIS-dependent controls
- adds fixture coverage for line labels, zoom-expression line placement, unreachable line zoom branches, point labels, and hidden labels

## Evidence
- The rejected waterway-label symbol-spacing probe changed Zermatt and Chamonix screenshots negligibly, so a narrower diagnostic is useful before rendering changes.
- Live audit after both Codex review fixes: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T081124Z/audit.md`
- Candidate groups: roads/trails 4, terrain/landcover 1, water 1.
- Candidate layers: `ferry-aerialway-label`, `path-pedestrian-label`, `road-label`, `road-number-shield`, `contour-label`, `waterway-label`.
- `road-number-shield` is included because its placement resolves from point to line within its reachable zoom range.
- Only `road-number-shield` and `waterway-label` expose Mapbox `layout.symbol-spacing`; other candidates mainly depend on filter/text placement semantics.

## Review feedback
- Addressed the first Codex inline comment by recognizing supported placement expressions whose output can resolve to `"line"`.
- Addressed the second Codex inline comment by checking zoom-expression line placement against layer zoom bounds.

## Validation
- `git diff --check`
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py::MapboxOutdoorsStyleAuditTests::test_build_style_audit_reports_line_label_repetition_candidates tests/test_mapbox_outdoors_style_audit.py::MapboxOutdoorsStyleAuditTests::test_symbol_placement_may_be_line_handles_expression_outputs -q --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `/tmp/qfit-scan-venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
- live audit command using the local QGIS Mapbox token source

