### PR TITLE
[codex] Strengthen high-zoom stream waterway width

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1404,6 +1404,9 @@ _WATERWAY_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], .
     ("z13-to-z16", 13.0, 16.0),
     ("z16-plus", 16.0, None),
 )
+# QGIS renders high-zoom stream-like waterways slightly too faint after the
+# px-to-mm conversion; keep the contrast nudge out of canal/river and shadow.
+_WATERWAY_OTHER_HIGH_ZOOM_QGIS_WIDTH_SCALE = 1.5
 _TURNING_FEATURE_LAYER_ID = "turning-feature"
 _TURNING_FEATURE_OUTLINE_LAYER_ID = "turning-feature-outline"
 _TURNING_FEATURE_CIRCLE_RADIUS_EXPRESSION = [
@@ -4065,6 +4068,12 @@ def _waterway_line_width_layer_variants(layer: dict[str, object]) -> list[dict[s
             if width is None:
                 continue
             line_width, effective_minzoom, effective_maxzoom = width
+            if (
+                base_layer_id == _WATERWAY_LAYER_ID
+                and class_suffix == "other"
+                and band_suffix == "z16-plus"
+            ):
+                line_width *= _WATERWAY_OTHER_HIGH_ZOOM_QGIS_WIDTH_SCALE
             variant = copy.deepcopy(layer)
             variant["id"] = _waterway_line_width_layer_id(layer_id, class_suffix, band_suffix)
             _set_zoom_bounds(variant, effective_minzoom, effective_maxzoom)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4007,7 +4007,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         low_other = by_id["waterway-other-z8-to-z13"]
         mid_major = by_id["waterway-canal-river-z13-to-z16"]
         high_major = by_id["waterway-canal-river-z16-plus"]
+        high_other = by_id["waterway-other-z16-plus"]
         shadow_low_major = by_id["waterway-shadow-z10-to-z13-canal-river"]
+        shadow_high_other = by_id["waterway-shadow-z16-plus-other"]
         self.assertEqual(low_major["minzoom"], 8)
         self.assertEqual(low_major["maxzoom"], 13.0)
         self.assertEqual(mid_major["minzoom"], 13.0)
@@ -4022,7 +4024,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(low_other["paint"]["line-width"], 0.022620108479255864)
         self.assertAlmostEqual(mid_major["paint"]["line-width"], 0.42585675726411115)
         self.assertAlmostEqual(high_major["paint"]["line-width"], 0.6780241671213343)
+        self.assertAlmostEqual(
+            high_other["paint"]["line-width"],
+            0.24743006346379784 * mapbox_config._WATERWAY_OTHER_HIGH_ZOOM_QGIS_WIDTH_SCALE,
+        )
         self.assertAlmostEqual(shadow_low_major["paint"]["line-width"], 0.14095142330582108)
+        self.assertAlmostEqual(shadow_high_other["paint"]["line-width"], 0.24743006346379784)
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("waterway-shadow-z16-plus-other"),
             "waterway-shadow",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4024,10 +4024,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(low_other["paint"]["line-width"], 0.022620108479255864)
         self.assertAlmostEqual(mid_major["paint"]["line-width"], 0.42585675726411115)
         self.assertAlmostEqual(high_major["paint"]["line-width"], 0.6780241671213343)
-        self.assertAlmostEqual(
-            high_other["paint"]["line-width"],
-            0.24743006346379784 * mapbox_config._WATERWAY_OTHER_HIGH_ZOOM_QGIS_WIDTH_SCALE,
-        )
+        self.assertAlmostEqual(high_other["paint"]["line-width"], 0.37114509519569676)
         self.assertAlmostEqual(shadow_low_major["paint"]["line-width"], 0.14095142330582108)
         self.assertAlmostEqual(shadow_high_other["paint"]["line-width"], 0.24743006346379784)
         self.assertEqual(


### PR DESCRIPTION
## Summary

- increase only the high-zoom non-canal/river `waterway` width used by the QGIS vector style approximation
- leave canal/river waterways and `waterway-shadow` widths unchanged
- add regression assertions for the adjusted high-zoom waterway split

## Why

Refs #949.

The remaining Zermatt piste comparison showed a subtle blue line at the left/lower-left that was weaker in QGIS than in the Mapbox GL reference. Layer-disable probes localized that line to `waterway`: removing `waterway` removed the line, while removing `path-bg` and piste foreground layers was pixel-identical to current QGIS.

A QGIS-only probe that scaled `waterway-other-z16-plus` by 1.5 moved the target view slightly closer without affecting nearby path/trail readability.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short -k 'waterway_line_width or aeroway_line_width'`
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- live Mapbox Outdoors all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260517T143914Z/summary.md`

Metric delta versus the post-#1110 matrix at `debug/mapbox-outdoors-comparison/all-cameras/20260517T141102Z/summary.json`:

| camera | NMA delta | RMS delta |
| --- | ---: | ---: |
| switzerland-alps-z5-outdoors | +0.000000 | +0.000000 |
| valais-geneva-outdoors | +0.000000 | +0.000000 |
| lausanne-lavaux-z10-outdoors | +0.000000 | +0.000000 |
| geneva-airport-motorway-z14-outdoors | +0.000000 | +0.000000 |
| chamonix-trails-z14-outdoors | +0.000000 | +0.000000 |
| zermatt-piste-z17-outdoors | -0.000007 | -0.000050 |
| zermatt-trails-z18-outdoors | -0.000012 | -0.000028 |

Visual check: the Zermatt piste blue waterway is slightly stronger and closer to Mapbox GL; surrounding path/trail readability was unchanged. This is intentionally a small approximation nudge, not a contour-label fix.
