### PR TITLE
Harden Mapbox road aggregate diagnostics

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -174,6 +174,23 @@ debug/mapbox-outdoors-contour-features/all-cameras/<UTC timestamp>/
 
 Use the aggregate table to check whether contour-label candidates are line-compatible, polygon-only, or absent across the z5-z18 comparison matrix. Per-camera status and error columns keep the batch useful when one camera fails before tile-level diagnostics can be collected. A polygon-only result means a Mapbox `symbol-spacing` or QGIS line-repeat tweak is not enough by itself; follow-up work should stay focused on QGIS vector-tile polygon/perimeter-label behavior or a separately validated contour-boundary overlay.
 
+## Road feature diagnostic
+
+When road/path hierarchy, high-detail trail behavior, road shields, or oneway arrows are the candidate parity slice, inspect the underlying road vector-tile features before changing QGIS style preprocessing:
+
+```bash
+export MAPBOX_ACCESS_TOKEN="***"
+python3 validation/mapbox_outdoors_road_features.py --all-cameras
+```
+
+The all-camera road diagnostic writes compact aggregate `road-features.json` and `summary.md` files under:
+
+```text
+debug/mapbox-outdoors-road-features/all-cameras/<UTC timestamp>/
+```
+
+Use the aggregate table to compare candidate road/path feature counts across the z5-z18 camera matrix before selecting a rendering slice. Per-camera status and error columns keep the batch useful when one camera fails before tile-level diagnostics can be collected.
+
 ## PR notes
 
 For rendering-sensitive Mapbox vector-style changes, include a concise validation note such as:

--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -644,6 +644,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["level_crossing_candidate_count"], 0)
         self.assertEqual(report["road_number_shield_candidate_count"], 0)
         self.assertEqual(report["road_exit_shield_candidate_count"], 0)
+        self.assertEqual(report["road_geometry_type_counts"], {"LineString": 8, "Polygon": 2})
+        self.assertEqual(report["pedestrian_polygon_class_counts"], {"pedestrian": 2})
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 2})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 2})

--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -629,6 +629,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertEqual(report["generated"], "2026-05-18T15:40:00+00:00")
         self.assertEqual(report["camera_count"], 2)
+        self.assertEqual(report["successful_camera_count"], 2)
+        self.assertEqual(report["failed_camera_count"], 0)
         self.assertEqual(report["tile_count"], 2)
         self.assertEqual(report["decoded_tile_count"], 2)
         self.assertEqual(report["road_feature_count"], 10)
@@ -688,9 +690,32 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["road_exit_shield_reflen_counts"], {})
         self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
         self.assertEqual(
-            [camera_report["camera"]["name"] for camera_report in report["cameras"]],
+            [camera_report["camera"] for camera_report in report["cameras"]],
             ["zermatt-trails-z18-outdoors", "chamonix-trails-z14-outdoors"],
         )
+        self.assertEqual([camera_report["status"] for camera_report in report["cameras"]], ["decoded", "decoded"])
+        self.assertNotIn("tiles", report["cameras"][0])
+
+    def test_collect_all_camera_road_feature_report_keeps_camera_errors(self):
+        generated = dt.datetime(2026, 5, 18, 15, 40, tzinfo=dt.timezone.utc)
+        report = collect_all_camera_road_feature_report(
+            RoadFeatureConfig(token="token", output_root=Path("/tmp"), tile_zoom=0, now=generated),
+            camera_names=("zermatt-trails-z18-outdoors", "missing-camera"),
+            style_fetcher=lambda _token, _owner, _style_id: {
+                "sources": {"composite": {"type": "vector", "url": "mapbox://mapbox.mapbox-streets-v8"}}
+            },
+            tile_fetcher=lambda _url: gzip.compress(b"tile"),
+            tile_decoder=lambda _payload: {"road": [], "motorway_junction": []},
+        )
+
+        self.assertEqual(report["camera_count"], 2)
+        self.assertEqual(report["successful_camera_count"], 1)
+        self.assertEqual(report["failed_camera_count"], 1)
+        self.assertEqual(report["tile_count"], 1)
+        self.assertEqual(report["decoded_tile_count"], 1)
+        self.assertEqual(report["cameras"][1]["camera"], "missing-camera")
+        self.assertEqual(report["cameras"][1]["status"], "error")
+        self.assertEqual(report["cameras"][1]["error"], "ValueError")
 
     def test_build_summary_markdown_includes_counts_and_samples(self):
         pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
@@ -883,6 +908,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "style_owner": "mapbox",
             "style_id": "outdoors-v12",
             "camera_count": 1,
+            "successful_camera_count": 1,
+            "failed_camera_count": 0,
             "decoded_tile_count": 1,
             "tile_count": 1,
             "road_feature_count": 4,
