### PR TITLE
[codex] add power output line analysis

### DIFF
--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .analysis_execution_dispatch import (
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
+    POWER_OUTPUT_MODE,
     SLOPE_GRADE_MODE,
 )
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult

--- a/analysis/application/analysis_execution_dispatch.py
+++ b/analysis/application/analysis_execution_dispatch.py
@@ -1,6 +1,7 @@
 from .activity_heatmap_analysis import run_activity_heatmap_analysis
 from .analysis_result_builder import build_empty_analysis_result
 from .frequent_start_points_analysis import run_frequent_start_points_analysis
+from .power_output_analysis import POWER_OUTPUT_MODE, run_power_output_analysis
 from .slope_grade_analysis import SLOPE_GRADE_MODE, run_slope_grade_analysis
 
 FREQUENT_STARTING_POINTS_MODE = "Most frequent starting points"
@@ -19,5 +20,8 @@ def dispatch_analysis_request(request):
 
     if request.analysis_mode == SLOPE_GRADE_MODE:
         return run_slope_grade_analysis(request)
+
+    if request.analysis_mode == POWER_OUTPUT_MODE:
+        return run_power_output_analysis(request)
 
     return build_empty_analysis_result()

--- a/analysis/application/power_output_analysis.py
+++ b/analysis/application/power_output_analysis.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .analysis_models import RunAnalysisRequest, RunAnalysisResult
+from .sample_layer_helpers import (
+    has_fields,
+    is_line_layer,
+    layer_features,
+    numeric_value,
+    sample_group_key,
+    sample_value,
+    sample_xy,
+)
+
+POWER_OUTPUT_MODE = "Power output lines"
+
+
+@dataclass(frozen=True)
+class PowerOutputClass:
+    """One deterministic watts class for activity power visualization."""
+
+    key: str
+    label: str
+    color_hex: str
+    min_watts: float | None = None
+    max_watts: float | None = None
+
+
+POWER_OUTPUT_CLASSES: tuple[PowerOutputClass, ...] = (
+    PowerOutputClass(
+        key="recovery",
+        label="Recovery (< 100 W)",
+        color_hex="#2c7fb8",
+        max_watts=100.0,
+    ),
+    PowerOutputClass(
+        key="endurance",
+        label="Endurance (100 W to 180 W)",
+        color_hex="#1a9850",
+        min_watts=100.0,
+        max_watts=180.0,
+    ),
+    PowerOutputClass(
+        key="tempo",
+        label="Tempo (180 W to 260 W)",
+        color_hex="#fee08b",
+        min_watts=180.0,
+        max_watts=260.0,
+    ),
+    PowerOutputClass(
+        key="threshold",
+        label="Threshold (260 W to 340 W)",
+        color_hex="#f46d43",
+        min_watts=260.0,
+        max_watts=340.0,
+    ),
+    PowerOutputClass(
+        key="anaerobic",
+        label="Anaerobic (>= 340 W)",
+        color_hex="#d73027",
+        min_watts=340.0,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class PowerOutputLayerPlan:
+    """Eligibility plan for one line layer targeted by power analysis."""
+
+    key: str
+    label: str
+    layer: object = None
+    enabled: bool = False
+    source_fields: tuple[str, ...] = ()
+    blocked_reason: str = ""
+
+
+@dataclass(frozen=True)
+class PowerOutputSegment:
+    """Pure per-distance segment classification for power-output styling."""
+
+    start_distance_m: float
+    end_distance_m: float
+    watts: float
+    power_class: PowerOutputClass
+
+
+@dataclass(frozen=True)
+class PowerOutputLineSegment:
+    """Render-ready power-output line segment derived from adjacent samples."""
+
+    layer_key: str
+    layer_label: str
+    source: object
+    source_id: object
+    start_xy: tuple[float, float]
+    end_xy: tuple[float, float]
+    start_distance_m: float
+    end_distance_m: float
+    watts: float
+    power_class: PowerOutputClass
+
+
+@dataclass(frozen=True)
+class PowerOutputAnalysisPlan:
+    """Render-neutral plan for activity power-output line analysis."""
+
+    layers: tuple[PowerOutputLayerPlan, ...]
+    power_classes: tuple[PowerOutputClass, ...] = POWER_OUTPUT_CLASSES
+
+    @property
+    def enabled_layers(self) -> tuple[PowerOutputLayerPlan, ...]:
+        return tuple(layer for layer in self.layers if layer.enabled)
+
+
+@dataclass(frozen=True)
+class PowerOutputLayerResult:
+    """Classified segment result for one power-output target layer."""
+
+    key: str
+    label: str
+    segments: tuple[PowerOutputSegment, ...] = ()
+
+    @property
+    def segment_count(self) -> int:
+        return len(self.segments)
+
+
+@dataclass(frozen=True)
+class PowerOutputAnalysisResult:
+    """Render-neutral power-output result for eligible line layers."""
+
+    plan: PowerOutputAnalysisPlan
+    layers: tuple[PowerOutputLayerResult, ...] = ()
+
+    @property
+    def segment_count(self) -> int:
+        return sum(layer.segment_count for layer in self.layers)
+
+
+POWER_OUTPUT_LEGEND = tuple(
+    power_class.label for power_class in POWER_OUTPUT_CLASSES
+)
+
+ACTIVITY_TRACKS_LABEL = "activity tracks"
+_ACTIVITY_POINT_POWER_FIELDS = ("watts", "stream_distance_m")
+_IGNORED_ROUTE_LAYER_KWARGS = frozenset(
+    ("route_tracks_layer", "route_points_layer", "route_profile_samples_layer")
+)
+
+
+def build_power_output_analysis_plan(
+    *,
+    activities_layer=None,
+    points_layer=None,
+    **route_layers,
+) -> PowerOutputAnalysisPlan:
+    """Build a pure eligibility plan for power-output line styling."""
+
+    _ignore_route_layer_kwargs(route_layers)
+    return PowerOutputAnalysisPlan(
+        layers=(_activity_track_plan(activities_layer, points_layer),)
+    )
+
+
+def run_power_output_analysis(
+    request: RunAnalysisRequest,
+) -> RunAnalysisResult:
+    """Return clear feedback for power-output line-analysis execution."""
+
+    result = build_power_output_analysis_result(
+        activities_layer=request.activities_layer,
+        points_layer=request.points_layer,
+    )
+    layer, _line_segments = _build_power_output_layer(request)
+    return RunAnalysisResult(
+        status=build_power_output_status(result),
+        layer=layer,
+    )
+
+
+def _build_power_output_layer(request: RunAnalysisRequest):
+    try:
+        from ..infrastructure.power_output_layer import (
+            build_power_output_layer,
+        )
+    except ImportError:
+        return None, ()
+
+    return build_power_output_layer(
+        activities_layer=request.activities_layer,
+        points_layer=request.points_layer,
+    )
+
+
+def build_power_output_analysis_result(
+    *,
+    activities_layer=None,
+    points_layer=None,
+    **route_layers,
+) -> PowerOutputAnalysisResult:
+    """Classify activity power-output segments."""
+
+    _ignore_route_layer_kwargs(route_layers)
+    plan = build_power_output_analysis_plan(
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+    )
+    layer_results = []
+    for layer_plan in plan.enabled_layers:
+        if layer_plan.key == "activity_tracks":
+            segments = build_activity_power_output_segments(points_layer)
+        else:
+            raise ValueError(
+                "Unsupported power-output layer key: {key}".format(
+                    key=layer_plan.key
+                )
+            )
+        layer_results.append(
+            PowerOutputLayerResult(
+                key=layer_plan.key,
+                label=layer_plan.label,
+                segments=segments,
+            )
+        )
+    return PowerOutputAnalysisResult(plan=plan, layers=tuple(layer_results))
+
+
+def build_power_output_status(result_or_plan) -> str:
+    """Summarize which line layers can be styled by power-output analysis."""
+
+    if isinstance(result_or_plan, PowerOutputAnalysisResult):
+        return _build_power_output_result_status(result_or_plan)
+
+    plan = result_or_plan
+    enabled = plan.enabled_layers
+    if enabled:
+        labels = ", ".join(layer.label for layer in enabled)
+        return f"Power output line analysis ready for {labels}."
+
+    reasons = tuple(
+        layer.blocked_reason
+        for layer in plan.layers
+        if layer.blocked_reason
+    )
+    if reasons:
+        return "Power output line analysis unchanged: " + "; ".join(reasons)
+    return (
+        "Power output line analysis unchanged: no eligible line layers found."
+    )
+
+
+def _build_power_output_result_status(
+    result: PowerOutputAnalysisResult,
+) -> str:
+    if result.layers and result.segment_count > 0:
+        classified_layers = tuple(
+            layer for layer in result.layers if layer.segment_count > 0
+        )
+        summaries = ", ".join(
+            "{label} ({count} {segment_word})".format(
+                label=layer.label,
+                count=layer.segment_count,
+                segment_word=(
+                    "segment" if layer.segment_count == 1 else "segments"
+                ),
+            )
+            for layer in classified_layers
+        )
+        return f"Power output line analysis classified {summaries}."
+
+    if result.plan.enabled_layers:
+        labels = ", ".join(layer.label for layer in result.plan.enabled_layers)
+        return (
+            "Power output line analysis found eligible {labels}, but no power "
+            "segments could be classified."
+        ).format(labels=labels)
+
+    return build_power_output_status(result.plan)
+
+
+def power_output_class_for_watts(watts: float) -> PowerOutputClass:
+    """Return the deterministic legend class for a watts value."""
+
+    for power_class in POWER_OUTPUT_CLASSES:
+        if _power_class_contains(power_class, watts):
+            return power_class
+    return POWER_OUTPUT_CLASSES[-1]
+
+
+def build_power_output_segments(
+    samples,
+    *,
+    distance_field: str = "stream_distance_m",
+    watts_field: str = "watts",
+) -> tuple[PowerOutputSegment, ...]:
+    """Build deterministic power-output segments from ordered sample rows."""
+
+    normalized = tuple(
+        _normalize_power_output_sample(sample, distance_field, watts_field)
+        for sample in samples
+    )
+    segments: list[PowerOutputSegment] = []
+    previous = None
+    for current in normalized:
+        if current is None:
+            continue
+        if previous is None:
+            previous = current
+            continue
+        start_distance, _start_watts = previous
+        end_distance, watts = current
+        if end_distance - start_distance <= 0:
+            continue
+        segments.append(
+            PowerOutputSegment(
+                start_distance_m=start_distance,
+                end_distance_m=end_distance,
+                watts=watts,
+                power_class=power_output_class_for_watts(watts),
+            )
+        )
+        previous = current
+    return tuple(segments)
+
+
+def build_activity_power_output_segments(
+    points_layer,
+) -> tuple[PowerOutputSegment, ...]:
+    """Build activity power-output segments from a point-sample layer."""
+
+    groups = _group_activity_samples(points_layer)
+    segments: list[PowerOutputSegment] = []
+    for group_samples in groups.values():
+        segments.extend(build_power_output_segments(group_samples))
+    return tuple(segments)
+
+
+def build_activity_power_output_line_segments(
+    points_layer,
+) -> tuple[PowerOutputLineSegment, ...]:
+    """Build render-ready activity line segments from point samples."""
+
+    groups = _group_activity_samples(points_layer)
+    line_segments: list[PowerOutputLineSegment] = []
+    for group_samples in groups.values():
+        line_segments.extend(_build_power_output_line_segments(group_samples))
+    return tuple(line_segments)
+
+
+def _build_power_output_line_segments(
+    samples,
+) -> tuple[PowerOutputLineSegment, ...]:
+    normalized = tuple(
+        _normalize_power_output_line_sample(sample)
+        for sample in samples
+    )
+    line_segments: list[PowerOutputLineSegment] = []
+    previous = None
+    for sample, current in zip(samples, normalized):
+        if current is None:
+            continue
+        if previous is None:
+            previous = current
+            continue
+
+        start_distance, _start_watts, start_xy = previous
+        end_distance, watts, end_xy = current
+        if end_distance - start_distance <= 0:
+            continue
+
+        line_segments.append(
+            PowerOutputLineSegment(
+                layer_key="activity_tracks",
+                layer_label=ACTIVITY_TRACKS_LABEL,
+                source=sample_value(sample, "source"),
+                source_id=sample_value(
+                    sample,
+                    "source_activity_id",
+                ),
+                start_xy=start_xy,
+                end_xy=end_xy,
+                start_distance_m=start_distance,
+                end_distance_m=end_distance,
+                watts=watts,
+                power_class=power_output_class_for_watts(watts),
+            )
+        )
+        previous = current
+    return tuple(line_segments)
+
+
+def _group_activity_samples(
+    points_layer,
+) -> dict[tuple[object, ...], list[object]]:
+    groups: dict[tuple[object, ...], list[object]] = {}
+    for sample in layer_features(points_layer):
+        key = sample_group_key(
+            sample,
+            (("source", "source_activity_id"),),
+        )
+        groups.setdefault(key, []).append(sample)
+    return groups
+
+
+def _normalize_power_output_sample(sample, distance_field, watts_field):
+    distance = numeric_value(sample_value(sample, distance_field))
+    watts = numeric_value(sample_value(sample, watts_field))
+    if distance is None or watts is None or watts < 0:
+        return None
+    return distance, watts
+
+
+def _normalize_power_output_line_sample(sample):
+    normalized = _normalize_power_output_sample(
+        sample,
+        "stream_distance_m",
+        "watts",
+    )
+    if normalized is None:
+        return None
+    xy = sample_xy(sample)
+    if xy is None:
+        return None
+    distance, watts = normalized
+    return distance, watts, xy
+
+
+def _power_class_contains(power_class: PowerOutputClass, watts: float) -> bool:
+    if power_class.min_watts is not None and watts < power_class.min_watts:
+        return False
+    if power_class.max_watts is not None and watts >= power_class.max_watts:
+        return False
+    return True
+
+
+def _activity_track_plan(
+    activities_layer,
+    points_layer,
+) -> PowerOutputLayerPlan:
+    if activities_layer is None:
+        return PowerOutputLayerPlan(
+            key="activity_tracks",
+            label=ACTIVITY_TRACKS_LABEL,
+            blocked_reason="activity track lines are not loaded",
+        )
+    if not is_line_layer(activities_layer):
+        return PowerOutputLayerPlan(
+            key="activity_tracks",
+            label=ACTIVITY_TRACKS_LABEL,
+            layer=activities_layer,
+            blocked_reason="activity track target is not a line layer",
+        )
+    has_power_fields = has_fields(
+        points_layer,
+        _ACTIVITY_POINT_POWER_FIELDS,
+    )
+    if not has_power_fields:
+        return PowerOutputLayerPlan(
+            key="activity_tracks",
+            label=ACTIVITY_TRACKS_LABEL,
+            layer=activities_layer,
+            blocked_reason=(
+                "activity tracks need point samples with watts and "
+                "stream_distance_m"
+            ),
+        )
+    return PowerOutputLayerPlan(
+        key="activity_tracks",
+        label=ACTIVITY_TRACKS_LABEL,
+        layer=activities_layer,
+        enabled=True,
+        source_fields=_ACTIVITY_POINT_POWER_FIELDS,
+    )
+
+
+def _ignore_route_layer_kwargs(route_layers):
+    unexpected = set(route_layers) - _IGNORED_ROUTE_LAYER_KWARGS
+    if unexpected:
+        unexpected_names = ", ".join(sorted(unexpected))
+        raise TypeError(
+            f"Unexpected power-output layer kwargs: {unexpected_names}"
+        )
+
+
+__all__ = [
+    "POWER_OUTPUT_CLASSES",
+    "POWER_OUTPUT_LEGEND",
+    "POWER_OUTPUT_MODE",
+    "PowerOutputAnalysisPlan",
+    "PowerOutputAnalysisResult",
+    "PowerOutputClass",
+    "PowerOutputLayerPlan",
+    "PowerOutputLayerResult",
+    "PowerOutputLineSegment",
+    "PowerOutputSegment",
+    "build_activity_power_output_line_segments",
+    "build_activity_power_output_segments",
+    "build_power_output_analysis_result",
+    "build_power_output_analysis_plan",
+    "build_power_output_segments",
+    "build_power_output_status",
+    "power_output_class_for_watts",
+    "run_power_output_analysis",
+]

--- a/analysis/application/sample_layer_helpers.py
+++ b/analysis/application/sample_layer_helpers.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+_LINE_GEOMETRY_TYPE = 1
+_LINE_WKB_TYPES = frozenset((2, 5))
+
+
+def layer_features(layer):
+    if layer is None:
+        return ()
+    features = getattr(layer, "getFeatures", None)
+    if not callable(features):
+        return ()
+    return features()
+
+
+def sample_group_key(sample, group_field_sets):
+    for group_fields in group_field_sets:
+        values = tuple(sample_value(sample, field_name) for field_name in group_fields)
+        if any(value not in (None, "") for value in values):
+            return values
+    return (None,)
+
+
+def sample_value(sample, field_name):
+    if isinstance(sample, dict):
+        return sample.get(field_name)
+    try:
+        return sample[field_name]
+    except (KeyError, IndexError, TypeError, AttributeError):
+        pass
+    value = getattr(sample, field_name, None)
+    if callable(value):
+        return value()
+    return value
+
+
+def numeric_value(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def sample_xy(sample):
+    geometry = _sample_geometry(sample)
+    if geometry is not None and not _is_empty_geometry(geometry):
+        point = _geometry_point(geometry)
+        xy = _point_xy(point)
+        if xy is not None:
+            return xy
+
+    lon = numeric_value(sample_value(sample, "lon"))
+    lat = numeric_value(sample_value(sample, "lat"))
+    if lon is None or lat is None:
+        return None
+    return lon, lat
+
+
+def is_line_layer(layer) -> bool:
+    geometry_type = _call_if_present(layer, "geometryType")
+    if _looks_like_line_geometry_type(geometry_type):
+        return True
+    wkb_type = _call_if_present(layer, "wkbType")
+    return _looks_like_line_wkb_type(wkb_type)
+
+
+def has_fields(layer, expected: Iterable[str]) -> bool:
+    field_names = _field_names(layer)
+    return all(field_name in field_names for field_name in expected)
+
+
+def _sample_geometry(sample):
+    geometry = getattr(sample, "geometry", None)
+    if callable(geometry):
+        return geometry()
+    return geometry
+
+
+def _is_empty_geometry(geometry) -> bool:
+    is_empty = getattr(geometry, "isEmpty", None)
+    return bool(is_empty()) if callable(is_empty) else False
+
+
+def _geometry_point(geometry):
+    as_point = getattr(geometry, "asPoint", None)
+    if callable(as_point):
+        return as_point()
+    return geometry
+
+
+def _point_xy(point):
+    if point is None:
+        return None
+    x_value = _coordinate_value(point, "x")
+    y_value = _coordinate_value(point, "y")
+    if x_value is None or y_value is None:
+        return None
+    return x_value, y_value
+
+
+def _coordinate_value(point, attr):
+    value = getattr(point, attr, None)
+    if callable(value):
+        value = value()
+    return numeric_value(value)
+
+
+def _field_names(layer) -> frozenset[str]:
+    if layer is None:
+        return frozenset()
+    fields = layer.fields() if callable(getattr(layer, "fields", None)) else ()
+    names: list[str] = []
+    for field in fields or ():
+        name = field.name() if callable(getattr(field, "name", None)) else field
+        if name:
+            names.append(str(name))
+    return frozenset(names)
+
+
+def _call_if_present(obj, attr: str):
+    method = getattr(obj, attr, None)
+    if callable(method):
+        return method()
+    return None
+
+
+def _looks_like_line_geometry_type(value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        lowered = value.lower()
+        return "line" in lowered and "polygon" not in lowered
+    # QgsWkbTypes.LineGeometry is 1 in QGIS, but keep this module QGIS-free.
+    return value == _LINE_GEOMETRY_TYPE
+
+
+def _looks_like_line_wkb_type(value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        lowered = value.lower()
+        return "line" in lowered and "polygon" not in lowered
+    # Common QgsWkbTypes values: LineString=2 and MultiLineString=5.
+    return value in _LINE_WKB_TYPES
+
+
+__all__ = [
+    "has_fields",
+    "is_line_layer",
+    "layer_features",
+    "numeric_value",
+    "sample_group_key",
+    "sample_value",
+    "sample_xy",
+]

--- a/analysis/application/slope_grade_analysis.py
+++ b/analysis/application/slope_grade_analysis.py
@@ -4,6 +4,15 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from .analysis_models import RunAnalysisRequest, RunAnalysisResult
+from .sample_layer_helpers import (
+    has_fields,
+    is_line_layer,
+    layer_features,
+    numeric_value,
+    sample_group_key,
+    sample_value,
+    sample_xy,
+)
 
 SLOPE_GRADE_MODE = "Slope grade lines"
 
@@ -145,8 +154,6 @@ _ACTIVITY_POINT_GRADE_FIELDS = ("grade_smooth_pct", "stream_distance_m")
 _IGNORED_ROUTE_LAYER_KWARGS = frozenset(
     ("route_tracks_layer", "route_points_layer", "route_profile_samples_layer")
 )
-_LINE_GEOMETRY_TYPE = 1
-_LINE_WKB_TYPES = frozenset((2, 5))
 
 
 def build_slope_grade_analysis_plan(
@@ -356,7 +363,7 @@ def build_activity_slope_grade_segments(points_layer) -> tuple[SlopeGradeSegment
     """Build activity slope-grade segments from a point-sample layer."""
 
     return _build_grouped_slope_grade_segments(
-        _layer_features(points_layer),
+        layer_features(points_layer),
         group_field_sets=(("source", "source_activity_id"),),
         distance_field="stream_distance_m",
         elevation_field=None,
@@ -370,7 +377,7 @@ def build_activity_slope_grade_line_segments(
     """Build render-ready activity line segments from point samples."""
 
     return _build_grouped_slope_grade_line_segments(
-        _layer_features(points_layer),
+        layer_features(points_layer),
         layer_key="activity_tracks",
         layer_label=ACTIVITY_TRACKS_LABEL,
         group_field_sets=(("source", "source_activity_id"),),
@@ -392,7 +399,7 @@ def _build_grouped_slope_grade_segments(
 ):
     groups: dict[tuple[object, ...], list[object]] = {}
     for sample in samples:
-        key = _sample_group_key(sample, group_field_sets)
+        key = sample_group_key(sample, group_field_sets)
         groups.setdefault(key, []).append(sample)
 
     segments: list[SlopeGradeSegment] = []
@@ -422,7 +429,7 @@ def _build_grouped_slope_grade_line_segments(
 ):
     groups: dict[tuple[object, ...], list[object]] = {}
     for sample in samples:
-        key = _sample_group_key(sample, group_field_sets)
+        key = sample_group_key(sample, group_field_sets)
         groups.setdefault(key, []).append(sample)
 
     line_segments: list[SlopeGradeLineSegment] = []
@@ -492,8 +499,8 @@ def _build_slope_grade_line_segments(
             SlopeGradeLineSegment(
                 layer_key=layer_key,
                 layer_label=layer_label,
-                source=_sample_value(sample, source_field),
-                source_id=_sample_value(sample, source_id_field),
+                source=sample_value(sample, source_field),
+                source_id=sample_value(sample, source_id_field),
                 start_xy=start_xy,
                 end_xy=end_xy,
                 start_distance_m=start_distance,
@@ -521,15 +528,15 @@ def _grade_class_contains(grade_class: SlopeGradeClass, grade_percent: float) ->
 
 
 def _normalize_slope_grade_sample(sample, distance_field, elevation_field, grade_field):
-    distance = _numeric_value(_sample_value(sample, distance_field))
+    distance = numeric_value(sample_value(sample, distance_field))
     if distance is None:
         return None
     elevation = None
     if elevation_field:
-        elevation = _numeric_value(_sample_value(sample, elevation_field))
+        elevation = numeric_value(sample_value(sample, elevation_field))
     grade = None
     if grade_field:
-        grade = _numeric_value(_sample_value(sample, grade_field))
+        grade = numeric_value(sample_value(sample, grade_field))
     return distance, elevation, grade
 
 
@@ -547,101 +554,11 @@ def _normalize_slope_grade_line_sample(
     )
     if normalized is None:
         return None
-    xy = _sample_xy(sample)
+    xy = sample_xy(sample)
     if xy is None:
         return None
     distance, elevation, grade = normalized
     return distance, elevation, grade, xy
-
-
-def _sample_xy(sample):
-    geometry = _sample_geometry(sample)
-    if geometry is not None and not _is_empty_geometry(geometry):
-        point = _geometry_point(geometry)
-        xy = _point_xy(point)
-        if xy is not None:
-            return xy
-
-    lon = _numeric_value(_sample_value(sample, "lon"))
-    lat = _numeric_value(_sample_value(sample, "lat"))
-    if lon is None or lat is None:
-        return None
-    return lon, lat
-
-
-def _sample_geometry(sample):
-    geometry = getattr(sample, "geometry", None)
-    if callable(geometry):
-        return geometry()
-    return geometry
-
-
-def _is_empty_geometry(geometry) -> bool:
-    is_empty = getattr(geometry, "isEmpty", None)
-    return bool(is_empty()) if callable(is_empty) else False
-
-
-def _geometry_point(geometry):
-    as_point = getattr(geometry, "asPoint", None)
-    if callable(as_point):
-        return as_point()
-    return geometry
-
-
-def _point_xy(point):
-    if point is None:
-        return None
-    x_value = _coordinate_value(point, "x")
-    y_value = _coordinate_value(point, "y")
-    if x_value is None or y_value is None:
-        return None
-    return x_value, y_value
-
-
-def _coordinate_value(point, attr):
-    value = getattr(point, attr, None)
-    if callable(value):
-        value = value()
-    return _numeric_value(value)
-
-
-def _layer_features(layer):
-    if layer is None:
-        return ()
-    features = getattr(layer, "getFeatures", None)
-    if not callable(features):
-        return ()
-    return features()
-
-
-def _sample_group_key(sample, group_field_sets):
-    for group_fields in group_field_sets:
-        values = tuple(_sample_value(sample, field_name) for field_name in group_fields)
-        if any(value not in (None, "") for value in values):
-            return values
-    return (None,)
-
-
-def _sample_value(sample, field_name):
-    if isinstance(sample, dict):
-        return sample.get(field_name)
-    try:
-        return sample[field_name]
-    except (KeyError, IndexError, TypeError, AttributeError):
-        pass
-    value = getattr(sample, field_name, None)
-    if callable(value):
-        return value()
-    return value
-
-
-def _numeric_value(value):
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def _activity_track_plan(activities_layer, points_layer) -> SlopeGradeLayerPlan:
@@ -651,14 +568,14 @@ def _activity_track_plan(activities_layer, points_layer) -> SlopeGradeLayerPlan:
             label=ACTIVITY_TRACKS_LABEL,
             blocked_reason="activity track lines are not loaded",
         )
-    if not _is_line_layer(activities_layer):
+    if not is_line_layer(activities_layer):
         return SlopeGradeLayerPlan(
             key="activity_tracks",
             label=ACTIVITY_TRACKS_LABEL,
             layer=activities_layer,
             blocked_reason="activity track target is not a line layer",
         )
-    if not _has_fields(points_layer, _ACTIVITY_POINT_GRADE_FIELDS):
+    if not has_fields(points_layer, _ACTIVITY_POINT_GRADE_FIELDS):
         return SlopeGradeLayerPlan(
             key="activity_tracks",
             label=ACTIVITY_TRACKS_LABEL,
@@ -675,57 +592,6 @@ def _activity_track_plan(activities_layer, points_layer) -> SlopeGradeLayerPlan:
         enabled=True,
         source_fields=_ACTIVITY_POINT_GRADE_FIELDS,
     )
-
-def _has_fields(layer, expected: Iterable[str]) -> bool:
-    field_names = _field_names(layer)
-    return all(field_name in field_names for field_name in expected)
-
-
-def _field_names(layer) -> frozenset[str]:
-    if layer is None:
-        return frozenset()
-    fields = layer.fields() if callable(getattr(layer, "fields", None)) else ()
-    names: list[str] = []
-    for field in fields or ():
-        name = field.name() if callable(getattr(field, "name", None)) else field
-        if name:
-            names.append(str(name))
-    return frozenset(names)
-
-
-def _is_line_layer(layer) -> bool:
-    geometry_type = _call_if_present(layer, "geometryType")
-    if _looks_like_line_geometry_type(geometry_type):
-        return True
-    wkb_type = _call_if_present(layer, "wkbType")
-    return _looks_like_line_wkb_type(wkb_type)
-
-
-def _call_if_present(obj, attr: str):
-    method = getattr(obj, attr, None)
-    if callable(method):
-        return method()
-    return None
-
-
-def _looks_like_line_geometry_type(value) -> bool:
-    if value is None:
-        return False
-    if isinstance(value, str):
-        lowered = value.lower()
-        return "line" in lowered and "polygon" not in lowered
-    # QgsWkbTypes.LineGeometry is 1 in QGIS, but keep this module QGIS-free.
-    return value == _LINE_GEOMETRY_TYPE
-
-
-def _looks_like_line_wkb_type(value) -> bool:
-    if value is None:
-        return False
-    if isinstance(value, str):
-        lowered = value.lower()
-        return "line" in lowered and "polygon" not in lowered
-    # Common QgsWkbTypes values: LineString=2 and MultiLineString=5.
-    return value in _LINE_WKB_TYPES
 
 
 __all__ = [

--- a/analysis/infrastructure/power_output_layer.py
+++ b/analysis/infrastructure/power_output_layer.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtGui import QColor
+from qgis.core import (
+    QgsCategorizedSymbolRenderer,
+    QgsFeature,
+    QgsField,
+    QgsGeometry,
+    QgsLineSymbol,
+    QgsPointXY,
+    QgsRendererCategory,
+    QgsSimpleLineSymbolLayer,
+    QgsVectorLayer,
+)
+
+from ..application.power_output_analysis import (
+    POWER_OUTPUT_CLASSES,
+    build_activity_power_output_line_segments,
+    build_power_output_analysis_plan,
+)
+
+POWER_OUTPUT_LAYER_NAME = "qfit power output lines"
+
+
+def build_power_output_layer(
+    *,
+    activities_layer=None,
+    points_layer=None,
+    **route_layers,
+):
+    """Create a styled memory line layer for activity power-output segments."""
+
+    plan = build_power_output_analysis_plan(
+        activities_layer=activities_layer,
+        points_layer=points_layer,
+        **route_layers,
+    )
+    line_segments = []
+    if _plan_enables_layer(plan, "activity_tracks"):
+        line_segments.extend(
+            build_activity_power_output_line_segments(points_layer)
+        )
+
+    if not line_segments:
+        return None, ()
+
+    layer = _build_memory_layer(points_layer)
+    provider = layer.dataProvider()
+    provider.addAttributes(
+        [
+            QgsField("layer_key", QVariant.String),
+            QgsField("layer_label", QVariant.String),
+            QgsField("source", QVariant.String),
+            QgsField("source_id", QVariant.String),
+            QgsField("power_class", QVariant.String),
+            QgsField("power_label", QVariant.String),
+            QgsField("watts", QVariant.Double),
+            QgsField("start_distance_m", QVariant.Double),
+            QgsField("end_distance_m", QVariant.Double),
+        ]
+    )
+    layer.updateFields()
+
+    provider.addFeatures(_features_for_segments(layer, line_segments))
+    layer.updateExtents()
+    _apply_power_output_style(layer)
+    return layer, tuple(line_segments)
+
+
+def _plan_enables_layer(plan, layer_key):
+    return any(layer.key == layer_key for layer in plan.enabled_layers)
+
+
+def _build_memory_layer(source_layer):
+    crs = _layer_crs(source_layer)
+    authid = crs.authid() if crs is not None and crs.isValid() else "EPSG:4326"
+    return QgsVectorLayer(
+        f"LineString?crs={authid}",
+        POWER_OUTPUT_LAYER_NAME,
+        "memory",
+    )
+
+
+def _layer_crs(layer):
+    crs = getattr(layer, "crs", None)
+    return crs() if callable(crs) else None
+
+
+def _features_for_segments(layer, line_segments):
+    features = []
+    for line_segment in line_segments:
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(
+            QgsGeometry.fromPolylineXY(
+                [
+                    QgsPointXY(*line_segment.start_xy),
+                    QgsPointXY(*line_segment.end_xy),
+                ]
+            )
+        )
+        feature["layer_key"] = line_segment.layer_key
+        feature["layer_label"] = line_segment.layer_label
+        feature["source"] = _string_or_empty(line_segment.source)
+        feature["source_id"] = _string_or_empty(line_segment.source_id)
+        feature["power_class"] = line_segment.power_class.key
+        feature["power_label"] = line_segment.power_class.label
+        feature["watts"] = line_segment.watts
+        feature["start_distance_m"] = line_segment.start_distance_m
+        feature["end_distance_m"] = line_segment.end_distance_m
+        features.append(feature)
+    return features
+
+
+def _string_or_empty(value):
+    return "" if value is None else str(value)
+
+
+def _apply_power_output_style(layer):
+    categories = []
+    for power_class in POWER_OUTPUT_CLASSES:
+        symbol = _build_power_output_symbol(power_class.color_hex)
+        categories.append(
+            QgsRendererCategory(power_class.key, symbol, power_class.label)
+        )
+    layer.setRenderer(QgsCategorizedSymbolRenderer("power_class", categories))
+    layer.setOpacity(0.95)
+    layer.triggerRepaint()
+
+
+def _build_power_output_symbol(color_hex):
+    symbol = QgsLineSymbol()
+    symbol.deleteSymbolLayer(0)
+    line_layer = QgsSimpleLineSymbolLayer()
+    line_layer.setColor(QColor(color_hex))
+    line_layer.setWidth(0.9)
+    symbol.appendSymbolLayer(line_layer)
+    return symbol
+
+
+__all__ = [
+    "POWER_OUTPUT_LAYER_NAME",
+    "build_power_output_layer",
+]

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -49,6 +49,7 @@ from .analysis.application.analysis_request_builder import (
 from .analysis.infrastructure.frequent_start_points_layer import (
     FREQUENT_STARTING_POINTS_LAYER_NAME,
 )
+from .analysis.infrastructure.power_output_layer import POWER_OUTPUT_LAYER_NAME
 from .analysis.infrastructure.slope_grade_layer import SLOPE_GRADE_LAYER_NAME
 from .atlas.export_service import (
     AtlasExportResult,
@@ -1174,6 +1175,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         analysis_layer_names = {
             FREQUENT_STARTING_POINTS_LAYER_NAME,
             ACTIVITY_HEATMAP_LAYER_NAME,
+            POWER_OUTPUT_LAYER_NAME,
             SLOPE_GRADE_LAYER_NAME,
         }
         for layer in tuple(project.mapLayers().values()):

--- a/tests/test_analysis_execution_dispatch.py
+++ b/tests/test_analysis_execution_dispatch.py
@@ -5,6 +5,7 @@ from tests import _path  # noqa: F401
 from qfit.analysis.application.analysis_controller import (
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
+    POWER_OUTPUT_MODE,
     SLOPE_GRADE_MODE,
 )
 from qfit.analysis.application.analysis_models import RunAnalysisRequest
@@ -57,6 +58,22 @@ class TestAnalysisExecutionDispatch(unittest.TestCase):
 
         with patch(
             "qfit.analysis.application.analysis_execution_dispatch.run_slope_grade_analysis",
+            return_value="result",
+        ) as run_analysis:
+            result = dispatch_analysis_request(request)
+
+        self.assertEqual(result, "result")
+        run_analysis.assert_called_once_with(request)
+
+    def test_dispatch_analysis_request_routes_power_output_mode(self):
+        request = RunAnalysisRequest(
+            analysis_mode=POWER_OUTPUT_MODE,
+            activities_layer="activities-layer",
+            points_layer="points-layer",
+        )
+
+        with patch(
+            "qfit.analysis.application.analysis_execution_dispatch.run_power_output_analysis",
             return_value="result",
         ) as run_analysis:
             result = dispatch_analysis_request(request)

--- a/tests/test_analysis_page.py
+++ b/tests/test_analysis_page.py
@@ -70,7 +70,12 @@ class AnalysisPageContentTest(unittest.TestCase):
         )
         self.assertEqual(
             content.analysis_mode_combo.items,
-            ["Heatmap", "Most frequent starting points", "Slope grade lines"],
+            [
+                "Heatmap",
+                "Most frequent starting points",
+                "Slope grade lines",
+                "Power output lines",
+            ],
         )
         self.assertEqual(content.current_analysis_mode(), "Heatmap")
         self.assertEqual(

--- a/tests/test_local_first_analysis_controls.py
+++ b/tests/test_local_first_analysis_controls.py
@@ -183,12 +183,18 @@ class LocalFirstAnalysisControlsTests(unittest.TestCase):
             "Most frequent starting points",
             "Heatmap",
             "Slope grade lines",
+            "Power output lines",
         ):
             combo.addItem(mode)
 
         self.assertEqual(
             local_first_analysis_mode_options(combo),
-            ("Most frequent starting points", "Heatmap", "Slope grade lines"),
+            (
+                "Most frequent starting points",
+                "Heatmap",
+                "Slope grade lines",
+                "Power output lines",
+            ),
         )
 
     def test_bind_exposes_user_facing_modes_and_selects_first_real_mode(self):
@@ -198,6 +204,7 @@ class LocalFirstAnalysisControlsTests(unittest.TestCase):
             "Most frequent starting points",
             "Heatmap",
             "Slope grade lines",
+            "Power output lines",
         ):
             combo.addItem(mode)
         dock = SimpleNamespace(analysisModeComboBox=combo)
@@ -209,7 +216,12 @@ class LocalFirstAnalysisControlsTests(unittest.TestCase):
         )
 
         analysis_content.set_analysis_mode_options.assert_called_once_with(
-            ("Most frequent starting points", "Heatmap", "Slope grade lines"),
+            (
+                "Most frequent starting points",
+                "Heatmap",
+                "Slope grade lines",
+                "Power output lines",
+            ),
             selected="Most frequent starting points",
         )
         self.assertEqual(combo.currentText(), "Most frequent starting points")
@@ -221,6 +233,7 @@ class LocalFirstAnalysisControlsTests(unittest.TestCase):
             "Most frequent starting points",
             "Heatmap",
             "Slope grade lines",
+            "Power output lines",
         ):
             combo.addItem(mode)
         dock = SimpleNamespace(analysisModeComboBox=combo)
@@ -232,7 +245,12 @@ class LocalFirstAnalysisControlsTests(unittest.TestCase):
         )
 
         analysis_content.set_analysis_mode_options.assert_called_once_with(
-            ("Most frequent starting points", "Heatmap", "Slope grade lines"),
+            (
+                "Most frequent starting points",
+                "Heatmap",
+                "Slope grade lines",
+                "Power output lines",
+            ),
             selected="Most frequent starting points",
         )
         self.assertEqual(combo.currentText(), "Most frequent starting points")

--- a/tests/test_power_output_analysis.py
+++ b/tests/test_power_output_analysis.py
@@ -1,0 +1,434 @@
+import unittest
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+from qfit.analysis.application.analysis_models import RunAnalysisRequest
+from qfit.analysis.application.power_output_analysis import (
+    POWER_OUTPUT_CLASSES,
+    POWER_OUTPUT_LEGEND,
+    POWER_OUTPUT_MODE,
+    PowerOutputAnalysisPlan,
+    PowerOutputLayerPlan,
+    build_activity_power_output_line_segments,
+    build_activity_power_output_segments,
+    build_power_output_analysis_result,
+    build_power_output_analysis_plan,
+    build_power_output_segments,
+    build_power_output_status,
+    power_output_class_for_watts,
+    run_power_output_analysis,
+)
+
+
+class _Field:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _Layer:
+    def __init__(self, *, geometry="LineString", fields=()):
+        self._geometry = geometry
+        self._fields = tuple(_Field(name) for name in fields)
+
+    def geometryType(self):
+        return self._geometry
+
+    def fields(self):
+        return self._fields
+
+
+class _FeatureSample:
+    def __init__(self, values, *, geometry=None):
+        self._values = values
+        self._geometry = geometry
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def geometry(self):
+        return self._geometry
+
+
+class _Point:
+    def __init__(self, x, y):
+        self._x = x
+        self._y = y
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+
+class _Geometry:
+    def __init__(self, x, y):
+        self._point = _Point(x, y)
+
+    def isEmpty(self):
+        return False
+
+    def asPoint(self):
+        return self._point
+
+
+class _FeatureLayer:
+    def __init__(self, features, *, fields=()):
+        self._features = tuple(features)
+        self._fields = tuple(_Field(name) for name in fields)
+
+    def getFeatures(self):
+        return iter(self._features)
+
+    def fields(self):
+        return self._fields
+
+
+class PowerOutputAnalysisTests(unittest.TestCase):
+    def test_legend_uses_documented_deterministic_watts_classes(self):
+        self.assertEqual(POWER_OUTPUT_MODE, "Power output lines")
+        self.assertEqual(
+            POWER_OUTPUT_LEGEND,
+            (
+                "Recovery (< 100 W)",
+                "Endurance (100 W to 180 W)",
+                "Tempo (180 W to 260 W)",
+                "Threshold (260 W to 340 W)",
+                "Anaerobic (>= 340 W)",
+            ),
+        )
+        self.assertEqual(
+            [power_class.color_hex for power_class in POWER_OUTPUT_CLASSES],
+            ["#2c7fb8", "#1a9850", "#fee08b", "#f46d43", "#d73027"],
+        )
+
+    def test_classifies_watts_boundaries_deterministically(self):
+        self.assertEqual(power_output_class_for_watts(99.9).key, "recovery")
+        self.assertEqual(power_output_class_for_watts(100.0).key, "endurance")
+        self.assertEqual(power_output_class_for_watts(180.0).key, "tempo")
+        self.assertEqual(power_output_class_for_watts(260.0).key, "threshold")
+        self.assertEqual(power_output_class_for_watts(340.0).key, "anaerobic")
+
+    def test_builds_power_segments_from_ordered_samples(self):
+        segments = build_power_output_segments(
+            (
+                {"stream_distance_m": 0, "watts": 80},
+                {"stream_distance_m": 100, "watts": 210},
+                {"stream_distance_m": 200, "watts": 355},
+            )
+        )
+
+        self.assertEqual(len(segments), 2)
+        self.assertEqual(segments[0].start_distance_m, 0.0)
+        self.assertEqual(segments[0].end_distance_m, 100.0)
+        self.assertEqual(segments[0].watts, 210.0)
+        self.assertEqual(segments[0].power_class.key, "tempo")
+        self.assertEqual(segments[1].power_class.key, "anaerobic")
+
+    def test_builds_activity_segments_per_activity_key(self):
+        segments = build_activity_power_output_segments(
+            _FeatureLayer(
+                (
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 0,
+                            "watts": 90,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 100,
+                            "watts": 220,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-2",
+                            "stream_distance_m": 0,
+                            "watts": 120,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-2",
+                            "stream_distance_m": 100,
+                            "watts": 300,
+                        }
+                    ),
+                )
+            )
+        )
+
+        self.assertEqual(
+            tuple(segment.power_class.key for segment in segments),
+            ("tempo", "threshold"),
+        )
+
+    def test_builds_activity_line_segments_from_point_sample_geometry(self):
+        segments = build_activity_power_output_line_segments(
+            _FeatureLayer(
+                (
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 0,
+                            "watts": 80,
+                        },
+                        geometry=_Geometry(6.6, 46.5),
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 100,
+                            "watts": 210,
+                        },
+                        geometry=_Geometry(6.7, 46.6),
+                    ),
+                )
+            )
+        )
+
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0].layer_key, "activity_tracks")
+        self.assertEqual(segments[0].source_id, "a-1")
+        self.assertEqual(segments[0].start_xy, (6.6, 46.5))
+        self.assertEqual(segments[0].end_xy, (6.7, 46.6))
+        self.assertEqual(segments[0].power_class.key, "tempo")
+
+    def test_line_segment_builders_do_not_connect_across_sample_groups(self):
+        segments = build_activity_power_output_line_segments(
+            _FeatureLayer(
+                (
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 0,
+                            "watts": 110,
+                        },
+                        geometry=_Geometry(6.6, 46.5),
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-2",
+                            "stream_distance_m": 100,
+                            "watts": 250,
+                        },
+                        geometry=_Geometry(6.7, 46.6),
+                    ),
+                )
+            )
+        )
+
+        self.assertEqual(segments, ())
+
+    def test_result_classifies_segments_for_eligible_activity_tracks(self):
+        result = build_power_output_analysis_result(
+            activities_layer=_Layer(fields=("name",)),
+            points_layer=_FeatureLayer(
+                (
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 0,
+                            "watts": 90,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 100,
+                            "watts": 210,
+                        }
+                    ),
+                ),
+                fields=("stream_distance_m", "watts"),
+            ),
+        )
+
+        self.assertEqual(result.segment_count, 1)
+        self.assertEqual(result.layers[0].segments[0].power_class.key, "tempo")
+        self.assertEqual(
+            build_power_output_status(result),
+            (
+                "Power output line analysis classified activity tracks "
+                "(1 segment)."
+            ),
+        )
+
+    def test_result_reports_when_eligible_layers_have_no_segments(self):
+        result = build_power_output_analysis_result(
+            activities_layer=_Layer(fields=("name",)),
+            points_layer=_FeatureLayer(
+                (),
+                fields=("stream_distance_m", "watts"),
+            ),
+        )
+
+        self.assertEqual(result.segment_count, 0)
+        self.assertEqual(
+            build_power_output_status(result),
+            (
+                "Power output line analysis found eligible activity tracks, "
+                "but no "
+                "power segments could be classified."
+            ),
+        )
+
+    def test_analysis_result_rejects_unhandled_plan_layer_keys(self):
+        with patch(
+            "qfit.analysis.application.power_output_analysis."
+            "build_power_output_analysis_plan",
+            return_value=PowerOutputAnalysisPlan(
+                layers=(
+                    PowerOutputLayerPlan(
+                        key="future_layer",
+                        label="future layer",
+                        enabled=True,
+                    ),
+                )
+            ),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Unsupported power-output layer key: future_layer",
+            ):
+                build_power_output_analysis_result()
+
+    def test_segments_skip_invalid_or_non_forward_samples_and_recover(self):
+        segments = build_power_output_segments(
+            (
+                {"stream_distance_m": 0, "watts": 90},
+                {"stream_distance_m": 0, "watts": 120},
+                {"stream_distance_m": "bad", "watts": 180},
+                {"stream_distance_m": 100, "watts": None},
+                {"stream_distance_m": 200, "watts": 260},
+            )
+        )
+
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0].start_distance_m, 0.0)
+        self.assertEqual(segments[0].end_distance_m, 200.0)
+        self.assertEqual(segments[0].power_class.key, "threshold")
+
+    def test_plan_targets_only_eligible_activity_line_layers(self):
+        plan = build_power_output_analysis_plan(
+            activities_layer=_Layer(fields=("name",)),
+            points_layer=_Layer(fields=("watts", "stream_distance_m")),
+        )
+
+        self.assertEqual(
+            tuple(layer.key for layer in plan.enabled_layers),
+            ("activity_tracks",),
+        )
+        self.assertEqual(
+            plan.layers[0].source_fields,
+            ("watts", "stream_distance_m"),
+        )
+        self.assertEqual(
+            build_power_output_status(plan),
+            "Power output line analysis ready for activity tracks.",
+        )
+
+    def test_plan_reports_missing_power_point_samples(self):
+        plan = build_power_output_analysis_plan(
+            activities_layer=_Layer(fields=("name",)),
+            points_layer=_Layer(fields=("stream_distance_m",)),
+        )
+
+        self.assertEqual(plan.enabled_layers, ())
+        self.assertIn(
+            "watts and stream_distance_m",
+            plan.layers[0].blocked_reason,
+        )
+
+    def test_plan_rejects_non_line_targets(self):
+        plan = build_power_output_analysis_plan(
+            activities_layer=_Layer(geometry="Polygon", fields=("name",)),
+            points_layer=_Layer(fields=("watts", "stream_distance_m")),
+        )
+
+        self.assertEqual(plan.enabled_layers, ())
+        self.assertIn(
+            "activity track target is not a line layer",
+            plan.layers[0].blocked_reason,
+        )
+
+    def test_route_layer_kwargs_are_accepted_but_ignored(self):
+        plan = build_power_output_analysis_plan(
+            activities_layer=None,
+            route_tracks_layer=object(),
+            route_points_layer=object(),
+            route_profile_samples_layer=object(),
+        )
+
+        self.assertEqual(plan.enabled_layers, ())
+
+    def test_unexpected_kwargs_are_rejected(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "Unexpected power-output layer kwargs",
+        ):
+            build_power_output_analysis_plan(extra_layer=object())
+
+    def test_run_power_output_analysis_builds_status_and_layer(self):
+        request = RunAnalysisRequest(
+            analysis_mode=POWER_OUTPUT_MODE,
+            activities_layer=_Layer(fields=("name",)),
+            points_layer=_FeatureLayer(
+                (
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 0,
+                            "watts": 90,
+                        }
+                    ),
+                    _FeatureSample(
+                        {
+                            "source": "strava",
+                            "source_activity_id": "a-1",
+                            "stream_distance_m": 100,
+                            "watts": 210,
+                        }
+                    ),
+                ),
+                fields=("watts", "stream_distance_m"),
+            ),
+        )
+
+        with patch(
+            "qfit.analysis.application.power_output_analysis."
+            "_build_power_output_layer",
+            return_value=("power-layer", ("segment",)),
+        ):
+            result = run_power_output_analysis(request)
+
+        self.assertEqual(
+            result.status,
+            (
+                "Power output line analysis classified activity tracks "
+                "(1 segment)."
+            ),
+        )
+        self.assertEqual(result.layer, "power-layer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_power_output_layer.py
+++ b/tests/test_power_output_layer.py
@@ -1,0 +1,368 @@
+import importlib
+import sys
+import unittest
+from types import ModuleType
+
+from tests import _path  # noqa: F401
+
+
+class _FeatureSample:
+    def __init__(self, values, *, geometry=None):
+        self._values = values
+        self._geometry = geometry
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def geometry(self):
+        return self._geometry
+
+
+class _Field:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _FeatureLayer:
+    def __init__(self, features, *, crs_authid="EPSG:4326", fields=()):
+        self._features = tuple(features)
+        self._crs = _Crs(crs_authid)
+        self._fields = tuple(_Field(name) for name in fields)
+
+    def getFeatures(self):
+        return iter(self._features)
+
+    def crs(self):
+        return self._crs
+
+    def fields(self):
+        return self._fields
+
+
+class _TargetLayer:
+    def __init__(self, geometry="LineString"):
+        self._geometry = geometry
+
+    def geometryType(self):
+        return self._geometry
+
+
+class _Crs:
+    def __init__(self, authid):
+        self._authid = authid
+
+    def isValid(self):
+        return bool(self._authid)
+
+    def authid(self):
+        return self._authid
+
+
+class _Point:
+    def __init__(self, x, y):
+        self._x = x
+        self._y = y
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+
+class _Geometry:
+    def __init__(self, x, y):
+        self._point = _Point(x, y)
+
+    def isEmpty(self):
+        return False
+
+    def asPoint(self):
+        return self._point
+
+
+class PowerOutputLayerTests(unittest.TestCase):
+    def test_builds_styled_memory_layer_from_activity_line_segments(self):
+        module = _load_power_output_layer_with_qgis_stub()
+        points_layer = _FeatureLayer(
+            (
+                _FeatureSample(
+                    {
+                        "source": "strava",
+                        "source_activity_id": "a-1",
+                        "stream_distance_m": 0,
+                        "watts": 80,
+                    },
+                    geometry=_Geometry(6.6, 46.5),
+                ),
+                _FeatureSample(
+                    {
+                        "source": "strava",
+                        "source_activity_id": "a-1",
+                        "stream_distance_m": 100,
+                        "watts": 210,
+                    },
+                    geometry=_Geometry(6.7, 46.6),
+                ),
+            ),
+            crs_authid="EPSG:2056",
+            fields=("stream_distance_m", "watts"),
+        )
+
+        layer, segments = module.build_power_output_layer(
+            activities_layer=_TargetLayer(),
+            points_layer=points_layer,
+        )
+
+        self.assertEqual(layer.name, module.POWER_OUTPUT_LAYER_NAME)
+        self.assertEqual(layer.crs_authid, "EPSG:2056")
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(len(layer.features), 1)
+        self.assertEqual(layer.features[0].attrs["power_class"], "tempo")
+        self.assertEqual(layer.features[0].attrs["source_id"], "a-1")
+        self.assertEqual(layer.features[0].attrs["watts"], 210.0)
+        self.assertEqual(
+            layer.features[0].geometry,
+            ((6.6, 46.5), (6.7, 46.6)),
+        )
+        self.assertEqual(layer.renderer.field_name, "power_class")
+        self.assertEqual(len(layer.renderer.categories), 5)
+        self.assertAlmostEqual(layer.opacity, 0.95)
+        self.assertEqual(layer.repaint_count, 1)
+
+    def test_returns_empty_result_when_no_line_segments_are_available(self):
+        module = _load_power_output_layer_with_qgis_stub()
+
+        layer, segments = module.build_power_output_layer(
+            activities_layer=_TargetLayer(),
+            points_layer=_FeatureLayer(
+                (),
+                fields=("stream_distance_m", "watts"),
+            ),
+        )
+
+        self.assertIsNone(layer)
+        self.assertEqual(segments, ())
+
+    def test_accepts_but_ignores_saved_route_layers(self):
+        module = _load_power_output_layer_with_qgis_stub()
+
+        layer, segments = module.build_power_output_layer(
+            route_tracks_layer=_TargetLayer(),
+            route_profile_samples_layer=_FeatureLayer(
+                (),
+                fields=("distance_m",),
+            ),
+        )
+
+        self.assertIsNone(layer)
+        self.assertEqual(segments, ())
+
+    def test_skips_overlay_when_activity_target_is_not_a_line_layer(self):
+        module = _load_power_output_layer_with_qgis_stub()
+        points_layer = _FeatureLayer(
+            (
+                _FeatureSample(
+                    {
+                        "source": "strava",
+                        "source_activity_id": "a-1",
+                        "stream_distance_m": 0,
+                        "watts": 80,
+                    },
+                    geometry=_Geometry(6.6, 46.5),
+                ),
+                _FeatureSample(
+                    {
+                        "source": "strava",
+                        "source_activity_id": "a-1",
+                        "stream_distance_m": 100,
+                        "watts": 210,
+                    },
+                    geometry=_Geometry(6.7, 46.6),
+                ),
+            ),
+            fields=("stream_distance_m", "watts"),
+        )
+
+        layer, segments = module.build_power_output_layer(
+            activities_layer=_TargetLayer(geometry="Point"),
+            points_layer=points_layer,
+        )
+
+        self.assertIsNone(layer)
+        self.assertEqual(segments, ())
+
+
+class _QVariant:
+    String = "String"
+    Double = "Double"
+
+
+class _QColor:
+    def __init__(self, value):
+        self.value = value
+
+
+class _QgsField:
+    def __init__(self, name, field_type):
+        self.name = name
+        self.field_type = field_type
+
+
+class _QgsFeature:
+    def __init__(self, fields=None):
+        self.fields = fields
+        self.attrs = {}
+        self.geometry = None
+
+    def setGeometry(self, geometry):
+        self.geometry = geometry
+
+    def __setitem__(self, key, value):
+        self.attrs[key] = value
+
+
+class _QgsGeometry:
+    @staticmethod
+    def fromPolylineXY(points):
+        return tuple((point.x, point.y) for point in points)
+
+
+class _QgsPointXY:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+class _Provider:
+    def __init__(self, layer):
+        self.layer = layer
+
+    def addAttributes(self, fields):
+        self.layer.field_defs.extend(fields)
+
+    def addFeatures(self, features):
+        self.layer.features.extend(features)
+
+
+class _QgsVectorLayer:
+    def __init__(self, uri, name, provider_name):
+        self.uri = uri
+        self.name = name
+        self.provider_name = provider_name
+        self.crs_authid = uri.split("crs=", 1)[1]
+        self.field_defs = []
+        self.features = []
+        self.renderer = None
+        self.opacity = None
+        self.repaint_count = 0
+
+    def dataProvider(self):
+        return _Provider(self)
+
+    def updateFields(self):
+        self.fields_updated = True
+
+    def updateExtents(self):
+        self.extents_updated = True
+
+    def fields(self):
+        return self.field_defs
+
+    def setRenderer(self, renderer):
+        self.renderer = renderer
+
+    def setOpacity(self, opacity):
+        self.opacity = opacity
+
+    def triggerRepaint(self):
+        self.repaint_count += 1
+
+
+class _QgsCategorizedSymbolRenderer:
+    def __init__(self, field_name, categories):
+        self.field_name = field_name
+        self.categories = categories
+
+
+class _QgsRendererCategory:
+    def __init__(self, value, symbol, label):
+        self.value = value
+        self.symbol = symbol
+        self.label = label
+
+
+class _QgsLineSymbol:
+    def __init__(self):
+        self.deleted = []
+        self.layers = []
+
+    def deleteSymbolLayer(self, index):
+        self.deleted.append(index)
+
+    def appendSymbolLayer(self, layer):
+        self.layers.append(layer)
+
+
+class _QgsSimpleLineSymbolLayer:
+    def __init__(self):
+        self.color = None
+        self.width = None
+
+    def setColor(self, color):
+        self.color = color
+
+    def setWidth(self, width):
+        self.width = width
+
+
+def _load_power_output_layer_with_qgis_stub():
+    for name in (
+        "qfit.analysis.infrastructure.power_output_layer",
+        "qgis",
+        "qgis.PyQt",
+        "qgis.PyQt.QtCore",
+        "qgis.PyQt.QtGui",
+        "qgis.core",
+    ):
+        sys.modules.pop(name, None)
+
+    qgis = ModuleType("qgis")
+    pyqt = ModuleType("qgis.PyQt")
+    qtcore = ModuleType("qgis.PyQt.QtCore")
+    qtgui = ModuleType("qgis.PyQt.QtGui")
+    core = ModuleType("qgis.core")
+    qtcore.QVariant = _QVariant
+    qtgui.QColor = _QColor
+    core.QgsCategorizedSymbolRenderer = _QgsCategorizedSymbolRenderer
+    core.QgsFeature = _QgsFeature
+    core.QgsField = _QgsField
+    core.QgsGeometry = _QgsGeometry
+    core.QgsLineSymbol = _QgsLineSymbol
+    core.QgsPointXY = _QgsPointXY
+    core.QgsRendererCategory = _QgsRendererCategory
+    core.QgsSimpleLineSymbolLayer = _QgsSimpleLineSymbolLayer
+    core.QgsVectorLayer = _QgsVectorLayer
+    qgis.PyQt = pyqt
+    qgis.core = core
+    pyqt.QtCore = qtcore
+    pyqt.QtGui = qtgui
+    sys.modules.update(
+        {
+            "qgis": qgis,
+            "qgis.PyQt": pyqt,
+            "qgis.PyQt.QtCore": qtcore,
+            "qgis.PyQt.QtGui": qtgui,
+            "qgis.core": core,
+        }
+    )
+    return importlib.import_module(
+        "qfit.analysis.infrastructure.power_output_layer"
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2295,8 +2295,14 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         current_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
         stale_layer = _FakeLayer(self.module.FREQUENT_STARTING_POINTS_LAYER_NAME)
         stale_heatmap_layer = _FakeLayer("qfit activity heatmap")
+        stale_power_layer = _FakeLayer(self.module.POWER_OUTPUT_LAYER_NAME)
         project = _FakeProject(
-            {"one": stale_layer, "two": _FakeLayer("other"), "three": stale_heatmap_layer}
+            {
+                "one": stale_layer,
+                "two": _FakeLayer("other"),
+                "three": stale_heatmap_layer,
+                "four": stale_power_layer,
+            }
         )
         dock.analysis_layer = current_layer
         dock._atlas_export_completed = True
@@ -2311,7 +2317,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         canvas.refresh.assert_called_once_with()
         self.assertEqual(
             project.removed,
-            [current_layer.id(), stale_layer.id(), stale_heatmap_layer.id()],
+            [
+                current_layer.id(),
+                stale_layer.id(),
+                stale_heatmap_layer.id(),
+                stale_power_layer.id(),
+            ],
         )
 
     def test_clear_analysis_layer_is_noop_when_no_analysis_is_displayed(self):

--- a/ui/application/local_first_analysis_controls.py
+++ b/ui/application/local_first_analysis_controls.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from ...analysis.application.analysis_execution_dispatch import (
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
+    POWER_OUTPUT_MODE,
     SLOPE_GRADE_MODE,
 )
 
@@ -13,6 +14,7 @@ ANALYSIS_MODE_LABELS = (
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
     SLOPE_GRADE_MODE,
+    POWER_OUTPUT_MODE,
 )
 
 

--- a/ui/dockwidget/analysis_page.py
+++ b/ui/dockwidget/analysis_page.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from qfit.analysis.application.analysis_execution_dispatch import (
     FREQUENT_STARTING_POINTS_MODE,
     HEATMAP_MODE,
+    POWER_OUTPUT_MODE,
     SLOPE_GRADE_MODE,
 )
 
@@ -92,7 +93,12 @@ class AnalysisPageContent(QWidget):
         self.analysis_mode_combo = QComboBox(self)
         self.analysis_mode_combo.setObjectName("qfitWizardAnalysisModeComboBox")
         self.set_analysis_mode_options(
-            (HEATMAP_MODE, FREQUENT_STARTING_POINTS_MODE, SLOPE_GRADE_MODE)
+            (
+                HEATMAP_MODE,
+                FREQUENT_STARTING_POINTS_MODE,
+                SLOPE_GRADE_MODE,
+                POWER_OUTPUT_MODE,
+            )
         )
         if hasattr(self.analysis_mode_combo, "currentTextChanged"):
             self.analysis_mode_combo.currentTextChanged.connect(


### PR DESCRIPTION
## Summary

- adds a "Power output lines" analysis mode for activity tracks
- classifies activity point samples by watts into deterministic power classes
- renders classified power segments as a styled QGIS memory line layer and clears it with other analysis overlays

## Validation

- python3 -m pytest tests/ -x -q --tb=short
- Headless PyQGIS render smoke: built two power-output line segments and verified a nonblank rendered map image

Refs #966
