### PR TITLE
[codex] summarize qfit label control omissions

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -20,6 +20,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _label_style_summary_rows,
     _load_original_style,
     _postprocessed_label_records,
+    _source_label_control_omission_summary_rows,
     _source_label_control_summary_rows,
     _source_label_fanout_summary_rows,
     build_label_settings_paths,
@@ -562,6 +563,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(report["source_label_fanout_by_base_layer"][0]["converted_label_styles"], 1)
         self.assertEqual(report["source_label_control_summary_by_base_layer"][0]["base_style_layer_id"], "contour-label")
         self.assertEqual(report["source_label_control_summary_by_base_layer"][0]["source_label_rows"], 1)
+        self.assertEqual(report["source_label_control_omission_summary_by_base_layer"], [])
         self.assertEqual(report["source_label_layer_count"], 1)
 
     def test_label_style_summary_groups_density_relevant_settings(self):
@@ -718,6 +720,54 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(settlement_row["missing_paint_controls"], {"text-color": 1, "text-halo-color": 1})
         self.assertEqual(rows[1]["missing_control_count"], 0)
 
+    def test_source_label_control_omission_summary_groups_known_qfit_omissions(self):
+        rows = _source_label_control_omission_summary_rows(
+            [
+                {
+                    "base_style_layer_id": "settlement-major-label",
+                    "style_name": "settlement-major-label-z4-to-z6-dot-11-left",
+                    "qfit_style_layer_id": "settlement-major-label-z4-to-z6-dot-11-left",
+                    "layout": {"symbol-sort-key": ["get", "symbolrank"], "text-field": ["get", "name"]},
+                    "paint": {},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {},
+                },
+                {
+                    "base_style_layer_id": "country-label",
+                    "style_name": "country-label",
+                    "qfit_style_layer_id": "country-label",
+                    "layout": {"icon-image": "", "text-field": ["get", "name"]},
+                    "paint": {"icon-opacity": 0.6, "text-color": "#111111"},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {},
+                },
+                {
+                    "base_style_layer_id": "poi-label",
+                    "style_name": "poi-label-z17-plus-icon",
+                    "qfit_style_layer_id": "poi-label-z17-plus-icon",
+                    "qfit_filter": [">=", ["get", "sizerank"], 13.0],
+                    "layout": {"icon-image": "restaurant", "text-field": ["get", "name"]},
+                    "paint": {"icon-opacity": ["step", ["get", "sizerank"], 0, 13.0, 1]},
+                    "qfit_layout": {"icon-image": "restaurant", "text-field": ["get", "name"]},
+                    "qfit_paint": {},
+                },
+            ]
+        )
+
+        self.assertEqual([row["base_style_layer_id"] for row in rows], ["country-label", "poi-label", "settlement-major-label"])
+        country_row = rows[0]
+        self.assertEqual(country_row["omitted_control_count"], 2)
+        self.assertEqual(country_row["omitted_controls"], {"layout.icon-image": 1, "paint.icon-opacity": 1})
+        self.assertEqual(
+            country_row["omission_reasons"],
+            {"empty icon-image removed": 1, "icon-opacity removed with no QGIS icon": 1},
+        )
+        self.assertEqual(
+            rows[1]["omission_reasons"],
+            {"icon-opacity encoded by label visibility split": 1},
+        )
+        self.assertEqual(rows[2]["omission_reasons"], {"settlement symbol-sort-key encoded by qfit split": 1})
+
     def test_collect_label_settings_runs_with_fake_qgis_runtime(self):
         modules = {
             **_fake_qgis_modules(),
@@ -822,6 +872,18 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "missing_paint_controls": {},
                 }
             ],
