### PR TITLE
[codex] preserve high-zoom hillshade shadows

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -3200,6 +3200,12 @@ def _hillshade_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
     variants: list[dict[str, object]] = []
 
+    def variant_paint(variant: dict[str, object]) -> dict[str, object]:
+        variant_paint = variant["paint"]
+        if not isinstance(variant_paint, dict):
+            raise TypeError("Hillshade layer paint must be a dictionary.")
+        return variant_paint
+
     split_zoom_band = _effective_zoom_band(
         existing_minzoom,
         existing_maxzoom,
@@ -3214,8 +3220,7 @@ def _hillshade_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[
             layer.get("filter"),
             ["==", ["get", "class"], "shadow"],
         )
-        shadow_paint = shadow_layer["paint"]
-        assert isinstance(shadow_paint, dict)
+        shadow_paint = variant_paint(shadow_layer)
         shadow_paint["fill-color"] = _HILLSHADE_SHADOW_FILL_COLOR
         variants.append(shadow_layer)
 
@@ -3233,8 +3238,7 @@ def _hillshade_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[
             layer.get("filter"),
             ["!=", ["get", "class"], "shadow"],
         )
-        highlight_paint = highlight_layer["paint"]
-        assert isinstance(highlight_paint, dict)
+        highlight_paint = variant_paint(highlight_layer)
         highlight_paint["fill-color"] = _HILLSHADE_HIGHLIGHT_FILL_COLOR
         variants.append(highlight_layer)
 
@@ -3252,10 +3256,9 @@ def _hillshade_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[
             layer.get("filter"),
             ["==", ["get", "class"], "shadow"],
         )
-        high_zoom_shadow_paint = high_zoom_shadow_layer.get("paint")
-        if isinstance(high_zoom_shadow_paint, dict):
-            high_zoom_shadow_paint["fill-color"] = _HILLSHADE_SHADOW_FILL_COLOR
-            variants.append(high_zoom_shadow_layer)
+        high_zoom_shadow_paint = variant_paint(high_zoom_shadow_layer)
+        high_zoom_shadow_paint["fill-color"] = _HILLSHADE_SHADOW_FILL_COLOR
+        variants.append(high_zoom_shadow_layer)
 
         high_zoom_highlight_layer = copy.deepcopy(layer)
         high_zoom_highlight_layer["id"] = f"{_HILLSHADE_LAYER_ID}-highlight-z13-plus"
@@ -3264,10 +3267,9 @@ def _hillshade_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[
             layer.get("filter"),
             ["!=", ["get", "class"], "shadow"],
         )
-        high_zoom_highlight_paint = high_zoom_highlight_layer.get("paint")
-        if isinstance(high_zoom_highlight_paint, dict):
-            high_zoom_highlight_paint["fill-color"] = _HILLSHADE_HIGHLIGHT_FILL_COLOR
-            variants.append(high_zoom_highlight_layer)
+        high_zoom_highlight_paint = variant_paint(high_zoom_highlight_layer)
+        high_zoom_highlight_paint["fill-color"] = _HILLSHADE_HIGHLIGHT_FILL_COLOR
+        variants.append(high_zoom_highlight_layer)
 
     return variants or None
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2218,6 +2218,8 @@ def _hillshade_base_layer_id(layer_id: object) -> str | None:
         f"{_HILLSHADE_LAYER_ID}-shadow",
         f"{_HILLSHADE_LAYER_ID}-highlight",
         f"{_HILLSHADE_LAYER_ID}-z13-plus",
+        f"{_HILLSHADE_LAYER_ID}-shadow-z13-plus",
+        f"{_HILLSHADE_LAYER_ID}-highlight-z13-plus",
     }:
         return _HILLSHADE_LAYER_ID
     return None
