### PR TITLE
Expand label settings diagnostic

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -521,6 +521,23 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("25/-25", markdown)
         self.assertIn("pipe\\|key", markdown)
 
+    def test_summary_markdown_collapses_empty_compound_cells(self):
+        report = {
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "generated": "2026-05-18T10:02:00+00:00",
+            "sprite_context_loaded": False,
+            "sprite_definition_count": 0,
+            "label_count": 1,
+            "labels": [{"style_name": "sparse-label"}],
+        }
+
+        markdown = build_summary_markdown(report)
+
+        self.assertIn("sparse-label", markdown)
+        self.assertNotIn("— —", markdown)
+        self.assertNotIn("—/—", markdown)
+
     def test_write_report_writes_json_and_summary(self):
         report = {
             "style_owner": "mapbox",

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -38,6 +38,48 @@ class FakeProperties:
         return self._keys
 
 
+class FakeColor:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class FakeTextBuffer:
+    def enabled(self):
+        return True
+
+    def size(self):
+        return 0.5291666667
+
+    def sizeUnit(self):
+        return SimpleNamespace(name="Millimeters")
+
+    def color(self):
+        return FakeColor("#dcdcd4")
+
+    def opacity(self):
+        return 0.75
+
+
+class FakeTextFormat:
+    def size(self):
+        return 2.5135416667
+
+    def sizeUnit(self):
+        return SimpleNamespace(name="Millimeters")
+
+    def color(self):
+        return FakeColor("#626250")
+
+    def opacity(self):
+        return 0.9
+
+    def buffer(self):
+        return FakeTextBuffer()
+
+
 class FakeStyle:
     def __init__(self, *, style_name, layer_name):
         self._style_name = style_name
@@ -76,9 +118,19 @@ class FakeSettings:
     repeatDistanceUnit = SimpleNamespace(name="Millimeters")
     displayAll = False
     obstacle = True
+    placementFlags = 1
+    labelPerPart = False
+    mergeLines = False
+    maxCurvedCharAngleIn = 25.0
+    maxCurvedCharAngleOut = -25.0
+    overrunDistance = 0.0
+    overrunDistanceUnit = SimpleNamespace(name="Millimeters")
 
     def dataDefinedProperties(self):
         return FakeProperties([87, 50])
+
+    def format(self):
+        return FakeTextFormat()
 
 
 class FakeQgsApplication:
@@ -239,6 +291,22 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["repeat_distance_unit"], "Millimeters")
         self.assertFalse(record["display_all"])
         self.assertTrue(record["obstacle"])
+        self.assertEqual(record["placement_flags"], 1)
+        self.assertFalse(record["label_per_part"])
+        self.assertFalse(record["merge_lines"])
+        self.assertEqual(record["max_curved_char_angle_in"], 25.0)
+        self.assertEqual(record["max_curved_char_angle_out"], -25.0)
+        self.assertEqual(record["overrun_distance"], 0.0)
+        self.assertEqual(record["overrun_distance_unit"], "Millimeters")
+        self.assertAlmostEqual(record["text_size"], 2.5135416667)
+        self.assertEqual(record["text_size_unit"], "Millimeters")
+        self.assertEqual(record["text_color"], "#626250")
+        self.assertEqual(record["text_opacity"], 0.9)
+        self.assertTrue(record["buffer_enabled"])
+        self.assertAlmostEqual(record["buffer_size"], 0.5291666667)
+        self.assertEqual(record["buffer_size_unit"], "Millimeters")
+        self.assertEqual(record["buffer_color"], "#dcdcd4")
+        self.assertEqual(record["buffer_opacity"], 0.75)
         self.assertEqual(record["data_defined_property_keys"], [50, 87])
 
     def test_ensure_qgis_application_reuses_or_creates_application(self):
@@ -419,6 +487,22 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distance_unit": "Millimeters",
                     "display_all": False,
                     "obstacle": True,
+                    "placement_flags": 1,
+                    "label_per_part": False,
+                    "merge_lines": False,
+                    "max_curved_char_angle_in": 25.0,
+                    "max_curved_char_angle_out": -25.0,
+                    "overrun_distance": 0.0,
+                    "overrun_distance_unit": "Millimeters",
+                    "text_size": 2.5135416667,
+                    "text_size_unit": "Millimeters",
+                    "text_color": "#626250",
+                    "text_opacity": 0.9,
+                    "buffer_enabled": True,
+                    "buffer_size": 0.5291666667,
+                    "buffer_size_unit": "Millimeters",
+                    "buffer_color": "#dcdcd4",
+                    "buffer_opacity": 0.75,
                     "data_defined_property_keys": ["pipe|key"],
                 }
             ],
@@ -432,6 +516,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("contour-label", markdown)
         self.assertIn("concat", markdown)
         self.assertIn("Millimeters", markdown)
+        self.assertIn("#626250", markdown)
+        self.assertIn("#dcdcd4", markdown)
+        self.assertIn("25/-25", markdown)
         self.assertIn("pipe\\|key", markdown)
 
     def test_write_report_writes_json_and_summary(self):

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -329,6 +329,13 @@ def _markdown_value(value: object) -> str:
     return str(value).replace("|", "\\|")
 
 
