### PR TITLE
Fix outdoor contour line width parity

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -4497,8 +4497,8 @@ def _split_water_label_typography_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
-def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
-    """Split audited contour index opacity expressions into static QGIS zoom bands."""
+def _contour_line_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited contour index styling into static QGIS zoom bands."""
     layer_id = str(layer.get("id") or "")
     paint = layer.get("paint")
     if layer_id != _CONTOUR_LINE_LAYER_ID or layer.get("type") != "line" or not isinstance(paint, dict):
@@ -4533,7 +4533,7 @@ def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[
     return variants or None
 
 
-def _split_contour_line_opacity_layers_for_qgis(layers: object) -> object:
+def _split_contour_line_layers_for_qgis(layers: object) -> object:
     if not isinstance(layers, list):
         return layers
     expanded_layers: list[object] = []
@@ -4541,7 +4541,7 @@ def _split_contour_line_opacity_layers_for_qgis(layers: object) -> object:
         if not isinstance(layer, dict):
             expanded_layers.append(layer)
             continue
-        variants = _contour_line_opacity_layer_variants(layer)
+        variants = _contour_line_layer_variants(layer)
         expanded_layers.extend(variants if variants is not None else [layer])
     return expanded_layers
 
@@ -5699,7 +5699,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_turning_feature_circle_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_waterway_label_symbol_spacing_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_water_label_typography_layers_for_qgis(style.get("layers"))
-    style["layers"] = _split_contour_line_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_contour_line_layers_for_qgis(style.get("layers"))
     color_props = {
         "line-color", "fill-color", "fill-outline-color", "circle-color",
         "circle-stroke-color", "text-color", "text-halo-color",

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -4512,12 +4512,10 @@ def _contour_line_layer_variants(layer: dict[str, object]) -> list[dict[str, obj
     paint = layer.get("paint")
     if layer_id != _CONTOUR_LINE_LAYER_ID or layer.get("type") != "line" or not isinstance(paint, dict):
         return None
-    if (
-        paint.get("line-opacity") != _CONTOUR_LINE_OPACITY_EXPRESSION
-        or paint.get("line-width") != _CONTOUR_LINE_WIDTH_EXPRESSION
-    ):
+    if paint.get("line-opacity") != _CONTOUR_LINE_OPACITY_EXPRESSION:
         return None
 
+    should_override_line_width = paint.get("line-width") == _CONTOUR_LINE_WIDTH_EXPRESSION
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
     variants: list[dict[str, object]] = []
@@ -4537,10 +4535,11 @@ def _contour_line_layer_variants(layer: dict[str, object]) -> list[dict[str, obj
         variant_paint = variant["paint"]
         assert isinstance(variant_paint, dict)
         variant_paint["line-opacity"] = line_opacity
-        variant_paint["line-width"] = max(
-            0.1,
-            min(line_width_px * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM),
-        )
+        if should_override_line_width:
+            variant_paint["line-width"] = max(
+                0.1,
+                min(line_width_px * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM),
+            )
         variants.append(variant)
     return variants or None
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1510,6 +1510,15 @@ _CONTOUR_LINE_OPACITY_EXPRESSION = [
     13,
     ["match", ["get", "index"], [1, 2], 0.3, 0.5],
 ]
+_CONTOUR_LINE_WIDTH_EXPRESSION = [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    13,
+    ["match", ["get", "index"], [1, 2], 0.5, 0.6],
+    16,
+    ["match", ["get", "index"], [1, 2], 0.8, 1.2],
+]
 _CONTOUR_LINE_VARIANTS: tuple[
     tuple[str, object, float | None, float | None, float, float],
     ...,
@@ -4503,7 +4512,10 @@ def _contour_line_layer_variants(layer: dict[str, object]) -> list[dict[str, obj
     paint = layer.get("paint")
     if layer_id != _CONTOUR_LINE_LAYER_ID or layer.get("type") != "line" or not isinstance(paint, dict):
         return None
-    if paint.get("line-opacity") != _CONTOUR_LINE_OPACITY_EXPRESSION:
+    if (
+        paint.get("line-opacity") != _CONTOUR_LINE_OPACITY_EXPRESSION
+        or paint.get("line-width") != _CONTOUR_LINE_WIDTH_EXPRESSION
+    ):
         return None
 
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1510,16 +1510,18 @@ _CONTOUR_LINE_OPACITY_EXPRESSION = [
     13,
     ["match", ["get", "index"], [1, 2], 0.3, 0.5],
 ]
-_CONTOUR_LINE_OPACITY_VARIANTS: tuple[
-    tuple[str, object, float | None, float | None, float],
+_CONTOUR_LINE_VARIANTS: tuple[
+    tuple[str, object, float | None, float | None, float, float],
     ...,
 ] = (
-    ("index-minor-below-z11", ["match", ["get", "index"], [1, 2], True, False], None, 11.0, 0.15),
-    ("index-minor-z11-to-z13", ["match", ["get", "index"], [1, 2], True, False], 11.0, 13.0, 0.225),
-    ("index-minor-z13-plus", ["match", ["get", "index"], [1, 2], True, False], 13.0, None, 0.3),
-    ("index-major-below-z11", ["match", ["get", "index"], [1, 2], False, True], None, 11.0, 0.3),
-    ("index-major-z11-to-z13", ["match", ["get", "index"], [1, 2], False, True], 11.0, 13.0, 0.4),
-    ("index-major-z13-plus", ["match", ["get", "index"], [1, 2], False, True], 13.0, None, 0.5),
+    ("index-minor-below-z11", ["match", ["get", "index"], [1, 2], True, False], None, 11.0, 0.15, 0.5),
+    ("index-minor-z11-to-z13", ["match", ["get", "index"], [1, 2], True, False], 11.0, 13.0, 0.225, 0.5),
+    ("index-minor-z13-to-z16", ["match", ["get", "index"], [1, 2], True, False], 13.0, 16.0, 0.3, 0.65),
+    ("index-minor-z16-plus", ["match", ["get", "index"], [1, 2], True, False], 16.0, None, 0.3, 0.8),
+    ("index-major-below-z11", ["match", ["get", "index"], [1, 2], False, True], None, 11.0, 0.3, 0.6),
+    ("index-major-z11-to-z13", ["match", ["get", "index"], [1, 2], False, True], 11.0, 13.0, 0.4, 0.6),
+    ("index-major-z13-to-z16", ["match", ["get", "index"], [1, 2], False, True], 13.0, 16.0, 0.5, 0.9),
+    ("index-major-z16-plus", ["match", ["get", "index"], [1, 2], False, True], 16.0, None, 0.5, 1.2),
 )
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,
@@ -4507,7 +4509,14 @@ def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
     variants: list[dict[str, object]] = []
-    for suffix, index_filter, band_minzoom, band_maxzoom, line_opacity in _CONTOUR_LINE_OPACITY_VARIANTS:
+    for (
+        suffix,
+        index_filter,
+        band_minzoom,
+        band_maxzoom,
+        line_opacity,
+        line_width_px,
+    ) in _CONTOUR_LINE_VARIANTS:
         if _effective_zoom_band(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom) is None:
             continue
         variant = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
@@ -4516,6 +4525,10 @@ def _contour_line_opacity_layer_variants(layer: dict[str, object]) -> list[dict[
         variant_paint = variant["paint"]
         assert isinstance(variant_paint, dict)
         variant_paint["line-opacity"] = line_opacity
+        variant_paint["line-width"] = max(
+            0.1,
+            min(line_width_px * _MAPBOX_PIXEL_TO_MM, _MAX_LINE_WIDTH_MM),
+        )
         variants.append(variant)
     return variants or None
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4580,25 +4580,37 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 4)
+        self.assertEqual(len(result["layers"]), 6)
         by_id = {layer["id"]: layer for layer in result["layers"]}
         minor_fade = by_id["contour-line-index-minor-z11-to-z13"]
-        minor_full = by_id["contour-line-index-minor-z13-plus"]
+        minor_mid = by_id["contour-line-index-minor-z13-to-z16"]
+        minor_full = by_id["contour-line-index-minor-z16-plus"]
         major_fade = by_id["contour-line-index-major-z11-to-z13"]
-        major_full = by_id["contour-line-index-major-z13-plus"]
+        major_mid = by_id["contour-line-index-major-z13-to-z16"]
+        major_full = by_id["contour-line-index-major-z16-plus"]
         self.assertEqual(minor_fade["minzoom"], 11)
         self.assertEqual(minor_fade["maxzoom"], 13.0)
-        self.assertEqual(minor_full["minzoom"], 13.0)
+        self.assertEqual((minor_mid["minzoom"], minor_mid["maxzoom"]), (13.0, 16.0))
+        self.assertEqual(minor_full["minzoom"], 16.0)
         self.assertNotIn("maxzoom", minor_full)
         self.assertEqual(major_fade["minzoom"], 11)
         self.assertEqual(major_fade["maxzoom"], 13.0)
-        self.assertEqual(major_full["minzoom"], 13.0)
+        self.assertEqual((major_mid["minzoom"], major_mid["maxzoom"]), (13.0, 16.0))
+        self.assertEqual(major_full["minzoom"], 16.0)
         self.assertNotIn("maxzoom", major_full)
         self.assertAlmostEqual(minor_fade["paint"]["line-opacity"], 0.225)
+        self.assertAlmostEqual(minor_mid["paint"]["line-opacity"], 0.3)
         self.assertAlmostEqual(minor_full["paint"]["line-opacity"], 0.3)
         self.assertAlmostEqual(major_fade["paint"]["line-opacity"], 0.4)
+        self.assertAlmostEqual(major_mid["paint"]["line-opacity"], 0.5)
         self.assertAlmostEqual(major_full["paint"]["line-opacity"], 0.5)
-        for layer in (minor_fade, minor_full):
+        self.assertAlmostEqual(minor_fade["paint"]["line-width"], 0.5 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(minor_mid["paint"]["line-width"], 0.65 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(minor_full["paint"]["line-width"], 0.8 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(major_fade["paint"]["line-width"], 0.6 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(major_mid["paint"]["line-width"], 0.9 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(major_full["paint"]["line-width"], 1.2 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        for layer in (minor_fade, minor_mid, minor_full):
             self.assertEqual(
                 layer["filter"],
                 [
@@ -4608,7 +4620,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 ],
             )
             self.assertEqual(layer["paint"]["line-color"], "hsl(33, 20%, 50%)")
-        for layer in (major_fade, major_full):
+        for layer in (major_fade, major_mid, major_full):
             self.assertEqual(
                 layer["filter"],
                 [
@@ -4624,7 +4636,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 6)
+        self.assertEqual(len(result["layers"]), 8)
         by_id = {layer["id"]: layer for layer in result["layers"]}
         minor_below = by_id["contour-line-index-minor-below-z11"]
         major_below = by_id["contour-line-index-major-below-z11"]
@@ -4634,6 +4646,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(major_below["maxzoom"], 11.0)
         self.assertAlmostEqual(minor_below["paint"]["line-opacity"], 0.15)
         self.assertAlmostEqual(major_below["paint"]["line-opacity"], 0.3)
+        self.assertAlmostEqual(minor_below["paint"]["line-width"], 0.5 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(major_below["paint"]["line-width"], 0.6 * mapbox_config._MAPBOX_PIXEL_TO_MM)
         self.assertEqual(
             minor_below["filter"],
             [
@@ -4673,9 +4687,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result[0], "not-a-layer")
         self.assertEqual(result[1]["id"], "contour-line-index-minor-z11-to-z13")
-        self.assertEqual(result[2]["id"], "contour-line-index-minor-z13-plus")
-        self.assertEqual(result[3]["id"], "contour-line-index-major-z11-to-z13")
-        self.assertEqual(result[4]["id"], "contour-line-index-major-z13-plus")
+        self.assertEqual(result[2]["id"], "contour-line-index-minor-z13-to-z16")
+        self.assertEqual(result[3]["id"], "contour-line-index-minor-z16-plus")
+        self.assertEqual(result[4]["id"], "contour-line-index-major-z11-to-z13")
+        self.assertEqual(result[5]["id"], "contour-line-index-major-z13-to-z16")
+        self.assertEqual(result[6]["id"], "contour-line-index-major-z16-plus")
 
     def test_filter_simplification_snapshots_terrain_fill_filters(self):
         landuse_filter = [

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4552,7 +4552,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[9]["id"], "water-point-label-other-name-en")
         self.assertEqual(result[10]["id"], "water-point-label-other-name")
 
-    def _contour_line_layer(self, line_opacity=None, minzoom=11):
+    def _contour_line_layer(self, line_opacity=None, line_width=None, minzoom=11):
         if line_opacity is None:
             line_opacity = [
                 "interpolate",
@@ -4563,6 +4563,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 13,
                 ["match", ["get", "index"], [1, 2], 0.3, 0.5],
             ]
+        if line_width is None:
+            line_width = [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                13,
+                ["match", ["get", "index"], [1, 2], 0.5, 0.6],
+                16,
+                ["match", ["get", "index"], [1, 2], 0.8, 1.2],
+            ]
         return {
             "id": "contour-line",
             "type": "line",
@@ -4572,6 +4582,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             "paint": {
                 "line-color": "hsl(33, 20%, 50%)",
                 "line-opacity": line_opacity,
+                "line-width": line_width,
             },
         }
 
@@ -4674,6 +4685,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(len(result["layers"]), 1)
         self.assertEqual(result["layers"][0]["id"], "contour-line")
         self.assertEqual(result["layers"][0]["paint"]["line-opacity"], line_opacity)
+
+    def test_contour_line_width_is_not_overwritten_when_shape_changes(self):
+        line_width = ["interpolate", ["linear"], ["zoom"], 13, 0.25, 16, 0.5]
+        style = {"layers": [self._contour_line_layer(line_width=line_width)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "contour-line")
+        self.assertEqual(result["layers"][0]["paint"]["line-width"], 0.1)
 
     def test_contour_line_helpers_keep_passthrough_inputs(self):
         unchanged_layers = "not-a-layer-list"

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4687,14 +4687,29 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][0]["paint"]["line-opacity"], line_opacity)
 
     def test_contour_line_width_is_not_overwritten_when_shape_changes(self):
-        line_width = ["interpolate", ["linear"], ["zoom"], 13, 0.25, 16, 0.5]
+        line_width = ["interpolate", ["linear"], ["zoom"], 13, 2.0, 16, 2.0]
         style = {"layers": [self._contour_line_layer(line_width=line_width)]}
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 1)
-        self.assertEqual(result["layers"][0]["id"], "contour-line")
-        self.assertEqual(result["layers"][0]["paint"]["line-width"], 0.1)
+        self.assertEqual(len(result["layers"]), 6)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(
+            by_id["contour-line-index-minor-z11-to-z13"]["paint"]["line-opacity"],
+            0.225,
+        )
+        self.assertEqual(
+            by_id["contour-line-index-major-z13-to-z16"]["paint"]["line-opacity"],
+            0.5,
+        )
+        self.assertEqual(
+            by_id["contour-line-index-minor-z11-to-z13"]["paint"]["line-width"],
+            2.0 * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
+        self.assertAlmostEqual(
+            by_id["contour-line-index-major-z16-plus"]["paint"]["line-width"],
+            2.0 * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
 
     def test_contour_line_helpers_keep_passthrough_inputs(self):
         unchanged_layers = "not-a-layer-list"

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4675,15 +4675,15 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][0]["id"], "contour-line")
         self.assertEqual(result["layers"][0]["paint"]["line-opacity"], line_opacity)
 
-    def test_contour_line_opacity_helpers_keep_passthrough_inputs(self):
+    def test_contour_line_helpers_keep_passthrough_inputs(self):
         unchanged_layers = "not-a-layer-list"
         mixed_layers = ["not-a-layer", self._contour_line_layer()]
 
         self.assertIs(
-            mapbox_config._split_contour_line_opacity_layers_for_qgis(unchanged_layers),
+            mapbox_config._split_contour_line_layers_for_qgis(unchanged_layers),
             unchanged_layers,
         )
-        result = mapbox_config._split_contour_line_opacity_layers_for_qgis(mixed_layers)
+        result = mapbox_config._split_contour_line_layers_for_qgis(mixed_layers)
 
         self.assertEqual(result[0], "not-a-layer")
         self.assertEqual(result[1]["id"], "contour-line-index-minor-z11-to-z13")


### PR DESCRIPTION
## Summary
- Split Mapbox Outdoors contour-line preprocessing into minor/major index zoom bands that also carry representative line widths.
- Keep the existing contour opacity behavior, but avoid the generic QGIS line-width simplifier turning all contour variants into ~2 px lines.
- Leave contour labels, terrain colors, roads, trails, and raster mode unchanged.

## Issue
- Part of #949.

## Visual comparison
- Harness: `python3 validation/mapbox_outdoors_comparison.py chamonix-trails-z14-outdoors`
- Candidate artifacts: `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260517T195744Z`
- Baseline artifacts: `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260517T185610Z`
- Metrics: mean Δ improved `-0.001756989833`; RMS Δ improved `-0.000435732944`; changed pixel ratio improved `-0.005148437500`.
- Visual review: candidate reduces over-dense contour texture and improves trail separation without label regressions.

- Harness: `python3 validation/mapbox_outdoors_comparison.py zermatt-trails-z18-outdoors`
- Candidate artifacts: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260517T195752Z`
- Baseline artifacts: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260517T185616Z`
- Metrics: mean Δ moved `+0.000083174473`; RMS Δ moved `+0.000133428040`; visual review found the change effectively neutral at this urban zoom.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q -k 'contour_line_opacity' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
