### PR TITLE
[codex] add all-camera road feature diagnostic

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -328,8 +328,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
     def test_collect_all_camera_road_feature_report_aggregates_camera_counts(self):
         generated = dt.datetime(2026, 5, 18, 15, 40, tzinfo=dt.timezone.utc)
+        style_calls = []
 
         def style_fetcher(_token, _owner, _style_id):
+            style_calls.append((_token, _owner, _style_id))
             return {"sources": {"composite": {"type": "vector", "url": "mapbox://mapbox.mapbox-streets-v8"}}}
 
         def decoder(_payload):
@@ -360,6 +362,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
         self.assertEqual(report["pedestrian_line_type_counts"], {"pedestrian": 2})
         self.assertEqual(report["path_line_type_counts"], {"footway": 2})
+        self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
         self.assertEqual(
             [camera_report["camera"]["name"] for camera_report in report["cameras"]],
             ["zermatt-trails-z18-outdoors", "chamonix-trails-z14-outdoors"],

--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -4,7 +4,7 @@ import io
 import json
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -13,10 +13,13 @@ from tests import _path  # noqa: F401
 from qfit.validation import mapbox_outdoors_road_features as road_features
 from qfit.validation.mapbox_outdoors_road_features import (
     RoadFeatureConfig,
+    build_all_camera_road_feature_paths,
+    build_all_camera_summary_markdown,
     build_parser,
     build_road_feature_paths,
     build_run_directory,
     build_summary_markdown,
+    collect_all_camera_road_feature_report,
     collect_road_feature_report,
     is_path_line_candidate,
     is_pedestrian_line_candidate,
@@ -25,6 +28,7 @@ from qfit.validation.mapbox_outdoors_road_features import (
     main,
     resolve_mapbox_token,
     road_tile_record,
+    write_all_camera_report,
     write_report,
 )
 
@@ -322,6 +326,45 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                 tile_decoder=lambda _payload: {"road": []},
             )
 
+    def test_collect_all_camera_road_feature_report_aggregates_camera_counts(self):
+        generated = dt.datetime(2026, 5, 18, 15, 40, tzinfo=dt.timezone.utc)
+
+        def style_fetcher(_token, _owner, _style_id):
+            return {"sources": {"composite": {"type": "vector", "url": "mapbox://mapbox.mapbox-streets-v8"}}}
+
+        def decoder(_payload):
+            return {
+                "road": [
+                    _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
+                    _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
+                    _feature("LineString", {"class": "path", "type": "footway", "structure": "none"}),
+                ]
+            }
+
+        report = collect_all_camera_road_feature_report(
+            RoadFeatureConfig(token="token", output_root=Path("/tmp"), tile_zoom=0, now=generated),
+            camera_names=("zermatt-trails-z18-outdoors", "chamonix-trails-z14-outdoors"),
+            style_fetcher=style_fetcher,
+            tile_fetcher=lambda _url: gzip.compress(b"tile"),
+            tile_decoder=decoder,
+        )
+
+        self.assertEqual(report["generated"], "2026-05-18T15:40:00+00:00")
+        self.assertEqual(report["camera_count"], 2)
+        self.assertEqual(report["tile_count"], 2)
+        self.assertEqual(report["decoded_tile_count"], 2)
+        self.assertEqual(report["road_feature_count"], 6)
+        self.assertEqual(report["pedestrian_polygon_candidate_count"], 2)
+        self.assertEqual(report["pedestrian_line_candidate_count"], 2)
+        self.assertEqual(report["path_line_candidate_count"], 2)
+        self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
+        self.assertEqual(report["pedestrian_line_type_counts"], {"pedestrian": 2})
+        self.assertEqual(report["path_line_type_counts"], {"footway": 2})
+        self.assertEqual(
+            [camera_report["camera"]["name"] for camera_report in report["cameras"]],
+            ["zermatt-trails-z18-outdoors", "chamonix-trails-z14-outdoors"],
+        )
+
     def test_build_summary_markdown_includes_counts_and_samples(self):
         report = {
             "generated": "2026-05-18T14:12:00+00:00",
@@ -368,6 +411,44 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("## Sample pedestrian line candidates", markdown)
         self.assertIn("## Sample path line candidates", markdown)
 
+    def test_build_all_camera_summary_markdown_includes_camera_rows(self):
+        report = {
+            "generated": "2026-05-18T15:40:00+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "camera_count": 1,
+            "decoded_tile_count": 1,
+            "tile_count": 1,
+            "road_feature_count": 3,
+            "pedestrian_polygon_candidate_count": 1,
+            "pedestrian_line_candidate_count": 1,
+            "path_line_candidate_count": 1,
+            "pedestrian_polygon_type_counts": {"pedestrian": 1},
+            "pedestrian_line_type_counts": {"pedestrian": 1},
+            "path_line_type_counts": {"footway": 1},
+            "cameras": [
+                {
+                    "camera": {"name": "zermatt-trails-z18-outdoors", "zoom": 18.0},
+                    "tile_zoom": 18,
+                    "decoded_tile_count": 1,
+                    "tile_count": 1,
+                    "road_feature_count": 3,
+                    "pedestrian_polygon_candidate_count": 1,
+                    "pedestrian_line_candidate_count": 1,
+                    "path_line_candidate_count": 1,
+                    "pedestrian_polygon_type_counts": {"pedestrian": 1},
+                    "pedestrian_line_type_counts": {"pedestrian": 1},
+                    "path_line_type_counts": {"footway": 1},
+                }
+            ],
+        }
+
+        markdown = build_all_camera_summary_markdown(report)
+
+        self.assertIn("# Mapbox Outdoors road feature diagnostic - all cameras", markdown)
+        self.assertIn("Cameras: 1", markdown)
+        self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 3 | 1 | 1 | 1 |", markdown)
+
     def test_write_report_writes_json_and_markdown(self):
         report = {
             "generated": "2026-05-18T14:12:00+00:00",
@@ -390,6 +471,28 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
             self.assertEqual(json.loads(paths.json_path.read_text()), report)
             self.assertIn("Road features: 0", paths.summary_path.read_text())
+
+    def test_write_all_camera_report_writes_json_and_markdown(self):
+        report = {
+            "generated": "2026-05-18T15:40:00+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "camera_count": 0,
+            "decoded_tile_count": 0,
+            "tile_count": 0,
+            "road_feature_count": 0,
+            "pedestrian_polygon_candidate_count": 0,
+            "pedestrian_line_candidate_count": 0,
+            "path_line_candidate_count": 0,
+            "cameras": [],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = build_all_camera_road_feature_paths(Path(tmpdir) / "run")
+            write_all_camera_report(report, paths)
+
+            self.assertEqual(json.loads(paths.json_path.read_text()), report)
+            self.assertIn("all cameras", paths.summary_path.read_text())
 
     def test_private_helpers_cover_url_fetching_and_sample_limits(self):
         response = mock.Mock()
@@ -428,6 +531,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             ]
         )
         self.assertEqual(args.camera, "camera-name")
+        self.assertFalse(args.all_cameras)
         self.assertEqual(args.tile_zoom, 14)
 
         captured = {}
@@ -454,6 +558,40 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(captured["config"].tile_zoom, 14)
         self.assertEqual(captured["paths"].summary_path.name, "summary.md")
         self.assertIn("summary.md", stdout.getvalue())
+
+    def test_main_wires_all_camera_mode_to_aggregate_report_output(self):
+        captured = {}
+
+        def fake_collect(config):
+            captured["config"] = config
+            return {"camera_count": 0, "cameras": []}
+
+        def fake_write(report, paths):
+            captured["report"] = report
+            captured["paths"] = paths
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stdout = io.StringIO()
+            with (
+                mock.patch.object(road_features, "collect_all_camera_road_feature_report", side_effect=fake_collect),
+                mock.patch.object(road_features, "write_all_camera_report", side_effect=fake_write),
+                redirect_stdout(stdout),
+            ):
+                result = main(["--all-cameras", "--mapbox-token", "token", "--output-root", tmpdir])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(captured["config"].camera_name, road_features.DEFAULT_CAMERA_NAME)
+        self.assertEqual(captured["report"], {"camera_count": 0, "cameras": []})
+        self.assertEqual(captured["paths"].run_dir.parent.name, "all-cameras")
+        self.assertIn("summary.md", stdout.getvalue())
+
+    def test_main_rejects_single_camera_with_all_camera_mode(self):
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            result = main(["camera-name", "--all-cameras"])
+
+        self.assertEqual(result, 2)
+        self.assertIn("either a single camera or --all-cameras", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -73,13 +73,6 @@ class RoadFeaturePaths:
 
 
 @dataclass(frozen=True)
-class RoadFeatureMatrixPaths:
-    run_dir: Path
-    json_path: Path
-    summary_path: Path
-
-
-@dataclass(frozen=True)
 class RoadFeatureConfig:
     token: str | None
     output_root: Path
@@ -99,8 +92,8 @@ def build_road_feature_paths(run_dir: Path) -> RoadFeaturePaths:
     )
 
 
-def build_all_camera_road_feature_paths(run_dir: Path) -> RoadFeatureMatrixPaths:
-    return RoadFeatureMatrixPaths(
+def build_all_camera_road_feature_paths(run_dir: Path) -> RoadFeaturePaths:
+    return RoadFeaturePaths(
         run_dir=run_dir,
         json_path=run_dir / "road-features.json",
         summary_path=run_dir / "summary.md",
@@ -249,10 +242,11 @@ def _load_original_style(config: RoadFeatureConfig, style_fetcher) -> dict[str, 
 def _road_tileset_context(
     config: RoadFeatureConfig,
     style_fetcher: Callable[[str, str, str], dict[str, object]] | None,
+    style_definition: dict[str, object] | None = None,
 ) -> tuple[list[str], str]:
     fetch_style = style_fetcher if style_fetcher is not None else mapbox_config.fetch_mapbox_style_definition
-    style_definition = _load_original_style(config, fetch_style)
-    tileset_ids = mapbox_config.extract_mapbox_vector_source_ids(style_definition)
+    resolved_style_definition = style_definition if style_definition is not None else _load_original_style(config, fetch_style)
+    tileset_ids = mapbox_config.extract_mapbox_vector_source_ids(resolved_style_definition)
     if not config.token:
         raise ValueError("A Mapbox token is required to fetch vector tiles.")
     tile_url_template = mapbox_config.build_mapbox_vector_tiles_url(
@@ -284,11 +278,12 @@ def collect_road_feature_report(
     config: RoadFeatureConfig,
     *,
     style_fetcher: Callable[[str, str, str], dict[str, object]] | None = None,
+    style_definition: dict[str, object] | None = None,
     tile_fetcher: TileFetcher | None = None,
     tile_decoder: TileDecoder | None = None,
 ) -> dict[str, object]:
     _ensure_package_parent_on_path()
-    tileset_ids, tile_url_template = _road_tileset_context(config, style_fetcher)
+    tileset_ids, tile_url_template = _road_tileset_context(config, style_fetcher, style_definition)
     camera = _camera_by_name(config.camera_name)
     tile_zoom = config.tile_zoom if config.tile_zoom is not None else recommended_tile_zoom(float(camera.zoom))
     tile_bounds = tile_bounds_for_web_mercator_extent(_camera_extent(camera), tile_zoom)
@@ -363,6 +358,8 @@ def collect_all_camera_road_feature_report(
 ) -> dict[str, object]:
     generated = config.now or dt.datetime.now(dt.timezone.utc)
     names = list(camera_names) if camera_names is not None else _all_camera_names()
+    fetch_style = style_fetcher if style_fetcher is not None else mapbox_config.fetch_mapbox_style_definition
+    style_definition = _load_original_style(config, fetch_style)
     camera_reports = [
         collect_road_feature_report(
             RoadFeatureConfig(
@@ -376,6 +373,7 @@ def collect_all_camera_road_feature_report(
                 now=generated,
             ),
             style_fetcher=style_fetcher,
+            style_definition=style_definition,
             tile_fetcher=tile_fetcher,
             tile_decoder=tile_decoder,
         )
@@ -528,7 +526,7 @@ def write_report(report: dict[str, object], paths: RoadFeaturePaths) -> None:
     paths.summary_path.write_text(build_summary_markdown(report), encoding="utf-8")
 
 
-def write_all_camera_report(report: dict[str, object], paths: RoadFeatureMatrixPaths) -> None:
+def write_all_camera_report(report: dict[str, object], paths: RoadFeaturePaths) -> None:
     paths.run_dir.mkdir(parents=True, exist_ok=True)
     paths.json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     paths.summary_path.write_text(build_all_camera_summary_markdown(report), encoding="utf-8")

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -73,6 +73,13 @@ class RoadFeaturePaths:
 
 
 @dataclass(frozen=True)
+class RoadFeatureMatrixPaths:
+    run_dir: Path
+    json_path: Path
+    summary_path: Path
+
+
+@dataclass(frozen=True)
 class RoadFeatureConfig:
     token: str | None
     output_root: Path
@@ -86,6 +93,14 @@ class RoadFeatureConfig:
 
 def build_road_feature_paths(run_dir: Path) -> RoadFeaturePaths:
     return RoadFeaturePaths(
+        run_dir=run_dir,
+        json_path=run_dir / "road-features.json",
+        summary_path=run_dir / "summary.md",
+    )
+
+
+def build_all_camera_road_feature_paths(run_dir: Path) -> RoadFeatureMatrixPaths:
+    return RoadFeatureMatrixPaths(
         run_dir=run_dir,
         json_path=run_dir / "road-features.json",
         summary_path=run_dir / "summary.md",
@@ -249,6 +264,22 @@ def _road_tileset_context(
     return tileset_ids, tile_url_template
 
 
+def _all_camera_names() -> list[str]:
+    _ensure_package_parent_on_path()
+    from qfit.validation.mapbox_outdoors_comparison import CAMERAS
+
+    return list(CAMERAS.keys())
+
+
+def _sum_reports(reports: Iterable[dict[str, object]], key: str) -> int:
+    total = 0
+    for report in reports:
+        value = report.get(key)
+        if isinstance(value, int):
+            total += value
+    return total
+
+
 def collect_road_feature_report(
     config: RoadFeatureConfig,
     *,
@@ -322,6 +353,74 @@ def collect_road_feature_report(
     }
 
 
+def collect_all_camera_road_feature_report(
+    config: RoadFeatureConfig,
+    *,
+    camera_names: Iterable[str] | None = None,
+    style_fetcher: Callable[[str, str, str], dict[str, object]] | None = None,
+    tile_fetcher: TileFetcher | None = None,
+    tile_decoder: TileDecoder | None = None,
+) -> dict[str, object]:
+    generated = config.now or dt.datetime.now(dt.timezone.utc)
+    names = list(camera_names) if camera_names is not None else _all_camera_names()
+    camera_reports = [
+        collect_road_feature_report(
+            RoadFeatureConfig(
+                token=config.token,
+                output_root=config.output_root,
+                camera_name=camera_name,
+                style_owner=config.style_owner,
+                style_id=config.style_id,
+                style_json_path=config.style_json_path,
+                tile_zoom=config.tile_zoom,
+                now=generated,
+            ),
+            style_fetcher=style_fetcher,
+            tile_fetcher=tile_fetcher,
+            tile_decoder=tile_decoder,
+        )
+        for camera_name in names
+    ]
+    return {
+        "style_owner": config.style_owner,
+        "style_id": config.style_id,
+        "generated": generated.isoformat(),
+        "camera_count": len(camera_reports),
+        "tile_count": _sum_reports(camera_reports, "tile_count"),
+        "decoded_tile_count": _sum_reports(camera_reports, "decoded_tile_count"),
+        "failed_tile_count": _sum_reports(camera_reports, "failed_tile_count"),
+        "road_feature_count": _sum_reports(camera_reports, "road_feature_count"),
+        "pedestrian_polygon_candidate_count": _sum_reports(
+            camera_reports,
+            "pedestrian_polygon_candidate_count",
+        ),
+        "pedestrian_line_candidate_count": _sum_reports(
+            camera_reports,
+            "pedestrian_line_candidate_count",
+        ),
+        "path_line_candidate_count": _sum_reports(camera_reports, "path_line_candidate_count"),
+        "road_geometry_type_counts": _combined_record_counts(camera_reports, "road_geometry_type_counts"),
+        "pedestrian_polygon_class_counts": _combined_record_counts(
+            camera_reports,
+            "pedestrian_polygon_class_counts",
+        ),
+        "pedestrian_polygon_type_counts": _combined_record_counts(
+            camera_reports,
+            "pedestrian_polygon_type_counts",
+        ),
+        "pedestrian_polygon_structure_counts": _combined_record_counts(
+            camera_reports,
+            "pedestrian_polygon_structure_counts",
+        ),
+        "pedestrian_line_type_counts": _combined_record_counts(
+            camera_reports,
+            "pedestrian_line_type_counts",
+        ),
+        "path_line_type_counts": _combined_record_counts(camera_reports, "path_line_type_counts"),
+        "cameras": camera_reports,
+    }
+
+
 def build_summary_markdown(report: dict[str, object]) -> str:
     camera = report.get("camera") if isinstance(report.get("camera"), dict) else {}
     lines = [
@@ -377,16 +476,69 @@ def build_summary_markdown(report: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
+    lines = [
+        "# Mapbox Outdoors road feature diagnostic - all cameras",
+        "",
+        f"Generated: {report.get('generated')}",
+        f"Style: {report.get('style_owner')}/{report.get('style_id')}",
+        f"Cameras: {report.get('camera_count')}",
+        f"Tiles: {report.get('decoded_tile_count')}/{report.get('tile_count')} decoded",
+        f"Road features: {report.get('road_feature_count')}",
+        f"Pedestrian/path polygon candidates: {report.get('pedestrian_polygon_candidate_count')}",
+        f"Pedestrian line candidates: {report.get('pedestrian_line_candidate_count')}",
+        f"Path line candidates: {report.get('path_line_candidate_count')}",
+        f"Pedestrian polygon type counts: {_markdown_value(report.get('pedestrian_polygon_type_counts'))}",
+        f"Pedestrian line type counts: {_markdown_value(report.get('pedestrian_line_type_counts'))}",
+        f"Path line type counts: {_markdown_value(report.get('path_line_type_counts'))}",
+        "",
+        "| Camera | Camera zoom | Tile zoom | Tiles | Road | Pedestrian/path polygons | Pedestrian lines | Path lines | Polygon types | Pedestrian line types | Path line types |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |",
+    ]
+    camera_reports = report.get("cameras")
+    rows = camera_reports if isinstance(camera_reports, list) else []
+    for camera_report in rows:
+        if not isinstance(camera_report, dict):
+            continue
+        camera = camera_report.get("camera") if isinstance(camera_report.get("camera"), dict) else {}
+        lines.append(
+            "| {camera_name} | {camera_zoom} | {tile_zoom} | {tiles} | {road} | {polygons} | {pedestrian_lines} | {path_lines} | {polygon_types} | {pedestrian_types} | {path_types} |".format(
+                camera_name=_markdown_value(camera.get("name")),
+                camera_zoom=_markdown_value(camera.get("zoom")),
+                tile_zoom=_markdown_value(camera_report.get("tile_zoom")),
+                tiles=(
+                    f"{_markdown_value(camera_report.get('decoded_tile_count'))}/"
+                    f"{_markdown_value(camera_report.get('tile_count'))}"
+                ),
+                road=_markdown_value(camera_report.get("road_feature_count")),
+                polygons=_markdown_value(camera_report.get("pedestrian_polygon_candidate_count")),
+                pedestrian_lines=_markdown_value(camera_report.get("pedestrian_line_candidate_count")),
+                path_lines=_markdown_value(camera_report.get("path_line_candidate_count")),
+                polygon_types=_markdown_value(camera_report.get("pedestrian_polygon_type_counts")),
+                pedestrian_types=_markdown_value(camera_report.get("pedestrian_line_type_counts")),
+                path_types=_markdown_value(camera_report.get("path_line_type_counts")),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
 def write_report(report: dict[str, object], paths: RoadFeaturePaths) -> None:
     paths.run_dir.mkdir(parents=True, exist_ok=True)
     paths.json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     paths.summary_path.write_text(build_summary_markdown(report), encoding="utf-8")
 
 
+def write_all_camera_report(report: dict[str, object], paths: RoadFeatureMatrixPaths) -> None:
+    paths.run_dir.mkdir(parents=True, exist_ok=True)
+    paths.json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    paths.summary_path.write_text(build_all_camera_summary_markdown(report), encoding="utf-8")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Generate Mapbox Outdoors road vector-tile feature diagnostics.")
     arguments = (
-        (("camera",), {"nargs": "?", "default": DEFAULT_CAMERA_NAME}),
+        (("camera",), {"nargs": "?"}),
+        (("--all-cameras",), {"action": "store_true", "help": "Inspect every comparison harness camera."}),
         (("--style-json",), {"type": Path, "help": "Read an already downloaded Mapbox style JSON file."}),
         (("--style-owner",), {"default": DEFAULT_MAPBOX_STYLE_OWNER}),
         (("--style-id",), {"default": DEFAULT_MAPBOX_STYLE_ID}),
@@ -403,7 +555,7 @@ def _config_from_args(args: argparse.Namespace, now: dt.datetime) -> RoadFeature
     config_kwargs = {
         "token": resolve_mapbox_token(provided_token=args.mapbox_token),
         "output_root": args.output_root,
-        "camera_name": args.camera,
+        "camera_name": args.camera or DEFAULT_CAMERA_NAME,
         "style_owner": args.style_owner,
         "style_id": args.style_id,
         "style_json_path": args.style_json,
@@ -415,12 +567,22 @@ def _config_from_args(args: argparse.Namespace, now: dt.datetime) -> RoadFeature
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.all_cameras and args.camera:
+        print("error: pass either a single camera or --all-cameras, not both.", file=sys.stderr)
+        return 2
     config = _config_from_args(args, dt.datetime.now(dt.timezone.utc))
-    report = collect_road_feature_report(config)
-    paths = build_road_feature_paths(
-        build_run_directory(output_root=config.output_root, camera_name=config.camera_name, now=config.now)
-    )
-    write_report(report, paths)
+    if args.all_cameras:
+        report = collect_all_camera_road_feature_report(config)
+        paths = build_all_camera_road_feature_paths(
+            build_run_directory(output_root=config.output_root, camera_name="all-cameras", now=config.now)
+        )
+        write_all_camera_report(report, paths)
+    else:
+        report = collect_road_feature_report(config)
+        paths = build_road_feature_paths(
+            build_run_directory(output_root=config.output_root, camera_name=config.camera_name, now=config.now)
+        )
+        write_report(report, paths)
     print(paths.summary_path)
     return 0
 


### PR DESCRIPTION
## Summary

- Add `--all-cameras` to the Mapbox Outdoors road-feature diagnostic.
- Write aggregate JSON/Markdown under `debug/mapbox-outdoors-road-features/all-cameras/<timestamp>/`.
- Keep the existing single-camera mode intact and reject mixed single-camera plus `--all-cameras` CLI usage.

Refs #949.

## Live evidence

Token-backed local run after review-feedback fixes:

- `python3 validation/mapbox_outdoors_road_features.py --all-cameras`
- Artifact: `debug/mapbox-outdoors-road-features/all-cameras/20260518T154052Z/summary.md`
- 7/7 cameras completed.
- 62/62 vector tiles decoded.
- 8,361 road source-layer features.
- 54 pedestrian/path polygon candidates.
- 462 pedestrian line candidates.
- 461 road-path-aligned path line candidates.

The candidate rows are concentrated in Geneva z14, Chamonix z14, Zermatt piste z17, and Zermatt trails z18. The z5, z8, and z10 cameras have road features but no matching pedestrian/path candidates, which helps keep the next #949 road-styling comparison scoped to the high-detail cameras.

## Review feedback addressed

- Reused the existing `RoadFeaturePaths` dataclass for all-camera output paths instead of adding a structurally identical dataclass.
- Preloaded the Mapbox style once for `--all-cameras` and reused that style across per-camera reports.

## Validation

- `python3 -m py_compile validation/mapbox_outdoors_road_features.py`
- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `coverage run -m unittest tests.test_mapbox_outdoors_road_features -v && coverage report -m validation/mapbox_outdoors_road_features.py`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 validation/mapbox_outdoors_road_features.py --all-cameras` with the local QGIS-profile token source
