### PR TITLE
Flag contour label geometry status

### DIFF
--- a/tests/test_mapbox_outdoors_contour_features.py
+++ b/tests/test_mapbox_outdoors_contour_features.py
@@ -175,6 +175,64 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             },
         )
 
+    def test_contour_tile_record_covers_remaining_candidate_geometry_statuses(self):
+        cases = [
+            (
+                [
+                    {
+                        "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+                        "properties": {"index": 1},
+                    }
+                ],
+                {
+                    "status": "no_candidates",
+                    "candidate_count": 0,
+                    "line_compatible_count": 0,
+                    "polygon_count": 0,
+                    "other_count": 0,
+                },
+            ),
+            (
+                [
+                    {
+                        "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+                        "properties": {"index": 5},
+                    },
+                    {
+                        "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+                        "properties": {"index": 10},
+                    },
+                ],
+                {
+                    "status": "mixed_with_line_compatible",
+                    "candidate_count": 2,
+                    "line_compatible_count": 1,
+                    "polygon_count": 1,
+                    "other_count": 0,
+                },
+            ),
+            (
+                [{"geometry": {"type": "Point", "coordinates": [0, 0]}, "properties": {"index": 5}}],
+                {
+                    "status": "no_line_compatible",
+                    "candidate_count": 1,
+                    "line_compatible_count": 0,
+                    "polygon_count": 0,
+                    "other_count": 1,
+                },
+            ),
+        ]
+        for features, expected in cases:
+            with self.subTest(status=expected["status"]):
+                record = contour_tile_record(
+                    tile={"z": 14, "x": 8504, "y": 5833},
+                    tile_url_template="https://example.test/{z}/{x}/{y}.mvt",
+                    tile_fetcher=lambda _url: gzip.compress(b"tile"),
+                    tile_decoder=lambda _payload, features=features: {"contour": {"features": features}},
+                )
+
+                self.assertEqual(record["candidate_label_geometry"], expected)
+
     def test_contour_tile_record_reports_fetch_or_decode_errors(self):
         def failing_fetcher(_url):
             raise RuntimeError("offline")

--- a/tests/test_mapbox_outdoors_contour_features.py
+++ b/tests/test_mapbox_outdoors_contour_features.py
@@ -127,12 +127,53 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
         self.assertEqual(record["index_counts"], {"1": 1, "10": 1, "5": 1})
         self.assertEqual(record["geometry_type_counts"], {"LineString": 1, "MultiPolygon": 1, "Polygon": 1})
         self.assertEqual(record["candidate_geometry_type_counts"], {"MultiPolygon": 1, "Polygon": 1})
+        self.assertEqual(
+            record["candidate_label_geometry"],
+            {
+                "status": "polygon_only",
+                "candidate_count": 2,
+                "line_compatible_count": 0,
+                "polygon_count": 2,
+                "other_count": 0,
+            },
+        )
         self.assertEqual(record["sample_candidates"][0]["ele"], 1200)
         self.assertEqual(
             record["sample_candidates"][0]["geometry"],
             {"type": "Polygon", "point_count": 4, "part_count": 1, "bounds": [0.0, 0.0, 2.0, 2.0]},
         )
         self.assertEqual(record["sample_candidates"][1]["property_keys"], ["ele", "extra", "index"])
+
+    def test_contour_tile_record_marks_line_compatible_candidate_geometry(self):
+        def decoder(_payload):
+            return {
+                "contour": {
+                    "features": [
+                        {
+                            "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+                            "properties": {"ele": 1200, "index": 5},
+                        }
+                    ]
+                }
+            }
+
+        record = contour_tile_record(
+            tile={"z": 14, "x": 8504, "y": 5833},
+            tile_url_template="https://example.test/{z}/{x}/{y}.mvt",
+            tile_fetcher=lambda _url: gzip.compress(b"tile"),
+            tile_decoder=decoder,
+        )
+
+        self.assertEqual(
+            record["candidate_label_geometry"],
+            {
+                "status": "line_compatible",
+                "candidate_count": 1,
+                "line_compatible_count": 1,
+                "polygon_count": 0,
+                "other_count": 0,
+            },
+        )
 
     def test_contour_tile_record_reports_fetch_or_decode_errors(self):
         def failing_fetcher(_url):
@@ -209,6 +250,8 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
         self.assertEqual(report["generated"], "2026-05-18T11:35:00+00:00")
         self.assertEqual(report["geometry_type_counts"], {"LineString": 1, "Polygon": 2})
         self.assertEqual(report["candidate_geometry_type_counts"], {"Polygon": 2})
