### PR TITLE
[codex] Preserve high-zoom trail widths

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -630,6 +630,15 @@ _PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, 
     # width relationship instead of clamping both strokes to the same value.
     ("z16-plus", 16.0, None, 17.0),
 )
+_PATH_TRAIL_LINE_WIDTH_LAYER_IDS = {
+    "bridge-path-trail",
+    "road-path-trail",
+    "tunnel-path-trail",
+}
+_PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
+    ("below-z16", None, 16.0, 15.0),
+    ("z16-plus", 16.0, None, 18.0),
+)
 _PATH_BACKGROUND_LINE_COLOR_LAYER_IDS = {
     "bridge-path-bg",
     "road-path-bg",
@@ -2204,17 +2213,38 @@ def _path_background_line_color_base_layer_id(layer_id: object) -> str | None:
     return None
 
 
-def _pedestrian_line_width_base_layer_id(layer_id: object) -> str | None:
+def _line_width_zoom_band_base_layer_id(
+    layer_id: object,
+    *,
+    layer_ids: set[str],
+    zoom_bands: tuple[tuple[str, float | None, float | None, float], ...],
+) -> str | None:
     normalized = str(layer_id or "")
-    if normalized in _PEDESTRIAN_LINE_WIDTH_LAYER_IDS:
+    if normalized in layer_ids:
         return normalized
-    for suffix, _band_minzoom, _band_maxzoom, _target_zoom in _PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS:
+    for suffix, _band_minzoom, _band_maxzoom, _target_zoom in zoom_bands:
         band_suffix = f"-{suffix}"
         if normalized.endswith(band_suffix):
             base_layer_id = normalized[: -len(band_suffix)]
-            if base_layer_id in _PEDESTRIAN_LINE_WIDTH_LAYER_IDS:
+            if base_layer_id in layer_ids:
                 return base_layer_id
     return None
+
+
+def _pedestrian_line_width_base_layer_id(layer_id: object) -> str | None:
+    return _line_width_zoom_band_base_layer_id(
+        layer_id,
+        layer_ids=_PEDESTRIAN_LINE_WIDTH_LAYER_IDS,
+        zoom_bands=_PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS,
+    )
+
+
+def _path_trail_line_width_base_layer_id(layer_id: object) -> str | None:
+    return _line_width_zoom_band_base_layer_id(
+        layer_id,
+        layer_ids=_PATH_TRAIL_LINE_WIDTH_LAYER_IDS,
+        zoom_bands=_PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS,
+    )
 
 
 def _regional_major_road_width_base_layer_id(layer_id: object) -> str | None:
@@ -2295,6 +2325,7 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
         _landcover_fill_opacity_base_layer_id(layer_id),
         _landuse_fill_opacity_base_layer_id(layer_id),
         _path_background_line_color_base_layer_id(layer_id),
+        _path_trail_line_width_base_layer_id(layer_id),
         _pedestrian_line_width_base_layer_id(layer_id),
     ):
         if resolved_layer_id is not None:
