### PR TITLE
chore: expose Mapbox road feature signatures

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -199,17 +199,36 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["pedestrian_polygon_structure_counts"], {"none": 2})
         self.assertEqual(record["pedestrian_polygon_layer_counts"], {"(missing)": 1, "0": 1})
         self.assertEqual(record["pedestrian_polygon_surface_counts"], {"paved": 1, "unpaved": 1})
+        self.assertEqual(
+            record["pedestrian_polygon_signature_counts"],
+            {
+                "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)": 1,
+                "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0": 1,
+            },
+        )
         self.assertEqual(record["pedestrian_line_type_counts"], {"pedestrian": 1})
         self.assertEqual(record["pedestrian_line_structure_counts"], {"none": 1})
         self.assertEqual(record["pedestrian_line_layer_counts"], {"1": 1})
         self.assertEqual(record["pedestrian_line_surface_counts"], {"paved": 1})
+        self.assertEqual(
+            record["pedestrian_line_signature_counts"],
+            {"class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=1": 1},
+        )
         self.assertEqual(record["path_line_type_counts"], {"footway": 1})
         self.assertEqual(record["path_line_structure_counts"], {"none": 1})
         self.assertEqual(record["path_line_layer_counts"], {"(missing)": 1})
         self.assertEqual(record["path_line_surface_counts"], {"unpaved": 1})
+        self.assertEqual(
+            record["path_line_signature_counts"],
+            {"class=path; type=footway; surface=unpaved; structure=none; layer=(missing)": 1},
+        )
         self.assertEqual(record["step_line_structure_counts"], {"none": 1})
         self.assertEqual(record["step_line_layer_counts"], {"0": 1})
         self.assertEqual(record["step_line_surface_counts"], {"paved": 1})
+        self.assertEqual(
+            record["step_line_signature_counts"],
+            {"class=path; type=steps; surface=paved; structure=none; layer=0": 1},
+        )
         self.assertEqual(record["oneway_arrow_class_counts"], {"motorway": 1, "street": 1})
         self.assertEqual(record["oneway_arrow_structure_counts"], {"bridge": 1, "none": 1})
         self.assertEqual(record["oneway_arrow_layer_counts"], {"(missing)": 1, "0": 1})
@@ -340,15 +359,31 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 1})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 1})
         self.assertEqual(report["pedestrian_polygon_surface_counts"], {"paved": 1})
+        self.assertEqual(
+            report["pedestrian_polygon_signature_counts"],
+            {"class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0": 1},
+        )
         self.assertEqual(report["pedestrian_line_structure_counts"], {"none": 1})
         self.assertEqual(report["pedestrian_line_layer_counts"], {"0": 1})
+        self.assertEqual(
+            report["pedestrian_line_signature_counts"],
+            {"class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0": 1},
+        )
         self.assertEqual(report["path_line_type_counts"], {"footway": 1})
         self.assertEqual(report["path_line_structure_counts"], {"none": 1})
         self.assertEqual(report["path_line_layer_counts"], {"(missing)": 1})
         self.assertEqual(report["path_line_surface_counts"], {"unpaved": 1})
+        self.assertEqual(
+            report["path_line_signature_counts"],
+            {"class=path; type=footway; surface=unpaved; structure=none; layer=(missing)": 1},
+        )
         self.assertEqual(report["step_line_structure_counts"], {"bridge": 1})
         self.assertEqual(report["step_line_layer_counts"], {"(missing)": 1})
         self.assertEqual(report["step_line_surface_counts"], {"paved": 1})
+        self.assertEqual(
+            report["step_line_signature_counts"],
+            {"class=path; type=steps; surface=paved; structure=bridge; layer=(missing)": 1},
+        )
         self.assertEqual(report["oneway_arrow_class_counts"], {})
         self.assertEqual(report["oneway_arrow_structure_counts"], {})
         self.assertEqual(report["oneway_arrow_layer_counts"], {})
@@ -471,17 +506,33 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 2})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 2})
         self.assertEqual(report["pedestrian_polygon_surface_counts"], {"paved": 2})
