### PR TITLE
Add contour geometry diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_contour_features.py
+++ b/tests/test_mapbox_outdoors_contour_features.py
@@ -95,9 +95,21 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             return {
                 "contour": {
                     "features": [
-                        {"properties": {"ele": 1200, "index": 5, "class": "contour"}},
-                        {"properties": {"ele": 1210, "index": 1}},
-                        {"properties": {"ele": 1300, "index": "10", "extra": "kept-key"}},
+                        {
+                            "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [2, 0], [2, 2], [0, 0]]]},
+                            "properties": {"ele": 1200, "index": 5, "class": "contour"},
+                        },
+                        {
+                            "geometry": {"type": "LineString", "coordinates": [[3, 4], [5, 6]]},
+                            "properties": {"ele": 1210, "index": 1},
+                        },
+                        {
+                            "geometry": {
+                                "type": "MultiPolygon",
+                                "coordinates": [[[[10, 20], [11, 20], [11, 21], [10, 20]]]],
+                            },
+                            "properties": {"ele": 1300, "index": "10", "extra": "kept-key"},
+                        },
                     ]
                 }
             }
@@ -113,7 +125,13 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
         self.assertEqual(record["contour_feature_count"], 3)
         self.assertEqual(record["contour_label_candidate_count"], 2)
         self.assertEqual(record["index_counts"], {"1": 1, "10": 1, "5": 1})
+        self.assertEqual(record["geometry_type_counts"], {"LineString": 1, "MultiPolygon": 1, "Polygon": 1})
+        self.assertEqual(record["candidate_geometry_type_counts"], {"MultiPolygon": 1, "Polygon": 1})
         self.assertEqual(record["sample_candidates"][0]["ele"], 1200)
+        self.assertEqual(
+            record["sample_candidates"][0]["geometry"],
+            {"type": "Polygon", "point_count": 4, "part_count": 1, "bounds": [0.0, 0.0, 2.0, 2.0]},
+        )
         self.assertEqual(record["sample_candidates"][1]["property_keys"], ["ele", "extra", "index"])
 
     def test_contour_tile_record_reports_fetch_or_decode_errors(self):
@@ -155,9 +173,18 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             return {
                 "contour": {
                     "features": [
-                        {"properties": {"ele": 1000, "index": 5}},
-                        {"properties": {"ele": 1010, "index": 1}},
-                        {"properties": {"ele": 1200, "index": 10}},
+                        {
+                            "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+                            "properties": {"ele": 1000, "index": 5},
+                        },
+                        {
+                            "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+                            "properties": {"ele": 1010, "index": 1},
+                        },
+                        {
+                            "geometry": {"type": "Polygon", "coordinates": [[[2, 2], [3, 2], [3, 3], [2, 2]]]},
+                            "properties": {"ele": 1200, "index": 10},
+                        },
                     ]
                 }
             }
@@ -180,6 +207,8 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
         self.assertEqual(report["contour_feature_count"], 3)
         self.assertEqual(report["contour_label_candidate_count"], 2)
         self.assertEqual(report["generated"], "2026-05-18T11:35:00+00:00")
+        self.assertEqual(report["geometry_type_counts"], {"LineString": 1, "Polygon": 2})
+        self.assertEqual(report["candidate_geometry_type_counts"], {"Polygon": 2})
 
     def test_write_report_writes_json_and_markdown(self):
         report = {
@@ -193,7 +222,9 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             "contour_feature_count": 3,
             "contour_label_candidate_count": 2,
             "index_counts": {"1": 1, "5": 2},
-            "sample_candidates": [{"ele": 1000, "index": 5}],
+            "geometry_type_counts": {"LineString": 1, "Polygon": 2},
+            "candidate_geometry_type_counts": {"Polygon": 2},
+            "sample_candidates": [{"ele": 1000, "index": 5, "geometry": {"type": "Polygon"}}],
             "tiles": [
                 {
                     "z": 14,
@@ -203,12 +234,15 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
                     "contour_feature_count": 3,
                     "contour_label_candidate_count": 2,
                     "index_counts": {"1": 1, "5": 2},
+                    "geometry_type_counts": {"LineString": 1, "Polygon": 2},
+                    "candidate_geometry_type_counts": {"Polygon": 2},
                 }
             ],
         }
         markdown = build_summary_markdown(report)
 
         self.assertIn("Contour-label candidates (index 5/10): 2", markdown)
