### PR TITLE
chore: summarize Mapbox line label repeat spacing

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -685,8 +685,41 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(contour_row["repeat_distances"], {"0": 1})
         waterway_row = rows[1]
         self.assertEqual(waterway_row["missing_qfit_symbol_spacing"], 0)
+        self.assertEqual(waterway_row["zero_repeat_distance_count"], 0)
         self.assertEqual(waterway_row["qfit_symbol_spacings"], {"400": 1})
         self.assertEqual(waterway_row["repeat_distances"], {"66.1458": 1})
+
+    def test_line_label_repeat_spacing_summary_deduplicates_shared_label_records(self):
+        rows = _line_label_repeat_spacing_rows(
+            [
+                {
+                    "base_style_layer_id": "road-label",
+                    "style_name": "road-label-alias",
+                    "qfit_style_layer_id": "road-label-z15-plus",
+                    "qfit_layout": {"symbol-placement": "line"},
+                },
+                {
+                    "base_style_layer_id": "road-label",
+                    "style_name": "road-label-z15-plus",
+                    "qfit_style_layer_id": "road-label-z15-plus",
+                    "qfit_layout": {"symbol-placement": "line"},
+                },
+            ],
+            [
+                {
+                    "base_style_layer_id": "road-label",
+                    "style_name": "road-label-z15-plus",
+                    "geometry_type": "Line",
+                    "placement": "Curved",
+                    "repeat_distance": 66.1458333333,
+                },
+            ],
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["source_label_rows"], 2)
+        self.assertEqual(rows[0]["converted_line_label_styles"], 1)
+        self.assertEqual(rows[0]["repeat_distances"], {"66.1458": 1})
 
     def test_source_label_fanout_summary_groups_qfit_style_expansion(self):
         rows = _source_label_fanout_summary_rows(

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -18,6 +18,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _geometry_generator_markdown_value,
     _label_settings_report,
     _label_style_summary_rows,
+    _line_label_repeat_spacing_rows,
     _load_original_style,
     _postprocessed_label_records,
     _source_label_control_omission_summary_rows,
@@ -560,6 +561,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(report["label_count"], 1)
         self.assertEqual(report["label_style_summary_by_base_layer"][0]["base_style_layer_id"], "contour-label")
         self.assertEqual(report["label_style_summary_by_base_layer"][0]["count"], 1)
+        self.assertEqual(report["line_label_repeat_spacing_by_base_layer"], [])
         self.assertEqual(report["source_label_fanout_by_base_layer"][0]["base_style_layer_id"], "contour-label")
         self.assertEqual(report["source_label_fanout_by_base_layer"][0]["converted_label_styles"], 1)
         self.assertEqual(report["source_label_control_summary_by_base_layer"][0]["base_style_layer_id"], "contour-label")
@@ -617,6 +619,74 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(road_row["priorities"], {"4": 2})
         self.assertEqual(road_row["repeat_distances"], {"39.6875": 1, "66.1458": 1})
         self.assertEqual(road_row["display_all"], {"false": 2})
+
+    def test_line_label_repeat_spacing_summary_highlights_missing_spacing_and_zero_repeat(self):
+        rows = _line_label_repeat_spacing_rows(
+            [
+                {
+                    "base_style_layer_id": "contour-label",
+                    "style_name": "contour-label",
+                    "qfit_style_layer_id": "contour-label",
+                    "layout": {"symbol-placement": "line"},
+                    "qfit_layout": {"symbol-placement": "line"},
+                },
+                {
+                    "base_style_layer_id": "waterway-label",
+                    "style_name": "waterway-label-z17-plus",
+                    "qfit_style_layer_id": "waterway-label-z17-plus",
+                    "layout": {"symbol-placement": "line", "symbol-spacing": ["interpolate"]},
+                    "qfit_layout": {"symbol-placement": "line", "symbol-spacing": 400.0},
+                },
+                {
+                    "base_style_layer_id": "water-line-label",
+                    "style_name": "water-line-label",
+                    "qfit_style_layer_id": "water-line-label",
+                    "layout": {"symbol-placement": "line-center"},
+                    "qfit_layout": {"symbol-placement": "line-center"},
+                },
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-z11-plus",
+                    "qfit_style_layer_id": "road-number-shield-z11-plus",
+                    "layout": {"symbol-placement": "line", "icon-image": ["get", "shield"]},
+                    "qfit_layout": {"symbol-placement": "line", "icon-image": "default-2"},
+                },
+            ],
+            [
+                {
+                    "base_style_layer_id": "contour-label",
+                    "style_name": "contour-label",
+                    "geometry_type": "Line",
+                    "placement": "Curved",
+                    "repeat_distance": 0.0,
+                },
+                {
+                    "base_style_layer_id": "waterway-label",
+                    "style_name": "waterway-label-z17-plus",
+                    "geometry_type": "Line",
+                    "placement": "Curved",
+                    "repeat_distance": 66.1458333333,
+                },
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-z11-plus",
+                    "geometry_type": "Line",
+                    "placement": "Horizontal",
+                    "repeat_distance": 0.0,
+                },
+            ],
+        )
+
+        self.assertEqual([row["base_style_layer_id"] for row in rows], ["contour-label", "waterway-label"])
+        contour_row = rows[0]
+        self.assertEqual(contour_row["missing_qfit_symbol_spacing"], 1)
+        self.assertEqual(contour_row["zero_repeat_distance_count"], 1)
+        self.assertEqual(contour_row["qfit_symbol_spacings"], {"(missing)": 1})
+        self.assertEqual(contour_row["repeat_distances"], {"0": 1})
+        waterway_row = rows[1]
+        self.assertEqual(waterway_row["missing_qfit_symbol_spacing"], 0)
+        self.assertEqual(waterway_row["qfit_symbol_spacings"], {"400": 1})
+        self.assertEqual(waterway_row["repeat_distances"], {"66.1458": 1})
 
     def test_source_label_fanout_summary_groups_qfit_style_expansion(self):
         rows = _source_label_fanout_summary_rows(
@@ -981,6 +1051,20 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "merge_lines": {"false": 1},
                 }
             ],
