### PR TITLE
Add source label controls diagnostic

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -433,12 +433,15 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "minzoom": 12,
                     "filter": ["==", ["get", "index"], 5],
                     "layout": {
+                        "icon-image": "mountain",
+                        "icon-size": 0.8,
                         "symbol-placement": "line",
                         "text-field": ["concat", ["get", "ele"], " m"],
                         "text-size": ["interpolate", ["linear"], ["zoom"], 12, 10, 16, 12],
                         "text-max-angle": 25,
                     },
                     "paint": {
+                        "icon-opacity": 0.75,
                         "text-color": "#626250",
                         "text-halo-color": "#dcdcd4",
                         "text-halo-width": 2,
@@ -455,11 +458,14 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "source-layer": "contour",
                     "minzoom": 12,
                     "layout": {
+                        "icon-image": "mountain",
+                        "icon-size": 0.8,
                         "symbol-placement": "line",
                         "text-field": ["concat", ["get", "ele"], " m"],
                         "text-size": 9,
                     },
                     "paint": {
+                        "icon-opacity": 0.75,
                         "text-color": "#626250",
                         "text-halo-color": "#dcdcd4",
                     },
@@ -479,10 +485,37 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["qfit_style_layer_id"], "contour-label")
         self.assertEqual(record["source_layer"], "contour")
         self.assertEqual(record["filter"], ["==", ["get", "index"], 5])
+        self.assertEqual(record["layout"]["icon-image"], "mountain")
+        self.assertEqual(record["layout"]["icon-size"], 0.8)
         self.assertEqual(record["layout"]["symbol-placement"], "line")
         self.assertEqual(record["layout"]["text-size"], ["interpolate", ["linear"], ["zoom"], 12, 10, 16, 12])
+        self.assertEqual(record["paint"]["icon-opacity"], 0.75)
         self.assertEqual(record["paint"]["text-halo-width"], 2)
+        self.assertEqual(record["qfit_layout"]["icon-image"], "mountain")
         self.assertEqual(record["qfit_layout"]["text-size"], 9)
+
+    def test_source_label_layer_records_marks_missing_qfit_layer(self):
+        records = source_label_layer_records(
+            {
+                "version": 8,
+                "layers": [
+                    {
+                        "id": "contour-label",
+                        "type": "symbol",
+                        "source-layer": "contour",
+                        "layout": {"text-field": ["get", "ele"]},
+                        "paint": {"text-color": "#626250"},
+                    }
+                ],
+            },
+            {"version": 8, "layers": []},
+            [{"base_style_layer_id": "contour-label", "style_name": "contour-label"}],
+        )
+
+        self.assertEqual(records[0]["qfit_style_layer_id"], None)
+        self.assertEqual(records[0]["qfit_filter"], None)
+        self.assertEqual(records[0]["qfit_layout"], {})
+        self.assertEqual(records[0]["qfit_paint"], {})
 
     def test_label_settings_report_captures_summary_metadata(self):
         report = _label_settings_report(
@@ -644,6 +677,21 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "sprite_definition_count": 0,
             "label_count": 1,
             "labels": [{"style_name": "sparse-label"}],
+            "source_label_layer_count": 1,
+            "source_label_layers": [
+                {
+                    "base_style_layer_id": "sparse-label",
+                    "style_name": "sparse-label",
+                    "qfit_style_layer_id": None,
+                    "source_layer": "sparse",
+                    "filter": [],
+                    "qfit_filter": [],
+                    "layout": {},
+                    "paint": {},
+                    "qfit_layout": {},
+                    "qfit_paint": {},
+                }
+            ],
         }
 
         markdown = build_summary_markdown(report)
@@ -651,6 +699,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("sparse-label", markdown)
         self.assertNotIn("— —", markdown)
         self.assertNotIn("—/—", markdown)
+        self.assertNotIn("[]", markdown)
+        self.assertIn("| sparse-label | sparse-label | — | sparse | all | — | — | — |", markdown)
 
     def test_write_report_writes_json_and_summary(self):
         report = {

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -512,8 +512,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             [{"base_style_layer_id": "contour-label", "style_name": "contour-label"}],
         )
 
