### PR TITLE
[codex] Improve low-zoom settlement label density

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -829,7 +829,7 @@ _LABEL_ICON_VISIBILITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, 
 )
 _SETTLEMENT_DOT_ICON_SPLIT_ZOOM = 8.0
 _SETTLEMENT_SYMBOL_SORT_KEY_EXPRESSION = ["get", "symbolrank"]
-_SETTLEMENT_MAJOR_LOW_ZOOM_QGIS_FILTER_SAMPLE_ZOOM = 6.0
+_SETTLEMENT_MAJOR_LOW_ZOOM_QGIS_FILTER_SAMPLE_ZOOM = 7.0
 _SETTLEMENT_MINOR_LOW_ZOOM_QGIS_MIN_ZOOM = 6.0
 _SETTLEMENT_DOT_ICON_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
     ("z2-to-z4", 2.0, 4.0),
@@ -5427,8 +5427,8 @@ def _zoom_normalized_filter_expression_for_qgis(layer: dict[str, object], value:
         and base_mapbox_style_layer_id_for_qfit(layer_id) == _SETTLEMENT_MAJOR_LABEL_LAYER_ID
         and layer_id.startswith(f"{_SETTLEMENT_MAJOR_LABEL_LAYER_ID}-z4-to-z6-")
     ):
-        # At z5 QGIS otherwise samples just below z6 and misses rank-7 cities
-        # such as Zurich and Milan, leaving minor towns to dominate the hierarchy.
+        # At z5 QGIS otherwise samples just below z6 and misses rank-8/9
+        # major cities, leaving the broad regional hierarchy too sparse.
         target_zoom = _SETTLEMENT_MAJOR_LOW_ZOOM_QGIS_FILTER_SAMPLE_ZOOM
     if target_zoom is None:
         target_zoom = _representative_zoom_in_layer_range(layer.get("minzoom"), layer.get("maxzoom"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2369,7 +2369,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 city_filter,
             ],
         )
-        self.assertIn(["<", ["get", "symbolrank"], 8], low_zoom_city_layer["filter"][1])
+        self.assertIn(["<", ["get", "symbolrank"], 10], low_zoom_city_layer["filter"][1])
         self.assertEqual(
             dot_layer["filter"],
             [


### PR DESCRIPTION
## Summary

This PR broadens the low-zoom QGIS settlement-major snapshot for the z4-z6 Mapbox Outdoors band so QGIS keeps rank-8/9 major city candidates in the broad Switzerland/Alps view.

The previous accepted slice made z5 cleaner by allowing rank-7 cities while suppressing low-zoom town dots. The live z5 visual comparison still looked too sparse compared with Mapbox GL. Sampling the next major-settlement branch adds regional city structure such as Strasbourg, Stuttgart, Munich, Zurich/Geneva-area labels, Lyon, Turin, Genoa, Bologna, Innsbruck, Salzburg, Graz, Trieste/Ljubljana-region labels, and similar candidates.

Issue context: #949 remains the active Mapbox Outdoors parity umbrella after this PR.

## Evidence

Live comparison artifacts:

- Candidate z5 run: `debug/mapbox-outdoors-comparison/switzerland-alps-z5-outdoors/20260518T043613Z`
- Candidate all-camera matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260518T043816Z/summary.md`
- Baseline after PR #1123: `debug/mapbox-outdoors-comparison/all-cameras/20260518T042237Z/summary.md`

The z5 pixel metric worsens because the added labels do not match Mapbox GL placement/content pixel-for-pixel:

- normalized mean delta: `+0.004663301107`
- normalized RMS delta: `+0.010803087308`

Visual review still favors the candidate: baseline is too sparse for the reference’s low-zoom city hierarchy, while the candidate restores a more Mapbox-like regional settlement network without obvious z5 label clutter. Other cameras are unchanged or show only tiny live-reference drift.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q -k 'settlement' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live Mapbox/QGIS comparison for `switzerland-alps-z5-outdoors`
- Live Mapbox/QGIS all-camera comparison matrix
