### PR TITLE
[codex] Capture label geometry generator diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -15,6 +15,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _convert_style_to_labeling,
     _ensure_qgis_application,
     _fetch_sprite_resources,
+    _geometry_generator_markdown_value,
     _label_settings_report,
     _load_original_style,
     _postprocessed_label_records,
@@ -126,6 +127,9 @@ class FakeSettings:
     placementFlags = 1
     labelPerPart = False
     mergeLines = False
+    geometryGenerator = "boundary($geometry)"
+    geometryGeneratorEnabled = True
+    geometryGeneratorType = SimpleNamespace(name="Line")
     maxCurvedCharAngleIn = 25.0
     maxCurvedCharAngleOut = -25.0
     overrunDistance = 0.0
@@ -300,6 +304,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["placement_flags"], 1)
         self.assertFalse(record["label_per_part"])
         self.assertFalse(record["merge_lines"])
+        self.assertEqual(record["geometry_generator"], "boundary($geometry)")
+        self.assertTrue(record["geometry_generator_enabled"])
+        self.assertEqual(record["geometry_generator_type"], "Line")
         self.assertEqual(record["max_curved_char_angle_in"], 25.0)
         self.assertEqual(record["max_curved_char_angle_out"], -25.0)
         self.assertEqual(record["overrun_distance"], 0.0)
@@ -628,6 +635,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "placement_flags": 1,
                     "label_per_part": False,
                     "merge_lines": False,
+                    "geometry_generator": "boundary($geometry)",
+                    "geometry_generator_enabled": True,
+                    "geometry_generator_type": "Line",
                     "max_curved_char_angle_in": 25.0,
                     "max_curved_char_angle_out": -25.0,
                     "overrun_distance": 0.0,
@@ -671,6 +681,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("Sprite context loaded: yes", markdown)
         self.assertIn("contour-label", markdown)
         self.assertIn("| contour-label | contour-label | contour | Line |", markdown)
+        self.assertIn("yes Line boundary($geometry)", markdown)
         self.assertIn("concat", markdown)
         self.assertIn("Millimeters", markdown)
         self.assertIn("#626250", markdown)
@@ -682,6 +693,29 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("| contour-label | contour-label | contour-label | contour | 12+", markdown)
         self.assertIn("\"symbol-placement\":\"line\"", markdown)
         self.assertIn("\"text-halo-color\":\"#dcdcd4\"", markdown)
+
+    def test_geometry_generator_markdown_handles_missing_disabled_and_enabled_values(self):
+        self.assertEqual(_geometry_generator_markdown_value({}), "—")
+        self.assertEqual(
+            _geometry_generator_markdown_value(
+                {
+                    "geometry_generator": "",
+                    "geometry_generator_enabled": False,
+                    "geometry_generator_type": "Point",
+                }
+            ),
+            "no",
+        )
+        self.assertEqual(
+            _geometry_generator_markdown_value(
+                {
+                    "geometry_generator": "boundary($geometry)",
+                    "geometry_generator_enabled": True,
+                    "geometry_generator_type": "Line",
+                }
+            ),
+            "yes Line boundary($geometry)",
+        )
 
     def test_summary_markdown_collapses_empty_compound_cells(self):
         report = {

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -327,6 +327,9 @@ def label_settings_record(style: object, settings: object) -> dict[str, object]:
         "placement_flags": _settings_value(settings, "placementFlags"),
         "label_per_part": _settings_value(settings, "labelPerPart"),
         "merge_lines": _settings_value(settings, "mergeLines"),
+        "geometry_generator": _settings_value(settings, "geometryGenerator"),
+        "geometry_generator_enabled": _settings_value(settings, "geometryGeneratorEnabled"),
+        "geometry_generator_type": _enum_name(_settings_value(settings, "geometryGeneratorType")),
         "max_curved_char_angle_in": _settings_value(settings, "maxCurvedCharAngleIn"),
         "max_curved_char_angle_out": _settings_value(settings, "maxCurvedCharAngleOut"),
         "overrun_distance": _settings_value(settings, "overrunDistance"),
@@ -508,6 +511,23 @@ def _compound_markdown_value(*values: object, separator: str = " ") -> str:
     return separator.join(rendered_values)
 
 
+def _geometry_generator_markdown_value(row: dict[str, object]) -> str:
+    if row.get("geometry_generator_enabled") is False:
+        return "no"
+    generator = row.get("geometry_generator")
+    if (
+        row.get("geometry_generator_enabled") is None
+        and row.get("geometry_generator_type") is None
+        and (generator is None or generator == "")
+    ):
+        return "—"
+    return _compound_markdown_value(
+        row.get("geometry_generator_enabled"),
+        row.get("geometry_generator_type"),
+        row.get("geometry_generator"),
+    )
+
+
 def _json_markdown_value(value: object) -> str:
     if value is None or value == {} or value == []:
         return "—"
@@ -539,14 +559,14 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Sprite context loaded: {_markdown_value(report.get('sprite_context_loaded'))}",
         f"Sprite definitions: {_markdown_value(report.get('sprite_definition_count'))}",
         "",
-        "| Base layer | Style | Source layer | Geometry | Field | Expr | Priority | Placement | Placement flags | Repeat distance | Repeat unit | Display all | Obstacle | Text size | Text color | Text opacity | Buffer | Buffer size | Buffer color | Buffer opacity | Label/part | Merge lines | Curve angles | Overrun | Data-defined keys |",
-        "| --- | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | --- | --- | --- | ---: | --- | ---: | --- | ---: | --- | ---: | --- | --- | --- | --- | --- |",
+        "| Base layer | Style | Source layer | Geometry | Field | Expr | Priority | Placement | Placement flags | Repeat distance | Repeat unit | Display all | Obstacle | Text size | Text color | Text opacity | Buffer | Buffer size | Buffer color | Buffer opacity | Label/part | Merge lines | Geometry generator | Curve angles | Overrun | Data-defined keys |",
+        "| --- | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | --- | --- | --- | ---: | --- | ---: | --- | ---: | --- | ---: | --- | --- | --- | --- | --- | --- |",
     ]
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {base} | {style} | {source} | {geometry} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {text_size} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {curve_angles} | {overrun} | {keys} |".format(
+            "| {base} | {style} | {source} | {geometry} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {text_size} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {generator} | {curve_angles} | {overrun} | {keys} |".format(
                 base=_markdown_value(row.get("base_style_layer_id")),
                 style=_markdown_value(row.get("style_name")),
                 source=_markdown_value(row.get("source_layer")),
@@ -569,6 +589,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
                 buffer_opacity=_markdown_value(row.get("buffer_opacity")),
                 label_per_part=_markdown_value(row.get("label_per_part")),
                 merge_lines=_markdown_value(row.get("merge_lines")),
+                generator=_geometry_generator_markdown_value(row),
                 curve_angles=_compound_markdown_value(
                     row.get("max_curved_char_angle_in"),
                     row.get("max_curved_char_angle_out"),


### PR DESCRIPTION
## Summary

- Add QGIS label geometry-generator fields to the Mapbox Outdoors label-settings diagnostic JSON.
- Show generator state compactly in the diagnostic Markdown table.
- Cover enabled, disabled, and missing generator states in tests.

## Evidence

- This follows the #949 contour-label probe where forcing polygon/boundary label geometry crashed QGIS rendering.
- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260518T130539Z/summary.md`.
- The live `contour-label` row now records `Geometry = Line`, `Placement = Curved`, and `Geometry generator = no`; JSON also captures the disabled generator's default type as `Point`.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `git diff --check -- validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_label_settings.py`
- `python3 -m pytest tests/ -x -q --tb=short`
