### PR TITLE
fix: fallback pedestrian polygon pattern fill

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -3949,15 +3949,29 @@ def _road_pedestrian_polygon_pattern_fill_opacity_layer_variants(
         zoom_bands=_ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_ZOOM_BANDS,
     )
     if variants is None:
-        return None
+        fallback_layer = _road_pedestrian_polygon_pattern_fallback_layer(layer)
+        return [fallback_layer] if fallback_layer is not None else None
     for variant in variants:
-        paint = variant.get("paint")
-        if not isinstance(paint, dict):
-            continue
-        if paint.get("fill-pattern") == _ROAD_PEDESTRIAN_POLYGON_PATTERN:
-            paint.pop("fill-pattern", None)
-            paint.setdefault("fill-color", _ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_FILL_COLOR)
+        _apply_road_pedestrian_polygon_pattern_fallback(variant)
     return variants
+
+
+def _road_pedestrian_polygon_pattern_fallback_layer(
+    layer: dict[str, object],
+) -> dict[str, object] | None:
+    if layer.get("id") != _ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID or layer.get("type") != "fill":
+        return None
+    fallback_layer = copy.deepcopy(layer)
+    return fallback_layer if _apply_road_pedestrian_polygon_pattern_fallback(fallback_layer) else None
+
+
+def _apply_road_pedestrian_polygon_pattern_fallback(layer: dict[str, object]) -> bool:
+    paint = layer.get("paint")
+    if not isinstance(paint, dict) or paint.get("fill-pattern") != _ROAD_PEDESTRIAN_POLYGON_PATTERN:
+        return False
+    paint.pop("fill-pattern", None)
+    paint.setdefault("fill-color", _ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_FILL_COLOR)
+    return True
 
 
 def _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(layers: object) -> object:

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1335,6 +1335,8 @@ _WETLAND_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], 
     ("z10_5-plus", 10.5, None),
 )
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID = "road-pedestrian-polygon-pattern"
+_ROAD_PEDESTRIAN_POLYGON_PATTERN = "pedestrian-polygon"
+_ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_FILL_COLOR = "hsl(0, 0%, 96%)"
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_EXPRESSIONS = {
     _ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 16, 0, 17, 1],
 }
@@ -3939,13 +3941,23 @@ def _road_pedestrian_polygon_pattern_fill_opacity_layer_variants(
     layer: dict[str, object],
 ) -> list[dict[str, object]] | None:
     """Split audited pedestrian polygon pattern opacity fade into static QGIS zoom bands."""
-    return _zoom_expression_opacity_layer_variants(
+    variants = _zoom_expression_opacity_layer_variants(
         layer,
         layer_type="fill",
         paint_property="fill-opacity",
         expressions_by_layer_id=_ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_EXPRESSIONS,
         zoom_bands=_ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_ZOOM_BANDS,
     )
+    if variants is None:
+        return None
+    for variant in variants:
+        paint = variant.get("paint")
+        if not isinstance(paint, dict):
+            continue
+        if paint.get("fill-pattern") == _ROAD_PEDESTRIAN_POLYGON_PATTERN:
+            paint.pop("fill-pattern", None)
+            paint.setdefault("fill-color", _ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_FILL_COLOR)
+    return variants
 
 
 def _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(layers: object) -> object:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3760,6 +3760,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(len(result["layers"]), 1)
         self.assertEqual(result["layers"][0]["id"], "road-pedestrian-polygon-pattern")
         self.assertEqual(result["layers"][0]["paint"]["fill-opacity"], fill_opacity)
+        self.assertNotIn("fill-pattern", result["layers"][0]["paint"])
+        self.assertEqual(result["layers"][0]["paint"]["fill-color"], "hsl(0, 0%, 96%)")
 
     def test_road_pedestrian_polygon_pattern_fill_opacity_helpers_keep_passthrough_inputs(self):
         unchanged_layers = "not-a-layer-list"

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3747,7 +3747,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(fade_layer["paint"]["fill-opacity"], 0.5)
         self.assertAlmostEqual(full_layer["paint"]["fill-opacity"], 1.0)
         for layer in result["layers"]:
-            self.assertEqual(layer["paint"]["fill-pattern"], "pedestrian-polygon")
+            self.assertNotIn("fill-pattern", layer["paint"])
+            self.assertEqual(layer["paint"]["fill-color"], "hsl(0, 0%, 96%)")
             self.assertEqual(layer["filter"], ["==", ["geometry-type"], "Polygon"])
 
     def test_road_pedestrian_polygon_pattern_fill_opacity_is_not_split_when_shape_changes(self):


### PR DESCRIPTION
## Summary

- replace the unsupported Mapbox Outdoors pedestrian polygon fill pattern with a neutral QGIS-safe solid fill after the existing opacity-band split
- keep the change scoped to the audited `road-pedestrian-polygon-pattern` variants
- update the mapbox style simplification regression test

Refs #949.

## Evidence

- Probe artifact: `debug/tmp-inspection/pedestrian-pattern-fallback/20260518T160101Z/summary.md`
- Visual inspection: neutral fallback improved the Zermatt z18 central pedestrian corridor visibility versus current QGIS; the warm fallback was too subtle.
- Live all-camera matrix after the change: `debug/mapbox-outdoors-comparison/all-cameras/20260518T160434Z/summary.md`
- Live style audit after the change: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260518T160450Z/audit.json`

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
