### PR TITLE
fix: reduce high-zoom waterway label repetition

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -723,7 +723,7 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
 
         self.service._apply_label_priority(labeling)
 
-        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
+        self.assertAlmostEqual(settings.repeatDistance, 600 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_contour_label_appends_metre_suffix_without_repeat_distance(self):
@@ -905,7 +905,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
         self.service._apply_label_priority(labeling)
 
-        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
+        self.assertAlmostEqual(settings.repeatDistance, 600 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_existing_line_label_repeat_distance_is_preserved(self):

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -53,11 +53,13 @@ _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "path-pedestrian-label",
 }
 # Representative-zoom values from mapbox_config's waterway-label spacing
-# expression after qfit splits it into static QGIS zoom bands.
+# expression after qfit splits it into static QGIS zoom bands.  The z17+
+# value is wider than Mapbox's raw 400 px spacing because QGIS repeats labels
+# more densely along segmented waterways in the Zermatt z18 comparison.
 _WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER = {
     "z13-to-z15": 250.0,
     "z15-to-z17": 325.0,
-    "z17-plus": 400.0,
+    "z17-plus": 600.0,
 }
 _CONTOUR_LABEL_ELEVATION_FIELD_EXPRESSION = '"ele"'
 _CONTOUR_LABEL_EXPRESSION = "concat(\"ele\", ' m')"


### PR DESCRIPTION
## Summary

- Increase the high-zoom `waterway-label-z17-plus` QGIS repeat distance from 400 px to 600 px.
- Keep lower waterway-label zoom bands on the audited Mapbox spacing values.
- Update both real-PyQGIS and mock label-priority tests for the new z17+ repeat distance.

## Evidence

- #949 visual checkpoint identified Zermatt z18 waterway label repetition as a remaining visible parity gap.
- Probe artifact with the 600 px z17+ spacing:
  - `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260518T090456Z/qgis-vector-render.png`
- Baseline artifacts for comparison:
  - `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260518T074404Z/mapbox-gl-reference.png`
  - `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260518T074404Z/qgis-vector-render.png`
- Visual comparison: the 600 px probe reduces repeated `Matter Vispa` labels and is closer to the Mapbox reference, with no obvious nearby road/path-label regression.
- Label-settings diagnostic after the change:
  - `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T090631Z/summary.md`
  - `waterway-label-z17-plus` reports repeat distance `158.75` mm, matching 600 px at 25.4 / 96.

## Tests

- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check -- visualization/infrastructure/background_map_service.py tests/test_background_map_service.py`

Part of #949.
