### PR TITLE
Add Mapbox road surface diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -489,6 +489,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("Path line candidates: 1", markdown)
         self.assertIn("Step line candidates: 1", markdown)
         self.assertIn('Pedestrian polygon surface counts: {"paved":1}', markdown)
+        self.assertIn('Pedestrian line surface counts: {"paved":1}', markdown)
         self.assertIn('Path line surface counts: {"unpaved":1}', markdown)
         self.assertIn('Step line structure counts: {"none":1}', markdown)
         self.assertIn('Step line surface counts: {"paved":1}', markdown)

--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -143,13 +143,19 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
     def test_road_tile_record_counts_pedestrian_polygons_and_line_candidates(self):
         road_features = [
-            _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
-            _feature("MultiPolygon", {"class": "path", "type": "footway", "structure": "none"}),
+            _feature(
+                "Polygon",
+                {"class": "pedestrian", "type": "pedestrian", "structure": "none", "surface": "paved"},
+            ),
+            _feature("MultiPolygon", {"class": "path", "type": "footway", "structure": "none", "surface": "unpaved"}),
             _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "bridge"}),
-            _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
+            _feature(
+                "LineString",
+                {"class": "pedestrian", "type": "pedestrian", "structure": "none", "surface": "paved"},
+            ),
             _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": -1}),
-            _feature("LineString", {"class": "path", "type": "footway", "structure": "none"}),
-            _feature("MultiLineString", {"class": "path", "type": "steps", "structure": "none"}),
+            _feature("LineString", {"class": "path", "type": "footway", "structure": "none", "surface": "unpaved"}),
+            _feature("MultiLineString", {"class": "path", "type": "steps", "structure": "none", "surface": "paved"}),
             _feature("LineString", {"class": "street", "type": "street", "structure": "none"}),
         ]
 
@@ -171,9 +177,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["step_line_candidate_count"], 1)
         self.assertEqual(record["pedestrian_polygon_class_counts"], {"path": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_type_counts"], {"footway": 1, "pedestrian": 1})
+        self.assertEqual(record["pedestrian_polygon_surface_counts"], {"paved": 1, "unpaved": 1})
         self.assertEqual(record["pedestrian_line_type_counts"], {"pedestrian": 1})
+        self.assertEqual(record["pedestrian_line_surface_counts"], {"paved": 1})
         self.assertEqual(record["path_line_type_counts"], {"footway": 1})
+        self.assertEqual(record["path_line_surface_counts"], {"unpaved": 1})
         self.assertEqual(record["step_line_structure_counts"], {"none": 1})
+        self.assertEqual(record["step_line_surface_counts"], {"paved": 1})
         self.assertEqual(record["sample_pedestrian_polygons"][0]["properties"]["class"], "pedestrian")
         self.assertEqual(record["sample_step_lines"][0]["properties"]["type"], "steps")
 
@@ -208,7 +218,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["pedestrian_line_candidate_count"], 1)
         self.assertEqual(record["road_geometry_type_counts"]["(missing)"], 1)
         self.assertEqual(record["pedestrian_polygon_type_counts"], {'["plaza"]': 1, "(missing)": 1})
+        self.assertEqual(record["pedestrian_polygon_surface_counts"], {"(missing)": 2})
         self.assertEqual(record["pedestrian_line_type_counts"], {'{"kind":"lane"}': 1})
+        self.assertEqual(record["pedestrian_line_surface_counts"], {"(missing)": 1})
         self.assertEqual(record["sample_pedestrian_polygons"][0]["geometry"]["bounds"], [0.0, 0.0, 4.0, 5.0])
         self.assertEqual(record["sample_pedestrian_lines"][0]["geometry"]["point_count"], 1)
 
@@ -250,10 +262,22 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             return {
                 "road": {
                     "features": [
-                        _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
-                        _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
-                        _feature("LineString", {"class": "path", "type": "footway", "structure": "none"}),
-                        _feature("LineString", {"class": "path", "type": "steps", "structure": "bridge"}),
+                        _feature(
+                            "Polygon",
+                            {"class": "pedestrian", "type": "pedestrian", "structure": "none", "surface": "paved"},
+                        ),
+                        _feature(
+                            "LineString",
+                            {"class": "pedestrian", "type": "pedestrian", "structure": "none", "surface": "paved"},
+                        ),
+                        _feature(
+                            "LineString",
+                            {"class": "path", "type": "footway", "structure": "none", "surface": "unpaved"},
+                        ),
+                        _feature(
+                            "LineString",
+                            {"class": "path", "type": "steps", "structure": "bridge", "surface": "paved"},
+                        ),
                     ]
                 }
             }
@@ -276,8 +300,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["path_line_candidate_count"], 1)
         self.assertEqual(report["step_line_candidate_count"], 1)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 1})