-        self.assertEqual(records[0]["qfit_style_layer_id"], None)
-        self.assertEqual(records[0]["qfit_filter"], None)
+        self.assertIsNone(records[0]["qfit_style_layer_id"])
+        self.assertIsNone(records[0]["qfit_filter"])
         self.assertEqual(records[0]["qfit_layout"], {})
         self.assertEqual(records[0]["qfit_paint"], {})
 

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -26,6 +26,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     load_style_definition,
     main,
     resolve_mapbox_token,
+    source_label_layer_records,
     write_report,
 )
 
@@ -421,6 +422,68 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual([record["base_style_layer_id"] for record in records], ["road-label", "waterway-label"])
         self.assertEqual(_postprocessed_label_records(None, fake_apply_label_priority), [])
 
+    def test_source_label_layer_records_align_original_and_qfit_controls(self):
+        original_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "contour-label",
+                    "type": "symbol",
+                    "source-layer": "contour",
+                    "minzoom": 12,
+                    "filter": ["==", ["get", "index"], 5],
+                    "layout": {
+                        "symbol-placement": "line",
+                        "text-field": ["concat", ["get", "ele"], " m"],
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 12, 10, 16, 12],
+                        "text-max-angle": 25,
+                    },
+                    "paint": {
+                        "text-color": "#626250",
+                        "text-halo-color": "#dcdcd4",
+                        "text-halo-width": 2,
+                    },
+                }
+            ],
+        }
+        qfit_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "contour-label",
+                    "type": "symbol",
+                    "source-layer": "contour",
+                    "minzoom": 12,
+                    "layout": {
+                        "symbol-placement": "line",
+                        "text-field": ["concat", ["get", "ele"], " m"],
+                        "text-size": 9,
+                    },
+                    "paint": {
+                        "text-color": "#626250",
+                        "text-halo-color": "#dcdcd4",
+                    },
+                }
+            ],
+        }
+
+        records = source_label_layer_records(
+            original_style,
+            qfit_style,
+            [{"base_style_layer_id": "contour-label", "style_name": "contour-label"}],
+        )
+
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record["base_style_layer_id"], "contour-label")
+        self.assertEqual(record["qfit_style_layer_id"], "contour-label")
+        self.assertEqual(record["source_layer"], "contour")
+        self.assertEqual(record["filter"], ["==", ["get", "index"], 5])
+        self.assertEqual(record["layout"]["symbol-placement"], "line")
+        self.assertEqual(record["layout"]["text-size"], ["interpolate", ["linear"], ["zoom"], 12, 10, 16, 12])
+        self.assertEqual(record["paint"]["text-halo-width"], 2)
+        self.assertEqual(record["qfit_layout"]["text-size"], 9)
+
     def test_label_settings_report_captures_summary_metadata(self):
         report = _label_settings_report(
             config=LabelSettingsConfig(token="token", output_root=Path("/tmp")),
@@ -428,6 +491,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             sprite_loaded=True,
             sprite_count=440,
             records=[{"style_name": "contour-label"}],
+            source_label_layers=[{"base_style_layer_id": "contour-label"}],
         )
 
         self.assertEqual(report["style_owner"], "mapbox")
@@ -436,6 +500,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertTrue(report["sprite_context_loaded"])
         self.assertEqual(report["sprite_definition_count"], 440)
         self.assertEqual(report["label_count"], 1)
