### PR TITLE
[codex] Summarize unresolved Mapbox label controls

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -23,6 +23,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _source_label_control_omission_summary_rows,
     _source_label_control_summary_rows,
     _source_label_fanout_summary_rows,
+    _source_label_unresolved_control_summary_rows,
     build_label_settings_paths,
     build_run_directory,
     build_summary_markdown,
@@ -564,6 +565,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(report["source_label_control_summary_by_base_layer"][0]["base_style_layer_id"], "contour-label")
         self.assertEqual(report["source_label_control_summary_by_base_layer"][0]["source_label_rows"], 1)
         self.assertEqual(report["source_label_control_omission_summary_by_base_layer"], [])
+        self.assertEqual(report["source_label_unresolved_control_summary_by_base_layer"], [])
         self.assertEqual(report["source_label_layer_count"], 1)
 
     def test_label_style_summary_groups_density_relevant_settings(self):
@@ -768,6 +770,49 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         self.assertEqual(rows[2]["omission_reasons"], {"settlement symbol-sort-key encoded by qfit split": 1})
 
+    def test_source_label_unresolved_control_summary_ignores_known_qfit_omissions(self):
+        rows = _source_label_unresolved_control_summary_rows(
+            [
+                {
+                    "base_style_layer_id": "settlement-major-label",
+                    "style_name": "settlement-major-label-z4-to-z6-dot-11-left",
+                    "qfit_style_layer_id": "settlement-major-label-z4-to-z6-dot-11-left",
+                    "layout": {
+                        "symbol-sort-key": ["get", "symbolrank"],
+                        "text-anchor": ["get", "text_anchor"],
+                        "text-field": ["get", "name"],
+                    },
+                    "paint": {"text-color": "#111111", "text-halo-color": "#ffffff"},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {"text-color": "#111111"},
+                },
+                {
+                    "base_style_layer_id": "country-label",
+                    "style_name": "country-label",
+                    "qfit_style_layer_id": "country-label",
+                    "layout": {"icon-image": "", "text-field": ["get", "name"]},
+                    "paint": {"icon-opacity": 0.6, "text-color": "#111111"},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {"text-color": "#111111"},
+                },
+                {
+                    "base_style_layer_id": "poi-label",
+                    "style_name": "poi-label-z16-plus-text",
+                    "qfit_style_layer_id": "poi-label-z16-plus-text",
+                    "layout": {"text-field": ["get", "name"]},
+                    "paint": {"text-color": "#69575d", "text-halo-color": "#ffffff"},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {"text-color": "#69575d"},
+                },
+            ]
+        )
+
+        self.assertEqual([row["base_style_layer_id"] for row in rows], ["settlement-major-label", "poi-label"])
+        self.assertEqual(rows[0]["unresolved_control_count"], 2)
+        self.assertEqual(rows[0]["unresolved_controls"], {"layout.text-anchor": 1, "paint.text-halo-color": 1})
+        self.assertEqual(rows[1]["unresolved_control_count"], 1)
+        self.assertEqual(rows[1]["unresolved_controls"], {"paint.text-halo-color": 1})
+
     def test_collect_label_settings_runs_with_fake_qgis_runtime(self):
         modules = {
             **_fake_qgis_modules(),
@@ -884,6 +929,14 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     },
                 }
             ],
