### PR TITLE
Fix Swiss motorway shield rendering

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1749,9 +1749,14 @@ def _is_road_number_shield_icon_image(expr: object) -> bool:
     )
 
 
-def _road_shield_icon_match(field_name: str, reflen: int) -> list[object]:
+def _road_shield_icon_match(
+    field_name: str,
+    reflen: int,
+    excluded_sprite_bases: Iterable[str] = (),
+) -> list[object]:
     fallback = f"default-{reflen}"
-    values = _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen]
+    excluded = set(excluded_sprite_bases)
+    values = tuple(value for value in _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen] if value not in excluded)
     return [
         "match",
         ["get", field_name],
@@ -1818,6 +1823,11 @@ def _road_shield_literal_icon_layer_variants(
     remaining_layer["filter"] = _with_additional_filter_clauses(
         layer.get("filter"),
         _road_shield_remaining_icon_filter(field_name, literal_bases),
+    )
+    remaining_layer["layout"]["icon-image"] = _road_shield_icon_match(
+        field_name,
+        reflen,
+        literal_bases,
     )
     variants.append(remaining_layer)
     return variants

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -332,6 +332,9 @@ _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN = {
         "tr-motorway",
     ),
 }
+_ROAD_SHIELD_LITERAL_ICON_TEXT_COLORS = {
+    "ch-motorway": "hsl(0, 0%, 100%)",
+}
 
 _BACKGROUND_PRESETS = {
     "Outdoor": {
@@ -1770,6 +1773,56 @@ def _road_shield_reflen_range_filter(max_reflen: int) -> list[object]:
     ]
 
 
+def _road_shield_literal_icon_bases(reflen: int) -> tuple[str, ...]:
+    return tuple(
+        sprite_base
+        for sprite_base in _ROAD_SHIELD_LITERAL_ICON_TEXT_COLORS
+        if sprite_base in _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen]
+    )
+
+
+def _road_shield_literal_icon_filter(field_name: str, sprite_base: str) -> list[object]:
+    return ["==", ["get", field_name], sprite_base]
+
+
+def _road_shield_remaining_icon_filter(field_name: str, sprite_bases: tuple[str, ...]) -> list[object]:
+    return ["match", ["get", field_name], list(sprite_bases), False, True]
+
+
+def _road_shield_literal_icon_layer_variants(
+    layer: dict[str, object],
+    *,
+    field_name: str,
+    reflen: int,
+) -> list[dict[str, object]]:
+    literal_bases = _road_shield_literal_icon_bases(reflen)
+    if not literal_bases:
+        return [layer]
+
+    variants: list[dict[str, object]] = []
+    for sprite_base in literal_bases:
+        literal_layer = copy.deepcopy(layer)
+        literal_layer["id"] = f"{layer['id']}-{sprite_base}-icon"
+        literal_layer["filter"] = _with_additional_filter_clauses(
+            layer.get("filter"),
+            _road_shield_literal_icon_filter(field_name, sprite_base),
+        )
+        literal_layer["layout"]["icon-image"] = f"{sprite_base}-{reflen}"
+        paint = literal_layer.setdefault("paint", {})
+        if isinstance(paint, dict):
+            paint["text-color"] = _ROAD_SHIELD_LITERAL_ICON_TEXT_COLORS[sprite_base]
+        variants.append(literal_layer)
+
+    remaining_layer = copy.deepcopy(layer)
+    remaining_layer["id"] = f"{layer['id']}-remaining-icons"
+    remaining_layer["filter"] = _with_additional_filter_clauses(
+        layer.get("filter"),
+        _road_shield_remaining_icon_filter(field_name, literal_bases),
+    )
+    variants.append(remaining_layer)
+    return variants
+
+
 def _road_shield_filter_with_string_reflen_range(filter_value: object) -> object:
     if not isinstance(filter_value, list):
         return filter_value
@@ -2142,7 +2195,13 @@ def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[st
             ["has", "shield_beta"],
         )
         beta_layer["layout"]["icon-image"] = _road_shield_icon_match("shield_beta", reflen)
-        variants.append(beta_layer)
+        variants.extend(
+            _road_shield_literal_icon_layer_variants(
+                beta_layer,
+                field_name="shield_beta",
+                reflen=reflen,
+            )
+        )
 
         shield_layer = copy.deepcopy(layer)
         shield_layer["id"] = f"{_ROAD_NUMBER_SHIELD_LAYER_ID}-{reflen}"
@@ -2152,7 +2211,13 @@ def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[st
             ["!", ["has", "shield_beta"]],
         )
         shield_layer["layout"]["icon-image"] = _road_shield_icon_match("shield", reflen)
-        variants.append(shield_layer)
+        variants.extend(
+            _road_shield_literal_icon_layer_variants(
+                shield_layer,
+                field_name="shield",
+                reflen=reflen,
+            )
+        )
     return variants
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1680,10 +1680,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             [layer["id"] for layer in result["layers"]],
             [
                 "before",
-                "road-number-shield-2-beta",
-                "road-number-shield-2",
-                "road-number-shield-3-beta",
-                "road-number-shield-3",
+                "road-number-shield-2-beta-ch-motorway-icon",
+                "road-number-shield-2-beta-remaining-icons",
+                "road-number-shield-2-ch-motorway-icon",
+                "road-number-shield-2-remaining-icons",
+                "road-number-shield-3-beta-ch-motorway-icon",
+                "road-number-shield-3-beta-remaining-icons",
+                "road-number-shield-3-ch-motorway-icon",
+                "road-number-shield-3-remaining-icons",
                 "road-number-shield-4-beta",
                 "road-number-shield-4",
                 "road-number-shield-5-beta",
@@ -1694,7 +1698,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ],
         )
         by_id = {layer["id"]: layer for layer in result["layers"]}
