### PR TITLE
[codex] Classify known Mapbox icon omissions

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -770,14 +770,99 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         self.assertEqual(rows[2]["omission_reasons"], {"settlement symbol-sort-key encoded by qfit split": 1})
 
+    def test_source_label_control_omission_summary_groups_icon_image_split_omissions(self):
+        rows = _source_label_control_omission_summary_rows(
+            [
+                {
+                    "base_style_layer_id": "poi-label",
+                    "style_name": "poi-label-z17-plus-text",
+                    "qfit_style_layer_id": "poi-label-z17-plus-text",
+                    "qfit_filter": [">=", ["get", "sizerank"], 13.0],
+                    "layout": {
+                        "icon-image": ["image", ["get", "maki"]],
+                        "text-field": ["get", "name"],
+                    },
+                    "paint": {},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {},
+                },
+                {
+                    "base_style_layer_id": "settlement-minor-label",
+                    "style_name": "settlement-minor-label-z8-to-z10-name",
+                    "qfit_style_layer_id": "settlement-minor-label-z8-to-z10-name",
+                    "qfit_minzoom": 8,
+                    "layout": {
+                        "icon-image": [
+                            "step",
+                            ["zoom"],
+                            ["case", ["==", ["get", "capital"], 2], "border-dot-13", "dot-11"],
+                            8,
+                            "",
+                        ],
+                        "text-field": ["get", "name"],
+                    },
+                    "paint": {},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {},
+                },
+            ]
+        )
+
+        self.assertEqual([row["base_style_layer_id"] for row in rows], ["poi-label", "settlement-minor-label"])
+        self.assertEqual(rows[0]["omission_reasons"], {"icon-image encoded by label visibility split": 1})
+        self.assertEqual(rows[1]["omission_reasons"], {"settlement icon-image empty at qfit zoom split": 1})
+
+    def test_source_label_unresolved_control_summary_keeps_non_zoom_empty_icon_fallbacks(self):
+        rows = _source_label_unresolved_control_summary_rows(
+            [
+                {
+                    "base_style_layer_id": "settlement-minor-label",
+                    "style_name": "settlement-minor-label-z8-to-z10-name",
+                    "qfit_style_layer_id": "settlement-minor-label-z8-to-z10-name",
+                    "qfit_minzoom": 8,
+                    "layout": {
+                        "icon-image": ["case", ["==", ["get", "capital"], 2], "dot-11", ""],
+                        "text-field": ["get", "name"],
+                    },
+                    "paint": {},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {},
+                },
+                {
+                    "base_style_layer_id": "settlement-minor-label",
+                    "style_name": "settlement-minor-label-z10-plus-name",
+                    "qfit_style_layer_id": "settlement-minor-label-z10-plus-name",
+                    "qfit_minzoom": 10,
+                    "layout": {
+                        "icon-image": ["step", ["zoom"], "dot-10", 8, "", 9, "dot-11"],
+                        "text-field": ["get", "name"],
+                    },
+                    "paint": {},
+                    "qfit_layout": {"text-field": ["get", "name"]},
+                    "qfit_paint": {},
+                }
+            ]
+        )
+
+        self.assertEqual(rows[0]["base_style_layer_id"], "settlement-minor-label")
+        self.assertEqual(rows[0]["unresolved_controls"], {"layout.icon-image": 2})
+
     def test_source_label_unresolved_control_summary_ignores_known_qfit_omissions(self):
         rows = _source_label_unresolved_control_summary_rows(
             [
                 {
                     "base_style_layer_id": "settlement-major-label",
-                    "style_name": "settlement-major-label-z4-to-z6-dot-11-left",
-                    "qfit_style_layer_id": "settlement-major-label-z4-to-z6-dot-11-left",
+                    "style_name": "settlement-major-label-z8-plus-name",
+                    "qfit_style_layer_id": "settlement-major-label-z8-plus-name",
+                    "qfit_minzoom": 8,
                     "layout": {
+                        "icon-image": [
+                            "step",
+                            ["zoom"],
+                            ["case", ["==", ["get", "capital"], 2], "border-dot-13", "dot-11"],
+                            8,
+                            "",
+                        ],
                         "symbol-sort-key": ["get", "symbolrank"],
                         "text-anchor": ["get", "text_anchor"],
                         "text-field": ["get", "name"],
@@ -799,7 +884,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "base_style_layer_id": "poi-label",
                     "style_name": "poi-label-z16-plus-text",
                     "qfit_style_layer_id": "poi-label-z16-plus-text",
-                    "layout": {"text-field": ["get", "name"]},
+                    "qfit_filter": [">=", ["get", "sizerank"], 13.0],
+                    "layout": {
+                        "icon-image": ["image", ["get", "maki"]],
+                        "text-field": ["get", "name"],
+                    },
                     "paint": {"text-color": "#69575d", "text-halo-color": "#ffffff"},
                     "qfit_layout": {"text-field": ["get", "name"]},
                     "qfit_paint": {"text-color": "#69575d"},

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -610,11 +610,48 @@ def _is_icon_visibility_split(row: dict[str, object]) -> bool:
     return style_id.endswith(("-icon", "-text")) and _nested_contains_value(row.get("qfit_filter"), "sizerank")
 
 
+def _is_text_split_icon_image_omission(row: dict[str, object], section: str, key: str) -> bool:
+    style_id = str(row.get("qfit_style_layer_id") or row.get("style_name") or "")
+    return (
+        section == "layout"
+        and key == "icon-image"
+        and style_id.endswith("-text")
+        and _nested_contains_value(row.get("qfit_filter"), "sizerank")
+    )
+
+
+def _zoom_step_outputs_at_or_before(value: object, zoom: float, expected: object) -> bool:
+    if not isinstance(value, list) or len(value) < 4 or value[0] != "step" or value[1] != ["zoom"]:
+        return False
+    output = value[2]
+    for index in range(3, len(value) - 1, 2):
+        stop = value[index]
+        if isinstance(stop, (int, float)) and stop <= zoom:
+            output = value[index + 1]
+    return output == expected
+
+
+def _is_settlement_zoom_empty_icon_omission(row: dict[str, object], section: str, key: str) -> bool:
+    if section != "layout" or key != "icon-image":
+        return False
+    base_layer = str(row.get("base_style_layer_id") or row.get("style_name") or "")
+    if base_layer not in {"settlement-major-label", "settlement-minor-label"}:
+        return False
+    qfit_minzoom = row.get("qfit_minzoom")
+    return isinstance(qfit_minzoom, (int, float)) and _zoom_step_outputs_at_or_before(
+        _source_icon_image(row), qfit_minzoom, ""
+    )
+
+
 def _known_missing_control_reason(row: dict[str, object], section: str, key: str) -> str | None:
     if _is_empty_icon_image_omission(row, section, key):
         return "empty icon-image removed"
     if _is_settlement_sort_key_omission(row, section, key):
         return "settlement symbol-sort-key encoded by qfit split"
+    if _is_text_split_icon_image_omission(row, section, key):
+        return "icon-image encoded by label visibility split"
+    if _is_settlement_zoom_empty_icon_omission(row, section, key):
+        return "settlement icon-image empty at qfit zoom split"
     if section == "paint" and key == "icon-opacity":
         if _is_icon_opacity_without_qgis_icon(row):
             return "icon-opacity removed with no QGIS icon"


### PR DESCRIPTION
## Summary

- classify remaining label `icon-image` gaps that are known qfit outcomes rather than unresolved Mapbox control gaps
- account for text-only icon visibility splits in POI/natural labels
- account for settlement zoom splits where Mapbox's icon expression resolves to an empty icon at the qfit split zoom

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- local Mapbox Outdoors label-settings diagnostics run with the configured token; unresolved label-control summary is empty after these known omissions are classified
