### PR TITLE
chore: expose Mapbox one-way arrow diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -21,6 +21,7 @@ from qfit.validation.mapbox_outdoors_road_features import (
     build_summary_markdown,
     collect_all_camera_road_feature_report,
     collect_road_feature_report,
+    is_oneway_arrow_candidate,
     is_path_line_candidate,
     is_pedestrian_line_candidate,
     is_pedestrian_polygon_candidate,
@@ -109,6 +110,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         step_path_line = _feature("LineString", {"class": "path", "type": "steps", "structure": "none"})
         bridge_step_line = _feature("LineString", {"class": "path", "type": "steps", "structure": "bridge"})
         tunnel_step_line = _feature("LineString", {"class": "path", "type": "steps", "structure": "tunnel"})
+        low_zoom_street_oneway = _feature("LineString", {"class": "street", "structure": "none", "oneway": "true"})
+        high_zoom_track_oneway = _feature("LineString", {"class": "track", "structure": "none", "oneway": "true"})
+        motorway_oneway = _feature("LineString", {"class": "motorway", "structure": "bridge", "oneway": "true"})
+        bool_oneway = _feature("LineString", {"class": "street", "structure": "none", "oneway": True})
+        unsupported_oneway_class = _feature("LineString", {"class": "path", "structure": "none", "oneway": "true"})
         unsupported_step_line = _feature(
             "LineString",
             {"class": "path", "type": "steps", "structure": "unsupported"},
@@ -132,6 +138,16 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertTrue(is_step_line_candidate(step_path_line))
         self.assertTrue(is_step_line_candidate(bridge_step_line))
         self.assertTrue(is_step_line_candidate(tunnel_step_line))
+        self.assertFalse(is_oneway_arrow_candidate(low_zoom_street_oneway, tile_zoom=15))
+        self.assertTrue(is_oneway_arrow_candidate(low_zoom_street_oneway, tile_zoom=16))
+        self.assertFalse(is_oneway_arrow_candidate(low_zoom_street_oneway))
+        self.assertFalse(is_oneway_arrow_candidate(high_zoom_track_oneway, tile_zoom=15))
+        self.assertTrue(is_oneway_arrow_candidate(high_zoom_track_oneway, tile_zoom=16))
+        self.assertFalse(is_oneway_arrow_candidate(high_zoom_track_oneway))
+        self.assertFalse(is_oneway_arrow_candidate(motorway_oneway, tile_zoom=15))
+        self.assertTrue(is_oneway_arrow_candidate(motorway_oneway, tile_zoom=16))
+        self.assertFalse(is_oneway_arrow_candidate(bool_oneway, tile_zoom=16))
+        self.assertFalse(is_oneway_arrow_candidate(unsupported_oneway_class, tile_zoom=16))
         self.assertFalse(is_step_line_candidate(unsupported_step_line))
         self.assertFalse(is_step_line_candidate(sidewalk_path_line))
         self.assertFalse(is_path_line_candidate(sidewalk_path_line, tile_zoom=15))
@@ -156,6 +172,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": -1}),
             _feature("LineString", {"class": "path", "type": "footway", "structure": "none", "surface": "unpaved"}),
             _feature("MultiLineString", {"class": "path", "type": "steps", "structure": "none", "layer": 0, "surface": "paved"}),
+            _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
+            _feature("LineString", {"class": "motorway", "structure": "bridge", "oneway": "true"}),
             _feature("LineString", {"class": "street", "type": "street", "structure": "none"}),
         ]
 
@@ -170,11 +188,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
 
         self.assertEqual(record["status"], "decoded")
-        self.assertEqual(record["road_feature_count"], 8)
+        self.assertEqual(record["road_feature_count"], 10)
         self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(record["pedestrian_line_candidate_count"], 1)
         self.assertEqual(record["path_line_candidate_count"], 1)
         self.assertEqual(record["step_line_candidate_count"], 1)
+        self.assertEqual(record["oneway_arrow_candidate_count"], 2)
         self.assertEqual(record["pedestrian_polygon_class_counts"], {"path": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_type_counts"], {"footway": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_structure_counts"], {"none": 2})
@@ -191,8 +210,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["step_line_structure_counts"], {"none": 1})
         self.assertEqual(record["step_line_layer_counts"], {"0": 1})
         self.assertEqual(record["step_line_surface_counts"], {"paved": 1})
