### PR TITLE
[codex] Sample path dash arrays in layer zoom bands

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -5083,19 +5083,27 @@ def _literal_line_dasharray(value: object) -> list[object] | None:
     return None
 
 
-def _representative_line_dasharray_interpolate_output(expr: list[object]) -> object | None:
+def _representative_line_dasharray_interpolate_output(
+    expr: list[object],
+    *,
+    target_zoom: float = _REPRESENTATIVE_STYLE_ZOOM,
+) -> object | None:
     if len(expr) < 5:
         return None
     if expr[2] == ["zoom"]:
-        return _nearest_zoom_stop_value(expr)
+        return _nearest_zoom_stop_value(expr, target_zoom=target_zoom)
     return expr[4]
 
 
-def _representative_line_dasharray_step_output(expr: list[object]) -> object | None:
+def _representative_line_dasharray_step_output(
+    expr: list[object],
+    *,
+    target_zoom: float = _REPRESENTATIVE_STYLE_ZOOM,
+) -> object | None:
     if len(expr) < 3:
         return None
     if expr[1] == ["zoom"]:
-        return _step_zoom_value(expr)
+        return _step_zoom_value(expr, target_zoom=target_zoom)
     return expr[2]
 
 
@@ -5105,15 +5113,26 @@ def _case_expression_output_candidates(expr: list[object]) -> list[object]:
     return [expr[-1], *(expr[index] for index in range(len(expr) - 2, 1, -2))]
 
 
-def _first_line_dasharray_literal(candidates: list[object]) -> list[object] | None:
+def _first_line_dasharray_literal(
+    candidates: list[object],
+    *,
+    target_zoom: float = _REPRESENTATIVE_STYLE_ZOOM,
+) -> list[object] | None:
     for candidate in candidates:
-        literal_dasharray = _extract_line_dasharray_literal(candidate)
+        literal_dasharray = _extract_line_dasharray_literal(
+            candidate,
+            target_zoom=target_zoom,
+        )
         if literal_dasharray is not None:
             return literal_dasharray
     return None
 
 
-def _extract_line_dasharray_literal(expr: object) -> list[object] | None:
+def _extract_line_dasharray_literal(
+    expr: object,
+    *,
+    target_zoom: float = _REPRESENTATIVE_STYLE_ZOOM,
+) -> list[object] | None:
     """Extract a literal QGIS-safe dash pattern from simple Mapbox expressions."""
     literal_dasharray = _literal_line_dasharray(expr)
     if literal_dasharray is not None:
@@ -5123,15 +5142,31 @@ def _extract_line_dasharray_literal(expr: object) -> list[object] | None:
 
     op = expr[0]
     if op == "interpolate":
-        return _extract_line_dasharray_literal(_representative_line_dasharray_interpolate_output(expr))
+        return _extract_line_dasharray_literal(
+            _representative_line_dasharray_interpolate_output(expr, target_zoom=target_zoom),
+            target_zoom=target_zoom,
+        )
     if op == "step":
-        return _extract_line_dasharray_literal(_representative_line_dasharray_step_output(expr))
+        return _extract_line_dasharray_literal(
+            _representative_line_dasharray_step_output(expr, target_zoom=target_zoom),
+            target_zoom=target_zoom,
+        )
     if op == "match":
-        return _extract_line_dasharray_literal(expr[-1]) if len(expr) >= 5 else None
+        return (
+            _extract_line_dasharray_literal(expr[-1], target_zoom=target_zoom)
+            if len(expr) >= 5
+            else None
+        )
     if op == "case":
-        return _first_line_dasharray_literal(_case_expression_output_candidates(expr))
+        return _first_line_dasharray_literal(
+            _case_expression_output_candidates(expr),
+            target_zoom=target_zoom,
+        )
     if op == "coalesce":
-        return _first_line_dasharray_literal(list(reversed(expr[1:])))
+        return _first_line_dasharray_literal(
+            list(reversed(expr[1:])),
+            target_zoom=target_zoom,
+        )
     return None
 
 
@@ -6021,7 +6056,18 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                     if blur_width_mm is not None:
                         props[prop] = blur_width_mm
                 elif prop == "line-dasharray":
-                    dasharray = _extract_line_dasharray_literal(val)
+                    dasharray_target_zoom = _representative_zoom_in_layer_range(
+                        layer.get("minzoom"),
+                        layer.get("maxzoom"),
+                    )
+                    dasharray = _extract_line_dasharray_literal(
+                        val,
+                        target_zoom=(
+                            dasharray_target_zoom
+                            if dasharray_target_zoom is not None
+                            else _REPRESENTATIVE_STYLE_ZOOM
+                        ),
+                    )
                     if dasharray is not None:
                         props[prop] = dasharray
                 elif prop in _FULL_OPACITY_PROPS:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1983,6 +1983,48 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][3]["paint"]["line-dasharray"], [5, 2])
         self.assertIsInstance(style["layers"][0]["paint"]["line-dasharray"][2], list)
 
+    def test_split_high_zoom_path_layers_use_layer_zoom_for_dasharray(self):
+        path_filter = [
+            "all",
+            ["==", ["get", "class"], "path"],
+            [
+                "step",
+                ["zoom"],
+                ["!", ["match", ["get", "type"], ["steps", "sidewalk", "crossing"], True, False]],
+                16,
+                ["!=", ["get", "type"], "steps"],
+            ],
+            ["==", ["geometry-type"], "LineString"],
+        ]
+        path_dasharray = [
+            "step",
+            ["zoom"],
+            ["literal", [4, 0.3]],
+            15,
+            ["literal", [1.75, 0.3]],
+            16,
+            ["literal", [1, 0.3]],
+            17,
+            ["literal", [1, 0.25]],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "road-path",
+                    "type": "line",
+                    "minzoom": 12,
+                    "filter": path_filter,
+                    "paint": {"line-dasharray": path_dasharray},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        self.assertEqual(by_id["road-path-below-z16"]["paint"]["line-dasharray"], [4, 0.3])
+        self.assertEqual(by_id["road-path-z16-plus"]["paint"]["line-dasharray"], [1, 0.3])
+
     def test_ferry_line_widths_keep_lake_routes_visible(self):
         ferry_width = ["interpolate", ["exponential", 1.5], ["zoom"], 14, 0.5, 20, 1]
         style = {


### PR DESCRIPTION
## Summary
- Sample zoom-only `paint.line-dasharray` expressions at each layer's effective zoom band instead of always using the global z12 representative zoom.
- Keeps high-zoom Mapbox Outdoors path/trail/pedestrian dash patterns closer to their z16+ source stops after qfit splits those layers for QGIS.
- Adds a regression test for split high-zoom `road-path` dasharray handling.

## Root Cause
qfit already split high-zoom path layers into z16+ variants, but the dasharray literalizer still evaluated zoom steps at z12. The z18 Zermatt style therefore kept low-zoom dash stops like `[4, 0.3]` on `road-path-z16-plus` instead of the high-zoom stop `[1, 0.3]`.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- Live Zermatt comparison: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260518T133139Z/`
- Live all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260518T133347Z/summary.md`

## Visual Notes
The live style preprocessing diff changed only seven z16+ path/trail/pedestrian dash arrays. Manual visual review found modestly improved/normalized dashed path and trail styling in Zermatt, no visible Geneva regression, and no material drift in the z5/z8/z10/z14 Chamonix/z17 Zermatt matrix cameras.
