### PR TITLE
[codex] fix QGIS Mapbox label priorities

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -601,6 +601,71 @@ class SnapExtentMockTests(unittest.TestCase):
         self.assertEqual(len(args), 4)
 
 
+@unittest.skipUnless(QGIS_AVAILABLE, SKIP_REAL)
+class ApplyLabelPriorityRealTests(unittest.TestCase):
+    """Covers QGIS label-setting post-processing when real QGIS imports are available."""
+
+    def setUp(self):
+        from qgis.core import QgsApplication
+
+        from tests.qgis_app import get_shared_qgis_app
+
+        self.qgs = get_shared_qgis_app(QgsApplication)
+        self.service = BackgroundMapService()
+
+    def _make_style(self, layer_name, style_name=None):
+        style = MagicMock()
+        style.layerName.return_value = layer_name
+        style.styleName.return_value = style_name if style_name is not None else layer_name
+        settings = MagicMock()
+        settings.dataDefinedProperties.return_value = MagicMock()
+        style.labelSettings.return_value = settings
+        return style, settings
+
+    def test_priority_uses_qgis_style_name_not_tile_source_layer(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("place_label", "settlement-major-label")
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 8)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_priority_uses_base_layer_for_split_style_name(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("poi_label", "poi-label-z17-plus")
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 2)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_priority_persists_on_real_qgis_labeling_style_copies(self):
+        from qgis.core import (
+            QgsPalLayerSettings,
+            QgsVectorTileBasicLabeling,
+            QgsVectorTileBasicLabelingStyle,
+        )
+
+        labeling = QgsVectorTileBasicLabeling()
+        style = QgsVectorTileBasicLabelingStyle()
+        style.setLayerName("poi_label")
+        style.setStyleName("poi-label-z17-plus")
+        settings = QgsPalLayerSettings()
+        settings.priority = 5
+        style.setLabelSettings(settings)
+        labeling.setStyles([style])
+
+        self.service._apply_label_priority(labeling)
+
+        updated_style = labeling.styles()[0]
+        self.assertEqual(updated_style.styleName(), "poi-label-z17-plus")
+        self.assertEqual(updated_style.layerName(), "poi_label")
+        self.assertEqual(updated_style.labelSettings().priority, 2)
+
+
 @unittest.skipIf(QGIS_AVAILABLE, SKIP_MOCK)
 @unittest.skipIf(_mock_bms_cls is None, SKIP_MOCK_LOAD)
 class ApplyLabelPriorityMockTests(unittest.TestCase):
@@ -616,9 +681,10 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
     def tearDown(self):
         self._sys_patch.stop()
 
-    def _make_style(self, layer_name):
+    def _make_style(self, layer_name, style_name=None):
         style = MagicMock()
         style.layerName.return_value = layer_name
+        style.styleName.return_value = style_name if style_name is not None else layer_name
         settings = MagicMock()
         settings.dataDefinedProperties.return_value = MagicMock()
         style.labelSettings.return_value = settings
@@ -637,6 +703,26 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
     def test_priority_set_for_split_poi_layer(self):
         labeling = MagicMock()
         style, settings = self._make_style("poi-label-z17-plus")
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 2)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_priority_uses_qgis_style_name_not_tile_source_layer(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("place_label", "settlement-major-label")
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 8)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_priority_uses_base_layer_for_split_style_name(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("poi_label", "poi-label-z17-plus")
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -763,6 +763,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         labeling = MagicMock()
         style = MagicMock()
         style.layerName.return_value = "country-label"
+        style.styleName.return_value = "country-label"
         style.labelSettings.return_value = None
         labeling.styles.return_value = [style]
 

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -29,6 +29,17 @@ from ...mapbox_config import (
 _WORKING_CRS = "EPSG:3857"
 
 
+def _label_style_mapbox_layer_id(style) -> str:
+    for accessor in ("styleName", "layerName"):
+        try:
+            layer_id = getattr(style, accessor)()
+        except AttributeError:
+            continue
+        if isinstance(layer_id, str) and layer_id:
+            return base_mapbox_style_layer_id_for_qfit(layer_id)
+    return ""
+
+
 class BackgroundMapService:
     """Manages Mapbox background tile layers (raster and vector) in the QGIS project.
 
@@ -175,8 +186,10 @@ class BackgroundMapService:
         try:
             from qgis.core import QgsProperty  # noqa: PLC0415
 
-            for style in labeling.styles():
-                layer_name = base_mapbox_style_layer_id_for_qfit(style.layerName())
+            styles = list(labeling.styles())
+            changed = False
+            for style in styles:
+                layer_name = _label_style_mapbox_layer_id(style)
                 priority = _LAYER_PRIORITIES.get(layer_name)
                 if priority is None:
                     continue
@@ -194,6 +207,9 @@ class BackgroundMapService:
                     )
                     settings.setDataDefinedProperties(dd_props)
                 style.setLabelSettings(settings)
+                changed = True
+            if changed:
+                labeling.setStyles(styles)
         except (RuntimeError, AttributeError):
             logger.debug("Mapbox GL style application skipped", exc_info=True)
 


### PR DESCRIPTION
Part of #949.

## Summary
- Use QGIS vector-tile label styleName() before layerName() when mapping converted labels back to Mapbox style layer ids.
- Reapply modified label styles with setStyles() because QGIS returns copies from styles().
- Add real-QGIS and mock regression coverage for style-name mapping and persisted priorities.

## Root cause
QGIS exposes the vector-tile source layer through layerName() (road, place_label, poi_label) and the original Mapbox style layer id through styleName(). qfit was reading layerName(), so most Mapbox-specific label priorities never matched. The copied styles returned by styles() also need to be installed back onto the labeling object.

## Validation
- python3 -m pytest tests/test_background_map_service.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short — 2116 passed, 166 skipped, 149 subtests passed
- git diff --check
- /tmp/qfit-scan-venv/bin/python scripts/run_plugin_security_scan.py --allow-findings — exit 0; existing Bandit/flake8 findings, detect-secrets clean
- Live QGIS label introspection: selected converted styles now persist intended priorities, e.g. road-label 3 -> 5, settlement-major-label 4 -> 8, country-label 5 -> 10
- Live Mapbox/QGIS all-camera comparison: debug/mapbox-outdoors-comparison/all-cameras/20260517T085209Z/summary.md

The live visual comparison shows a small hierarchy/readability tradeoff rather than a pixel-metric win. This PR keeps the change focused on making the existing intended qfit label-priority hook actually take effect; follow-up #949 slices can tune the priority table separately.