-        beta_layer = result["layers"][1]
+        beta_layer = by_id["road-number-shield-2-beta-ch-motorway-icon"]
         self.assertEqual(
             beta_layer["filter"],
             [
@@ -1731,42 +1735,58 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 ],
                 ["match", ["get", "reflen"], 2, True, "2", True, False],
                 ["has", "shield_beta"],
+                ["==", ["get", "shield_beta"], "ch-motorway"],
             ],
         )
         self.assertEqual(beta_layer["layout"]["text-field"], ["get", "ref"])
         self.assertEqual(beta_layer["layout"]["symbol-placement"], "line")
         self.assertAlmostEqual(beta_layer["layout"]["symbol-spacing"], 466.66666666666663)
-        self.assertEqual(beta_layer["layout"]["icon-image"][:2], ["match", ["get", "shield_beta"]])
-        self.assertIn("ch-motorway-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("gr-motorway-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("au-national-highway-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("cl-highway-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("hu-main-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("md-main-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("pk-national-highway-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("qa-main-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("sa-highway-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("th-highway-2", beta_layer["layout"]["icon-image"])
-        self.assertIn("us-highway-2", beta_layer["layout"]["icon-image"])
-        self.assertEqual(beta_layer["layout"]["icon-image"][-1], "default-2")
+        self.assertEqual(beta_layer["layout"]["icon-image"], "ch-motorway-2")
+        self.assertEqual(beta_layer["paint"]["text-color"], "hsl(0, 0%, 100%)")
 
-        shield_layer = result["layers"][2]
+        remaining_beta_layer = by_id["road-number-shield-2-beta-remaining-icons"]
         self.assertEqual(
-            shield_layer["filter"][-2:],
+            remaining_beta_layer["filter"][-2:],
+            [
+                ["has", "shield_beta"],
+                ["match", ["get", "shield_beta"], ["ch-motorway"], False, True],
+            ],
+        )
+        self.assertEqual(
+            remaining_beta_layer["layout"]["icon-image"][:2],
+            ["match", ["get", "shield_beta"]],
+        )
+        self.assertIn("gr-motorway-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("au-national-highway-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("cl-highway-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("hu-main-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("md-main-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("pk-national-highway-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("qa-main-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("sa-highway-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("th-highway-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertIn("us-highway-2", remaining_beta_layer["layout"]["icon-image"])
+        self.assertEqual(remaining_beta_layer["layout"]["icon-image"][-1], "default-2")
+
+        shield_layer = by_id["road-number-shield-2-remaining-icons"]
+        self.assertEqual(
+            shield_layer["filter"][-3:],
             [
                 ["match", ["get", "reflen"], 2, True, "2", True, False],
                 ["!", ["has", "shield_beta"]],
+                ["match", ["get", "shield"], ["ch-motorway"], False, True],
             ],
         )
         self.assertEqual(shield_layer["layout"]["icon-image"][:2], ["match", ["get", "shield"]])
         self.assertIn("rectangle-yellow-2", shield_layer["layout"]["icon-image"])
-        self.assertIn("au-national-highway-3", by_id["road-number-shield-3-beta"]["layout"]["icon-image"])
-        self.assertIn("cl-highway-3", by_id["road-number-shield-3-beta"]["layout"]["icon-image"])
-        self.assertIn("md-main-3", by_id["road-number-shield-3-beta"]["layout"]["icon-image"])
-        self.assertIn("pk-national-highway-3", by_id["road-number-shield-3-beta"]["layout"]["icon-image"])
-        self.assertIn("qa-main-3", by_id["road-number-shield-3-beta"]["layout"]["icon-image"])
-        self.assertIn("sa-highway-3", by_id["road-number-shield-3-beta"]["layout"]["icon-image"])
-        self.assertIn("us-highway-3", by_id["road-number-shield-3-beta"]["layout"]["icon-image"])
+        self.assertEqual(by_id["road-number-shield-3-ch-motorway-icon"]["layout"]["icon-image"], "ch-motorway-3")
+        self.assertIn("au-national-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
+        self.assertIn("cl-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
+        self.assertIn("md-main-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
+        self.assertIn("pk-national-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
+        self.assertIn("qa-main-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
+        self.assertIn("sa-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
+        self.assertIn("us-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
         self.assertIn("md-main-4", by_id["road-number-shield-4-beta"]["layout"]["icon-image"])
         self.assertIn("qa-main-4", by_id["road-number-shield-4-beta"]["layout"]["icon-image"])
         self.assertIn("th-highway-4", by_id["road-number-shield-4-beta"]["layout"]["icon-image"])
@@ -1814,12 +1834,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 20)
+        self.assertEqual(len(result["layers"]), 28)
         by_id = {layer["id"]: layer for layer in result["layers"]}
-        low_layer = by_id["road-number-shield-2-beta-below-z11"]
+        low_layer = by_id["road-number-shield-2-beta-ch-motorway-icon-below-z11"]
         self.assertEqual(low_layer["maxzoom"], 11.0)
         self.assertEqual(low_layer["layout"]["symbol-placement"], "point")
         self.assertAlmostEqual(low_layer["layout"]["symbol-spacing"], 400.0)
+        self.assertEqual(low_layer["layout"]["icon-image"], "ch-motorway-2")
+        self.assertEqual(low_layer["paint"]["text-color"], "hsl(0, 0%, 100%)")
         self.assertIn(
             [
                 "match",
@@ -1858,10 +1880,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             low_layer["filter"],
         )
         self.assertIn(["has", "shield_beta"], low_layer["filter"])
+        self.assertIn(["==", ["get", "shield_beta"], "ch-motorway"], low_layer["filter"])
 
-        high_layer = by_id["road-number-shield-2-beta-z11-plus"]
+        high_layer = by_id["road-number-shield-2-beta-ch-motorway-icon-z11-plus"]
         self.assertEqual(high_layer["minzoom"], 11.0)
         self.assertEqual(high_layer["layout"]["symbol-placement"], "line")
+        self.assertEqual(high_layer["layout"]["icon-image"], "ch-motorway-2")
         self.assertAlmostEqual(
             high_layer["layout"]["symbol-spacing"],
             466.66666666666663,
@@ -1872,9 +1896,19 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             high_layer["filter"],
         )
         self.assertIn(["has", "shield_beta"], high_layer["filter"])
+        self.assertIn(["==", ["get", "shield_beta"], "ch-motorway"], high_layer["filter"])
+        remaining_low_layer = by_id["road-number-shield-2-beta-remaining-icons-below-z11"]
+        self.assertIn(
+            ["match", ["get", "shield_beta"], ["ch-motorway"], False, True],
+            remaining_low_layer["filter"],
+        )
+        self.assertEqual(
+            remaining_low_layer["layout"]["icon-image"][:2],
+            ["match", ["get", "shield_beta"]],
+        )
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit(
-                "road-number-shield-2-beta-below-z11"
+                "road-number-shield-2-beta-ch-motorway-icon-below-z11"
             ),
             "road-number-shield",
         )

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1756,6 +1756,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             remaining_beta_layer["layout"]["icon-image"][:2],
             ["match", ["get", "shield_beta"]],
         )
+        self.assertNotIn("ch-motorway", remaining_beta_layer["layout"]["icon-image"])
+        self.assertNotIn("ch-motorway-2", remaining_beta_layer["layout"]["icon-image"])
         self.assertIn("gr-motorway-2", remaining_beta_layer["layout"]["icon-image"])
         self.assertIn("au-national-highway-2", remaining_beta_layer["layout"]["icon-image"])
         self.assertIn("cl-highway-2", remaining_beta_layer["layout"]["icon-image"])
@@ -1778,8 +1780,18 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ],
         )
         self.assertEqual(shield_layer["layout"]["icon-image"][:2], ["match", ["get", "shield"]])
+        self.assertNotIn("ch-motorway", shield_layer["layout"]["icon-image"])
+        self.assertNotIn("ch-motorway-2", shield_layer["layout"]["icon-image"])
         self.assertIn("rectangle-yellow-2", shield_layer["layout"]["icon-image"])
         self.assertEqual(by_id["road-number-shield-3-ch-motorway-icon"]["layout"]["icon-image"], "ch-motorway-3")
+        self.assertNotIn(
+            "ch-motorway",
+            by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"],
+        )
+        self.assertNotIn(
+            "ch-motorway-3",
+            by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"],
+        )
         self.assertIn("au-national-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
         self.assertIn("cl-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
         self.assertIn("md-main-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -1093,6 +1093,12 @@ def _match_expression_string_outputs(expr: object) -> list[str]:
     return sorted({str(output) for output in outputs if isinstance(output, str)})
 
 
+def _icon_image_string_outputs(expr: object) -> list[str]:
+    if isinstance(expr, str) and expr:
+        return [expr]
+    return _match_expression_string_outputs(expr)
+
+
 def _qfit_road_number_shield_sprite_outputs(simplified_layers: list[dict[str, object]]) -> list[str]:
     outputs: set[str] = set()
     for layer in simplified_layers:
@@ -1101,7 +1107,7 @@ def _qfit_road_number_shield_sprite_outputs(simplified_layers: list[dict[str, ob
         layout = layer.get("layout")
         if not isinstance(layout, dict):
             continue
-        outputs.update(_match_expression_string_outputs(layout.get("icon-image")))
+        outputs.update(_icon_image_string_outputs(layout.get("icon-image")))
     return sorted(outputs)
 
 


### PR DESCRIPTION
## Summary

- split Swiss motorway road-number shields into literal QGIS icon layers
- keep the existing data-driven shield match path for all non-Swiss-motorway shield values
- preserve white motorway shield text and add regression coverage for the generated split filters/layers

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q -k 'road_number_shield or road_exit_shield' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- live `validation/mapbox_outdoors_comparison.py lausanne-lavaux-z10-outdoors` with local Mapbox token
  - candidate artifacts: `debug/mapbox-outdoors-comparison/lausanne-lavaux-z10-outdoors/20260517T182937Z`
  - visual QA: red Swiss motorway shields are closer to Mapbox than the prior generic white boxes, and text remains readable
- live `validation/mapbox_outdoors_comparison.py --all-cameras` with local Mapbox token
  - matrix summary: `debug/mapbox-outdoors-comparison/all-cameras/20260517T183158Z/summary.md`
  - metric deltas vs merged-main matrix `20260517T180139Z`:
    - `valais-geneva-outdoors`: Mean Δ -0.000923354666, RMS Δ -0.003189882584
    - `lausanne-lavaux-z10-outdoors`: Mean Δ -0.000804089506, RMS Δ -0.003066587410
    - `geneva-airport-motorway-z14-outdoors`: Mean Δ -0.000083421841, RMS Δ -0.000350877075
    - unrelated cameras were neutral except tiny z18 live-reference drift

Fixes part of #949.