+            "source_label_unresolved_control_summary_by_base_layer": [
+                {
+                    "base_style_layer_id": "settlement-major-label",
+                    "source_label_rows": 4,
+                    "unresolved_control_count": 6,
+                    "unresolved_controls": {"layout.text-anchor": 4, "paint.text-halo-color": 2},
+                }
+            ],
             "source_label_layer_count": 1,
             "labels": [
                 {
@@ -958,6 +1011,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("## Known qfit label control omissions by base layer", markdown)
         self.assertIn(
             "| country-label | 10 | 20 | layout.icon-image=10, paint.icon-opacity=10 | empty icon-image removed=10, icon-opacity removed with no QGIS icon=10 |",
+            markdown,
+        )
+        self.assertIn("## Unresolved label control gaps by base layer", markdown)
+        self.assertIn(
+            "| settlement-major-label | 4 | 6 | layout.text-anchor=4, paint.text-halo-color=2 |",
             markdown,
         )
         self.assertIn("## Converted QGIS label styles", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -646,6 +646,17 @@ def _known_missing_control_reason_values(
                 yield reason
 
 
+def _unresolved_missing_control_values(
+    rows: list[dict[str, object]],
+    source_section: str,
+    qfit_section: str,
+) -> Iterable[str]:
+    for row in rows:
+        for key in _missing_section_keys(row, source_section, qfit_section):
+            if _known_missing_control_reason(row, source_section, key) is None:
+                yield f"{source_section}.{key}"
+
+
 def _source_label_control_summary_rows(source_label_layers: list[dict[str, object]]) -> list[dict[str, object]]:
     grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
     for row in source_label_layers:
@@ -676,6 +687,41 @@ def _source_label_control_summary_rows(source_label_layers: list[dict[str, objec
         rows,
         key=lambda row: (
             -int(row["missing_control_count"]),
+            -int(row["source_label_rows"]),
+            str(row["base_style_layer_id"]),
+        ),
+    )
+
+
+def _source_label_unresolved_control_summary_rows(source_label_layers: list[dict[str, object]]) -> list[dict[str, object]]:
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in source_label_layers:
+        if not isinstance(row, dict):
+            continue
+        base_layer = str(row.get("base_style_layer_id") or row.get("style_name") or "")
+        if base_layer:
+            grouped[base_layer].append(row)
+
+    rows: list[dict[str, object]] = []
+    for base_layer, source_rows in grouped.items():
+        unresolved_controls = Counter(
+            _unresolved_missing_control_values(source_rows, "layout", "qfit_layout")
+        )
+        unresolved_controls.update(_unresolved_missing_control_values(source_rows, "paint", "qfit_paint"))
+        if not unresolved_controls:
+            continue
+        rows.append(
+            {
+                "base_style_layer_id": base_layer,
+                "source_label_rows": len(source_rows),
+                "unresolved_control_count": sum(unresolved_controls.values()),
+                "unresolved_controls": dict(sorted(unresolved_controls.items(), key=lambda item: (-item[1], item[0]))),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda row: (
+            -int(row["unresolved_control_count"]),
             -int(row["source_label_rows"]),
             str(row["base_style_layer_id"]),
         ),
@@ -745,6 +791,9 @@ def _label_settings_report(
         "source_label_fanout_by_base_layer": _source_label_fanout_summary_rows(source_label_layer_rows, records),
         "source_label_control_summary_by_base_layer": _source_label_control_summary_rows(source_label_layer_rows),
         "source_label_control_omission_summary_by_base_layer": _source_label_control_omission_summary_rows(
+            source_label_layer_rows
+        ),
+        "source_label_unresolved_control_summary_by_base_layer": _source_label_unresolved_control_summary_rows(
             source_label_layer_rows
         ),
         "source_label_layer_count": len(source_label_layer_rows),
@@ -971,6 +1020,30 @@ def _append_source_label_control_omission_summary(lines: list[str], summary_rows
         lines.append("")
 
 
+def _append_source_label_unresolved_control_summary(lines: list[str], summary_rows: list[object]) -> None:
+    if summary_rows:
+        lines.extend(
+            [
+                "## Unresolved label control gaps by base layer",
+                "",
+                "| Base layer | Source rows | Unresolved controls | Controls |",
+                "| --- | ---: | ---: | --- |",
+            ]
+        )
+        for row in summary_rows:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "| {base} | {source_rows} | {unresolved_count} | {unresolved_controls} |".format(
+                    base=_markdown_value(row.get("base_style_layer_id")),
+                    source_rows=_markdown_value(row.get("source_label_rows")),
+                    unresolved_count=_markdown_value(row.get("unresolved_control_count")),
+                    unresolved_controls=_count_map_markdown_value(row.get("unresolved_controls")),
+                )
+            )
+        lines.append("")
+
+
 def _append_converted_label_rows(lines: list[str], rows: list[object]) -> None:
     lines.extend(
         [
@@ -1073,6 +1146,10 @@ def build_summary_markdown(report: dict[str, object]) -> str:
     source_control_omission_rows = (
         source_control_omission_summary if isinstance(source_control_omission_summary, list) else []
     )
+    source_unresolved_control_summary = report.get("source_label_unresolved_control_summary_by_base_layer")
+    source_unresolved_control_rows = (
+        source_unresolved_control_summary if isinstance(source_unresolved_control_summary, list) else []
+    )
     source_labels = report.get("source_label_layers")
     source_rows = source_labels if isinstance(source_labels, list) else []
     lines = [
@@ -1088,6 +1165,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
     _append_source_label_fanout_summary(lines, source_fanout_rows)
     _append_source_label_control_summary(lines, source_control_rows)
     _append_source_label_control_omission_summary(lines, source_control_omission_rows)
+    _append_source_label_unresolved_control_summary(lines, source_unresolved_control_rows)
     _append_converted_label_rows(lines, rows)
     _append_source_label_rows(lines, report, source_rows)
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary

- add an unresolved label-control summary to the Mapbox Outdoors label diagnostics report
- separate known qfit omissions from remaining label-control gaps so #949 follow-up slices can be ranked by unresolved controls
- render the unresolved summary in the Markdown report

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- local Mapbox Outdoors label-settings diagnostics run with the configured token; the Markdown report rendered the unresolved-control section