+        self.assertEqual(report["candidate_label_geometry"]["status"], "polygon_only")
+        self.assertEqual(report["candidate_label_geometry"]["line_compatible_count"], 0)
 
     def test_write_report_writes_json_and_markdown(self):
         report = {
@@ -224,6 +267,13 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             "index_counts": {"1": 1, "5": 2},
             "geometry_type_counts": {"LineString": 1, "Polygon": 2},
             "candidate_geometry_type_counts": {"Polygon": 2},
+            "candidate_label_geometry": {
+                "status": "polygon_only",
+                "candidate_count": 2,
+                "line_compatible_count": 0,
+                "polygon_count": 2,
+                "other_count": 0,
+            },
             "sample_candidates": [{"ele": 1000, "index": 5, "geometry": {"type": "Polygon"}}],
             "tiles": [
                 {
@@ -243,6 +293,7 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
 
         self.assertIn("Contour-label candidates (index 5/10): 2", markdown)
         self.assertIn('Candidate geometry types: {"Polygon":2}', markdown)
+        self.assertIn('Candidate label geometry: {"candidate_count":2', markdown)
         self.assertIn("| 14 | 8504 | 5833 | decoded | 3 | 2 |", markdown)
         self.assertIn("Sample contour-label candidates", markdown)
 

--- a/validation/mapbox_outdoors_contour_features.py
+++ b/validation/mapbox_outdoors_contour_features.py
@@ -25,6 +25,13 @@ CONTOUR_LABEL_INDICES = (5, 10)
 SAMPLE_PROPERTY_KEYS = ("ele", "index", "class", "worldview", "level", "sizerank", "name")
 MAX_SAMPLE_CANDIDATES = 12
 MISSING_VALUE = "(missing)"
+LINE_COMPATIBLE_GEOMETRY_TYPES = {"LineString", "MultiLineString"}
+POLYGON_GEOMETRY_TYPES = {"Polygon", "MultiPolygon"}
+LABEL_GEOMETRY_NO_CANDIDATES = "no_candidates"
+LABEL_GEOMETRY_LINE_COMPATIBLE = "line_compatible"
+LABEL_GEOMETRY_MIXED_WITH_LINES = "mixed_with_line_compatible"
+LABEL_GEOMETRY_POLYGON_ONLY = "polygon_only"
+LABEL_GEOMETRY_NO_LINE_COMPATIBLE = "no_line_compatible"
 
 TileFetcher = Callable[[str], bytes]
 TileDecoder = Callable[[bytes], dict[str, object]]
@@ -297,6 +304,33 @@ def _count_geometry_types(features: list[dict[str, object]]) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
+def _count_geometry_family(geometry_type_counts: dict[str, int], geometry_types: set[str]) -> int:
+    return sum(count for geometry_type, count in geometry_type_counts.items() if geometry_type in geometry_types)
+
+
+def _candidate_label_geometry(geometry_type_counts: dict[str, int]) -> dict[str, object]:
+    total = sum(geometry_type_counts.values())
+    line_compatible_count = _count_geometry_family(geometry_type_counts, LINE_COMPATIBLE_GEOMETRY_TYPES)
+    polygon_count = _count_geometry_family(geometry_type_counts, POLYGON_GEOMETRY_TYPES)
+    other_count = max(0, total - line_compatible_count - polygon_count)
+    status = LABEL_GEOMETRY_NO_CANDIDATES
+    if total and line_compatible_count == total:
+        status = LABEL_GEOMETRY_LINE_COMPATIBLE
+    elif line_compatible_count:
+        status = LABEL_GEOMETRY_MIXED_WITH_LINES
+    elif total and polygon_count == total:
+        status = LABEL_GEOMETRY_POLYGON_ONLY
+    elif total:
+        status = LABEL_GEOMETRY_NO_LINE_COMPATIBLE
+    return {
+        "status": status,
+        "candidate_count": total,
+        "line_compatible_count": line_compatible_count,
+        "polygon_count": polygon_count,
+        "other_count": other_count,
+    }
+
+
 def _candidate_sample(tile: dict[str, int], feature: dict[str, object]) -> dict[str, object]:
     properties = _feature_properties(feature)
     sample = {key: properties[key] for key in SAMPLE_PROPERTY_KEYS if key in properties}
@@ -324,6 +358,7 @@ def contour_tile_record(
         return {**tile, "status": "error", "error": type(exc).__name__, "message": str(exc)}
     features = _decoded_layer_features(decoded, CONTOUR_SOURCE_LAYER)
     candidates = [feature for feature in features if is_contour_label_candidate(_feature_properties(feature))]
+    candidate_geometry_type_counts = _count_geometry_types(candidates)
     return {
         **tile,
         "status": "decoded",
@@ -332,7 +367,8 @@ def contour_tile_record(
         "contour_label_candidate_count": len(candidates),
         "index_counts": _count_indices(features),
         "geometry_type_counts": _count_geometry_types(features),
-        "candidate_geometry_type_counts": _count_geometry_types(candidates),
+        "candidate_geometry_type_counts": candidate_geometry_type_counts,
+        "candidate_label_geometry": _candidate_label_geometry(candidate_geometry_type_counts),
         "sample_candidates": [
             _candidate_sample(tile, feature) for feature in candidates[:MAX_SAMPLE_CANDIDATES]
         ],
@@ -430,6 +466,7 @@ def collect_contour_feature_report(
     ]
     decoded_tile_count = sum(1 for tile in tile_records if tile.get("status") == "decoded")
     generated = config.now or dt.datetime.now(dt.timezone.utc)
+    candidate_geometry_type_counts = _combined_record_counts(tile_records, "candidate_geometry_type_counts")
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
@@ -454,7 +491,8 @@ def collect_contour_feature_report(
         ),
         "index_counts": _combined_index_counts(tile_records),
         "geometry_type_counts": _combined_record_counts(tile_records, "geometry_type_counts"),
-        "candidate_geometry_type_counts": _combined_record_counts(tile_records, "candidate_geometry_type_counts"),
+        "candidate_geometry_type_counts": candidate_geometry_type_counts,
+        "candidate_label_geometry": _candidate_label_geometry(candidate_geometry_type_counts),
         "sample_candidates": _combined_samples(tile_records),
         "tiles": tile_records,
     }
@@ -482,6 +520,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Index counts: {_markdown_value(report.get('index_counts'))}",
         f"Geometry types: {_markdown_value(report.get('geometry_type_counts'))}",
         f"Candidate geometry types: {_markdown_value(report.get('candidate_geometry_type_counts'))}",
+        f"Candidate label geometry: {_markdown_value(report.get('candidate_label_geometry'))}",
         "",
         "| z | x | y | Status | Contour features | Label candidates | Index counts | Geometry types | Candidate geometry types |",
         "| ---: | ---: | ---: | --- | ---: | ---: | --- | --- | --- |",


### PR DESCRIPTION
Refs #949.

## Summary

- Added a `candidate_label_geometry` summary to the contour feature diagnostic.
- The new summary classifies contour-label candidates as line-compatible, mixed, polygon-only, no-line-compatible, or no candidates.
- Added tests for the live-observed polygon-only case and a line-compatible control case.

## Live evidence

Generated with the local QGIS-profile Mapbox token source; credentials are not stored in the artifacts.

- Chamonix z14:
  - `debug/mapbox-outdoors-contour-features/chamonix-trails-z14-outdoors/20260518T121540Z/summary.md`
  - `debug/mapbox-outdoors-contour-features/chamonix-trails-z14-outdoors/20260518T121540Z/contour-features.json`
  - 12/12 tiles decoded, 1,351 contour features, 268 contour-label candidates.
  - Candidate geometry types: `{"MultiPolygon":27,"Polygon":241}`.
  - Candidate label geometry: `{"candidate_count":268,"line_compatible_count":0,"other_count":0,"polygon_count":268,"status":"polygon_only"}`.
- Zermatt piste z17:
  - `debug/mapbox-outdoors-contour-features/zermatt-piste-z17-outdoors/20260518T121540Z/summary.md`
  - `debug/mapbox-outdoors-contour-features/zermatt-piste-z17-outdoors/20260518T121540Z/contour-features.json`
  - 9/9 tiles decoded, 898 contour features, 182 contour-label candidates.
  - Candidate geometry types: `{"MultiPolygon":1,"Polygon":181}`.
  - Candidate label geometry: `{"candidate_count":182,"line_compatible_count":0,"other_count":0,"polygon_count":182,"status":"polygon_only"}`.

Why this slice: the previous live placement probe showed simple QGIS placement-mode switches did not restore contour labels. This diagnostic status keeps future runs from requiring manual JSON interpretation: the alpine candidate features are present, but none are line-compatible.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_contour_features.py -q --tb=short`: 10 passed.
- `python3 -m pytest tests/ -x -q --tb=short`: 2162 passed, 173 skipped, 153 subtests passed.
- `git diff --check -- validation/mapbox_outdoors_contour_features.py tests/test_mapbox_outdoors_contour_features.py`: clean.
