### PR TITLE
[codex] Improve Swiss motorway shield priority

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -665,6 +665,29 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         self.assertEqual(updated_style.layerName(), "poi_label")
         self.assertEqual(updated_style.labelSettings().priority, 5)
 
+    def test_priority_promotes_swiss_motorway_shields_without_promoting_other_shields(self):
+        labeling = MagicMock()
+        swiss_style, swiss_settings = self._make_style(
+            "road",
+            "road-number-shield-2-beta-ch-motorway-icon-z11-plus",
+        )
+        other_style, _other_settings = self._make_style(
+            "road",
+            "road-number-shield-2-beta-ch-motorway-icon-below-z11",
+        )
+        remaining_style, _remaining_settings = self._make_style(
+            "road",
+            "road-number-shield-2-beta-remaining-icons-z11-plus",
+        )
+        labeling.styles.return_value = [swiss_style, other_style, remaining_style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(swiss_settings.priority, 6)
+        swiss_style.setLabelSettings.assert_called_once_with(swiss_settings)
+        other_style.setLabelSettings.assert_not_called()
+        remaining_style.setLabelSettings.assert_not_called()
+
 
 @unittest.skipIf(QGIS_AVAILABLE, SKIP_MOCK)
 @unittest.skipIf(_mock_bms_cls is None, SKIP_MOCK_LOAD)
@@ -747,6 +770,29 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
                 self.assertEqual(settings.priority, expected_priority)
                 style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_priority_promotes_swiss_motorway_shields_without_promoting_other_shields(self):
+        labeling = MagicMock()
+        swiss_style, swiss_settings = self._make_style(
+            "road",
+            "road-number-shield-2-beta-ch-motorway-icon-z11-plus",
+        )
+        other_style, _other_settings = self._make_style(
+            "road",
+            "road-number-shield-2-beta-ch-motorway-icon-below-z11",
+        )
+        remaining_style, _remaining_settings = self._make_style(
+            "road",
+            "road-number-shield-2-beta-remaining-icons-z11-plus",
+        )
+        labeling.styles.return_value = [swiss_style, other_style, remaining_style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(swiss_settings.priority, 6)
+        swiss_style.setLabelSettings.assert_called_once_with(swiss_settings)
+        other_style.setLabelSettings.assert_not_called()
+        remaining_style.setLabelSettings.assert_not_called()
 
     def test_data_defined_priority_for_settlement_layer(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -27,6 +27,24 @@ from ...mapbox_config import (
 )
 
 _WORKING_CRS = "EPSG:3857"
+_LABEL_PRIORITIES = {
+    "continent-label": 10,
+    "country-label": 10,
+    "state-label": 9,
+    "settlement-major-label": 8,
+    "settlement-minor-label": 6,
+    "settlement-subdivision-label": 3,
+    "water-point-label": 7,
+    "water-line-label": 6,
+    "natural-line-label": 4,
+    "natural-point-label": 4,
+    "poi-label": 5,
+    "road-label": 4,
+    "airport-label": 8,
+}
+_SETTLEMENT_LAYERS = {"settlement-major-label", "settlement-minor-label"}
+_SWISS_MOTORWAY_SHIELD_PRIORITY = 6
+_SWISS_MOTORWAY_SHIELD_Z11_STYLE_MARKER = "ch-motorway-icon-z11-plus"
 
 
 def _label_style_mapbox_layer_id(style) -> str:
@@ -38,6 +56,23 @@ def _label_style_mapbox_layer_id(style) -> str:
         if isinstance(layer_id, str) and layer_id:
             return base_mapbox_style_layer_id_for_qfit(layer_id)
     return ""
+
+
+def _label_style_name(style) -> str:
+    try:
+        style_name = style.styleName()
+    except AttributeError:
+        return ""
+    return style_name if isinstance(style_name, str) else ""
+
+
+def _label_priority(layer_name: str, style) -> int | None:
+    if (
+        layer_name == "road-number-shield"
+        and _SWISS_MOTORWAY_SHIELD_Z11_STYLE_MARKER in _label_style_name(style)
+    ):
+        return _SWISS_MOTORWAY_SHIELD_PRIORITY
+    return _LABEL_PRIORITIES.get(layer_name)
 
 
 class BackgroundMapService:
@@ -166,23 +201,6 @@ class BackgroundMapService:
         return False
 
     def _apply_label_priority(self, labeling) -> None:
-        _LAYER_PRIORITIES = {
-            "continent-label": 10,
-            "country-label": 10,
-            "state-label": 9,
-            "settlement-major-label": 8,
-            "settlement-minor-label": 6,
-            "settlement-subdivision-label": 3,
-            "water-point-label": 7,
-            "water-line-label": 6,
-            "natural-line-label": 4,
-            "natural-point-label": 4,
-            "poi-label": 5,
-            "road-label": 4,
-            "airport-label": 8,
-        }
-        _SETTLEMENT_LAYERS = {"settlement-major-label", "settlement-minor-label"}
-
         try:
             from qgis.core import QgsProperty  # noqa: PLC0415
 
@@ -190,14 +208,7 @@ class BackgroundMapService:
             changed = False
             for style in styles:
                 layer_name = _label_style_mapbox_layer_id(style)
-                priority = _LAYER_PRIORITIES.get(layer_name)
-                try:
-                    style_name_value = style.styleName()
-                except AttributeError:
-                    style_name_value = ""
-                style_name = style_name_value if isinstance(style_name_value, str) else ""
-                if layer_name == "road-number-shield" and "ch-motorway-icon-z11-plus" in style_name:
-                    priority = 6
+                priority = _label_priority(layer_name, style)
                 if priority is None:
                     continue
                 settings = style.labelSettings()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -191,6 +191,13 @@ class BackgroundMapService:
             for style in styles:
                 layer_name = _label_style_mapbox_layer_id(style)
                 priority = _LAYER_PRIORITIES.get(layer_name)
+                try:
+                    style_name_value = style.styleName()
+                except AttributeError:
+                    style_name_value = ""
+                style_name = style_name_value if isinstance(style_name_value, str) else ""
+                if layer_name == "road-number-shield" and "ch-motorway-icon-z11-plus" in style_name:
+                    priority = 6
                 if priority is None:
                     continue
                 settings = style.labelSettings()


### PR DESCRIPTION
## Summary

- raise only the z11+ Swiss motorway shield label variants above regular road labels
- leave low-zoom/below-z11 road shields and non-Swiss shield variants at the QGIS converter default priority
- add real-QGIS/mock-QGIS regression coverage for the targeted priority override

## Evidence

This is a narrow follow-up to #949. Broader shield-priority probes were rejected because they improved road shields but suppressed settlement labels around Nyon, Vevey, Sierre/Visp, and Interlaken. This slice only targets the z11+ Swiss motorway shield variants, where the Geneva motorway camera showed a clean improvement.

Live comparison evidence:

- Accepted matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260518T064526Z/summary.md`
- Baseline matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260518T054806Z/summary.md`
- Geneva z14 accepted artifact: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260518T064510Z/`
- Zermatt z18 accepted artifact: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260518T064521Z/`

Observed effects:

- z5, z8, z10, Chamonix z14, and Zermatt piste z17 stayed byte-identical in diff metrics.
- Geneva motorway z14 changed only around the target shield labels; visual review found modestly better Swiss motorway shield retention without new label clutter or important label suppression.
- Zermatt trails z18 had a tiny metric improvement and no visible regression.

## Validation

- `python3 -m pytest tests/test_background_map_service.py -q -k 'priority' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 validation/mapbox_outdoors_comparison.py --all-cameras`

