### PR TITLE
chore: expose Mapbox road exit shield diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -25,6 +25,7 @@ from qfit.validation.mapbox_outdoors_road_features import (
     is_path_line_candidate,
     is_pedestrian_line_candidate,
     is_pedestrian_polygon_candidate,
+    is_road_exit_shield_candidate,
     is_road_number_shield_candidate,
     is_step_line_candidate,
     load_style_definition,
@@ -129,6 +130,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         zero_reflen_shield_line = _feature("LineString", {"class": "primary", "reflen": 0, "len": 6001})
         long_reflen_shield_line = _feature("LineString", {"class": "primary", "reflen": 7, "len": 6001})
         bool_reflen_shield_line = _feature("LineString", {"class": "primary", "reflen": True, "len": 6001})
+        road_exit_shield = _feature("Point", {"ref": "12", "reflen": 2})
+        string_reflen_road_exit_shield = _feature("Point", {"ref": "A1", "reflen": "2"})
+        low_zoom_road_exit_shield = _feature("Point", {"ref": "12", "reflen": 2})
+        missing_reflen_road_exit_shield = _feature("Point", {"ref": "12"})
+        zero_reflen_road_exit_shield = _feature("Point", {"ref": "12", "reflen": 0})
+        long_reflen_road_exit_shield = _feature("Point", {"ref": "1234567890", "reflen": 10})
+        bool_reflen_road_exit_shield = _feature("Point", {"ref": "12", "reflen": True})
         unsupported_step_line = _feature(
             "LineString",
             {"class": "path", "type": "steps", "structure": "unsupported"},
@@ -177,6 +185,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertFalse(is_road_number_shield_candidate(long_reflen_shield_line, tile_zoom=14))
         self.assertFalse(is_road_number_shield_candidate(bool_reflen_shield_line, tile_zoom=14))
         self.assertFalse(is_road_number_shield_candidate(z14_shield_line))
+        self.assertTrue(is_road_exit_shield_candidate(road_exit_shield, tile_zoom=14))
+        self.assertTrue(is_road_exit_shield_candidate(string_reflen_road_exit_shield, tile_zoom=14))
+        self.assertFalse(is_road_exit_shield_candidate(low_zoom_road_exit_shield, tile_zoom=13))
+        self.assertFalse(is_road_exit_shield_candidate(missing_reflen_road_exit_shield, tile_zoom=14))
+        self.assertFalse(is_road_exit_shield_candidate(zero_reflen_road_exit_shield, tile_zoom=14))
+        self.assertFalse(is_road_exit_shield_candidate(long_reflen_road_exit_shield, tile_zoom=14))
+        self.assertFalse(is_road_exit_shield_candidate(bool_reflen_road_exit_shield, tile_zoom=14))
+        self.assertFalse(is_road_exit_shield_candidate(road_exit_shield))
         self.assertFalse(is_step_line_candidate(unsupported_step_line))
         self.assertFalse(is_step_line_candidate(sidewalk_path_line))
         self.assertFalse(is_path_line_candidate(sidewalk_path_line, tile_zoom=15))
@@ -217,9 +233,16 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             _feature("LineString", {"class": "service", "reflen": 2, "structure": "none"}),
             _feature("LineString", {"class": "street", "type": "street", "structure": "none"}),
         ]
+        motorway_junction_features = [
+            _feature("Point", {"ref": "12", "reflen": 2}),
+            _feature("Point", {"ref": "1234567890", "reflen": 10}),
+        ]
 
         def decoder(_payload):
-            return {"road": {"features": road_features}}
+            return {
+                "road": {"features": road_features},
+                "motorway_junction": {"features": motorway_junction_features},
+            }
 
         record = road_tile_record(
             tile={"z": 18, "x": 136712, "y": 93238},
@@ -230,12 +253,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertEqual(record["status"], "decoded")
         self.assertEqual(record["road_feature_count"], 12)
+        self.assertEqual(record["motorway_junction_feature_count"], 2)
         self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(record["pedestrian_line_candidate_count"], 1)
         self.assertEqual(record["path_line_candidate_count"], 1)
         self.assertEqual(record["step_line_candidate_count"], 1)
         self.assertEqual(record["oneway_arrow_candidate_count"], 2)
         self.assertEqual(record["road_number_shield_candidate_count"], 1)
+        self.assertEqual(record["road_exit_shield_candidate_count"], 1)
         self.assertEqual(record["pedestrian_polygon_class_counts"], {"path": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_type_counts"], {"footway": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_structure_counts"], {"none": 2})
@@ -282,10 +307,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             record["road_number_shield_signature_counts"],
             {"class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0": 1},
         )
+        self.assertEqual(record["road_exit_shield_reflen_counts"], {"2": 1})
+        self.assertEqual(record["road_exit_shield_signature_counts"], {"ref=12; reflen=2": 1})
         self.assertEqual(record["sample_pedestrian_polygons"][0]["properties"]["class"], "pedestrian")
         self.assertEqual(record["sample_step_lines"][0]["properties"]["type"], "steps")
         self.assertEqual(record["sample_oneway_arrow_lines"][0]["properties"]["oneway"], "true")
         self.assertEqual(record["sample_road_number_shields"][0]["properties"]["shield"], "ch-primary")
+        self.assertEqual(record["sample_road_exit_shields"][0]["properties"]["ref"], "12")
 
     def test_road_tile_record_accepts_flat_layer_lists_and_summarizes_irregular_features(self):
         road_features = [
@@ -314,10 +342,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertEqual(record["status"], "decoded")
         self.assertEqual(record["road_feature_count"], 4)
+        self.assertEqual(record["motorway_junction_feature_count"], 0)
         self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(record["pedestrian_line_candidate_count"], 1)
         self.assertEqual(record["oneway_arrow_candidate_count"], 0)
         self.assertEqual(record["road_number_shield_candidate_count"], 0)
+        self.assertEqual(record["road_exit_shield_candidate_count"], 0)
         self.assertEqual(record["road_geometry_type_counts"]["(missing)"], 1)
         self.assertEqual(record["pedestrian_polygon_type_counts"], {'["plaza"]': 1, "(missing)": 1})
         self.assertEqual(record["pedestrian_polygon_structure_counts"], {"none": 2})
@@ -340,6 +370,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertEqual(record["status"], "decoded")
         self.assertEqual(record["road_feature_count"], 0)
+        self.assertEqual(record["motorway_junction_feature_count"], 0)
 
     def test_road_tile_record_marks_decode_errors(self):
         record = road_tile_record(
@@ -386,7 +417,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                         ),
                         _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
                     ]
-                }
+                },
+                "motorway_junction": {
+                    "features": [_feature("Point", {"ref": "12", "reflen": 2})]
+                },
             }
 
         report = collect_road_feature_report(
@@ -402,12 +436,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["tile_count"], 1)
         self.assertEqual(report["decoded_tile_count"], 1)
         self.assertEqual(report["road_feature_count"], 5)
