### PR TITLE
Fix outdoor trail overlay legibility

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -672,6 +672,7 @@ _PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, 
     ("below-z16", None, 16.0, 15.0),
     ("z16-plus", 16.0, None, 18.0),
 )
+_PATH_TRAIL_LINE_WIDTH_QGIS_SCALE = 1.35
 _PATH_BACKGROUND_LINE_COLOR_LAYER_IDS = {
     "bridge-path-bg",
     "road-path-bg",
@@ -2547,6 +2548,7 @@ def _line_width_zoom_band_layer_variants(
     *,
     layer_ids: set[str],
     zoom_bands: tuple[tuple[str, float | None, float | None, float], ...],
+    line_width_scale: float = 1.0,
 ) -> list[dict[str, object]] | None:
     layer_id = str(layer.get("id") or "")
     paint = layer.get("paint")
@@ -2578,6 +2580,7 @@ def _line_width_zoom_band_layer_variants(
         line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
         if line_width_mm is None:
             continue
+        line_width_mm = max(0.1, min(line_width_mm * line_width_scale, _MAX_LINE_WIDTH_MM))
 
         variant = copy.deepcopy(layer)
         variant["id"] = f"{layer_id}-{suffix}"
@@ -2595,6 +2598,7 @@ def _path_trail_line_width_layer_variants(layer: dict[str, object]) -> list[dict
         layer,
         layer_ids=_PATH_TRAIL_LINE_WIDTH_LAYER_IDS,
         zoom_bands=_PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS,
+        line_width_scale=_PATH_TRAIL_LINE_WIDTH_QGIS_SCALE,
     )
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5263,10 +5263,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         low_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 15.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
+            * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
         )
         high_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 18.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
+            * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
         )
 
         self.assertAlmostEqual(
@@ -5298,7 +5300,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertAlmostEqual(
             by_id["road-minor"]["paint"]["line-width"],
-            low_width_mm,
+            (
+                mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 15.0)
+                * mapbox_config._MAPBOX_PIXEL_TO_MM
+            ),
         )
 
     def test_pedestrian_line_width_splits_high_zoom_widths(self):


### PR DESCRIPTION
## Summary

- scale only Mapbox Outdoors hiking/mountain-bike/trail overlay line widths for QGIS
- leave general path, background/casing, pedestrian, color, dash, and filter handling unchanged
- update the existing trail-width regression test to cover the QGIS scale and unchanged non-trail line widths

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q -k 'path_trail_line_width or path_background_line_color or high_zoom_path_line_width' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- live `validation/mapbox_outdoors_comparison.py chamonix-trails-z14-outdoors` with local Mapbox token
  - candidate artifacts: `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260517T185610Z`
  - Mean Δ improved by `-0.000102235385`; RMS Δ improved by `-0.000275774955` vs `20260517T183145Z`
- live `validation/mapbox_outdoors_comparison.py zermatt-trails-z18-outdoors` with local Mapbox token
  - candidate artifacts: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260517T185616Z`
  - Mean Δ improved by `-0.000018864606`; RMS Δ improved by `-0.000067007126` vs `20260517T183154Z`
- visual QA: trail overlays are modestly more legible in Chamonix and Zermatt without becoming heavy or cluttered

Fixes part of #949.