+        self.assertEqual(report["pedestrian_polygon_surface_counts"], {"paved": 1})
         self.assertEqual(report["path_line_type_counts"], {"footway": 1})
+        self.assertEqual(report["path_line_surface_counts"], {"unpaved": 1})
         self.assertEqual(report["step_line_structure_counts"], {"bridge": 1})
+        self.assertEqual(report["step_line_surface_counts"], {"paved": 1})
         self.assertEqual(len(calls), 1)
         self.assertIn("mapbox.mapbox-streets-v8/0/0/0.mvt", calls[0])
 
@@ -355,10 +382,22 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         def decoder(_payload):
             return {
                 "road": [
-                    _feature("Polygon", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
-                    _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none"}),
-                    _feature("LineString", {"class": "path", "type": "footway", "structure": "none"}),
-                    _feature("LineString", {"class": "path", "type": "steps", "structure": "tunnel"}),
+                    _feature(
+                        "Polygon",
+                        {"class": "pedestrian", "type": "pedestrian", "structure": "none", "surface": "paved"},
+                    ),
+                    _feature(
+                        "LineString",
+                        {"class": "pedestrian", "type": "pedestrian", "structure": "none", "surface": "paved"},
+                    ),
+                    _feature(
+                        "LineString",
+                        {"class": "path", "type": "footway", "structure": "none", "surface": "unpaved"},
+                    ),
+                    _feature(
+                        "LineString",
+                        {"class": "path", "type": "steps", "structure": "tunnel", "surface": "paved"},
+                    ),
                 ]
             }
 
@@ -380,9 +419,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["path_line_candidate_count"], 2)
         self.assertEqual(report["step_line_candidate_count"], 2)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
+        self.assertEqual(report["pedestrian_polygon_surface_counts"], {"paved": 2})
         self.assertEqual(report["pedestrian_line_type_counts"], {"pedestrian": 2})
+        self.assertEqual(report["pedestrian_line_surface_counts"], {"paved": 2})
         self.assertEqual(report["path_line_type_counts"], {"footway": 2})
+        self.assertEqual(report["path_line_surface_counts"], {"unpaved": 2})
         self.assertEqual(report["step_line_structure_counts"], {"tunnel": 2})
+        self.assertEqual(report["step_line_surface_counts"], {"paved": 2})
         self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
         self.assertEqual(
             [camera_report["camera"]["name"] for camera_report in report["cameras"]],
@@ -404,9 +447,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
+            "pedestrian_polygon_surface_counts": {"paved": 1},
             "pedestrian_line_type_counts": {"pedestrian": 1},
+            "pedestrian_line_surface_counts": {"paved": 1},
             "path_line_type_counts": {"footway": 1},
+            "path_line_surface_counts": {"unpaved": 1},
             "step_line_structure_counts": {"none": 1},
+            "step_line_surface_counts": {"paved": 1},
             "sample_pedestrian_polygons": [{"properties": {"class": "pedestrian"}}],
             "sample_pedestrian_lines": [{"properties": {"class": "pedestrian"}}],
             "sample_path_lines": [{"properties": {"class": "path"}}],
@@ -424,9 +471,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
+                    "pedestrian_polygon_surface_counts": {"paved": 1},
                     "pedestrian_line_type_counts": {"pedestrian": 1},
+                    "pedestrian_line_surface_counts": {"paved": 1},
                     "path_line_type_counts": {"footway": 1},
+                    "path_line_surface_counts": {"unpaved": 1},
                     "step_line_structure_counts": {"none": 1},
+                    "step_line_surface_counts": {"paved": 1},
                 }
             ],
         }
