### PR TITLE
[codex] Add line-label spacing audit values

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -522,6 +522,17 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         },
                     },
                     {
+                        "id": "path-pedestrian-label",
+                        "type": "symbol",
+                        "source-layer": "road",
+                        "minzoom": 12,
+                        "layout": {
+                            "symbol-placement": "line",
+                            "text-field": ["get", "name"],
+                            "text-size": 9,
+                        },
+                    },
+                    {
                         "id": "poi-label",
                         "type": "symbol",
                         "source-layer": "poi_label",
@@ -540,13 +551,24 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         candidates = audit["summary"]["line_label_repetition_candidates"]
         self.assertEqual(
             [candidate["layer"] for candidate in candidates],
-            ["road-label", "road-shield", "waterway-label"],
+            ["path-pedestrian-label", "road-label", "road-shield", "waterway-label"],
         )
-        road_candidate, shield_candidate, waterway_candidate = candidates
+        path_candidate, road_candidate, shield_candidate, waterway_candidate = candidates
+        self.assertEqual(path_candidate["group"], "roads/trails")
+        self.assertEqual(path_candidate["source_layer"], "road")
+        self.assertEqual(path_candidate["zoom_band"], "z≥12")
+        self.assertEqual(path_candidate["symbol_placement"], "line")
+        self.assertIsNone(path_candidate["symbol_spacing"])
+        self.assertEqual(
+            path_candidate["line_label_control_properties"],
+            ["layout.symbol-placement", "layout.text-field", "layout.text-size"],
+        )
         self.assertEqual(road_candidate["group"], "roads/trails")
         self.assertEqual(road_candidate["source_layer"], "road")
         self.assertEqual(road_candidate["zoom_band"], "z≥10")
         self.assertEqual(road_candidate["filter_operator_signature"], "==, all, get, has")
+        self.assertEqual(road_candidate["symbol_placement"], "line")
+        self.assertEqual(road_candidate["symbol_spacing"], ["step", ["zoom"], 150, 14, 250])
         self.assertEqual(
             road_candidate["line_label_control_properties"],
             ["filter", "layout.symbol-placement", "layout.symbol-spacing", "layout.text-field", "layout.text-size"],
@@ -557,6 +579,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(shield_candidate["source_layer"], "road")
         self.assertEqual(shield_candidate["zoom_band"], "z≥6")
         self.assertEqual(shield_candidate["filter_operator_signature"], "<=, all, get, has")
+        self.assertEqual(shield_candidate["symbol_placement"], ["step", ["zoom"], "point", 11, "line"])
         self.assertEqual(
             shield_candidate["line_label_control_properties"],
             ["filter", "layout.symbol-placement", "layout.symbol-spacing", "layout.text-field"],
@@ -568,20 +591,24 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )
         self.assertEqual(waterway_candidate["group"], "water")
         self.assertEqual(waterway_candidate["source_layer"], "natural_label")
+        self.assertEqual(
+            waterway_candidate["symbol_spacing"],
+            ["interpolate", ["linear", 1], ["zoom"], 15, 250, 17, 400],
+        )
         self.assertEqual(waterway_candidate["qfit_simplified_control_properties"], ["layout.symbol-spacing"])
         self.assertEqual(waterway_candidate["qgis_dependent_control_properties"], ["filter"])
         self.assertEqual(
             audit["summary"]["line_label_repetition_candidates_by_layer_group"],
-            [{"group": "roads/trails", "count": 2}, {"group": "water", "count": 1}],
+            [{"group": "roads/trails", "count": 3}, {"group": "water", "count": 1}],
         )
         self.assertEqual(
             audit["summary"]["line_label_repetition_controls_by_property"],
             [
+                {"property": "layout.symbol-placement", "count": 4},
+                {"property": "layout.text-field", "count": 4},
                 {"property": "filter", "count": 3},
-                {"property": "layout.symbol-placement", "count": 3},
                 {"property": "layout.symbol-spacing", "count": 3},
-                {"property": "layout.text-field", "count": 3},
-                {"property": "layout.text-size", "count": 2},
+                {"property": "layout.text-size", "count": 3},
                 {"property": "layout.text-max-angle", "count": 1},
             ],
         )
@@ -604,6 +631,13 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("#### Line label repetition controls by property", markdown)
         self.assertIn("#### Line label repetition controls simplified/substituted by qfit", markdown)
         self.assertIn("#### Line label repetition QGIS-dependent controls", markdown)
+        self.assertIn("Symbol placement", markdown)
+        self.assertIn("Symbol spacing", markdown)
+        self.assertIn(
+            "| `roads/trails` | `path-pedestrian-label` | `road` | z≥12 | `(none)` | "
+            "<code>&quot;line&quot;</code> | — |",
+            markdown,
+        )
         self.assertIn("| `roads/trails` | `road-label` | `road` | z≥10 | `==, all, get, has` |", markdown)
         self.assertIn("| `roads/trails` | `road-shield` | `road` | z≥6 | `<=, all, get, has` |", markdown)
         self.assertIn("| `water` | `waterway-label` | `natural_label` | z≥13 | `==, get` |", markdown)

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -1588,6 +1588,7 @@ def _line_label_repetition_candidate_rows(layers: list[dict[str, object]]) -> li
     for layer in layers:
         if not _is_line_label_repetition_candidate_layer(layer):
             continue
+        layout = layer.get("layout") if isinstance(layer.get("layout"), dict) else {}
         controls = _label_density_control_properties(layer)
         control_set = set(controls)
         rows.append(
@@ -1597,6 +1598,8 @@ def _line_label_repetition_candidate_rows(layers: list[dict[str, object]]) -> li
                 "source_layer": str(layer.get("source_layer") or ""),
                 "zoom_band": str(layer.get("zoom_band") or _ALL_ZOOMS_BAND),
                 _FILTER_OPERATOR_SIGNATURE_KEY: _operator_signature(_qgis_filter_value(layer)),
+                "symbol_placement": layout.get("symbol-placement"),
+                "symbol_spacing": layout.get("symbol-spacing") if "symbol-spacing" in layout else None,
                 "line_label_control_properties": controls,
                 _QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY: _qfit_simplified_control_properties(layer, control_set),
                 _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY: _qgis_dependent_control_properties(layer, control_set),
@@ -3805,22 +3808,34 @@ def _markdown_line_label_repetition_candidate_table(
         return [empty, ""]
     lines = [
         (
-            "| Layer group | Layer | Source layer | Zoom | Filter operators | Line-label controls | "
-            "Simplified/substituted by qfit | QGIS-dependent controls |"
+            "| Layer group | Layer | Source layer | Zoom | Filter operators | Symbol placement | "
+            "Symbol spacing | Line-label controls | Simplified/substituted by qfit | QGIS-dependent controls |"
         ),
-        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
     ]
     for row in rows:
+        symbol_placement = row.get("symbol_placement")
+        symbol_spacing = row.get("symbol_spacing")
         lines.append(
             (
                 "| `{group}` | `{layer}` | `{source_layer}` | {zoom} | `{filter_operators}` | "
-                "{controls} | {simplified} | {unresolved} |"
+                "{symbol_placement} | {symbol_spacing} | {controls} | {simplified} | {unresolved} |"
             ).format(
                 group=row.get("group", ""),
                 layer=row.get("layer", ""),
                 source_layer=row.get("source_layer", ""),
                 zoom=row.get("zoom_band", _ALL_ZOOMS_BAND),
                 filter_operators=row.get(_FILTER_OPERATOR_SIGNATURE_KEY, _NO_OPERATOR_SIGNATURE),
+                symbol_placement=(
+                    f"<code>{html.escape(_compact_json(symbol_placement))}</code>"
+                    if symbol_placement is not None
+                    else "—"
+                ),
+                symbol_spacing=(
+                    f"<code>{html.escape(_compact_json(symbol_spacing))}</code>"
+                    if symbol_spacing is not None
+                    else "—"
+                ),
                 controls=_markdown_list(list(row.get("line_label_control_properties") or [])),
                 simplified=_markdown_list(list(row.get(_QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY) or [])),
                 unresolved=_markdown_list(list(row.get(_QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY) or [])),


### PR DESCRIPTION
## Summary

- Add explicit `symbol_placement` and `symbol_spacing` values to the Mapbox Outdoors line-label repetition audit rows.
- Show those values in the audit Markdown table so road/path/contour labels with no spacing control are visible without manually inspecting the JSON.
- Extend the line-label audit test with a path label that has line placement but no `symbol-spacing`.

## Why

For #949, the latest z18 investigation showed that the remaining road/path label repetition gap should not be chased through another simple spacing PR when the main road/path candidates do not expose a spacing value. This makes that evidence visible in the audit output itself.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q -k 'line_label_repetition or symbol_placement_may_be_line' --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Offline audit smoke run on the post-#1124 z18 Zermatt Trails QGIS preprocessed style; the generated line-label section now shows road/path/contour rows with `Symbol spacing` as `—` and shield/waterway rows with scalar spacing values.