+            "source_label_control_omission_summary_by_base_layer": [
+                {
+                    "base_style_layer_id": "country-label",
+                    "source_label_rows": 10,
+                    "omitted_control_count": 20,
+                    "omitted_controls": {"layout.icon-image": 10, "paint.icon-opacity": 10},
+                    "omission_reasons": {
+                        "empty icon-image removed": 10,
+                        "icon-opacity removed with no QGIS icon": 10,
+                    },
+                }
+            ],
             "source_label_layer_count": 1,
             "labels": [
                 {
@@ -891,6 +953,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("## Source label control coverage by base layer", markdown)
         self.assertIn(
             "| contour-label | 1 | 0 | symbol-placement=1, text-field=1 | symbol-placement=1, text-field=1 | — | text-color=1, text-halo-color=1 | text-color=1, text-halo-color=1 | — |",
+            markdown,
+        )
+        self.assertIn("## Known qfit label control omissions by base layer", markdown)
+        self.assertIn(
+            "| country-label | 10 | 20 | layout.icon-image=10, paint.icon-opacity=10 | empty icon-image removed=10, icon-opacity removed with no QGIS icon=10 |",
             markdown,
         )
         self.assertIn("## Converted QGIS label styles", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -565,6 +565,87 @@ def _missing_section_key_values(rows: list[dict[str, object]], source_section: s
         yield from _missing_section_keys(row, source_section, qfit_section)
 
 
+def _nested_contains_value(value: object, expected: object) -> bool:
+    if value == expected:
+        return True
+    if isinstance(value, list):
+        return any(_nested_contains_value(item, expected) for item in value)
+    if isinstance(value, dict):
+        return any(_nested_contains_value(item, expected) for item in value.values())
+    return False
+
+
+def _section_value(row: dict[str, object], section: str, key: str) -> object:
+    source_section = row.get(section)
+    source_values = source_section if isinstance(source_section, dict) else {}
+    return source_values.get(key)
+
+
+def _is_empty_icon_image_omission(row: dict[str, object], section: str, key: str) -> bool:
+    return section == "layout" and key == "icon-image" and _section_value(row, section, key) == ""
+
+
+def _is_settlement_sort_key_omission(row: dict[str, object], section: str, key: str) -> bool:
+    base_layer = str(row.get("base_style_layer_id") or "")
+    return (
+        section == "layout"
+        and key == "symbol-sort-key"
+        and base_layer in {"settlement-major-label", "settlement-minor-label"}
+        and _section_value(row, section, key) == ["get", "symbolrank"]
+    )
+
+
+def _source_icon_image(row: dict[str, object]) -> object:
+    source_layout = row.get("layout")
+    return source_layout.get("icon-image") if isinstance(source_layout, dict) else None
+
+
+def _is_icon_opacity_without_qgis_icon(row: dict[str, object]) -> bool:
+    qfit_layout = row.get("qfit_layout")
+    return isinstance(qfit_layout, dict) and "icon-image" not in qfit_layout and _source_icon_image(row) in (None, "")
+
+
+def _is_icon_visibility_split(row: dict[str, object]) -> bool:
+    style_id = str(row.get("qfit_style_layer_id") or row.get("style_name") or "")
+    return style_id.endswith(("-icon", "-text")) and _nested_contains_value(row.get("qfit_filter"), "sizerank")
+
+
+def _known_missing_control_reason(row: dict[str, object], section: str, key: str) -> str | None:
+    if _is_empty_icon_image_omission(row, section, key):
+        return "empty icon-image removed"
+    if _is_settlement_sort_key_omission(row, section, key):
+        return "settlement symbol-sort-key encoded by qfit split"
+    if section == "paint" and key == "icon-opacity":
+        if _is_icon_opacity_without_qgis_icon(row):
+            return "icon-opacity removed with no QGIS icon"
+        if _is_icon_visibility_split(row):
+            return "icon-opacity encoded by label visibility split"
+    return None
+
+
+def _known_missing_control_values(
+    rows: list[dict[str, object]],
+    source_section: str,
+    qfit_section: str,
+) -> Iterable[str]:
+    for row in rows:
+        for key in _missing_section_keys(row, source_section, qfit_section):
+            if _known_missing_control_reason(row, source_section, key) is not None:
+                yield f"{source_section}.{key}"
+
+
+def _known_missing_control_reason_values(
+    rows: list[dict[str, object]],
+    source_section: str,
+    qfit_section: str,
+) -> Iterable[str]:
+    for row in rows:
+        for key in _missing_section_keys(row, source_section, qfit_section):
+            reason = _known_missing_control_reason(row, source_section, key)
+            if reason is not None:
+                yield reason
+
+
 def _source_label_control_summary_rows(source_label_layers: list[dict[str, object]]) -> list[dict[str, object]]:
     grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
     for row in source_label_layers:
@@ -601,6 +682,45 @@ def _source_label_control_summary_rows(source_label_layers: list[dict[str, objec
     )
 
 
+def _source_label_control_omission_summary_rows(source_label_layers: list[dict[str, object]]) -> list[dict[str, object]]:
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in source_label_layers:
+        if not isinstance(row, dict):
+            continue
+        base_layer = str(row.get("base_style_layer_id") or row.get("style_name") or "")
+        if base_layer:
+            grouped[base_layer].append(row)
+
+    rows: list[dict[str, object]] = []
+    for base_layer, source_rows in grouped.items():
+        omitted_controls = Counter(
+            _known_missing_control_values(source_rows, "layout", "qfit_layout")
+        )
+        omitted_controls.update(_known_missing_control_values(source_rows, "paint", "qfit_paint"))
+        if not omitted_controls:
+            continue
+        rows.append(
+            {
+                "base_style_layer_id": base_layer,
+                "source_label_rows": len(source_rows),
+                "omitted_control_count": sum(omitted_controls.values()),
+                "omitted_controls": dict(sorted(omitted_controls.items(), key=lambda item: (-item[1], item[0]))),
+                "omission_reasons": _sorted_count_map(
+                    tuple(_known_missing_control_reason_values(source_rows, "layout", "qfit_layout"))
+                    + tuple(_known_missing_control_reason_values(source_rows, "paint", "qfit_paint"))
+                ),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda row: (
+            -int(row["omitted_control_count"]),
+            -int(row["source_label_rows"]),
+            str(row["base_style_layer_id"]),
+        ),
+    )
+
+
 def _label_settings_report(
     *,
     config: LabelSettingsConfig,
@@ -624,6 +744,9 @@ def _label_settings_report(
         "label_style_summary_by_base_layer": _label_style_summary_rows(records),
         "source_label_fanout_by_base_layer": _source_label_fanout_summary_rows(source_label_layer_rows, records),
         "source_label_control_summary_by_base_layer": _source_label_control_summary_rows(source_label_layer_rows),
+        "source_label_control_omission_summary_by_base_layer": _source_label_control_omission_summary_rows(
+            source_label_layer_rows
+        ),
         "source_label_layer_count": len(source_label_layer_rows),
         "source_label_layers": source_label_layer_rows,
     }
@@ -823,6 +946,31 @@ def _append_source_label_control_summary(lines: list[str], summary_rows: list[ob
         lines.append("")
 
 
+def _append_source_label_control_omission_summary(lines: list[str], summary_rows: list[object]) -> None:
+    if summary_rows:
+        lines.extend(
+            [
+                "## Known qfit label control omissions by base layer",
+                "",
+                "| Base layer | Source rows | Known omissions | Omitted controls | Reasons |",
+                "| --- | ---: | ---: | --- | --- |",
+            ]
+        )
+        for row in summary_rows:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "| {base} | {source_rows} | {omitted_count} | {omitted_controls} | {reasons} |".format(
+                    base=_markdown_value(row.get("base_style_layer_id")),
+                    source_rows=_markdown_value(row.get("source_label_rows")),
+                    omitted_count=_markdown_value(row.get("omitted_control_count")),
+                    omitted_controls=_count_map_markdown_value(row.get("omitted_controls")),
+                    reasons=_count_map_markdown_value(row.get("omission_reasons")),
+                )
+            )
+        lines.append("")
+
+
 def _append_converted_label_rows(lines: list[str], rows: list[object]) -> None:
     lines.extend(
         [
@@ -921,6 +1069,10 @@ def build_summary_markdown(report: dict[str, object]) -> str:
     source_fanout_rows = source_fanout_summary if isinstance(source_fanout_summary, list) else []
     source_control_summary = report.get("source_label_control_summary_by_base_layer")
     source_control_rows = source_control_summary if isinstance(source_control_summary, list) else []
+    source_control_omission_summary = report.get("source_label_control_omission_summary_by_base_layer")
+    source_control_omission_rows = (
+        source_control_omission_summary if isinstance(source_control_omission_summary, list) else []
+    )
     source_labels = report.get("source_label_layers")
     source_rows = source_labels if isinstance(source_labels, list) else []
     lines = [
@@ -935,6 +1087,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
     _append_label_style_summary(lines, summary_rows)
     _append_source_label_fanout_summary(lines, source_fanout_rows)
     _append_source_label_control_summary(lines, source_control_rows)
+    _append_source_label_control_omission_summary(lines, source_control_omission_rows)
     _append_converted_label_rows(lines, rows)
     _append_source_label_rows(lines, report, source_rows)
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add a known qfit label control omissions summary to the Mapbox Outdoors label-settings diagnostic
- group intentionally omitted label controls and omission reasons by base Mapbox layer
- keep the missing-control coverage table intact while separating known qfit substitutions from unresolved gaps

Continues #949.

## Validation
- python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- git diff --check
- live Mapbox Outdoors label-settings diagnostic wrote debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260519T161315Z/summary.md