@@ -2350,19 +2381,23 @@ def _path_high_zoom_line_width(expr: object, layer_id: object, prop: str, minzoo
     return _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
 
 
-def _pedestrian_line_width_mm(expr: object, target_zoom: float) -> float | None:
+def _line_width_mm_at_zoom(expr: object, target_zoom: float) -> float | None:
     width_px = _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
     if width_px is None:
         return None
     return max(0.1, min(width_px * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM))
 
 
-def _pedestrian_line_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
-    """Split audited pedestrian widths into static QGIS zoom bands."""
+def _line_width_zoom_band_layer_variants(
+    layer: dict[str, object],
+    *,
+    layer_ids: set[str],
+    zoom_bands: tuple[tuple[str, float | None, float | None, float], ...],
+) -> list[dict[str, object]] | None:
     layer_id = str(layer.get("id") or "")
     paint = layer.get("paint")
     if (
-        layer_id not in _PEDESTRIAN_LINE_WIDTH_LAYER_IDS
+        layer_id not in layer_ids
         or layer.get("type") != "line"
         or not isinstance(paint, dict)
     ):
@@ -2374,7 +2409,7 @@ def _pedestrian_line_width_layer_variants(layer: dict[str, object]) -> list[dict
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
     variants: list[dict[str, object]] = []
-    for suffix, band_minzoom, band_maxzoom, target_zoom in _PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS:
+    for suffix, band_minzoom, band_maxzoom, target_zoom in zoom_bands:
         effective_zoom_band = _effective_zoom_band(
             existing_minzoom,
             existing_maxzoom,
@@ -2386,7 +2421,7 @@ def _pedestrian_line_width_layer_variants(layer: dict[str, object]) -> list[dict
         sampled_zoom = _zoom_in_layer_range(target_zoom, *effective_zoom_band)
         if sampled_zoom is None:
             continue
-        line_width_mm = _pedestrian_line_width_mm(line_width, sampled_zoom)
+        line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
         if line_width_mm is None:
             continue
 
@@ -2400,7 +2435,32 @@ def _pedestrian_line_width_layer_variants(layer: dict[str, object]) -> list[dict
     return variants or None
 
 
-def _split_pedestrian_line_width_layers_for_qgis(layers: object) -> object:
+def _path_trail_line_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited hiking trail overlay widths into static QGIS zoom bands."""
+    return _line_width_zoom_band_layer_variants(
+        layer,
+        layer_ids=_PATH_TRAIL_LINE_WIDTH_LAYER_IDS,
+        zoom_bands=_PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS,
+    )
+
+
+def _split_path_trail_line_width_layers_for_qgis(layers: object) -> object:
+    return _split_line_width_zoom_band_layers_for_qgis(
+        layers,
+        variants_for_layer=_path_trail_line_width_layer_variants,
+    )
+
+
+def _pedestrian_line_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited pedestrian widths into static QGIS zoom bands."""
+    return _line_width_zoom_band_layer_variants(
+        layer,
+        layer_ids=_PEDESTRIAN_LINE_WIDTH_LAYER_IDS,
+        zoom_bands=_PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS,
+    )
+
+
+def _split_line_width_zoom_band_layers_for_qgis(layers: object, *, variants_for_layer) -> object:
     if not isinstance(layers, list):
         return layers
     expanded_layers: list[object] = []
@@ -2408,9 +2468,16 @@ def _split_pedestrian_line_width_layers_for_qgis(layers: object) -> object:
         if not isinstance(layer, dict):
             expanded_layers.append(layer)
             continue
-        variants = _pedestrian_line_width_layer_variants(layer)
+        variants = variants_for_layer(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
+
+
+def _split_pedestrian_line_width_layers_for_qgis(layers: object) -> object:
+    return _split_line_width_zoom_band_layers_for_qgis(
+        layers,
+        variants_for_layer=_pedestrian_line_width_layer_variants,
+    )
 
 
 def _regional_major_road_width_scale(layer_id: object) -> float:
@@ -5412,6 +5479,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_path_type_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_background_line_color_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_path_trail_line_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_pedestrian_line_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5007,6 +5007,96 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ],
         )
 
+    def test_path_trail_line_width_splits_high_zoom_widths(self):
+        trail_width = ["interpolate", ["exponential", 1.5], ["zoom"], 15, 1, 18, 4]
+        style = {
+            "layers": [
+                {
+                    "id": "road-path-trail",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-width": copy.deepcopy(trail_width),
+                    },
+                },
+                {
+                    "id": "bridge-path-trail",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {"line-width": copy.deepcopy(trail_width)},
+                },
+                {
+                    "id": "tunnel-path-trail",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {"line-width": copy.deepcopy(trail_width)},
+                },
+                {
+                    "id": "road-minor",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {"line-width": copy.deepcopy(trail_width)},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [
+                "road-path-trail-below-z16",
+                "road-path-trail-z16-plus",
+                "bridge-path-trail-below-z16",
+                "bridge-path-trail-z16-plus",
+                "tunnel-path-trail-below-z16",
+                "tunnel-path-trail-z16-plus",
+                "road-minor",
+            ],
+        )
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 15.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+        )
+        high_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 18.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+        )
+
+        self.assertAlmostEqual(
+            by_id["road-path-trail-below-z16"]["paint"]["line-width"],
+            low_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["road-path-trail-z16-plus"]["paint"]["line-width"],
+            high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-path-trail-z16-plus"]["paint"]["line-width"],
+            high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["tunnel-path-trail-z16-plus"]["paint"]["line-width"],
+            high_width_mm,
+        )
+        self.assertEqual(by_id["road-path-trail-below-z16"]["maxzoom"], 16.0)
+        self.assertEqual(by_id["road-path-trail-z16-plus"]["minzoom"], 16.0)
+        self.assertEqual(by_id["bridge-path-trail-below-z16"]["minzoom"], 14)
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-trail-z16-plus"),
+            "road-path-trail",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("tunnel-path-trail-z16-plus"),
+            "tunnel-path-trail",
+        )
+        self.assertAlmostEqual(
+            by_id["road-minor"]["paint"]["line-width"],
+            low_width_mm,
+        )
+
     def test_pedestrian_line_width_splits_high_zoom_widths(self):
         pedestrian_width = [
             "interpolate",


### PR DESCRIPTION
## Summary

- Split audited Mapbox Outdoors hiking trail overlay layers into static `below-z16` and `z16-plus` QGIS variants.
- Sample z16+ trail overlay widths at z18 so `road-path-trail`, `bridge-path-trail`, and `tunnel-path-trail` keep Mapbox's high-zoom prominence.
- Reuse the high-zoom width helper for pedestrian/trail variants and map generated trail variants back to their original Mapbox layer ids.

Fixes part of #949.

## Evidence

- Live Outdoors style inspection showed the trail overlay layers use `line-width` from 1 px at z15 to 4 px at z18, but qfit previously collapsed them to the low-width 1 px snapshot.
- Focused z18 probe: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260517T120634Z/`.
- Accepted all-camera matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260517T120808Z/summary.json`.

Metric deltas for the accepted matrix versus the post-#1104 baseline `20260517T114239Z`:

| Camera | Changed delta | Mean delta | RMS delta |
| --- | ---: | ---: | ---: |
| `switzerland-alps-z5-outdoors` | +0.000000000000 | +0.000000000000 | +0.000000000000 |
| `valais-geneva-outdoors` | +0.000000000000 | +0.000000000000 | +0.000000000000 |
| `lausanne-lavaux-z10-outdoors` | -0.000007812500 | -0.000110758215 | -0.000248176446 |
| `geneva-airport-motorway-z14-outdoors` | +0.000000000000 | +0.000000000000 | +0.000000000000 |
| `chamonix-trails-z14-outdoors` | -0.000098958333 | -0.000013546206 | -0.000014208906 |
| `zermatt-trails-z18-outdoors` | -0.000010416667 | +0.000008689633 | +0.000011689646 |

Visual read: the wider z18 trail overlay makes hiking/MTB trail markings easier to detect and more Mapbox-like without visibly hurting label readability. z5/z8/Geneva guardrails were unchanged.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -k 'path_trail_line_width or pedestrian_line_width or high_zoom_path_line_width or path_background_line_color or path_type_filters' -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings` (`detect-secrets` clean; existing allow-findings Bandit/Flake8 categories only)
- `python3 validation/mapbox_outdoors_comparison.py --all-cameras --browser-timeout-ms 45000` with the local QGIS-profile Mapbox token source
