### PR TITLE
[codex] split Mapbox exit shield icon layers

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1724,32 +1724,6 @@ def _poi_label_icon_image_fallback(layer_id: object, expr: object) -> object:
     return _maki_icon_match(_POI_LABEL_MAKI_ICON_VALUES, "marker")
 
 
-def _road_exit_shield_icon_fallback(layer_id: object, expr: object) -> object:
-    """Replace Mapbox Outdoors road-exit shield concat sprites with a finite match."""
-    if str(layer_id or "") != _ROAD_EXIT_SHIELD_LAYER_ID or expr != _ROAD_EXIT_SHIELD_ICON_IMAGE:
-        return _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE
-    # QGIS validates the match fallback against the loaded sprite sheet up front,
-    # even though audited road-exit features use reflen values in the 1..9 range.
-    # Keep the fallback on an existing sprite instead of a missing sentinel so this
-    # replacement does not reintroduce a sprite-retrieval warning. Malformed or
-    # out-of-range reflen values therefore fall back to the one-character shield.
-    return [
-        "match",
-        ["get", "reflen"],
-        *(
-            item
-            for reflen in range(1, 10)
-            for item in (
-                reflen,
-                f"motorway-exit-{reflen}",
-                str(reflen),
-                f"motorway-exit-{reflen}",
-            )
-        ),
-        "motorway-exit-1",
-    ]
-
-
 def _expression_references_get_field(expr: object, field_name: str) -> bool:
     if isinstance(expr, list):
         if expr == ["get", field_name]:
@@ -2252,6 +2226,30 @@ def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[st
     return variants
 
 
+def _road_exit_shield_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    if str(layer.get("id") or "") != _ROAD_EXIT_SHIELD_LAYER_ID:
+        return None
+    layout = layer.get("layout")
+    if not isinstance(layout, dict) or layout.get("icon-image") != _ROAD_EXIT_SHIELD_ICON_IMAGE:
+        return None
+
+    variants: list[dict[str, object]] = []
+    base_filter = _road_shield_filter_with_string_reflen_range(layer.get("filter"))
+    for reflen in range(1, 10):
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{_ROAD_EXIT_SHIELD_LAYER_ID}-{reflen}"
+        if base_filter is False:
+            variant["filter"] = False
+        else:
+            variant["filter"] = _with_additional_filter_clauses(
+                base_filter,
+                _road_shield_reflen_filter(reflen),
+            )
+        variant["layout"]["icon-image"] = f"motorway-exit-{reflen}"
+        variants.append(variant)
+    return variants
+
+
 def _road_number_shield_zoom_layer_variants(
     layer: dict[str, object],
 ) -> list[dict[str, object]] | None:
@@ -2308,9 +2306,27 @@ def _split_road_number_shield_zoom_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _expand_road_exit_shield_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _road_exit_shield_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _is_road_number_shield_layer_id(layer_id: object) -> bool:
     normalized = str(layer_id or "")
     return normalized == _ROAD_NUMBER_SHIELD_LAYER_ID or normalized.startswith(f"{_ROAD_NUMBER_SHIELD_LAYER_ID}-")
+
+
+def _is_road_exit_shield_layer_id(layer_id: object) -> bool:
+    normalized = str(layer_id or "")
+    return normalized == _ROAD_EXIT_SHIELD_LAYER_ID or normalized.startswith(f"{_ROAD_EXIT_SHIELD_LAYER_ID}-")
 
 
 def _is_poi_label_layer_id(layer_id: object) -> bool:
@@ -2508,6 +2524,7 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
     for matches_layer_id, base_layer_id in (
         (_is_waterway_label_layer_id, _WATERWAY_LABEL_LAYER_ID),
         (_is_road_number_shield_layer_id, _ROAD_NUMBER_SHIELD_LAYER_ID),
+        (_is_road_exit_shield_layer_id, _ROAD_EXIT_SHIELD_LAYER_ID),
         (_is_road_label_layer_id, _ROAD_LABEL_LAYER_ID),
         (_is_poi_label_layer_id, _POI_LABEL_LAYER_ID),
         (_is_gate_label_layer_id, _GATE_LABEL_LAYER_ID),
@@ -5862,6 +5879,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_major_link_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_class_line_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _expand_road_number_shield_layers_for_qgis(style.get("layers"))
+    style["layers"] = _expand_road_exit_shield_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_number_shield_zoom_layers_for_qgis(
         style.get("layers")
     )
@@ -6018,10 +6036,6 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                         props[prop] = icon_image
                         continue
                     icon_image = _poi_label_icon_image_fallback(base_layer_id, val)
-                    if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
-                        props[prop] = icon_image
-                        continue
-                    icon_image = _road_exit_shield_icon_fallback(layer_id, val)
                     if icon_image is not _ICON_IMAGE_SIMPLIFICATION_NOT_AVAILABLE:
                         props[prop] = icon_image
                         continue

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1564,12 +1564,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][1]["layout"]["text-max-width"], text_max_width)
         self.assertEqual(result["layers"][2]["layout"]["text-anchor"], text_anchor)
 
