### PR TITLE
feat: add Mapbox label settings diagnostic

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -1,0 +1,171 @@
+import datetime as dt
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from tests import _path  # noqa: F401
+
+from qfit.validation.mapbox_outdoors_label_settings import (
+    build_label_settings_paths,
+    build_run_directory,
+    build_summary_markdown,
+    label_settings_record,
+    load_style_definition,
+    resolve_mapbox_token,
+    write_report,
+)
+
+
+class FakeProperties:
+    def __init__(self, keys):
+        self._keys = keys
+
+    def propertyKeys(self):
+        return self._keys
+
+
+class FakeStyle:
+    def __init__(self, *, style_name, layer_name):
+        self._style_name = style_name
+        self._layer_name = layer_name
+
+    def styleName(self):
+        return self._style_name
+
+    def layerName(self):
+        return self._layer_name
+
+
+class FakeSettings:
+    fieldName = '"name"'
+    isExpression = True
+    priority = 7
+    placement = SimpleNamespace(name="Line")
+    repeatDistance = 66.1458333333
+    repeatDistanceUnit = SimpleNamespace(name="Millimeters")
+    displayAll = False
+    obstacle = True
+
+    def dataDefinedProperties(self):
+        return FakeProperties([87, 50])
+
+
+class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
+    def test_resolve_mapbox_token_prefers_argument_then_environment(self):
+        self.assertEqual(
+            resolve_mapbox_token(
+                provided_token="arg-token",
+                environ={"MAPBOX_ACCESS_TOKEN": "env-token", "QFIT_MAPBOX_ACCESS_TOKEN": "qfit-token"},
+            ),
+            "arg-token",
+        )
+        self.assertEqual(
+            resolve_mapbox_token(provided_token=None, environ={"MAPBOX_ACCESS_TOKEN": "env-token"}),
+            "env-token",
+        )
+        self.assertEqual(
+            resolve_mapbox_token(provided_token=None, environ={"QFIT_MAPBOX_ACCESS_TOKEN": "qfit-token"}),
+            "qfit-token",
+        )
+        self.assertIsNone(resolve_mapbox_token(provided_token=None, environ={}))
+
+    def test_build_run_directory_uses_style_slug_and_timestamp(self):
+        run_dir = build_run_directory(
+            output_root=Path("/tmp/qfit-labels"),
+            style_owner="mapbox",
+            style_id="outdoors-v12",
+            now=dt.datetime(2026, 5, 18, 8, 22, tzinfo=dt.timezone.utc),
+        )
+
+        self.assertEqual(run_dir, Path("/tmp/qfit-labels/mapbox-outdoors-v12/20260518T082200Z"))
+
+    def test_build_label_settings_paths_are_predictable(self):
+        paths = build_label_settings_paths(Path("/tmp/run"))
+
+        self.assertEqual(paths.json_path, Path("/tmp/run/label-settings.json"))
+        self.assertEqual(paths.summary_path, Path("/tmp/run/summary.md"))
+
+    def test_load_style_definition_requires_json_object(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            good_path = Path(tmpdir) / "style.json"
+            good_path.write_text(json.dumps({"version": 8, "layers": []}), encoding="utf-8")
+            self.assertEqual(load_style_definition(good_path), {"version": 8, "layers": []})
+
+            bad_path = Path(tmpdir) / "bad.json"
+            bad_path.write_text("[]", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_style_definition(bad_path)
+
+    def test_label_settings_record_captures_qgis_fields_and_base_layer(self):
+        record = label_settings_record(
+            FakeStyle(style_name="road-label-z15-plus", layer_name="road"),
+            FakeSettings(),
+        )
+
+        self.assertEqual(record["style_name"], "road-label-z15-plus")
+        self.assertEqual(record["base_style_layer_id"], "road-label")
+        self.assertEqual(record["source_layer"], "road")
+        self.assertEqual(record["field_name"], '"name"')
+        self.assertTrue(record["is_expression"])
+        self.assertEqual(record["priority"], 7)
+        self.assertEqual(record["placement"], "Line")
+        self.assertAlmostEqual(record["repeat_distance"], 66.1458333333)
+        self.assertEqual(record["repeat_distance_unit"], "Millimeters")
+        self.assertEqual(record["data_defined_property_keys"], [50, 87])
+
+    def test_summary_markdown_lists_label_settings(self):
+        report = {
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "generated": "2026-05-18T08:22:00+00:00",
+            "sprite_context_loaded": True,
+            "sprite_definition_count": 440,
+            "label_count": 1,
+            "labels": [
+                {
+                    "base_style_layer_id": "contour-label",
+                    "style_name": "contour-label",
+                    "source_layer": "contour",
+                    "field_name": "concat(\"ele\", ' m')",
+                    "is_expression": True,
+                    "priority": 3,
+                    "placement": "Line",
+                    "repeat_distance": 0.0,
+                    "repeat_distance_unit": "Millimeters",
+                    "display_all": False,
+                    "obstacle": True,
+                    "data_defined_property_keys": [],
+                }
+            ],
+        }
+
+        markdown = build_summary_markdown(report)
+
+        self.assertIn("# Mapbox Outdoors QGIS label settings — mapbox/outdoors-v12", markdown)
+        self.assertIn("Converted label styles: 1", markdown)
+        self.assertIn("Sprite context loaded: yes", markdown)
+        self.assertIn("contour-label", markdown)
+        self.assertIn("concat", markdown)
+        self.assertIn("Millimeters", markdown)
+
+    def test_write_report_writes_json_and_summary(self):
+        report = {
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "generated": "2026-05-18T08:22:00+00:00",
+            "label_count": 0,
+            "labels": [],
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = build_label_settings_paths(Path(tmpdir) / "run")
+
+            write_report(report, paths)
+
+            self.assertEqual(json.loads(paths.json_path.read_text(encoding="utf-8"))["label_count"], 0)
+            self.assertIn("Converted label styles: 0", paths.summary_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -144,10 +144,12 @@ class FakeConverter:
 
 class FakeBackgroundMapService:
     applied_count = 0
+    labeling = None
 
-    def _apply_label_priority(self, labeling):
-        type(self).applied_count += 1
-        self.labeling = labeling
+
+def fake_apply_label_priority(labeling):
+    FakeBackgroundMapService.applied_count += 1
+    FakeBackgroundMapService.labeling = labeling
 
 
 def _fake_qgis_modules():
@@ -163,7 +165,7 @@ def _fake_qgis_modules():
 
 def _fake_background_map_service_module():
     module = types.ModuleType("qfit.visualization.infrastructure.background_map_service")
-    module.BackgroundMapService = FakeBackgroundMapService
+    module.apply_mapbox_label_priority = fake_apply_label_priority
     return module
 
 
@@ -171,6 +173,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
     def setUp(self):
         FakeQgsApplication._instance = None
         FakeBackgroundMapService.applied_count = 0
+        FakeBackgroundMapService.labeling = None
         FakeConversionContext.last_instance = None
         FakeConverter.last_style = None
 
@@ -234,6 +237,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["placement"], "Line")
         self.assertAlmostEqual(record["repeat_distance"], 66.1458333333)
         self.assertEqual(record["repeat_distance_unit"], "Millimeters")
+        self.assertFalse(record["display_all"])
+        self.assertTrue(record["obstacle"])
         self.assertEqual(record["data_defined_property_keys"], [50, 87])
 
     def test_ensure_qgis_application_reuses_or_creates_application(self):
@@ -340,12 +345,13 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     FakeLabelStyle(style_name="road-label-z15-plus", layer_name="road", settings=FakeSettings()),
                 ]
             ),
-            FakeBackgroundMapService,
+            fake_apply_label_priority,
         )
 
         self.assertEqual(FakeBackgroundMapService.applied_count, 1)