+        self.assertEqual(
+            report["pedestrian_polygon_signature_counts"],
+            {"class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0": 2},
+        )
         self.assertEqual(report["pedestrian_line_type_counts"], {"pedestrian": 2})
         self.assertEqual(report["pedestrian_line_structure_counts"], {"none": 2})
         self.assertEqual(report["pedestrian_line_layer_counts"], {"0": 2})
         self.assertEqual(report["pedestrian_line_surface_counts"], {"paved": 2})
+        self.assertEqual(
+            report["pedestrian_line_signature_counts"],
+            {"class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0": 2},
+        )
         self.assertEqual(report["path_line_type_counts"], {"footway": 2})
         self.assertEqual(report["path_line_structure_counts"], {"none": 2})
         self.assertEqual(report["path_line_layer_counts"], {"(missing)": 2})
         self.assertEqual(report["path_line_surface_counts"], {"unpaved": 2})
+        self.assertEqual(
+            report["path_line_signature_counts"],
+            {"class=path; type=footway; surface=unpaved; structure=none; layer=(missing)": 2},
+        )
         self.assertEqual(report["step_line_structure_counts"], {"tunnel": 2})
         self.assertEqual(report["step_line_layer_counts"], {"(missing)": 2})
         self.assertEqual(report["step_line_surface_counts"], {"paved": 2})
+        self.assertEqual(
+            report["step_line_signature_counts"],
+            {"class=path; type=steps; surface=paved; structure=tunnel; layer=(missing)": 2},
+        )
         self.assertEqual(report["oneway_arrow_class_counts"], {})
         self.assertEqual(report["oneway_arrow_structure_counts"], {})
         self.assertEqual(report["oneway_arrow_layer_counts"], {})
@@ -492,6 +543,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
 
     def test_build_summary_markdown_includes_counts_and_samples(self):