-    def test_road_exit_shield_concat_icon_uses_reflen_sprite_match_fallback(self):
+    def test_road_exit_shield_concat_icon_expands_to_reflen_sprite_layers(self):
         exit_icon = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
         other_concat_icon = ["concat", "motorway-exit-", ["get", "reflen"]]
         style = {
             "layers": [
-                {"id": "road-exit-shield", "layout": {"icon-image": exit_icon}},
+                {
+                    "id": "road-exit-shield",
+                    "filter": ["all", ["has", "reflen"], ["<=", ["get", "reflen"], 9]],
+                    "layout": {"icon-image": exit_icon, "text-field": ["get", "ref"]},
+                },
                 {"id": "road-number-shield", "layout": {"icon-image": exit_icon}},
                 {"id": "road-exit-shield", "layout": {"icon-image": other_concat_icon}},
             ]
@@ -1578,51 +1582,83 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         result = simplify_mapbox_style_expressions(style)
 
         self.assertEqual(
-            result["layers"][0]["layout"]["icon-image"],
+            [layer["id"] for layer in result["layers"][:9]],
+            [f"road-exit-shield-{reflen}" for reflen in range(1, 10)],
+        )
+        self.assertEqual(result["layers"][0]["layout"]["icon-image"], "motorway-exit-1")
+        self.assertEqual(result["layers"][0]["layout"]["text-field"], ["get", "ref"])
+        self.assertEqual(result["layers"][8]["layout"]["icon-image"], "motorway-exit-9")
+        self.assertEqual(
+            result["layers"][1]["filter"],
             [
-                "match",
-                ["get", "reflen"],
-                1,
-                "motorway-exit-1",
-                "1",
-                "motorway-exit-1",
-                2,
-                "motorway-exit-2",
-                "2",
-                "motorway-exit-2",
-                3,
-                "motorway-exit-3",
-                "3",
-                "motorway-exit-3",
-                4,
-                "motorway-exit-4",
-                "4",
-                "motorway-exit-4",
-                5,
-                "motorway-exit-5",
-                "5",
-                "motorway-exit-5",
-                6,
-                "motorway-exit-6",
-                "6",
-                "motorway-exit-6",
-                7,
-                "motorway-exit-7",
-                "7",
-                "motorway-exit-7",
-                8,
-                "motorway-exit-8",
-                "8",
-                "motorway-exit-8",
-                9,
-                "motorway-exit-9",
-                "9",
-                "motorway-exit-9",
-                "motorway-exit-1",
+                "all",
+                ["has", "reflen"],
+                [
+                    "match",
+                    ["get", "reflen"],
+                    1,
+                    True,
+                    "1",
+                    True,
+                    2,
+                    True,
+                    "2",
+                    True,
+                    3,
+                    True,
+                    "3",
+                    True,
+                    4,
+                    True,
+                    "4",
+                    True,
+                    5,
+                    True,
+                    "5",
+                    True,
+                    6,
+                    True,
+                    "6",
+                    True,
+                    7,
+                    True,
+                    "7",
+                    True,
+                    8,
+                    True,
+                    "8",
+                    True,
+                    9,
+                    True,
+                    "9",
+                    True,
+                    False,
+                ],
+                ["match", ["get", "reflen"], 2, True, "2", True, False],
             ],
         )
-        self.assertEqual(result["layers"][1]["layout"]["icon-image"], exit_icon)
-        self.assertEqual(result["layers"][2]["layout"]["icon-image"], other_concat_icon)
+        self.assertEqual(result["layers"][9]["layout"]["icon-image"], exit_icon)
+        self.assertEqual(result["layers"][10]["layout"]["icon-image"], other_concat_icon)
+
+    def test_road_exit_shield_split_preserves_disabled_filter(self):
+        exit_icon = ["concat", "motorway-exit-", ["to-string", ["get", "reflen"]]]
+        style = {
+            "layers": [
+                {
+                    "id": "road-exit-shield",
+                    "filter": False,
+                    "layout": {"icon-image": exit_icon},
+                }
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [f"road-exit-shield-{reflen}" for reflen in range(1, 10)],
+        )
+        self.assertTrue(all(layer["filter"] == ["==", 1, 0] for layer in result["layers"]))
 
     @staticmethod
     def _road_number_shield_icon_case():


### PR DESCRIPTION
## Summary

- split Mapbox Outdoors road-exit shield icon expressions into reflen-specific QGIS layers
- preserve numeric and string reflen matches while handing QGIS literal motorway-exit sprite names
- keep road-number shield preprocessing unchanged

## Validation

- `python3 -m pytest tests/test_mapbox_config.py tests/test_mapbox_outdoors_style_audit.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- live style audit with QGIS converter warnings: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260519T142313Z/audit.json`
- targeted live comparison for `geneva-airport-motorway-z14-outdoors`: `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260519T142403Z/manifest.json`

## Rendering Evidence

The live audit confirms all motorway-exit sprite definitions `motorway-exit-1` through `motorway-exit-9` are present in the Mapbox Outdoors sprite sheet. With QGIS sprite context loaded, converter warnings remain at 0 after qfit preprocessing.

The targeted Geneva airport z14 QGIS render completed successfully. Compared with the current `origin/main` QGIS render for the same camera, the branch changed 402 of 1,152,000 pixels (`0.000349`), so the behavior is localized to the expected exit-shield symbol path.

Closes no issue; continues #949.
