### PR TITLE
chore: expose Mapbox road shield diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -25,6 +25,7 @@ from qfit.validation.mapbox_outdoors_road_features import (
     is_path_line_candidate,
     is_pedestrian_line_candidate,
     is_pedestrian_polygon_candidate,
+    is_road_number_shield_candidate,
     is_step_line_candidate,
     load_style_definition,
     main,
@@ -115,6 +116,19 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         motorway_oneway = _feature("LineString", {"class": "motorway", "structure": "bridge", "oneway": "true"})
         bool_oneway = _feature("LineString", {"class": "street", "structure": "none", "oneway": True})
         unsupported_oneway_class = _feature("LineString", {"class": "path", "structure": "none", "oneway": "true"})
+        low_zoom_shield_point = _feature("Point", {"class": "primary", "reflen": "2", "len": 10})
+        high_zoom_shield_point = _feature("Point", {"class": "primary", "reflen": "2", "len": 3000})
+        low_zoom_shield_line = _feature("LineString", {"class": "primary", "reflen": 2, "len": 6000})
+        z11_shield_line = _feature("LineString", {"class": "primary", "reflen": 2, "len": 6001})
+        short_z11_shield_line = _feature("LineString", {"class": "primary", "reflen": 2, "len": 2500})
+        z12_shield_line = _feature("LineString", {"class": "primary", "reflen": "2", "len": "2501"})
+        z13_shield_line = _feature("LineString", {"class": "primary", "reflen": 2, "len": 1001})
+        z14_shield_line = _feature("LineString", {"class": "primary", "reflen": 2, "len": 2501})
+        missing_length_shield_line = _feature("LineString", {"class": "primary", "reflen": 2})
+        service_shield_line = _feature("LineString", {"class": "service", "reflen": 2, "len": 6001})
+        zero_reflen_shield_line = _feature("LineString", {"class": "primary", "reflen": 0, "len": 6001})
+        long_reflen_shield_line = _feature("LineString", {"class": "primary", "reflen": 7, "len": 6001})
+        bool_reflen_shield_line = _feature("LineString", {"class": "primary", "reflen": True, "len": 6001})
         unsupported_step_line = _feature(
             "LineString",
             {"class": "path", "type": "steps", "structure": "unsupported"},
@@ -148,6 +162,21 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertTrue(is_oneway_arrow_candidate(motorway_oneway, tile_zoom=16))
         self.assertFalse(is_oneway_arrow_candidate(bool_oneway, tile_zoom=16))
         self.assertFalse(is_oneway_arrow_candidate(unsupported_oneway_class, tile_zoom=16))
+        self.assertFalse(is_road_number_shield_candidate(low_zoom_shield_point, tile_zoom=5))
+        self.assertTrue(is_road_number_shield_candidate(low_zoom_shield_point, tile_zoom=10))
+        self.assertFalse(is_road_number_shield_candidate(high_zoom_shield_point, tile_zoom=11))
+        self.assertFalse(is_road_number_shield_candidate(low_zoom_shield_line, tile_zoom=10))
+        self.assertTrue(is_road_number_shield_candidate(z11_shield_line, tile_zoom=11))
+        self.assertFalse(is_road_number_shield_candidate(short_z11_shield_line, tile_zoom=11))
+        self.assertTrue(is_road_number_shield_candidate(z12_shield_line, tile_zoom=12))
+        self.assertFalse(is_road_number_shield_candidate(z13_shield_line, tile_zoom=13))
+        self.assertTrue(is_road_number_shield_candidate(z14_shield_line, tile_zoom=14))
+        self.assertFalse(is_road_number_shield_candidate(missing_length_shield_line, tile_zoom=14))
+        self.assertFalse(is_road_number_shield_candidate(service_shield_line, tile_zoom=14))
+        self.assertFalse(is_road_number_shield_candidate(zero_reflen_shield_line, tile_zoom=14))
+        self.assertFalse(is_road_number_shield_candidate(long_reflen_shield_line, tile_zoom=14))
+        self.assertFalse(is_road_number_shield_candidate(bool_reflen_shield_line, tile_zoom=14))
+        self.assertFalse(is_road_number_shield_candidate(z14_shield_line))
         self.assertFalse(is_step_line_candidate(unsupported_step_line))
         self.assertFalse(is_step_line_candidate(sidewalk_path_line))
         self.assertFalse(is_path_line_candidate(sidewalk_path_line, tile_zoom=15))
@@ -174,6 +203,18 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             _feature("MultiLineString", {"class": "path", "type": "steps", "structure": "none", "layer": 0, "surface": "paved"}),
             _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
             _feature("LineString", {"class": "motorway", "structure": "bridge", "oneway": "true"}),
+            _feature(
+                "LineString",
+                {
+                    "class": "primary",
+                    "reflen": "2",
+                    "shield": "ch-primary",
+                    "structure": "none",
+                    "layer": 0,
+                    "len": 3000,
+                },
+            ),
+            _feature("LineString", {"class": "service", "reflen": 2, "structure": "none"}),
             _feature("LineString", {"class": "street", "type": "street", "structure": "none"}),
         ]
 
@@ -188,12 +229,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
 
         self.assertEqual(record["status"], "decoded")
-        self.assertEqual(record["road_feature_count"], 10)
+        self.assertEqual(record["road_feature_count"], 12)
         self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(record["pedestrian_line_candidate_count"], 1)
         self.assertEqual(record["path_line_candidate_count"], 1)
         self.assertEqual(record["step_line_candidate_count"], 1)
         self.assertEqual(record["oneway_arrow_candidate_count"], 2)
+        self.assertEqual(record["road_number_shield_candidate_count"], 1)
         self.assertEqual(record["pedestrian_polygon_class_counts"], {"path": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_type_counts"], {"footway": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_structure_counts"], {"none": 2})
@@ -232,9 +274,18 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["oneway_arrow_class_counts"], {"motorway": 1, "street": 1})
         self.assertEqual(record["oneway_arrow_structure_counts"], {"bridge": 1, "none": 1})
         self.assertEqual(record["oneway_arrow_layer_counts"], {"(missing)": 1, "0": 1})
