### PR TITLE
[codex] Strengthen ferry route line visibility

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -596,6 +596,8 @@ _MAJOR_LINK_WIDTH_MINIMUM_MM_BY_PROP = {
     "line-width": 0.1,
     "line-gap-width": 0.0,
 }
+_FERRY_LINE_LAYER_IDS = {"ferry", "ferry-auto"}
+_FERRY_LINE_QGIS_WIDTH_SCALE = 1.5
 _ROAD_CLASS_LINE_COLOR_VARIANTS_BY_LAYER_ID = {
     "bridge-major-link": (("motorway_link", "motorway-link"), ("trunk_link", "trunk-link")),
     "bridge-major-link-2": (("motorway_link", "motorway-link"), ("trunk_link", "trunk-link")),
@@ -5726,6 +5728,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                     if width is not None:
                         if is_regional_road_width_variant:
                             width *= _regional_major_road_width_scale(layer_id)
+                        if base_layer_id in _FERRY_LINE_LAYER_IDS and prop == "line-width":
+                            # Thin Lake Geneva ferry routes nearly disappear after
+                            # px-to-mm conversion in the z10 comparison camera.
+                            width *= _FERRY_LINE_QGIS_WIDTH_SCALE
                         # Convert px → mm (96 DPI) and clamp to sane range
                         width_mm = width * _MAPBOX_PIXEL_TO_MM
                         if is_regional_road_width_variant and prop == "line-width":

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1847,6 +1847,22 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][3]["paint"]["line-dasharray"], [5, 2])
         self.assertIsInstance(style["layers"][0]["paint"]["line-dasharray"][2], list)
 
+    def test_ferry_line_widths_keep_lake_routes_visible(self):
+        ferry_width = ["interpolate", ["exponential", 1.5], ["zoom"], 14, 0.5, 20, 1]
+        style = {
+            "layers": [
+                {"id": "ferry", "paint": {"line-width": copy.deepcopy(ferry_width)}},
+                {"id": "ferry-auto", "paint": {"line-width": copy.deepcopy(ferry_width)}},
+                {"id": "road-path", "paint": {"line-width": copy.deepcopy(ferry_width)}},
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertAlmostEqual(result["layers"][0]["paint"]["line-width"], 0.1984375)
+        self.assertAlmostEqual(result["layers"][1]["paint"]["line-width"], 0.1984375)
+        self.assertAlmostEqual(result["layers"][2]["paint"]["line-width"], 0.13229166666666667)
+
     def test_data_driven_line_dasharray_expressions_use_safe_literal_fallbacks(self):
         style = {
             "layers": [


### PR DESCRIPTION
## Summary

- scale only Mapbox Outdoors `ferry` and `ferry-auto` line widths by 1.5 in the QGIS style conversion
- keep the existing generic width conversion unchanged for other road/path layers
- add a regression test pinning the ferry width nudge and the unchanged road-path width

## Evidence

The current #949 visual comparison showed Lake Geneva ferry/route lines visible in the Mapbox reference but nearly disappearing in the QGIS render around Lausanne/Lavaux. A narrow probe on `ferry` and `ferry-auto` improved the current Lausanne camera without touching unrelated layer families.

Single-camera probe:
- `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260517T150755Z`
- NMA: `0.045460 -> 0.045336`
- RMS: `0.089577 -> 0.089324`

All-camera probe:
- `debug/mapbox-outdoors-comparison/all-cameras/20260517T150924Z/summary.md`
- lower-zoom Switzerland unchanged
- Lausanne/Lavaux improved by NMA `-0.000126`, RMS `-0.000257`
- no camera regressed numerically

Vision review agreed the candidate makes Lake Geneva ferry lines more readable and closer to the Mapbox reference without crowding nearby roads or labels.

## Validation

- `git diff --check`
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short -k 'ferry_line_widths or regional_major_road or major_link_width or waterway_line_width'`
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949

