### PR TITLE
[codex] Space Mapbox line labels in QGIS

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -689,6 +689,8 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         remaining_style.setLabelSettings.assert_not_called()
 
     def test_line_label_repeat_distance_uses_mapbox_default_spacing(self):
+        from qgis.core import Qgis
+
         labeling = MagicMock()
         style, settings = self._make_style("road", "road-label-z15-plus")
         settings.repeatDistance = 0.0
@@ -698,6 +700,7 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
 
         self.assertEqual(settings.priority, 4)
         self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_low_zoom_road_label_repeat_distance_uses_audited_spacing(self):
@@ -849,6 +852,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
         self.assertEqual(settings.priority, 4)
         self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_low_zoom_road_label_repeat_distance_uses_audited_spacing(self):

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -700,6 +700,18 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 
+    def test_low_zoom_road_label_repeat_distance_uses_audited_spacing(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "road-label-z12-to-z15")
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 4)
+        self.assertAlmostEqual(settings.repeatDistance, 150 * 25.4 / 96)
+        style.setLabelSettings.assert_called_once_with(settings)
+
     def test_waterway_label_repeat_distance_uses_split_symbol_spacing(self):
         labeling = MagicMock()
         style, settings = self._make_style("natural_label", "waterway-label-z17-plus")
@@ -837,6 +849,18 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
         self.assertEqual(settings.priority, 4)
         self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_low_zoom_road_label_repeat_distance_uses_audited_spacing(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "road-label-below-z12")
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 4)
+        self.assertAlmostEqual(settings.repeatDistance, 150 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_waterway_label_repeat_distance_uses_split_symbol_spacing(self):

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -688,6 +688,39 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         other_style.setLabelSettings.assert_not_called()
         remaining_style.setLabelSettings.assert_not_called()
 
+    def test_line_label_repeat_distance_uses_mapbox_default_spacing(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 4)
+        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_waterway_label_repeat_distance_uses_split_symbol_spacing(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("natural_label", "waterway-label-z17-plus")
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_contour_label_repeat_distance_is_left_unchanged(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("contour", "contour-label")
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        style.setLabelSettings.assert_not_called()
+
 
 @unittest.skipIf(QGIS_AVAILABLE, SKIP_MOCK)
 @unittest.skipIf(_mock_bms_cls is None, SKIP_MOCK_LOAD)
@@ -793,6 +826,51 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         swiss_style.setLabelSettings.assert_called_once_with(swiss_settings)
         other_style.setLabelSettings.assert_not_called()
         remaining_style.setLabelSettings.assert_not_called()
+
+    def test_line_label_repeat_distance_uses_mapbox_default_spacing(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 4)
+        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_waterway_label_repeat_distance_uses_split_symbol_spacing(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("natural_label", "waterway-label-z17-plus")
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_existing_line_label_repeat_distance_is_preserved(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.repeatDistance = 12.5
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.priority, 4)
+        self.assertEqual(settings.repeatDistance, 12.5)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_contour_label_repeat_distance_is_left_unchanged(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("contour", "contour-label")
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        style.setLabelSettings.assert_not_called()
 
     def test_data_defined_priority_for_settlement_layer(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -52,6 +52,8 @@ _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "ferry-aerialway-label",
     "path-pedestrian-label",
 }
+# Representative-zoom values from mapbox_config's waterway-label spacing
+# expression after qfit splits it into static QGIS zoom bands.
 _WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER = {
     "z13-to-z15": 250.0,
     "z15-to-z17": 325.0,
@@ -131,6 +133,7 @@ def _apply_label_settings(
     priority: int | None,
     repeat_distance: float | None,
     qgs_property,
+    qgis,
 ) -> bool:
     changed = False
     if priority is not None:
@@ -140,6 +143,7 @@ def _apply_label_settings(
         changed = True
     if repeat_distance is not None and _needs_repeat_distance(settings):
         settings.repeatDistance = repeat_distance
+        settings.repeatDistanceUnit = qgis.RenderUnit.Millimeters
         changed = True
     return changed
 
@@ -271,7 +275,7 @@ class BackgroundMapService:
 
     def _apply_label_priority(self, labeling) -> None:
         try:
-            from qgis.core import QgsProperty  # noqa: PLC0415
+            from qgis.core import QgsProperty, Qgis  # noqa: PLC0415
 
             styles = list(labeling.styles())
             changed = False
@@ -290,6 +294,7 @@ class BackgroundMapService:
                     priority=priority,
                     repeat_distance=repeat_distance,
                     qgs_property=QgsProperty,
+                    qgis=Qgis,
                 ):
                     style.setLabelSettings(settings)
                     changed = True

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -109,11 +109,11 @@ def _needs_repeat_distance(settings) -> bool:
     return not isinstance(repeat_distance, (int, float)) or repeat_distance <= 0
 
 
-def _apply_settlement_label_priority(settings, QgsProperty) -> None:
+def _apply_settlement_label_priority(settings, qgs_property) -> None:
     dd_props = settings.dataDefinedProperties()
     dd_props.setProperty(
         87,
-        QgsProperty.fromExpression(
+        qgs_property.fromExpression(
             "greatest(1, least(10, 10 - coalesce(to_int(\"symbolrank\"), to_int(\"sizerank\"), 8) + 1))"
         ),
     )
@@ -126,13 +126,13 @@ def _apply_label_settings(
     layer_name: str,
     priority: int | None,
     repeat_distance: float | None,
-    QgsProperty,
+    qgs_property,
 ) -> bool:
     changed = False
     if priority is not None:
         settings.priority = priority
         if layer_name in _SETTLEMENT_LAYERS:
-            _apply_settlement_label_priority(settings, QgsProperty)
+            _apply_settlement_label_priority(settings, qgs_property)
         changed = True
     if repeat_distance is not None and _needs_repeat_distance(settings):
         settings.repeatDistance = repeat_distance
@@ -285,7 +285,7 @@ class BackgroundMapService:
                     layer_name=layer_name,
                     priority=priority,
                     repeat_distance=repeat_distance,
-                    QgsProperty=QgsProperty,
+                    qgs_property=QgsProperty,
                 ):
                     style.setLabelSettings(settings)
                     changed = True

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -45,6 +45,18 @@ _LABEL_PRIORITIES = {
 _SETTLEMENT_LAYERS = {"settlement-major-label", "settlement-minor-label"}
 _SWISS_MOTORWAY_SHIELD_PRIORITY = 6
 _SWISS_MOTORWAY_SHIELD_Z11_STYLE_MARKER = "ch-motorway-icon-z11-plus"
+_MAPBOX_SYMBOL_PIXEL_TO_MM = 25.4 / 96.0
+_MAPBOX_DEFAULT_SYMBOL_SPACING_PX = 250.0
+_LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
+    "ferry-aerialway-label",
+    "path-pedestrian-label",
+    "road-label",
+}
+_WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER = {
+    "z13-to-z15": 250.0,
+    "z15-to-z17": 325.0,
+    "z17-plus": 400.0,
+}
 
 
 def _label_style_mapbox_layer_id(style) -> str:
@@ -73,6 +85,59 @@ def _label_priority(layer_name: str, style) -> int | None:
     ):
         return _SWISS_MOTORWAY_SHIELD_PRIORITY
     return _LABEL_PRIORITIES.get(layer_name)
+
+
+def _symbol_spacing_mm(pixels: float) -> float:
+    return pixels * _MAPBOX_SYMBOL_PIXEL_TO_MM
+
+
+def _label_repeat_distance(layer_name: str, style) -> float | None:
+    if layer_name in _LINE_LABEL_REPEAT_DISTANCE_LAYERS:
+        return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
+    if layer_name != "waterway-label":
+        return None
+
+    style_name = _label_style_name(style)
+    for marker, pixels in _WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER.items():
+        if marker in style_name:
+            return _symbol_spacing_mm(pixels)
+    return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
+
+
+def _needs_repeat_distance(settings) -> bool:
+    repeat_distance = getattr(settings, "repeatDistance", 0.0)
+    return not isinstance(repeat_distance, (int, float)) or repeat_distance <= 0
+
+
+def _apply_settlement_label_priority(settings, QgsProperty) -> None:
+    dd_props = settings.dataDefinedProperties()
+    dd_props.setProperty(
+        87,
+        QgsProperty.fromExpression(
+            "greatest(1, least(10, 10 - coalesce(to_int(\"symbolrank\"), to_int(\"sizerank\"), 8) + 1))"
+        ),
+    )
+    settings.setDataDefinedProperties(dd_props)
+
+
+def _apply_label_settings(
+    settings,
+    *,
+    layer_name: str,
+    priority: int | None,
+    repeat_distance: float | None,
+    QgsProperty,
+) -> bool:
+    changed = False
+    if priority is not None:
+        settings.priority = priority
+        if layer_name in _SETTLEMENT_LAYERS:
+            _apply_settlement_label_priority(settings, QgsProperty)
+        changed = True
+    if repeat_distance is not None and _needs_repeat_distance(settings):
+        settings.repeatDistance = repeat_distance
+        changed = True
+    return changed
 
 
 class BackgroundMapService:
@@ -209,23 +274,21 @@ class BackgroundMapService:
             for style in styles:
                 layer_name = _label_style_mapbox_layer_id(style)
                 priority = _label_priority(layer_name, style)
-                if priority is None:
+                repeat_distance = _label_repeat_distance(layer_name, style)
+                if priority is None and repeat_distance is None:
                     continue
                 settings = style.labelSettings()
                 if settings is None:
                     continue
-                settings.priority = priority
-                if layer_name in _SETTLEMENT_LAYERS:
-                    dd_props = settings.dataDefinedProperties()
-                    dd_props.setProperty(
-                        87,
-                        QgsProperty.fromExpression(
-                            "greatest(1, least(10, 10 - coalesce(to_int(\"symbolrank\"), to_int(\"sizerank\"), 8) + 1))"
-                        ),
-                    )
-                    settings.setDataDefinedProperties(dd_props)
-                style.setLabelSettings(settings)
-                changed = True
+                if _apply_label_settings(
+                    settings,
+                    layer_name=layer_name,
+                    priority=priority,
+                    repeat_distance=repeat_distance,
+                    QgsProperty=QgsProperty,
+                ):
+                    style.setLabelSettings(settings)
+                    changed = True
             if changed:
                 labeling.setStyles(styles)
         except (RuntimeError, AttributeError):

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -47,10 +47,10 @@ _SWISS_MOTORWAY_SHIELD_PRIORITY = 6
 _SWISS_MOTORWAY_SHIELD_Z11_STYLE_MARKER = "ch-motorway-icon-z11-plus"
 _MAPBOX_SYMBOL_PIXEL_TO_MM = 25.4 / 96.0
 _MAPBOX_DEFAULT_SYMBOL_SPACING_PX = 250.0
+_ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX = 150.0
 _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "ferry-aerialway-label",
     "path-pedestrian-label",
-    "road-label",
 }
 _WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER = {
     "z13-to-z15": 250.0,
@@ -92,12 +92,16 @@ def _symbol_spacing_mm(pixels: float) -> float:
 
 
 def _label_repeat_distance(layer_name: str, style) -> float | None:
+    style_name = _label_style_name(style)
+    if layer_name == "road-label":
+        if style_name in {"road-label-below-z12", "road-label-z12-to-z15"}:
+            return _symbol_spacing_mm(_ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX)
+        return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
     if layer_name in _LINE_LABEL_REPEAT_DISTANCE_LAYERS:
         return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
     if layer_name != "waterway-label":
         return None
 
-    style_name = _label_style_name(style)
     for marker, pixels in _WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER.items():
         if marker in style_name:
             return _symbol_spacing_mm(pixels)


### PR DESCRIPTION
## Summary

- apply Mapbox line-symbol repeat spacing to QGIS line labels when the converter leaves repeatDistance at zero
- use the audited 150 px low/mid road-label spacing and Mapbox's 250 px default for high-zoom road labels
- use Mapbox's 250 px default for path/pedestrian and ferry/aerialway labels
- use the existing qfit waterway-label zoom bands to apply 250/325/400 px spacing
- leave contour labels, shield labels, and any existing nonzero QGIS repeat distance untouched

## Why

Live #949 visual comparison showed QGIS over-repeating road and waterway line labels at z14/z18. Mapbox's style spec defaults symbol-spacing to 250 pixels, and Mapbox Outdoors uses a 150 px road-label spacing below z14, while QGIS converted these affected labels with repeatDistance = 0 mm. This patch converts the relevant Mapbox pixel spacing to the millimeter render unit used by the existing QGIS converter context.

## Evidence

- QGIS label-settings diagnostic after the final patch: debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T074316Z/summary.md
- Live all-camera comparison after the final patch: debug/mapbox-outdoors-comparison/all-cameras/20260518T074408Z/summary.md
- Visual review accepted Chamonix z14 and Zermatt z18 before/after renders: Zermatt road and Matter Vispa labels repeat less aggressively, while Chamonix did not show obvious label-loss regressions.
- Follow-up visual review accepted Lausanne z10 and Geneva z14 after Codex feedback: low/mid road-label density is preserved rather than under-labeled.

## Review Feedback

- Addressed Codex feedback about preserving low-zoom road-label spacing by using 150 px for road-label-below-z12 and road-label-z12-to-z15, while keeping 250 px for road-label-z15-plus.

## Validation

- python3 -m pytest tests/test_background_map_service.py -q -k 'repeat_distance or priority' --tb=short
- python3 -m pytest tests/test_background_map_service.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- python3 validation/mapbox_outdoors_comparison.py --all-cameras