+        pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
+        path_signature = "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)"
+        step_signature = "class=path; type=steps; surface=paved; structure=none; layer=0"
         report = {
             "generated": "2026-05-18T14:12:00+00:00",
             "style_owner": "mapbox",
@@ -510,17 +564,21 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
             "pedestrian_polygon_surface_counts": {"paved": 1},
+            "pedestrian_polygon_signature_counts": {pedestrian_signature: 1},
             "pedestrian_line_type_counts": {"pedestrian": 1},
             "pedestrian_line_structure_counts": {"none": 1},
             "pedestrian_line_layer_counts": {"0": 1},
             "pedestrian_line_surface_counts": {"paved": 1},
+            "pedestrian_line_signature_counts": {pedestrian_signature: 1},
             "path_line_type_counts": {"footway": 1},
             "path_line_structure_counts": {"none": 1},
             "path_line_layer_counts": {"(missing)": 1},
             "path_line_surface_counts": {"unpaved": 1},
+            "path_line_signature_counts": {path_signature: 1},
             "step_line_structure_counts": {"none": 1},
             "step_line_layer_counts": {"0": 1},
             "step_line_surface_counts": {"paved": 1},
+            "step_line_signature_counts": {step_signature: 1},
             "oneway_arrow_class_counts": {"street": 1},
             "oneway_arrow_structure_counts": {"none": 1},
             "oneway_arrow_layer_counts": {"0": 1},
@@ -546,17 +604,21 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
                     "pedestrian_polygon_surface_counts": {"paved": 1},
+                    "pedestrian_polygon_signature_counts": {pedestrian_signature: 1},
                     "pedestrian_line_type_counts": {"pedestrian": 1},
                     "pedestrian_line_structure_counts": {"none": 1},
                     "pedestrian_line_layer_counts": {"0": 1},
                     "pedestrian_line_surface_counts": {"paved": 1},
+                    "pedestrian_line_signature_counts": {pedestrian_signature: 1},
                     "path_line_type_counts": {"footway": 1},
                     "path_line_structure_counts": {"none": 1},
                     "path_line_layer_counts": {"(missing)": 1},
                     "path_line_surface_counts": {"unpaved": 1},
+                    "path_line_signature_counts": {path_signature: 1},
                     "step_line_structure_counts": {"none": 1},
                     "step_line_layer_counts": {"0": 1},
                     "step_line_surface_counts": {"paved": 1},
+                    "step_line_signature_counts": {step_signature: 1},
                     "oneway_arrow_class_counts": {"street": 1},
                     "oneway_arrow_structure_counts": {"none": 1},
                     "oneway_arrow_layer_counts": {"0": 1},
@@ -574,15 +636,19 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn('Pedestrian polygon structure counts: {"none":1}', markdown)
         self.assertIn('Pedestrian polygon layer counts: {"0":1}', markdown)
         self.assertIn('Pedestrian polygon surface counts: {"paved":1}', markdown)
+        self.assertIn(f'Pedestrian polygon signatures: {{"{pedestrian_signature}":1}}', markdown)
         self.assertIn('Pedestrian line structure counts: {"none":1}', markdown)
         self.assertIn('Pedestrian line layer counts: {"0":1}', markdown)
         self.assertIn('Pedestrian line surface counts: {"paved":1}', markdown)
+        self.assertIn(f'Pedestrian line signatures: {{"{pedestrian_signature}":1}}', markdown)
         self.assertIn('Path line structure counts: {"none":1}', markdown)
         self.assertIn('Path line layer counts: {"(missing)":1}', markdown)
         self.assertIn('Path line surface counts: {"unpaved":1}', markdown)
+        self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
         self.assertIn('Step line structure counts: {"none":1}', markdown)
         self.assertIn('Step line layer counts: {"0":1}', markdown)
         self.assertIn('Step line surface counts: {"paved":1}', markdown)
+        self.assertIn(f'Step line signatures: {{"{step_signature}":1}}', markdown)
         self.assertIn('One-way arrow class counts: {"street":1}', markdown)
         self.assertIn('One-way arrow structure counts: {"none":1}', markdown)
         self.assertIn('One-way arrow layer counts: {"0":1}', markdown)
@@ -593,6 +659,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("## Sample one-way arrow candidates", markdown)
 
     def test_build_all_camera_summary_markdown_includes_camera_rows(self):
+        pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
+        path_signature = "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)"
+        step_signature = "class=path; type=steps; surface=paved; structure=bridge; layer=(missing)"
         report = {
             "generated": "2026-05-18T15:40:00+00:00",
             "style_owner": "mapbox",
@@ -610,17 +679,21 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
             "pedestrian_polygon_surface_counts": {"paved": 1},
+            "pedestrian_polygon_signature_counts": {pedestrian_signature: 1},
             "pedestrian_line_type_counts": {"pedestrian": 1},
             "pedestrian_line_structure_counts": {"none": 1},
             "pedestrian_line_layer_counts": {"0": 1},
             "pedestrian_line_surface_counts": {"paved": 1},
+            "pedestrian_line_signature_counts": {pedestrian_signature: 1},
             "path_line_type_counts": {"footway": 1},
             "path_line_structure_counts": {"none": 1},
             "path_line_layer_counts": {"(missing)": 1},
             "path_line_surface_counts": {"unpaved": 1},
+            "path_line_signature_counts": {path_signature: 1},
             "step_line_structure_counts": {"bridge": 1},
             "step_line_layer_counts": {"(missing)": 1},
             "step_line_surface_counts": {"paved": 1},
+            "step_line_signature_counts": {step_signature: 1},
             "oneway_arrow_class_counts": {"street": 1},
             "oneway_arrow_structure_counts": {"none": 1},
             "oneway_arrow_layer_counts": {"0": 1},
@@ -640,17 +713,21 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
                     "pedestrian_polygon_surface_counts": {"paved": 1},
+                    "pedestrian_polygon_signature_counts": {pedestrian_signature: 1},
                     "pedestrian_line_type_counts": {"pedestrian": 1},
                     "pedestrian_line_structure_counts": {"none": 1},
                     "pedestrian_line_layer_counts": {"0": 1},
                     "pedestrian_line_surface_counts": {"paved": 1},
+                    "pedestrian_line_signature_counts": {pedestrian_signature: 1},
                     "path_line_type_counts": {"footway": 1},
                     "path_line_structure_counts": {"none": 1},
                     "path_line_layer_counts": {"(missing)": 1},
                     "path_line_surface_counts": {"unpaved": 1},
+                    "path_line_signature_counts": {path_signature: 1},
                     "step_line_structure_counts": {"bridge": 1},
                     "step_line_layer_counts": {"(missing)": 1},
                     "step_line_surface_counts": {"paved": 1},
+                    "step_line_signature_counts": {step_signature: 1},
                     "oneway_arrow_class_counts": {"street": 1},
                     "oneway_arrow_structure_counts": {"none": 1},
                     "oneway_arrow_layer_counts": {"0": 1},
@@ -663,6 +740,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("# Mapbox Outdoors road feature diagnostic - all cameras", markdown)
         self.assertIn("Cameras: 1", markdown)
         self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 4 | 1 | 1 | 1 | 1 | 1 |", markdown)
+        self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
 
     def test_write_report_writes_json_and_markdown(self):
         report = {

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -5,7 +5,7 @@ import datetime as dt
 import json
 import math
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -80,6 +80,7 @@ SAMPLE_PROPERTY_KEYS = (
     "oneway",
     "surface",
 )
+ROAD_FEATURE_SIGNATURE_KEYS = ("class", "type", "surface", "structure", "layer")
 
 
 @dataclass(frozen=True)
@@ -185,14 +186,36 @@ def is_oneway_arrow_candidate(feature: dict[str, object], *, tile_zoom: int | No
     )
 
 
+def _property_count_label(value: object) -> str:
+    if isinstance(value, (dict, list)):
+        value = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return str(value)
+
+
+def _feature_signature(feature: dict[str, object], keys: Sequence[str]) -> str:
+    properties = _feature_properties(feature)
+    return "; ".join(
+        f"{key}={_property_count_label(properties.get(key, MISSING_VALUE))}"
+        for key in keys
+    )
+
+
 def _count_by_property(features: Iterable[dict[str, object]], key: str) -> dict[str, int]:
     counts: dict[str, int] = {}
     for feature in features:
-        value = _feature_properties(feature).get(key, MISSING_VALUE)
-        if isinstance(value, (dict, list)):
-            value = json.dumps(value, sort_keys=True, separators=(",", ":"))
-        normalized = str(value)
+        normalized = _property_count_label(_feature_properties(feature).get(key, MISSING_VALUE))
         counts[normalized] = counts.get(normalized, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _count_property_signatures(
+    features: Iterable[dict[str, object]],
+    keys: Sequence[str],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for feature in features:
+        signature = _feature_signature(feature, keys)
+        counts[signature] = counts.get(signature, 0) + 1
     return dict(sorted(counts.items()))
 
 
@@ -254,17 +277,27 @@ def road_tile_record(
         "pedestrian_polygon_structure_counts": _count_by_property(pedestrian_polygons, "structure"),
         "pedestrian_polygon_layer_counts": _count_by_property(pedestrian_polygons, "layer"),
         "pedestrian_polygon_surface_counts": _count_by_property(pedestrian_polygons, "surface"),
+        "pedestrian_polygon_signature_counts": _count_property_signatures(
+            pedestrian_polygons,
+            ROAD_FEATURE_SIGNATURE_KEYS,
+        ),
         "pedestrian_line_type_counts": _count_by_property(pedestrian_lines, "type"),
         "pedestrian_line_structure_counts": _count_by_property(pedestrian_lines, "structure"),
         "pedestrian_line_layer_counts": _count_by_property(pedestrian_lines, "layer"),
         "pedestrian_line_surface_counts": _count_by_property(pedestrian_lines, "surface"),
+        "pedestrian_line_signature_counts": _count_property_signatures(
+            pedestrian_lines,
+            ROAD_FEATURE_SIGNATURE_KEYS,
+        ),
         "path_line_type_counts": _count_by_property(path_lines, "type"),
         "path_line_structure_counts": _count_by_property(path_lines, "structure"),
         "path_line_layer_counts": _count_by_property(path_lines, "layer"),
         "path_line_surface_counts": _count_by_property(path_lines, "surface"),
+        "path_line_signature_counts": _count_property_signatures(path_lines, ROAD_FEATURE_SIGNATURE_KEYS),
         "step_line_structure_counts": _count_by_property(step_lines, "structure"),
         "step_line_layer_counts": _count_by_property(step_lines, "layer"),
         "step_line_surface_counts": _count_by_property(step_lines, "surface"),
+        "step_line_signature_counts": _count_property_signatures(step_lines, ROAD_FEATURE_SIGNATURE_KEYS),
         "oneway_arrow_class_counts": _count_by_property(oneway_arrow_lines, "class"),
         "oneway_arrow_structure_counts": _count_by_property(oneway_arrow_lines, "structure"),
         "oneway_arrow_layer_counts": _count_by_property(oneway_arrow_lines, "layer"),
@@ -306,17 +339,21 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("Pedestrian polygon structure counts", "pedestrian_polygon_structure_counts"),
     ("Pedestrian polygon layer counts", "pedestrian_polygon_layer_counts"),
     ("Pedestrian polygon surface counts", "pedestrian_polygon_surface_counts"),
+    ("Pedestrian polygon signatures", "pedestrian_polygon_signature_counts"),
     ("Pedestrian line type counts", "pedestrian_line_type_counts"),
     ("Pedestrian line structure counts", "pedestrian_line_structure_counts"),
     ("Pedestrian line layer counts", "pedestrian_line_layer_counts"),
     ("Pedestrian line surface counts", "pedestrian_line_surface_counts"),
+    ("Pedestrian line signatures", "pedestrian_line_signature_counts"),
     ("Path line type counts", "path_line_type_counts"),
     ("Path line structure counts", "path_line_structure_counts"),
     ("Path line layer counts", "path_line_layer_counts"),
     ("Path line surface counts", "path_line_surface_counts"),
+    ("Path line signatures", "path_line_signature_counts"),
     ("Step line structure counts", "step_line_structure_counts"),
     ("Step line layer counts", "step_line_layer_counts"),
     ("Step line surface counts", "step_line_surface_counts"),
+    ("Step line signatures", "step_line_signature_counts"),
     ("One-way arrow class counts", "oneway_arrow_class_counts"),
     ("One-way arrow structure counts", "oneway_arrow_structure_counts"),
     ("One-way arrow layer counts", "oneway_arrow_layer_counts"),
@@ -332,17 +369,21 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Polygon structures", "pedestrian_polygon_structure_counts", "---"),
     ("Polygon layers", "pedestrian_polygon_layer_counts", "---"),
     ("Polygon surfaces", "pedestrian_polygon_surface_counts", "---"),
+    ("Polygon signatures", "pedestrian_polygon_signature_counts", "---"),
     ("Pedestrian line types", "pedestrian_line_type_counts", "---"),
     ("Pedestrian line structures", "pedestrian_line_structure_counts", "---"),
     ("Pedestrian line layers", "pedestrian_line_layer_counts", "---"),
     ("Pedestrian line surfaces", "pedestrian_line_surface_counts", "---"),
+    ("Pedestrian line signatures", "pedestrian_line_signature_counts", "---"),
     ("Path line types", "path_line_type_counts", "---"),
     ("Path line structures", "path_line_structure_counts", "---"),
     ("Path line layers", "path_line_layer_counts", "---"),
     ("Path line surfaces", "path_line_surface_counts", "---"),
+    ("Path line signatures", "path_line_signature_counts", "---"),
     ("Step structures", "step_line_structure_counts", "---"),
     ("Step layers", "step_line_layer_counts", "---"),
     ("Step surfaces", "step_line_surface_counts", "---"),
+    ("Step signatures", "step_line_signature_counts", "---"),
     ("One-way arrow classes", "oneway_arrow_class_counts", "---"),
     ("One-way arrow structures", "oneway_arrow_structure_counts", "---"),
     ("One-way arrow layers", "oneway_arrow_layer_counts", "---"),
@@ -494,6 +535,10 @@ def collect_road_feature_report(
             tile_records,
             "pedestrian_polygon_surface_counts",
         ),
+        "pedestrian_polygon_signature_counts": _combined_record_counts(
+            tile_records,
+            "pedestrian_polygon_signature_counts",
+        ),
         "pedestrian_line_type_counts": _combined_record_counts(tile_records, "pedestrian_line_type_counts"),
         "pedestrian_line_structure_counts": _combined_record_counts(
             tile_records,
@@ -501,13 +546,19 @@ def collect_road_feature_report(
         ),
         "pedestrian_line_layer_counts": _combined_record_counts(tile_records, "pedestrian_line_layer_counts"),
         "pedestrian_line_surface_counts": _combined_record_counts(tile_records, "pedestrian_line_surface_counts"),
+        "pedestrian_line_signature_counts": _combined_record_counts(
+            tile_records,
+            "pedestrian_line_signature_counts",
+        ),
         "path_line_type_counts": _combined_record_counts(tile_records, "path_line_type_counts"),
         "path_line_structure_counts": _combined_record_counts(tile_records, "path_line_structure_counts"),
         "path_line_layer_counts": _combined_record_counts(tile_records, "path_line_layer_counts"),
         "path_line_surface_counts": _combined_record_counts(tile_records, "path_line_surface_counts"),
+        "path_line_signature_counts": _combined_record_counts(tile_records, "path_line_signature_counts"),
         "step_line_structure_counts": _combined_record_counts(tile_records, "step_line_structure_counts"),
         "step_line_layer_counts": _combined_record_counts(tile_records, "step_line_layer_counts"),
         "step_line_surface_counts": _combined_record_counts(tile_records, "step_line_surface_counts"),
+        "step_line_signature_counts": _combined_record_counts(tile_records, "step_line_signature_counts"),
         "oneway_arrow_class_counts": _combined_record_counts(tile_records, "oneway_arrow_class_counts"),
         "oneway_arrow_structure_counts": _combined_record_counts(tile_records, "oneway_arrow_structure_counts"),
         "oneway_arrow_layer_counts": _combined_record_counts(tile_records, "oneway_arrow_layer_counts"),
@@ -592,6 +643,10 @@ def collect_all_camera_road_feature_report(
             camera_reports,
             "pedestrian_polygon_surface_counts",
         ),
+        "pedestrian_polygon_signature_counts": _combined_record_counts(
+            camera_reports,
+            "pedestrian_polygon_signature_counts",
+        ),
         "pedestrian_line_type_counts": _combined_record_counts(
             camera_reports,
             "pedestrian_line_type_counts",
@@ -608,13 +663,19 @@ def collect_all_camera_road_feature_report(
             camera_reports,
             "pedestrian_line_surface_counts",
         ),
+        "pedestrian_line_signature_counts": _combined_record_counts(
+            camera_reports,
+            "pedestrian_line_signature_counts",
+        ),
         "path_line_type_counts": _combined_record_counts(camera_reports, "path_line_type_counts"),
         "path_line_structure_counts": _combined_record_counts(camera_reports, "path_line_structure_counts"),
         "path_line_layer_counts": _combined_record_counts(camera_reports, "path_line_layer_counts"),
         "path_line_surface_counts": _combined_record_counts(camera_reports, "path_line_surface_counts"),
+        "path_line_signature_counts": _combined_record_counts(camera_reports, "path_line_signature_counts"),
         "step_line_structure_counts": _combined_record_counts(camera_reports, "step_line_structure_counts"),
         "step_line_layer_counts": _combined_record_counts(camera_reports, "step_line_layer_counts"),
         "step_line_surface_counts": _combined_record_counts(camera_reports, "step_line_surface_counts"),
+        "step_line_signature_counts": _combined_record_counts(camera_reports, "step_line_signature_counts"),
         "oneway_arrow_class_counts": _combined_record_counts(camera_reports, "oneway_arrow_class_counts"),
         "oneway_arrow_structure_counts": _combined_record_counts(camera_reports, "oneway_arrow_structure_counts"),
         "oneway_arrow_layer_counts": _combined_record_counts(camera_reports, "oneway_arrow_layer_counts"),


### PR DESCRIPTION
## Summary

- add combined class/type/surface/structure/layer signature buckets to the Mapbox Outdoors road-feature diagnostic
- include those signatures in tile-level, single-camera, and all-camera JSON/Markdown summaries
- cover tile records, aggregation, and Markdown output with regression tests

## Evidence

- Live all-camera diagnostic: `debug/mapbox-outdoors-road-features/all-cameras/20260519T113553Z/summary.md`
- Result: 62/62 vector tiles decoded across the current seven-camera matrix.
- The new signatures expose actual pedestrian/path/step feature combinations, for example Zermatt z18 separates paved pedestrian corridors, paved path lines with positive layers, and missing-surface foot/path lines instead of relying on separate marginal counts.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949.