+        self.assertIn('Candidate geometry types: {"Polygon":2}', markdown)
         self.assertIn("| 14 | 8504 | 5833 | decoded | 3 | 2 |", markdown)
         self.assertIn("Sample contour-label candidates", markdown)
 

--- a/validation/mapbox_outdoors_contour_features.py
+++ b/validation/mapbox_outdoors_contour_features.py
@@ -193,6 +193,76 @@ def _feature_properties(feature: dict[str, object]) -> dict[str, object]:
     return properties if isinstance(properties, dict) else {}
 
 
+def _geometry_type(feature: dict[str, object]) -> str:
+    geometry = feature.get("geometry")
+    if not isinstance(geometry, dict):
+        return "(missing)"
+    geometry_type = geometry.get("type")
+    return geometry_type if isinstance(geometry_type, str) and geometry_type else "(missing)"
+
+
+def _is_coordinate_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_coordinate_pair(value: object) -> bool:
+    return (
+        isinstance(value, (list, tuple))
+        and len(value) >= 2
+        and _is_coordinate_number(value[0])
+        and _is_coordinate_number(value[1])
+    )
+
+
+def _coordinate_bounds(coordinate: list[object] | tuple[object, ...]) -> list[float]:
+    x = float(coordinate[0])
+    y = float(coordinate[1])
+    return [x, y, x, y]
+
+
+def _merge_bounds(left: list[float] | None, right: list[float] | None) -> list[float] | None:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return [min(left[0], right[0]), min(left[1], right[1]), max(left[2], right[2]), max(left[3], right[3])]
+
+
+def _coordinate_stats(coordinates: object) -> dict[str, object]:
+    if _is_coordinate_pair(coordinates):
+        return {"point_count": 1, "part_count": 1, "bounds": _coordinate_bounds(coordinates)}
+    if not isinstance(coordinates, (list, tuple)) or not coordinates:
+        return {"point_count": 0, "part_count": 0}
+    if all(_is_coordinate_pair(coordinate) for coordinate in coordinates):
+        bounds: list[float] | None = None
+        for coordinate in coordinates:
+            bounds = _merge_bounds(bounds, _coordinate_bounds(coordinate))
+        return {"point_count": len(coordinates), "part_count": 1, "bounds": bounds}
+
+    point_count = 0
+    part_count = 0
+    bounds = None
+    for child in coordinates:
+        child_stats = _coordinate_stats(child)
+        point_count += int(child_stats.get("point_count") or 0)
+        part_count += int(child_stats.get("part_count") or 0)
+        child_bounds = child_stats.get("bounds")
+        if isinstance(child_bounds, list):
+            bounds = _merge_bounds(bounds, child_bounds)
+    summary: dict[str, object] = {"point_count": point_count, "part_count": part_count}
+    if bounds is not None:
+        summary["bounds"] = bounds
+    return summary
+
+
+def _geometry_summary(feature: dict[str, object]) -> dict[str, object]:
+    geometry = feature.get("geometry")
+    summary: dict[str, object] = {"type": _geometry_type(feature)}
+    if isinstance(geometry, dict):
+        summary.update(_coordinate_stats(geometry.get("coordinates")))
+    return summary
+
+
 def _normalized_index(value: object) -> int | None:
     if isinstance(value, bool):
         return None