@@ -3243,13 +3245,29 @@ def _hillshade_fill_color_layer_variants(layer: dict[str, object]) -> list[dict[
         None,
     )
     if high_zoom_band is not None:
-        high_zoom_layer = copy.deepcopy(layer)
-        high_zoom_layer["id"] = f"{_HILLSHADE_LAYER_ID}-z13-plus"
-        _set_zoom_bounds(high_zoom_layer, *high_zoom_band)
-        high_zoom_paint = high_zoom_layer["paint"]
-        assert isinstance(high_zoom_paint, dict)
-        high_zoom_paint["fill-color"] = _HILLSHADE_HIGHLIGHT_FILL_COLOR
-        variants.append(high_zoom_layer)
+        high_zoom_shadow_layer = copy.deepcopy(layer)
+        high_zoom_shadow_layer["id"] = f"{_HILLSHADE_LAYER_ID}-shadow-z13-plus"
+        _set_zoom_bounds(high_zoom_shadow_layer, *high_zoom_band)
+        high_zoom_shadow_layer["filter"] = _with_additional_filter_clauses(
+            layer.get("filter"),
+            ["==", ["get", "class"], "shadow"],
+        )
+        high_zoom_shadow_paint = high_zoom_shadow_layer.get("paint")
+        if isinstance(high_zoom_shadow_paint, dict):
+            high_zoom_shadow_paint["fill-color"] = _HILLSHADE_SHADOW_FILL_COLOR
+            variants.append(high_zoom_shadow_layer)
+
+        high_zoom_highlight_layer = copy.deepcopy(layer)
+        high_zoom_highlight_layer["id"] = f"{_HILLSHADE_LAYER_ID}-highlight-z13-plus"
+        _set_zoom_bounds(high_zoom_highlight_layer, *high_zoom_band)
+        high_zoom_highlight_layer["filter"] = _with_additional_filter_clauses(
+            layer.get("filter"),
+            ["!=", ["get", "class"], "shadow"],
+        )
+        high_zoom_highlight_paint = high_zoom_highlight_layer.get("paint")
+        if isinstance(high_zoom_highlight_paint, dict):
+            high_zoom_highlight_paint["fill-color"] = _HILLSHADE_HIGHLIGHT_FILL_COLOR
+            variants.append(high_zoom_highlight_layer)
 
     return variants or None
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2807,25 +2807,36 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(
             [layer["id"] for layer in result["layers"]],
-            ["hillshade-shadow", "hillshade-highlight", "hillshade-z13-plus"],
+            [
+                "hillshade-shadow",
+                "hillshade-highlight",
+                "hillshade-shadow-z13-plus",
+                "hillshade-highlight-z13-plus",
+            ],
         )
         by_id = {layer["id"]: layer for layer in result["layers"]}
         shadow = by_id["hillshade-shadow"]
         highlight = by_id["hillshade-highlight"]
-        high_zoom = by_id["hillshade-z13-plus"]
+        high_zoom_shadow = by_id["hillshade-shadow-z13-plus"]
+        high_zoom_highlight = by_id["hillshade-highlight-z13-plus"]
         self.assertEqual(shadow["minzoom"], 0)
         self.assertEqual(shadow["maxzoom"], 13.0)
         self.assertEqual(highlight["minzoom"], 11.0)
         self.assertEqual(highlight["maxzoom"], 13.0)
-        self.assertEqual(high_zoom["minzoom"], 13.0)
-        self.assertEqual(high_zoom["maxzoom"], 16)
+        self.assertEqual(high_zoom_shadow["minzoom"], 13.0)
+        self.assertEqual(high_zoom_shadow["maxzoom"], 16)
+        self.assertEqual(high_zoom_highlight["minzoom"], 13.0)
+        self.assertEqual(high_zoom_highlight["maxzoom"], 16)
         self.assertEqual(shadow["paint"]["fill-color"], "hsla(66, 38%, 17%, 0.08)")
         self.assertEqual(highlight["paint"]["fill-color"], "hsla(60, 20%, 95%, 0.14)")
-        self.assertEqual(high_zoom["paint"]["fill-color"], "hsla(60, 20%, 95%, 0.14)")
+        self.assertEqual(high_zoom_shadow["paint"]["fill-color"], "hsla(66, 38%, 17%, 0.08)")
+        self.assertEqual(high_zoom_highlight["paint"]["fill-color"], "hsla(60, 20%, 95%, 0.14)")
         self.assertIn(["==", ["get", "class"], "shadow"], shadow["filter"])
         self.assertIn(["!=", ["get", "class"], "shadow"], highlight["filter"])
+        self.assertIn(["==", ["get", "class"], "shadow"], high_zoom_shadow["filter"])
+        self.assertIn(["!=", ["get", "class"], "shadow"], high_zoom_highlight["filter"])
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("hillshade-z13-plus"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("hillshade-shadow-z13-plus"),
             "hillshade",
         )
 
@@ -2861,7 +2872,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "hillshade")
         self.assertEqual(result[2]["id"], "hillshade-shadow")
         self.assertEqual(result[3]["id"], "hillshade-highlight")
