### PR TITLE
[codex] Normalize offset filter comparisons

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -5189,6 +5189,34 @@ def _additive_identity_filter(value: list[object], *, root: bool) -> object:
     return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
 
 
+def _numeric_literal(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _comparison_left_offset_filter(value: list[object]) -> object:
+    if len(value) != 3 or value[0] not in {"<", "<=", ">", ">="}:
+        return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+    left = _simplify_filter_expression_for_qgis(value[1], root=False)
+    right = _simplify_filter_expression_for_qgis(value[2], root=False)
+    right_number = _numeric_literal(right)
+    if right_number is None or not isinstance(left, list) or len(left) != 3:
+        return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+
+    arithmetic_operator = left[0]
+    expression = left[1]
+    offset = _numeric_literal(left[2])
+    if arithmetic_operator == "+" and offset is None:
+        expression = left[2]
+        offset = _numeric_literal(left[1])
+    if arithmetic_operator not in {"+", "-"} or offset is None:
+        return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+
+    adjusted_right = right_number - offset if arithmetic_operator == "+" else right_number + offset
+    return [value[0], _simplify_filter_expression_for_qgis(expression, root=False), adjusted_right]
+
+
 def _simplify_filter_expression_for_qgis(value: object, *, root: bool = True) -> object:
     """Apply semantics-preserving filter rewrites that QGIS parses more reliably."""
     if isinstance(value, bool):
@@ -5211,6 +5239,10 @@ def _simplify_filter_expression_for_qgis(value: object, *, root: bool = True) ->
         additive_identity = _additive_identity_filter(value, root=root)
         if additive_identity is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
             return additive_identity
+    if operator in {"<", "<=", ">", ">="}:
+        comparison_filter = _comparison_left_offset_filter(value)
+        if comparison_filter is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
+            return comparison_filter
     return [operator, *[_simplify_filter_expression_for_qgis(item, root=False) for item in value[1:]]]
 
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -5217,6 +5217,23 @@ def _comparison_left_offset_filter(value: list[object]) -> object:
     return [value[0], _simplify_filter_expression_for_qgis(expression, root=False), adjusted_right]
 
 
+def _special_filter_simplification_for_qgis(
+    value: list[object],
+    operator: object,
+    *,
+    root: bool,
+) -> object:
+    for simplify in (_inverted_boolean_match_filter, _simple_case_filter):
+        simplified = simplify(value)
+        if simplified is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
+            return simplified
+    if operator in {"+", "-"}:
+        return _additive_identity_filter(value, root=root)
+    if operator in {"<", "<=", ">", ">="}:
+        return _comparison_left_offset_filter(value)
+    return _FILTER_SIMPLIFICATION_NOT_AVAILABLE
+
+
 def _simplify_filter_expression_for_qgis(value: object, *, root: bool = True) -> object:
     """Apply semantics-preserving filter rewrites that QGIS parses more reliably."""
     if isinstance(value, bool):
@@ -5229,20 +5246,9 @@ def _simplify_filter_expression_for_qgis(value: object, *, root: bool = True) ->
     operator = value[0]
     if operator == "literal":
         return value
-    inverted_match = _inverted_boolean_match_filter(value)
-    if inverted_match is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
-        return inverted_match
-    case_filter = _simple_case_filter(value)
-    if case_filter is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
-        return case_filter
-    if operator in {"+", "-"}:
-        additive_identity = _additive_identity_filter(value, root=root)
-        if additive_identity is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
-            return additive_identity
-    if operator in {"<", "<=", ">", ">="}:
-        comparison_filter = _comparison_left_offset_filter(value)
-        if comparison_filter is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
-            return comparison_filter
+    special_filter = _special_filter_simplification_for_qgis(value, operator, root=root)
+    if special_filter is not _FILTER_SIMPLIFICATION_NOT_AVAILABLE:
+        return special_filter
     return [operator, *[_simplify_filter_expression_for_qgis(item, root=False) for item in value[1:]]]
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2071,6 +2071,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 {
                     "filter": ["<=", ["+", ["get", "filterrank"], 0], ["-", 12, 0]],
                 },
+                {
+                    "filter": ["<=", ["-", ["get", "filterrank"], 2], 12],
+                },
                 {"filter": True},
             ]
         }
@@ -2088,7 +2091,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][2]["filter"], ["==", ["get", "class"], "park"])
         self.assertEqual(result["layers"][3]["filter"], ["!", ["==", ["get", "class"], "park"]])
         self.assertEqual(result["layers"][4]["filter"], ["<=", ["get", "filterrank"], 12])
-        self.assertEqual(result["layers"][5]["filter"], ["==", 1, 1])
+        self.assertEqual(result["layers"][5]["filter"], ["<=", ["get", "filterrank"], 14.0])
+        self.assertEqual(result["layers"][6]["filter"], ["==", 1, 1])
         self.assertEqual(style["layers"][0]["filter"][0], "!")
 
     def test_filter_simplification_snapshots_zoom_dependent_filters(self):
@@ -5775,6 +5779,20 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                         ["-", ["to-number", ["get", "sizerank"]], ["interpolate", ["linear"], ["zoom"], 12, 0, 18, 14]],
                         14,
                     ]
+                },
+                {
+                    "id": "landuse",
+                    "type": "fill",
+                    "minzoom": 15,
+                    "filter": [
+                        "<=",
+                        [
+                            "-",
+                            ["to-number", ["get", "sizerank"]],
+                            ["interpolate", ["exponential", 1.5], ["zoom"], 12, 0, 18, 14],
+                        ],
+                        14,
+                    ]
                 }
             ]
         }
@@ -5785,6 +5803,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             result["layers"][0]["filter"],
             ["<=", ["to-number", ["get", "sizerank"]], 14],
         )
+        self.assertEqual(result["layers"][1]["filter"][0:2], ["<=", ["to-number", ["get", "sizerank"]]])
+        self.assertAlmostEqual(result["layers"][1]["filter"][2], 17.2)
 
     def test_filter_simplification_normalizes_zoom_arithmetic_operators(self):
         style = {


### PR DESCRIPTION
## Summary

- Normalize parser-friendly numeric-offset comparisons such as `['<=', ['-', expr, 2], 12]` into `['<=', expr, 14]` before handing filters to QGIS.
- Cover both a simple nonzero offset comparison and the high-zoom landuse `sizerank` filter shape identified by the live #949 audit.

## Why

For #949, the post-#1125 live style audit left one QGIS filter parser warning after sprite context: `landuse-other-z10-plus-rock-high-zoom` still contained a subtraction inside a comparison after zoom sampling. This PR keeps the same numeric predicate but rewrites the offset onto the literal comparison bound so QGIS can parse it.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q -k 'filter_expressions_use_parser_friendly_equivalents or filter_simplification_normalizes_nested_zoom_arithmetic' --tb=short`
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live style audit with QGIS converter and filter parser probes: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260518T054703Z/audit.md`
- Audit result: QGIS parser accepted 478/478 qfit-preprocessed filters, rejected 0; runtime sprite-context warnings dropped to 0.
- Full live comparison matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260518T054806Z/summary.md`
- Metrics vs post-#1124 baseline were unchanged at z5-z10, improved at Geneva z14 and Zermatt z17/z18, and Chamonix z14 was visually stable despite a tiny mean/RMS uptick.
- Visual review of Chamonix z14, Zermatt piste z17, and Zermatt trails z18 QGIS before/after renders showed no obvious terrain or landuse regression.

## Notes

#949 remains open for the broader Mapbox Outdoors parity investigation.
