### PR TITLE
Widen high-zoom path casings

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -650,6 +650,7 @@ _PATH_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES = (
 _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 18.0
 _PATH_LOW_ZOOM_LINE_WIDTH_LAYER_PREFIXES = ("road-path-below-z16",)
 _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 14.0
+_PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.5
 _PEDESTRIAN_LINE_WIDTH_LAYER_IDS = {
     "bridge-pedestrian",
     "bridge-pedestrian-case",
@@ -2558,16 +2559,25 @@ def _should_sample_path_low_zoom_line_width(layer_id: object, prop: str, maxzoom
 
 
 def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: object, maxzoom: object) -> float | None:
+    high_zoom_path_width = False
     if _should_sample_path_low_zoom_line_width(layer_id, prop, maxzoom):
         target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
     elif _should_sample_path_high_zoom_line_width(layer_id, prop, minzoom):
         target_sample_zoom = _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+        high_zoom_path_width = True
     else:
         return None
     target_zoom = _zoom_in_layer_range(target_sample_zoom, minzoom, maxzoom)
     if target_zoom is None:
         return None
-    return _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
+    width = _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
+    if (
+        width is not None
+        and high_zoom_path_width
+        and _path_background_line_color_base_layer_id(layer_id) is not None
+    ):
+        width *= _PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
+    return width
 
 
 def _line_width_mm_at_zoom(expr: object, target_zoom: float) -> float | None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5247,12 +5247,22 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
         high_width_mm = 7 * mapbox_config._MAPBOX_PIXEL_TO_MM
+        high_background_width_mm = min(
+            high_width_mm * mapbox_config._PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE,
+            mapbox_config._MAX_LINE_WIDTH_MM,
+        )
         self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path-z16-plus"]["paint"]["line-width"], high_width_mm)
         self.assertAlmostEqual(by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"], low_width_mm)
-        self.assertAlmostEqual(by_id["road-path-bg-z16-plus-outdoor"]["paint"]["line-width"], high_width_mm)
-        self.assertAlmostEqual(by_id["bridge-path-bg-z16-plus-outdoor"]["paint"]["line-width"], high_width_mm)
+        self.assertAlmostEqual(
+            by_id["road-path-bg-z16-plus-outdoor"]["paint"]["line-width"],
+            high_background_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-path-bg-z16-plus-outdoor"]["paint"]["line-width"],
+            high_background_width_mm,
+        )
         self.assertAlmostEqual(by_id["road-minor"]["paint"]["line-width"], low_width_mm)
 
     def test_high_zoom_path_line_width_clamps_to_split_layer_maxzoom(self):


### PR DESCRIPTION
## Summary

- Widen high-zoom Mapbox Outdoors path background/casing strokes by 1.5x after the existing zoom-band sampling.
- Keep core path strokes, low-zoom path backgrounds, and non-path road widths unchanged.
- Update the mapbox style simplification regression test so the high-zoom background-only behavior is explicit.

## Evidence

This follows the #949 Zermatt z18 path/trail visual probe. The casing-focused render made orange path/trail edges closer to the Mapbox GL reference than the current QGIS baseline and was lower-risk than the earlier pure trail-width probes.

- Mapbox reference: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260518T074404Z/mapbox-gl-reference.png`
- Current QGIS baseline after #1132: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260518T090456Z/qgis-vector-render.png`
- Casing probe: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260518T092631Z/qgis-vector-render.png`

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check -- mapbox_config.py tests/test_mapbox_config.py`

Fixes part of #949.
