### PR TITLE
[codex] extend Mapbox road icon diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -21,11 +21,13 @@ from qfit.validation.mapbox_outdoors_road_features import (
     build_summary_markdown,
     collect_all_camera_road_feature_report,
     collect_road_feature_report,
+    is_level_crossing_candidate,
     is_oneway_arrow_candidate,
     is_path_line_candidate,
     is_pedestrian_line_candidate,
     is_pedestrian_polygon_candidate,
     is_road_exit_shield_candidate,
+    is_road_intersection_candidate,
     is_road_number_shield_candidate,
     is_step_line_candidate,
     load_style_definition,
@@ -117,6 +119,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         motorway_oneway = _feature("LineString", {"class": "motorway", "structure": "bridge", "oneway": "true"})
         bool_oneway = _feature("LineString", {"class": "street", "structure": "none", "oneway": True})
         unsupported_oneway_class = _feature("LineString", {"class": "path", "structure": "none", "oneway": "true"})
+        road_intersection = _feature("Point", {"class": "intersection", "name": "Rue du Lac"})
+        low_zoom_road_intersection = _feature("Point", {"class": "intersection", "name": "Rue du Lac"})
+        unnamed_road_intersection = _feature("Point", {"class": "intersection"})
+        line_road_intersection = _feature("LineString", {"class": "intersection", "name": "Rue du Lac"})
+        level_crossing = _feature("Point", {"class": "level_crossing", "structure": "none", "layer": 0})
+        low_zoom_level_crossing = _feature("Point", {"class": "level_crossing", "structure": "none"})
+        line_level_crossing = _feature("LineString", {"class": "level_crossing", "structure": "none"})
         low_zoom_shield_point = _feature("Point", {"class": "primary", "reflen": "2", "len": 10})
         high_zoom_shield_point = _feature("Point", {"class": "primary", "reflen": "2", "len": 3000})
         low_zoom_shield_line = _feature("LineString", {"class": "primary", "reflen": 2, "len": 6000})
@@ -170,6 +179,15 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertTrue(is_oneway_arrow_candidate(motorway_oneway, tile_zoom=16))
         self.assertFalse(is_oneway_arrow_candidate(bool_oneway, tile_zoom=16))
         self.assertFalse(is_oneway_arrow_candidate(unsupported_oneway_class, tile_zoom=16))
+        self.assertTrue(is_road_intersection_candidate(road_intersection, tile_zoom=15))
+        self.assertFalse(is_road_intersection_candidate(low_zoom_road_intersection, tile_zoom=14))
+        self.assertFalse(is_road_intersection_candidate(road_intersection))
+        self.assertFalse(is_road_intersection_candidate(unnamed_road_intersection, tile_zoom=15))
+        self.assertFalse(is_road_intersection_candidate(line_road_intersection, tile_zoom=15))
+        self.assertTrue(is_level_crossing_candidate(level_crossing, tile_zoom=16))
+        self.assertFalse(is_level_crossing_candidate(low_zoom_level_crossing, tile_zoom=15))
+        self.assertFalse(is_level_crossing_candidate(level_crossing))
+        self.assertFalse(is_level_crossing_candidate(line_level_crossing, tile_zoom=16))
         self.assertFalse(is_road_number_shield_candidate(low_zoom_shield_point, tile_zoom=5))
         self.assertTrue(is_road_number_shield_candidate(low_zoom_shield_point, tile_zoom=10))
         self.assertFalse(is_road_number_shield_candidate(high_zoom_shield_point, tile_zoom=11))
@@ -219,6 +237,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             _feature("MultiLineString", {"class": "path", "type": "steps", "structure": "none", "layer": 0, "surface": "paved"}),
             _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
             _feature("LineString", {"class": "motorway", "structure": "bridge", "oneway": "true"}),
+            _feature("Point", {"class": "intersection", "name": "A1"}),
+            _feature("Point", {"class": "level_crossing", "structure": "none", "layer": 0}),
             _feature(
                 "LineString",
                 {
@@ -252,13 +272,15 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
 
         self.assertEqual(record["status"], "decoded")
-        self.assertEqual(record["road_feature_count"], 12)
+        self.assertEqual(record["road_feature_count"], 14)
         self.assertEqual(record["motorway_junction_feature_count"], 2)
         self.assertEqual(record["pedestrian_polygon_candidate_count"], 2)
         self.assertEqual(record["pedestrian_line_candidate_count"], 1)
         self.assertEqual(record["path_line_candidate_count"], 1)
         self.assertEqual(record["step_line_candidate_count"], 1)
         self.assertEqual(record["oneway_arrow_candidate_count"], 2)
+        self.assertEqual(record["road_intersection_candidate_count"], 1)
+        self.assertEqual(record["level_crossing_candidate_count"], 1)
         self.assertEqual(record["road_number_shield_candidate_count"], 1)
         self.assertEqual(record["road_exit_shield_candidate_count"], 1)
         self.assertEqual(record["pedestrian_polygon_class_counts"], {"path": 1, "pedestrian": 1})
@@ -299,6 +321,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["oneway_arrow_class_counts"], {"motorway": 1, "street": 1})
         self.assertEqual(record["oneway_arrow_structure_counts"], {"bridge": 1, "none": 1})
         self.assertEqual(record["oneway_arrow_layer_counts"], {"(missing)": 1, "0": 1})
+        self.assertEqual(record["road_intersection_name_counts"], {"A1": 1})
+        self.assertEqual(record["road_intersection_signature_counts"], {"class=intersection; name=A1": 1})
+        self.assertEqual(record["level_crossing_structure_counts"], {"none": 1})
+        self.assertEqual(record["level_crossing_layer_counts"], {"0": 1})
+        self.assertEqual(
+            record["level_crossing_signature_counts"],
+            {"class=level_crossing; structure=none; layer=0": 1},
+        )
         self.assertEqual(record["road_number_shield_class_counts"], {"primary": 1})
         self.assertEqual(record["road_number_shield_reflen_counts"], {"2": 1})
         self.assertEqual(record["road_number_shield_structure_counts"], {"none": 1})
@@ -312,6 +342,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["sample_pedestrian_polygons"][0]["properties"]["class"], "pedestrian")
         self.assertEqual(record["sample_step_lines"][0]["properties"]["type"], "steps")
         self.assertEqual(record["sample_oneway_arrow_lines"][0]["properties"]["oneway"], "true")
+        self.assertEqual(record["sample_road_intersections"][0]["properties"]["name"], "A1")
+        self.assertEqual(record["sample_level_crossings"][0]["properties"]["class"], "level_crossing")
         self.assertEqual(record["sample_road_number_shields"][0]["properties"]["shield"], "ch-primary")
         self.assertEqual(record["sample_road_exit_shields"][0]["properties"]["ref"], "12")
 
@@ -442,6 +474,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["path_line_candidate_count"], 1)
         self.assertEqual(report["step_line_candidate_count"], 1)
         self.assertEqual(report["oneway_arrow_candidate_count"], 0)
