### PR TITLE
Improve Mapbox aeroway line contrast

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -5808,6 +5808,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                 # QGIS renders Mapbox's airport aeroway fill too close to the
                 # surrounding airport landuse in the Geneva z14 comparison.
                 paint["fill-color"] = _AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR
+        if base_layer_id == _AEROWAY_LINE_LAYER_ID and layer.get("type") == "line":
+            paint = layer.get("paint")
+            if isinstance(paint, dict) and paint.get("line-color") == _AEROWAY_POLYGON_FILL_COLOR:
+                paint["line-color"] = _AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR
 
         for section in ("paint", "layout"):
             props = layer.get(section)

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1377,6 +1377,8 @@ _AEROWAY_POLYGON_LAYER_ID = "aeroway-polygon"
 _AEROWAY_POLYGON_FILL_COLOR = "hsl(230, 36%, 74%)"
 _AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR = "hsl(230, 36%, 70%)"
 _AEROWAY_LINE_LAYER_ID = "aeroway-line"
+_AEROWAY_LINE_COLOR = "hsl(230, 36%, 74%)"
+_AEROWAY_LINE_QGIS_CONTRAST_COLOR = "hsl(230, 36%, 70%)"
 _AEROWAY_LINE_WIDTH_EXPRESSION = [
     "interpolate",
     ["exponential", 1.5],
@@ -5810,8 +5812,10 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                 paint["fill-color"] = _AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR
         if base_layer_id == _AEROWAY_LINE_LAYER_ID and layer.get("type") == "line":
             paint = layer.get("paint")
-            if isinstance(paint, dict) and paint.get("line-color") == _AEROWAY_POLYGON_FILL_COLOR:
-                paint["line-color"] = _AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR
+            if isinstance(paint, dict) and paint.get("line-color") == _AEROWAY_LINE_COLOR:
+                # QGIS renders the audited Outdoors aeroway stroke too washed
+                # out against airport landuse in the Geneva z14 comparison.
+                paint["line-color"] = _AEROWAY_LINE_QGIS_CONTRAST_COLOR
 
         for section in ("paint", "layout"):
             props = layer.get(section)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3996,7 +3996,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "water-shadow-z13-to-z16")
         self.assertEqual(result[3]["id"], "water-shadow-z16-plus")
 
-    def _aeroway_line_layer(self, line_width=None, line_color="hsl(230, 24%, 87%)"):
+    def _aeroway_line_layer(self, line_width=None, line_color=mapbox_config._AEROWAY_LINE_COLOR):
         if line_width is None:
             line_width = copy.deepcopy(mapbox_config._AEROWAY_LINE_WIDTH_EXPRESSION)
         return {
@@ -4049,6 +4049,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(mid_other["paint"]["line-width"], 1.5640310125536836)
         self.assertAlmostEqual(high_runway["paint"]["line-width"], 3.0)
         self.assertAlmostEqual(high_other["paint"]["line-width"], 2.3487964134195747)
+        for layer in by_id.values():
+            self.assertEqual(
+                layer["paint"]["line-color"],
+                mapbox_config._AEROWAY_LINE_QGIS_CONTRAST_COLOR,
+            )
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("aeroway-line-other-z16-plus"),
             "aeroway-line",
@@ -4066,8 +4071,17 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         for layer in result["layers"]:
             self.assertEqual(
                 layer["paint"]["line-color"],
-                mapbox_config._AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR,
+                mapbox_config._AEROWAY_LINE_QGIS_CONTRAST_COLOR,
             )
+
+    def test_aeroway_line_color_leaves_non_matching_color_unchanged(self):
+        line_color = "hsl(230, 24%, 87%)"
+        style = {"layers": [self._aeroway_line_layer(line_color=line_color)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        for layer in result["layers"]:
+            self.assertEqual(layer["paint"]["line-color"], line_color)
 
     def test_aeroway_line_width_is_not_split_when_shape_changes(self):
         line_width = ["interpolate", ["linear"], ["zoom"], 9, 0.5, 18, 20]

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3996,7 +3996,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "water-shadow-z13-to-z16")
         self.assertEqual(result[3]["id"], "water-shadow-z16-plus")
 
-    def _aeroway_line_layer(self, line_width=None):
+    def _aeroway_line_layer(self, line_width=None, line_color="hsl(230, 24%, 87%)"):
         if line_width is None:
             line_width = copy.deepcopy(mapbox_config._AEROWAY_LINE_WIDTH_EXPRESSION)
         return {
@@ -4006,7 +4006,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             "source-layer": "aeroway",
             "filter": ["==", ["geometry-type"], "LineString"],
             "paint": {
-                "line-color": "hsl(230, 24%, 87%)",
+                "line-color": line_color,
                 "line-opacity": ["interpolate", ["linear"], ["zoom"], 10, 0, 11, 1],
                 "line-width": line_width,
             },
@@ -4053,6 +4053,21 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config.base_mapbox_style_layer_id_for_qfit("aeroway-line-other-z16-plus"),
             "aeroway-line",
         )
+
+    def test_aeroway_line_color_uses_qgis_contrast_color(self):
+        style = {
+            "layers": [
+                self._aeroway_line_layer(line_color=mapbox_config._AEROWAY_POLYGON_FILL_COLOR)
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        for layer in result["layers"]:
+            self.assertEqual(
+                layer["paint"]["line-color"],
+                mapbox_config._AEROWAY_POLYGON_QGIS_CONTRAST_FILL_COLOR,
+            )
 
     def test_aeroway_line_width_is_not_split_when_shape_changes(self):
         line_width = ["interpolate", ["linear"], ["zoom"], 9, 0.5, 18, 20]


### PR DESCRIPTION
## Summary

- apply the existing QGIS aeroway contrast color to matching Mapbox Outdoors `aeroway-line` strokes
- keep the override scoped to the audited literal aeroway color used by Mapbox Outdoors
- add unit coverage for the line-color contrast path

## Evidence

#949's Geneva airport camera showed the runway/taxiway linework too washed out against the airport landuse fill.

Live comparison:
- baseline: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260517T183141Z`
- candidate: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260518T030823Z`

Metrics were mixed:
- changed pixel ratio: `+0.000070312500`
- mean absolute channel delta: `+0.107452835648`
- RMS channel delta: `-0.009677000035`

Visual review found the candidate makes the main runway and taxiway/apron linework more legible without obvious collateral damage to nearby roads, labels, shields, parks, or buildings.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q -k 'aeroway_line_width or aeroway_line_color or aeroway_polygon_fill' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