+        self.assertEqual(report["source_label_layer_count"], 1)
 
     def test_collect_label_settings_runs_with_fake_qgis_runtime(self):
         modules = {
@@ -445,7 +510,19 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         with mock.patch.dict(sys.modules, modules):
             with mock.patch(
                 "qfit.mapbox_config.fetch_mapbox_style_definition",
-                return_value={"version": 8, "layers": [], "sprite": "sprite-url"},
+                return_value={
+                    "version": 8,
+                    "layers": [
+                        {
+                            "id": "road-label",
+                            "type": "symbol",
+                            "source-layer": "road",
+                            "layout": {"text-field": ["get", "name"], "text-size": 11},
+                            "paint": {"text-color": "#111111"},
+                        }
+                    ],
+                    "sprite": "sprite-url",
+                },
             ) as fetch_style:
                 with mock.patch(
                     "qfit.mapbox_config.fetch_mapbox_sprite_resources",
@@ -453,7 +530,18 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                 ) as fetch_sprites:
                     with mock.patch(
                         "qfit.mapbox_config.simplify_mapbox_style_expressions",
-                        return_value={"version": 8, "layers": [{"id": "road-label-z15-plus"}]},
+                        return_value={
+                            "version": 8,
+                            "layers": [
+                                {
+                                    "id": "road-label-z15-plus",
+                                    "type": "symbol",
+                                    "source-layer": "road",
+                                    "layout": {"text-field": ["get", "name"], "text-size": 11},
+                                    "paint": {"text-color": "#111111"},
+                                }
+                            ],
+                        },
                     ):
                         report = collect_label_settings(LabelSettingsConfig(token="token", output_root=Path("/tmp")))
 
@@ -464,6 +552,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertFalse(report["sprite_context_loaded"])
         self.assertEqual(report["label_count"], 1)
         self.assertEqual(report["labels"][0]["base_style_layer_id"], "road-label")
+        self.assertEqual(report["source_label_layer_count"], 1)
+        self.assertEqual(report["source_label_layers"][0]["qfit_style_layer_id"], "road-label-z15-plus")
         self.assertIsNone(FakeQgsApplication.instance())
 
     def test_summary_markdown_lists_label_settings(self):
@@ -474,6 +564,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "sprite_context_loaded": True,
             "sprite_definition_count": 440,
             "label_count": 1,
+            "source_label_layer_count": 1,
             "labels": [
                 {
                     "base_style_layer_id": "contour-label",
@@ -506,6 +597,24 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "data_defined_property_keys": ["pipe|key"],
                 }
             ],
+            "source_label_layers": [
+                {
+                    "base_style_layer_id": "contour-label",
+                    "style_name": "contour-label",
+                    "qfit_style_layer_id": "contour-label",
+                    "source_layer": "contour",
+                    "minzoom": 12,
+                    "maxzoom": None,
+                    "qfit_minzoom": 12,
+                    "qfit_maxzoom": None,
+                    "filter": ["==", ["get", "index"], 5],
+                    "qfit_filter": ["==", ["get", "index"], 5],
+                    "layout": {"symbol-placement": "line", "text-field": ["concat", ["get", "ele"], " m"]},
+                    "paint": {"text-color": "#626250", "text-halo-color": "#dcdcd4"},
+                    "qfit_layout": {"symbol-placement": "line", "text-field": ["concat", ["get", "ele"], " m"]},
+                    "qfit_paint": {"text-color": "#626250", "text-halo-color": "#dcdcd4"},
+                }
+            ],
         }
 
         markdown = build_summary_markdown(report)
@@ -520,6 +629,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("#dcdcd4", markdown)
         self.assertIn("25/-25", markdown)
         self.assertIn("pipe\\|key", markdown)
+        self.assertIn("## Source Mapbox label controls", markdown)
+        self.assertIn("Source label layers: 1", markdown)
+        self.assertIn("| contour-label | contour-label | contour-label | contour | 12+", markdown)
+        self.assertIn("\"symbol-placement\":\"line\"", markdown)
+        self.assertIn("\"text-halo-color\":\"#dcdcd4\"", markdown)
 
     def test_summary_markdown_collapses_empty_compound_cells(self):
         report = {

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -437,6 +437,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                         "icon-size": 0.8,
                         "symbol-placement": "line",
                         "text-field": ["concat", ["get", "ele"], " m"],
+                        "text-letter-spacing": ["match", ["get", "class"], "ocean", 0.25, 0.01],
+                        "text-max-width": ["match", ["get", "class"], "ocean", 4, 10],
                         "text-size": ["interpolate", ["linear"], ["zoom"], 12, 10, 16, 12],
                         "text-max-angle": 25,
                     },
@@ -462,6 +464,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                         "icon-size": 0.8,
                         "symbol-placement": "line",
                         "text-field": ["concat", ["get", "ele"], " m"],
+                        "text-letter-spacing": 0.25,
+                        "text-max-width": 4,
                         "text-size": 9,
                     },
                     "paint": {
@@ -488,10 +492,14 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["layout"]["icon-image"], "mountain")
         self.assertEqual(record["layout"]["icon-size"], 0.8)
         self.assertEqual(record["layout"]["symbol-placement"], "line")
