### PR TITLE
[codex] Capture label geometry diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -82,9 +82,10 @@ class FakeTextFormat:
 
 
 class FakeStyle:
-    def __init__(self, *, style_name, layer_name):
+    def __init__(self, *, style_name, layer_name, geometry_type=None):
         self._style_name = style_name
         self._layer_name = layer_name
+        self._geometry_type = geometry_type or SimpleNamespace(name="Line")
 
     def styleName(self):
         return self._style_name
@@ -92,10 +93,13 @@ class FakeStyle:
     def layerName(self):
         return self._layer_name
 
+    def geometryType(self):
+        return self._geometry_type
+
 
 class FakeLabelStyle(FakeStyle):
-    def __init__(self, *, style_name, layer_name, settings):
-        super().__init__(style_name=style_name, layer_name=layer_name)
+    def __init__(self, *, style_name, layer_name, settings, geometry_type=None):
+        super().__init__(style_name=style_name, layer_name=layer_name, geometry_type=geometry_type)
         self._settings = settings
 
     def labelSettings(self):
@@ -284,6 +288,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["style_name"], "road-label-z15-plus")
         self.assertEqual(record["base_style_layer_id"], "road-label")
         self.assertEqual(record["source_layer"], "road")
+        self.assertEqual(record["geometry_type"], "Line")
         self.assertEqual(record["field_name"], '"name"')
         self.assertTrue(record["is_expression"])
         self.assertEqual(record["priority"], 7)
@@ -611,6 +616,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "base_style_layer_id": "contour-label",
                     "style_name": "contour-label",
                     "source_layer": "contour",
+                    "geometry_type": "Line",
                     "field_name": "concat(\"ele\", ' m')",
                     "is_expression": True,
                     "priority": 3,
@@ -664,6 +670,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("Converted label styles: 1", markdown)
         self.assertIn("Sprite context loaded: yes", markdown)
         self.assertIn("contour-label", markdown)
+        self.assertIn("| contour-label | contour-label | contour | Line |", markdown)
         self.assertIn("concat", markdown)
         self.assertIn("Millimeters", markdown)
         self.assertIn("#626250", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -315,6 +315,7 @@ def label_settings_record(style: object, settings: object) -> dict[str, object]:
         "style_name": style_name_text,
         "base_style_layer_id": base_mapbox_style_layer_id_for_qfit(style_name_text),
         "source_layer": layer_name if isinstance(layer_name, str) else "",
+        "geometry_type": _enum_name(_method_value(style, "geometryType")),
         "field_name": _settings_value(settings, "fieldName"),
         "is_expression": _settings_value(settings, "isExpression"),
         "priority": _settings_value(settings, "priority"),
@@ -538,17 +539,18 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Sprite context loaded: {_markdown_value(report.get('sprite_context_loaded'))}",
         f"Sprite definitions: {_markdown_value(report.get('sprite_definition_count'))}",
         "",
-        "| Base layer | Style | Source layer | Field | Expr | Priority | Placement | Placement flags | Repeat distance | Repeat unit | Display all | Obstacle | Text size | Text color | Text opacity | Buffer | Buffer size | Buffer color | Buffer opacity | Label/part | Merge lines | Curve angles | Overrun | Data-defined keys |",
-        "| --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | --- | --- | --- | ---: | --- | ---: | --- | ---: | --- | ---: | --- | --- | --- | --- | --- |",
+        "| Base layer | Style | Source layer | Geometry | Field | Expr | Priority | Placement | Placement flags | Repeat distance | Repeat unit | Display all | Obstacle | Text size | Text color | Text opacity | Buffer | Buffer size | Buffer color | Buffer opacity | Label/part | Merge lines | Curve angles | Overrun | Data-defined keys |",
+        "| --- | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | --- | --- | --- | ---: | --- | ---: | --- | ---: | --- | ---: | --- | --- | --- | --- | --- |",
     ]
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {base} | {style} | {source} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {text_size} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {curve_angles} | {overrun} | {keys} |".format(
+            "| {base} | {style} | {source} | {geometry} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {text_size} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {curve_angles} | {overrun} | {keys} |".format(
                 base=_markdown_value(row.get("base_style_layer_id")),
                 style=_markdown_value(row.get("style_name")),
                 source=_markdown_value(row.get("source_layer")),
+                geometry=_markdown_value(row.get("geometry_type")),
                 field=_markdown_value(row.get("field_name")),
                 expr=_markdown_value(row.get("is_expression")),
                 priority=_markdown_value(row.get("priority")),


### PR DESCRIPTION
## Summary

- Add the converted QGIS vector-tile label style geometry type to the Mapbox Outdoors label-settings diagnostic JSON.
- Show the geometry type in the diagnostic Markdown table beside source layer and placement.
- Cover the new field in the fake-QGIS diagnostic tests.

## Evidence

- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T124137Z/summary.md`.
- The live `contour-label` row now records `Geometry = Line` and `Placement = Curved`, which can be compared directly with the contour feature diagnostic's polygon-only candidate status.
- A local probe that changed the converted contour label style to polygon geometry crashed the QGIS render path, so this PR keeps the change diagnostic-only.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `git diff --check -- validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_label_settings.py`
- `python3 -m pytest tests/ -x -q --tb=short`
