### PR TITLE
Improve low-zoom settlement hierarchy

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -829,6 +829,8 @@ _LABEL_ICON_VISIBILITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, 
 )
 _SETTLEMENT_DOT_ICON_SPLIT_ZOOM = 8.0
 _SETTLEMENT_SYMBOL_SORT_KEY_EXPRESSION = ["get", "symbolrank"]
+_SETTLEMENT_MAJOR_LOW_ZOOM_QGIS_FILTER_SAMPLE_ZOOM = 6.0
+_SETTLEMENT_MINOR_LOW_ZOOM_QGIS_MIN_ZOOM = 6.0
 _SETTLEMENT_DOT_ICON_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
     ("z2-to-z4", 2.0, 4.0),
     ("z4-to-z6", 4.0, 6.0),
@@ -3106,6 +3108,41 @@ def _settlement_major_low_zoom_text_justify_variants(layer: dict[str, object]) -
     return variants
 
 
+def _is_suppressed_settlement_minor_low_zoom_band(base_layer_id: str, band_maxzoom: float | None) -> bool:
+    return (
+        base_layer_id == _SETTLEMENT_MINOR_LABEL_LAYER_ID
+        and band_maxzoom is not None
+        and band_maxzoom <= _SETTLEMENT_MINOR_LOW_ZOOM_QGIS_MIN_ZOOM
+    )
+
+
+def _settlement_dot_icon_zoom_bands_for_layer(
+    base_layer_id: str,
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+):
+    for zoom_suffix, band_minzoom, band_maxzoom in _SETTLEMENT_DOT_ICON_ZOOM_BANDS:
+        if not _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom):
+            continue
+        if _is_suppressed_settlement_minor_low_zoom_band(base_layer_id, band_maxzoom):
+            # The z5 comparison reads these minor towns as clutter while Mapbox
+            # emphasizes only country/state and major settlement hierarchy.
+            continue
+        yield zoom_suffix, band_minzoom, band_maxzoom
+
+
+def _settlement_dot_icon_layer_has_suppressed_zoom_band(
+    base_layer_id: str,
+    existing_minzoom: float | None,
+    existing_maxzoom: float | None,
+) -> bool:
+    return any(
+        _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom)
+        and _is_suppressed_settlement_minor_low_zoom_band(base_layer_id, band_maxzoom)
+        for _zoom_suffix, band_minzoom, band_maxzoom in _SETTLEMENT_DOT_ICON_ZOOM_BANDS
+    )
+
+
 def _settlement_dot_icon_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split Mapbox's low-zoom settlement dot icons from z8+ centered labels."""
     if not _has_settlement_dot_icon_expression(layer):