+        self.assertEqual(record["oneway_arrow_class_counts"], {"motorway": 1, "street": 1})
+        self.assertEqual(record["oneway_arrow_structure_counts"], {"bridge": 1, "none": 1})
+        self.assertEqual(record["oneway_arrow_layer_counts"], {"(missing)": 1, "0": 1})
         self.assertEqual(record["sample_pedestrian_polygons"][0]["properties"]["class"], "pedestrian")
         self.assertEqual(record["sample_step_lines"][0]["properties"]["type"], "steps")
+        self.assertEqual(record["sample_oneway_arrow_lines"][0]["properties"]["oneway"], "true")
 
     def test_road_tile_record_accepts_flat_layer_lists_and_summarizes_irregular_features(self):
         road_features = [
@@ -223,6 +246,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["road_feature_count"], 4)
         self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(record["pedestrian_line_candidate_count"], 1)
+        self.assertEqual(record["oneway_arrow_candidate_count"], 0)
         self.assertEqual(record["road_geometry_type_counts"]["(missing)"], 1)
         self.assertEqual(record["pedestrian_polygon_type_counts"], {'["plaza"]': 1, "(missing)": 1})
         self.assertEqual(record["pedestrian_polygon_structure_counts"], {"none": 2})
@@ -289,6 +313,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                             "LineString",
                             {"class": "path", "type": "steps", "structure": "bridge", "surface": "paved"},
                         ),
+                        _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
                     ]
                 }
             }
@@ -305,11 +330,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["tile_zoom"], 0)
         self.assertEqual(report["tile_count"], 1)
         self.assertEqual(report["decoded_tile_count"], 1)
-        self.assertEqual(report["road_feature_count"], 4)
+        self.assertEqual(report["road_feature_count"], 5)
         self.assertEqual(report["pedestrian_polygon_candidate_count"], 1)
         self.assertEqual(report["pedestrian_line_candidate_count"], 1)
         self.assertEqual(report["path_line_candidate_count"], 1)
         self.assertEqual(report["step_line_candidate_count"], 1)
+        self.assertEqual(report["oneway_arrow_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 1})
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 1})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 1})
@@ -323,6 +349,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["step_line_structure_counts"], {"bridge": 1})
         self.assertEqual(report["step_line_layer_counts"], {"(missing)": 1})
         self.assertEqual(report["step_line_surface_counts"], {"paved": 1})
+        self.assertEqual(report["oneway_arrow_class_counts"], {})
+        self.assertEqual(report["oneway_arrow_structure_counts"], {})
+        self.assertEqual(report["oneway_arrow_layer_counts"], {})
         self.assertEqual(len(calls), 1)
         self.assertIn("mapbox.mapbox-streets-v8/0/0/0.mvt", calls[0])
 
@@ -416,6 +445,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                         "LineString",
                         {"class": "path", "type": "steps", "structure": "tunnel", "surface": "paved"},
                     ),
+                    _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
                 ]
             }
 
@@ -431,11 +461,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["camera_count"], 2)
         self.assertEqual(report["tile_count"], 2)
         self.assertEqual(report["decoded_tile_count"], 2)