@@ -218,9 +288,19 @@ def _count_indices(features: list[dict[str, object]]) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
-def _candidate_sample(tile: dict[str, int], properties: dict[str, object]) -> dict[str, object]:
+def _count_geometry_types(features: list[dict[str, object]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for feature in features:
+        geometry_type = _geometry_type(feature)
+        counts[geometry_type] = counts.get(geometry_type, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _candidate_sample(tile: dict[str, int], feature: dict[str, object]) -> dict[str, object]:
+    properties = _feature_properties(feature)
     sample = {key: properties[key] for key in SAMPLE_PROPERTY_KEYS if key in properties}
     sample["tile"] = tile
+    sample["geometry"] = _geometry_summary(feature)
     sample["property_keys"] = sorted(str(key) for key in properties.keys())
     return sample
 
@@ -250,22 +330,28 @@ def contour_tile_record(
         "contour_feature_count": len(features),
         "contour_label_candidate_count": len(candidates),
         "index_counts": _count_indices(features),
+        "geometry_type_counts": _count_geometry_types(features),
+        "candidate_geometry_type_counts": _count_geometry_types(candidates),
         "sample_candidates": [
-            _candidate_sample(tile, _feature_properties(feature)) for feature in candidates[:MAX_SAMPLE_CANDIDATES]
+            _candidate_sample(tile, feature) for feature in candidates[:MAX_SAMPLE_CANDIDATES]
         ],
     }
 
 
-def _combined_index_counts(tile_records: list[dict[str, object]]) -> dict[str, int]:
+def _combined_record_counts(tile_records: list[dict[str, object]], count_key: str) -> dict[str, int]:
     counts: dict[str, int] = {}
     for tile_record in tile_records:
-        index_counts = tile_record.get("index_counts")
-        if not isinstance(index_counts, dict):
+        record_counts = tile_record.get(count_key)
+        if not isinstance(record_counts, dict):
             continue
-        for index, count in index_counts.items():
+        for index, count in record_counts.items():
             if isinstance(count, int):
                 counts[str(index)] = counts.get(str(index), 0) + count
     return dict(sorted(counts.items()))
+
+
+def _combined_index_counts(tile_records: list[dict[str, object]]) -> dict[str, int]:
+    return _combined_record_counts(tile_records, "index_counts")
 
 
 def _combined_samples(tile_records: list[dict[str, object]]) -> list[dict[str, object]]:
@@ -366,6 +452,8 @@ def collect_contour_feature_report(
             int(tile.get("contour_label_candidate_count") or 0) for tile in tile_records
         ),
         "index_counts": _combined_index_counts(tile_records),
+        "geometry_type_counts": _combined_record_counts(tile_records, "geometry_type_counts"),
+        "candidate_geometry_type_counts": _combined_record_counts(tile_records, "candidate_geometry_type_counts"),
         "sample_candidates": _combined_samples(tile_records),
         "tiles": tile_records,
     }
@@ -391,9 +479,11 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Contour features: {report.get('contour_feature_count')}",
         f"Contour-label candidates (index 5/10): {report.get('contour_label_candidate_count')}",
         f"Index counts: {_markdown_value(report.get('index_counts'))}",
+        f"Geometry types: {_markdown_value(report.get('geometry_type_counts'))}",
+        f"Candidate geometry types: {_markdown_value(report.get('candidate_geometry_type_counts'))}",
         "",
-        "| z | x | y | Status | Contour features | Label candidates | Index counts |",
-        "| ---: | ---: | ---: | --- | ---: | ---: | --- |",
+        "| z | x | y | Status | Contour features | Label candidates | Index counts | Geometry types | Candidate geometry types |",
+        "| ---: | ---: | ---: | --- | ---: | ---: | --- | --- | --- |",
     ]
     tiles = report.get("tiles")
     tile_rows = tiles if isinstance(tiles, list) else []
@@ -401,7 +491,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         if not isinstance(tile, dict):
             continue
         lines.append(
-            "| {z} | {x} | {y} | {status} | {feature_count} | {candidate_count} | {index_counts} |".format(
+            "| {z} | {x} | {y} | {status} | {feature_count} | {candidate_count} | {index_counts} | {geometry_counts} | {candidate_geometry_counts} |".format(
                 z=_markdown_value(tile.get("z")),
                 x=_markdown_value(tile.get("x")),
                 y=_markdown_value(tile.get("y")),
@@ -409,6 +499,8 @@ def build_summary_markdown(report: dict[str, object]) -> str:
                 feature_count=_markdown_value(tile.get("contour_feature_count")),
                 candidate_count=_markdown_value(tile.get("contour_label_candidate_count")),
                 index_counts=_markdown_value(tile.get("index_counts")),
+                geometry_counts=_markdown_value(tile.get("geometry_type_counts")),
+                candidate_geometry_counts=_markdown_value(tile.get("candidate_geometry_type_counts")),
             )
         )
     samples = report.get("sample_candidates")

--- a/validation/mapbox_outdoors_contour_features.py
+++ b/validation/mapbox_outdoors_contour_features.py
@@ -24,6 +24,7 @@ CONTOUR_SOURCE_LAYER = "contour"
 CONTOUR_LABEL_INDICES = (5, 10)
 SAMPLE_PROPERTY_KEYS = ("ele", "index", "class", "worldview", "level", "sizerank", "name")
 MAX_SAMPLE_CANDIDATES = 12
+MISSING_VALUE = "(missing)"
 
 TileFetcher = Callable[[str], bytes]
 TileDecoder = Callable[[bytes], dict[str, object]]
@@ -196,9 +197,9 @@ def _feature_properties(feature: dict[str, object]) -> dict[str, object]:
 def _geometry_type(feature: dict[str, object]) -> str:
     geometry = feature.get("geometry")
     if not isinstance(geometry, dict):
-        return "(missing)"
+        return MISSING_VALUE
     geometry_type = geometry.get("type")
-    return geometry_type if isinstance(geometry_type, str) and geometry_type else "(missing)"
+    return geometry_type if isinstance(geometry_type, str) and geometry_type else MISSING_VALUE
 
 
 def _is_coordinate_number(value: object) -> bool:
@@ -283,7 +284,7 @@ def _count_indices(features: list[dict[str, object]]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for feature in features:
         index = _normalized_index(_feature_properties(feature).get("index"))
-        key = str(index) if index is not None else "(missing)"
+        key = str(index) if index is not None else MISSING_VALUE
         counts[key] = counts.get(key, 0) + 1
     return dict(sorted(counts.items()))
 


### PR DESCRIPTION
Refs #949.

## Summary

- Extended the Mapbox Outdoors contour feature diagnostic with decoded geometry summaries.
- Per tile and aggregate reports now include geometry type counts for all contour features and for `index in {5,10}` contour-label candidates.
- Sample contour-label candidates now include geometry type, part count, point count, and decoded coordinate bounds.

## Live evidence

Generated with the local QGIS-profile Mapbox token source; credentials are not stored in the artifacts.

- Chamonix z14:
  - `debug/mapbox-outdoors-contour-features/chamonix-trails-z14-outdoors/20260518T114712Z/summary.md`
  - `debug/mapbox-outdoors-contour-features/chamonix-trails-z14-outdoors/20260518T114712Z/contour-features.json`
  - 12/12 tiles decoded, 1,351 contour features, 268 contour-label candidates.
  - Geometry types: `{"MultiPolygon":133,"Polygon":1218}`.
  - Candidate geometry types: `{"MultiPolygon":27,"Polygon":241}`.
- Zermatt piste z17:
  - `debug/mapbox-outdoors-contour-features/zermatt-piste-z17-outdoors/20260518T114712Z/summary.md`
  - `debug/mapbox-outdoors-contour-features/zermatt-piste-z17-outdoors/20260518T114712Z/contour-features.json`
  - 9/9 tiles decoded, 898 contour features, 182 contour-label candidates.
  - Geometry types: `{"MultiPolygon":13,"Polygon":885}`.
  - Candidate geometry types: `{"MultiPolygon":1,"Polygon":181}`.

Interpretation: the missing contour-label gap now has a reproducible geometry clue. In both alpine cameras, decoded `contour-label` candidates are polygon or multipolygon geometries, not line strings. That can explain why QGIS can still draw contour outlines while line-placement labels fail to appear, and it points the next #949 slice toward testing whether QGIS label placement can label polygon boundaries or whether qfit needs a geometry-aware contour-label workaround.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_contour_features.py -q --tb=short`: 9 passed.
- `python3 -m pytest tests/ -x -q --tb=short`: 2161 passed, 173 skipped, 153 subtests passed.
- `git diff --check -- validation/mapbox_outdoors_contour_features.py tests/test_mapbox_outdoors_contour_features.py`: clean.
