### PR TITLE
fix: soften low-zoom admin boundary halos

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -219,6 +219,9 @@ _ROAD_NUMBER_SHIELD_POINT_TO_LINE_FILTER_EXPRESSION = [
 _ROAD_EXIT_SHIELD_LAYER_ID = "road-exit-shield"
 _ROAD_EXIT_SHIELD_ICON_IMAGE = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
 _BOUNDARY_BG_LINE_OPACITY_LAYER_IDS = {"admin-0-boundary-bg", "admin-1-boundary-bg"}
+# QGIS renders Mapbox's blurred country/admin boundary background too bright in
+# the z5 Switzerland-Alps comparison; keep the nudge limited to that halo layer.
+_BOUNDARY_BG_QGIS_LINE_OPACITY_SCALE = 0.7
 _AIRPORT_LABEL_LAYER_ID = "airport-label"
 _TRANSIT_LABEL_LAYER_ID = "transit-label"
 _TRANSIT_LABEL_STOP_TYPE_EXCLUSION = ["!=", ["get", "stop_type"], "entrance"]
@@ -5506,7 +5509,9 @@ def _boundary_bg_line_opacity(
     if base_layer_id not in _BOUNDARY_BG_LINE_OPACITY_LAYER_IDS or prop != "line-opacity":
         return None
     opacity = _extract_zoom_scalar_size(expr, minzoom=minzoom, maxzoom=maxzoom)
-    return _clamp_opacity_value(opacity)
+    if opacity is None:
+        return None
+    return _clamp_opacity_value(opacity * _BOUNDARY_BG_QGIS_LINE_OPACITY_SCALE)
 
 
 def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> dict[str, object]:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1219,8 +1219,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(result["layers"][0]["paint"]["line-opacity"], 0.5)
-        self.assertEqual(result["layers"][1]["paint"]["line-opacity"], 0.5)
+        self.assertAlmostEqual(result["layers"][0]["paint"]["line-opacity"], 0.35)
+        self.assertAlmostEqual(result["layers"][1]["paint"]["line-opacity"], 0.35)
         self.assertEqual(result["layers"][2]["paint"]["line-opacity"], boundary_opacity)
         self.assertEqual(result["layers"][3]["paint"]["line-opacity"], mixed_opacity)
 


### PR DESCRIPTION
## Summary

- scale QGIS admin boundary background opacity to 70% of the Mapbox scalar value
- keep the change limited to admin-0/admin-1 boundary background halo layers
- update the boundary opacity regression test for the QGIS-adjusted scalar output

## Validation

- python3 -m pytest tests/test_mapbox_config.py -q -k boundary_bg --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- Live single-camera probe: debug/mapbox-outdoors-comparison/switzerland-alps-z5-outdoors/20260517T161641Z
  - boundary-bg opacity changed from 0.5 to 0.35 in qgis-preprocessed-style.json
  - NMA 0.070509755 -> 0.070429145
  - RMS 0.123450915 -> 0.123371595
- Live all-camera probe: debug/mapbox-outdoors-comparison/all-cameras/20260517T161813Z/summary.md
  - Switzerland z5 improved NMA -0.000080610, RMS -0.000079320
  - Lausanne/Lavaux improved NMA -0.000074331, RMS -0.000187869
  - Geneva airport, Zermatt piste, and Zermatt trails unchanged
  - Valais/Geneva and Chamonix had tiny metric regressions; visual review found no obvious regressions and boundary/terrain/road readability remained acceptable
- Vision review of the z5 candidate found the admin boundary halos closer to Mapbox and no obvious road/terrain/label regressions

## Notes

This is a small #949 style parity slice. The raw Mapbox Outdoors style uses a saturated boundary background color; QGIS renders that blurred halo too brightly at low zoom, so this keeps the adjustment scoped to the QGIS-preprocessed admin boundary background opacity.
