### PR TITLE
test: capture QGIS preprocessed style artifact

### DIFF
--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -97,6 +97,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(paths.qgis_png, Path("/tmp/run/qgis-vector-render.png"))
         self.assertEqual(paths.diff_png, Path("/tmp/run/mapbox-gl-vs-qgis-diff.png"))
         self.assertEqual(paths.metrics_json, Path("/tmp/run/metrics.json"))
+        self.assertEqual(paths.qgis_preprocessed_style_json, Path("/tmp/run/qgis-preprocessed-style.json"))
         self.assertEqual(paths.manifest_json, Path("/tmp/run/manifest.json"))
 
     def test_resolve_token_prefers_argument_then_environment(self):
@@ -306,10 +307,13 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             def renderedImage(self):
                 return FakeRenderedImage()
 
+        captured_style = {}
+
         class FakeBackgroundMapService:
             def _apply_mapbox_gl_style(self, layer, style_definition, *, sprite_resources=None):
                 layer.applied_style = style_definition
                 layer.sprite_resources = sprite_resources
+                captured_style["style_definition"] = style_definition
 
         fake_core = types.ModuleType("qgis.core")
         fake_core.QgsApplication = FakeQgsApplication
@@ -330,7 +334,10 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             raise AssertionError("style should be loaded from the provided style JSON")
 
         fake_mapbox_config.fetch_mapbox_style_definition = fail_fetch_style_definition
-        fake_mapbox_config.simplify_mapbox_style_expressions = lambda style: style
+        fake_mapbox_config.simplify_mapbox_style_expressions = lambda style: {
+            **style,
+            "metadata": {"qfit-preprocessed": True, "token": "test-mapbox-token"},
+        }
         fake_mapbox_config.extract_mapbox_vector_source_ids = lambda _style: ["mapbox.mapbox-streets-v8"]
         fake_mapbox_config.build_vector_tile_layer_uri = lambda *_args, **_kwargs: "vector://style"
         fake_mapbox_config.fetch_mapbox_sprite_resources = lambda *_args, **_kwargs: "sprite-resources"
@@ -351,15 +358,23 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             },
         ):
             output_path = Path(tmpdir) / "qgis-vector.png"
+            preprocessed_style_path = Path(tmpdir) / "qgis-preprocessed-style.json"
 
             render_qgis_vector(
                 camera=CAMERAS["valais-geneva-outdoors"],
                 token="test-mapbox-token",
                 output_path=output_path,
                 style_definition=SAMPLE_STYLE,
+                qgis_preprocessed_style_path=preprocessed_style_path,
             )
 
             self.assertEqual(output_path.read_bytes(), PNG_PLACEHOLDER)
+            preprocessed_style_text = preprocessed_style_path.read_text(encoding="utf-8")
+            preprocessed_style = json.loads(preprocessed_style_text)
+
+            self.assertTrue(captured_style["style_definition"]["metadata"]["qfit-preprocessed"])
+            self.assertTrue(preprocessed_style["metadata"]["qfit-preprocessed"])
+            self.assertNotIn("test-mapbox-token", preprocessed_style_text)
 
     def test_headless_qt_platform_defaults_to_offscreen_without_overriding_callers(self):
         from qfit.validation import mapbox_outdoors_comparison