@@ -3116,9 +3153,11 @@ def _settlement_dot_icon_layer_variants(layer: dict[str, object]) -> list[dict[s
     layer_id = str(layer.get("id") or base_layer_id)
     variants: list[dict[str, object]] = []
 
-    for zoom_suffix, band_minzoom, band_maxzoom in _SETTLEMENT_DOT_ICON_ZOOM_BANDS:
-        if not _zoom_ranges_overlap(existing_minzoom, existing_maxzoom, band_minzoom, band_maxzoom):
-            continue
+    for zoom_suffix, band_minzoom, band_maxzoom in _settlement_dot_icon_zoom_bands_for_layer(
+        base_layer_id,
+        existing_minzoom,
+        existing_maxzoom,
+    ):
         for suffix, icon_filter, icon_image, text_radial_offset in _SETTLEMENT_DOT_ICON_VARIANTS:
             icon_layer = _apply_zoom_band_bounds(layer, band_minzoom, band_maxzoom)
             icon_layer["id"] = f"{layer_id}-{zoom_suffix}-{suffix}"
@@ -3140,6 +3179,12 @@ def _settlement_dot_icon_layer_variants(layer: dict[str, object]) -> list[dict[s
         variants.extend(_settlement_minor_text_filter_zoom_variants(text_layer) or [text_layer])
 
     if not variants:
+        if _settlement_dot_icon_layer_has_suppressed_zoom_band(
+            base_layer_id,
+            existing_minzoom,
+            existing_maxzoom,
+        ):
+            return []
         return None
     field_variants: list[dict[str, object]] = []
     for variant in variants:
@@ -5376,6 +5421,15 @@ def _zoom_normalized_filter_expression_for_qgis(layer: dict[str, object], value:
         if override_zoom is not None
         else None
     )
+    layer_id = str(layer.get("id") or "")
+    if (
+        target_zoom is None
+        and base_mapbox_style_layer_id_for_qfit(layer_id) == _SETTLEMENT_MAJOR_LABEL_LAYER_ID
+        and layer_id.startswith(f"{_SETTLEMENT_MAJOR_LABEL_LAYER_ID}-z4-to-z6-")
+    ):
+        # At z5 QGIS otherwise samples just below z6 and misses rank-7 cities
+        # such as Zurich and Milan, leaving minor towns to dominate the hierarchy.
+        target_zoom = _SETTLEMENT_MAJOR_LOW_ZOOM_QGIS_FILTER_SAMPLE_ZOOM
     if target_zoom is None:
         target_zoom = _representative_zoom_in_layer_range(layer.get("minzoom"), layer.get("maxzoom"))
     if target_zoom is None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2340,6 +2340,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             True,
         ]
         capital_layer = by_id["settlement-major-label-z2-to-z4-capital-border-dot-left"]
+        low_zoom_city_layer = by_id["settlement-major-label-z4-to-z6-dot-11-center"]
         dot_layer = by_id["settlement-major-label-z7-to-z8-dot-10-right"]
         center_layer = by_id["settlement-major-label-z2-to-z4-dot-11-center"]
         text_layer = by_id["settlement-major-label-z8-plus"]
@@ -2368,6 +2369,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 city_filter,
             ],
         )
+        self.assertIn(["<", ["get", "symbolrank"], 8], low_zoom_city_layer["filter"][1])
         self.assertEqual(
             dot_layer["filter"],
             [
@@ -2418,7 +2420,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 17)
+        self.assertEqual(len(result["layers"]), 9)
         by_id = {layer["id"]: layer for layer in result["layers"]}
         town_filter = ["match", ["get", "type"], ["town"], True, False]
         for suffix, icon_name in (
@@ -2427,15 +2429,35 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ("dot-10", "dot-10"),
             ("dot-9", "dot-9"),
         ):
-            layer = by_id[f"settlement-minor-label-z2-to-z4-{suffix}"]
+            self.assertNotIn(f"settlement-minor-label-z2-to-z4-{suffix}", by_id)
+            self.assertNotIn(f"settlement-minor-label-z4-to-z6-{suffix}", by_id)
+            layer = by_id[f"settlement-minor-label-z6-to-z7-{suffix}"]
             self.assertEqual(layer["layout"]["icon-image"], icon_name)
             self.assertNotIn("symbol-sort-key", layer["layout"])
             self.assertEqual(layer["filter"][-1], town_filter)
-        self.assertEqual(by_id["settlement-minor-label-z2-to-z4-dot-11"]["filter"][1][2], [">", ["get", "symbolrank"], 6])
+        self.assertEqual(by_id["settlement-minor-label-z6-to-z7-dot-11"]["filter"][1][2], [">=", ["get", "symbolrank"], 8])
         self.assertEqual(by_id["settlement-minor-label-z7-to-z8-dot-11"]["filter"][1][2], [">=", ["get", "symbolrank"], 10])
         self.assertNotIn("icon-image", by_id["settlement-minor-label-z8-plus"]["layout"])
         self.assertNotIn("symbol-sort-key", by_id["settlement-minor-label-z8-plus"]["layout"])
         self.assertEqual(by_id["settlement-minor-label-z8-plus"]["filter"][-1], town_filter)
+
+    def test_filter_simplification_suppresses_low_zoom_only_minor_settlement_dots(self):
+        style = {
+            "layers": [
+                {
+                    "id": "settlement-minor-label",
+                    "type": "symbol",
+                    "minzoom": 2,
+                    "maxzoom": 6,
+                    "filter": ["<=", ["get", "filterrank"], 3],
+                    "layout": self._settlement_dot_icon_layout(),
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"], [])
 
     def test_filter_simplification_splits_settlement_label_name_en_fallbacks(self):
         base_filter = ["<=", ["get", "filterrank"], 3]


### PR DESCRIPTION
## Summary

- improve the z5 Mapbox Outdoors settlement hierarchy for QGIS vector rendering
- sample `settlement-major-label` z4-z6 filters at z6 so rank-7 major cities can appear
- suppress `settlement-minor-label` dot variants below z6 to reduce low-zoom town clutter

## Evidence

Live Switzerland/Alps z5 comparison using the local Mapbox token source:

- baseline after #1122: `debug/mapbox-outdoors-comparison/switzerland-alps-z5-outdoors/20260518T032144Z`
- accepted candidate: `debug/mapbox-outdoors-comparison/switzerland-alps-z5-outdoors/20260518T041102Z`
- changed pixel ratio: `-0.000440972222`
- normalized mean absolute channel delta: `-0.000510657226`
- normalized RMS channel delta: `-0.000657171195`

Visual review: the candidate adds major-city labels such as Brussels, Frankfurt, Vienna, Milan, and Barcelona while removing distracting low-zoom town labels such as Tubingen, Landshut, Troyes, Bourges, and Neuchatel. It remains sparser than Mapbox GL, but the hierarchy is cleaner and closer in intent without visible overlabeling.

Rejected probes before this slice:

- preserving `symbol-sort-key` for settlement layers was byte-identical in QGIS
- adding rank-7 major cities without suppressing minor towns improved hierarchy but regressed metrics

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q -k 'settlement' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- live Mapbox Outdoors comparison: `debug/mapbox-outdoors-comparison/switzerland-alps-z5-outdoors/20260518T041102Z`

Issue tracking: qfit issue 949 remains open for follow-up Mapbox Outdoors parity slices.