@@ -437,7 +488,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("Pedestrian/path polygon candidates: 1", markdown)
         self.assertIn("Path line candidates: 1", markdown)
         self.assertIn("Step line candidates: 1", markdown)
+        self.assertIn('Pedestrian polygon surface counts: {"paved":1}', markdown)
+        self.assertIn('Path line surface counts: {"unpaved":1}', markdown)
         self.assertIn('Step line structure counts: {"none":1}', markdown)
+        self.assertIn('Step line surface counts: {"paved":1}', markdown)
         self.assertIn("## Sample pedestrian/path polygon candidates", markdown)
         self.assertIn("## Sample pedestrian line candidates", markdown)
         self.assertIn("## Sample path line candidates", markdown)
@@ -457,9 +511,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
+            "pedestrian_polygon_surface_counts": {"paved": 1},
             "pedestrian_line_type_counts": {"pedestrian": 1},
+            "pedestrian_line_surface_counts": {"paved": 1},
             "path_line_type_counts": {"footway": 1},
+            "path_line_surface_counts": {"unpaved": 1},
             "step_line_structure_counts": {"bridge": 1},
+            "step_line_surface_counts": {"paved": 1},
             "cameras": [
                 {
                     "camera": {"name": "zermatt-trails-z18-outdoors", "zoom": 18.0},
@@ -472,9 +530,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
+                    "pedestrian_polygon_surface_counts": {"paved": 1},
                     "pedestrian_line_type_counts": {"pedestrian": 1},
+                    "pedestrian_line_surface_counts": {"paved": 1},
                     "path_line_type_counts": {"footway": 1},
+                    "path_line_surface_counts": {"unpaved": 1},
                     "step_line_structure_counts": {"bridge": 1},
+                    "step_line_surface_counts": {"paved": 1},
                 }
             ],
         }

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -220,9 +220,13 @@ def road_tile_record(
         "pedestrian_polygon_class_counts": _count_by_property(pedestrian_polygons, "class"),
         "pedestrian_polygon_type_counts": _count_by_property(pedestrian_polygons, "type"),
         "pedestrian_polygon_structure_counts": _count_by_property(pedestrian_polygons, "structure"),
+        "pedestrian_polygon_surface_counts": _count_by_property(pedestrian_polygons, "surface"),
         "pedestrian_line_type_counts": _count_by_property(pedestrian_lines, "type"),
+        "pedestrian_line_surface_counts": _count_by_property(pedestrian_lines, "surface"),
         "path_line_type_counts": _count_by_property(path_lines, "type"),
+        "path_line_surface_counts": _count_by_property(path_lines, "surface"),
         "step_line_structure_counts": _count_by_property(step_lines, "structure"),
+        "step_line_surface_counts": _count_by_property(step_lines, "surface"),
         "sample_pedestrian_polygons": [
             _feature_sample(tile, feature) for feature in pedestrian_polygons[:MAX_SAMPLE_FEATURES]
         ],
@@ -254,9 +258,13 @@ _SUMMARY_COUNT_FIELDS = (
 )
 _SUMMARY_COUNT_MAP_FIELDS = (
     ("Pedestrian polygon type counts", "pedestrian_polygon_type_counts"),
+    ("Pedestrian polygon surface counts", "pedestrian_polygon_surface_counts"),
     ("Pedestrian line type counts", "pedestrian_line_type_counts"),
+    ("Pedestrian line surface counts", "pedestrian_line_surface_counts"),
     ("Path line type counts", "path_line_type_counts"),
+    ("Path line surface counts", "path_line_surface_counts"),
     ("Step line structure counts", "step_line_structure_counts"),
+    ("Step line surface counts", "step_line_surface_counts"),
 )
 _ROAD_FEATURE_TABLE_FIELDS = (
     ("Road", "road_feature_count", "---:"),
@@ -265,9 +273,13 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Path lines", "path_line_candidate_count", "---:"),
     ("Step lines", "step_line_candidate_count", "---:"),
     ("Polygon types", "pedestrian_polygon_type_counts", "---"),
+    ("Polygon surfaces", "pedestrian_polygon_surface_counts", "---"),
     ("Pedestrian line types", "pedestrian_line_type_counts", "---"),
+    ("Pedestrian line surfaces", "pedestrian_line_surface_counts", "---"),
     ("Path line types", "path_line_type_counts", "---"),
+    ("Path line surfaces", "path_line_surface_counts", "---"),
     ("Step structures", "step_line_structure_counts", "---"),
+    ("Step surfaces", "step_line_surface_counts", "---"),
 )
 
 
@@ -405,9 +417,16 @@ def collect_road_feature_report(
             tile_records,
             "pedestrian_polygon_structure_counts",
         ),
+        "pedestrian_polygon_surface_counts": _combined_record_counts(
+            tile_records,
+            "pedestrian_polygon_surface_counts",
+        ),
         "pedestrian_line_type_counts": _combined_record_counts(tile_records, "pedestrian_line_type_counts"),
+        "pedestrian_line_surface_counts": _combined_record_counts(tile_records, "pedestrian_line_surface_counts"),
         "path_line_type_counts": _combined_record_counts(tile_records, "path_line_type_counts"),
+        "path_line_surface_counts": _combined_record_counts(tile_records, "path_line_surface_counts"),
         "step_line_structure_counts": _combined_record_counts(tile_records, "step_line_structure_counts"),
+        "step_line_surface_counts": _combined_record_counts(tile_records, "step_line_surface_counts"),
         "sample_pedestrian_polygons": _combined_samples(tile_records, "sample_pedestrian_polygons"),
         "sample_pedestrian_lines": _combined_samples(tile_records, "sample_pedestrian_lines"),
         "sample_path_lines": _combined_samples(tile_records, "sample_path_lines"),
@@ -479,12 +498,22 @@ def collect_all_camera_road_feature_report(
             camera_reports,
             "pedestrian_polygon_structure_counts",
         ),
+        "pedestrian_polygon_surface_counts": _combined_record_counts(
+            camera_reports,
+            "pedestrian_polygon_surface_counts",
+        ),
         "pedestrian_line_type_counts": _combined_record_counts(
             camera_reports,
             "pedestrian_line_type_counts",
         ),
+        "pedestrian_line_surface_counts": _combined_record_counts(
+            camera_reports,
+            "pedestrian_line_surface_counts",
+        ),
         "path_line_type_counts": _combined_record_counts(camera_reports, "path_line_type_counts"),
+        "path_line_surface_counts": _combined_record_counts(camera_reports, "path_line_surface_counts"),
         "step_line_structure_counts": _combined_record_counts(camera_reports, "step_line_structure_counts"),
+        "step_line_surface_counts": _combined_record_counts(camera_reports, "step_line_surface_counts"),
         "cameras": camera_reports,
     }
 


### PR DESCRIPTION
Refs #949

## Summary

- Add surface-count buckets to the Mapbox Outdoors road-feature diagnostic for pedestrian/path polygons, pedestrian lines, path lines, and step lines.
- Include those counts in the generated JSON plus single-camera and all-camera Markdown summaries.
- Keep this diagnostic-only so future path/pedestrian render probes can target paved pedestrian corridors separately from generic paths/trails.

## Evidence

- Live all-camera diagnostic: `debug/mapbox-outdoors-road-features/all-cameras/20260518T182729Z/summary.md`
- The live run decoded 62/62 tiles and now shows useful surface splits, including Zermatt z18 paved pedestrian polygons/lines mixed with missing and unpaved path surfaces.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