+        self.assertEqual(record["road_number_shield_class_counts"], {"primary": 1})
+        self.assertEqual(record["road_number_shield_reflen_counts"], {"2": 1})
+        self.assertEqual(record["road_number_shield_structure_counts"], {"none": 1})
+        self.assertEqual(record["road_number_shield_layer_counts"], {"0": 1})
+        self.assertEqual(
+            record["road_number_shield_signature_counts"],
+            {"class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0": 1},
+        )
         self.assertEqual(record["sample_pedestrian_polygons"][0]["properties"]["class"], "pedestrian")
         self.assertEqual(record["sample_step_lines"][0]["properties"]["type"], "steps")
         self.assertEqual(record["sample_oneway_arrow_lines"][0]["properties"]["oneway"], "true")
+        self.assertEqual(record["sample_road_number_shields"][0]["properties"]["shield"], "ch-primary")
 
     def test_road_tile_record_accepts_flat_layer_lists_and_summarizes_irregular_features(self):
         road_features = [
@@ -266,6 +317,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(record["pedestrian_line_candidate_count"], 1)
         self.assertEqual(record["oneway_arrow_candidate_count"], 0)
+        self.assertEqual(record["road_number_shield_candidate_count"], 0)
         self.assertEqual(record["road_geometry_type_counts"]["(missing)"], 1)
         self.assertEqual(record["pedestrian_polygon_type_counts"], {'["plaza"]': 1, "(missing)": 1})
         self.assertEqual(record["pedestrian_polygon_structure_counts"], {"none": 2})
@@ -355,6 +407,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["path_line_candidate_count"], 1)
         self.assertEqual(report["step_line_candidate_count"], 1)
         self.assertEqual(report["oneway_arrow_candidate_count"], 0)
+        self.assertEqual(report["road_number_shield_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 1})
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 1})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 1})
@@ -387,6 +440,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["oneway_arrow_class_counts"], {})
         self.assertEqual(report["oneway_arrow_structure_counts"], {})
         self.assertEqual(report["oneway_arrow_layer_counts"], {})
