### PR TITLE
[codex] rebalance Mapbox label priorities

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -639,7 +639,7 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
 
         self.service._apply_label_priority(labeling)
 
-        self.assertEqual(settings.priority, 2)
+        self.assertEqual(settings.priority, 5)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_priority_persists_on_real_qgis_labeling_style_copies(self):
@@ -663,7 +663,7 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         updated_style = labeling.styles()[0]
         self.assertEqual(updated_style.styleName(), "poi-label-z17-plus")
         self.assertEqual(updated_style.layerName(), "poi_label")
-        self.assertEqual(updated_style.labelSettings().priority, 2)
+        self.assertEqual(updated_style.labelSettings().priority, 5)
 
 
 @unittest.skipIf(QGIS_AVAILABLE, SKIP_MOCK)
@@ -707,7 +707,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
         self.service._apply_label_priority(labeling)
 
-        self.assertEqual(settings.priority, 2)
+        self.assertEqual(settings.priority, 5)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_priority_uses_qgis_style_name_not_tile_source_layer(self):
@@ -727,8 +727,26 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
         self.service._apply_label_priority(labeling)
 
-        self.assertEqual(settings.priority, 2)
+        self.assertEqual(settings.priority, 5)
         style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_priority_tuning_favors_airport_and_poi_over_roads(self):
+        cases = [
+            ("airport_label", "airport-label", 8),
+            ("poi_label", "poi-label", 5),
+            ("road", "road-label", 4),
+            ("natural_label", "natural-point-label", 4),
+        ]
+        for layer_name, style_name, expected_priority in cases:
+            with self.subTest(style_name=style_name):
+                labeling = MagicMock()
+                style, settings = self._make_style(layer_name, style_name)
+                labeling.styles.return_value = [style]
+
+                self.service._apply_label_priority(labeling)
+
+                self.assertEqual(settings.priority, expected_priority)
+                style.setLabelSettings.assert_called_once_with(settings)
 
     def test_data_defined_priority_for_settlement_layer(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -176,10 +176,10 @@ class BackgroundMapService:
             "water-point-label": 7,
             "water-line-label": 6,
             "natural-line-label": 4,
-            "natural-point-label": 2,
-            "poi-label": 2,
-            "road-label": 5,
-            "airport-label": 5,
+            "natural-point-label": 4,
+            "poi-label": 5,
+            "road-label": 4,
+            "airport-label": 8,
         }
         _SETTLEMENT_LAYERS = {"settlement-major-label", "settlement-minor-label"}
 


### PR DESCRIPTION
Part of #949.

## Summary
- Raise Mapbox Outdoors POI, natural-point, and airport label priorities now that QGIS style-name priority handling is active.
- Lower road-label priority slightly so POI/airport/outdoor labels can survive QGIS label collisions more like Mapbox Outdoors.
- Update real-QGIS and mock regression coverage for the adjusted priority table.

## Why
After #1100, qfit's existing label priority hook actually applies to converted QGIS vector-tile label styles. Live comparison showed the post-#1100 render was still too road-label-forward: POIs, airport context, and outdoor/natural labels were weaker than Mapbox GL. This PR keeps the tuning conservative and scoped to label collision priority.

## Validation
- `python3 -m pytest tests/test_background_map_service.py::ApplyLabelPriorityRealTests tests/test_background_map_service.py::ApplyLabelPriorityMockTests -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short` — 2117 passed, 166 skipped, 153 subtests passed
- `git diff --check`
- `/tmp/qfit-scan-venv/bin/python scripts/run_plugin_security_scan.py --allow-findings` — exit 0; existing Bandit/flake8 findings, detect-secrets clean
- Focused live comparison: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T092429Z/` and `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260517T092434Z/`
- Full live matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260517T092623Z/summary.md`

Metric deltas versus post-#1100 full matrix (`20260517T085209Z`):

| Camera | Changed ratio delta | Mean error delta | RMS error delta |
| --- | ---: | ---: | ---: |
| `switzerland-alps-z5-outdoors` | +0.000000000 | +0.000000000 | +0.000000000 |
| `valais-geneva-outdoors` | +0.000000000 | +0.000000000 | +0.000000000 |
| `lausanne-lavaux-z10-outdoors` | +0.000000000 | -0.000002768 | -0.000004391 |
| `geneva-airport-motorway-z14-outdoors` | -0.000844618 | -0.000624326 | -0.001894145 |
| `chamonix-trails-z14-outdoors` | +0.000309896 | +0.000012977 | -0.000144359 |
| `zermatt-trails-z18-outdoors` | -0.000000868 | -0.000055006 | -0.000437862 |

The focused visual review found a modest but real parity improvement: more Geneva airport/POI labels and more Chamonix outdoor/tourism labels survive, with only mild clutter risk.