+        self.assertIsInstance(FakeBackgroundMapService.labeling, FakeLabeling)
         self.assertEqual([record["base_style_layer_id"] for record in records], ["road-label", "waterway-label"])
-        self.assertEqual(_postprocessed_label_records(None, FakeBackgroundMapService), [])
+        self.assertEqual(_postprocessed_label_records(None, fake_apply_label_priority), [])
 
     def test_label_settings_report_captures_summary_metadata(self):
         report = _label_settings_report(
@@ -413,7 +419,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distance_unit": "Millimeters",
                     "display_all": False,
                     "obstacle": True,
-                    "data_defined_property_keys": [],
+                    "data_defined_property_keys": ["pipe|key"],
                 }
             ],
         }
@@ -426,6 +432,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("contour-label", markdown)
         self.assertIn("concat", markdown)
         self.assertIn("Millimeters", markdown)
+        self.assertIn("pipe\\|key", markdown)
 
     def test_write_report_writes_json_and_summary(self):
         report = {

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -1,18 +1,31 @@
 import datetime as dt
+import importlib
 import json
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_label_settings import (
+    LabelSettingsConfig,
+    _convert_style_to_labeling,
+    _ensure_qgis_application,
+    _fetch_sprite_resources,
+    _label_settings_report,
+    _load_original_style,
+    _postprocessed_label_records,
     build_label_settings_paths,
     build_run_directory,
     build_summary_markdown,
+    collect_label_settings,
     label_settings_record,
     load_style_definition,
+    main,
     resolve_mapbox_token,
     write_report,
 )
@@ -38,6 +51,23 @@ class FakeStyle:
         return self._layer_name
 
 
+class FakeLabelStyle(FakeStyle):
+    def __init__(self, *, style_name, layer_name, settings):
+        super().__init__(style_name=style_name, layer_name=layer_name)
+        self._settings = settings
+
+    def labelSettings(self):
+        return self._settings
+
+
+class FakeLabeling:
+    def __init__(self, styles):
+        self._styles = styles
+
+    def styles(self):
+        return self._styles
+
+
 class FakeSettings:
     fieldName = '"name"'
     isExpression = True
@@ -52,7 +82,93 @@ class FakeSettings:
         return FakeProperties([87, 50])
 
 
+class FakeQgsApplication:
+    _instance = None
+
+    def __init__(self, args, enabled):
+        self.args = args
+        self.enabled = enabled
+        self.initialized = False
+        self.exited = False
+
+    @classmethod
+    def instance(cls):
+        return cls._instance
+
+    def initQgis(self):
+        self.initialized = True
+        type(self)._instance = self
+
+    def exitQgis(self):
+        self.exited = True
+        type(self)._instance = None
+
+
+class FakeConversionContext:
+    last_instance = None
+
+    def __init__(self):
+        self.target_unit = None
+        self.pixel_factor = None
+        type(self).last_instance = self
+
+    def setTargetUnit(self, unit):
+        self.target_unit = unit
+
+    def setPixelSizeConversionFactor(self, factor):
+        self.pixel_factor = factor
+
+
+class FakeConverter:
+    Success = "success"
+    last_style = None
+
+    def __init__(self):
+        self._labeling = FakeLabeling(
+            [
+                FakeLabelStyle(
+                    style_name="road-label-z15-plus",
+                    layer_name="road",
+                    settings=FakeSettings(),
+                )
+            ]
+        )
+
+    def convert(self, style, context):
+        type(self).last_style = style
+        self.context = context
+        return self.Success
+
+    def labeling(self):
+        return self._labeling
+
+
+class FakeBackgroundMapService:
+    applied_count = 0
+
+    def _apply_label_priority(self, labeling):
+        type(self).applied_count += 1
+        self.labeling = labeling
+
+
+def _fake_qgis_modules():
+    qgis_module = types.ModuleType("qgis")
+    core_module = types.ModuleType("qgis.core")
+    core_module.QgsApplication = FakeQgsApplication
+    core_module.QgsMapBoxGlStyleConversionContext = FakeConversionContext
+    core_module.QgsMapBoxGlStyleConverter = FakeConverter
+    core_module.Qgis = SimpleNamespace(RenderUnit=SimpleNamespace(Millimeters="millimeters"))
+    qgis_module.core = core_module
+    return {"qgis": qgis_module, "qgis.core": core_module}
+
+
 class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
+    def setUp(self):
+        FakeQgsApplication._instance = None
+        FakeBackgroundMapService.applied_count = 0
+        FakeConversionContext.last_instance = None
+        FakeConverter.last_style = None
+
     def test_resolve_mapbox_token_prefers_argument_then_environment(self):
         self.assertEqual(
             resolve_mapbox_token(
@@ -115,6 +231,162 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["repeat_distance_unit"], "Millimeters")
         self.assertEqual(record["data_defined_property_keys"], [50, 87])
 
+    def test_ensure_qgis_application_reuses_or_creates_application(self):
+        existing_app = FakeQgsApplication([], False)
+        FakeQgsApplication._instance = existing_app
+
+        app, created = _ensure_qgis_application(FakeQgsApplication)
+
+        self.assertIs(app, existing_app)
+        self.assertFalse(created)
+
+        FakeQgsApplication._instance = None
+        app, created = _ensure_qgis_application(FakeQgsApplication)
+
+        self.assertTrue(created)
+        self.assertTrue(app.initialized)
+        self.assertIs(FakeQgsApplication.instance(), app)
+
+    def test_load_original_style_uses_fixture_or_live_fetcher(self):
+        config = LabelSettingsConfig(token=None, output_root=Path("/tmp"))
+        with self.assertRaises(ValueError):
+            _load_original_style(config, lambda *_args: {})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            style_path = Path(tmpdir) / "style.json"
+            style_path.write_text(json.dumps({"version": 8, "layers": []}), encoding="utf-8")
+            self.assertEqual(
+                _load_original_style(
+                    LabelSettingsConfig(token=None, output_root=Path("/tmp"), style_json_path=style_path),
+                    lambda *_args: {"unexpected": True},
+                ),
+                {"version": 8, "layers": []},
+            )
+
+        calls = []
+
+        def fetcher(token, owner, style_id):
+            calls.append((token, owner, style_id))
+            return {"version": 8}
+
+        self.assertEqual(
+            _load_original_style(LabelSettingsConfig(token="token", output_root=Path("/tmp")), fetcher),
+            {"version": 8},
+        )
+        self.assertEqual(calls, [("token", "mapbox", "outdoors-v12")])
+
+    def test_fetch_sprite_resources_handles_disabled_success_and_failures(self):
+        config = LabelSettingsConfig(token="token", output_root=Path("/tmp"), include_sprite_context=False)
+
+        self.assertEqual(_fetch_sprite_resources(config, {"sprite": "sprite-url"}, lambda *_args, **_kwargs: None), (None, 0))
+
+        resources = SimpleNamespace(definitions={"poi": {}, "water": {}})
+        calls = []
+
+        def fetcher(token, owner, style_id, *, sprite_url):
+            calls.append((token, owner, style_id, sprite_url))
+            return resources
+
+        loaded, count = _fetch_sprite_resources(
+            LabelSettingsConfig(token="token", output_root=Path("/tmp")),
+            {"sprite": "sprite-url"},
+            fetcher,
+        )
+
+        self.assertIs(loaded, resources)
+        self.assertEqual(count, 2)
+        self.assertEqual(calls, [("token", "mapbox", "outdoors-v12", "sprite-url")])
+
+        def failing_fetcher(*_args, **_kwargs):
+            raise RuntimeError("unavailable")
+
+        self.assertEqual(
+            _fetch_sprite_resources(
+                LabelSettingsConfig(token="token", output_root=Path("/tmp")),
+                {"sprite": "sprite-url"},
+                failing_fetcher,
+            ),
+            (None, 0),
+        )
+
+    def test_convert_style_to_labeling_uses_qgis_converter_context(self):
+        result, labeling, sprite_loaded = _convert_style_to_labeling(
+            {"version": 8},
+            None,
+            (
+                FakeConversionContext,
+                FakeConverter,
+                SimpleNamespace(RenderUnit=SimpleNamespace(Millimeters="millimeters")),
+            ),
+        )
+
+        self.assertEqual(result, "success")
+        self.assertIsInstance(labeling, FakeLabeling)
+        self.assertFalse(sprite_loaded)
+        self.assertEqual(FakeConverter.last_style, {"version": 8})
+        self.assertEqual(FakeConversionContext.last_instance.target_unit, "millimeters")
+        self.assertAlmostEqual(FakeConversionContext.last_instance.pixel_factor, 25.4 / 96.0)
+
+    def test_postprocessed_label_records_sorts_and_applies_runtime_priorities(self):
+        records = _postprocessed_label_records(
+            FakeLabeling(
+                [
+                    FakeLabelStyle(style_name="waterway-label-z17-plus", layer_name="waterway", settings=FakeSettings()),
+                    FakeLabelStyle(style_name="road-label-z15-plus", layer_name="road", settings=FakeSettings()),
+                ]
+            ),
+            FakeBackgroundMapService,
+        )
+
+        self.assertEqual(FakeBackgroundMapService.applied_count, 1)
+        self.assertEqual([record["base_style_layer_id"] for record in records], ["road-label", "waterway-label"])
+        self.assertEqual(_postprocessed_label_records(None, FakeBackgroundMapService), [])
+
+    def test_label_settings_report_captures_summary_metadata(self):
+        report = _label_settings_report(
+            config=LabelSettingsConfig(token="token", output_root=Path("/tmp")),
+            result="success",
+            sprite_loaded=True,
+            sprite_count=440,
+            records=[{"style_name": "contour-label"}],
+        )
+
+        self.assertEqual(report["style_owner"], "mapbox")
+        self.assertEqual(report["style_id"], "outdoors-v12")
+        self.assertEqual(report["qgis_converter_result"], "success")
+        self.assertTrue(report["sprite_context_loaded"])
+        self.assertEqual(report["sprite_definition_count"], 440)
+        self.assertEqual(report["label_count"], 1)
+
+    def test_collect_label_settings_runs_with_fake_qgis_runtime(self):
+        background_map_service = importlib.import_module(
+            "qfit.visualization.infrastructure.background_map_service"
+        )
+        with mock.patch.dict(sys.modules, _fake_qgis_modules()):
+            with mock.patch(
+                "qfit.mapbox_config.fetch_mapbox_style_definition",
+                return_value={"version": 8, "layers": [], "sprite": "sprite-url"},
+            ) as fetch_style:
+                with mock.patch(
+                    "qfit.mapbox_config.fetch_mapbox_sprite_resources",
+                    return_value=SimpleNamespace(definitions={"road": {}}, image_bytes=b"not-an-image"),
+                ) as fetch_sprites:
+                    with mock.patch(
+                        "qfit.mapbox_config.simplify_mapbox_style_expressions",
+                        return_value={"version": 8, "layers": [{"id": "road-label-z15-plus"}]},
+                    ):
+                        with mock.patch.object(background_map_service, "BackgroundMapService", FakeBackgroundMapService):
+                            report = collect_label_settings(LabelSettingsConfig(token="token", output_root=Path("/tmp")))
+
+        fetch_style.assert_called_once_with("token", "mapbox", "outdoors-v12")
+        fetch_sprites.assert_called_once()
+        self.assertEqual(report["qgis_converter_result"], "success")
+        self.assertEqual(report["sprite_definition_count"], 1)
+        self.assertFalse(report["sprite_context_loaded"])
+        self.assertEqual(report["label_count"], 1)
+        self.assertEqual(report["labels"][0]["base_style_layer_id"], "road-label")
+        self.assertIsNone(FakeQgsApplication.instance())
+
     def test_summary_markdown_lists_label_settings(self):
         report = {
             "style_owner": "mapbox",
@@ -165,6 +437,38 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
 
             self.assertEqual(json.loads(paths.json_path.read_text(encoding="utf-8"))["label_count"], 0)
             self.assertIn("Converted label styles: 0", paths.summary_path.read_text(encoding="utf-8"))
+
+    def test_main_writes_report_from_arguments(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            style_path = Path(tmpdir) / "style.json"
+            output_root = Path(tmpdir) / "labels"
+            style_path.write_text(json.dumps({"version": 8, "layers": []}), encoding="utf-8")
+
+            with mock.patch(
+                "qfit.validation.mapbox_outdoors_label_settings.collect_label_settings",
+                return_value={
+                    "style_owner": "mapbox",
+                    "style_id": "outdoors-v12",
+                    "generated": "2026-05-18T08:22:00+00:00",
+                    "label_count": 0,
+                    "labels": [],
+                },
+            ) as collect:
+                exit_code = main(
+                    [
+                        "--style-json",
+                        str(style_path),
+                        "--output-root",
+                        str(output_root),
+                        "--no-sprite-context",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            collect.assert_called_once()
+            self.assertEqual(collect.call_args.args[0].style_json_path, style_path)
+            self.assertFalse(collect.call_args.args[0].include_sprite_context)
+            self.assertEqual(len(list(output_root.glob("mapbox-outdoors-v12/*/summary.md"))), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import importlib
 import json
 import sys
 import tempfile
@@ -160,6 +159,12 @@ def _fake_qgis_modules():
     core_module.Qgis = SimpleNamespace(RenderUnit=SimpleNamespace(Millimeters="millimeters"))
     qgis_module.core = core_module
     return {"qgis": qgis_module, "qgis.core": core_module}
+
+
+def _fake_background_map_service_module():
+    module = types.ModuleType("qfit.visualization.infrastructure.background_map_service")
+    module.BackgroundMapService = FakeBackgroundMapService
+    return module
 
 
 class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
@@ -359,10 +364,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(report["label_count"], 1)
 
     def test_collect_label_settings_runs_with_fake_qgis_runtime(self):
-        background_map_service = importlib.import_module(
-            "qfit.visualization.infrastructure.background_map_service"
-        )
-        with mock.patch.dict(sys.modules, _fake_qgis_modules()):
+        modules = {
+            **_fake_qgis_modules(),
+            "qfit.visualization.infrastructure.background_map_service": _fake_background_map_service_module(),
+        }
+        with mock.patch.dict(sys.modules, modules):
             with mock.patch(
                 "qfit.mapbox_config.fetch_mapbox_style_definition",
                 return_value={"version": 8, "layers": [], "sprite": "sprite-url"},
@@ -375,8 +381,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                         "qfit.mapbox_config.simplify_mapbox_style_expressions",
                         return_value={"version": 8, "layers": [{"id": "road-label-z15-plus"}]},
                     ):
-                        with mock.patch.object(background_map_service, "BackgroundMapService", FakeBackgroundMapService):
-                            report = collect_label_settings(LabelSettingsConfig(token="token", output_root=Path("/tmp")))
+                        report = collect_label_settings(LabelSettingsConfig(token="token", output_root=Path("/tmp")))
 
         fetch_style.assert_called_once_with("token", "mapbox", "outdoors-v12")
         fetch_sprites.assert_called_once()

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -212,10 +212,10 @@ def _convert_style_to_labeling(qfit_style: dict[str, object], sprite_resources: 
     return result, converter.labeling(), sprite_loaded
 
 
-def _postprocessed_label_records(labeling: object | None, background_map_service_cls) -> list[dict[str, object]]:
+def _postprocessed_label_records(labeling: object | None, apply_label_priority) -> list[dict[str, object]]:
     if labeling is None:
         return []
-    background_map_service_cls()._apply_label_priority(labeling)
+    apply_label_priority(labeling)
     return sorted(
         _iter_label_records(labeling),
         key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
@@ -261,7 +261,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
         fetch_mapbox_style_definition,
         simplify_mapbox_style_expressions,
     )
-    from qfit.visualization.infrastructure.background_map_service import BackgroundMapService
+    from qfit.visualization.infrastructure.background_map_service import apply_mapbox_label_priority
 
     app, created_app = _ensure_qgis_application(QgsApplication)
     try:
@@ -273,7 +273,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             sprite_resources,
             (QgsMapBoxGlStyleConversionContext, QgsMapBoxGlStyleConverter, Qgis),
         )
-        records = _postprocessed_label_records(labeling, BackgroundMapService)
+        records = _postprocessed_label_records(labeling, apply_mapbox_label_priority)
         return _label_settings_report(
             config=config,
             result=result,
@@ -294,7 +294,7 @@ def _markdown_value(value: object) -> str:
     if isinstance(value, float):
         return f"{value:.6g}"
     if isinstance(value, list):
-        return ", ".join(str(item) for item in value) if value else "—"
+        return ", ".join(str(item).replace("|", "\\|") for item in value) if value else "—"
     return str(value).replace("|", "\\|")
 
 

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -198,15 +198,15 @@ def _fetch_sprite_resources(config: LabelSettingsConfig, original_style: dict[st
 
 
 def _convert_style_to_labeling(qfit_style: dict[str, object], sprite_resources: object | None, qgis_modules) -> tuple[object, object, bool]:
-    QgsMapBoxGlStyleConversionContext, QgsMapBoxGlStyleConverter, Qgis = qgis_modules
-    ctx = QgsMapBoxGlStyleConversionContext()
-    ctx.setTargetUnit(Qgis.RenderUnit.Millimeters)
+    conversion_context_cls, converter_cls, qgis_api = qgis_modules
+    ctx = conversion_context_cls()
+    ctx.setTargetUnit(qgis_api.RenderUnit.Millimeters)
     ctx.setPixelSizeConversionFactor(25.4 / 96.0)
     sprite_loaded = _apply_sprite_context(ctx, sprite_resources)
 
-    converter = QgsMapBoxGlStyleConverter()
+    converter = converter_cls()
     result = converter.convert(qfit_style, ctx)
-    success_value = getattr(QgsMapBoxGlStyleConverter, "Success", None)
+    success_value = getattr(converter_cls, "Success", None)
     if success_value is not None and result != success_value:
         raise RuntimeError(f"QGIS Mapbox style conversion failed: {result}")
     return result, converter.labeling(), sprite_loaded

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PARENT = REPO_ROOT.parent
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-label-settings"
+DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
+DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
+DEFAULT_QT_QPA_PLATFORM = "offscreen"
+
+
+@dataclass(frozen=True)
+class LabelSettingsPaths:
+    run_dir: Path
+    json_path: Path
+    summary_path: Path
+
+
+@dataclass(frozen=True)
+class LabelSettingsConfig:
+    token: str | None
+    output_root: Path
+    style_owner: str = DEFAULT_MAPBOX_STYLE_OWNER
+    style_id: str = DEFAULT_MAPBOX_STYLE_ID
+    style_json_path: Path | None = None
+    include_sprite_context: bool = True
+    now: dt.datetime | None = None
+
+
+def _ensure_package_parent_on_path() -> None:
+    package_parent = str(PACKAGE_PARENT)
+    if package_parent not in sys.path:
+        sys.path.insert(0, package_parent)
+
+
+def _ensure_headless_qt_platform() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", DEFAULT_QT_QPA_PLATFORM)
+
+
+def resolve_mapbox_token(*, provided_token: str | None, environ: dict[str, str] | None = None) -> str | None:
+    env = os.environ if environ is None else environ
+    return provided_token or env.get("MAPBOX_ACCESS_TOKEN") or env.get("QFIT_MAPBOX_ACCESS_TOKEN")
+
+
+def load_style_definition(path: Path) -> dict[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected Mapbox style JSON object in {path}")
+    return data
+
+
+def _style_slug(style_owner: str, style_id: str) -> str:
+    return f"{style_owner}-{style_id}".replace("/", "-")
+
+
+def build_run_directory(
+    *,
+    output_root: Path,
+    style_owner: str,
+    style_id: str,
+    now: dt.datetime | None = None,
+) -> Path:
+    timestamp = (now or dt.datetime.now(dt.timezone.utc)).astimezone(dt.timezone.utc)
+    return output_root / _style_slug(style_owner, style_id) / timestamp.strftime("%Y%m%dT%H%M%SZ")
+
+
+def build_label_settings_paths(run_dir: Path) -> LabelSettingsPaths:
+    return LabelSettingsPaths(
+        run_dir=run_dir,
+        json_path=run_dir / "label-settings.json",
+        summary_path=run_dir / "summary.md",
+    )
+
+
+def _method_value(obj: object, method_name: str) -> object:
+    method = getattr(obj, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        return method()
+    except (AttributeError, RuntimeError, TypeError):
+        return None
+
+
+def _enum_name(value: object) -> object:
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    return str(value) if value is not None else None
+
+
+def _settings_value(settings: object, name: str) -> object:
+    try:
+        value = getattr(settings, name)
+    except (AttributeError, RuntimeError):
+        return None
+    return _enum_name(value) if name.endswith("Unit") or name == "placement" else value
+
+
+def _data_defined_property_keys(settings: object) -> list[object]:
+    properties = _method_value(settings, "dataDefinedProperties")
+    keys = _method_value(properties, "propertyKeys") if properties is not None else None
+    if keys is None:
+        return []
+    try:
+        return sorted(keys)
+    except TypeError:
+        return list(keys)
+
+
+def label_settings_record(style: object, settings: object) -> dict[str, object]:
+    _ensure_package_parent_on_path()
+    from qfit.mapbox_config import base_mapbox_style_layer_id_for_qfit
+
+    style_name = _method_value(style, "styleName")
+    layer_name = _method_value(style, "layerName")
+    style_name_text = style_name if isinstance(style_name, str) else ""
+    return {
+        "style_name": style_name_text,
+        "base_style_layer_id": base_mapbox_style_layer_id_for_qfit(style_name_text),
+        "source_layer": layer_name if isinstance(layer_name, str) else "",
+        "field_name": _settings_value(settings, "fieldName"),
+        "is_expression": _settings_value(settings, "isExpression"),
+        "priority": _settings_value(settings, "priority"),
+        "placement": _settings_value(settings, "placement"),
+        "repeat_distance": _settings_value(settings, "repeatDistance"),
+        "repeat_distance_unit": _settings_value(settings, "repeatDistanceUnit"),
+        "display_all": _settings_value(settings, "displayAll"),
+        "obstacle": _settings_value(settings, "obstacle"),
+        "data_defined_property_keys": _data_defined_property_keys(settings),
+    }
+
+
+def _iter_label_records(labeling: object) -> Iterable[dict[str, object]]:
+    for style in list(_method_value(labeling, "styles") or []):
+        settings = _method_value(style, "labelSettings")
+        if settings is None:
+            continue
+        yield label_settings_record(style, settings)
+
+
+def _apply_sprite_context(ctx: object, sprite_resources: object | None) -> bool:
+    if sprite_resources is None:
+        return False
+    try:
+        from qgis.PyQt.QtGui import QImage  # type: ignore[import-not-found]
+
+        sprite_image = QImage()
+        if not sprite_image.loadFromData(sprite_resources.image_bytes):
+            return False
+        argb_format = getattr(QImage, "Format_ARGB32", None)
+        if argb_format is not None:
+            sprite_image = sprite_image.convertToFormat(argb_format)
+        ctx.setSprites(sprite_image, sprite_resources.definitions)
+        return True
+    except (AttributeError, ImportError, RuntimeError, TypeError):
+        return False
+
+
+def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
+    _ensure_package_parent_on_path()
+    _ensure_headless_qt_platform()
+    try:
+        from qgis.core import (  # type: ignore[import-not-found]
+            QgsApplication,
+            QgsMapBoxGlStyleConversionContext,
+            QgsMapBoxGlStyleConverter,
+            Qgis,
+        )
+    except ImportError as exc:  # pragma: no cover - depends on optional PyQGIS runtime
+        raise RuntimeError("QGIS label settings diagnostics require PyQGIS.") from exc
+
+    from qfit.mapbox_config import (
+        fetch_mapbox_sprite_resources,
+        fetch_mapbox_style_definition,
+        simplify_mapbox_style_expressions,
+    )
+    from qfit.visualization.infrastructure.background_map_service import BackgroundMapService
+
+    app = QgsApplication.instance()
+    created_app = app is None
+    if created_app:
+        app = QgsApplication([], False)
+        app.initQgis()
+
+    try:
+        if config.style_json_path is not None:
+            original_style = load_style_definition(config.style_json_path)
+        else:
+            if not config.token:
+                raise ValueError("A Mapbox token is required unless --style-json is provided.")
+            original_style = fetch_mapbox_style_definition(config.token, config.style_owner, config.style_id)
+        qfit_style = simplify_mapbox_style_expressions(original_style)
+
+        sprite_loaded = False
+        sprite_count = 0
+        sprite_resources = None
+        if config.include_sprite_context and config.token:
+            try:
+                sprite_resources = fetch_mapbox_sprite_resources(
+                    config.token,
+                    config.style_owner,
+                    config.style_id,
+                    sprite_url=original_style.get("sprite"),
+                )
+                sprite_count = len(sprite_resources.definitions)
+            except (KeyError, OSError, RuntimeError, TypeError, ValueError):
+                sprite_resources = None
+
+        ctx = QgsMapBoxGlStyleConversionContext()
+        ctx.setTargetUnit(Qgis.RenderUnit.Millimeters)
+        ctx.setPixelSizeConversionFactor(25.4 / 96.0)
+        sprite_loaded = _apply_sprite_context(ctx, sprite_resources)
+
+        converter = QgsMapBoxGlStyleConverter()
+        result = converter.convert(qfit_style, ctx)
+        success_value = getattr(QgsMapBoxGlStyleConverter, "Success", None)
+        if success_value is not None and result != success_value:
+            raise RuntimeError(f"QGIS Mapbox style conversion failed: {result}")
+
+        labeling = converter.labeling()
+        if labeling is None:
+            records: list[dict[str, object]] = []
+        else:
+            BackgroundMapService()._apply_label_priority(labeling)
+            records = sorted(
+                _iter_label_records(labeling),
+                key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
+            )
+
+        return {
+            "style_owner": config.style_owner,
+            "style_id": config.style_id,
+            "generated": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "qgis_converter_result": result,
+            "sprite_context_requested": config.include_sprite_context,
+            "sprite_context_loaded": sprite_loaded,
+            "sprite_definition_count": sprite_count,
+            "label_count": len(records),
+            "labels": records,
+        }
+    finally:
+        if created_app:
+            app.exitQgis()
+
+
+def _markdown_value(value: object) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value) if value else "—"
+    return str(value).replace("|", "\\|")
+
+
+def build_summary_markdown(report: dict[str, object]) -> str:
+    labels = report.get("labels")
+    rows = labels if isinstance(labels, list) else []
+    lines = [
+        f"# Mapbox Outdoors QGIS label settings — {report.get('style_owner')}/{report.get('style_id')}",
+        "",
+        f"Generated: {report.get('generated')}",
+        f"Converted label styles: {report.get('label_count', len(rows))}",
+        f"Sprite context loaded: {_markdown_value(report.get('sprite_context_loaded'))}",
+        f"Sprite definitions: {_markdown_value(report.get('sprite_definition_count'))}",
+        "",
+        "| Base layer | Style | Source layer | Field | Expr | Priority | Placement | Repeat distance | Repeat unit | Display all | Obstacle | Data-defined keys |",
+        "| --- | --- | --- | --- | --- | ---: | --- | ---: | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        lines.append(
+            "| {base} | {style} | {source} | {field} | {expr} | {priority} | {placement} | {repeat} | {unit} | {display_all} | {obstacle} | {keys} |".format(
+                base=_markdown_value(row.get("base_style_layer_id")),
+                style=_markdown_value(row.get("style_name")),
+                source=_markdown_value(row.get("source_layer")),
+                field=_markdown_value(row.get("field_name")),
+                expr=_markdown_value(row.get("is_expression")),
+                priority=_markdown_value(row.get("priority")),
+                placement=_markdown_value(row.get("placement")),
+                repeat=_markdown_value(row.get("repeat_distance")),
+                unit=_markdown_value(row.get("repeat_distance_unit")),
+                display_all=_markdown_value(row.get("display_all")),
+                obstacle=_markdown_value(row.get("obstacle")),
+                keys=_markdown_value(row.get("data_defined_property_keys")),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_report(report: dict[str, object], paths: LabelSettingsPaths) -> None:
+    paths.run_dir.mkdir(parents=True, exist_ok=True)
+    paths.json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    paths.summary_path.write_text(build_summary_markdown(report), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate QGIS converted-label settings diagnostics.")
+    parser.add_argument("--style-json", type=Path, help="Read an already downloaded Mapbox style JSON file.")
+    parser.add_argument("--style-owner", default=DEFAULT_MAPBOX_STYLE_OWNER)
+    parser.add_argument("--style-id", default=DEFAULT_MAPBOX_STYLE_ID)
+    parser.add_argument("--mapbox-token", help="Mapbox token. Prefer MAPBOX_ACCESS_TOKEN or QFIT_MAPBOX_ACCESS_TOKEN.")
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--no-sprite-context", action="store_true", help="Do not attach Mapbox sprite resources.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    token = resolve_mapbox_token(provided_token=args.mapbox_token)
+    config = LabelSettingsConfig(
+        token=token,
+        output_root=args.output_root,
+        style_owner=args.style_owner,
+        style_id=args.style_id,
+        style_json_path=args.style_json,
+        include_sprite_context=not args.no_sprite_context,
+    )
+    paths = build_label_settings_paths(
+        build_run_directory(
+            output_root=config.output_root,
+            style_owner=config.style_owner,
+            style_id=config.style_id,
+            now=config.now,
+        )
+    )
+    report = collect_label_settings(config)
+    write_report(report, paths)
+    print(paths.summary_path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -140,7 +140,7 @@ def label_settings_record(style: object, settings: object) -> dict[str, object]:
 
 
 def _iter_label_records(labeling: object) -> Iterable[dict[str, object]]:
-    for style in list(_method_value(labeling, "styles") or []):
+    for style in _method_value(labeling, "styles") or []:
         settings = _method_value(style, "labelSettings")
         if settings is None:
             continue
@@ -165,6 +165,84 @@ def _apply_sprite_context(ctx: object, sprite_resources: object | None) -> bool:
         return False
 
 
+def _ensure_qgis_application(qgs_application):
+    app = qgs_application.instance()
+    created_app = app is None
+    if created_app:
+        app = qgs_application([], False)
+        app.initQgis()
+    return app, created_app
+
+
+def _load_original_style(config: LabelSettingsConfig, fetch_mapbox_style_definition) -> dict[str, object]:
+    if config.style_json_path is not None:
+        return load_style_definition(config.style_json_path)
+    if not config.token:
+        raise ValueError("A Mapbox token is required unless --style-json is provided.")
+    return fetch_mapbox_style_definition(config.token, config.style_owner, config.style_id)
+
+
+def _fetch_sprite_resources(config: LabelSettingsConfig, original_style: dict[str, object], fetch_mapbox_sprite_resources):
+    if not config.include_sprite_context or not config.token:
+        return None, 0
+    try:
+        resources = fetch_mapbox_sprite_resources(
+            config.token,
+            config.style_owner,
+            config.style_id,
+            sprite_url=original_style.get("sprite"),
+        )
+    except (KeyError, OSError, RuntimeError, TypeError, ValueError):
+        return None, 0
+    return resources, len(resources.definitions)
+
+
+def _convert_style_to_labeling(qfit_style: dict[str, object], sprite_resources: object | None, qgis_modules) -> tuple[object, object, bool]:
+    QgsMapBoxGlStyleConversionContext, QgsMapBoxGlStyleConverter, Qgis = qgis_modules
+    ctx = QgsMapBoxGlStyleConversionContext()
+    ctx.setTargetUnit(Qgis.RenderUnit.Millimeters)
+    ctx.setPixelSizeConversionFactor(25.4 / 96.0)
+    sprite_loaded = _apply_sprite_context(ctx, sprite_resources)
+
+    converter = QgsMapBoxGlStyleConverter()
+    result = converter.convert(qfit_style, ctx)
+    success_value = getattr(QgsMapBoxGlStyleConverter, "Success", None)
+    if success_value is not None and result != success_value:
+        raise RuntimeError(f"QGIS Mapbox style conversion failed: {result}")
+    return result, converter.labeling(), sprite_loaded
+
+
+def _postprocessed_label_records(labeling: object | None, background_map_service_cls) -> list[dict[str, object]]:
+    if labeling is None:
+        return []
+    background_map_service_cls()._apply_label_priority(labeling)
+    return sorted(
+        _iter_label_records(labeling),
+        key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
+    )
+
+
+def _label_settings_report(
+    *,
+    config: LabelSettingsConfig,
+    result: object,
+    sprite_loaded: bool,
+    sprite_count: int,
+    records: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "style_owner": config.style_owner,
+        "style_id": config.style_id,
+        "generated": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "qgis_converter_result": result,
+        "sprite_context_requested": config.include_sprite_context,
+        "sprite_context_loaded": sprite_loaded,
+        "sprite_definition_count": sprite_count,
+        "label_count": len(records),
+        "labels": records,
+    }
+
+
 def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
     _ensure_package_parent_on_path()
     _ensure_headless_qt_platform()
@@ -185,68 +263,24 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
     )
     from qfit.visualization.infrastructure.background_map_service import BackgroundMapService
 
-    app = QgsApplication.instance()
-    created_app = app is None
-    if created_app:
-        app = QgsApplication([], False)
-        app.initQgis()
-
+    app, created_app = _ensure_qgis_application(QgsApplication)
     try:
-        if config.style_json_path is not None:
-            original_style = load_style_definition(config.style_json_path)
-        else:
-            if not config.token:
-                raise ValueError("A Mapbox token is required unless --style-json is provided.")
-            original_style = fetch_mapbox_style_definition(config.token, config.style_owner, config.style_id)
+        original_style = _load_original_style(config, fetch_mapbox_style_definition)
         qfit_style = simplify_mapbox_style_expressions(original_style)
-
-        sprite_loaded = False
-        sprite_count = 0
-        sprite_resources = None
-        if config.include_sprite_context and config.token:
-            try:
-                sprite_resources = fetch_mapbox_sprite_resources(
-                    config.token,
-                    config.style_owner,
-                    config.style_id,
-                    sprite_url=original_style.get("sprite"),
-                )
-                sprite_count = len(sprite_resources.definitions)
-            except (KeyError, OSError, RuntimeError, TypeError, ValueError):
-                sprite_resources = None
-
-        ctx = QgsMapBoxGlStyleConversionContext()
-        ctx.setTargetUnit(Qgis.RenderUnit.Millimeters)
-        ctx.setPixelSizeConversionFactor(25.4 / 96.0)
-        sprite_loaded = _apply_sprite_context(ctx, sprite_resources)
-
-        converter = QgsMapBoxGlStyleConverter()
-        result = converter.convert(qfit_style, ctx)
-        success_value = getattr(QgsMapBoxGlStyleConverter, "Success", None)
-        if success_value is not None and result != success_value:
-            raise RuntimeError(f"QGIS Mapbox style conversion failed: {result}")
-
-        labeling = converter.labeling()
-        if labeling is None:
-            records: list[dict[str, object]] = []
-        else:
-            BackgroundMapService()._apply_label_priority(labeling)
-            records = sorted(
-                _iter_label_records(labeling),
-                key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
-            )
-
-        return {
-            "style_owner": config.style_owner,
-            "style_id": config.style_id,
-            "generated": dt.datetime.now(dt.timezone.utc).isoformat(),
-            "qgis_converter_result": result,
-            "sprite_context_requested": config.include_sprite_context,
-            "sprite_context_loaded": sprite_loaded,
-            "sprite_definition_count": sprite_count,
-            "label_count": len(records),
-            "labels": records,
-        }
+        sprite_resources, sprite_count = _fetch_sprite_resources(config, original_style, fetch_mapbox_sprite_resources)
+        result, labeling, sprite_loaded = _convert_style_to_labeling(
+            qfit_style,
+            sprite_resources,
+            (QgsMapBoxGlStyleConversionContext, QgsMapBoxGlStyleConverter, Qgis),
+        )
+        records = _postprocessed_label_records(labeling, BackgroundMapService)
+        return _label_settings_report(
+            config=config,
+            result=result,
+            sprite_loaded=sprite_loaded,
+            sprite_count=sprite_count,
+            records=records,
+        )
     finally:
         if created_app:
             app.exitQgis()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -168,6 +168,41 @@ def _apply_label_settings(
     return changed
 
 
+def apply_mapbox_label_priority(labeling) -> None:
+    try:
+        from qgis.core import QgsProperty, Qgis  # noqa: PLC0415
+
+        styles = list(labeling.styles())
+        changed = False
+        for style in styles:
+            layer_name = _label_style_mapbox_layer_id(style)
+            priority = _label_priority(layer_name, style)
+            repeat_distance = _label_repeat_distance(layer_name, style)
+            if priority is None and repeat_distance is None and layer_name != "contour-label":
+                continue
+            settings = style.labelSettings()
+            if settings is None:
+                continue
+            field_expression = _label_field_expression(layer_name, settings)
+            if priority is None and repeat_distance is None and field_expression is None:
+                continue
+            if _apply_label_settings(
+                settings,
+                layer_name=layer_name,
+                priority=priority,
+                repeat_distance=repeat_distance,
+                field_expression=field_expression,
+                qgs_property=QgsProperty,
+                qgis=Qgis,
+            ):
+                style.setLabelSettings(settings)
+                changed = True
+        if changed:
+            labeling.setStyles(styles)
+    except (RuntimeError, AttributeError):
+        logger.debug("Mapbox GL style application skipped", exc_info=True)
+
+
 class BackgroundMapService:
     """Manages Mapbox background tile layers (raster and vector) in the QGIS project.
 
@@ -294,38 +329,7 @@ class BackgroundMapService:
         return False
 
     def _apply_label_priority(self, labeling) -> None:
-        try:
-            from qgis.core import QgsProperty, Qgis  # noqa: PLC0415
-
-            styles = list(labeling.styles())
-            changed = False
-            for style in styles:
-                layer_name = _label_style_mapbox_layer_id(style)
-                priority = _label_priority(layer_name, style)
-                repeat_distance = _label_repeat_distance(layer_name, style)
-                if priority is None and repeat_distance is None and layer_name != "contour-label":
-                    continue
-                settings = style.labelSettings()
-                if settings is None:
-                    continue
-                field_expression = _label_field_expression(layer_name, settings)
-                if priority is None and repeat_distance is None and field_expression is None:
-                    continue
-                if _apply_label_settings(
-                    settings,
-                    layer_name=layer_name,
-                    priority=priority,
-                    repeat_distance=repeat_distance,
-                    field_expression=field_expression,
-                    qgs_property=QgsProperty,
-                    qgis=Qgis,
-                ):
-                    style.setLabelSettings(settings)
-                    changed = True
-            if changed:
-                labeling.setStyles(styles)
-        except (RuntimeError, AttributeError):
-            logger.debug("Mapbox GL style application skipped", exc_info=True)
+        apply_mapbox_label_priority(labeling)
 
     def _apply_sprite_resources_to_context(self, ctx: object, sprite_resources: MapboxSpriteResources | None) -> None:
         if sprite_resources is None:


### PR DESCRIPTION
## Summary

- Add a reproducible Mapbox Outdoors QGIS label-settings diagnostic under `validation/mapbox_outdoors_label_settings.py`.
- Capture QGIS-converted label style state after qfit preprocessing and runtime label post-processing, including field expression, priority, placement, repeat distance, repeat unit, display/obstacle flags, and data-defined property keys.
- Write both `label-settings.json` and a compact `summary.md` under `debug/mapbox-outdoors-label-settings/<style>/<timestamp>/`.

## Evidence

- This replaces the ad hoc converted-label probes used for #1128, #1129, and #1130 with a checked-in diagnostic.
- Fresh live run using the local QGIS profile token source generated:
  - `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T082848Z/summary.md`
  - `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T082848Z/label-settings.json`
- The live report captured `209` converted label styles with sprite context loaded and `440` sprite definitions.
- The report confirms current runtime state for recent #949 label slices:
  - `contour-label` field `concat("ele", ' m')`
  - `road-label-below-z12` repeat distance `39.6875` mm
  - `road-label-z15-plus` repeat distance `66.14583333333333` mm
  - `waterway-label-z17-plus` repeat distance `105.83333333333333` mm

## Tests

- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check -- validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_label_settings.py`

Part of #949.

