### PR TITLE
fix: accept string road number shield reflen

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1757,6 +1757,34 @@ def _road_shield_icon_match(field_name: str, reflen: int) -> list[object]:
     ]
 
 
+def _road_shield_reflen_filter(reflen: int) -> list[object]:
+    return ["match", ["get", "reflen"], reflen, True, str(reflen), True, False]
+
+
+def _road_shield_reflen_range_filter(max_reflen: int) -> list[object]:
+    return [
+        "match",
+        ["get", "reflen"],
+        *(value for reflen in range(1, max_reflen + 1) for value in (reflen, True, str(reflen), True)),
+        False,
+    ]
+
+
+def _road_shield_filter_with_string_reflen_range(filter_value: object) -> object:
+    if not isinstance(filter_value, list):
+        return filter_value
+    if filter_value[:1] == ["<="] and len(filter_value) == 3 and filter_value[1] == ["get", "reflen"]:
+        max_reflen = filter_value[2]
+        if isinstance(max_reflen, int) and not isinstance(max_reflen, bool) and max_reflen > 0:
+            return _road_shield_reflen_range_filter(max_reflen)
+    if filter_value[:1] == ["all"]:
+        return [
+            "all",
+            *(_road_shield_filter_with_string_reflen_range(child) for child in filter_value[1:]),
+        ]
+    return filter_value
+
+
 def _with_additional_filter_clauses(filter_value: object, *clauses: object) -> object:
     filter_copy = copy.deepcopy(filter_value)
     if isinstance(filter_copy, list) and filter_copy[:1] == ["all"]:
@@ -2104,12 +2132,13 @@ def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[st
         return None
 
     variants: list[dict[str, object]] = []
+    base_filter = _road_shield_filter_with_string_reflen_range(layer.get("filter"))
     for reflen in sorted(_ROAD_SHIELD_SPRITE_BASES_BY_REFLEN):
         beta_layer = copy.deepcopy(layer)
         beta_layer["id"] = f"{_ROAD_NUMBER_SHIELD_LAYER_ID}-{reflen}-beta"
         beta_layer["filter"] = _with_additional_filter_clauses(
-            layer.get("filter"),
-            ["==", ["get", "reflen"], reflen],
+            base_filter,
+            _road_shield_reflen_filter(reflen),
             ["has", "shield_beta"],
         )
         beta_layer["layout"]["icon-image"] = _road_shield_icon_match("shield_beta", reflen)
@@ -2118,8 +2147,8 @@ def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[st
         shield_layer = copy.deepcopy(layer)
         shield_layer["id"] = f"{_ROAD_NUMBER_SHIELD_LAYER_ID}-{reflen}"
         shield_layer["filter"] = _with_additional_filter_clauses(
-            layer.get("filter"),
-            ["==", ["get", "reflen"], reflen],
+            base_filter,
+            _road_shield_reflen_filter(reflen),
             ["!", ["has", "shield_beta"]],
         )
         shield_layer["layout"]["icon-image"] = _road_shield_icon_match("shield", reflen)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1700,8 +1700,36 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             [
                 "all",
                 ["has", "reflen"],
-                ["<=", ["get", "reflen"], 6],
-                ["==", ["get", "reflen"], 2],
+                [
+                    "match",
+                    ["get", "reflen"],
+                    1,
+                    True,
+                    "1",
+                    True,
+                    2,
+                    True,
+                    "2",
+                    True,
+                    3,
+                    True,
+                    "3",
+                    True,
+                    4,
+                    True,
+                    "4",
+                    True,
+                    5,
+                    True,
+                    "5",
+                    True,
+                    6,
+                    True,
+                    "6",
+                    True,
+                    False,
+                ],
+                ["match", ["get", "reflen"], 2, True, "2", True, False],
                 ["has", "shield_beta"],
             ],
         )
@@ -1723,7 +1751,13 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(beta_layer["layout"]["icon-image"][-1], "default-2")
 
         shield_layer = result["layers"][2]
-        self.assertEqual(shield_layer["filter"][-2:], [["==", ["get", "reflen"], 2], ["!", ["has", "shield_beta"]]])
+        self.assertEqual(
+            shield_layer["filter"][-2:],
+            [
+                ["match", ["get", "reflen"], 2, True, "2", True, False],
+                ["!", ["has", "shield_beta"]],
+            ],
+        )
         self.assertEqual(shield_layer["layout"]["icon-image"][:2], ["match", ["get", "shield"]])
         self.assertIn("rectangle-yellow-2", shield_layer["layout"]["icon-image"])
         self.assertIn("au-national-highway-3", by_id["road-number-shield-3-beta"]["layout"]["icon-image"])
@@ -1786,8 +1820,43 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(low_layer["maxzoom"], 11.0)
         self.assertEqual(low_layer["layout"]["symbol-placement"], "point")
         self.assertAlmostEqual(low_layer["layout"]["symbol-spacing"], 400.0)
+        self.assertIn(
+            [
+                "match",
+                ["get", "reflen"],
+                1,
+                True,
+                "1",
+                True,
+                2,
+                True,
+                "2",
+                True,
+                3,
+                True,
+                "3",
+                True,
+                4,
+                True,
+                "4",
+                True,
+                5,
+                True,
+                "5",
+                True,
+                6,
+                True,
+                "6",
+                True,
+                False,
+            ],
+            low_layer["filter"],
+        )
         self.assertIn(["==", ["geometry-type"], "Point"], low_layer["filter"])
-        self.assertIn(["==", ["get", "reflen"], 2], low_layer["filter"])
+        self.assertIn(
+            ["match", ["get", "reflen"], 2, True, "2", True, False],
+            low_layer["filter"],
+        )
         self.assertIn(["has", "shield_beta"], low_layer["filter"])
 
         high_layer = by_id["road-number-shield-2-beta-z11-plus"]
@@ -1798,7 +1867,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             466.66666666666663,
         )
         self.assertIn([">", ["get", "len"], 2500], high_layer["filter"])
-        self.assertIn(["==", ["get", "reflen"], 2], high_layer["filter"])
+        self.assertIn(
+            ["match", ["get", "reflen"], 2, True, "2", True, False],
+            high_layer["filter"],
+        )
         self.assertIn(["has", "shield_beta"], high_layer["filter"])
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit(


### PR DESCRIPTION
## Summary

- make generated road-number shield split filters match numeric and string `reflen` values
- keep existing road-number shield sprite/icon matching and point/line zoom splitting behavior unchanged
- update shield regression tests for the new numeric/string split filter shape

## Issue

Part of #949.

After #1116, road-exit shield icon fallback accepts string `reflen` values. This follow-up closes the same type gap in the generated road-number shield split filters, where qfit previously added numeric-only `reflen` equality clauses.

## Visual comparison

- Harness: `python3 validation/mapbox_outdoors_comparison.py geneva-airport-motorway-z14-outdoors`
- Branch artifacts: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T173547Z`
- Baseline artifacts: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T172344Z`
- Result: QGIS render and diff image hashes are byte-identical; metrics unchanged. The preprocessed style now shows `["match", ["get", "reflen"], [2, "2"], true, false]` in generated road-number shield split filters.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q -k 'road_number_shield or road_exit_shield' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
