### PR TITLE
[codex] add Mapbox road feature diagnostic

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -1,0 +1,460 @@
+import datetime as dt
+import gzip
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from tests import _path  # noqa: F401
+
+from qfit.validation import mapbox_outdoors_road_features as road_features
+from qfit.validation.mapbox_outdoors_road_features import (
+    RoadFeatureConfig,
+    build_parser,
+    build_road_feature_paths,
+    build_run_directory,
+    build_summary_markdown,
+    collect_road_feature_report,
+    is_path_line_candidate,
+    is_pedestrian_line_candidate,
+    is_pedestrian_polygon_candidate,
+    load_style_definition,
+    main,
+    resolve_mapbox_token,
+    road_tile_record,
+    write_report,
+)
+
+
+def _feature(geometry_type, properties):
+    return {
+        "geometry": {"type": geometry_type, "coordinates": [[0, 0], [1, 1]]},
+        "properties": properties,
+    }
+
+
+class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
+    def test_resolve_mapbox_token_prefers_argument_then_environment(self):
+        self.assertEqual(
+            resolve_mapbox_token(
+                provided_token="arg-token",
+                environ={"MAPBOX_ACCESS_TOKEN": "env-token", "QFIT_MAPBOX_ACCESS_TOKEN": "qfit-token"},
+            ),
+            "arg-token",
+        )
+        self.assertEqual(
+            resolve_mapbox_token(provided_token=None, environ={"MAPBOX_ACCESS_TOKEN": "env-token"}),
+            "env-token",
+        )
+        self.assertEqual(
+            resolve_mapbox_token(provided_token=None, environ={"QFIT_MAPBOX_ACCESS_TOKEN": "qfit-token"}),
+            "qfit-token",
+        )
+        self.assertIsNone(resolve_mapbox_token(provided_token=None, environ={}))
+
+    def test_build_paths_are_predictable(self):
+        run_dir = build_run_directory(
+            output_root=Path("/tmp/roads"),
+            camera_name="zermatt",
+            now=dt.datetime(2026, 5, 18, 14, 5, tzinfo=dt.timezone.utc),
+        )
+        paths = build_road_feature_paths(run_dir)
+
+        self.assertEqual(run_dir, Path("/tmp/roads/zermatt/20260518T140500Z"))
+        self.assertEqual(paths.json_path, run_dir / "road-features.json")
+        self.assertEqual(paths.summary_path, run_dir / "summary.md")
+
+    def test_load_style_definition_requires_json_object(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            style_path = Path(tmpdir) / "style.json"
+            style_path.write_text('{"version": 8}\n', encoding="utf-8")
+            self.assertEqual(load_style_definition(style_path), {"version": 8})
+
+            style_path.write_text('["not", "an", "object"]\n', encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_style_definition(style_path)
+
+    def test_candidate_filters_match_pedestrian_polygon_and_line_style_inputs(self):
+        pedestrian_polygon = _feature(
+            "Polygon",
+            {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": 0},
+        )
+        path_polygon = _feature("MultiPolygon", {"class": "path", "type": "footway", "structure": "ford"})
+        bridge_polygon = _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "bridge"})
+        negative_layer_polygon = _feature(
+            "Polygon",
+            {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": -1},
+        )
+        pedestrian_line = _feature(
+            "LineString",
+            {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": 1},
+        )
+        negative_layer_line = _feature(
+            "LineString",
+            {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": -1},
+        )
+        path_line = _feature("MultiLineString", {"class": "path", "type": "footway", "structure": "none"})
+        negative_layer_path_line = _feature(
+            "LineString",
+            {"class": "path", "type": "footway", "structure": "none", "layer": -1},
+        )
+        step_path_line = _feature("LineString", {"class": "path", "type": "steps", "structure": "none"})
+        sidewalk_path_line = _feature("LineString", {"class": "path", "type": "sidewalk", "structure": "none"})
+        crossing_path_line = _feature("LineString", {"class": "path", "type": "crossing", "structure": "none"})
+        missing_structure_path_line = _feature("LineString", {"class": "path", "type": "footway"})
+
+        self.assertTrue(is_pedestrian_polygon_candidate(pedestrian_polygon))
+        self.assertTrue(is_pedestrian_polygon_candidate(path_polygon))
+        self.assertFalse(is_pedestrian_polygon_candidate(bridge_polygon))
+        self.assertFalse(is_pedestrian_polygon_candidate(negative_layer_polygon))
+        self.assertFalse(is_pedestrian_polygon_candidate(pedestrian_line))
+        self.assertTrue(is_pedestrian_line_candidate(pedestrian_line))
+        self.assertFalse(is_pedestrian_line_candidate(negative_layer_line))
+        self.assertFalse(is_pedestrian_line_candidate(path_line))
+        self.assertTrue(is_path_line_candidate(path_line))
+        self.assertFalse(is_path_line_candidate(negative_layer_path_line))
+        self.assertFalse(is_path_line_candidate(step_path_line, tile_zoom=15))
+        self.assertFalse(is_path_line_candidate(step_path_line, tile_zoom=16))
+        self.assertFalse(is_path_line_candidate(sidewalk_path_line, tile_zoom=15))
+        self.assertTrue(is_path_line_candidate(sidewalk_path_line, tile_zoom=16))
+        self.assertFalse(is_path_line_candidate(crossing_path_line, tile_zoom=15))
+        self.assertTrue(is_path_line_candidate(crossing_path_line, tile_zoom=16))
+        self.assertFalse(is_path_line_candidate(missing_structure_path_line))
+        self.assertFalse(is_path_line_candidate(pedestrian_line))
+
+    def test_road_tile_record_counts_pedestrian_polygons_and_line_candidates(self):
+        road_features = [
+            _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
+            _feature("MultiPolygon", {"class": "path", "type": "footway", "structure": "none"}),
+            _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "bridge"}),
+            _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
+            _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": -1}),
+            _feature("LineString", {"class": "path", "type": "footway", "structure": "none"}),
+            _feature("MultiLineString", {"class": "path", "type": "steps", "structure": "none"}),
+            _feature("LineString", {"class": "street", "type": "street", "structure": "none"}),
+        ]
+
+        def decoder(_payload):
+            return {"road": {"features": road_features}}
+
+        record = road_tile_record(
+            tile={"z": 18, "x": 136712, "y": 93238},
+            tile_url_template="https://example.test/{z}/{x}/{y}.mvt",
+            tile_fetcher=lambda _url: gzip.compress(b"tile"),
+            tile_decoder=decoder,
+        )
+
+        self.assertEqual(record["status"], "decoded")
+        self.assertEqual(record["road_feature_count"], 8)
+        self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
+        self.assertEqual(record["pedestrian_line_candidate_count"], 1)
+        self.assertEqual(record["path_line_candidate_count"], 1)
+        self.assertEqual(record["pedestrian_polygon_class_counts"], {"path": 1, "pedestrian": 1})
+        self.assertEqual(record["pedestrian_polygon_type_counts"], {"footway": 1, "pedestrian": 1})
+        self.assertEqual(record["pedestrian_line_type_counts"], {"pedestrian": 1})
+        self.assertEqual(record["path_line_type_counts"], {"footway": 1})
+        self.assertEqual(record["sample_pedestrian_polygons"][0]["properties"]["class"], "pedestrian")
+
+    def test_road_tile_record_accepts_flat_layer_lists_and_summarizes_irregular_features(self):
+        road_features = [
+            {
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [1, 2]], [[2, 3], [4, 5]]],
+                },
+                "properties": {"class": "pedestrian", "type": ["plaza"], "structure": "none"},
+            },
+            {
+                "geometry": {"type": "LineString", "coordinates": [7, 8]},
+                "properties": {"class": "pedestrian", "type": {"kind": "lane"}, "structure": "none"},
+            },
+            {"geometry": {"type": "Polygon"}, "properties": {"class": "path", "structure": "none"}},
+            {"properties": {"class": "street"}},
+            "ignore-me",
+        ]
+
+        record = road_tile_record(
+            tile={"z": 18, "x": 1, "y": 2},
+            tile_url_template="https://example.test/{z}/{x}/{y}.mvt",
+            tile_fetcher=lambda _url: gzip.compress(b"tile"),
+            tile_decoder=lambda _payload: {"road": road_features},
+        )
+
+        self.assertEqual(record["status"], "decoded")
+        self.assertEqual(record["road_feature_count"], 4)
+        self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
+        self.assertEqual(record["pedestrian_line_candidate_count"], 1)
+        self.assertEqual(record["road_geometry_type_counts"]["(missing)"], 1)
+        self.assertEqual(record["pedestrian_polygon_type_counts"], {'["plaza"]': 1, "(missing)": 1})
+        self.assertEqual(record["pedestrian_line_type_counts"], {'{"kind":"lane"}': 1})
+        self.assertEqual(record["sample_pedestrian_polygons"][0]["geometry"]["bounds"], [0.0, 0.0, 4.0, 5.0])
+        self.assertEqual(record["sample_pedestrian_lines"][0]["geometry"]["point_count"], 1)
+
+    def test_road_tile_record_treats_non_list_layer_as_empty(self):
+        record = road_tile_record(
+            tile={"z": 18, "x": 1, "y": 2},
+            tile_url_template="https://example.test/{z}/{x}/{y}.mvt",
+            tile_fetcher=lambda _url: gzip.compress(b"tile"),
+            tile_decoder=lambda _payload: {"road": "not-a-layer"},
+        )
+
+        self.assertEqual(record["status"], "decoded")
+        self.assertEqual(record["road_feature_count"], 0)
+
+    def test_road_tile_record_marks_decode_errors(self):
+        record = road_tile_record(
+            tile={"z": 18, "x": 1, "y": 2},
+            tile_url_template="https://example.test/{z}/{x}/{y}.mvt",
+            tile_fetcher=lambda _url: b"not-gzip",
+            tile_decoder=lambda _payload: (_ for _ in ()).throw(ValueError("bad tile")),
+        )
+
+        self.assertEqual(record["status"], "error")
+        self.assertEqual(record["error"], "ValueError")
+
+    def test_collect_road_feature_report_uses_style_tiles_and_camera(self):
+        generated = dt.datetime(2026, 5, 18, 14, 12, tzinfo=dt.timezone.utc)
+        calls = []
+
+        def style_fetcher(token, owner, style_id):
+            self.assertEqual((token, owner, style_id), ("token", "mapbox", "outdoors-v12"))
+            return {"sources": {"composite": {"type": "vector", "url": "mapbox://mapbox.mapbox-streets-v8"}}}
+
+        def tile_fetcher(url):
+            calls.append(url)
+            return gzip.compress(b"tile")
+
+        def decoder(_payload):
+            return {
+                "road": {
+                    "features": [
+                        _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
+                        _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
+                        _feature("LineString", {"class": "path", "type": "footway", "structure": "none"}),
+                    ]
+                }
+            }
+
+        report = collect_road_feature_report(
+            RoadFeatureConfig(token="token", output_root=Path("/tmp"), tile_zoom=0, now=generated),
+            style_fetcher=style_fetcher,
+            tile_fetcher=tile_fetcher,
+            tile_decoder=decoder,
+        )
+
+        self.assertEqual(report["generated"], "2026-05-18T14:12:00+00:00")
+        self.assertEqual(report["camera"]["name"], "zermatt-trails-z18-outdoors")
+        self.assertEqual(report["tile_zoom"], 0)
+        self.assertEqual(report["tile_count"], 1)
+        self.assertEqual(report["decoded_tile_count"], 1)
+        self.assertEqual(report["road_feature_count"], 3)
+        self.assertEqual(report["pedestrian_polygon_candidate_count"], 1)
+        self.assertEqual(report["pedestrian_line_candidate_count"], 1)
+        self.assertEqual(report["path_line_candidate_count"], 1)
+        self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 1})
+        self.assertEqual(report["path_line_type_counts"], {"footway": 1})
+        self.assertEqual(len(calls), 1)
+        self.assertIn("mapbox.mapbox-streets-v8/0/0/0.mvt", calls[0])
+
+    def test_collect_road_feature_report_can_load_style_json_file(self):
+        generated = dt.datetime(2026, 5, 18, 14, 12, tzinfo=dt.timezone.utc)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            style_path = Path(tmpdir) / "style.json"
+            style_path.write_text(
+                json.dumps({"sources": {"composite": {"type": "vector", "url": "mapbox://mapbox.mapbox-streets-v8"}}}),
+                encoding="utf-8",
+            )
+            report = collect_road_feature_report(
+                RoadFeatureConfig(
+                    token="token",
+                    output_root=Path(tmpdir),
+                    style_json_path=style_path,
+                    tile_zoom=0,
+                    now=generated,
+                ),
+                tile_fetcher=lambda _url: gzip.compress(b"tile"),
+                tile_decoder=lambda _payload: {"road": []},
+            )
+
+        self.assertEqual(report["tileset_ids"], ["mapbox.mapbox-streets-v8"])
+        self.assertEqual(report["road_feature_count"], 0)
+
+    def test_collect_road_feature_report_requires_token_for_style_and_tiles(self):
+        with self.assertRaisesRegex(ValueError, "style-json"):
+            collect_road_feature_report(
+                RoadFeatureConfig(token=None, output_root=Path("/tmp"), tile_zoom=0),
+                style_fetcher=lambda _token, _owner, _style_id: {},
+                tile_fetcher=lambda _url: gzip.compress(b"tile"),
+                tile_decoder=lambda _payload: {"road": []},
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            style_path = Path(tmpdir) / "style.json"
+            style_path.write_text(
+                json.dumps({"sources": {"composite": {"type": "vector", "url": "mapbox://mapbox.mapbox-streets-v8"}}}),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "vector tiles"):
+                collect_road_feature_report(
+                    RoadFeatureConfig(token=None, output_root=Path(tmpdir), style_json_path=style_path, tile_zoom=0),
+                    tile_fetcher=lambda _url: gzip.compress(b"tile"),
+                    tile_decoder=lambda _payload: {"road": []},
+                )
+            with self.assertRaisesRegex(ValueError, "vector tiles"):
+                collect_road_feature_report(
+                    RoadFeatureConfig(token="", output_root=Path(tmpdir), style_json_path=style_path, tile_zoom=0),
+                    tile_fetcher=lambda _url: gzip.compress(b"tile"),
+                    tile_decoder=lambda _payload: {"road": []},
+                )
+
+    def test_collect_road_feature_report_rejects_unknown_camera(self):
+        with self.assertRaisesRegex(ValueError, "Unknown comparison camera"):
+            collect_road_feature_report(
+                RoadFeatureConfig(token="token", output_root=Path("/tmp"), camera_name="missing-camera", tile_zoom=0),
+                style_fetcher=lambda _token, _owner, _style_id: {
+                    "sources": {"composite": {"type": "vector", "url": "mapbox://mapbox.mapbox-streets-v8"}}
+                },
+                tile_fetcher=lambda _url: gzip.compress(b"tile"),
+                tile_decoder=lambda _payload: {"road": []},
+            )
+
+    def test_build_summary_markdown_includes_counts_and_samples(self):
+        report = {
+            "generated": "2026-05-18T14:12:00+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "camera": {"name": "zermatt-trails-z18-outdoors"},
+            "tile_zoom": 18,
+            "decoded_tile_count": 1,
+            "tile_count": 1,
+            "road_feature_count": 3,
+            "pedestrian_polygon_candidate_count": 1,
+            "pedestrian_line_candidate_count": 1,
+            "path_line_candidate_count": 1,
+            "pedestrian_polygon_type_counts": {"pedestrian": 1},
+            "pedestrian_line_type_counts": {"pedestrian": 1},
+            "path_line_type_counts": {"footway": 1},
+            "sample_pedestrian_polygons": [{"properties": {"class": "pedestrian"}}],
+            "sample_pedestrian_lines": [{"properties": {"class": "pedestrian"}}],
+            "sample_path_lines": [{"properties": {"class": "path"}}],
+            "tiles": [
+                "ignore-me",
+                {
+                    "z": 18,
+                    "x": 1,
+                    "y": 2,
+                    "status": "decoded",
+                    "road_feature_count": 3,
+                    "pedestrian_polygon_candidate_count": 1,
+                    "pedestrian_line_candidate_count": 1,
+                    "path_line_candidate_count": 1,
+                    "pedestrian_polygon_type_counts": {"pedestrian": 1},
+                    "pedestrian_line_type_counts": {"pedestrian": 1},
+                    "path_line_type_counts": {"footway": 1},
+                }
+            ],
+        }
+
+        markdown = build_summary_markdown(report)
+
+        self.assertIn("# Mapbox Outdoors road feature diagnostic - zermatt-trails-z18-outdoors", markdown)
+        self.assertIn("Pedestrian/path polygon candidates: 1", markdown)
+        self.assertIn("Path line candidates: 1", markdown)
+        self.assertIn("## Sample pedestrian/path polygon candidates", markdown)
+        self.assertIn("## Sample pedestrian line candidates", markdown)
+        self.assertIn("## Sample path line candidates", markdown)
+
+    def test_write_report_writes_json_and_markdown(self):
+        report = {
+            "generated": "2026-05-18T14:12:00+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "camera": {"name": "zermatt-trails-z18-outdoors"},
+            "tile_zoom": 18,
+            "decoded_tile_count": 0,
+            "tile_count": 0,
+            "road_feature_count": 0,
+            "pedestrian_polygon_candidate_count": 0,
+            "pedestrian_line_candidate_count": 0,
+            "path_line_candidate_count": 0,
+            "tiles": [],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = build_road_feature_paths(Path(tmpdir) / "run")
+            write_report(report, paths)
+
+            self.assertEqual(json.loads(paths.json_path.read_text()), report)
+            self.assertIn("Road features: 0", paths.summary_path.read_text())
+
+    def test_private_helpers_cover_url_fetching_and_sample_limits(self):
+        response = mock.Mock()
+        response.read.return_value = b"tile"
+        response.__enter__ = mock.Mock(return_value=response)
+        response.__exit__ = mock.Mock(return_value=None)
+        with mock.patch("qfit.validation.mapbox_outdoors_contour_features.urlopen", return_value=response) as urlopen:
+            self.assertEqual(road_features._fetch_url_bytes("https://example.test/tile.mvt"), b"tile")
+        urlopen.assert_called_once_with("https://example.test/tile.mvt", timeout=20)
+
+        self.assertEqual(road_features._merge_bounds([0, 0, 1, 1], None), [0, 0, 1, 1])
+        self.assertEqual(road_features._combined_record_counts([{"counts": "bad"}], "counts"), {})
+        many_samples = [{"sample": i} for i in range(road_features.MAX_SAMPLE_FEATURES + 3)]
+        self.assertEqual(
+            road_features._combined_samples([{"samples": many_samples}, {"samples": [{"sample": "extra"}]}], "samples"),
+            many_samples[: road_features.MAX_SAMPLE_FEATURES],
+        )
+
+    def test_parser_and_main_wire_cli_arguments_to_report_output(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "camera-name",
+                "--style-json",
+                "/tmp/style.json",
+                "--style-owner",
+                "owner",
+                "--style-id",
+                "style",
+                "--mapbox-token",
+                "token",
+                "--tile-zoom",
+                "14",
+                "--output-root",
+                "/tmp/out",
+            ]
+        )
+        self.assertEqual(args.camera, "camera-name")
+        self.assertEqual(args.tile_zoom, 14)
+
+        captured = {}
+
+        def fake_collect(config):
+            captured["config"] = config
+            return {"camera": {"name": config.camera_name}, "tiles": []}
+
+        def fake_write(report, paths):
+            captured["report"] = report
+            captured["paths"] = paths
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stdout = io.StringIO()
+            with (
+                mock.patch.object(road_features, "collect_road_feature_report", side_effect=fake_collect),
+                mock.patch.object(road_features, "write_report", side_effect=fake_write),
+                redirect_stdout(stdout),
+            ):
+                result = main(["camera-name", "--mapbox-token", "token", "--tile-zoom", "14", "--output-root", tmpdir])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(captured["config"].camera_name, "camera-name")
+        self.assertEqual(captured["config"].tile_zoom, 14)
+        self.assertEqual(captured["paths"].summary_path.name, "summary.md")
+        self.assertIn("summary.md", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import math
+import sys
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PARENT = REPO_ROOT.parent
+package_parent = str(PACKAGE_PARENT)
+if package_parent not in sys.path:
+    sys.path.insert(0, package_parent)
+
+from qfit import mapbox_config
+from qfit.validation.mapbox_outdoors_contour_features import (
+    TileDecoder,
+    TileFetcher,
+    _camera_by_name,
+    _camera_extent,
+    _combined_record_counts,
+    _decoded_layer_features,
+    _default_tile_decoder,
+    _ensure_package_parent_on_path,
+    _feature_properties,
+    _fetch_url_bytes,
+    _geometry_summary,
+    _geometry_type,
+    _markdown_value,
+    _merge_bounds,
+    _TILE_ERROR_TYPES,
+    build_run_directory,
+    decode_vector_tile_bytes,
+    iter_tile_coordinates,
+    load_style_definition,
+    recommended_tile_zoom,
+    resolve_mapbox_token,
+    tile_bounds_for_web_mercator_extent,
+)
+
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-road-features"
+DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
+DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
+DEFAULT_CAMERA_NAME = "zermatt-trails-z18-outdoors"
+ROAD_SOURCE_LAYER = "road"
+MISSING_VALUE = "(missing)"
+MAX_SAMPLE_FEATURES = 12
+PEDESTRIAN_PATH_CLASSES = {"path", "pedestrian"}
+SURFACE_STRUCTURES = {"none", "ford"}
+LINE_GEOMETRY_TYPES = {"LineString", "MultiLineString"}
+POLYGON_GEOMETRY_TYPES = {"Polygon", "MultiPolygon"}
+LOW_ZOOM_PATH_EXCLUDED_TYPES = {"crossing", "sidewalk", "steps"}
+HIGH_ZOOM_PATH_EXCLUDED_TYPES = {"steps"}
+SAMPLE_PROPERTY_KEYS = (
+    "class",
+    "type",
+    "structure",
+    "layer",
+    "name",
+    "oneway",
+    "surface",
+)
+
+
+@dataclass(frozen=True)
+class RoadFeaturePaths:
+    run_dir: Path
+    json_path: Path
+    summary_path: Path
+
+
+@dataclass(frozen=True)
+class RoadFeatureConfig:
+    token: str | None
+    output_root: Path
+    camera_name: str = DEFAULT_CAMERA_NAME
+    style_owner: str = DEFAULT_MAPBOX_STYLE_OWNER
+    style_id: str = DEFAULT_MAPBOX_STYLE_ID
+    style_json_path: Path | None = None
+    tile_zoom: int | None = None
+    now: dt.datetime | None = None
+
+
+def build_road_feature_paths(run_dir: Path) -> RoadFeaturePaths:
+    return RoadFeaturePaths(
+        run_dir=run_dir,
+        json_path=run_dir / "road-features.json",
+        summary_path=run_dir / "summary.md",
+    )
+
+
+def _structure_is_surface(properties: dict[str, object]) -> bool:
+    structure = properties.get("structure")
+    return structure in SURFACE_STRUCTURES
+
+
+def _layer_is_nonnegative(properties: dict[str, object]) -> bool:
+    layer = properties.get("layer")
+    return layer is None or (
+        not isinstance(layer, bool) and isinstance(layer, (int, float)) and math.isfinite(float(layer)) and layer >= 0
+    )
+
+
+def is_pedestrian_polygon_candidate(feature: dict[str, object]) -> bool:
+    properties = _feature_properties(feature)
+    return (
+        properties.get("class") in PEDESTRIAN_PATH_CLASSES
+        and _structure_is_surface(properties)
+        and _layer_is_nonnegative(properties)
+        and _geometry_type(feature) in POLYGON_GEOMETRY_TYPES
+    )
+
+
+def is_pedestrian_line_candidate(feature: dict[str, object]) -> bool:
+    properties = _feature_properties(feature)
+    return (
+        properties.get("class") == "pedestrian"
+        and _structure_is_surface(properties)
+        and _layer_is_nonnegative(properties)
+        and _geometry_type(feature) in LINE_GEOMETRY_TYPES
+    )
+
+
+def is_path_line_candidate(feature: dict[str, object], *, tile_zoom: int | None = None) -> bool:
+    properties = _feature_properties(feature)
+    if tile_zoom is not None:
+        excluded_types = LOW_ZOOM_PATH_EXCLUDED_TYPES if tile_zoom < 16 else HIGH_ZOOM_PATH_EXCLUDED_TYPES
+        path_type = properties.get("type")
+        if isinstance(path_type, str) and path_type in excluded_types:
+            return False
+    return (
+        properties.get("class") == "path"
+        and _structure_is_surface(properties)
+        and _layer_is_nonnegative(properties)
+        and _geometry_type(feature) in LINE_GEOMETRY_TYPES
+    )
+
+
+def _count_by_property(features: Iterable[dict[str, object]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for feature in features:
+        value = _feature_properties(feature).get(key, MISSING_VALUE)
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, sort_keys=True, separators=(",", ":"))
+        normalized = str(value)
+        counts[normalized] = counts.get(normalized, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _count_geometry_types(features: Iterable[dict[str, object]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for feature in features:
+        geometry_type = _geometry_type(feature)
+        counts[geometry_type] = counts.get(geometry_type, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _feature_sample(tile: dict[str, int], feature: dict[str, object]) -> dict[str, object]:
+    properties = _feature_properties(feature)
+    return {
+        "tile": tile,
+        "properties": {key: properties[key] for key in SAMPLE_PROPERTY_KEYS if key in properties},
+        "geometry": _geometry_summary(feature),
+        "property_keys": sorted(str(key) for key in properties.keys()),
+    }
+
+
+def _tile_url(tile_url_template: str, tile: dict[str, int]) -> str:
+    return tile_url_template.format(z=tile["z"], x=tile["x"], y=tile["y"])
+
+
+def road_tile_record(
+    *,
+    tile: dict[str, int],
+    tile_url_template: str,
+    tile_fetcher: TileFetcher,
+    tile_decoder: TileDecoder,
+) -> dict[str, object]:
+    try:
+        tile_bytes = tile_fetcher(_tile_url(tile_url_template, tile))
+        decoded = decode_vector_tile_bytes(tile_bytes, tile_decoder)
+    except _TILE_ERROR_TYPES as exc:
+        return {**tile, "status": "error", "error": type(exc).__name__, "message": str(exc)}
+    road_features = _decoded_layer_features(decoded, ROAD_SOURCE_LAYER)
+    pedestrian_polygons = [feature for feature in road_features if is_pedestrian_polygon_candidate(feature)]
+    pedestrian_lines = [feature for feature in road_features if is_pedestrian_line_candidate(feature)]
+    path_lines = [feature for feature in road_features if is_path_line_candidate(feature, tile_zoom=tile.get("z"))]
+    return {
+        **tile,
+        "status": "decoded",
+        "byte_count": len(tile_bytes),
+        "road_feature_count": len(road_features),
+        "pedestrian_polygon_candidate_count": len(pedestrian_polygons),
+        "pedestrian_line_candidate_count": len(pedestrian_lines),
+        "path_line_candidate_count": len(path_lines),
+        "road_geometry_type_counts": _count_geometry_types(road_features),
+        "pedestrian_polygon_class_counts": _count_by_property(pedestrian_polygons, "class"),
+        "pedestrian_polygon_type_counts": _count_by_property(pedestrian_polygons, "type"),
+        "pedestrian_polygon_structure_counts": _count_by_property(pedestrian_polygons, "structure"),
+        "pedestrian_line_type_counts": _count_by_property(pedestrian_lines, "type"),
+        "path_line_type_counts": _count_by_property(path_lines, "type"),
+        "sample_pedestrian_polygons": [
+            _feature_sample(tile, feature) for feature in pedestrian_polygons[:MAX_SAMPLE_FEATURES]
+        ],
+        "sample_pedestrian_lines": [
+            _feature_sample(tile, feature) for feature in pedestrian_lines[:MAX_SAMPLE_FEATURES]
+        ],
+        "sample_path_lines": [_feature_sample(tile, feature) for feature in path_lines[:MAX_SAMPLE_FEATURES]],
+    }
+
+
+def _combined_samples(tile_records: list[dict[str, object]], sample_key: str) -> list[dict[str, object]]:
+    samples: list[dict[str, object]] = []
+    for tile_record in tile_records:
+        tile_samples = tile_record.get(sample_key)
+        if isinstance(tile_samples, list):
+            samples.extend(sample for sample in tile_samples if isinstance(sample, dict))
+        if len(samples) >= MAX_SAMPLE_FEATURES:
+            break
+    return samples[:MAX_SAMPLE_FEATURES]
+
+
+def _load_original_style(config: RoadFeatureConfig, style_fetcher) -> dict[str, object]:
+    if config.style_json_path is not None:
+        return load_style_definition(config.style_json_path)
+    if not config.token:
+        raise ValueError("A Mapbox token is required unless --style-json is provided.")
+    return style_fetcher(config.token, config.style_owner, config.style_id)
+
+
+def _road_tileset_context(
+    config: RoadFeatureConfig,
+    style_fetcher: Callable[[str, str, str], dict[str, object]] | None,
+) -> tuple[list[str], str]:
+    fetch_style = style_fetcher if style_fetcher is not None else mapbox_config.fetch_mapbox_style_definition
+    style_definition = _load_original_style(config, fetch_style)
+    tileset_ids = mapbox_config.extract_mapbox_vector_source_ids(style_definition)
+    if not config.token:
+        raise ValueError("A Mapbox token is required to fetch vector tiles.")
+    tile_url_template = mapbox_config.build_mapbox_vector_tiles_url(
+        config.token,
+        config.style_owner,
+        config.style_id,
+        tileset_ids=tileset_ids,
+    )
+    return tileset_ids, tile_url_template
+
+
+def collect_road_feature_report(
+    config: RoadFeatureConfig,
+    *,
+    style_fetcher: Callable[[str, str, str], dict[str, object]] | None = None,
+    tile_fetcher: TileFetcher | None = None,
+    tile_decoder: TileDecoder | None = None,
+) -> dict[str, object]:
+    _ensure_package_parent_on_path()
+    tileset_ids, tile_url_template = _road_tileset_context(config, style_fetcher)
+    camera = _camera_by_name(config.camera_name)
+    tile_zoom = config.tile_zoom if config.tile_zoom is not None else recommended_tile_zoom(float(camera.zoom))
+    tile_bounds = tile_bounds_for_web_mercator_extent(_camera_extent(camera), tile_zoom)
+    fetch_tile = tile_fetcher or _fetch_url_bytes
+    decode_tile = tile_decoder or _default_tile_decoder
+    tile_records = [
+        road_tile_record(
+            tile=tile,
+            tile_url_template=tile_url_template,
+            tile_fetcher=fetch_tile,
+            tile_decoder=decode_tile,
+        )
+        for tile in iter_tile_coordinates(tile_bounds, tile_zoom)
+    ]
+    decoded_tile_count = sum(1 for tile in tile_records if tile.get("status") == "decoded")
+    generated = config.now or dt.datetime.now(dt.timezone.utc)
+    return {
+        "style_owner": config.style_owner,
+        "style_id": config.style_id,
+        "generated": generated.isoformat(),
+        "camera": {
+            "name": camera.name,
+            "longitude": camera.longitude,
+            "latitude": camera.latitude,
+            "zoom": camera.zoom,
+            "width": camera.width,
+            "height": camera.height,
+        },
+        "tile_zoom": tile_zoom,
+        "tile_bounds": tile_bounds,
+        "tileset_ids": tileset_ids,
+        "tile_count": len(tile_records),
+        "decoded_tile_count": decoded_tile_count,
+        "failed_tile_count": len(tile_records) - decoded_tile_count,
+        "road_feature_count": sum(int(tile.get("road_feature_count") or 0) for tile in tile_records),
+        "pedestrian_polygon_candidate_count": sum(
+            int(tile.get("pedestrian_polygon_candidate_count") or 0) for tile in tile_records
+        ),
+        "pedestrian_line_candidate_count": sum(
+            int(tile.get("pedestrian_line_candidate_count") or 0) for tile in tile_records
+        ),
+        "path_line_candidate_count": sum(int(tile.get("path_line_candidate_count") or 0) for tile in tile_records),
+        "road_geometry_type_counts": _combined_record_counts(tile_records, "road_geometry_type_counts"),
+        "pedestrian_polygon_class_counts": _combined_record_counts(
+            tile_records,
+            "pedestrian_polygon_class_counts",
+        ),
+        "pedestrian_polygon_type_counts": _combined_record_counts(
+            tile_records,
+            "pedestrian_polygon_type_counts",
+        ),
+        "pedestrian_polygon_structure_counts": _combined_record_counts(
+            tile_records,
+            "pedestrian_polygon_structure_counts",
+        ),
+        "pedestrian_line_type_counts": _combined_record_counts(tile_records, "pedestrian_line_type_counts"),
+        "path_line_type_counts": _combined_record_counts(tile_records, "path_line_type_counts"),
+        "sample_pedestrian_polygons": _combined_samples(tile_records, "sample_pedestrian_polygons"),
+        "sample_pedestrian_lines": _combined_samples(tile_records, "sample_pedestrian_lines"),
+        "sample_path_lines": _combined_samples(tile_records, "sample_path_lines"),
+        "tiles": tile_records,
+    }
+
+
+def build_summary_markdown(report: dict[str, object]) -> str:
+    camera = report.get("camera") if isinstance(report.get("camera"), dict) else {}
+    lines = [
+        f"# Mapbox Outdoors road feature diagnostic - {camera.get('name')}",
+        "",
+        f"Generated: {report.get('generated')}",
+        f"Style: {report.get('style_owner')}/{report.get('style_id')}",
+        f"Tile zoom: {report.get('tile_zoom')}",
+        f"Tiles: {report.get('decoded_tile_count')}/{report.get('tile_count')} decoded",
+        f"Road features: {report.get('road_feature_count')}",
+        f"Pedestrian/path polygon candidates: {report.get('pedestrian_polygon_candidate_count')}",
+        f"Pedestrian line candidates: {report.get('pedestrian_line_candidate_count')}",
+        f"Path line candidates: {report.get('path_line_candidate_count')}",
+        f"Pedestrian polygon type counts: {_markdown_value(report.get('pedestrian_polygon_type_counts'))}",
+        f"Pedestrian line type counts: {_markdown_value(report.get('pedestrian_line_type_counts'))}",
+        f"Path line type counts: {_markdown_value(report.get('path_line_type_counts'))}",
+        "",
+        "| z | x | y | Status | Road | Pedestrian/path polygons | Pedestrian lines | Path lines | Polygon types | Pedestrian line types | Path line types |",
+        "| ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | --- | --- | --- |",
+    ]
+    tiles = report.get("tiles")
+    tile_rows = tiles if isinstance(tiles, list) else []
+    for tile in tile_rows:
+        if not isinstance(tile, dict):
+            continue
+        lines.append(
+            "| {z} | {x} | {y} | {status} | {road} | {polygons} | {pedestrian_lines} | {path_lines} | {polygon_types} | {pedestrian_types} | {path_types} |".format(
+                z=_markdown_value(tile.get("z")),
+                x=_markdown_value(tile.get("x")),
+                y=_markdown_value(tile.get("y")),
+                status=_markdown_value(tile.get("status")),
+                road=_markdown_value(tile.get("road_feature_count")),
+                polygons=_markdown_value(tile.get("pedestrian_polygon_candidate_count")),
+                pedestrian_lines=_markdown_value(tile.get("pedestrian_line_candidate_count")),
+                path_lines=_markdown_value(tile.get("path_line_candidate_count")),
+                polygon_types=_markdown_value(tile.get("pedestrian_polygon_type_counts")),
+                pedestrian_types=_markdown_value(tile.get("pedestrian_line_type_counts")),
+                path_types=_markdown_value(tile.get("path_line_type_counts")),
+            )
+        )
+    sample_sections = (
+        ("Sample pedestrian/path polygon candidates", "sample_pedestrian_polygons"),
+        ("Sample pedestrian line candidates", "sample_pedestrian_lines"),
+        ("Sample path line candidates", "sample_path_lines"),
+    )
+    for heading, key in sample_sections:
+        samples = report.get(key)
+        sample_rows = samples if isinstance(samples, list) else []
+        if sample_rows:
+            lines.extend(["", f"## {heading}", ""])
+            for sample in sample_rows:
+                lines.append(f"- {_markdown_value(sample)}")
+    return "\n".join(lines) + "\n"
+
+
+def write_report(report: dict[str, object], paths: RoadFeaturePaths) -> None:
+    paths.run_dir.mkdir(parents=True, exist_ok=True)
+    paths.json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    paths.summary_path.write_text(build_summary_markdown(report), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate Mapbox Outdoors road vector-tile feature diagnostics.")
+    arguments = (
+        (("camera",), {"nargs": "?", "default": DEFAULT_CAMERA_NAME}),
+        (("--style-json",), {"type": Path, "help": "Read an already downloaded Mapbox style JSON file."}),
+        (("--style-owner",), {"default": DEFAULT_MAPBOX_STYLE_OWNER}),
+        (("--style-id",), {"default": DEFAULT_MAPBOX_STYLE_ID}),
+        (("--mapbox-token",), {"help": "Mapbox token. Prefer MAPBOX_ACCESS_TOKEN or QFIT_MAPBOX_ACCESS_TOKEN."}),
+        (("--tile-zoom",), {"type": int, "help": "Override the integer vector-tile zoom to inspect."}),
+        (("--output-root",), {"type": Path, "default": DEFAULT_OUTPUT_ROOT}),
+    )
+    for names, options in arguments:
+        parser.add_argument(*names, **options)
+    return parser
+
+
+def _config_from_args(args: argparse.Namespace, now: dt.datetime) -> RoadFeatureConfig:
+    config_kwargs = {
+        "token": resolve_mapbox_token(provided_token=args.mapbox_token),
+        "output_root": args.output_root,
+        "camera_name": args.camera,
+        "style_owner": args.style_owner,
+        "style_id": args.style_id,
+        "style_json_path": args.style_json,
+        "tile_zoom": args.tile_zoom,
+        "now": now,
+    }
+    return RoadFeatureConfig(**config_kwargs)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = _config_from_args(args, dt.datetime.now(dt.timezone.utc))
+    report = collect_road_feature_report(config)
+    paths = build_road_feature_paths(
+        build_run_directory(output_root=config.output_root, camera_name=config.camera_name, now=config.now)
+    )
+    write_report(report, paths)
+    print(paths.summary_path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a repeatable Mapbox Outdoors road-vector diagnostic for the comparison camera used in #949.
- Report decoded road features, pedestrian/path polygon candidates, pedestrian line candidates, path line candidates, property counts, and representative samples as JSON plus Markdown.
- Cover token/style loading, tile decoding, candidate filters, malformed tile shapes, summary output, and CLI wiring with unit tests.

## Evidence

- Live zermatt-trails-z18-outdoors run wrote `debug/mapbox-outdoors-road-features/zermatt-trails-z18-outdoors/20260518T150641Z/summary.md`.
- That run decoded 12/12 z18 tiles and found 352 road features, 9 pedestrian/path polygon candidates, 191 pedestrian line candidates, and 95 z16+ road-path line candidates after excluding step paths.
- The diagnostic keeps the #949 pedestrian/path investigation repeatable before taking another style-rendering change.

## Review feedback addressed

- Reject empty tokens before vector-tile URL generation.
- Require explicit `structure` values of `none` or `ford` for surface candidates.
- Apply the nonnegative layer guard to path-line candidates.
- Mirror the road-path split by excluding `steps`, `sidewalk`, and `crossing` below z16, and `steps` at z16+.
- Restore the expected top-level blank lines.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `coverage run -m unittest tests.test_mapbox_outdoors_road_features -v && coverage report -m validation/mapbox_outdoors_road_features.py`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949