-        self.assertEqual(report["road_feature_count"], 8)
+        self.assertEqual(report["road_feature_count"], 10)
         self.assertEqual(report["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(report["pedestrian_line_candidate_count"], 2)
         self.assertEqual(report["path_line_candidate_count"], 2)
         self.assertEqual(report["step_line_candidate_count"], 2)
+        self.assertEqual(report["oneway_arrow_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 2})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 2})
@@ -451,6 +482,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["step_line_structure_counts"], {"tunnel": 2})
         self.assertEqual(report["step_line_layer_counts"], {"(missing)": 2})
         self.assertEqual(report["step_line_surface_counts"], {"paved": 2})
+        self.assertEqual(report["oneway_arrow_class_counts"], {})
+        self.assertEqual(report["oneway_arrow_structure_counts"], {})
+        self.assertEqual(report["oneway_arrow_layer_counts"], {})
         self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
         self.assertEqual(
             [camera_report["camera"]["name"] for camera_report in report["cameras"]],
@@ -466,11 +500,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "tile_zoom": 18,
             "decoded_tile_count": 1,
             "tile_count": 1,
-            "road_feature_count": 3,
+            "road_feature_count": 4,
             "pedestrian_polygon_candidate_count": 1,
             "pedestrian_line_candidate_count": 1,
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
+            "oneway_arrow_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
@@ -486,10 +521,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "step_line_structure_counts": {"none": 1},
             "step_line_layer_counts": {"0": 1},
             "step_line_surface_counts": {"paved": 1},
+            "oneway_arrow_class_counts": {"street": 1},
+            "oneway_arrow_structure_counts": {"none": 1},
+            "oneway_arrow_layer_counts": {"0": 1},
             "sample_pedestrian_polygons": [{"properties": {"class": "pedestrian"}}],
             "sample_pedestrian_lines": [{"properties": {"class": "pedestrian"}}],
             "sample_path_lines": [{"properties": {"class": "path"}}],
             "sample_step_lines": [{"properties": {"type": "steps"}}],
+            "sample_oneway_arrow_lines": [{"properties": {"class": "street", "oneway": "true"}}],
             "tiles": [
                 "ignore-me",
                 {
@@ -497,11 +536,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "x": 1,
                     "y": 2,
                     "status": "decoded",
-                    "road_feature_count": 3,
+                    "road_feature_count": 4,
                     "pedestrian_polygon_candidate_count": 1,
                     "pedestrian_line_candidate_count": 1,
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
+                    "oneway_arrow_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
@@ -517,6 +557,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "step_line_structure_counts": {"none": 1},
                     "step_line_layer_counts": {"0": 1},
                     "step_line_surface_counts": {"paved": 1},
+                    "oneway_arrow_class_counts": {"street": 1},
+                    "oneway_arrow_structure_counts": {"none": 1},
+                    "oneway_arrow_layer_counts": {"0": 1},
                 }
             ],
         }
@@ -527,6 +570,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("Pedestrian/path polygon candidates: 1", markdown)
         self.assertIn("Path line candidates: 1", markdown)
         self.assertIn("Step line candidates: 1", markdown)
+        self.assertIn("One-way arrow candidates: 1", markdown)
         self.assertIn('Pedestrian polygon structure counts: {"none":1}', markdown)
         self.assertIn('Pedestrian polygon layer counts: {"0":1}', markdown)
         self.assertIn('Pedestrian polygon surface counts: {"paved":1}', markdown)
@@ -539,10 +583,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn('Step line structure counts: {"none":1}', markdown)
         self.assertIn('Step line layer counts: {"0":1}', markdown)
         self.assertIn('Step line surface counts: {"paved":1}', markdown)
+        self.assertIn('One-way arrow class counts: {"street":1}', markdown)
+        self.assertIn('One-way arrow structure counts: {"none":1}', markdown)
+        self.assertIn('One-way arrow layer counts: {"0":1}', markdown)
         self.assertIn("## Sample pedestrian/path polygon candidates", markdown)
         self.assertIn("## Sample pedestrian line candidates", markdown)
         self.assertIn("## Sample path line candidates", markdown)
         self.assertIn("## Sample step line candidates", markdown)
+        self.assertIn("## Sample one-way arrow candidates", markdown)
 
     def test_build_all_camera_summary_markdown_includes_camera_rows(self):
         report = {
@@ -552,11 +600,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "camera_count": 1,
             "decoded_tile_count": 1,
             "tile_count": 1,
-            "road_feature_count": 3,
+            "road_feature_count": 4,
             "pedestrian_polygon_candidate_count": 1,
             "pedestrian_line_candidate_count": 1,
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
+            "oneway_arrow_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
@@ -572,17 +621,21 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "step_line_structure_counts": {"bridge": 1},
             "step_line_layer_counts": {"(missing)": 1},
             "step_line_surface_counts": {"paved": 1},
+            "oneway_arrow_class_counts": {"street": 1},
+            "oneway_arrow_structure_counts": {"none": 1},
+            "oneway_arrow_layer_counts": {"0": 1},
             "cameras": [
                 {
                     "camera": {"name": "zermatt-trails-z18-outdoors", "zoom": 18.0},
                     "tile_zoom": 18,
                     "decoded_tile_count": 1,
                     "tile_count": 1,
-                    "road_feature_count": 3,
+                    "road_feature_count": 4,
                     "pedestrian_polygon_candidate_count": 1,
                     "pedestrian_line_candidate_count": 1,
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
+                    "oneway_arrow_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
@@ -598,6 +651,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "step_line_structure_counts": {"bridge": 1},
                     "step_line_layer_counts": {"(missing)": 1},
                     "step_line_surface_counts": {"paved": 1},
+                    "oneway_arrow_class_counts": {"street": 1},
+                    "oneway_arrow_structure_counts": {"none": 1},
+                    "oneway_arrow_layer_counts": {"0": 1},
                 }
             ],
         }
@@ -606,7 +662,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertIn("# Mapbox Outdoors road feature diagnostic - all cameras", markdown)
         self.assertIn("Cameras: 1", markdown)
-        self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 3 | 1 | 1 | 1 | 1 |", markdown)
+        self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 4 | 1 | 1 | 1 | 1 | 1 |", markdown)
 
     def test_write_report_writes_json_and_markdown(self):
         report = {

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -55,6 +55,22 @@ POLYGON_GEOMETRY_TYPES = {"Polygon", "MultiPolygon"}
 LOW_ZOOM_PATH_EXCLUDED_TYPES = {"crossing", "sidewalk", "steps"}
 HIGH_ZOOM_PATH_EXCLUDED_TYPES = {"steps"}
 STEP_STRUCTURES = {"none", "ford", "bridge", "tunnel"}
+ONEWAY_ARROW_MIN_ZOOM = 16
+ONEWAY_ARROW_BLUE_CLASSES = {
+    "primary",
+    "primary_link",
+    "secondary",
+    "secondary_link",
+    "service",
+    "street",
+    "street_limited",
+    "tertiary",
+    "tertiary_link",
+    "track",
+}
+ONEWAY_ARROW_WHITE_CLASSES = {"motorway", "motorway_link", "trunk", "trunk_link"}
+ONEWAY_ARROW_CLASSES = ONEWAY_ARROW_BLUE_CLASSES | ONEWAY_ARROW_WHITE_CLASSES
+ONEWAY_ARROW_STRUCTURES = {"none", "ford", "bridge", "tunnel"}
 SAMPLE_PROPERTY_KEYS = (
     "class",
     "type",
@@ -157,6 +173,18 @@ def is_step_line_candidate(feature: dict[str, object]) -> bool:
     )
 
 
+def is_oneway_arrow_candidate(feature: dict[str, object], *, tile_zoom: int | None = None) -> bool:
+    properties = _feature_properties(feature)
+    return (
+        tile_zoom is not None
+        and tile_zoom >= ONEWAY_ARROW_MIN_ZOOM
+        and properties.get("oneway") == "true"
+        and properties.get("class") in ONEWAY_ARROW_CLASSES
+        and properties.get("structure") in ONEWAY_ARROW_STRUCTURES
+        and _geometry_type(feature) in LINE_GEOMETRY_TYPES
+    )
+
+
 def _count_by_property(features: Iterable[dict[str, object]], key: str) -> dict[str, int]:
     counts: dict[str, int] = {}
     for feature in features:
@@ -207,6 +235,9 @@ def road_tile_record(
     pedestrian_lines = [feature for feature in road_features if is_pedestrian_line_candidate(feature)]
     path_lines = [feature for feature in road_features if is_path_line_candidate(feature, tile_zoom=tile.get("z"))]
     step_lines = [feature for feature in road_features if is_step_line_candidate(feature)]
+    oneway_arrow_lines = [
+        feature for feature in road_features if is_oneway_arrow_candidate(feature, tile_zoom=tile.get("z"))
+    ]
     return {
         **tile,
         "status": "decoded",
@@ -216,6 +247,7 @@ def road_tile_record(
         "pedestrian_line_candidate_count": len(pedestrian_lines),
         "path_line_candidate_count": len(path_lines),
         "step_line_candidate_count": len(step_lines),
+        "oneway_arrow_candidate_count": len(oneway_arrow_lines),
         "road_geometry_type_counts": _count_geometry_types(road_features),
         "pedestrian_polygon_class_counts": _count_by_property(pedestrian_polygons, "class"),
         "pedestrian_polygon_type_counts": _count_by_property(pedestrian_polygons, "type"),
@@ -233,6 +265,9 @@ def road_tile_record(
         "step_line_structure_counts": _count_by_property(step_lines, "structure"),
         "step_line_layer_counts": _count_by_property(step_lines, "layer"),
         "step_line_surface_counts": _count_by_property(step_lines, "surface"),
+        "oneway_arrow_class_counts": _count_by_property(oneway_arrow_lines, "class"),
+        "oneway_arrow_structure_counts": _count_by_property(oneway_arrow_lines, "structure"),
+        "oneway_arrow_layer_counts": _count_by_property(oneway_arrow_lines, "layer"),
         "sample_pedestrian_polygons": [
             _feature_sample(tile, feature) for feature in pedestrian_polygons[:MAX_SAMPLE_FEATURES]
         ],
@@ -241,6 +276,9 @@ def road_tile_record(
         ],
         "sample_path_lines": [_feature_sample(tile, feature) for feature in path_lines[:MAX_SAMPLE_FEATURES]],
         "sample_step_lines": [_feature_sample(tile, feature) for feature in step_lines[:MAX_SAMPLE_FEATURES]],
+        "sample_oneway_arrow_lines": [
+            _feature_sample(tile, feature) for feature in oneway_arrow_lines[:MAX_SAMPLE_FEATURES]
+        ],
     }
 
 
@@ -261,6 +299,7 @@ _SUMMARY_COUNT_FIELDS = (
     ("Pedestrian line candidates", "pedestrian_line_candidate_count"),
     ("Path line candidates", "path_line_candidate_count"),
     ("Step line candidates", "step_line_candidate_count"),
+    ("One-way arrow candidates", "oneway_arrow_candidate_count"),
 )
 _SUMMARY_COUNT_MAP_FIELDS = (
     ("Pedestrian polygon type counts", "pedestrian_polygon_type_counts"),
@@ -278,6 +317,9 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("Step line structure counts", "step_line_structure_counts"),
     ("Step line layer counts", "step_line_layer_counts"),
     ("Step line surface counts", "step_line_surface_counts"),
+    ("One-way arrow class counts", "oneway_arrow_class_counts"),
+    ("One-way arrow structure counts", "oneway_arrow_structure_counts"),
+    ("One-way arrow layer counts", "oneway_arrow_layer_counts"),
 )
 _ROAD_FEATURE_TABLE_FIELDS = (
     ("Road", "road_feature_count", "---:"),
@@ -285,6 +327,7 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Pedestrian lines", "pedestrian_line_candidate_count", "---:"),
     ("Path lines", "path_line_candidate_count", "---:"),
     ("Step lines", "step_line_candidate_count", "---:"),
+    ("One-way arrows", "oneway_arrow_candidate_count", "---:"),
     ("Polygon types", "pedestrian_polygon_type_counts", "---"),
     ("Polygon structures", "pedestrian_polygon_structure_counts", "---"),
     ("Polygon layers", "pedestrian_polygon_layer_counts", "---"),
@@ -300,6 +343,9 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Step structures", "step_line_structure_counts", "---"),
     ("Step layers", "step_line_layer_counts", "---"),
     ("Step surfaces", "step_line_surface_counts", "---"),
+    ("One-way arrow classes", "oneway_arrow_class_counts", "---"),
+    ("One-way arrow structures", "oneway_arrow_structure_counts", "---"),
+    ("One-way arrow layers", "oneway_arrow_layer_counts", "---"),
 )
 
 
@@ -424,6 +470,9 @@ def collect_road_feature_report(
         ),
         "path_line_candidate_count": sum(int(tile.get("path_line_candidate_count") or 0) for tile in tile_records),
         "step_line_candidate_count": sum(int(tile.get("step_line_candidate_count") or 0) for tile in tile_records),
+        "oneway_arrow_candidate_count": sum(
+            int(tile.get("oneway_arrow_candidate_count") or 0) for tile in tile_records
+        ),
         "road_geometry_type_counts": _combined_record_counts(tile_records, "road_geometry_type_counts"),
         "pedestrian_polygon_class_counts": _combined_record_counts(
             tile_records,
@@ -459,10 +508,14 @@ def collect_road_feature_report(
         "step_line_structure_counts": _combined_record_counts(tile_records, "step_line_structure_counts"),
         "step_line_layer_counts": _combined_record_counts(tile_records, "step_line_layer_counts"),
         "step_line_surface_counts": _combined_record_counts(tile_records, "step_line_surface_counts"),
+        "oneway_arrow_class_counts": _combined_record_counts(tile_records, "oneway_arrow_class_counts"),
+        "oneway_arrow_structure_counts": _combined_record_counts(tile_records, "oneway_arrow_structure_counts"),
+        "oneway_arrow_layer_counts": _combined_record_counts(tile_records, "oneway_arrow_layer_counts"),
         "sample_pedestrian_polygons": _combined_samples(tile_records, "sample_pedestrian_polygons"),
         "sample_pedestrian_lines": _combined_samples(tile_records, "sample_pedestrian_lines"),
         "sample_path_lines": _combined_samples(tile_records, "sample_path_lines"),
         "sample_step_lines": _combined_samples(tile_records, "sample_step_lines"),
+        "sample_oneway_arrow_lines": _combined_samples(tile_records, "sample_oneway_arrow_lines"),
         "tiles": tile_records,
     }
 
@@ -517,6 +570,7 @@ def collect_all_camera_road_feature_report(
         ),
         "path_line_candidate_count": _sum_reports(camera_reports, "path_line_candidate_count"),
         "step_line_candidate_count": _sum_reports(camera_reports, "step_line_candidate_count"),
+        "oneway_arrow_candidate_count": _sum_reports(camera_reports, "oneway_arrow_candidate_count"),
         "road_geometry_type_counts": _combined_record_counts(camera_reports, "road_geometry_type_counts"),
         "pedestrian_polygon_class_counts": _combined_record_counts(
             camera_reports,
@@ -561,6 +615,9 @@ def collect_all_camera_road_feature_report(
         "step_line_structure_counts": _combined_record_counts(camera_reports, "step_line_structure_counts"),
         "step_line_layer_counts": _combined_record_counts(camera_reports, "step_line_layer_counts"),
         "step_line_surface_counts": _combined_record_counts(camera_reports, "step_line_surface_counts"),
+        "oneway_arrow_class_counts": _combined_record_counts(camera_reports, "oneway_arrow_class_counts"),
+        "oneway_arrow_structure_counts": _combined_record_counts(camera_reports, "oneway_arrow_structure_counts"),
+        "oneway_arrow_layer_counts": _combined_record_counts(camera_reports, "oneway_arrow_layer_counts"),
         "cameras": camera_reports,
     }
 
@@ -589,6 +646,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         ("Sample pedestrian line candidates", "sample_pedestrian_lines"),
         ("Sample path line candidates", "sample_path_lines"),
         ("Sample step line candidates", "sample_step_lines"),
+        ("Sample one-way arrow candidates", "sample_oneway_arrow_lines"),
     )
     for heading, key in sample_sections:
         samples = report.get(key)


### PR DESCRIPTION
## Summary

- add minzoom-aware one-way arrow candidate buckets to the Mapbox Outdoors road-feature diagnostic
- report candidate counts, class/structure/layer buckets, and samples in JSON/Markdown summaries
- cover tile-level, single-camera, all-camera, and Markdown output with regression tests

## Evidence

- Live all-camera diagnostic: `debug/mapbox-outdoors-road-features/all-cameras/20260519T112437Z/summary.md`
- Result: 62/62 vector tiles decoded; 0 active one-way arrow candidates found across the current seven-camera matrix after respecting the Mapbox arrow-layer minzoom.
- This keeps lower-zoom road-heavy cameras from overstating arrows that the Mapbox style cannot render yet, while preserving the diagnostic buckets for future z16+ road views.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

This is diagnostic-only and does not change runtime rendering.