+        self.assertEqual(report["motorway_junction_feature_count"], 1)
         self.assertEqual(report["pedestrian_polygon_candidate_count"], 1)
         self.assertEqual(report["pedestrian_line_candidate_count"], 1)
         self.assertEqual(report["path_line_candidate_count"], 1)
         self.assertEqual(report["step_line_candidate_count"], 1)
         self.assertEqual(report["oneway_arrow_candidate_count"], 0)
         self.assertEqual(report["road_number_shield_candidate_count"], 0)
+        self.assertEqual(report["road_exit_shield_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 1})
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 1})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 1})
@@ -444,6 +480,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
         self.assertEqual(report["road_number_shield_structure_counts"], {})
         self.assertEqual(report["road_number_shield_layer_counts"], {})
+        self.assertEqual(report["road_exit_shield_reflen_counts"], {})
         self.assertEqual(len(calls), 1)
         self.assertIn("mapbox.mapbox-streets-v8/0/0/0.mvt", calls[0])
 
@@ -465,11 +502,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     now=generated,
                 ),
                 tile_fetcher=lambda _url: gzip.compress(b"tile"),
-                tile_decoder=lambda _payload: {"road": []},
+                tile_decoder=lambda _payload: {"road": [], "motorway_junction": []},
             )
 
         self.assertEqual(report["tileset_ids"], ["mapbox.mapbox-streets-v8"])
         self.assertEqual(report["road_feature_count"], 0)
+        self.assertEqual(report["motorway_junction_feature_count"], 0)
 
     def test_collect_road_feature_report_requires_token_for_style_and_tiles(self):
         with self.assertRaisesRegex(ValueError, "style-json"):
@@ -538,7 +576,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                         {"class": "path", "type": "steps", "structure": "tunnel", "surface": "paved"},
                     ),
                     _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
