### PR TITLE
Sample low-zoom Mapbox path widths

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -648,6 +648,8 @@ _PATH_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES = (
     "bridge-path-bg-z16-plus",
 )
 _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 18.0
+_PATH_LOW_ZOOM_LINE_WIDTH_LAYER_PREFIXES = ("road-path-below-z16",)
+_PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 14.0
 _PEDESTRIAN_LINE_WIDTH_LAYER_IDS = {
     "bridge-pedestrian",
     "bridge-pedestrian-case",
@@ -2538,10 +2540,27 @@ def _should_sample_path_high_zoom_line_width(layer_id: object, prop: str, minzoo
     )
 
 
-def _path_high_zoom_line_width(expr: object, layer_id: object, prop: str, minzoom: object, maxzoom: object) -> float | None:
-    if not _should_sample_path_high_zoom_line_width(layer_id, prop, minzoom):
+def _should_sample_path_low_zoom_line_width(layer_id: object, prop: str, maxzoom: object) -> bool:
+    if prop != "line-width":
+        return False
+    normalized = str(layer_id or "")
+    if any(
+        normalized == prefix or normalized.startswith(f"{prefix}-")
+        for prefix in _PATH_LOW_ZOOM_LINE_WIDTH_LAYER_PREFIXES
+    ):
+        return True
+    layer_maxzoom = _numeric_zoom_bound(maxzoom)
+    return normalized == "road-path" and layer_maxzoom is not None and layer_maxzoom <= _PATH_TYPE_FILTER_SPLIT_ZOOM
+
+
+def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: object, maxzoom: object) -> float | None:
+    if _should_sample_path_low_zoom_line_width(layer_id, prop, maxzoom):
+        target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+    elif _should_sample_path_high_zoom_line_width(layer_id, prop, minzoom):
+        target_sample_zoom = _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+    else:
         return None
-    target_zoom = _zoom_in_layer_range(_PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM, minzoom, maxzoom)
+    target_zoom = _zoom_in_layer_range(target_sample_zoom, minzoom, maxzoom)
     if target_zoom is None:
         return None
     return _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
@@ -5852,7 +5871,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         props[prop] = fallback
                 elif prop in _WIDTH_PROPS:
                     width = None
-                    width = _path_high_zoom_line_width(
+                    width = _path_split_line_width(
                         val,
                         layer_id,
                         prop,

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5123,7 +5123,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[3]["id"], "bridge-path-bg-below-z16-outdoor")
         self.assertEqual(result[4]["id"], "bridge-path-bg-below-z16-remaining")
 
-    def test_high_zoom_path_line_width_uses_split_zoom_band(self):
+    def test_path_line_width_uses_split_zoom_band_samples(self):
         path_filter = [
             "all",
             ["==", ["get", "class"], "path"],
@@ -5143,6 +5143,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     "id": "road-path",
                     "type": "line",
                     "minzoom": 12,
+                    "filter": copy.deepcopy(path_filter),
+                    "paint": {"line-width": copy.deepcopy(line_width)},
+                },
+                {
+                    "id": "road-path",
+                    "type": "line",
+                    "minzoom": 12,
+                    "maxzoom": 15,
                     "filter": copy.deepcopy(path_filter),
                     "paint": {"line-width": copy.deepcopy(line_width)},
                 },
@@ -5179,8 +5187,13 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
         low_width_mm = 1 * mapbox_config._MAPBOX_PIXEL_TO_MM
+        path_core_low_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(line_width, 14.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+        )
         high_width_mm = 7 * mapbox_config._MAPBOX_PIXEL_TO_MM
-        self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], low_width_mm)
+        self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], path_core_low_width_mm)
+        self.assertAlmostEqual(by_id["road-path"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path-z16-plus"]["paint"]["line-width"], high_width_mm)
         self.assertAlmostEqual(by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"], low_width_mm)
         self.assertAlmostEqual(by_id["road-path-bg-z16-plus-outdoor"]["paint"]["line-width"], high_width_mm)


### PR DESCRIPTION
## Summary
- Sample `road-path-below-z16` line width at z14 so low-zoom path cores do not collapse to the z13 hairline.
- Keep path casing/background and z16+ path width sampling unchanged.
- Update Mapbox preprocessing coverage for the low-zoom path core width.

## Evidence
- Chamonix z13.75 live comparison improved mean absolute delta from `8.89377` to `8.83784` and RMS from `20.92092` to `20.77255`.
- Zermatt z18 live comparison remained safe, with mean absolute delta from `8.09921` to `8.09340` and RMS from `22.22941` to `22.20607`.
- Visual audit of the Chamonix artifacts found the wider path core closer to Mapbox GL without obvious over-wide or over-bright paths.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q -k 'path_line_width or path_type_filters or path_background_line_color or path_trail_line_width' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short` (`2122 passed, 166 skipped, 153 subtests passed`)

Refs #949
