### PR TITLE
[codex] Summarize sprite-context audit warnings

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -2891,6 +2891,35 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(fake_app.created[0].init_qgis_calls, 1)
         self.assertEqual(fake_app.created[0].exit_qgis_calls, 1)
 
+    def test_audit_markdown_summarizes_sprite_context_warning_count(self):
+        markdown = build_audit_markdown(
+            {
+                "style": {"label": "mapbox/outdoors-v12"},
+                "generated_at": "2026-05-18T06:05:00Z",
+                "layer_count": 0,
+                "layers": [],
+                "summary": {},
+                "qgis_converter_warnings": {
+                    "raw": {"count": 1},
+                    "qfit_preprocessed": {"count": 9},
+                    "warning_count_delta": -8,
+                    "reduced_by_qfit": {},
+                    "with_sprite_context_probe": {
+                        "summary": {"count": 0},
+                        "warning_count_delta_from_qfit": 9,
+                    },
+                },
+            }
+        )
+        qgis_section = markdown.split("### QGIS converter warnings", 1)[1].split(
+            "#### Remaining warnings by message",
+            1,
+        )[0]
+
+        self.assertIn("After qfit preprocessing: 9", qgis_section)
+        self.assertIn("After qfit preprocessing with sprite context: 0", qgis_section)
+        self.assertIn("Sprite context warning count delta from qfit preprocessing: 9", qgis_section)
+
     def test_qgis_converter_warning_report_reuses_existing_qgis_app(self):
         existing_app = object()
         fake_qgis, fake_core, fake_app, _fake_converter = _fake_qgis_modules(

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -4455,6 +4455,21 @@ def _markdown_probe_unresolved_property_sections(
     ]
 
 
+def _markdown_sprite_context_converter_overview(probe: object) -> list[str]:
+    if not isinstance(probe, dict):
+        return []
+    summary = probe.get("summary")
+    if not isinstance(summary, dict):
+        return []
+    return [
+        f"After qfit preprocessing with sprite context: {summary.get('count', 0)}",
+        (
+            "Sprite context warning count delta from qfit preprocessing: "
+            f"{probe.get('warning_count_delta_from_qfit', 0)}"
+        ),
+    ]
+
+
 def _markdown_line_opacity_probe(probe: object) -> list[str]:
     lines = _markdown_expression_property_probe(
         probe,
@@ -5247,6 +5262,7 @@ def _markdown_qgis_converter_warnings(report: object) -> list[str]:
         "",
         f"Raw style warnings: {raw.get('count', 0)}",
         f"After qfit preprocessing: {qfit.get('count', 0)}",
+        *_markdown_sprite_context_converter_overview(sprite_context_probe),
         f"Warning count delta: {report.get('warning_count_delta', 0)}",
         "",
     ]


### PR DESCRIPTION
## Summary

This small #949 diagnostic slice makes the QGIS converter warning overview show the sprite-context-adjusted warning count when Mapbox sprite resources are available.

The current live audit had an easy-to-misread headline:
- raw style warnings: 159
- after qfit preprocessing without sprite context: 979
- runtime-equivalent sprite-context warnings: 0

The runtime sprite context is the relevant signal for qfit's Mapbox sprite-aware path, so the overview now includes that count directly before the detailed sprite-context probe.

## Evidence

Fresh live audit on this branch:

- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260518T060751Z/audit.md`
- `After qfit preprocessing with sprite context: 0`
- `Sprite context warning count delta from qfit preprocessing: 979`
- `Rejected by the QGIS parser probe: 0`
- `Warnings with sprite context: 0`

This is diagnostic-only; it does not change rendering.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q -k 'sprite_context_warning_count or qgis_converter_warning_report' --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

#949 remains open for follow-up Mapbox Outdoors parity slices.