+            "line_label_repeat_spacing_by_base_layer": [
+                {
+                    "base_style_layer_id": "contour-label",
+                    "source_label_rows": 1,
+                    "converted_line_label_styles": 1,
+                    "missing_qfit_symbol_spacing": 1,
+                    "source_symbol_spacings": {"(missing)": 1},
+                    "qfit_symbol_spacings": {"(missing)": 1},
+                    "repeat_distances": {"0": 1},
+                    "placements": {"Curved": 1},
+                    "style_names": {"contour-label": 1},
+                    "zero_repeat_distance_count": 1,
+                }
+            ],
             "source_label_fanout_by_base_layer": [
                 {
                     "base_style_layer_id": "contour-label",
@@ -1090,6 +1174,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("Sprite context loaded: yes", markdown)
         self.assertIn("## Label style summary by base layer", markdown)
         self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
+        self.assertIn("## Line label repeat spacing by base layer", markdown)
+        self.assertIn(
+            "| contour-label | 1 | 1 | 1 | (missing)=1 | (missing)=1 | 0=1 | Curved=1 | contour-label=1 |",
+            markdown,
+        )
         self.assertIn("## Source label fan-out by base layer", markdown)
         self.assertIn('| contour-label | 1 | 1 | 1 | contour=1 | 12+=1 | 12+=1 | "name"=1 |', markdown)
         self.assertIn("## Source label control coverage by base layer", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -501,71 +501,103 @@ def _line_label_record_for_repeat(row: dict[str, object]) -> bool:
     return row.get("geometry_type") == "Line" or placement in {"Curved", "Line", "Horizontal"}
 
 
-def _line_label_repeat_spacing_rows(
-    source_label_layers: list[dict[str, object]],
-    label_records: list[dict[str, object]],
-) -> list[dict[str, object]]:
+def _base_style_layer_id(row: dict[str, object]) -> str:
+    return str(row.get("base_style_layer_id") or row.get("style_name") or "")
+
+
+def _deduplicated_label_records(records: Iterable[dict[str, object]]) -> list[dict[str, object]]:
+    deduplicated: list[dict[str, object]] = []
+    seen_record_ids: set[int] = set()
+    for record in records:
+        record_id = id(record)
+        if record_id in seen_record_ids:
+            continue
+        seen_record_ids.add(record_id)
+        deduplicated.append(record)
+    return deduplicated
+
+
+def _label_records_by_style(label_records: list[dict[str, object]]) -> dict[str, list[dict[str, object]]]:
     labels_by_style: dict[str, list[dict[str, object]]] = defaultdict(list)
     for record in label_records:
         style_name = str(record.get("style_name") or "")
         if style_name:
             labels_by_style[style_name].append(record)
+    return labels_by_style
 
+
+def _matched_label_records_for_source_row(
+    row: dict[str, object],
+    labels_by_style: dict[str, list[dict[str, object]]],
+) -> list[dict[str, object]]:
+    style_keys = {str(row.get("style_name") or ""), str(row.get("qfit_style_layer_id") or "")}
+    return _deduplicated_label_records(
+        record
+        for style_key in style_keys
+        for record in labels_by_style.get(style_key, [])
+    )
+
+
+def _line_label_source_groups(
+    source_label_layers: list[dict[str, object]],
+    labels_by_style: dict[str, list[dict[str, object]]],
+) -> dict[str, list[tuple[dict[str, object], list[dict[str, object]]]]]:
     grouped: dict[str, list[tuple[dict[str, object], list[dict[str, object]]]]] = defaultdict(list)
     for row in source_label_layers:
-        if not isinstance(row, dict) or not _is_line_label_source_row(row):
-            continue
-        base_layer = str(row.get("base_style_layer_id") or row.get("style_name") or "")
-        if not base_layer:
-            continue
-        style_keys = {str(row.get("style_name") or ""), str(row.get("qfit_style_layer_id") or "")}
-        seen_label_ids: set[int] = set()
-        matched_labels = []
-        for style_key in style_keys:
-            for record in labels_by_style.get(style_key, []):
-                label_id = id(record)
-                if label_id in seen_label_ids:
-                    continue
-                seen_label_ids.add(label_id)
-                matched_labels.append(record)
-        grouped[base_layer].append((row, matched_labels))
+        if isinstance(row, dict) and _is_line_label_source_row(row):
+            base_layer = _base_style_layer_id(row)
+            if base_layer:
+                grouped[base_layer].append((row, _matched_label_records_for_source_row(row, labels_by_style)))
+    return grouped
 
-    rows: list[dict[str, object]] = []
+
+def _repeat_label_records(
+    grouped_rows: list[tuple[dict[str, object], list[dict[str, object]]]],
+) -> list[dict[str, object]]:
+    return _deduplicated_label_records(
+        record
+        for _row, labels in grouped_rows
+        for record in labels
+        if _line_label_record_for_repeat(record)
+    )
+
+
+def _line_label_repeat_spacing_row(
+    base_layer: str,
+    source_rows: list[dict[str, object]],
+    line_label_rows: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "base_style_layer_id": base_layer,
+        "source_label_rows": len(source_rows),
+        "converted_line_label_styles": len(line_label_rows),
+        "missing_qfit_symbol_spacing": sum(
+            1
+            for row in source_rows
+            if _section_control(row, "qfit_layout", "symbol-spacing") is None
+        ),
+        "source_symbol_spacings": _sorted_count_map(
+            _section_control(row, "layout", "symbol-spacing") for row in source_rows
+        ),
+        "qfit_symbol_spacings": _sorted_count_map(
+            _section_control(row, "qfit_layout", "symbol-spacing") for row in source_rows
+        ),
+        "repeat_distances": _sorted_count_map(row.get("repeat_distance") for row in line_label_rows),
+        "placements": _sorted_count_map(row.get("placement") for row in line_label_rows),
+        "style_names": _sorted_count_map(row.get("style_name") for row in source_rows),
+        "zero_repeat_distance_count": sum(1 for row in line_label_rows if row.get("repeat_distance") == 0),
+    }
+
+
+def _line_label_repeat_spacing_rows(
+    source_label_layers: list[dict[str, object]],
+    label_records: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    grouped = _line_label_source_groups(source_label_layers, _label_records_by_style(label_records))
+    rows = []
     for base_layer, grouped_rows in grouped.items():
         source_rows = [row for row, _labels in grouped_rows]
-        line_label_rows: list[dict[str, object]] = []
-        seen_line_label_ids: set[int] = set()
-        for _row, labels in grouped_rows:
-            for record in labels:
-                label_id = id(record)
-                if label_id in seen_line_label_ids or not _line_label_record_for_repeat(record):
-                    continue
-                seen_line_label_ids.add(label_id)
-                line_label_rows.append(record)
-        rows.append(
-            {
-                "base_style_layer_id": base_layer,
-                "source_label_rows": len(source_rows),
-                "converted_line_label_styles": len(line_label_rows),
-                "missing_qfit_symbol_spacing": sum(
-                    1
-                    for row in source_rows
-                    if _section_control(row, "qfit_layout", "symbol-spacing") is None
-                ),
-                "source_symbol_spacings": _sorted_count_map(
-                    _section_control(row, "layout", "symbol-spacing") for row in source_rows
-                ),
-                "qfit_symbol_spacings": _sorted_count_map(
-                    _section_control(row, "qfit_layout", "symbol-spacing") for row in source_rows
-                ),
-                "repeat_distances": _sorted_count_map(row.get("repeat_distance") for row in line_label_rows),
-                "placements": _sorted_count_map(row.get("placement") for row in line_label_rows),
-                "style_names": _sorted_count_map(row.get("style_name") for row in source_rows),
-                "zero_repeat_distance_count": sum(
-                    1 for row in line_label_rows if row.get("repeat_distance") == 0
-                ),
-            }
-        )
+        rows.append(_line_label_repeat_spacing_row(base_layer, source_rows, _repeat_label_records(grouped_rows)))
     return sorted(
         rows,
         key=lambda row: (

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -484,6 +484,92 @@ def _label_style_summary_rows(records: list[dict[str, object]]) -> list[dict[str
     return sorted(rows, key=lambda row: (-int(row["count"]), str(row["base_style_layer_id"])))
 
 
+def _section_control(row: dict[str, object], section: str, key: str) -> object:
+    values = row.get(section)
+    return values.get(key) if isinstance(values, dict) else None
+
+
+def _is_line_label_source_row(row: dict[str, object]) -> bool:
+    return (
+        _section_control(row, "qfit_layout", "symbol-placement") == "line"
+        and _section_control(row, "qfit_layout", "icon-image") is None
+    )
+
+
+def _line_label_record_for_repeat(row: dict[str, object]) -> bool:
+    placement = row.get("placement")
+    return row.get("geometry_type") == "Line" or placement in {"Curved", "Line", "Horizontal"}
+
+
+def _line_label_repeat_spacing_rows(
+    source_label_layers: list[dict[str, object]],
+    label_records: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    labels_by_style: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for record in label_records:
+        style_name = str(record.get("style_name") or "")
+        if style_name:
+            labels_by_style[style_name].append(record)
+
+    grouped: dict[str, list[tuple[dict[str, object], list[dict[str, object]]]]] = defaultdict(list)
+    for row in source_label_layers:
+        if not isinstance(row, dict) or not _is_line_label_source_row(row):
+            continue
+        base_layer = str(row.get("base_style_layer_id") or row.get("style_name") or "")
+        if not base_layer:
+            continue
+        style_keys = {str(row.get("style_name") or ""), str(row.get("qfit_style_layer_id") or "")}
+        matched_labels = [
+            record
+            for style_key in style_keys
+            for record in labels_by_style.get(style_key, [])
+        ]
+        grouped[base_layer].append((row, matched_labels))
+
+    rows: list[dict[str, object]] = []
+    for base_layer, grouped_rows in grouped.items():
+        source_rows = [row for row, _labels in grouped_rows]
+        line_label_rows = [
+            record
+            for _row, labels in grouped_rows
+            for record in labels
+            if _line_label_record_for_repeat(record)
+        ]
+        rows.append(
+            {
+                "base_style_layer_id": base_layer,
+                "source_label_rows": len(source_rows),
+                "converted_line_label_styles": len(line_label_rows),
+                "missing_qfit_symbol_spacing": sum(
+                    1
+                    for row in source_rows
+                    if _section_control(row, "qfit_layout", "symbol-spacing") is None
+                ),
+                "source_symbol_spacings": _sorted_count_map(
+                    _section_control(row, "layout", "symbol-spacing") for row in source_rows
+                ),
+                "qfit_symbol_spacings": _sorted_count_map(
+                    _section_control(row, "qfit_layout", "symbol-spacing") for row in source_rows
+                ),
+                "repeat_distances": _sorted_count_map(row.get("repeat_distance") for row in line_label_rows),
+                "placements": _sorted_count_map(row.get("placement") for row in line_label_rows),
+                "style_names": _sorted_count_map(row.get("style_name") for row in source_rows),
+                "zero_repeat_distance_count": sum(
+                    1 for row in line_label_rows if row.get("repeat_distance") == 0
+                ),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda row: (
+            -int(row["zero_repeat_distance_count"]),
+            -int(row["missing_qfit_symbol_spacing"]),
+            -int(row["converted_line_label_styles"]),
+            str(row["base_style_layer_id"]),
+        ),
+    )
+
+
 def _source_label_fanout_summary_rows(
     source_label_layers: list[dict[str, object]],
     label_records: list[dict[str, object]],
@@ -825,6 +911,7 @@ def _label_settings_report(
         "label_count": len(records),
         "labels": records,
         "label_style_summary_by_base_layer": _label_style_summary_rows(records),
+        "line_label_repeat_spacing_by_base_layer": _line_label_repeat_spacing_rows(source_label_layer_rows, records),
         "source_label_fanout_by_base_layer": _source_label_fanout_summary_rows(source_label_layer_rows, records),
         "source_label_control_summary_by_base_layer": _source_label_control_summary_rows(source_label_layer_rows),
         "source_label_control_omission_summary_by_base_layer": _source_label_control_omission_summary_rows(
@@ -970,6 +1057,35 @@ def _append_label_style_summary(lines: list[str], summary_rows: list[object]) ->
                     obstacle=_count_map_markdown_value(row.get("obstacle")),
                     label_per_part=_count_map_markdown_value(row.get("label_per_part")),
                     merge_lines=_count_map_markdown_value(row.get("merge_lines")),
+                )
+            )
+        lines.append("")
+
+
+def _append_line_label_repeat_spacing_summary(lines: list[str], summary_rows: list[object]) -> None:
+    if summary_rows:
+        lines.extend(
+            [
+                "## Line label repeat spacing by base layer",
+                "",
+                "| Base layer | Source rows | Converted line styles | Missing QGIS symbol-spacing | Source symbol-spacing | QGIS symbol-spacing | QGIS repeat distances | QGIS placements | Styles |",
+                "| --- | ---: | ---: | ---: | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for row in summary_rows:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "| {base} | {source_rows} | {converted} | {missing_spacing} | {source_spacing} | {qfit_spacing} | {repeat} | {placements} | {styles} |".format(
+                    base=_markdown_value(row.get("base_style_layer_id")),
+                    source_rows=_markdown_value(row.get("source_label_rows")),
+                    converted=_markdown_value(row.get("converted_line_label_styles")),
+                    missing_spacing=_markdown_value(row.get("missing_qfit_symbol_spacing")),
+                    source_spacing=_count_map_markdown_value(row.get("source_symbol_spacings")),
+                    qfit_spacing=_count_map_markdown_value(row.get("qfit_symbol_spacings")),
+                    repeat=_count_map_markdown_value(row.get("repeat_distances")),
+                    placements=_count_map_markdown_value(row.get("placements")),
+                    styles=_count_map_markdown_value(row.get("style_names")),
                 )
             )
         lines.append("")
@@ -1175,6 +1291,8 @@ def build_summary_markdown(report: dict[str, object]) -> str:
     rows = labels if isinstance(labels, list) else []
     label_summary = report.get("label_style_summary_by_base_layer")
     summary_rows = label_summary if isinstance(label_summary, list) else []
+    line_repeat_summary = report.get("line_label_repeat_spacing_by_base_layer")
+    line_repeat_rows = line_repeat_summary if isinstance(line_repeat_summary, list) else []
     source_fanout_summary = report.get("source_label_fanout_by_base_layer")
     source_fanout_rows = source_fanout_summary if isinstance(source_fanout_summary, list) else []
     source_control_summary = report.get("source_label_control_summary_by_base_layer")
@@ -1199,6 +1317,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         "",
     ]
     _append_label_style_summary(lines, summary_rows)
+    _append_line_label_repeat_spacing_summary(lines, line_repeat_rows)
     _append_source_label_fanout_summary(lines, source_fanout_rows)
     _append_source_label_control_summary(lines, source_control_rows)
     _append_source_label_control_omission_summary(lines, source_control_omission_rows)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -519,22 +519,29 @@ def _line_label_repeat_spacing_rows(
         if not base_layer:
             continue
         style_keys = {str(row.get("style_name") or ""), str(row.get("qfit_style_layer_id") or "")}
-        matched_labels = [
-            record
-            for style_key in style_keys
-            for record in labels_by_style.get(style_key, [])
-        ]
+        seen_label_ids: set[int] = set()
+        matched_labels = []
+        for style_key in style_keys:
+            for record in labels_by_style.get(style_key, []):
+                label_id = id(record)
+                if label_id in seen_label_ids:
+                    continue
+                seen_label_ids.add(label_id)
+                matched_labels.append(record)
         grouped[base_layer].append((row, matched_labels))
 
     rows: list[dict[str, object]] = []
     for base_layer, grouped_rows in grouped.items():
         source_rows = [row for row, _labels in grouped_rows]
-        line_label_rows = [
-            record
-            for _row, labels in grouped_rows
-            for record in labels
-            if _line_label_record_for_repeat(record)
-        ]
+        line_label_rows: list[dict[str, object]] = []
+        seen_line_label_ids: set[int] = set()
+        for _row, labels in grouped_rows:
+            for record in labels:
+                label_id = id(record)
+                if label_id in seen_line_label_ids or not _line_label_record_for_repeat(record):
+                    continue
+                seen_line_label_ids.add(label_id)
+                line_label_rows.append(record)
         rows.append(
             {
                 "base_style_layer_id": base_layer,


### PR DESCRIPTION
## Summary
- add a line-label repeat-spacing section to the Mapbox Outdoors label-settings diagnostic
- report text line labels by base layer with source/QGIS symbol-spacing, converted repeat distances, placements, and style fan-out
- exclude icon-backed line symbols such as road shields so the table stays focused on textual line-label repetition

## Live evidence
- Generated with the local QGIS-profile Mapbox token source without printing the token:
  - `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260519T195455Z/summary.md`
- New section highlights `contour-label` as the only textual line-label group with both missing QGIS `symbol-spacing` and converted repeat distance `0`.
- `road-label`, `ferry-aerialway-label`, and `path-pedestrian-label` also lack explicit QGIS `symbol-spacing` but convert to non-zero repeat distances.
- `waterway-label` remains the known explicit-spacing comparison case.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949.