@@ -932,9 +959,12 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "road_exit_shield_signature_counts": {exit_shield_signature: 1},
             "cameras": [
                 {
-                    "camera": {"name": "zermatt-trails-z18-outdoors", "zoom": 18.0},
+                    "status": "decoded",
+                    "camera": "zermatt-trails-z18-outdoors",
+                    "camera_zoom": 18.0,
                     "tile_zoom": 18,
                     "decoded_tile_count": 1,
+                    "failed_tile_count": 0,
                     "tile_count": 1,
                     "road_feature_count": 4,
                     "motorway_junction_feature_count": 1,
@@ -989,7 +1019,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertIn("# Mapbox Outdoors road feature diagnostic - all cameras", markdown)
         self.assertIn("Cameras: 1", markdown)
-        self.assertIn("| zermatt-trails-z18-outdoors | 18.0 | 18 | 1/1 | 4 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |", markdown)
+        self.assertIn('Camera statuses: {"decoded":1}', markdown)
+        self.assertIn("| zermatt-trails-z18-outdoors | decoded | 18.0 | 18 | 1/1 | - | 4 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |", markdown)
         self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
         self.assertIn(f'Road exit shield signatures: {{"{exit_shield_signature}":1}}', markdown)
 

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -632,6 +632,40 @@ def _sum_reports(reports: Iterable[dict[str, object]], key: str) -> int:
     return total
 
 
+def _all_camera_status_counts(rows: Iterable[dict[str, object]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        status = row.get("status")
+        if isinstance(status, str) and status:
+            counts[status] = counts.get(status, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _all_camera_row(report: dict[str, object]) -> dict[str, object]:
+    camera = report.get("camera") if isinstance(report.get("camera"), dict) else {}
+    row = {
+        "status": "decoded",
+        "camera": camera.get("name"),
+        "camera_zoom": camera.get("zoom"),
+        "tile_zoom": report.get("tile_zoom"),
+        "tile_count": report.get("tile_count"),
+        "decoded_tile_count": report.get("decoded_tile_count"),
+        "failed_tile_count": report.get("failed_tile_count"),
+    }
+    for _label, key, _alignment in _ROAD_FEATURE_TABLE_FIELDS:
+        row[key] = report.get(key)
+    return row
+
+
+def _all_camera_error_row(camera_name: str, exc: Exception) -> dict[str, object]:
+    return {
+        "status": "error",
+        "camera": camera_name,
+        "error": type(exc).__name__,
+        "message": str(exc),
+    }
+
+
 def collect_road_feature_report(
     config: RoadFeatureConfig,
     *,
@@ -809,30 +843,37 @@ def collect_all_camera_road_feature_report(
     names = list(camera_names) if camera_names is not None else _all_camera_names()
     fetch_style = style_fetcher if style_fetcher is not None else mapbox_config.fetch_mapbox_style_definition
     style_definition = _load_original_style(config, fetch_style)
-    camera_reports = [
-        collect_road_feature_report(
-            RoadFeatureConfig(
-                token=config.token,
-                output_root=config.output_root,
-                camera_name=camera_name,
-                style_owner=config.style_owner,
-                style_id=config.style_id,
-                style_json_path=config.style_json_path,
-                tile_zoom=config.tile_zoom,
-                now=generated,
-            ),
-            style_fetcher=style_fetcher,
-            style_definition=style_definition,
-            tile_fetcher=tile_fetcher,
-            tile_decoder=tile_decoder,
-        )
-        for camera_name in names
-    ]
+    camera_reports: list[dict[str, object]] = []
+    for camera_name in names:
+        try:
+            report = collect_road_feature_report(
+                RoadFeatureConfig(
+                    token=config.token,
+                    output_root=config.output_root,
+                    camera_name=camera_name,
+                    style_owner=config.style_owner,
+                    style_id=config.style_id,
+                    style_json_path=config.style_json_path,
+                    tile_zoom=config.tile_zoom,
+                    now=generated,
+                ),
+                style_fetcher=style_fetcher,
+                style_definition=style_definition,
+                tile_fetcher=tile_fetcher,
+                tile_decoder=tile_decoder,
+            )
+        except Exception as exc:  # noqa: BLE001 - diagnostic batch should preserve other camera rows.
+            camera_reports.append(_all_camera_error_row(camera_name, exc))
+            continue
+        camera_reports.append(_all_camera_row(report))
+    status_counts = _all_camera_status_counts(camera_reports)
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
         "generated": generated.isoformat(),
         "camera_count": len(camera_reports),
+        "successful_camera_count": status_counts.get("decoded", 0),
+        "failed_camera_count": status_counts.get("error", 0),
         "tile_count": _sum_reports(camera_reports, "tile_count"),
         "decoded_tile_count": _sum_reports(camera_reports, "decoded_tile_count"),
         "failed_tile_count": _sum_reports(camera_reports, "failed_tile_count"),
@@ -994,25 +1035,32 @@ def build_summary_markdown(report: dict[str, object]) -> str:
 
 
 def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
+    camera_reports = report.get("cameras")
+    rows = camera_reports if isinstance(camera_reports, list) else []
     lines = [
         "# Mapbox Outdoors road feature diagnostic - all cameras",
         "",
         f"Generated: {report.get('generated')}",
         f"Style: {report.get('style_owner')}/{report.get('style_id')}",
         f"Cameras: {report.get('camera_count')}",
+        f"Camera statuses: {_markdown_value(_all_camera_status_counts(rows))}",
         f"Tiles: {report.get('decoded_tile_count')}/{report.get('tile_count')} decoded",
         *_feature_summary_lines(report),
         "",
         *_markdown_table_header(
-            (("Camera", "---"), ("Camera zoom", "---:"), ("Tile zoom", "---:"), ("Tiles", "---:"))
+            (
+                ("Camera", "---"),
+                ("Status", "---"),
+                ("Camera zoom", "---:"),
+                ("Tile zoom", "---:"),
+                ("Tiles", "---:"),
+                ("Error", "---"),
+            )
         ),
     ]
-    camera_reports = report.get("cameras")
-    rows = camera_reports if isinstance(camera_reports, list) else []
     for camera_report in rows:
         if not isinstance(camera_report, dict):
             continue
-        camera = camera_report.get("camera") if isinstance(camera_report.get("camera"), dict) else {}
         tiles = (
             f"{_markdown_value(camera_report.get('decoded_tile_count'))}/"
             f"{_markdown_value(camera_report.get('tile_count'))}"
@@ -1020,10 +1068,12 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
         lines.append(
             _markdown_table_row(
                 [
-                    camera.get("name"),
-                    camera.get("zoom"),
+                    camera_report.get("camera"),
+                    camera_report.get("status"),
+                    camera_report.get("camera_zoom"),
                     camera_report.get("tile_zoom"),
                     tiles,
+                    camera_report.get("error"),
                     *_road_feature_table_cells(camera_report),
                 ]
             )

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -651,6 +651,8 @@ def _all_camera_row(report: dict[str, object]) -> dict[str, object]:
         "tile_count": report.get("tile_count"),
         "decoded_tile_count": report.get("decoded_tile_count"),
         "failed_tile_count": report.get("failed_tile_count"),
+        "road_geometry_type_counts": report.get("road_geometry_type_counts"),
+        "pedestrian_polygon_class_counts": report.get("pedestrian_polygon_class_counts"),
     }
     for _label, key, _alignment in _ROAD_FEATURE_TABLE_FIELDS:
         row[key] = report.get(key)

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -657,7 +657,7 @@ def _all_camera_row(report: dict[str, object]) -> dict[str, object]:
     return row
 
 
-def _all_camera_error_row(camera_name: str, exc: Exception) -> dict[str, object]:
+def _all_camera_error_row(camera_name: str, exc: BaseException) -> dict[str, object]:
     return {
         "status": "error",
         "camera": camera_name,
@@ -862,7 +862,7 @@ def collect_all_camera_road_feature_report(
                 tile_fetcher=tile_fetcher,
                 tile_decoder=tile_decoder,
             )
-        except Exception as exc:  # noqa: BLE001 - diagnostic batch should preserve other camera rows.
+        except _TILE_ERROR_TYPES as exc:
             camera_reports.append(_all_camera_error_row(camera_name, exc))
             continue
         camera_reports.append(_all_camera_row(report))


### PR DESCRIPTION
## Summary
- make the Mapbox Outdoors road `--all-cameras` diagnostic keep compact per-camera rows instead of full tile-level payloads
- record per-camera decoded/error status so one camera-level failure does not discard the rest of the road/path evidence batch
- document the road feature diagnostic alongside the comparison and contour validation tools

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_road_features.py tests/test_mapbox_outdoors_road_features.py && git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`
- live road diagnostic with local QGIS-profile Mapbox token source: `debug/mapbox-outdoors-road-features/all-cameras/20260519T205437Z/summary.md`
  - 7/7 cameras decoded
  - 62/62 tiles decoded
  - 8308 road features
  - 458 path-line candidates
  - 70 step-line candidates
  - `road_geometry_type_counts` and `pedestrian_polygon_class_counts` remain populated in compact aggregate rows
  - aggregate camera rows do not embed tile payloads

Refs #949
