### PR TITLE
fix: strengthen Mapbox contour strokes

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1532,14 +1532,14 @@ _CONTOUR_LINE_VARIANTS: tuple[
     tuple[str, object, float | None, float | None, float, float],
     ...,
 ] = (
-    ("index-minor-below-z11", ["match", ["get", "index"], [1, 2], True, False], None, 11.0, 0.15, 0.5),
-    ("index-minor-z11-to-z13", ["match", ["get", "index"], [1, 2], True, False], 11.0, 13.0, 0.225, 0.5),
-    ("index-minor-z13-to-z16", ["match", ["get", "index"], [1, 2], True, False], 13.0, 16.0, 0.3, 0.65),
-    ("index-minor-z16-plus", ["match", ["get", "index"], [1, 2], True, False], 16.0, None, 0.3, 0.8),
-    ("index-major-below-z11", ["match", ["get", "index"], [1, 2], False, True], None, 11.0, 0.3, 0.6),
-    ("index-major-z11-to-z13", ["match", ["get", "index"], [1, 2], False, True], 11.0, 13.0, 0.4, 0.6),
-    ("index-major-z13-to-z16", ["match", ["get", "index"], [1, 2], False, True], 13.0, 16.0, 0.5, 0.9),
-    ("index-major-z16-plus", ["match", ["get", "index"], [1, 2], False, True], 16.0, None, 0.5, 1.2),
+    ("index-minor-below-z11", ["match", ["get", "index"], [1, 2], True, False], None, 11.0, 0.25, 0.7),
+    ("index-minor-z11-to-z13", ["match", ["get", "index"], [1, 2], True, False], 11.0, 13.0, 0.35, 0.7),
+    ("index-minor-z13-to-z16", ["match", ["get", "index"], [1, 2], True, False], 13.0, 16.0, 0.5, 1.0),
+    ("index-minor-z16-plus", ["match", ["get", "index"], [1, 2], True, False], 16.0, None, 0.55, 1.25),
+    ("index-major-below-z11", ["match", ["get", "index"], [1, 2], False, True], None, 11.0, 0.5, 0.9),
+    ("index-major-z11-to-z13", ["match", ["get", "index"], [1, 2], False, True], 11.0, 13.0, 0.65, 0.9),
+    ("index-major-z13-to-z16", ["match", ["get", "index"], [1, 2], False, True], 13.0, 16.0, 0.8, 1.4),
+    ("index-major-z16-plus", ["match", ["get", "index"], [1, 2], False, True], 16.0, None, 0.9, 1.9),
 )
 _FILTER_NORMALIZATION_ZOOM_OVERRIDES = {
     "bridge-minor": 14.0,

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4709,18 +4709,18 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual((major_mid["minzoom"], major_mid["maxzoom"]), (13.0, 16.0))
         self.assertEqual(major_full["minzoom"], 16.0)
         self.assertNotIn("maxzoom", major_full)
-        self.assertAlmostEqual(minor_fade["paint"]["line-opacity"], 0.225)
-        self.assertAlmostEqual(minor_mid["paint"]["line-opacity"], 0.3)
-        self.assertAlmostEqual(minor_full["paint"]["line-opacity"], 0.3)
-        self.assertAlmostEqual(major_fade["paint"]["line-opacity"], 0.4)
-        self.assertAlmostEqual(major_mid["paint"]["line-opacity"], 0.5)
-        self.assertAlmostEqual(major_full["paint"]["line-opacity"], 0.5)
-        self.assertAlmostEqual(minor_fade["paint"]["line-width"], 0.5 * mapbox_config._MAPBOX_PIXEL_TO_MM)
-        self.assertAlmostEqual(minor_mid["paint"]["line-width"], 0.65 * mapbox_config._MAPBOX_PIXEL_TO_MM)
-        self.assertAlmostEqual(minor_full["paint"]["line-width"], 0.8 * mapbox_config._MAPBOX_PIXEL_TO_MM)
-        self.assertAlmostEqual(major_fade["paint"]["line-width"], 0.6 * mapbox_config._MAPBOX_PIXEL_TO_MM)
-        self.assertAlmostEqual(major_mid["paint"]["line-width"], 0.9 * mapbox_config._MAPBOX_PIXEL_TO_MM)
-        self.assertAlmostEqual(major_full["paint"]["line-width"], 1.2 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(minor_fade["paint"]["line-opacity"], 0.35)
+        self.assertAlmostEqual(minor_mid["paint"]["line-opacity"], 0.5)
+        self.assertAlmostEqual(minor_full["paint"]["line-opacity"], 0.55)
+        self.assertAlmostEqual(major_fade["paint"]["line-opacity"], 0.65)
+        self.assertAlmostEqual(major_mid["paint"]["line-opacity"], 0.8)
+        self.assertAlmostEqual(major_full["paint"]["line-opacity"], 0.9)
+        self.assertAlmostEqual(minor_fade["paint"]["line-width"], 0.7 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(minor_mid["paint"]["line-width"], 1.0 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(minor_full["paint"]["line-width"], 1.25 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(major_fade["paint"]["line-width"], 0.9 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(major_mid["paint"]["line-width"], 1.4 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(major_full["paint"]["line-width"], 1.9 * mapbox_config._MAPBOX_PIXEL_TO_MM)
         for layer in (minor_fade, minor_mid, minor_full):
             self.assertEqual(
                 layer["filter"],
@@ -4755,10 +4755,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(minor_below["maxzoom"], 11.0)
         self.assertEqual(major_below["minzoom"], 10)
         self.assertEqual(major_below["maxzoom"], 11.0)
-        self.assertAlmostEqual(minor_below["paint"]["line-opacity"], 0.15)
-        self.assertAlmostEqual(major_below["paint"]["line-opacity"], 0.3)
-        self.assertAlmostEqual(minor_below["paint"]["line-width"], 0.5 * mapbox_config._MAPBOX_PIXEL_TO_MM)
-        self.assertAlmostEqual(major_below["paint"]["line-width"], 0.6 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(minor_below["paint"]["line-opacity"], 0.25)
+        self.assertAlmostEqual(major_below["paint"]["line-opacity"], 0.5)
+        self.assertAlmostEqual(minor_below["paint"]["line-width"], 0.7 * mapbox_config._MAPBOX_PIXEL_TO_MM)
+        self.assertAlmostEqual(major_below["paint"]["line-width"], 0.9 * mapbox_config._MAPBOX_PIXEL_TO_MM)
         self.assertEqual(
             minor_below["filter"],
             [
@@ -4796,11 +4796,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         by_id = {layer["id"]: layer for layer in result["layers"]}
         self.assertEqual(
             by_id["contour-line-index-minor-z11-to-z13"]["paint"]["line-opacity"],
-            0.225,
+            0.35,
         )
         self.assertEqual(
             by_id["contour-line-index-major-z13-to-z16"]["paint"]["line-opacity"],
-            0.5,
+            0.8,
         )
         self.assertEqual(
             by_id["contour-line-index-minor-z11-to-z13"]["paint"]["line-width"],


### PR DESCRIPTION
## Summary

- strengthen the audited Mapbox Outdoors `contour-line` QGIS opacity/width variants
- keep the existing index-minor/index-major and zoom-band split behavior
- update contour style simplification regression expectations

Refs #949.

## Evidence

- Probe artifact: `debug/tmp-inspection/contour-stroke-probe/20260518T162643Z/summary.md`
- Visual inspection: the stronger contour stroke variant improves Chamonix z14 and Zermatt piste z17 terrain readability without an obvious regression; the moderate probe was too subtle.
- Live all-camera matrix after the change: `debug/mapbox-outdoors-comparison/all-cameras/20260518T163631Z/summary.md`

Metric notes from the latest matrix, compared with the PR #1144 baseline:

- Zermatt piste z17 improved materially: mean delta `0.0073 -> 0.0043`, RMS `0.0280 -> 0.0203`.
- Zermatt trails z18 improved slightly: mean delta `0.0310 -> 0.0309`, RMS `0.0904 -> 0.0899`.
- Chamonix z14 whole-image metrics worsened slightly, but visual inspection showed improved contour/terrain readability closer to the Mapbox reference.
- z5, z8, z10, and Geneva z14 were unchanged or effectively unchanged.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
