### PR TITLE
[codex] Split high-zoom rock landuse color

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1206,6 +1206,7 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ("grass", ["match", ["get", "class"], "grass", True, False], _LANDUSE_AGRICULTURE_FILL_COLOR),
     ("glacier", ["match", ["get", "class"], "glacier", True, False], _LANDUSE_GLACIER_FILL_COLOR),
     ("sand", ["match", ["get", "class"], "sand", True, False], _LANDUSE_SAND_FILL_COLOR),
+    ("rock", ["match", ["get", "class"], "rock", True, False], _LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR),
     (
         "park-special",
         [
@@ -1246,6 +1247,7 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
                 "grass",
                 "glacier",
                 "sand",
+                "rock",
                 "park",
                 "airport",
                 "cemetery",

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1206,7 +1206,8 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ("grass", ["match", ["get", "class"], "grass", True, False], _LANDUSE_AGRICULTURE_FILL_COLOR),
     ("glacier", ["match", ["get", "class"], "glacier", True, False], _LANDUSE_GLACIER_FILL_COLOR),
     ("sand", ["match", ["get", "class"], "sand", True, False], _LANDUSE_SAND_FILL_COLOR),
-    ("rock", ["match", ["get", "class"], "rock", True, False], _LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR),
+    ("rock-low-zoom", ["match", ["get", "class"], "rock", True, False], _LANDUSE_ROCK_FILL_COLOR),
+    ("rock-high-zoom", ["match", ["get", "class"], "rock", True, False], _LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR),
     (
         "park-special",
         [
@@ -1263,6 +1264,11 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
         _LANDUSE_FALLBACK_FILL_COLOR,
     ),
 )
+_LANDUSE_CLASS_FILL_COLOR_VARIANT_ZOOM_BOUNDS = {
+    # Match the live Outdoors z16 rock-color stop without recoloring lower zooms.
+    "rock-low-zoom": (None, 16.0),
+    "rock-high-zoom": (16.0, None),
+}
 _LANDCOVER_CROP_FILL_COLOR = "hsla(68, 55%, 70%, 0.6)"
 _LANDCOVER_FALLBACK_FILL_COLOR = "hsl(98, 48%, 67%)"
 _LANDCOVER_FILL_COLOR_EXPRESSION = [
@@ -3627,9 +3633,24 @@ def _landuse_class_fill_color_layer_variants(layer: dict[str, object]) -> list[d
         return None
 
     variants: list[dict[str, object]] = []
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
     for suffix, class_filter, fill_color in _LANDUSE_CLASS_FILL_COLOR_VARIANTS:
+        band_minzoom, band_maxzoom = _LANDUSE_CLASS_FILL_COLOR_VARIANT_ZOOM_BOUNDS.get(
+            suffix,
+            (None, None),
+        )
+        effective_zoom_band = _effective_zoom_band(
+            existing_minzoom,
+            existing_maxzoom,
+            band_minzoom,
+            band_maxzoom,
+        )
+        if effective_zoom_band is None:
+            continue
         variant = copy.deepcopy(layer)
         variant["id"] = f"{layer_id}-{suffix}"
+        _set_zoom_bounds(variant, *effective_zoom_band)
         variant["filter"] = _with_additional_filter_clauses(layer.get("filter"), class_filter)
         variant_paint = variant["paint"]
         assert isinstance(variant_paint, dict)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3142,7 +3142,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS,
             {"landuse-other-z8-to-z10", "landuse-other-z10-plus"},
         )
-        self.assertEqual(len(result["layers"]), 36)
+        self.assertEqual(len(result["layers"]), 37)
         self.assertIn("landuse-other-below-z8", by_id)
         self.assertNotIn("landuse-other-below-z8-park", by_id)
         stable_class_variants = {
@@ -3152,7 +3152,6 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             "grass": (mapbox_config._LANDUSE_AGRICULTURE_FILL_COLOR, "grass"),
             "glacier": (mapbox_config._LANDUSE_GLACIER_FILL_COLOR, "glacier"),
             "sand": (mapbox_config._LANDUSE_SAND_FILL_COLOR, "sand"),
-            "rock": (mapbox_config._LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR, "rock"),
             "cemetery": (mapbox_config._LANDUSE_CEMETERY_FILL_COLOR, "cemetery"),
             "hospital": (mapbox_config._LANDUSE_HOSPITAL_FILL_COLOR, "hospital"),
             "pitch": (mapbox_config._LANDUSE_PITCH_FILL_COLOR, "pitch"),
@@ -3163,6 +3162,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         park_mid = by_id["landuse-other-z8-to-z10-park"]
         airport_mid = by_id["landuse-other-z8-to-z10-airport"]
         remaining_mid = by_id["landuse-other-z8-to-z10-remaining"]
+        rock_mid = by_id["landuse-other-z8-to-z10-rock-low-zoom"]
+        rock_high_low = by_id["landuse-other-z10-plus-rock-low-zoom"]
+        rock_high = by_id["landuse-other-z10-plus-rock-high-zoom"]
         park_special_high = by_id["landuse-other-z10-plus-park-special"]
         park_high = by_id["landuse-other-z10-plus-park"]
         airport_high = by_id["landuse-other-z10-plus-airport"]
@@ -3175,6 +3177,15 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     natural_layer["filter"][-1],
                     ["match", ["get", "class"], class_filter, True, False],
                 )
+        self.assertNotIn("landuse-other-z8-to-z10-rock-high-zoom", by_id)
+        self.assertEqual(rock_mid["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_FILL_COLOR)
+        self.assertEqual(rock_high_low["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_FILL_COLOR)
+        self.assertEqual(rock_high["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR)
+        for rock_layer in (rock_mid, rock_high_low, rock_high):
+            self.assertEqual(
+                rock_layer["filter"][-1],
+                ["match", ["get", "class"], "rock", True, False],
+            )
         self.assertEqual(park_special_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_SPECIAL_FILL_COLOR)
         self.assertEqual(park_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
         self.assertEqual(airport_mid["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
@@ -3193,6 +3204,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(park_mid["maxzoom"], 10.0)
         self.assertEqual(airport_high["minzoom"], 10.0)
         self.assertNotIn("maxzoom", airport_high)
+        self.assertEqual(rock_mid["minzoom"], 8.0)
+        self.assertEqual(rock_mid["maxzoom"], 10.0)
+        self.assertEqual(rock_high_low["minzoom"], 10.0)
+        self.assertEqual(rock_high_low["maxzoom"], 16.0)
+        self.assertEqual(rock_high["minzoom"], 16.0)
+        self.assertNotIn("maxzoom", rock_high)
         self.assertEqual(
             park_mid["filter"],
             [
@@ -3249,7 +3266,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             "landuse",
         )
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-rock"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-rock-high-zoom"),
             "landuse",
         )
 
@@ -3331,7 +3348,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "landuse-other-z10-plus-grass",
                 "landuse-other-z10-plus-glacier",
                 "landuse-other-z10-plus-sand",
-                "landuse-other-z10-plus-rock",
+                "landuse-other-z10-plus-rock-low-zoom",
+                "landuse-other-z10-plus-rock-high-zoom",
                 "landuse-other-z10-plus-park-special",
                 "landuse-other-z10-plus-park",
                 "landuse-other-z10-plus-airport",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3142,7 +3142,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS,
             {"landuse-other-z8-to-z10", "landuse-other-z10-plus"},
         )
-        self.assertEqual(len(result["layers"]), 34)
+        self.assertEqual(len(result["layers"]), 36)
         self.assertIn("landuse-other-below-z8", by_id)
         self.assertNotIn("landuse-other-below-z8-park", by_id)
         stable_class_variants = {
@@ -3152,6 +3152,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             "grass": (mapbox_config._LANDUSE_AGRICULTURE_FILL_COLOR, "grass"),
             "glacier": (mapbox_config._LANDUSE_GLACIER_FILL_COLOR, "glacier"),
             "sand": (mapbox_config._LANDUSE_SAND_FILL_COLOR, "sand"),
+            "rock": (mapbox_config._LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR, "rock"),
             "cemetery": (mapbox_config._LANDUSE_CEMETERY_FILL_COLOR, "cemetery"),
             "hospital": (mapbox_config._LANDUSE_HOSPITAL_FILL_COLOR, "hospital"),
             "pitch": (mapbox_config._LANDUSE_PITCH_FILL_COLOR, "pitch"),
@@ -3229,6 +3230,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     "grass",
                     "glacier",
                     "sand",
+                    "rock",
                     "park",
                     "airport",
                     "cemetery",
@@ -3244,6 +3246,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-airport"),
+            "landuse",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-rock"),
             "landuse",
         )
 
@@ -3325,6 +3331,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "landuse-other-z10-plus-grass",
                 "landuse-other-z10-plus-glacier",
                 "landuse-other-z10-plus-sand",
+                "landuse-other-z10-plus-rock",
                 "landuse-other-z10-plus-park-special",
                 "landuse-other-z10-plus-park",
                 "landuse-other-z10-plus-airport",


### PR DESCRIPTION
## Summary

- split `rock` landuse into QGIS-safe low/high zoom fill layers at the Mapbox Outdoors z16 color stop
- exclude `rock` from the high-zoom landuse fallback layer so alpine rock does not inherit the olive/tan fallback fill
- update the landuse split tests for the generated rock layers and zoom bounds

## Why

Refs #949.

The live Zermatt piste comparison camera showed broad high-zoom alpine terrain rendering as an olive/tan wash in QGIS while Mapbox GL rendered the same area as pale rocky terrain. A live vector-tile audit found `landuse.class = rock` polygons in that camera, and the existing QGIS split did not include `rock`, so those polygons fell through to `landuse-other-z10-plus-remaining`.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- live Mapbox Outdoors all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260517T141102Z/summary.md`

Metric delta versus the pre-change all-camera matrix at `debug/mapbox-outdoors-comparison/all-cameras/20260517T133511Z/summary.json`:

| camera | NMA delta | RMS delta |
| --- | ---: | ---: |
| switzerland-alps-z5-outdoors | +0.000000 | +0.000000 |
| valais-geneva-outdoors | +0.000000 | +0.000000 |
| lausanne-lavaux-z10-outdoors | -0.000042 | +0.000045 |
| geneva-airport-motorway-z14-outdoors | +0.000000 | +0.000000 |
| chamonix-trails-z14-outdoors | -0.002087 | -0.001656 |
| zermatt-piste-z17-outdoors | -0.100888 | -0.085977 |
| zermatt-trails-z18-outdoors | +0.001927 | +0.000527 |

The new Zermatt piste render is visually closer to Mapbox GL for alpine terrain/landuse. A follow-up Codex review noted the original static split would recolor lower zooms; the current patch preserves the low-zoom rock color below z16 and uses the high-zoom stop at z16+. The small z18 trail-camera metric increase was visually checked and did not show a meaningful terrain/landuse or trail-readability regression. Remaining visible gaps are contour elevation labels, stronger index contour emphasis, and the subtle blue line at left.