@@ -426,8 +441,9 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         def fake_browser_renderer(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
 
-        def fake_qgis_renderer(*, output_path, **_kwargs):
+        def fake_qgis_renderer(*, output_path, qgis_preprocessed_style_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
+            qgis_preprocessed_style_path.write_text(json.dumps(SAMPLE_STYLE), encoding="utf-8")
 
         def fake_diff_builder(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
@@ -449,18 +465,23 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             manifest_text = result.paths.manifest_json.read_text(encoding="utf-8")
             manifest = json.loads(manifest_text)
             metrics = json.loads(result.paths.metrics_json.read_text(encoding="utf-8"))
+            preprocessed_style = json.loads(result.paths.qgis_preprocessed_style_json.read_text(encoding="utf-8"))
 
         self.assertTrue(result.browser_captured)
         self.assertTrue(result.qgis_captured)
         self.assertTrue(result.diff_captured)
+        self.assertTrue(result.qgis_preprocessed_style_captured)
         self.assertNotIn("test-mapbox-token", manifest_text)
         self.assertEqual(manifest["camera"]["name"], "valais-geneva-outdoors")
         self.assertEqual(manifest["style_url"], "mapbox://styles/mapbox/outdoors-v12")
         self.assertTrue(manifest["captured"]["browser_reference"])
         self.assertTrue(manifest["captured"]["qgis_vector_render"])
         self.assertTrue(manifest["captured"]["diff"])
+        self.assertTrue(manifest["captured"]["qgis_preprocessed_style"])
+        self.assertTrue(manifest["outputs"]["qgis_preprocessed_style"].endswith("qgis-preprocessed-style.json"))
         self.assertEqual(manifest["metrics"]["changed_pixel_ratio"], 0.25)
         self.assertEqual(metrics["changed_pixel_ratio"], 0.25)
+        self.assertEqual(preprocessed_style, SAMPLE_STYLE)
 
     def test_run_comparison_passes_downloaded_style_json_to_renderers(self):
         captured_style_definitions = []

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -159,6 +159,7 @@ class ComparisonPaths:
     qgis_png: Path
     diff_png: Path
     metrics_json: Path
+    qgis_preprocessed_style_json: Path
     manifest_json: Path
 
 
@@ -181,6 +182,7 @@ class ComparisonResult:
     browser_captured: bool
     qgis_captured: bool
     diff_captured: bool
+    qgis_preprocessed_style_captured: bool = False
     image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
     style_json_path: str | None = None
 
@@ -205,6 +207,7 @@ def build_comparison_paths(*, run_dir: Path) -> ComparisonPaths:
         qgis_png=run_dir / "qgis-vector-render.png",
         diff_png=run_dir / "mapbox-gl-vs-qgis-diff.png",
         metrics_json=run_dir / "metrics.json",
+        qgis_preprocessed_style_json=run_dir / "qgis-preprocessed-style.json",
         manifest_json=run_dir / "manifest.json",
     )
 
@@ -279,12 +282,14 @@ def _redacted_manifest(
             "qgis_vector_render": str(result.paths.qgis_png),
             "diff": str(result.paths.diff_png),
             "metrics": str(result.paths.metrics_json),
+            "qgis_preprocessed_style": str(result.paths.qgis_preprocessed_style_json),
         },
         "style_json_path": result.style_json_path,
         "captured": {
             "browser_reference": result.browser_captured,
             "qgis_vector_render": result.qgis_captured,
             "diff": result.diff_captured,
+            "qgis_preprocessed_style": result.qgis_preprocessed_style_captured,
         },
         "metrics": result.image_metrics,
         "notes": [
@@ -497,6 +502,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     token: str,
     output_path: Path,
     style_definition: dict[str, object] | None = None,
+    qgis_preprocessed_style_path: Path | None = None,
 ) -> None:
     _ensure_package_parent_on_path()
     _ensure_headless_qt_platform()
@@ -540,6 +546,11 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
             else fetch_mapbox_style_definition(token, camera.style_owner, camera.style_id)
         )
         simplified_style = simplify_mapbox_style_expressions(resolved_style_definition)
+        if qgis_preprocessed_style_path is not None:
+            qgis_preprocessed_style_path.write_text(
+                redact_sensitive_text(json.dumps(simplified_style, indent=2), token) + "\n",
+                encoding="utf-8",
+            )
         sprite_resources = None
         try:
             sprite_resources = fetch_mapbox_sprite_resources(
@@ -656,6 +667,7 @@ def run_comparison(
     browser_captured = False
     qgis_captured = False
     diff_captured = False
+    qgis_preprocessed_style_captured = False
     image_metrics: ImageMetrics = {}
     style_definition = (
         load_style_definition(config.style_json_path)
@@ -679,8 +691,10 @@ def run_comparison(
             token=config.token,
             output_path=paths.qgis_png,
             style_definition=style_definition,
+            qgis_preprocessed_style_path=paths.qgis_preprocessed_style_json,
         )
         qgis_captured = True
+        qgis_preprocessed_style_captured = paths.qgis_preprocessed_style_json.exists()
 
     if config.diff and browser_captured and qgis_captured:
         image_metrics = diff_builder(
@@ -696,6 +710,7 @@ def run_comparison(
         browser_captured=browser_captured,
         qgis_captured=qgis_captured,
         diff_captured=diff_captured,
+        qgis_preprocessed_style_captured=qgis_preprocessed_style_captured,
         image_metrics=image_metrics,
         style_json_path=str(config.style_json_path) if config.style_json_path is not None else None,
     )


### PR DESCRIPTION
## Summary

- write the qfit-preprocessed QGIS style JSON into each Mapbox Outdoors comparison run
- include the new style artifact path and captured flag in the redacted manifest
- cover the artifact path, redaction, and manifest behavior in the comparison harness tests

## Validation

- python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- Live Geneva airport comparison with the local QGIS-profile Mapbox token:
  - debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T153343Z
  - manifest captured qgis_preprocessed_style: true
  - artifact: qgis-preprocessed-style.json
  - NMA 0.062498071, RMS 0.115550465
  - verified the manifest and preprocessed-style artifact do not contain the local token

## Notes

This is a validation-aid slice for #949. It does not change the rendered style output; it records the exact qfit-preprocessed style handed to QGIS so future parity probes can distinguish converter changes from QGIS renderer behavior.