-                ]
+                ],
+                "motorway_junction": [_feature("Point", {"ref": "12", "reflen": 2})],
             }
 
         report = collect_all_camera_road_feature_report(
@@ -554,12 +593,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["tile_count"], 2)
         self.assertEqual(report["decoded_tile_count"], 2)
         self.assertEqual(report["road_feature_count"], 10)
+        self.assertEqual(report["motorway_junction_feature_count"], 2)
         self.assertEqual(report["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(report["pedestrian_line_candidate_count"], 2)
         self.assertEqual(report["path_line_candidate_count"], 2)
         self.assertEqual(report["step_line_candidate_count"], 2)
         self.assertEqual(report["oneway_arrow_candidate_count"], 0)
         self.assertEqual(report["road_number_shield_candidate_count"], 0)
+        self.assertEqual(report["road_exit_shield_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 2})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 2})
@@ -598,6 +639,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
         self.assertEqual(report["road_number_shield_structure_counts"], {})
         self.assertEqual(report["road_number_shield_layer_counts"], {})
+        self.assertEqual(report["road_exit_shield_reflen_counts"], {})
         self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
         self.assertEqual(
             [camera_report["camera"]["name"] for camera_report in report["cameras"]],
@@ -609,6 +651,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         path_signature = "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)"
         step_signature = "class=path; type=steps; surface=paved; structure=none; layer=0"
         shield_signature = "class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0"
+        exit_shield_signature = "ref=12; reflen=2"
         report = {
             "generated": "2026-05-18T14:12:00+00:00",
             "style_owner": "mapbox",
@@ -618,12 +661,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "decoded_tile_count": 1,
             "tile_count": 1,
             "road_feature_count": 4,
+            "motorway_junction_feature_count": 1,
             "pedestrian_polygon_candidate_count": 1,
             "pedestrian_line_candidate_count": 1,
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
             "oneway_arrow_candidate_count": 1,
             "road_number_shield_candidate_count": 1,
+            "road_exit_shield_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
@@ -651,12 +696,15 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "road_number_shield_structure_counts": {"none": 1},
             "road_number_shield_layer_counts": {"0": 1},
             "road_number_shield_signature_counts": {shield_signature: 1},
+            "road_exit_shield_reflen_counts": {"2": 1},
+            "road_exit_shield_signature_counts": {exit_shield_signature: 1},
             "sample_pedestrian_polygons": [{"properties": {"class": "pedestrian"}}],
             "sample_pedestrian_lines": [{"properties": {"class": "pedestrian"}}],
             "sample_path_lines": [{"properties": {"class": "path"}}],
             "sample_step_lines": [{"properties": {"type": "steps"}}],
             "sample_oneway_arrow_lines": [{"properties": {"class": "street", "oneway": "true"}}],
             "sample_road_number_shields": [{"properties": {"class": "primary", "shield": "ch-primary"}}],
+            "sample_road_exit_shields": [{"properties": {"ref": "12", "reflen": 2}}],
             "tiles": [
                 "ignore-me",
                 {
@@ -665,12 +713,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "y": 2,
                     "status": "decoded",
                     "road_feature_count": 4,
+                    "motorway_junction_feature_count": 1,
                     "pedestrian_polygon_candidate_count": 1,
                     "pedestrian_line_candidate_count": 1,
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
                     "oneway_arrow_candidate_count": 1,
                     "road_number_shield_candidate_count": 1,
+                    "road_exit_shield_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
@@ -698,6 +748,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "road_number_shield_structure_counts": {"none": 1},
                     "road_number_shield_layer_counts": {"0": 1},
                     "road_number_shield_signature_counts": {shield_signature: 1},
+                    "road_exit_shield_reflen_counts": {"2": 1},
+                    "road_exit_shield_signature_counts": {exit_shield_signature: 1},
                 }
             ],
         }
@@ -710,6 +762,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("Step line candidates: 1", markdown)
         self.assertIn("One-way arrow candidates: 1", markdown)
         self.assertIn("Road number shield candidates: 1", markdown)
+        self.assertIn("Road exit shield candidates: 1", markdown)
         self.assertIn('Pedestrian polygon structure counts: {"none":1}', markdown)
         self.assertIn('Pedestrian polygon layer counts: {"0":1}', markdown)
         self.assertIn('Pedestrian polygon surface counts: {"paved":1}', markdown)
@@ -734,18 +787,22 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn('Road number shield structure counts: {"none":1}', markdown)
         self.assertIn('Road number shield layer counts: {"0":1}', markdown)
         self.assertIn(f'Road number shield signatures: {{"{shield_signature}":1}}', markdown)
+        self.assertIn('Road exit shield reflen counts: {"2":1}', markdown)
+        self.assertIn(f'Road exit shield signatures: {{"{exit_shield_signature}":1}}', markdown)
         self.assertIn("## Sample pedestrian/path polygon candidates", markdown)
         self.assertIn("## Sample pedestrian line candidates", markdown)
         self.assertIn("## Sample path line candidates", markdown)
         self.assertIn("## Sample step line candidates", markdown)
         self.assertIn("## Sample one-way arrow candidates", markdown)
         self.assertIn("## Sample road number shield candidates", markdown)
+        self.assertIn("## Sample road exit shield candidates", markdown)
 
     def test_build_all_camera_summary_markdown_includes_camera_rows(self):
         pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
         path_signature = "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)"
         step_signature = "class=path; type=steps; surface=paved; structure=bridge; layer=(missing)"
         shield_signature = "class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0"
+        exit_shield_signature = "ref=12; reflen=2"
         report = {
             "generated": "2026-05-18T15:40:00+00:00",
             "style_owner": "mapbox",
@@ -754,12 +811,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "decoded_tile_count": 1,
             "tile_count": 1,
             "road_feature_count": 4,
+            "motorway_junction_feature_count": 1,
             "pedestrian_polygon_candidate_count": 1,
             "pedestrian_line_candidate_count": 1,
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
             "oneway_arrow_candidate_count": 1,
             "road_number_shield_candidate_count": 1,
+            "road_exit_shield_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
@@ -787,6 +846,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "road_number_shield_structure_counts": {"none": 1},
             "road_number_shield_layer_counts": {"0": 1},
             "road_number_shield_signature_counts": {shield_signature: 1},
+            "road_exit_shield_reflen_counts": {"2": 1},
+            "road_exit_shield_signature_counts": {exit_shield_signature: 1},
             "cameras": [
                 {
                     "camera": {"name": "zermatt-trails-z18-outdoors", "zoom": 18.0},
@@ -794,12 +855,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "decoded_tile_count": 1,
                     "tile_count": 1,
                     "road_feature_count": 4,
+                    "motorway_junction_feature_count": 1,
                     "pedestrian_polygon_candidate_count": 1,
                     "pedestrian_line_candidate_count": 1,
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
                     "oneway_arrow_candidate_count": 1,
                     "road_number_shield_candidate_count": 1,
+                    "road_exit_shield_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
@@ -827,6 +890,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "road_number_shield_structure_counts": {"none": 1},
                     "road_number_shield_layer_counts": {"0": 1},
                     "road_number_shield_signature_counts": {shield_signature: 1},
+                    "road_exit_shield_reflen_counts": {"2": 1},
+                    "road_exit_shield_signature_counts": {exit_shield_signature: 1},
                 }
             ],
         }
@@ -835,8 +900,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertIn("# Mapbox Outdoors road feature diagnostic - all cameras", markdown)
         self.assertIn("Cameras: 1", markdown)
-        self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 4 | 1 | 1 | 1 | 1 | 1 | 1 |", markdown)
+        self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 4 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |", markdown)
         self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
+        self.assertIn(f'Road exit shield signatures: {{"{exit_shield_signature}":1}}', markdown)
 
     def test_write_report_writes_json_and_markdown(self):
         report = {

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -46,6 +46,7 @@ DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
 DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 DEFAULT_CAMERA_NAME = "zermatt-trails-z18-outdoors"
 ROAD_SOURCE_LAYER = "road"
+MOTORWAY_JUNCTION_SOURCE_LAYER = "motorway_junction"
 MISSING_VALUE = "(missing)"
 MAX_SAMPLE_FEATURES = 12
 PEDESTRIAN_PATH_CLASSES = {"path", "pedestrian"}
@@ -60,6 +61,8 @@ ROAD_NUMBER_SHIELD_MIN_ZOOM = 6
 ROAD_NUMBER_SHIELD_MAX_REFLEN = 6
 ROAD_NUMBER_SHIELD_EXCLUDED_CLASSES = {"pedestrian", "service"}
 ROAD_NUMBER_SHIELD_LINE_LENGTH_MIN = 2500.0
+ROAD_EXIT_SHIELD_MIN_ZOOM = 14
+ROAD_EXIT_SHIELD_MAX_REFLEN = 9
 ONEWAY_ARROW_BLUE_CLASSES = {
     "primary",
     "primary_link",
@@ -90,6 +93,7 @@ SAMPLE_PROPERTY_KEYS = (
 )
 ROAD_FEATURE_SIGNATURE_KEYS = ("class", "type", "surface", "structure", "layer")
 ROAD_NUMBER_SHIELD_SIGNATURE_KEYS = ("class", "reflen", "shield", "shield_beta", "structure", "layer")
+ROAD_EXIT_SHIELD_SIGNATURE_KEYS = ("ref", "reflen")
 
 
 @dataclass(frozen=True)
@@ -229,6 +233,18 @@ def is_road_number_shield_candidate(feature: dict[str, object], *, tile_zoom: in
     return length is not None and length > ROAD_NUMBER_SHIELD_LINE_LENGTH_MIN
 
 
+def is_road_exit_shield_candidate(feature: dict[str, object], *, tile_zoom: int | None = None) -> bool:
+    properties = _feature_properties(feature)
+    reflen = _finite_number(properties.get("reflen"))
+    return (
+        tile_zoom is not None
+        and tile_zoom >= ROAD_EXIT_SHIELD_MIN_ZOOM
+        and reflen is not None
+        and reflen > 0
+        and reflen <= ROAD_EXIT_SHIELD_MAX_REFLEN
+    )
+
+
 def _property_count_label(value: object) -> str:
     if isinstance(value, (dict, list)):
         value = json.dumps(value, sort_keys=True, separators=(",", ":"))
@@ -297,6 +313,7 @@ def road_tile_record(
     except _TILE_ERROR_TYPES as exc:
         return {**tile, "status": "error", "error": type(exc).__name__, "message": str(exc)}
     road_features = _decoded_layer_features(decoded, ROAD_SOURCE_LAYER)
+    motorway_junction_features = _decoded_layer_features(decoded, MOTORWAY_JUNCTION_SOURCE_LAYER)
     pedestrian_polygons = [feature for feature in road_features if is_pedestrian_polygon_candidate(feature)]
     pedestrian_lines = [feature for feature in road_features if is_pedestrian_line_candidate(feature)]
     path_lines = [feature for feature in road_features if is_path_line_candidate(feature, tile_zoom=tile.get("z"))]
@@ -307,17 +324,24 @@ def road_tile_record(
     road_number_shields = [
         feature for feature in road_features if is_road_number_shield_candidate(feature, tile_zoom=tile.get("z"))
     ]
+    road_exit_shields = [
+        feature
+        for feature in motorway_junction_features
+        if is_road_exit_shield_candidate(feature, tile_zoom=tile.get("z"))
+    ]
     return {
         **tile,
         "status": "decoded",
         "byte_count": len(tile_bytes),
         "road_feature_count": len(road_features),
+        "motorway_junction_feature_count": len(motorway_junction_features),
         "pedestrian_polygon_candidate_count": len(pedestrian_polygons),
         "pedestrian_line_candidate_count": len(pedestrian_lines),
         "path_line_candidate_count": len(path_lines),
         "step_line_candidate_count": len(step_lines),
         "oneway_arrow_candidate_count": len(oneway_arrow_lines),
         "road_number_shield_candidate_count": len(road_number_shields),
+        "road_exit_shield_candidate_count": len(road_exit_shields),
         "road_geometry_type_counts": _count_geometry_types(road_features),
         "pedestrian_polygon_class_counts": _count_by_property(pedestrian_polygons, "class"),
         "pedestrian_polygon_type_counts": _count_by_property(pedestrian_polygons, "type"),
@@ -356,6 +380,11 @@ def road_tile_record(
             road_number_shields,
             ROAD_NUMBER_SHIELD_SIGNATURE_KEYS,
         ),
+        "road_exit_shield_reflen_counts": _count_by_property(road_exit_shields, "reflen"),
+        "road_exit_shield_signature_counts": _count_property_signatures(
+            road_exit_shields,
+            ROAD_EXIT_SHIELD_SIGNATURE_KEYS,
+        ),
         "sample_pedestrian_polygons": [
             _feature_sample(tile, feature) for feature in pedestrian_polygons[:MAX_SAMPLE_FEATURES]
         ],
@@ -369,6 +398,9 @@ def road_tile_record(
         ],
         "sample_road_number_shields": [
             _feature_sample(tile, feature) for feature in road_number_shields[:MAX_SAMPLE_FEATURES]
+        ],
+        "sample_road_exit_shields": [
+            _feature_sample(tile, feature) for feature in road_exit_shields[:MAX_SAMPLE_FEATURES]
         ],
     }
 
@@ -386,12 +418,14 @@ def _combined_samples(tile_records: list[dict[str, object]], sample_key: str) ->
 
 _SUMMARY_COUNT_FIELDS = (
     ("Road features", "road_feature_count"),
+    ("Motorway junction features", "motorway_junction_feature_count"),
     ("Pedestrian/path polygon candidates", "pedestrian_polygon_candidate_count"),
     ("Pedestrian line candidates", "pedestrian_line_candidate_count"),
     ("Path line candidates", "path_line_candidate_count"),
     ("Step line candidates", "step_line_candidate_count"),
     ("One-way arrow candidates", "oneway_arrow_candidate_count"),
     ("Road number shield candidates", "road_number_shield_candidate_count"),
+    ("Road exit shield candidates", "road_exit_shield_candidate_count"),
 )
 _SUMMARY_COUNT_MAP_FIELDS = (
     ("Pedestrian polygon type counts", "pedestrian_polygon_type_counts"),
@@ -421,15 +455,19 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("Road number shield structure counts", "road_number_shield_structure_counts"),
     ("Road number shield layer counts", "road_number_shield_layer_counts"),
     ("Road number shield signatures", "road_number_shield_signature_counts"),
+    ("Road exit shield reflen counts", "road_exit_shield_reflen_counts"),
+    ("Road exit shield signatures", "road_exit_shield_signature_counts"),
 )
 _ROAD_FEATURE_TABLE_FIELDS = (
     ("Road", "road_feature_count", "---:"),
+    ("Motorway junctions", "motorway_junction_feature_count", "---:"),
     ("Pedestrian/path polygons", "pedestrian_polygon_candidate_count", "---:"),
     ("Pedestrian lines", "pedestrian_line_candidate_count", "---:"),
     ("Path lines", "path_line_candidate_count", "---:"),
     ("Step lines", "step_line_candidate_count", "---:"),
     ("One-way arrows", "oneway_arrow_candidate_count", "---:"),
     ("Road number shields", "road_number_shield_candidate_count", "---:"),
+    ("Road exit shields", "road_exit_shield_candidate_count", "---:"),
     ("Polygon types", "pedestrian_polygon_type_counts", "---"),
     ("Polygon structures", "pedestrian_polygon_structure_counts", "---"),
     ("Polygon layers", "pedestrian_polygon_layer_counts", "---"),
@@ -457,6 +495,8 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Shield structures", "road_number_shield_structure_counts", "---"),
     ("Shield layers", "road_number_shield_layer_counts", "---"),
     ("Shield signatures", "road_number_shield_signature_counts", "---"),
+    ("Exit shield reflens", "road_exit_shield_reflen_counts", "---"),
+    ("Exit shield signatures", "road_exit_shield_signature_counts", "---"),
 )
 
 
@@ -573,6 +613,9 @@ def collect_road_feature_report(
         "decoded_tile_count": decoded_tile_count,
         "failed_tile_count": len(tile_records) - decoded_tile_count,
         "road_feature_count": sum(int(tile.get("road_feature_count") or 0) for tile in tile_records),
+        "motorway_junction_feature_count": sum(
+            int(tile.get("motorway_junction_feature_count") or 0) for tile in tile_records
+        ),
         "pedestrian_polygon_candidate_count": sum(
             int(tile.get("pedestrian_polygon_candidate_count") or 0) for tile in tile_records
         ),
@@ -586,6 +629,9 @@ def collect_road_feature_report(
         ),
         "road_number_shield_candidate_count": sum(
             int(tile.get("road_number_shield_candidate_count") or 0) for tile in tile_records
+        ),
+        "road_exit_shield_candidate_count": sum(
+            int(tile.get("road_exit_shield_candidate_count") or 0) for tile in tile_records
         ),
         "road_geometry_type_counts": _combined_record_counts(tile_records, "road_geometry_type_counts"),
         "pedestrian_polygon_class_counts": _combined_record_counts(
@@ -649,12 +695,21 @@ def collect_road_feature_report(
             tile_records,
             "road_number_shield_signature_counts",
         ),
+        "road_exit_shield_reflen_counts": _combined_record_counts(
+            tile_records,
+            "road_exit_shield_reflen_counts",
+        ),
+        "road_exit_shield_signature_counts": _combined_record_counts(
+            tile_records,
+            "road_exit_shield_signature_counts",
+        ),
         "sample_pedestrian_polygons": _combined_samples(tile_records, "sample_pedestrian_polygons"),
         "sample_pedestrian_lines": _combined_samples(tile_records, "sample_pedestrian_lines"),
         "sample_path_lines": _combined_samples(tile_records, "sample_path_lines"),
         "sample_step_lines": _combined_samples(tile_records, "sample_step_lines"),
         "sample_oneway_arrow_lines": _combined_samples(tile_records, "sample_oneway_arrow_lines"),
         "sample_road_number_shields": _combined_samples(tile_records, "sample_road_number_shields"),
+        "sample_road_exit_shields": _combined_samples(tile_records, "sample_road_exit_shields"),
         "tiles": tile_records,
     }
 
@@ -699,6 +754,7 @@ def collect_all_camera_road_feature_report(
         "decoded_tile_count": _sum_reports(camera_reports, "decoded_tile_count"),
         "failed_tile_count": _sum_reports(camera_reports, "failed_tile_count"),
         "road_feature_count": _sum_reports(camera_reports, "road_feature_count"),
+        "motorway_junction_feature_count": _sum_reports(camera_reports, "motorway_junction_feature_count"),
         "pedestrian_polygon_candidate_count": _sum_reports(
             camera_reports,
             "pedestrian_polygon_candidate_count",
@@ -711,6 +767,7 @@ def collect_all_camera_road_feature_report(
         "step_line_candidate_count": _sum_reports(camera_reports, "step_line_candidate_count"),
         "oneway_arrow_candidate_count": _sum_reports(camera_reports, "oneway_arrow_candidate_count"),
         "road_number_shield_candidate_count": _sum_reports(camera_reports, "road_number_shield_candidate_count"),
+        "road_exit_shield_candidate_count": _sum_reports(camera_reports, "road_exit_shield_candidate_count"),
         "road_geometry_type_counts": _combined_record_counts(camera_reports, "road_geometry_type_counts"),
         "pedestrian_polygon_class_counts": _combined_record_counts(
             camera_reports,
@@ -788,6 +845,14 @@ def collect_all_camera_road_feature_report(
             camera_reports,
             "road_number_shield_signature_counts",
         ),
+        "road_exit_shield_reflen_counts": _combined_record_counts(
+            camera_reports,
+            "road_exit_shield_reflen_counts",
+        ),
+        "road_exit_shield_signature_counts": _combined_record_counts(
+            camera_reports,
+            "road_exit_shield_signature_counts",
+        ),
         "cameras": camera_reports,
     }
 
@@ -818,6 +883,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         ("Sample step line candidates", "sample_step_lines"),
         ("Sample one-way arrow candidates", "sample_oneway_arrow_lines"),
         ("Sample road number shield candidates", "sample_road_number_shields"),
+        ("Sample road exit shield candidates", "sample_road_exit_shields"),
     )
     for heading, key in sample_sections:
         samples = report.get(key)


### PR DESCRIPTION
## Summary
- add Mapbox Outdoors motorway-junction / road-exit-shield buckets to the road-feature diagnostic
- report active exit-shield candidate counts, reflen buckets, signatures, and samples in JSON/Markdown outputs
- keep the predicate aligned with the live Mapbox road-exit-shield layer: z14+, valid positive reflen <= 9

## Evidence
- Live converter audit: debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260519T115412Z/audit.json
  - road-exit-shield still contributes 19 QGIS sprite warnings from the qfit-preprocessed layout.icon-image match expression
  - the live style layer sources motorway_junction, starts at z14, and filters reflen <= 9
- Live all-camera road-feature diagnostic: debug/mapbox-outdoors-road-features/all-cameras/20260519T123142Z/summary.md
  - 62/62 tiles decoded
  - 21 motorway-junction features and 21 active road-exit-shield candidates across the seven-camera matrix
  - candidates are concentrated in Geneva airport z14 (16) and Chamonix z14 (5)
  - active exit-shield reflen buckets are 1, 2, and 3

## Validation
- python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- git diff --check

Refs #949
