### PR TITLE
[codex] split motorway trunk colors from z6

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -588,7 +588,7 @@ _ROAD_CLASS_LINE_COLOR_SUFFIXES = tuple(
         reverse=True,
     )
 )
-_ROAD_CLASS_LINE_COLOR_MIN_ZOOM = 12.0
+_ROAD_CLASS_LINE_COLOR_MIN_ZOOM = 6.0
 _MAJOR_LINK_WIDTH_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("z12-to-z16", 12.0, 16.0, 14.0),
     ("z16-plus", 16.0, None, 16.0),

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -879,7 +879,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "road-major-link-z12-to-z16")
         self.assertEqual(result[3]["id"], "road-major-link-z16-plus")
 
-    def test_motorway_trunk_line_color_splits_only_at_high_zoom(self):
+    def test_motorway_trunk_line_color_splits_from_z6_up(self):
         line_color = [
             "step",
             ["zoom"],
@@ -924,14 +924,32 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             [
                 "road-motorway-trunk-z3-to-z5",
                 "road-motorway-trunk-z5-to-z6",
-                "road-motorway-trunk-z6-to-z9",
-                "road-motorway-trunk-z9-to-z12",
+                "road-motorway-trunk-z6-to-z9-motorway",
+                "road-motorway-trunk-z6-to-z9-trunk",
+                "road-motorway-trunk-z9-to-z12-motorway",
+                "road-motorway-trunk-z9-to-z12-trunk",
                 "road-motorway-trunk-motorway",
                 "road-motorway-trunk-trunk",
             ],
         )
         self.assertEqual(
-            by_id["road-motorway-trunk-z6-to-z9"]["paint"]["line-color"],
+            by_id["road-motorway-trunk-z5-to-z6"]["paint"]["line-color"],
+            "hsl(35, 89%, 75%)",
+        )
+        self.assertEqual(
+            by_id["road-motorway-trunk-z6-to-z9-motorway"]["paint"]["line-color"],
+            "hsl(15, 88%, 69%)",
+        )
+        self.assertEqual(
+            by_id["road-motorway-trunk-z6-to-z9-trunk"]["paint"]["line-color"],
+            "hsl(35, 81%, 59%)",
+        )
+        self.assertEqual(
+            by_id["road-motorway-trunk-z9-to-z12-motorway"]["paint"]["line-color"],
+            "hsl(15, 100%, 75%)",
+        )
+        self.assertEqual(
+            by_id["road-motorway-trunk-z9-to-z12-trunk"]["paint"]["line-color"],
             "hsl(35, 89%, 75%)",
         )
         self.assertEqual(
@@ -942,9 +960,13 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             by_id["road-motorway-trunk-trunk"]["paint"]["line-color"],
             "hsl(35, 89%, 75%)",
         )
+        self.assertIn(
+            ["==", ["get", "class"], "motorway"],
+            by_id["road-motorway-trunk-z6-to-z9-motorway"]["filter"],
+        )
         self.assertIn(["==", ["get", "class"], "motorway"], by_id["road-motorway-trunk-motorway"]["filter"])
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-motorway-trunk-motorway"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-motorway-trunk-z6-to-z9-motorway"),
             "road-motorway-trunk",
         )
 


### PR DESCRIPTION
## Summary

Refs #949.

This keeps the existing motorway/trunk class-color split, but starts applying it from z6 instead of only from z12+. The z3-z6 broad-map bands stay unchanged so the low-zoom Switzerland view keeps its current balance, while z6+ regional views can preserve Mapbox's motorway/trunk color distinction.

## Evidence

Fresh live style audit on current main before the probe:

- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T110416Z/audit.json`

The audit still shows `road-motorway-trunk` flattening Mapbox's class color expression to the trunk fallback color after qfit preprocessing, while road/trail hierarchy remains one of the larger active #949 gaps.

I first tested splitting from z3; that made the z5 Switzerland view too loud and was rejected visually. This PR keeps the broad z3-z6 bands unchanged and only splits z6+.

Accepted z6+ probe artifacts:

- Full matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260517T110918Z/summary.json`
- Probe style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260517T111131Z/audit.json`

Metric deltas versus the post-#1102 baseline at `debug/mapbox-outdoors-comparison/all-cameras/20260517T102844Z/summary.json`:

| Camera | Changed delta | Mean delta | RMS delta |
| --- | ---: | ---: | ---: |
| `switzerland-alps-z5-outdoors` | +0.000000868056 | +0.000000295025 | +0.000000280654 |
| `valais-geneva-outdoors` | +0.000006944444 | +0.000889556100 | +0.002107814969 |
| `lausanne-lavaux-z10-outdoors` | +0.000052083333 | +0.000071107934 | +0.000102487832 |
| `geneva-airport-motorway-z14-outdoors` | +0.000000000000 | +0.000000000000 | +0.000000000000 |
| `chamonix-trails-z14-outdoors` | +0.000098958333 | +0.000013546206 | +0.000014208906 |
| `zermatt-trails-z18-outdoors` | +0.000000000000 | +0.000000000000 | +0.000000000000 |

Visual read:

- z5 broad Switzerland remains effectively unchanged.
- z8/z10 regional road hierarchy is closer to the Mapbox GL reference because motorway/trunk corridors read as the primary network again.
- Labels remain readable; roads become more prominent but not excessively so.
- z14 alpine/trail views are effectively unchanged for this slice.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q -k 'motorway_trunk_line_color or road_class_line_color or major_link_line_color'`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`
  - `2117 passed, 166 skipped, 153 subtests passed`
- `scripts/run_plugin_security_scan.py --allow-findings` through the local scanner venv
  - `detect-secrets`: clean
  - `bandit` / `flake8`: existing allow-findings reports only
