### PR TITLE
[codex] Add piste stress comparison camera

### DIFF
--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -72,6 +72,9 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(9.0 <= CAMERAS["lausanne-lavaux-z10-outdoors"].zoom <= 11.0)
         self.assertTrue(14.0 <= CAMERAS["geneva-airport-motorway-z14-outdoors"].zoom <= 14.5)
         self.assertTrue(13.0 <= CAMERAS["chamonix-trails-z14-outdoors"].zoom <= 14.5)
+        self.assertTrue(16.5 <= CAMERAS["zermatt-piste-z17-outdoors"].zoom <= 17.5)
+        self.assertIn("piste", CAMERAS["zermatt-piste-z17-outdoors"].description)
+        self.assertIn("cycleway", CAMERAS["zermatt-piste-z17-outdoors"].description)
         self.assertGreaterEqual(CAMERAS["zermatt-trails-z18-outdoors"].zoom, 18.0)
 
         listed = list_cameras()

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -125,6 +125,18 @@ CAMERAS: dict[str, MapboxComparisonCamera] = {
         width=1280,
         height=900,
     ),
+    "zermatt-piste-z17-outdoors": MapboxComparisonCamera(
+        name="zermatt-piste-z17-outdoors",
+        description=(
+            "z17 Zermatt ski-piste stress target for colored path casings, "
+            "cycleway/piste overlays, and high-zoom outdoor route legibility."
+        ),
+        longitude=7.71664,
+        latitude=46.01270,
+        zoom=17.0,
+        width=1280,
+        height=900,
+    ),
     "zermatt-trails-z18-outdoors": MapboxComparisonCamera(
         name="zermatt-trails-z18-outdoors",
         description=(


### PR DESCRIPTION
## Summary

- Add `zermatt-piste-z17-outdoors` to the Mapbox Outdoors comparison camera matrix.
- Cover the new camera in the comparison-harness zoom-band test so the all-camera matrix keeps a piste/cycleway stress target.
- This follows the #949 research checkpoint where a cycleway/piste width candidate looked plausible in style data but produced pixel-identical QGIS output in a piste-heavy probe.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live all-camera comparison using the local Mapbox token source:
  - `debug/mapbox-outdoors-comparison/all-cameras/20260517T133511Z/summary.md`
  - New camera artifact: `debug/mapbox-outdoors-comparison/zermatt-piste-z17-outdoors/20260517T133505Z/manifest.json`

Refs #949

