### PR TITLE
fix: append Mapbox contour label units

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -726,10 +726,27 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 
-    def test_contour_label_repeat_distance_is_left_unchanged(self):
+    def test_contour_label_appends_metre_suffix_without_repeat_distance(self):
         labeling = MagicMock()
         style, settings = self._make_style("contour", "contour-label")
         settings.repeatDistance = 0.0
+        settings.fieldName = '"ele"'
+        settings.isExpression = True
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.fieldName, "concat(\"ele\", ' m')")
+        self.assertTrue(settings.isExpression)
+        self.assertEqual(settings.repeatDistance, 0.0)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_contour_label_suffix_expression_is_left_unchanged(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("contour", "contour-label")
+        settings.repeatDistance = 0.0
+        settings.fieldName = "concat(\"ele\", ' m')"
+        settings.isExpression = True
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
@@ -890,10 +907,12 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.assertEqual(settings.repeatDistance, 12.5)
         style.setLabelSettings.assert_called_once_with(settings)
 
-    def test_contour_label_repeat_distance_is_left_unchanged(self):
+    def test_contour_label_suffix_expression_is_left_unchanged(self):
         labeling = MagicMock()
         style, settings = self._make_style("contour", "contour-label")
         settings.repeatDistance = 0.0
+        settings.fieldName = "concat(\"ele\", ' m')"
+        settings.isExpression = True
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
@@ -928,6 +947,19 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.service._apply_label_priority(labeling)
 
         style.setLabelSettings.assert_not_called()
+
+    def test_contour_label_appends_metre_suffix(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("contour", "contour-label")
+        settings.fieldName = '"ele"'
+        settings.isExpression = True
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.fieldName, "concat(\"ele\", ' m')")
+        self.assertTrue(settings.isExpression)
+        style.setLabelSettings.assert_called_once_with(settings)
 
     def test_none_settings_is_skipped(self):
         labeling = MagicMock()

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -753,6 +753,19 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
 
         style.setLabelSettings.assert_not_called()
 
+    def test_custom_contour_label_field_is_left_unchanged(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("contour", "contour-label")
+        settings.repeatDistance = 0.0
+        settings.fieldName = '"height_ft"'
+        settings.isExpression = True
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.fieldName, '"height_ft"')
+        style.setLabelSettings.assert_not_called()
+
 
 @unittest.skipIf(QGIS_AVAILABLE, SKIP_MOCK)
 @unittest.skipIf(_mock_bms_cls is None, SKIP_MOCK_LOAD)
@@ -960,6 +973,18 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.assertEqual(settings.fieldName, "concat(\"ele\", ' m')")
         self.assertTrue(settings.isExpression)
         style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_custom_contour_label_field_is_left_unchanged(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("contour", "contour-label")
+        settings.fieldName = '"height_ft"'
+        settings.isExpression = True
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.fieldName, '"height_ft"')
+        style.setLabelSettings.assert_not_called()
 
     def test_none_settings_is_skipped(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -59,6 +59,7 @@ _WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER = {
     "z15-to-z17": 325.0,
     "z17-plus": 400.0,
 }
+_CONTOUR_LABEL_EXPRESSION = "concat(\"ele\", ' m')"
 
 
 def _label_style_mapbox_layer_id(style) -> str:
@@ -110,6 +111,12 @@ def _label_repeat_distance(layer_name: str, style) -> float | None:
     return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
 
 
+def _label_field_expression(layer_name: str) -> str | None:
+    if layer_name == "contour-label":
+        return _CONTOUR_LABEL_EXPRESSION
+    return None
+
+
 def _needs_repeat_distance(settings) -> bool:
     repeat_distance = getattr(settings, "repeatDistance", 0.0)
     return not isinstance(repeat_distance, (int, float)) or repeat_distance <= 0
@@ -132,6 +139,7 @@ def _apply_label_settings(
     layer_name: str,
     priority: int | None,
     repeat_distance: float | None,
+    field_expression: str | None,
     qgs_property,
     qgis,
 ) -> bool:
@@ -144,6 +152,13 @@ def _apply_label_settings(
     if repeat_distance is not None and _needs_repeat_distance(settings):
         settings.repeatDistance = repeat_distance
         settings.repeatDistanceUnit = qgis.RenderUnit.Millimeters
+        changed = True
+    if field_expression is not None and (
+        getattr(settings, "fieldName", "") != field_expression
+        or not getattr(settings, "isExpression", False)
+    ):
+        settings.fieldName = field_expression
+        settings.isExpression = True
         changed = True
     return changed
 
@@ -283,7 +298,8 @@ class BackgroundMapService:
                 layer_name = _label_style_mapbox_layer_id(style)
                 priority = _label_priority(layer_name, style)
                 repeat_distance = _label_repeat_distance(layer_name, style)
-                if priority is None and repeat_distance is None:
+                field_expression = _label_field_expression(layer_name)
+                if priority is None and repeat_distance is None and field_expression is None:
                     continue
                 settings = style.labelSettings()
                 if settings is None:
@@ -293,6 +309,7 @@ class BackgroundMapService:
                     layer_name=layer_name,
                     priority=priority,
                     repeat_distance=repeat_distance,
+                    field_expression=field_expression,
                     qgs_property=QgsProperty,
                     qgis=Qgis,
                 ):

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -59,6 +59,7 @@ _WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER = {
     "z15-to-z17": 325.0,
     "z17-plus": 400.0,
 }
+_CONTOUR_LABEL_ELEVATION_FIELD_EXPRESSION = '"ele"'
 _CONTOUR_LABEL_EXPRESSION = "concat(\"ele\", ' m')"
 
 
@@ -111,8 +112,12 @@ def _label_repeat_distance(layer_name: str, style) -> float | None:
     return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
 
 
-def _label_field_expression(layer_name: str) -> str | None:
-    if layer_name == "contour-label":
+def _label_field_expression(layer_name: str, settings) -> str | None:
+    if (
+        layer_name == "contour-label"
+        and getattr(settings, "fieldName", "") == _CONTOUR_LABEL_ELEVATION_FIELD_EXPRESSION
+        and getattr(settings, "isExpression", False)
+    ):
         return _CONTOUR_LABEL_EXPRESSION
     return None
 
@@ -298,11 +303,13 @@ class BackgroundMapService:
                 layer_name = _label_style_mapbox_layer_id(style)
                 priority = _label_priority(layer_name, style)
                 repeat_distance = _label_repeat_distance(layer_name, style)
-                field_expression = _label_field_expression(layer_name)
-                if priority is None and repeat_distance is None and field_expression is None:
+                if priority is None and repeat_distance is None and layer_name != "contour-label":
                     continue
                 settings = style.labelSettings()
                 if settings is None:
+                    continue
+                field_expression = _label_field_expression(layer_name, settings)
+                if priority is None and repeat_distance is None and field_expression is None:
                     continue
                 if _apply_label_settings(
                     settings,


### PR DESCRIPTION
## Summary

- Append the Mapbox contour-label metre suffix in QGIS label settings only when the converter output is still the simplified `"ele"` expression.
- Keep qfit's current QGIS-safe `["get", "ele"]` preprocessing instead of handing QGIS the unsupported Mapbox `concat` expression directly.
- Leave custom contour-label fields untouched, and cover both the append and guard paths in real-QGIS and mock-QGIS tests.

## Evidence

- Live Mapbox/QGIS settings probe using the local token source:
  - Original Mapbox `contour-label` text field: `["concat", ["get", "ele"], " m"]`
  - qfit preprocessed text field: `["get", "ele"]`
  - QGIS before override: `('"ele"', True)`
  - QGIS after override: `concat("ele", ' m')`, expression mode `True`, parser error `False`
- QGIS expression evaluation probe: `concat("ele", ' m')` evaluates `1200` to `1200 m` with no parser or eval error.
- Chamonix z14 comparison artifact: `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260518T080019Z/`
- Zermatt z17 comparison artifact: `debug/mapbox-outdoors-comparison/zermatt-piste-z17-outdoors/20260518T080235Z/`
- Candidate QGIS renders were pixel-identical to the post-#1129 baselines for those two fixed cameras, so this is a label-content correctness fix with no observed render regression there.

## Tests

- `python3 -m pytest tests/test_background_map_service.py -q -k 'contour_label or custom_contour or repeat_distance or priority' --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.