-        self.assertEqual(result[4]["id"], "hillshade-z13-plus")
+        self.assertEqual(result[4]["id"], "hillshade-shadow-z13-plus")
+        self.assertEqual(result[5]["id"], "hillshade-highlight-z13-plus")
 
     def _landcover_layer(self, fill_opacity=None):
         if fill_opacity is None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2839,6 +2839,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config.base_mapbox_style_layer_id_for_qfit("hillshade-shadow-z13-plus"),
             "hillshade",
         )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("hillshade-highlight-z13-plus"),
+            "hillshade",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("hillshade-z13-plus"),
+            "hillshade",
+        )
 
     def test_hillshade_fill_color_skips_highlight_when_not_visible(self):
         style = {"layers": [self._hillshade_layer(maxzoom=10)]}


### PR DESCRIPTION
## Summary

Refs #949.

This preserves Mapbox Outdoors hillshade shadows above z13 instead of collapsing the high-zoom hillshade layer into the highlight color. The simplified QGIS style now emits separate high-zoom shadow and highlight layers:

- `hillshade-shadow-z13-plus`
- `hillshade-highlight-z13-plus`

The existing lower-zoom split remains unchanged, and the legacy `hillshade-z13-plus` base-layer mapping stays recognized for compatibility.

## Evidence

Root cause: after the earlier hillshade split, the z13+ fallback layer was unfiltered and used the highlight fill color for every hillshade class. In alpine z14 views this washed out the terrain relief relative to Mapbox GL.

Live comparison artifacts generated with the local Mapbox token source, without printing or committing the token:

- Chamonix single probe: `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260517T102722Z/`
- Full camera matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260517T102844Z/summary.json`

Full-matrix metric deltas versus the post-#1101 baseline at `20260517T092623Z`:

| Camera | Changed delta | Mean delta | RMS delta |
| --- | ---: | ---: | ---: |
| `switzerland-alps-z5-outdoors` | +0.000000000000 | +0.000000000000 | +0.000000000000 |
| `valais-geneva-outdoors` | +0.000000000000 | +0.000000000000 | +0.000000000000 |
| `lausanne-lavaux-z10-outdoors` | +0.000007812500 | +0.000113525781 | +0.000252716281 |
| `geneva-airport-motorway-z14-outdoors` | -0.000181423611 | -0.000250887346 | -0.000140682002 |
| `chamonix-trails-z14-outdoors` | -0.000907118056 | -0.053282263299 | -0.054095554584 |
| `zermatt-trails-z18-outdoors` | +0.000000868056 | -0.000010349719 | -0.000014986035 |

Visual audit: Chamonix terrain becomes more dimensional and closer to the Mapbox GL reference; trails, labels, and Geneva urban readability remain acceptable. The only material movement is the intended alpine high-zoom terrain improvement.

## Validation

- `python3 -m pytest tests/ -x -q --tb=short`  
  `2117 passed, 166 skipped, 153 subtests passed`
- `git diff --check`
- `python3 scripts/run_plugin_security_scan.py --allow-findings` through a temporary scanner venv matching the GitHub workflow packages
  - `detect-secrets`: clean
  - `bandit` / `flake8`: reported existing packaged-plugin findings under the workflow's allow-findings mode; this patch does not add new high-zoom hillshade assert findings
