### PR TITLE
Aggregate Mapbox contour diagnostics

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -166,13 +166,13 @@ export MAPBOX_ACCESS_TOKEN="***"
 python3 validation/mapbox_outdoors_contour_features.py --all-cameras
 ```
 
-The all-camera contour diagnostic writes `summary.json` and `summary.md` under:
+The all-camera contour diagnostic writes compact aggregate `summary.json` and `summary.md` files under:
 
 ```text
 debug/mapbox-outdoors-contour-features/all-cameras/<UTC timestamp>/
 ```
 
-Use the aggregate table to check whether contour-label candidates are line-compatible, polygon-only, or absent across the z5-z18 comparison matrix. A polygon-only result means a Mapbox `symbol-spacing` or QGIS line-repeat tweak is not enough by itself; follow-up work should stay focused on QGIS vector-tile polygon/perimeter-label behavior or a separately validated contour-boundary overlay.
+Use the aggregate table to check whether contour-label candidates are line-compatible, polygon-only, or absent across the z5-z18 comparison matrix. Per-camera status and error columns keep the batch useful when one camera fails before tile-level diagnostics can be collected. A polygon-only result means a Mapbox `symbol-spacing` or QGIS line-repeat tweak is not enough by itself; follow-up work should stay focused on QGIS vector-tile polygon/perimeter-label behavior or a separately validated contour-boundary overlay.
 
 ## PR notes
 

--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -157,6 +157,23 @@ For a slower but broader converter-warning triage pass, add `--include-qgis-prop
 
 Use the audit together with the screenshot harness: first identify high-signal gaps visually, then check the corresponding style layers to decide the smallest safe qfit preprocessing improvement.
 
+## Contour feature diagnostic
+
+When contour labels are the candidate parity slice, inspect the underlying vector-tile geometry before changing QGIS label behavior:
+
+```bash
+export MAPBOX_ACCESS_TOKEN="***"
+python3 validation/mapbox_outdoors_contour_features.py --all-cameras
+```
+
+The all-camera contour diagnostic writes `summary.json` and `summary.md` under:
+
+```text
+debug/mapbox-outdoors-contour-features/all-cameras/<UTC timestamp>/
+```
+
+Use the aggregate table to check whether contour-label candidates are line-compatible, polygon-only, or absent across the z5-z18 comparison matrix. A polygon-only result means a Mapbox `symbol-spacing` or QGIS line-repeat tweak is not enough by itself; follow-up work should stay focused on QGIS vector-tile polygon/perimeter-label behavior or a separately validated contour-boundary overlay.
+
 ## PR notes
 
 For rendering-sensitive Mapbox vector-style changes, include a concise validation note such as:

--- a/tests/test_mapbox_outdoors_contour_features.py
+++ b/tests/test_mapbox_outdoors_contour_features.py
@@ -4,14 +4,19 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_contour_features import (
     ContourFeatureConfig,
+    build_all_camera_contour_feature_paths,
+    build_all_camera_run_directory,
+    build_all_camera_summary_markdown,
     build_contour_feature_paths,
     build_run_directory,
     build_summary_markdown,
+    collect_all_camera_contour_feature_report,
     collect_contour_feature_report,
     contour_tile_record,
     decode_vector_tile_bytes,
@@ -22,6 +27,7 @@ from qfit.validation.mapbox_outdoors_contour_features import (
     resolve_mapbox_token,
     tile_bounds_for_web_mercator_extent,
     web_mercator_to_lon_lat,
+    write_all_camera_report,
     write_report,
 )
 
@@ -55,6 +61,17 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
 
         self.assertEqual(run_dir, Path("/tmp/contours/chamonix/20260518T112200Z"))
         self.assertEqual(paths.json_path, run_dir / "contour-features.json")
+        self.assertEqual(paths.summary_path, run_dir / "summary.md")
+
+    def test_build_all_camera_paths_are_predictable(self):
+        run_dir = build_all_camera_run_directory(
+            output_root=Path("/tmp/contours"),
+            now=dt.datetime(2026, 5, 18, 11, 22, tzinfo=dt.timezone.utc),
+        )
+        paths = build_all_camera_contour_feature_paths(run_dir)
+
+        self.assertEqual(run_dir, Path("/tmp/contours/all-cameras/20260518T112200Z"))
+        self.assertEqual(paths.json_path, run_dir / "summary.json")
         self.assertEqual(paths.summary_path, run_dir / "summary.md")
 
     def test_tile_helpers_cover_web_mercator_extent(self):
@@ -311,6 +328,63 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
         self.assertEqual(report["candidate_label_geometry"]["status"], "polygon_only")
         self.assertEqual(report["candidate_label_geometry"]["line_compatible_count"], 0)
 
+    def test_collect_all_camera_contour_feature_report_aggregates_camera_rows(self):
+        style_calls = []
+
+        def fetch_style(_token, _owner, _style_id):
+            style_calls.append((_token, _owner, _style_id))
+            return {
+                "version": 8,
+                "sources": {
+                    "composite": {
+                        "type": "vector",
+                        "url": "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2",
+                    }
+                },
+                "layers": [],
+            }
+
+        def decoder(_payload):
+            return {
+                "contour": {
+                    "features": [
+                        {
+                            "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+                            "properties": {"ele": 1000, "index": 5},
+                        },
+                        {
+                            "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+                            "properties": {"ele": 1010, "index": 1},
+                        },
+                    ]
+                }
+            }
+
+        generated = dt.datetime(2026, 5, 18, 11, 35, tzinfo=dt.timezone.utc)
+        with mock.patch(
+            "qfit.validation.mapbox_outdoors_contour_features._comparison_camera_names",
+            return_value=["chamonix-trails-z14-outdoors", "zermatt-trails-z18-outdoors"],
+        ):
+            report = collect_all_camera_contour_feature_report(
+                ContourFeatureConfig(token="token", output_root=Path("/tmp"), tile_zoom=0, now=generated),
+                style_fetcher=fetch_style,
+                tile_fetcher=lambda _url: gzip.compress(b"tile"),
+                tile_decoder=decoder,
+            )
+
+        self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
+        self.assertEqual(report["camera_count"], 2)
+        self.assertEqual(report["tile_count"], 2)
+        self.assertEqual(report["decoded_tile_count"], 2)
+        self.assertEqual(report["contour_feature_count"], 4)
+        self.assertEqual(report["contour_label_candidate_count"], 2)
+        self.assertEqual(report["candidate_label_geometry_statuses"], {"polygon_only": 2})
+        self.assertEqual(
+            [camera["camera"] for camera in report["cameras"]],
+            ["chamonix-trails-z14-outdoors", "zermatt-trails-z18-outdoors"],
+        )
+        self.assertEqual(len(report["camera_reports"]), 2)
+
     def test_write_report_writes_json_and_markdown(self):
         report = {
             "generated": "2026-05-18T11:22:00+00:00",
@@ -361,6 +435,56 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
 
             self.assertEqual(json.loads(paths.json_path.read_text(encoding="utf-8"))["tile_count"], 1)
             self.assertIn("Contour features: 3", paths.summary_path.read_text(encoding="utf-8"))
+
+    def test_write_all_camera_report_writes_json_and_markdown(self):
+        report = {
+            "generated": "2026-05-18T11:22:00+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "camera_count": 2,
+            "tile_count": 2,
+            "decoded_tile_count": 2,
+            "contour_feature_count": 4,
+            "contour_label_candidate_count": 2,
+            "candidate_label_geometry_statuses": {"no_candidates": 1, "polygon_only": 1},
+            "cameras": [
+                {
+                    "camera": "switzerland-alps-z5-outdoors",
+                    "camera_zoom": 5.0,
+                    "tile_zoom": 5,
+                    "tile_count": 1,
+                    "decoded_tile_count": 1,
+                    "contour_feature_count": 0,
+                    "contour_label_candidate_count": 0,
+                    "candidate_label_geometry_status": "no_candidates",
+                    "candidate_geometry_type_counts": {},
+                },
+                {
+                    "camera": "chamonix-trails-z14-outdoors",
+                    "camera_zoom": 14.0,
+                    "tile_zoom": 14,
+                    "tile_count": 1,
+                    "decoded_tile_count": 1,
+                    "contour_feature_count": 4,
+                    "contour_label_candidate_count": 2,
+                    "candidate_label_geometry_status": "polygon_only",
+                    "candidate_geometry_type_counts": {"Polygon": 2},
+                },
+            ],
+            "camera_reports": [],
+        }
+        markdown = build_all_camera_summary_markdown(report)
+
+        self.assertIn("# Mapbox Outdoors contour feature diagnostic - all cameras", markdown)
+        self.assertIn('Candidate label geometry statuses: {"no_candidates":1,"polygon_only":1}', markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | 14.0 | 14 | 1/1 | 4 | 2 | polygon_only |", markdown)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = build_all_camera_contour_feature_paths(Path(tmpdir) / "run")
+            write_all_camera_report(report, paths)
+
+            self.assertEqual(json.loads(paths.json_path.read_text(encoding="utf-8"))["camera_count"], 2)
+            self.assertIn("Cameras: 2", paths.summary_path.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/tests/test_mapbox_outdoors_contour_features.py
+++ b/tests/test_mapbox_outdoors_contour_features.py
@@ -23,6 +23,7 @@ from qfit.validation.mapbox_outdoors_contour_features import (
     is_contour_label_candidate,
     iter_tile_coordinates,
     lon_lat_to_tile,
+    main,
     recommended_tile_zoom,
     resolve_mapbox_token,
     tile_bounds_for_web_mercator_extent,
@@ -485,6 +486,90 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
 
             self.assertEqual(json.loads(paths.json_path.read_text(encoding="utf-8"))["camera_count"], 2)
             self.assertIn("Cameras: 2", paths.summary_path.read_text(encoding="utf-8"))
+
+    def test_main_writes_single_camera_report(self):
+        report = {
+            "generated": "2026-05-18T11:22:00+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "camera": {"name": "chamonix-trails-z14-outdoors"},
+            "tile_zoom": 14,
+            "tile_count": 1,
+            "decoded_tile_count": 1,
+            "contour_feature_count": 3,
+            "contour_label_candidate_count": 2,
+            "index_counts": {},
+            "geometry_type_counts": {},
+            "candidate_geometry_type_counts": {},
+            "candidate_label_geometry": {"status": "polygon_only"},
+            "sample_candidates": [],
+            "tiles": [],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "qfit.validation.mapbox_outdoors_contour_features.collect_contour_feature_report",
+                return_value=report,
+            ) as collect_report:
+                result = main([
+                    "chamonix-trails-z14-outdoors",
+                    "--mapbox-token",
+                    "token",
+                    "--output-root",
+                    tmpdir,
+                ])
+
+            self.assertIsNone(result)
+            collect_report.assert_called_once()
+            summaries = list(Path(tmpdir).glob("chamonix-trails-z14-outdoors/*/summary.md"))
+            self.assertEqual(len(summaries), 1)
+            self.assertIn("Contour features: 3", summaries[0].read_text(encoding="utf-8"))
+
+    def test_main_writes_all_camera_report(self):
+        report = {
+            "generated": "2026-05-18T11:22:00+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "camera_count": 1,
+            "tile_count": 1,
+            "decoded_tile_count": 1,
+            "contour_feature_count": 3,
+            "contour_label_candidate_count": 2,
+            "candidate_label_geometry_statuses": {"polygon_only": 1},
+            "cameras": [
+                {
+                    "camera": "chamonix-trails-z14-outdoors",
+                    "camera_zoom": 13.75,
+                    "tile_zoom": 14,
+                    "tile_count": 1,
+                    "decoded_tile_count": 1,
+                    "contour_feature_count": 3,
+                    "contour_label_candidate_count": 2,
+                    "candidate_label_geometry_status": "polygon_only",
+                    "candidate_geometry_type_counts": {"Polygon": 2},
+                }
+            ],
+            "camera_reports": [],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "qfit.validation.mapbox_outdoors_contour_features.collect_all_camera_contour_feature_report",
+                return_value=report,
+            ) as collect_report:
+                result = main([
+                    "--all-cameras",
+                    "--mapbox-token",
+                    "token",
+                    "--output-root",
+                    tmpdir,
+                ])
+
+            self.assertIsNone(result)
+            collect_report.assert_called_once()
+            summaries = list(Path(tmpdir).glob("all-cameras/*/summary.md"))
+            self.assertEqual(len(summaries), 1)
+            self.assertIn("Cameras: 1", summaries[0].read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/tests/test_mapbox_outdoors_contour_features.py
+++ b/tests/test_mapbox_outdoors_contour_features.py
@@ -375,6 +375,8 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
 
         self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
         self.assertEqual(report["camera_count"], 2)
+        self.assertEqual(report["successful_camera_count"], 2)
+        self.assertEqual(report["failed_camera_count"], 0)
         self.assertEqual(report["tile_count"], 2)
         self.assertEqual(report["decoded_tile_count"], 2)
         self.assertEqual(report["contour_feature_count"], 4)
@@ -384,7 +386,39 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             [camera["camera"] for camera in report["cameras"]],
             ["chamonix-trails-z14-outdoors", "zermatt-trails-z18-outdoors"],
         )
-        self.assertEqual(len(report["camera_reports"]), 2)
+        self.assertEqual([camera["status"] for camera in report["cameras"]], ["decoded", "decoded"])
+        self.assertNotIn("camera_reports", report)
+
+    def test_collect_all_camera_contour_feature_report_keeps_camera_errors(self):
+        def fetch_style(_token, _owner, _style_id):
+            return {
+                "version": 8,
+                "sources": {
+                    "composite": {
+                        "type": "vector",
+                        "url": "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2",
+                    }
+                },
+                "layers": [],
+            }
+
+        with mock.patch(
+            "qfit.validation.mapbox_outdoors_contour_features._comparison_camera_names",
+            return_value=["chamonix-trails-z14-outdoors", "missing-camera"],
+        ):
+            report = collect_all_camera_contour_feature_report(
+                ContourFeatureConfig(token="token", output_root=Path("/tmp"), tile_zoom=0),
+                style_fetcher=fetch_style,
+                tile_fetcher=lambda _url: gzip.compress(b"tile"),
+                tile_decoder=lambda _payload: {"contour": {"features": []}},
+            )
+
+        self.assertEqual(report["camera_count"], 2)
+        self.assertEqual(report["successful_camera_count"], 1)
+        self.assertEqual(report["failed_camera_count"], 1)
+        self.assertEqual(report["cameras"][1]["camera"], "missing-camera")
+        self.assertEqual(report["cameras"][1]["status"], "error")
+        self.assertEqual(report["cameras"][1]["error"], "ValueError")
 
     def test_write_report_writes_json_and_markdown(self):
         report = {
@@ -443,6 +477,8 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             "style_owner": "mapbox",
             "style_id": "outdoors-v12",
             "camera_count": 2,
+            "successful_camera_count": 2,
+            "failed_camera_count": 0,
             "tile_count": 2,
             "decoded_tile_count": 2,
             "contour_feature_count": 4,
@@ -450,6 +486,7 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             "candidate_label_geometry_statuses": {"no_candidates": 1, "polygon_only": 1},
             "cameras": [
                 {
+                    "status": "decoded",
                     "camera": "switzerland-alps-z5-outdoors",
                     "camera_zoom": 5.0,
                     "tile_zoom": 5,
@@ -461,6 +498,7 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
                     "candidate_geometry_type_counts": {},
                 },
                 {
+                    "status": "decoded",
                     "camera": "chamonix-trails-z14-outdoors",
                     "camera_zoom": 14.0,
                     "tile_zoom": 14,
@@ -472,19 +510,21 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
                     "candidate_geometry_type_counts": {"Polygon": 2},
                 },
             ],
-            "camera_reports": [],
         }
         markdown = build_all_camera_summary_markdown(report)
 
         self.assertIn("# Mapbox Outdoors contour feature diagnostic - all cameras", markdown)
+        self.assertIn('Camera statuses: {"decoded":2}', markdown)
         self.assertIn('Candidate label geometry statuses: {"no_candidates":1,"polygon_only":1}', markdown)
-        self.assertIn("| chamonix-trails-z14-outdoors | 14.0 | 14 | 1/1 | 4 | 2 | polygon_only |", markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | decoded | 14.0 | 14 | 1/1 | 4 | 2 | polygon_only |", markdown)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = build_all_camera_contour_feature_paths(Path(tmpdir) / "run")
             write_all_camera_report(report, paths)
 
-            self.assertEqual(json.loads(paths.json_path.read_text(encoding="utf-8"))["camera_count"], 2)
+            written = json.loads(paths.json_path.read_text(encoding="utf-8"))
+            self.assertEqual(written["camera_count"], 2)
+            self.assertNotIn("camera_reports", written)
             self.assertIn("Cameras: 2", paths.summary_path.read_text(encoding="utf-8"))
 
     def test_main_writes_single_camera_report(self):
@@ -531,6 +571,8 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             "style_owner": "mapbox",
             "style_id": "outdoors-v12",
             "camera_count": 1,
+            "successful_camera_count": 1,
+            "failed_camera_count": 0,
             "tile_count": 1,
             "decoded_tile_count": 1,
             "contour_feature_count": 3,
@@ -538,6 +580,7 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
             "candidate_label_geometry_statuses": {"polygon_only": 1},
             "cameras": [
                 {
+                    "status": "decoded",
                     "camera": "chamonix-trails-z14-outdoors",
                     "camera_zoom": 13.75,
                     "tile_zoom": 14,
@@ -549,7 +592,6 @@ class MapboxOutdoorsContourFeatureTests(unittest.TestCase):
                     "candidate_geometry_type_counts": {"Polygon": 2},
                 }
             ],
-            "camera_reports": [],
         }
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/validation/mapbox_outdoors_contour_features.py
+++ b/validation/mapbox_outdoors_contour_features.py
@@ -45,6 +45,13 @@ class ContourFeaturePaths:
 
 
 @dataclass(frozen=True)
+class AllCameraContourFeaturePaths:
+    run_dir: Path
+    json_path: Path
+    summary_path: Path
+
+
+@dataclass(frozen=True)
 class ContourFeatureConfig:
     token: str | None
     output_root: Path
@@ -91,6 +98,22 @@ def build_contour_feature_paths(run_dir: Path) -> ContourFeaturePaths:
     return ContourFeaturePaths(
         run_dir=run_dir,
         json_path=run_dir / "contour-features.json",
+        summary_path=run_dir / "summary.md",
+    )
+
+
+def build_all_camera_run_directory(
+    *,
+    output_root: Path,
+    now: dt.datetime | None = None,
+) -> Path:
+    return output_root / "all-cameras" / _utc_timestamp(now)
+
+
+def build_all_camera_contour_feature_paths(run_dir: Path) -> AllCameraContourFeaturePaths:
+    return AllCameraContourFeaturePaths(
+        run_dir=run_dir,
+        json_path=run_dir / "summary.json",
         summary_path=run_dir / "summary.md",
     )
 
@@ -412,6 +435,13 @@ def _camera_by_name(camera_name: str):
         raise ValueError(f"Unknown comparison camera: {camera_name}") from exc
 
 
+def _comparison_camera_names() -> list[str]:
+    _ensure_package_parent_on_path()
+    from qfit.validation.mapbox_outdoors_comparison import CAMERAS
+
+    return list(CAMERAS.keys())
+
+
 def _camera_extent(camera) -> tuple[float, float, float, float]:
     _ensure_package_parent_on_path()
     from qfit.validation.mapbox_outdoors_comparison import camera_extent_web_mercator
@@ -498,6 +528,95 @@ def collect_contour_feature_report(
     }
 
 
+def _all_camera_summary_counts(rows: list[dict[str, object]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        value = row.get(key)
+        if isinstance(value, str) and value:
+            counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _all_camera_row(report: dict[str, object]) -> dict[str, object]:
+    camera = report.get("camera") if isinstance(report.get("camera"), dict) else {}
+    candidate_geometry = (
+        report.get("candidate_label_geometry")
+        if isinstance(report.get("candidate_label_geometry"), dict)
+        else {}
+    )
+    return {
+        "camera": camera.get("name"),
+        "camera_zoom": camera.get("zoom"),
+        "tile_zoom": report.get("tile_zoom"),
+        "tile_count": report.get("tile_count"),
+        "decoded_tile_count": report.get("decoded_tile_count"),
+        "failed_tile_count": report.get("failed_tile_count"),
+        "contour_feature_count": report.get("contour_feature_count"),
+        "contour_label_candidate_count": report.get("contour_label_candidate_count"),
+        "candidate_label_geometry_status": candidate_geometry.get("status"),
+        "candidate_geometry_type_counts": report.get("candidate_geometry_type_counts"),
+    }
+
+
+def _config_for_camera(config: ContourFeatureConfig, camera_name: str) -> ContourFeatureConfig:
+    return ContourFeatureConfig(
+        token=config.token,
+        output_root=config.output_root,
+        camera_name=camera_name,
+        style_owner=config.style_owner,
+        style_id=config.style_id,
+        style_json_path=config.style_json_path,
+        tile_zoom=config.tile_zoom,
+        now=config.now,
+    )
+
+
+def collect_all_camera_contour_feature_report(
+    config: ContourFeatureConfig,
+    *,
+    style_fetcher: Callable[[str, str, str], dict[str, object]] | None = None,
+    tile_fetcher: TileFetcher | None = None,
+    tile_decoder: TileDecoder | None = None,
+) -> dict[str, object]:
+    _ensure_package_parent_on_path()
+    from qfit.mapbox_config import fetch_mapbox_style_definition
+
+    shared_style = _load_original_style(config, style_fetcher or fetch_mapbox_style_definition)
+
+    camera_reports = [
+        collect_contour_feature_report(
+            _config_for_camera(config, camera_name),
+            style_fetcher=lambda _token, _owner, _style_id: shared_style,
+            tile_fetcher=tile_fetcher,
+            tile_decoder=tile_decoder,
+        )
+        for camera_name in _comparison_camera_names()
+    ]
+    rows = [_all_camera_row(report) for report in camera_reports]
+    generated = config.now or dt.datetime.now(dt.timezone.utc)
+    return {
+        "style_owner": config.style_owner,
+        "style_id": config.style_id,
+        "generated": generated.isoformat(),
+        "camera_count": len(rows),
+        "tile_count": sum(int(report.get("tile_count") or 0) for report in camera_reports),
+        "decoded_tile_count": sum(int(report.get("decoded_tile_count") or 0) for report in camera_reports),
+        "failed_tile_count": sum(int(report.get("failed_tile_count") or 0) for report in camera_reports),
+        "contour_feature_count": sum(
+            int(report.get("contour_feature_count") or 0) for report in camera_reports
+        ),
+        "contour_label_candidate_count": sum(
+            int(report.get("contour_label_candidate_count") or 0) for report in camera_reports
+        ),
+        "candidate_label_geometry_statuses": _all_camera_summary_counts(
+            rows,
+            "candidate_label_geometry_status",
+        ),
+        "cameras": rows,
+        "camera_reports": camera_reports,
+    }
+
+
 def _markdown_value(value: object) -> str:
     if value is None:
         return "-"
@@ -558,9 +677,56 @@ def write_report(report: dict[str, object], paths: ContourFeaturePaths) -> None:
     paths.summary_path.write_text(build_summary_markdown(report), encoding="utf-8")
 
 
+def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
+    lines = [
+        "# Mapbox Outdoors contour feature diagnostic - all cameras",
+        "",
+        f"Generated: {report.get('generated')}",
+        f"Style: {report.get('style_owner')}/{report.get('style_id')}",
+        f"Cameras: {report.get('camera_count')}",
+        f"Tiles: {report.get('decoded_tile_count')}/{report.get('tile_count')} decoded",
+        f"Contour features: {report.get('contour_feature_count')}",
+        f"Contour-label candidates (index 5/10): {report.get('contour_label_candidate_count')}",
+        f"Candidate label geometry statuses: {_markdown_value(report.get('candidate_label_geometry_statuses'))}",
+        "",
+        "| Camera | Camera zoom | Tile zoom | Tiles decoded | Contour features | Label candidates | Candidate label geometry | Candidate geometry types |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+    ]
+    cameras = report.get("cameras")
+    camera_rows = cameras if isinstance(cameras, list) else []
+    for camera in camera_rows:
+        if not isinstance(camera, dict):
+            continue
+        lines.append(
+            "| {camera} | {camera_zoom} | {tile_zoom} | {decoded}/{tile_count} | {feature_count} | {candidate_count} | {candidate_geometry} | {candidate_geometry_types} |".format(
+                camera=_markdown_value(camera.get("camera")),
+                camera_zoom=_markdown_value(camera.get("camera_zoom")),
+                tile_zoom=_markdown_value(camera.get("tile_zoom")),
+                decoded=_markdown_value(camera.get("decoded_tile_count")),
+                tile_count=_markdown_value(camera.get("tile_count")),
+                feature_count=_markdown_value(camera.get("contour_feature_count")),
+                candidate_count=_markdown_value(camera.get("contour_label_candidate_count")),
+                candidate_geometry=_markdown_value(camera.get("candidate_label_geometry_status")),
+                candidate_geometry_types=_markdown_value(camera.get("candidate_geometry_type_counts")),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_all_camera_report(report: dict[str, object], paths: AllCameraContourFeaturePaths) -> None:
+    paths.run_dir.mkdir(parents=True, exist_ok=True)
+    paths.json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    paths.summary_path.write_text(build_all_camera_summary_markdown(report), encoding="utf-8")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Generate Mapbox Outdoors contour vector-tile feature diagnostics.")
-    parser.add_argument("camera", nargs="?", default=DEFAULT_CAMERA_NAME)
+    parser.add_argument("camera", nargs="?")
+    parser.add_argument(
+        "--all-cameras",
+        action="store_true",
+        help="Run the diagnostic across the full Mapbox Outdoors comparison camera matrix.",
+    )
     parser.add_argument("--style-json", type=Path, help="Read an already downloaded Mapbox style JSON file.")
     parser.add_argument("--style-owner", default=DEFAULT_MAPBOX_STYLE_OWNER)
     parser.add_argument("--style-id", default=DEFAULT_MAPBOX_STYLE_ID)
@@ -570,27 +736,38 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.all_cameras and args.camera:
+        parser.error("Do not pass a camera name with --all-cameras.")
     now = dt.datetime.now(dt.timezone.utc)
     config = ContourFeatureConfig(
         token=resolve_mapbox_token(provided_token=args.mapbox_token),
         output_root=args.output_root,
-        camera_name=args.camera,
+        camera_name=args.camera or DEFAULT_CAMERA_NAME,
         style_owner=args.style_owner,
         style_id=args.style_id,
         style_json_path=args.style_json,
         tile_zoom=args.tile_zoom,
         now=now,
     )
+    if args.all_cameras:
+        report = collect_all_camera_contour_feature_report(config)
+        paths = build_all_camera_contour_feature_paths(
+            build_all_camera_run_directory(output_root=config.output_root, now=config.now)
+        )
+        write_all_camera_report(report, paths)
+        print(paths.summary_path)
+        return
+
     report = collect_contour_feature_report(config)
     paths = build_contour_feature_paths(
         build_run_directory(output_root=config.output_root, camera_name=config.camera_name, now=config.now)
     )
     write_report(report, paths)
     print(paths.summary_path)
-    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover
-    raise SystemExit(main())
+    main()

--- a/validation/mapbox_outdoors_contour_features.py
+++ b/validation/mapbox_outdoors_contour_features.py
@@ -545,6 +545,7 @@ def _all_camera_row(report: dict[str, object]) -> dict[str, object]:
         else {}
     )
     return {
+        "status": "decoded",
         "camera": camera.get("name"),
         "camera_zoom": camera.get("zoom"),
         "tile_zoom": report.get("tile_zoom"),
@@ -556,6 +557,19 @@ def _all_camera_row(report: dict[str, object]) -> dict[str, object]:
         "candidate_label_geometry_status": candidate_geometry.get("status"),
         "candidate_geometry_type_counts": report.get("candidate_geometry_type_counts"),
     }
+
+
+def _all_camera_error_row(camera_name: str, exc: BaseException) -> dict[str, object]:
+    return {
+        "status": "error",
+        "camera": camera_name,
+        "error": type(exc).__name__,
+        "message": str(exc),
+    }
+
+
+def _all_camera_sum(rows: list[dict[str, object]], key: str) -> int:
+    return sum(int(row.get(key) or 0) for row in rows)
 
 
 def _config_for_camera(config: ContourFeatureConfig, camera_name: str) -> ContourFeatureConfig:
@@ -582,38 +596,41 @@ def collect_all_camera_contour_feature_report(
     from qfit.mapbox_config import fetch_mapbox_style_definition
 
     shared_style = _load_original_style(config, style_fetcher or fetch_mapbox_style_definition)
+    if not config.token:
+        raise ValueError("A Mapbox token is required to fetch vector tiles.")
 
-    camera_reports = [
-        collect_contour_feature_report(
-            _config_for_camera(config, camera_name),
-            style_fetcher=lambda _token, _owner, _style_id: shared_style,
-            tile_fetcher=tile_fetcher,
-            tile_decoder=tile_decoder,
-        )
-        for camera_name in _comparison_camera_names()
-    ]
-    rows = [_all_camera_row(report) for report in camera_reports]
+    rows: list[dict[str, object]] = []
+    for camera_name in _comparison_camera_names():
+        try:
+            report = collect_contour_feature_report(
+                _config_for_camera(config, camera_name),
+                style_fetcher=lambda _token, _owner, _style_id: shared_style,
+                tile_fetcher=tile_fetcher,
+                tile_decoder=tile_decoder,
+            )
+        except _TILE_ERROR_TYPES as exc:
+            rows.append(_all_camera_error_row(camera_name, exc))
+            continue
+        rows.append(_all_camera_row(report))
     generated = config.now or dt.datetime.now(dt.timezone.utc)
+    status_counts = _all_camera_summary_counts(rows, "status")
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
         "generated": generated.isoformat(),
         "camera_count": len(rows),
-        "tile_count": sum(int(report.get("tile_count") or 0) for report in camera_reports),
-        "decoded_tile_count": sum(int(report.get("decoded_tile_count") or 0) for report in camera_reports),
-        "failed_tile_count": sum(int(report.get("failed_tile_count") or 0) for report in camera_reports),
-        "contour_feature_count": sum(
-            int(report.get("contour_feature_count") or 0) for report in camera_reports
-        ),
-        "contour_label_candidate_count": sum(
-            int(report.get("contour_label_candidate_count") or 0) for report in camera_reports
-        ),
+        "successful_camera_count": status_counts.get("decoded", 0),
+        "failed_camera_count": status_counts.get("error", 0),
+        "tile_count": _all_camera_sum(rows, "tile_count"),
+        "decoded_tile_count": _all_camera_sum(rows, "decoded_tile_count"),
+        "failed_tile_count": _all_camera_sum(rows, "failed_tile_count"),
+        "contour_feature_count": _all_camera_sum(rows, "contour_feature_count"),
+        "contour_label_candidate_count": _all_camera_sum(rows, "contour_label_candidate_count"),
         "candidate_label_geometry_statuses": _all_camera_summary_counts(
             rows,
             "candidate_label_geometry_status",
         ),
         "cameras": rows,
-        "camera_reports": camera_reports,
     }
 
 
@@ -678,28 +695,30 @@ def write_report(report: dict[str, object], paths: ContourFeaturePaths) -> None:
 
 
 def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
+    cameras = report.get("cameras")
+    camera_rows = cameras if isinstance(cameras, list) else []
     lines = [
         "# Mapbox Outdoors contour feature diagnostic - all cameras",
         "",
         f"Generated: {report.get('generated')}",
         f"Style: {report.get('style_owner')}/{report.get('style_id')}",
         f"Cameras: {report.get('camera_count')}",
+        f"Camera statuses: {_markdown_value(_all_camera_summary_counts(camera_rows, 'status'))}",
         f"Tiles: {report.get('decoded_tile_count')}/{report.get('tile_count')} decoded",
         f"Contour features: {report.get('contour_feature_count')}",
         f"Contour-label candidates (index 5/10): {report.get('contour_label_candidate_count')}",
         f"Candidate label geometry statuses: {_markdown_value(report.get('candidate_label_geometry_statuses'))}",
         "",
-        "| Camera | Camera zoom | Tile zoom | Tiles decoded | Contour features | Label candidates | Candidate label geometry | Candidate geometry types |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+        "| Camera | Status | Camera zoom | Tile zoom | Tiles decoded | Contour features | Label candidates | Candidate label geometry | Candidate geometry types | Error |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |",
     ]
-    cameras = report.get("cameras")
-    camera_rows = cameras if isinstance(cameras, list) else []
     for camera in camera_rows:
         if not isinstance(camera, dict):
             continue
         lines.append(
-            "| {camera} | {camera_zoom} | {tile_zoom} | {decoded}/{tile_count} | {feature_count} | {candidate_count} | {candidate_geometry} | {candidate_geometry_types} |".format(
+            "| {camera} | {status} | {camera_zoom} | {tile_zoom} | {decoded}/{tile_count} | {feature_count} | {candidate_count} | {candidate_geometry} | {candidate_geometry_types} | {error} |".format(
                 camera=_markdown_value(camera.get("camera")),
+                status=_markdown_value(camera.get("status")),
                 camera_zoom=_markdown_value(camera.get("camera_zoom")),
                 tile_zoom=_markdown_value(camera.get("tile_zoom")),
                 decoded=_markdown_value(camera.get("decoded_tile_count")),
@@ -708,6 +727,7 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                 candidate_count=_markdown_value(camera.get("contour_label_candidate_count")),
                 candidate_geometry=_markdown_value(camera.get("candidate_label_geometry_status")),
                 candidate_geometry_types=_markdown_value(camera.get("candidate_geometry_type_counts")),
+                error=_markdown_value(camera.get("error")),
             )
         )
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary

- add `--all-cameras` support to the Mapbox Outdoors contour feature diagnostic
- aggregate contour feature counts, label-candidate geometry statuses, and per-camera rows into compact token-free `summary.json`/`summary.md` artifacts
- keep all-camera runs resilient to per-camera diagnostic failures and document the workflow for #949 contour-label investigations

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_contour_features.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_contour_features.py tests/test_mapbox_outdoors_contour_features.py && git diff --check`
- `python3 validation/mapbox_outdoors_contour_features.py --all-cameras` with the local QGIS-profile Mapbox token source; wrote `debug/mapbox-outdoors-contour-features/all-cameras/20260519T203611Z/summary.md`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