+        self.assertEqual(report["road_number_shield_class_counts"], {})
+        self.assertEqual(report["road_number_shield_reflen_counts"], {})
+        self.assertEqual(report["road_number_shield_structure_counts"], {})
+        self.assertEqual(report["road_number_shield_layer_counts"], {})
         self.assertEqual(len(calls), 1)
         self.assertIn("mapbox.mapbox-streets-v8/0/0/0.mvt", calls[0])
 
@@ -502,6 +559,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["path_line_candidate_count"], 2)
         self.assertEqual(report["step_line_candidate_count"], 2)
         self.assertEqual(report["oneway_arrow_candidate_count"], 0)
+        self.assertEqual(report["road_number_shield_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 2})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 2})
@@ -536,6 +594,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["oneway_arrow_class_counts"], {})
         self.assertEqual(report["oneway_arrow_structure_counts"], {})
         self.assertEqual(report["oneway_arrow_layer_counts"], {})
+        self.assertEqual(report["road_number_shield_class_counts"], {})
+        self.assertEqual(report["road_number_shield_reflen_counts"], {})
+        self.assertEqual(report["road_number_shield_structure_counts"], {})
+        self.assertEqual(report["road_number_shield_layer_counts"], {})
         self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
         self.assertEqual(
             [camera_report["camera"]["name"] for camera_report in report["cameras"]],
@@ -546,6 +608,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
         path_signature = "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)"
         step_signature = "class=path; type=steps; surface=paved; structure=none; layer=0"
+        shield_signature = "class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0"
         report = {
             "generated": "2026-05-18T14:12:00+00:00",
             "style_owner": "mapbox",
@@ -560,6 +623,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
             "oneway_arrow_candidate_count": 1,
+            "road_number_shield_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
@@ -582,11 +646,17 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "oneway_arrow_class_counts": {"street": 1},
             "oneway_arrow_structure_counts": {"none": 1},
             "oneway_arrow_layer_counts": {"0": 1},
+            "road_number_shield_class_counts": {"primary": 1},
+            "road_number_shield_reflen_counts": {"2": 1},
+            "road_number_shield_structure_counts": {"none": 1},
+            "road_number_shield_layer_counts": {"0": 1},
+            "road_number_shield_signature_counts": {shield_signature: 1},
             "sample_pedestrian_polygons": [{"properties": {"class": "pedestrian"}}],
             "sample_pedestrian_lines": [{"properties": {"class": "pedestrian"}}],
             "sample_path_lines": [{"properties": {"class": "path"}}],
             "sample_step_lines": [{"properties": {"type": "steps"}}],
             "sample_oneway_arrow_lines": [{"properties": {"class": "street", "oneway": "true"}}],
+            "sample_road_number_shields": [{"properties": {"class": "primary", "shield": "ch-primary"}}],
             "tiles": [
                 "ignore-me",
                 {
@@ -600,6 +670,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
                     "oneway_arrow_candidate_count": 1,
+                    "road_number_shield_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
@@ -622,6 +693,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "oneway_arrow_class_counts": {"street": 1},
                     "oneway_arrow_structure_counts": {"none": 1},
                     "oneway_arrow_layer_counts": {"0": 1},
+                    "road_number_shield_class_counts": {"primary": 1},
+                    "road_number_shield_reflen_counts": {"2": 1},
+                    "road_number_shield_structure_counts": {"none": 1},
+                    "road_number_shield_layer_counts": {"0": 1},
+                    "road_number_shield_signature_counts": {shield_signature: 1},
                 }
             ],
         }
@@ -633,6 +709,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("Path line candidates: 1", markdown)
         self.assertIn("Step line candidates: 1", markdown)
         self.assertIn("One-way arrow candidates: 1", markdown)
+        self.assertIn("Road number shield candidates: 1", markdown)
         self.assertIn('Pedestrian polygon structure counts: {"none":1}', markdown)
         self.assertIn('Pedestrian polygon layer counts: {"0":1}', markdown)
         self.assertIn('Pedestrian polygon surface counts: {"paved":1}', markdown)
@@ -652,16 +729,23 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn('One-way arrow class counts: {"street":1}', markdown)
         self.assertIn('One-way arrow structure counts: {"none":1}', markdown)
         self.assertIn('One-way arrow layer counts: {"0":1}', markdown)
+        self.assertIn('Road number shield class counts: {"primary":1}', markdown)
+        self.assertIn('Road number shield reflen counts: {"2":1}', markdown)
+        self.assertIn('Road number shield structure counts: {"none":1}', markdown)
+        self.assertIn('Road number shield layer counts: {"0":1}', markdown)
+        self.assertIn(f'Road number shield signatures: {{"{shield_signature}":1}}', markdown)
         self.assertIn("## Sample pedestrian/path polygon candidates", markdown)
         self.assertIn("## Sample pedestrian line candidates", markdown)
         self.assertIn("## Sample path line candidates", markdown)
         self.assertIn("## Sample step line candidates", markdown)
         self.assertIn("## Sample one-way arrow candidates", markdown)
+        self.assertIn("## Sample road number shield candidates", markdown)
 
     def test_build_all_camera_summary_markdown_includes_camera_rows(self):
         pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
         path_signature = "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)"
         step_signature = "class=path; type=steps; surface=paved; structure=bridge; layer=(missing)"
+        shield_signature = "class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0"
         report = {
             "generated": "2026-05-18T15:40:00+00:00",
             "style_owner": "mapbox",
@@ -675,6 +759,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
             "oneway_arrow_candidate_count": 1,
+            "road_number_shield_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
@@ -697,6 +782,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "oneway_arrow_class_counts": {"street": 1},
             "oneway_arrow_structure_counts": {"none": 1},
             "oneway_arrow_layer_counts": {"0": 1},
+            "road_number_shield_class_counts": {"primary": 1},
+            "road_number_shield_reflen_counts": {"2": 1},
+            "road_number_shield_structure_counts": {"none": 1},
+            "road_number_shield_layer_counts": {"0": 1},
+            "road_number_shield_signature_counts": {shield_signature: 1},
             "cameras": [
                 {
                     "camera": {"name": "zermatt-trails-z18-outdoors", "zoom": 18.0},
@@ -709,6 +799,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
                     "oneway_arrow_candidate_count": 1,
+                    "road_number_shield_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
@@ -731,6 +822,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "oneway_arrow_class_counts": {"street": 1},
                     "oneway_arrow_structure_counts": {"none": 1},
                     "oneway_arrow_layer_counts": {"0": 1},
+                    "road_number_shield_class_counts": {"primary": 1},
+                    "road_number_shield_reflen_counts": {"2": 1},
+                    "road_number_shield_structure_counts": {"none": 1},
+                    "road_number_shield_layer_counts": {"0": 1},
+                    "road_number_shield_signature_counts": {shield_signature: 1},
                 }
             ],
         }
@@ -739,7 +835,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertIn("# Mapbox Outdoors road feature diagnostic - all cameras", markdown)
         self.assertIn("Cameras: 1", markdown)
-        self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 4 | 1 | 1 | 1 | 1 | 1 |", markdown)
+        self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 4 | 1 | 1 | 1 | 1 | 1 | 1 |", markdown)
         self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
 
     def test_write_report_writes_json_and_markdown(self):

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -56,6 +56,10 @@ LOW_ZOOM_PATH_EXCLUDED_TYPES = {"crossing", "sidewalk", "steps"}
 HIGH_ZOOM_PATH_EXCLUDED_TYPES = {"steps"}
 STEP_STRUCTURES = {"none", "ford", "bridge", "tunnel"}
 ONEWAY_ARROW_MIN_ZOOM = 16
+ROAD_NUMBER_SHIELD_MIN_ZOOM = 6
+ROAD_NUMBER_SHIELD_MAX_REFLEN = 6
+ROAD_NUMBER_SHIELD_EXCLUDED_CLASSES = {"pedestrian", "service"}
+ROAD_NUMBER_SHIELD_LINE_LENGTH_MIN = 2500.0
 ONEWAY_ARROW_BLUE_CLASSES = {
     "primary",
     "primary_link",
@@ -76,11 +80,16 @@ SAMPLE_PROPERTY_KEYS = (
     "type",
     "structure",
     "layer",
+    "ref",
+    "reflen",
+    "shield",
+    "shield_beta",
     "name",
     "oneway",
     "surface",
 )
 ROAD_FEATURE_SIGNATURE_KEYS = ("class", "type", "surface", "structure", "layer")
+ROAD_NUMBER_SHIELD_SIGNATURE_KEYS = ("class", "reflen", "shield", "shield_beta", "structure", "layer")
 
 
 @dataclass(frozen=True)
@@ -186,6 +195,40 @@ def is_oneway_arrow_candidate(feature: dict[str, object], *, tile_zoom: int | No
     )
 
 
+def _finite_number(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            number = float(value)
+        except ValueError:
+            return None
+        return number if math.isfinite(number) else None
+    return None
+
+
+def is_road_number_shield_candidate(feature: dict[str, object], *, tile_zoom: int | None = None) -> bool:
+    properties = _feature_properties(feature)
+    reflen = _finite_number(properties.get("reflen"))
+    if (
+        tile_zoom is None
+        or tile_zoom < ROAD_NUMBER_SHIELD_MIN_ZOOM
+        or properties.get("class") in ROAD_NUMBER_SHIELD_EXCLUDED_CLASSES
+        or reflen is None
+        or reflen <= 0
+        or reflen > ROAD_NUMBER_SHIELD_MAX_REFLEN
+    ):
+        return False
+    if tile_zoom < 11:
+        return _geometry_type(feature) == "Point"
+    if _geometry_type(feature) not in LINE_GEOMETRY_TYPES:
+        return False
+    length = _finite_number(properties.get("len"))
+    return length is not None and length > ROAD_NUMBER_SHIELD_LINE_LENGTH_MIN
+
+
 def _property_count_label(value: object) -> str:
     if isinstance(value, (dict, list)):
         value = json.dumps(value, sort_keys=True, separators=(",", ":"))
@@ -261,6 +304,9 @@ def road_tile_record(
     oneway_arrow_lines = [
         feature for feature in road_features if is_oneway_arrow_candidate(feature, tile_zoom=tile.get("z"))
     ]
+    road_number_shields = [
+        feature for feature in road_features if is_road_number_shield_candidate(feature, tile_zoom=tile.get("z"))
+    ]
     return {
         **tile,
         "status": "decoded",
@@ -271,6 +317,7 @@ def road_tile_record(
         "path_line_candidate_count": len(path_lines),
         "step_line_candidate_count": len(step_lines),
         "oneway_arrow_candidate_count": len(oneway_arrow_lines),
+        "road_number_shield_candidate_count": len(road_number_shields),
         "road_geometry_type_counts": _count_geometry_types(road_features),
         "pedestrian_polygon_class_counts": _count_by_property(pedestrian_polygons, "class"),
         "pedestrian_polygon_type_counts": _count_by_property(pedestrian_polygons, "type"),
@@ -301,6 +348,14 @@ def road_tile_record(
         "oneway_arrow_class_counts": _count_by_property(oneway_arrow_lines, "class"),
         "oneway_arrow_structure_counts": _count_by_property(oneway_arrow_lines, "structure"),
         "oneway_arrow_layer_counts": _count_by_property(oneway_arrow_lines, "layer"),
+        "road_number_shield_class_counts": _count_by_property(road_number_shields, "class"),
+        "road_number_shield_reflen_counts": _count_by_property(road_number_shields, "reflen"),
+        "road_number_shield_structure_counts": _count_by_property(road_number_shields, "structure"),
+        "road_number_shield_layer_counts": _count_by_property(road_number_shields, "layer"),
+        "road_number_shield_signature_counts": _count_property_signatures(
+            road_number_shields,
+            ROAD_NUMBER_SHIELD_SIGNATURE_KEYS,
+        ),
         "sample_pedestrian_polygons": [
             _feature_sample(tile, feature) for feature in pedestrian_polygons[:MAX_SAMPLE_FEATURES]
         ],
@@ -311,6 +366,9 @@ def road_tile_record(
         "sample_step_lines": [_feature_sample(tile, feature) for feature in step_lines[:MAX_SAMPLE_FEATURES]],
         "sample_oneway_arrow_lines": [
             _feature_sample(tile, feature) for feature in oneway_arrow_lines[:MAX_SAMPLE_FEATURES]
+        ],
+        "sample_road_number_shields": [
+            _feature_sample(tile, feature) for feature in road_number_shields[:MAX_SAMPLE_FEATURES]
         ],
     }
 
@@ -333,6 +391,7 @@ _SUMMARY_COUNT_FIELDS = (
     ("Path line candidates", "path_line_candidate_count"),
     ("Step line candidates", "step_line_candidate_count"),
     ("One-way arrow candidates", "oneway_arrow_candidate_count"),
+    ("Road number shield candidates", "road_number_shield_candidate_count"),
 )
 _SUMMARY_COUNT_MAP_FIELDS = (
     ("Pedestrian polygon type counts", "pedestrian_polygon_type_counts"),
@@ -357,6 +416,11 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("One-way arrow class counts", "oneway_arrow_class_counts"),
     ("One-way arrow structure counts", "oneway_arrow_structure_counts"),
     ("One-way arrow layer counts", "oneway_arrow_layer_counts"),
+    ("Road number shield class counts", "road_number_shield_class_counts"),
+    ("Road number shield reflen counts", "road_number_shield_reflen_counts"),
+    ("Road number shield structure counts", "road_number_shield_structure_counts"),
+    ("Road number shield layer counts", "road_number_shield_layer_counts"),
+    ("Road number shield signatures", "road_number_shield_signature_counts"),
 )
 _ROAD_FEATURE_TABLE_FIELDS = (
     ("Road", "road_feature_count", "---:"),
@@ -365,6 +429,7 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Path lines", "path_line_candidate_count", "---:"),
     ("Step lines", "step_line_candidate_count", "---:"),
     ("One-way arrows", "oneway_arrow_candidate_count", "---:"),
+    ("Road number shields", "road_number_shield_candidate_count", "---:"),
     ("Polygon types", "pedestrian_polygon_type_counts", "---"),
     ("Polygon structures", "pedestrian_polygon_structure_counts", "---"),
     ("Polygon layers", "pedestrian_polygon_layer_counts", "---"),
@@ -387,6 +452,11 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("One-way arrow classes", "oneway_arrow_class_counts", "---"),
     ("One-way arrow structures", "oneway_arrow_structure_counts", "---"),
     ("One-way arrow layers", "oneway_arrow_layer_counts", "---"),
+    ("Shield classes", "road_number_shield_class_counts", "---"),
+    ("Shield reflens", "road_number_shield_reflen_counts", "---"),
+    ("Shield structures", "road_number_shield_structure_counts", "---"),
+    ("Shield layers", "road_number_shield_layer_counts", "---"),
+    ("Shield signatures", "road_number_shield_signature_counts", "---"),
 )
 
 
@@ -514,6 +584,9 @@ def collect_road_feature_report(
         "oneway_arrow_candidate_count": sum(
             int(tile.get("oneway_arrow_candidate_count") or 0) for tile in tile_records
         ),
+        "road_number_shield_candidate_count": sum(
+            int(tile.get("road_number_shield_candidate_count") or 0) for tile in tile_records
+        ),
         "road_geometry_type_counts": _combined_record_counts(tile_records, "road_geometry_type_counts"),
         "pedestrian_polygon_class_counts": _combined_record_counts(
             tile_records,
@@ -562,11 +635,26 @@ def collect_road_feature_report(
         "oneway_arrow_class_counts": _combined_record_counts(tile_records, "oneway_arrow_class_counts"),
         "oneway_arrow_structure_counts": _combined_record_counts(tile_records, "oneway_arrow_structure_counts"),
         "oneway_arrow_layer_counts": _combined_record_counts(tile_records, "oneway_arrow_layer_counts"),
+        "road_number_shield_class_counts": _combined_record_counts(tile_records, "road_number_shield_class_counts"),
+        "road_number_shield_reflen_counts": _combined_record_counts(
+            tile_records,
+            "road_number_shield_reflen_counts",
+        ),
+        "road_number_shield_structure_counts": _combined_record_counts(
+            tile_records,
+            "road_number_shield_structure_counts",
+        ),
+        "road_number_shield_layer_counts": _combined_record_counts(tile_records, "road_number_shield_layer_counts"),
+        "road_number_shield_signature_counts": _combined_record_counts(
+            tile_records,
+            "road_number_shield_signature_counts",
+        ),
         "sample_pedestrian_polygons": _combined_samples(tile_records, "sample_pedestrian_polygons"),
         "sample_pedestrian_lines": _combined_samples(tile_records, "sample_pedestrian_lines"),
         "sample_path_lines": _combined_samples(tile_records, "sample_path_lines"),
         "sample_step_lines": _combined_samples(tile_records, "sample_step_lines"),
         "sample_oneway_arrow_lines": _combined_samples(tile_records, "sample_oneway_arrow_lines"),
+        "sample_road_number_shields": _combined_samples(tile_records, "sample_road_number_shields"),
         "tiles": tile_records,
     }
 
@@ -622,6 +710,7 @@ def collect_all_camera_road_feature_report(
         "path_line_candidate_count": _sum_reports(camera_reports, "path_line_candidate_count"),
         "step_line_candidate_count": _sum_reports(camera_reports, "step_line_candidate_count"),
         "oneway_arrow_candidate_count": _sum_reports(camera_reports, "oneway_arrow_candidate_count"),
+        "road_number_shield_candidate_count": _sum_reports(camera_reports, "road_number_shield_candidate_count"),
         "road_geometry_type_counts": _combined_record_counts(camera_reports, "road_geometry_type_counts"),
         "pedestrian_polygon_class_counts": _combined_record_counts(
             camera_reports,
@@ -679,6 +768,26 @@ def collect_all_camera_road_feature_report(
         "oneway_arrow_class_counts": _combined_record_counts(camera_reports, "oneway_arrow_class_counts"),
         "oneway_arrow_structure_counts": _combined_record_counts(camera_reports, "oneway_arrow_structure_counts"),
         "oneway_arrow_layer_counts": _combined_record_counts(camera_reports, "oneway_arrow_layer_counts"),
+        "road_number_shield_class_counts": _combined_record_counts(
+            camera_reports,
+            "road_number_shield_class_counts",
+        ),
+        "road_number_shield_reflen_counts": _combined_record_counts(
+            camera_reports,
+            "road_number_shield_reflen_counts",
+        ),
+        "road_number_shield_structure_counts": _combined_record_counts(
+            camera_reports,
+            "road_number_shield_structure_counts",
+        ),
+        "road_number_shield_layer_counts": _combined_record_counts(
+            camera_reports,
+            "road_number_shield_layer_counts",
+        ),
+        "road_number_shield_signature_counts": _combined_record_counts(
+            camera_reports,
+            "road_number_shield_signature_counts",
+        ),
         "cameras": camera_reports,
     }
 
@@ -708,6 +817,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         ("Sample path line candidates", "sample_path_lines"),
         ("Sample step line candidates", "sample_step_lines"),
         ("Sample one-way arrow candidates", "sample_oneway_arrow_lines"),
+        ("Sample road number shield candidates", "sample_road_number_shields"),
     )
     for heading, key in sample_sections:
         samples = report.get(key)


### PR DESCRIPTION
## Summary
- add active Mapbox Outdoors road-number-shield candidate buckets to the road-feature diagnostic
- report shield class, reflen, structure, layer, and combined signature counts in JSON/Markdown outputs
- include sample shield candidates so future road-symbol parity work is grounded in live vector-tile features

## Evidence
- Live converter audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260519T115412Z/audit.json`
  - removing `layout.icon-image` from the qfit-preprocessed style reduces 840 QGIS sprite warnings
  - qfit-preprocessed filters are parser-supported in the live filter probe, so shield/icon evidence is a better next diagnostic target than filter syntax
- Live all-camera road-feature diagnostic: `debug/mapbox-outdoors-road-features/all-cameras/20260519T122113Z/summary.md`
  - 62/62 tiles decoded
  - 535 qfit-preprocessed road-number-shield candidates across the seven-camera matrix
  - candidates concentrate in z8/z10, with only 7 total z14 candidates after matching qfit's z11+ `len > 2500` line-geometry shield filter
  - z17/z18 Zermatt high-detail cameras have no active shield candidates in this matrix

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949