+        self.assertEqual(report["road_intersection_candidate_count"], 0)
+        self.assertEqual(report["level_crossing_candidate_count"], 0)
         self.assertEqual(report["road_number_shield_candidate_count"], 0)
         self.assertEqual(report["road_exit_shield_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 1})
@@ -476,6 +510,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["oneway_arrow_class_counts"], {})
         self.assertEqual(report["oneway_arrow_structure_counts"], {})
         self.assertEqual(report["oneway_arrow_layer_counts"], {})
+        self.assertEqual(report["road_intersection_name_counts"], {})
+        self.assertEqual(report["road_intersection_signature_counts"], {})
+        self.assertEqual(report["level_crossing_structure_counts"], {})
+        self.assertEqual(report["level_crossing_layer_counts"], {})
+        self.assertEqual(report["level_crossing_signature_counts"], {})
         self.assertEqual(report["road_number_shield_class_counts"], {})
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
         self.assertEqual(report["road_number_shield_structure_counts"], {})
@@ -599,6 +638,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["path_line_candidate_count"], 2)
         self.assertEqual(report["step_line_candidate_count"], 2)
         self.assertEqual(report["oneway_arrow_candidate_count"], 0)
+        self.assertEqual(report["road_intersection_candidate_count"], 0)
+        self.assertEqual(report["level_crossing_candidate_count"], 0)
         self.assertEqual(report["road_number_shield_candidate_count"], 0)
         self.assertEqual(report["road_exit_shield_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
@@ -635,6 +676,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["oneway_arrow_class_counts"], {})
         self.assertEqual(report["oneway_arrow_structure_counts"], {})
         self.assertEqual(report["oneway_arrow_layer_counts"], {})
+        self.assertEqual(report["road_intersection_name_counts"], {})
+        self.assertEqual(report["road_intersection_signature_counts"], {})
+        self.assertEqual(report["level_crossing_structure_counts"], {})
+        self.assertEqual(report["level_crossing_layer_counts"], {})
+        self.assertEqual(report["level_crossing_signature_counts"], {})
         self.assertEqual(report["road_number_shield_class_counts"], {})
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
         self.assertEqual(report["road_number_shield_structure_counts"], {})
@@ -650,6 +696,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
         path_signature = "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)"
         step_signature = "class=path; type=steps; surface=paved; structure=none; layer=0"
+        intersection_signature = "class=intersection; name=A1"
+        level_crossing_signature = "class=level_crossing; structure=none; layer=0"
         shield_signature = "class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0"
         exit_shield_signature = "ref=12; reflen=2"
         report = {
@@ -667,6 +715,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
             "oneway_arrow_candidate_count": 1,
+            "road_intersection_candidate_count": 1,
+            "level_crossing_candidate_count": 1,
             "road_number_shield_candidate_count": 1,
             "road_exit_shield_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
@@ -691,6 +741,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "oneway_arrow_class_counts": {"street": 1},
             "oneway_arrow_structure_counts": {"none": 1},
             "oneway_arrow_layer_counts": {"0": 1},
+            "road_intersection_name_counts": {"A1": 1},
+            "road_intersection_signature_counts": {intersection_signature: 1},
+            "level_crossing_structure_counts": {"none": 1},
+            "level_crossing_layer_counts": {"0": 1},
+            "level_crossing_signature_counts": {level_crossing_signature: 1},
             "road_number_shield_class_counts": {"primary": 1},
             "road_number_shield_reflen_counts": {"2": 1},
             "road_number_shield_structure_counts": {"none": 1},
@@ -703,6 +758,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "sample_path_lines": [{"properties": {"class": "path"}}],
             "sample_step_lines": [{"properties": {"type": "steps"}}],
             "sample_oneway_arrow_lines": [{"properties": {"class": "street", "oneway": "true"}}],
+            "sample_road_intersections": [{"properties": {"class": "intersection", "name": "A1"}}],
+            "sample_level_crossings": [{"properties": {"class": "level_crossing"}}],
             "sample_road_number_shields": [{"properties": {"class": "primary", "shield": "ch-primary"}}],
             "sample_road_exit_shields": [{"properties": {"ref": "12", "reflen": 2}}],
             "tiles": [
@@ -719,6 +776,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
                     "oneway_arrow_candidate_count": 1,
+                    "road_intersection_candidate_count": 1,
+                    "level_crossing_candidate_count": 1,
                     "road_number_shield_candidate_count": 1,
                     "road_exit_shield_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
@@ -743,6 +802,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "oneway_arrow_class_counts": {"street": 1},
                     "oneway_arrow_structure_counts": {"none": 1},
                     "oneway_arrow_layer_counts": {"0": 1},
+                    "road_intersection_name_counts": {"A1": 1},
+                    "road_intersection_signature_counts": {intersection_signature: 1},
+                    "level_crossing_structure_counts": {"none": 1},
+                    "level_crossing_layer_counts": {"0": 1},
+                    "level_crossing_signature_counts": {level_crossing_signature: 1},
                     "road_number_shield_class_counts": {"primary": 1},
                     "road_number_shield_reflen_counts": {"2": 1},
                     "road_number_shield_structure_counts": {"none": 1},
@@ -761,6 +825,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("Path line candidates: 1", markdown)
         self.assertIn("Step line candidates: 1", markdown)
         self.assertIn("One-way arrow candidates: 1", markdown)
+        self.assertIn("Road intersection candidates: 1", markdown)
+        self.assertIn("Level crossing candidates: 1", markdown)
         self.assertIn("Road number shield candidates: 1", markdown)
         self.assertIn("Road exit shield candidates: 1", markdown)
         self.assertIn('Pedestrian polygon structure counts: {"none":1}', markdown)
@@ -782,6 +848,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn('One-way arrow class counts: {"street":1}', markdown)
         self.assertIn('One-way arrow structure counts: {"none":1}', markdown)
         self.assertIn('One-way arrow layer counts: {"0":1}', markdown)
+        self.assertIn('Road intersection name counts: {"A1":1}', markdown)
+        self.assertIn(f'Road intersection signatures: {{"{intersection_signature}":1}}', markdown)
+        self.assertIn('Level crossing structure counts: {"none":1}', markdown)
+        self.assertIn('Level crossing layer counts: {"0":1}', markdown)
+        self.assertIn(f'Level crossing signatures: {{"{level_crossing_signature}":1}}', markdown)
         self.assertIn('Road number shield class counts: {"primary":1}', markdown)
         self.assertIn('Road number shield reflen counts: {"2":1}', markdown)
         self.assertIn('Road number shield structure counts: {"none":1}', markdown)
@@ -794,6 +865,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("## Sample path line candidates", markdown)
         self.assertIn("## Sample step line candidates", markdown)
         self.assertIn("## Sample one-way arrow candidates", markdown)
+        self.assertIn("## Sample road intersection candidates", markdown)
+        self.assertIn("## Sample level crossing candidates", markdown)
         self.assertIn("## Sample road number shield candidates", markdown)
         self.assertIn("## Sample road exit shield candidates", markdown)
 
@@ -801,6 +874,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
         path_signature = "class=path; type=footway; surface=unpaved; structure=none; layer=(missing)"
         step_signature = "class=path; type=steps; surface=paved; structure=bridge; layer=(missing)"
+        intersection_signature = "class=intersection; name=A1"
+        level_crossing_signature = "class=level_crossing; structure=none; layer=0"
         shield_signature = "class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0"
         exit_shield_signature = "ref=12; reflen=2"
         report = {
@@ -817,6 +892,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "path_line_candidate_count": 1,
             "step_line_candidate_count": 1,
             "oneway_arrow_candidate_count": 1,
+            "road_intersection_candidate_count": 1,
+            "level_crossing_candidate_count": 1,
             "road_number_shield_candidate_count": 1,
             "road_exit_shield_candidate_count": 1,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
@@ -841,6 +918,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "oneway_arrow_class_counts": {"street": 1},
             "oneway_arrow_structure_counts": {"none": 1},
             "oneway_arrow_layer_counts": {"0": 1},
+            "road_intersection_name_counts": {"A1": 1},
+            "road_intersection_signature_counts": {intersection_signature: 1},
+            "level_crossing_structure_counts": {"none": 1},
+            "level_crossing_layer_counts": {"0": 1},
+            "level_crossing_signature_counts": {level_crossing_signature: 1},
             "road_number_shield_class_counts": {"primary": 1},
             "road_number_shield_reflen_counts": {"2": 1},
             "road_number_shield_structure_counts": {"none": 1},
@@ -861,6 +943,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "path_line_candidate_count": 1,
                     "step_line_candidate_count": 1,
                     "oneway_arrow_candidate_count": 1,
+                    "road_intersection_candidate_count": 1,
+                    "level_crossing_candidate_count": 1,
                     "road_number_shield_candidate_count": 1,
                     "road_exit_shield_candidate_count": 1,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
@@ -885,6 +969,11 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "oneway_arrow_class_counts": {"street": 1},
                     "oneway_arrow_structure_counts": {"none": 1},
                     "oneway_arrow_layer_counts": {"0": 1},
+                    "road_intersection_name_counts": {"A1": 1},
+                    "road_intersection_signature_counts": {intersection_signature: 1},
+                    "level_crossing_structure_counts": {"none": 1},
+                    "level_crossing_layer_counts": {"0": 1},
+                    "level_crossing_signature_counts": {level_crossing_signature: 1},
                     "road_number_shield_class_counts": {"primary": 1},
                     "road_number_shield_reflen_counts": {"2": 1},
                     "road_number_shield_structure_counts": {"none": 1},

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -57,6 +57,8 @@ LOW_ZOOM_PATH_EXCLUDED_TYPES = {"crossing", "sidewalk", "steps"}
 HIGH_ZOOM_PATH_EXCLUDED_TYPES = {"steps"}
 STEP_STRUCTURES = {"none", "ford", "bridge", "tunnel"}
 ONEWAY_ARROW_MIN_ZOOM = 16
+ROAD_INTERSECTION_MIN_ZOOM = 15
+LEVEL_CROSSING_MIN_ZOOM = 16
 ROAD_NUMBER_SHIELD_MIN_ZOOM = 6
 ROAD_NUMBER_SHIELD_MAX_REFLEN = 6
 ROAD_NUMBER_SHIELD_EXCLUDED_CLASSES = {"pedestrian", "service"}
@@ -92,6 +94,8 @@ SAMPLE_PROPERTY_KEYS = (
     "surface",
 )
 ROAD_FEATURE_SIGNATURE_KEYS = ("class", "type", "surface", "structure", "layer")
+ROAD_INTERSECTION_SIGNATURE_KEYS = ("class", "name")
+LEVEL_CROSSING_SIGNATURE_KEYS = ("class", "structure", "layer")
 ROAD_NUMBER_SHIELD_SIGNATURE_KEYS = ("class", "reflen", "shield", "shield_beta", "structure", "layer")
 ROAD_EXIT_SHIELD_SIGNATURE_KEYS = ("ref", "reflen")
 
@@ -196,6 +200,27 @@ def is_oneway_arrow_candidate(feature: dict[str, object], *, tile_zoom: int | No
         and properties.get("class") in ONEWAY_ARROW_CLASSES
         and properties.get("structure") in ONEWAY_ARROW_STRUCTURES
         and _geometry_type(feature) in LINE_GEOMETRY_TYPES
+    )
+
+
+def is_road_intersection_candidate(feature: dict[str, object], *, tile_zoom: int | None = None) -> bool:
+    properties = _feature_properties(feature)
+    return (
+        tile_zoom is not None
+        and tile_zoom >= ROAD_INTERSECTION_MIN_ZOOM
+        and properties.get("class") == "intersection"
+        and "name" in properties
+        and _geometry_type(feature) == "Point"
+    )
+
+
+def is_level_crossing_candidate(feature: dict[str, object], *, tile_zoom: int | None = None) -> bool:
+    properties = _feature_properties(feature)
+    return (
+        tile_zoom is not None
+        and tile_zoom >= LEVEL_CROSSING_MIN_ZOOM
+        and properties.get("class") == "level_crossing"
+        and _geometry_type(feature) == "Point"
     )
 
 
@@ -321,6 +346,12 @@ def road_tile_record(
     oneway_arrow_lines = [
         feature for feature in road_features if is_oneway_arrow_candidate(feature, tile_zoom=tile.get("z"))
     ]
+    road_intersections = [
+        feature for feature in road_features if is_road_intersection_candidate(feature, tile_zoom=tile.get("z"))
+    ]
+    level_crossings = [
+        feature for feature in road_features if is_level_crossing_candidate(feature, tile_zoom=tile.get("z"))
+    ]
     road_number_shields = [
         feature for feature in road_features if is_road_number_shield_candidate(feature, tile_zoom=tile.get("z"))
     ]
@@ -340,6 +371,8 @@ def road_tile_record(
         "path_line_candidate_count": len(path_lines),
         "step_line_candidate_count": len(step_lines),
         "oneway_arrow_candidate_count": len(oneway_arrow_lines),
+        "road_intersection_candidate_count": len(road_intersections),
+        "level_crossing_candidate_count": len(level_crossings),
         "road_number_shield_candidate_count": len(road_number_shields),
         "road_exit_shield_candidate_count": len(road_exit_shields),
         "road_geometry_type_counts": _count_geometry_types(road_features),
@@ -372,6 +405,17 @@ def road_tile_record(
         "oneway_arrow_class_counts": _count_by_property(oneway_arrow_lines, "class"),
         "oneway_arrow_structure_counts": _count_by_property(oneway_arrow_lines, "structure"),
         "oneway_arrow_layer_counts": _count_by_property(oneway_arrow_lines, "layer"),
+        "road_intersection_name_counts": _count_by_property(road_intersections, "name"),
+        "road_intersection_signature_counts": _count_property_signatures(
+            road_intersections,
+            ROAD_INTERSECTION_SIGNATURE_KEYS,
+        ),
+        "level_crossing_structure_counts": _count_by_property(level_crossings, "structure"),
+        "level_crossing_layer_counts": _count_by_property(level_crossings, "layer"),
+        "level_crossing_signature_counts": _count_property_signatures(
+            level_crossings,
+            LEVEL_CROSSING_SIGNATURE_KEYS,
+        ),
         "road_number_shield_class_counts": _count_by_property(road_number_shields, "class"),
         "road_number_shield_reflen_counts": _count_by_property(road_number_shields, "reflen"),
         "road_number_shield_structure_counts": _count_by_property(road_number_shields, "structure"),
@@ -395,6 +439,12 @@ def road_tile_record(
         "sample_step_lines": [_feature_sample(tile, feature) for feature in step_lines[:MAX_SAMPLE_FEATURES]],
         "sample_oneway_arrow_lines": [
             _feature_sample(tile, feature) for feature in oneway_arrow_lines[:MAX_SAMPLE_FEATURES]
+        ],
+        "sample_road_intersections": [
+            _feature_sample(tile, feature) for feature in road_intersections[:MAX_SAMPLE_FEATURES]
+        ],
+        "sample_level_crossings": [
+            _feature_sample(tile, feature) for feature in level_crossings[:MAX_SAMPLE_FEATURES]
         ],
         "sample_road_number_shields": [
             _feature_sample(tile, feature) for feature in road_number_shields[:MAX_SAMPLE_FEATURES]
@@ -424,6 +474,8 @@ _SUMMARY_COUNT_FIELDS = (
     ("Path line candidates", "path_line_candidate_count"),
     ("Step line candidates", "step_line_candidate_count"),
     ("One-way arrow candidates", "oneway_arrow_candidate_count"),
+    ("Road intersection candidates", "road_intersection_candidate_count"),
+    ("Level crossing candidates", "level_crossing_candidate_count"),
     ("Road number shield candidates", "road_number_shield_candidate_count"),
     ("Road exit shield candidates", "road_exit_shield_candidate_count"),
 )
@@ -450,6 +502,11 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("One-way arrow class counts", "oneway_arrow_class_counts"),
     ("One-way arrow structure counts", "oneway_arrow_structure_counts"),
     ("One-way arrow layer counts", "oneway_arrow_layer_counts"),
+    ("Road intersection name counts", "road_intersection_name_counts"),
+    ("Road intersection signatures", "road_intersection_signature_counts"),
+    ("Level crossing structure counts", "level_crossing_structure_counts"),
+    ("Level crossing layer counts", "level_crossing_layer_counts"),
+    ("Level crossing signatures", "level_crossing_signature_counts"),
     ("Road number shield class counts", "road_number_shield_class_counts"),
     ("Road number shield reflen counts", "road_number_shield_reflen_counts"),
     ("Road number shield structure counts", "road_number_shield_structure_counts"),
@@ -466,6 +523,8 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Path lines", "path_line_candidate_count", "---:"),
     ("Step lines", "step_line_candidate_count", "---:"),
     ("One-way arrows", "oneway_arrow_candidate_count", "---:"),
+    ("Road intersections", "road_intersection_candidate_count", "---:"),
+    ("Level crossings", "level_crossing_candidate_count", "---:"),
     ("Road number shields", "road_number_shield_candidate_count", "---:"),
     ("Road exit shields", "road_exit_shield_candidate_count", "---:"),
     ("Polygon types", "pedestrian_polygon_type_counts", "---"),
@@ -490,6 +549,11 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("One-way arrow classes", "oneway_arrow_class_counts", "---"),
     ("One-way arrow structures", "oneway_arrow_structure_counts", "---"),
     ("One-way arrow layers", "oneway_arrow_layer_counts", "---"),
+    ("Road intersection names", "road_intersection_name_counts", "---"),
+    ("Road intersection signatures", "road_intersection_signature_counts", "---"),
+    ("Level crossing structures", "level_crossing_structure_counts", "---"),
+    ("Level crossing layers", "level_crossing_layer_counts", "---"),
+    ("Level crossing signatures", "level_crossing_signature_counts", "---"),
     ("Shield classes", "road_number_shield_class_counts", "---"),
     ("Shield reflens", "road_number_shield_reflen_counts", "---"),
     ("Shield structures", "road_number_shield_structure_counts", "---"),
@@ -627,6 +691,12 @@ def collect_road_feature_report(
         "oneway_arrow_candidate_count": sum(
             int(tile.get("oneway_arrow_candidate_count") or 0) for tile in tile_records
         ),
+        "road_intersection_candidate_count": sum(
+            int(tile.get("road_intersection_candidate_count") or 0) for tile in tile_records
+        ),
+        "level_crossing_candidate_count": sum(
+            int(tile.get("level_crossing_candidate_count") or 0) for tile in tile_records
+        ),
         "road_number_shield_candidate_count": sum(
             int(tile.get("road_number_shield_candidate_count") or 0) for tile in tile_records
         ),
@@ -681,6 +751,17 @@ def collect_road_feature_report(
         "oneway_arrow_class_counts": _combined_record_counts(tile_records, "oneway_arrow_class_counts"),
         "oneway_arrow_structure_counts": _combined_record_counts(tile_records, "oneway_arrow_structure_counts"),
         "oneway_arrow_layer_counts": _combined_record_counts(tile_records, "oneway_arrow_layer_counts"),
+        "road_intersection_name_counts": _combined_record_counts(tile_records, "road_intersection_name_counts"),
+        "road_intersection_signature_counts": _combined_record_counts(
+            tile_records,
+            "road_intersection_signature_counts",
+        ),
+        "level_crossing_structure_counts": _combined_record_counts(tile_records, "level_crossing_structure_counts"),
+        "level_crossing_layer_counts": _combined_record_counts(tile_records, "level_crossing_layer_counts"),
+        "level_crossing_signature_counts": _combined_record_counts(
+            tile_records,
+            "level_crossing_signature_counts",
+        ),
         "road_number_shield_class_counts": _combined_record_counts(tile_records, "road_number_shield_class_counts"),
         "road_number_shield_reflen_counts": _combined_record_counts(
             tile_records,
@@ -708,6 +789,8 @@ def collect_road_feature_report(
         "sample_path_lines": _combined_samples(tile_records, "sample_path_lines"),
         "sample_step_lines": _combined_samples(tile_records, "sample_step_lines"),
         "sample_oneway_arrow_lines": _combined_samples(tile_records, "sample_oneway_arrow_lines"),
+        "sample_road_intersections": _combined_samples(tile_records, "sample_road_intersections"),
+        "sample_level_crossings": _combined_samples(tile_records, "sample_level_crossings"),
         "sample_road_number_shields": _combined_samples(tile_records, "sample_road_number_shields"),
         "sample_road_exit_shields": _combined_samples(tile_records, "sample_road_exit_shields"),
         "tiles": tile_records,
@@ -766,6 +849,8 @@ def collect_all_camera_road_feature_report(
         "path_line_candidate_count": _sum_reports(camera_reports, "path_line_candidate_count"),
         "step_line_candidate_count": _sum_reports(camera_reports, "step_line_candidate_count"),
         "oneway_arrow_candidate_count": _sum_reports(camera_reports, "oneway_arrow_candidate_count"),
+        "road_intersection_candidate_count": _sum_reports(camera_reports, "road_intersection_candidate_count"),
+        "level_crossing_candidate_count": _sum_reports(camera_reports, "level_crossing_candidate_count"),
         "road_number_shield_candidate_count": _sum_reports(camera_reports, "road_number_shield_candidate_count"),
         "road_exit_shield_candidate_count": _sum_reports(camera_reports, "road_exit_shield_candidate_count"),
         "road_geometry_type_counts": _combined_record_counts(camera_reports, "road_geometry_type_counts"),
@@ -825,6 +910,17 @@ def collect_all_camera_road_feature_report(
         "oneway_arrow_class_counts": _combined_record_counts(camera_reports, "oneway_arrow_class_counts"),
         "oneway_arrow_structure_counts": _combined_record_counts(camera_reports, "oneway_arrow_structure_counts"),
         "oneway_arrow_layer_counts": _combined_record_counts(camera_reports, "oneway_arrow_layer_counts"),
+        "road_intersection_name_counts": _combined_record_counts(camera_reports, "road_intersection_name_counts"),
+        "road_intersection_signature_counts": _combined_record_counts(
+            camera_reports,
+            "road_intersection_signature_counts",
+        ),
+        "level_crossing_structure_counts": _combined_record_counts(camera_reports, "level_crossing_structure_counts"),
+        "level_crossing_layer_counts": _combined_record_counts(camera_reports, "level_crossing_layer_counts"),
+        "level_crossing_signature_counts": _combined_record_counts(
+            camera_reports,
+            "level_crossing_signature_counts",
+        ),
         "road_number_shield_class_counts": _combined_record_counts(
             camera_reports,
             "road_number_shield_class_counts",
@@ -882,6 +978,8 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         ("Sample path line candidates", "sample_path_lines"),
         ("Sample step line candidates", "sample_step_lines"),
         ("Sample one-way arrow candidates", "sample_oneway_arrow_lines"),
+        ("Sample road intersection candidates", "sample_road_intersections"),
+        ("Sample level crossing candidates", "sample_level_crossings"),
         ("Sample road number shield candidates", "sample_road_number_shields"),
         ("Sample road exit shield candidates", "sample_road_exit_shields"),
     )


### PR DESCRIPTION
## Summary

- extend the Mapbox Outdoors road-feature diagnostic with road-intersection and level-crossing icon candidate detection
- include aggregate counts, signatures, samples, and all-camera summary columns for those candidates
- refresh the live all-camera diagnostic; the current camera matrix has 0 road-intersection and 0 level-crossing candidates, so those icon layers are not a visible target in the sampled extents

Refs #949

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- live all-camera road-feature diagnostic generated at `debug/mapbox-outdoors-road-features/all-cameras/20260519T133316Z/summary.md` using the local Mapbox token without printing it