+def _compound_markdown_value(*values: object, separator: str = " ") -> str:
+    rendered_values = [_markdown_value(value) for value in values]
+    if all(value == "—" for value in rendered_values):
+        return "—"
+    return separator.join(rendered_values)
+
+
 def build_summary_markdown(report: dict[str, object]) -> str:
     labels = report.get("labels")
     rows = labels if isinstance(labels, list) else []
@@ -347,7 +354,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {base} | {style} | {source} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {text_size} {text_size_unit} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} {buffer_size_unit} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {curve_angles} | {overrun} | {keys} |".format(
+            "| {base} | {style} | {source} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {text_size} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {curve_angles} | {overrun} | {keys} |".format(
                 base=_markdown_value(row.get("base_style_layer_id")),
                 style=_markdown_value(row.get("style_name")),
                 source=_markdown_value(row.get("source_layer")),
@@ -360,24 +367,23 @@ def build_summary_markdown(report: dict[str, object]) -> str:
                 unit=_markdown_value(row.get("repeat_distance_unit")),
                 display_all=_markdown_value(row.get("display_all")),
                 obstacle=_markdown_value(row.get("obstacle")),
-                text_size=_markdown_value(row.get("text_size")),
-                text_size_unit=_markdown_value(row.get("text_size_unit")),
+                text_size=_compound_markdown_value(row.get("text_size"), row.get("text_size_unit")),
                 text_color=_markdown_value(row.get("text_color")),
                 text_opacity=_markdown_value(row.get("text_opacity")),
                 buffer_enabled=_markdown_value(row.get("buffer_enabled")),
-                buffer_size=_markdown_value(row.get("buffer_size")),
-                buffer_size_unit=_markdown_value(row.get("buffer_size_unit")),
+                buffer_size=_compound_markdown_value(row.get("buffer_size"), row.get("buffer_size_unit")),
                 buffer_color=_markdown_value(row.get("buffer_color")),
                 buffer_opacity=_markdown_value(row.get("buffer_opacity")),
                 label_per_part=_markdown_value(row.get("label_per_part")),
                 merge_lines=_markdown_value(row.get("merge_lines")),
-                curve_angles="{in_angle}/{out_angle}".format(
-                    in_angle=_markdown_value(row.get("max_curved_char_angle_in")),
-                    out_angle=_markdown_value(row.get("max_curved_char_angle_out")),
+                curve_angles=_compound_markdown_value(
+                    row.get("max_curved_char_angle_in"),
+                    row.get("max_curved_char_angle_out"),
+                    separator="/",
                 ),
-                overrun="{distance} {unit}".format(
-                    distance=_markdown_value(row.get("overrun_distance")),
-                    unit=_markdown_value(row.get("overrun_distance_unit")),
+                overrun=_compound_markdown_value(
+                    row.get("overrun_distance"),
+                    row.get("overrun_distance_unit"),
                 ),
                 keys=_markdown_value(row.get("data_defined_property_keys")),
             )

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -105,6 +105,29 @@ def _settings_value(settings: object, name: str) -> object:
     return _enum_name(value) if name.endswith("Unit") or name == "placement" else value
 
 
+def _color_name(value: object) -> object:
+    name = _method_value(value, "name")
+    return name if isinstance(name, str) else None
+
+
+def _label_format_record(settings: object) -> dict[str, object]:
+    text_format = _method_value(settings, "format")
+    buffer = _method_value(text_format, "buffer") if text_format is not None else None
+    text_color = _method_value(text_format, "color") if text_format is not None else None
+    buffer_color = _method_value(buffer, "color") if buffer is not None else None
+    return {
+        "text_size": _method_value(text_format, "size") if text_format is not None else None,
+        "text_size_unit": _enum_name(_method_value(text_format, "sizeUnit")) if text_format is not None else None,
+        "text_color": _color_name(text_color),
+        "text_opacity": _method_value(text_format, "opacity") if text_format is not None else None,
+        "buffer_enabled": _method_value(buffer, "enabled") if buffer is not None else None,
+        "buffer_size": _method_value(buffer, "size") if buffer is not None else None,
+        "buffer_size_unit": _enum_name(_method_value(buffer, "sizeUnit")) if buffer is not None else None,
+        "buffer_color": _color_name(buffer_color),
+        "buffer_opacity": _method_value(buffer, "opacity") if buffer is not None else None,
+    }
+
+
 def _data_defined_property_keys(settings: object) -> list[object]:
     properties = _method_value(settings, "dataDefinedProperties")
     keys = _method_value(properties, "propertyKeys") if properties is not None else None
@@ -135,6 +158,14 @@ def label_settings_record(style: object, settings: object) -> dict[str, object]:
         "repeat_distance_unit": _settings_value(settings, "repeatDistanceUnit"),
         "display_all": _settings_value(settings, "displayAll"),
         "obstacle": _settings_value(settings, "obstacle"),
+        "placement_flags": _settings_value(settings, "placementFlags"),
+        "label_per_part": _settings_value(settings, "labelPerPart"),
+        "merge_lines": _settings_value(settings, "mergeLines"),
+        "max_curved_char_angle_in": _settings_value(settings, "maxCurvedCharAngleIn"),
+        "max_curved_char_angle_out": _settings_value(settings, "maxCurvedCharAngleOut"),
+        "overrun_distance": _settings_value(settings, "overrunDistance"),
+        "overrun_distance_unit": _settings_value(settings, "overrunDistanceUnit"),
+        **_label_format_record(settings),
         "data_defined_property_keys": _data_defined_property_keys(settings),
     }
 
@@ -309,14 +340,14 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Sprite context loaded: {_markdown_value(report.get('sprite_context_loaded'))}",
         f"Sprite definitions: {_markdown_value(report.get('sprite_definition_count'))}",
         "",
-        "| Base layer | Style | Source layer | Field | Expr | Priority | Placement | Repeat distance | Repeat unit | Display all | Obstacle | Data-defined keys |",
-        "| --- | --- | --- | --- | --- | ---: | --- | ---: | --- | --- | --- | --- |",
+        "| Base layer | Style | Source layer | Field | Expr | Priority | Placement | Placement flags | Repeat distance | Repeat unit | Display all | Obstacle | Text size | Text color | Text opacity | Buffer | Buffer size | Buffer color | Buffer opacity | Label/part | Merge lines | Curve angles | Overrun | Data-defined keys |",
+        "| --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | --- | --- | --- | ---: | --- | ---: | --- | ---: | --- | ---: | --- | --- | --- | --- | --- |",
     ]
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {base} | {style} | {source} | {field} | {expr} | {priority} | {placement} | {repeat} | {unit} | {display_all} | {obstacle} | {keys} |".format(
+            "| {base} | {style} | {source} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {text_size} {text_size_unit} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} {buffer_size_unit} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {curve_angles} | {overrun} | {keys} |".format(
                 base=_markdown_value(row.get("base_style_layer_id")),
                 style=_markdown_value(row.get("style_name")),
                 source=_markdown_value(row.get("source_layer")),
@@ -324,10 +355,30 @@ def build_summary_markdown(report: dict[str, object]) -> str:
                 expr=_markdown_value(row.get("is_expression")),
                 priority=_markdown_value(row.get("priority")),
                 placement=_markdown_value(row.get("placement")),
+                placement_flags=_markdown_value(row.get("placement_flags")),
                 repeat=_markdown_value(row.get("repeat_distance")),
                 unit=_markdown_value(row.get("repeat_distance_unit")),
                 display_all=_markdown_value(row.get("display_all")),
                 obstacle=_markdown_value(row.get("obstacle")),
+                text_size=_markdown_value(row.get("text_size")),
+                text_size_unit=_markdown_value(row.get("text_size_unit")),
+                text_color=_markdown_value(row.get("text_color")),
+                text_opacity=_markdown_value(row.get("text_opacity")),
+                buffer_enabled=_markdown_value(row.get("buffer_enabled")),
+                buffer_size=_markdown_value(row.get("buffer_size")),
+                buffer_size_unit=_markdown_value(row.get("buffer_size_unit")),
+                buffer_color=_markdown_value(row.get("buffer_color")),
+                buffer_opacity=_markdown_value(row.get("buffer_opacity")),
+                label_per_part=_markdown_value(row.get("label_per_part")),
+                merge_lines=_markdown_value(row.get("merge_lines")),
+                curve_angles="{in_angle}/{out_angle}".format(
+                    in_angle=_markdown_value(row.get("max_curved_char_angle_in")),
+                    out_angle=_markdown_value(row.get("max_curved_char_angle_out")),
+                ),
+                overrun="{distance} {unit}".format(
+                    distance=_markdown_value(row.get("overrun_distance")),
+                    unit=_markdown_value(row.get("overrun_distance_unit")),
+                ),
                 keys=_markdown_value(row.get("data_defined_property_keys")),
             )
         )


### PR DESCRIPTION
## Summary

- Expand the Mapbox Outdoors QGIS label-settings diagnostic with text format, buffer, and line-placement fields.
- Include contour-relevant placement flags, label-per-part, merge-lines, curved-character angle, and overrun settings in JSON and Markdown output.
- Cover the new diagnostic fields with fake-QGIS unit tests.

## Evidence

This follows the #949 contour-label research checkpoint where priority, display-all, line-placement, filter-shape, and oversized-text probes all failed to make contour labels visible. The diagnostic now records the converted label details needed to separate styling from label-placement or candidate-generation causes.

Live diagnostic generated with the local QGIS profile token source, without printing or storing the token:

- `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T100717Z/summary.md`
- `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T100717Z/label-settings.json`

The live contour-label record now captures Curved placement, placement flags `1`, text size `2.51354` mm, text color `#626250`, full text opacity, enabled buffer size `0.529167` mm, buffer color `#dcdcd4`, `displayAll=false`, and zero repeat/overrun distance.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check -- validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_label_settings.py`

Continues #949.