+        self.assertEqual(record["layout"]["text-letter-spacing"], ["match", ["get", "class"], "ocean", 0.25, 0.01])
+        self.assertEqual(record["layout"]["text-max-width"], ["match", ["get", "class"], "ocean", 4, 10])
         self.assertEqual(record["layout"]["text-size"], ["interpolate", ["linear"], ["zoom"], 12, 10, 16, 12])
         self.assertEqual(record["paint"]["icon-opacity"], 0.75)
         self.assertEqual(record["paint"]["text-halo-width"], 2)
         self.assertEqual(record["qfit_layout"]["icon-image"], "mountain")
+        self.assertEqual(record["qfit_layout"]["text-letter-spacing"], 0.25)
+        self.assertEqual(record["qfit_layout"]["text-max-width"], 4)
         self.assertEqual(record["qfit_layout"]["text-size"], 9)
 
     def test_source_label_layer_records_marks_missing_qfit_layer(self):

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -21,6 +21,20 @@ _SOURCE_LABEL_LAYOUT_PROPERTIES = (
     "symbol-avoid-edges",
     "symbol-sort-key",
     "symbol-z-order",
+    "icon-allow-overlap",
+    "icon-anchor",
+    "icon-ignore-placement",
+    "icon-image",
+    "icon-keep-upright",
+    "icon-offset",
+    "icon-optional",
+    "icon-padding",
+    "icon-pitch-alignment",
+    "icon-rotate",
+    "icon-rotation-alignment",
+    "icon-size",
+    "icon-text-fit",
+    "icon-text-fit-padding",
     "text-field",
     "text-size",
     "text-font",
@@ -38,6 +52,13 @@ _SOURCE_LABEL_LAYOUT_PROPERTIES = (
     "visibility",
 )
 _SOURCE_LABEL_PAINT_PROPERTIES = (
+    "icon-color",
+    "icon-halo-blur",
+    "icon-halo-color",
+    "icon-halo-width",
+    "icon-opacity",
+    "icon-translate",
+    "icon-translate-anchor",
     "text-color",
     "text-halo-color",
     "text-halo-width",
@@ -119,18 +140,17 @@ def _source_label_layer_record(
     qfit_layer: dict[str, object] | None,
     style_name: str,
 ) -> dict[str, object]:
-    comparison_layer = qfit_layer or original_layer
     return {
         "base_style_layer_id": str(original_layer.get("id") or ""),
         "style_name": style_name,
-        "qfit_style_layer_id": str(comparison_layer.get("id") or ""),
+        "qfit_style_layer_id": str(qfit_layer.get("id") or "") if qfit_layer is not None else None,
         "source_layer": str(original_layer.get("source-layer") or ""),
         "minzoom": original_layer.get("minzoom"),
         "maxzoom": original_layer.get("maxzoom"),
-        "qfit_minzoom": comparison_layer.get("minzoom"),
-        "qfit_maxzoom": comparison_layer.get("maxzoom"),
+        "qfit_minzoom": qfit_layer.get("minzoom") if qfit_layer is not None else None,
+        "qfit_maxzoom": qfit_layer.get("maxzoom") if qfit_layer is not None else None,
         "filter": original_layer.get("filter"),
-        "qfit_filter": comparison_layer.get("filter"),
+        "qfit_filter": qfit_layer.get("filter") if qfit_layer is not None else None,
         "layout": _selected_section_properties(
             original_layer,
             "layout",
@@ -141,15 +161,15 @@ def _source_label_layer_record(
             "paint",
             _SOURCE_LABEL_PAINT_PROPERTIES,
         ),
-        "qfit_layout": _selected_section_properties(
-            comparison_layer,
-            "layout",
-            _SOURCE_LABEL_LAYOUT_PROPERTIES,
+        "qfit_layout": (
+            _selected_section_properties(qfit_layer, "layout", _SOURCE_LABEL_LAYOUT_PROPERTIES)
+            if qfit_layer is not None
+            else {}
         ),
-        "qfit_paint": _selected_section_properties(
-            comparison_layer,
-            "paint",
-            _SOURCE_LABEL_PAINT_PROPERTIES,
+        "qfit_paint": (
+            _selected_section_properties(qfit_layer, "paint", _SOURCE_LABEL_PAINT_PROPERTIES)
+            if qfit_layer is not None
+            else {}
         ),
     }
 
@@ -486,7 +506,7 @@ def _compound_markdown_value(*values: object, separator: str = " ") -> str:
 
 
 def _json_markdown_value(value: object) -> str:
-    if value is None or value == {}:
+    if value is None or value == {} or value == []:
         return "—"
     if isinstance(value, (dict, list)):
         return json.dumps(value, sort_keys=True, separators=(",", ":")).replace("|", "\\|")
@@ -579,7 +599,11 @@ def build_summary_markdown(report: dict[str, object]) -> str:
                 qfit_layer=_markdown_value(row.get("qfit_style_layer_id")),
                 source=_markdown_value(row.get("source_layer")),
                 zoom=_zoom_range_markdown_value(row.get("minzoom"), row.get("maxzoom")),
-                qfit_zoom=_zoom_range_markdown_value(row.get("qfit_minzoom"), row.get("qfit_maxzoom")),
+                qfit_zoom=(
+                    _zoom_range_markdown_value(row.get("qfit_minzoom"), row.get("qfit_maxzoom"))
+                    if row.get("qfit_style_layer_id") is not None
+                    else "—"
+                ),
                 filter=_json_markdown_value(row.get("filter")),
                 qfit_filter=_json_markdown_value(row.get("qfit_filter")),
                 layout=_json_markdown_value(row.get("layout")),

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -15,6 +15,36 @@ DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-label-settings"
 DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
 DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 DEFAULT_QT_QPA_PLATFORM = "offscreen"
+_SOURCE_LABEL_LAYOUT_PROPERTIES = (
+    "symbol-placement",
+    "symbol-spacing",
+    "symbol-avoid-edges",
+    "symbol-sort-key",
+    "symbol-z-order",
+    "text-field",
+    "text-size",
+    "text-font",
+    "text-max-angle",
+    "text-allow-overlap",
+    "text-ignore-placement",
+    "text-optional",
+    "text-keep-upright",
+    "text-padding",
+    "text-anchor",
+    "text-justify",
+    "text-offset",
+    "text-radial-offset",
+    "text-variable-anchor",
+    "visibility",
+)
+_SOURCE_LABEL_PAINT_PROPERTIES = (
+    "text-color",
+    "text-halo-color",
+    "text-halo-width",
+    "text-halo-blur",
+    "text-opacity",
+    "text-translate",
+)
 
 
 @dataclass(frozen=True)
@@ -55,6 +85,119 @@ def load_style_definition(path: Path) -> dict[str, object]:
     if not isinstance(data, dict):
         raise ValueError(f"Expected Mapbox style JSON object in {path}")
     return data
+
+
+def _style_layers(style_definition: dict[str, object]) -> list[dict[str, object]]:
+    layers = style_definition.get("layers")
+    if not isinstance(layers, list):
+        return []
+    return [layer for layer in layers if isinstance(layer, dict)]
+
+
+def _style_layers_by_id(style_definition: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {
+        str(layer.get("id")): layer
+        for layer in _style_layers(style_definition)
+        if isinstance(layer.get("id"), str)
+    }
+
+
+def _selected_section_properties(
+    layer: dict[str, object],
+    section: str,
+    property_names: tuple[str, ...],
+) -> dict[str, object]:
+    values = layer.get(section)
+    if not isinstance(values, dict):
+        return {}
+    return {property_name: values[property_name] for property_name in property_names if property_name in values}
+
+
+def _source_label_layer_record(
+    *,
+    original_layer: dict[str, object],
+    qfit_layer: dict[str, object] | None,
+    style_name: str,
+) -> dict[str, object]:
+    comparison_layer = qfit_layer or original_layer
+    return {
+        "base_style_layer_id": str(original_layer.get("id") or ""),
+        "style_name": style_name,
+        "qfit_style_layer_id": str(comparison_layer.get("id") or ""),
+        "source_layer": str(original_layer.get("source-layer") or ""),
+        "minzoom": original_layer.get("minzoom"),
+        "maxzoom": original_layer.get("maxzoom"),
+        "qfit_minzoom": comparison_layer.get("minzoom"),
+        "qfit_maxzoom": comparison_layer.get("maxzoom"),
+        "filter": original_layer.get("filter"),
+        "qfit_filter": comparison_layer.get("filter"),
+        "layout": _selected_section_properties(
+            original_layer,
+            "layout",
+            _SOURCE_LABEL_LAYOUT_PROPERTIES,
+        ),
+        "paint": _selected_section_properties(
+            original_layer,
+            "paint",
+            _SOURCE_LABEL_PAINT_PROPERTIES,
+        ),
+        "qfit_layout": _selected_section_properties(
+            comparison_layer,
+            "layout",
+            _SOURCE_LABEL_LAYOUT_PROPERTIES,
+        ),
+        "qfit_paint": _selected_section_properties(
+            comparison_layer,
+            "paint",
+            _SOURCE_LABEL_PAINT_PROPERTIES,
+        ),
+    }
+
+
+def source_label_layer_records(
+    original_style: dict[str, object],
+    qfit_style: dict[str, object],
+    label_records: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    _ensure_package_parent_on_path()
+    from qfit.mapbox_config import base_mapbox_style_layer_id_for_qfit
+
+    original_layers_by_id = _style_layers_by_id(original_style)
+    qfit_layers = _style_layers(qfit_style)
+    qfit_layers_by_id = _style_layers_by_id(qfit_style)
+    rows: list[dict[str, object]] = []
+    seen: set[tuple[str, str]] = set()
+    for label_record in label_records:
+        style_name = str(label_record.get("style_name") or "")
+        base_style_layer_id = str(label_record.get("base_style_layer_id") or "")
+        if not base_style_layer_id:
+            base_style_layer_id = base_mapbox_style_layer_id_for_qfit(style_name)
+        key = (base_style_layer_id, style_name)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        original_layer = original_layers_by_id.get(base_style_layer_id)
+        if original_layer is None:
+            continue
+        qfit_layer = qfit_layers_by_id.get(style_name) or qfit_layers_by_id.get(base_style_layer_id)
+        if qfit_layer is None:
+            qfit_layer = next(
+                (
+                    layer
+                    for layer in qfit_layers
+                    if base_mapbox_style_layer_id_for_qfit(str(layer.get("id") or "")) == base_style_layer_id
+                ),
+                None,
+            )
+        rows.append(
+            _source_label_layer_record(
+                original_layer=original_layer,
+                qfit_layer=qfit_layer,
+                style_name=style_name,
+            )
+        )
+    return sorted(rows, key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")))
 
 
 def _style_slug(style_owner: str, style_id: str) -> str:
@@ -260,7 +403,9 @@ def _label_settings_report(
     sprite_loaded: bool,
     sprite_count: int,
     records: list[dict[str, object]],
+    source_label_layers: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
+    source_label_layer_rows = source_label_layers or []
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
@@ -271,6 +416,8 @@ def _label_settings_report(
         "sprite_definition_count": sprite_count,
         "label_count": len(records),
         "labels": records,
+        "source_label_layer_count": len(source_label_layer_rows),
+        "source_label_layers": source_label_layer_rows,
     }
 
 
@@ -305,12 +452,14 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             (QgsMapBoxGlStyleConversionContext, QgsMapBoxGlStyleConverter, Qgis),
         )
         records = _postprocessed_label_records(labeling, apply_mapbox_label_priority)
+        source_label_layers = source_label_layer_records(original_style, qfit_style, records)
         return _label_settings_report(
             config=config,
             result=result,
             sprite_loaded=sprite_loaded,
             sprite_count=sprite_count,
             records=records,
+            source_label_layers=source_label_layers,
         )
     finally:
         if created_app:
@@ -336,9 +485,29 @@ def _compound_markdown_value(*values: object, separator: str = " ") -> str:
     return separator.join(rendered_values)
 
 
+def _json_markdown_value(value: object) -> str:
+    if value is None or value == {}:
+        return "—"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":")).replace("|", "\\|")
+    return _markdown_value(value)
+
+
+def _zoom_range_markdown_value(minzoom: object, maxzoom: object) -> str:
+    if minzoom is None and maxzoom is None:
+        return "all"
+    if maxzoom is None:
+        return f"{_markdown_value(minzoom)}+"
+    if minzoom is None:
+        return f"<{_markdown_value(maxzoom)}"
+    return _compound_markdown_value(minzoom, maxzoom, separator=" to ")
+
+
 def build_summary_markdown(report: dict[str, object]) -> str:
     labels = report.get("labels")
     rows = labels if isinstance(labels, list) else []
+    source_labels = report.get("source_label_layers")
+    source_rows = source_labels if isinstance(source_labels, list) else []
     lines = [
         f"# Mapbox Outdoors QGIS label settings — {report.get('style_owner')}/{report.get('style_id')}",
         "",
@@ -386,6 +555,37 @@ def build_summary_markdown(report: dict[str, object]) -> str:
                     row.get("overrun_distance_unit"),
                 ),
                 keys=_markdown_value(row.get("data_defined_property_keys")),
+            )
+        )
+    if source_rows:
+        lines.extend(
+            [
+                "",
+                "## Source Mapbox label controls",
+                "",
+                f"Source label layers: {report.get('source_label_layer_count', len(source_rows))}",
+                "",
+                "| Base layer | Style | QGIS layer | Source layer | Zoom | QGIS zoom | Filter | QGIS filter | Layout controls | Paint controls | QGIS layout | QGIS paint |",
+                "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+    for row in source_rows:
+        if not isinstance(row, dict):
+            continue
+        lines.append(
+            "| {base} | {style} | {qfit_layer} | {source} | {zoom} | {qfit_zoom} | {filter} | {qfit_filter} | {layout} | {paint} | {qfit_layout} | {qfit_paint} |".format(
+                base=_markdown_value(row.get("base_style_layer_id")),
+                style=_markdown_value(row.get("style_name")),
+                qfit_layer=_markdown_value(row.get("qfit_style_layer_id")),
+                source=_markdown_value(row.get("source_layer")),
+                zoom=_zoom_range_markdown_value(row.get("minzoom"), row.get("maxzoom")),
+                qfit_zoom=_zoom_range_markdown_value(row.get("qfit_minzoom"), row.get("qfit_maxzoom")),
+                filter=_json_markdown_value(row.get("filter")),
+                qfit_filter=_json_markdown_value(row.get("qfit_filter")),
+                layout=_json_markdown_value(row.get("layout")),
+                paint=_json_markdown_value(row.get("paint")),
+                qfit_layout=_json_markdown_value(row.get("qfit_layout")),
+                qfit_paint=_json_markdown_value(row.get("qfit_paint")),
             )
         )
     return "\n".join(lines) + "\n"

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -38,6 +38,8 @@ _SOURCE_LABEL_LAYOUT_PROPERTIES = (
     "text-field",
     "text-size",
     "text-font",
+    "text-letter-spacing",
+    "text-max-width",
     "text-max-angle",
     "text-allow-overlap",
     "text-ignore-placement",


### PR DESCRIPTION
## Summary

- add source Mapbox label paint/layout controls to the label-settings diagnostic JSON and Markdown summary
- align each converted QGIS label record with the original Mapbox layer and qfit-preprocessed layer where available
- include text, icon, and water-label typography controls, and make missing qfit-layer matches explicit in the diagnostic output
- cover the new source-control records and Markdown section with tests

## Evidence

- Live artifact generated with the local QGIS-profile Mapbox token source:
  - `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T105608Z/summary.md`
  - `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T105608Z/label-settings.json`
- The live report captured 209 converted labels and 209 source label-layer control rows.
- For `contour-label`, the report shows the original Mapbox controls next to qfit controls:
  - Mapbox `layout.text-field`: `concat(get(ele), " m")`
  - qfit `layout.text-field`: `get(ele)`
  - Mapbox `layout.text-size`: zoom interpolation from 9.5 to 12
  - qfit `layout.text-size`: scalar 9.5
  - Mapbox/qfit text paint controls remain aligned for color, halo color, and halo width
- For `water-point-label`, the report now preserves `text-letter-spacing` and `text-max-width` expressions beside qfit scalar variants.

## Tests

- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short` (18 passed)
- `python3 -m pytest tests/ -x -q --tb=short` (2152 passed, 173 skipped, 153 subtests passed)
- `git diff --check -- validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_label_settings.py`

Refs #949.
