### PR TITLE
Add Mapbox comparison contact sheet

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -19,6 +19,7 @@ A complete run writes:
 - `mapbox-gl-vs-qgis-diff.png` — pixel diff for quick drift inspection
 - `metrics.json` — simple image-diff metrics such as changed-pixel ratio when diff generation runs
 - `manifest.json` — camera, output paths, capture status, and metrics without any token values
+- `contact-sheet.jpg` — all-camera side-by-side thumbnail sheet when running the matrix mode
 
 ## Cameras
 
@@ -85,7 +86,7 @@ python3 validation/mapbox_outdoors_comparison.py \
 `--all-cameras` uses the same capture options as a single-camera run, so you can combine it with setup-isolation flags such as `--skip-qgis` or `--skip-browser`.
 Do not pass a positional camera name with `--all-cameras`; use one mode or the other.
 Each camera is captured in its own child Python process so a local Chromium/PyQGIS crash in one camera does not kill the whole matrix runner or expose token values on the command line. If any camera fails or times out, the runner continues with the remaining cameras and exits non-zero with the failed camera names.
-The parent run also writes token-free aggregate `summary.json` and `summary.md` files under `debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/` with per-camera subprocess status, artifact status, manifest paths, captured image artifact paths, and the main diff metrics. Treat rows with missing manifests or unavailable metrics as operational smoke-test output, not visual parity evidence.
+The parent run also writes token-free aggregate `summary.json` and `summary.md` files under `debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/` with per-camera subprocess status, artifact status, manifest paths, captured image artifact paths, and the main diff metrics. When captured images are available and Pillow can load them, the same directory includes `contact-sheet.jpg` so the Mapbox GL reference, QGIS render, and diff columns can be inspected as one overview image. Treat rows with missing manifests or unavailable metrics as operational smoke-test output, not visual parity evidence.
 
 ## Partial captures
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -14,9 +14,13 @@ from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_comparison import (
     CAMERAS,
+    CONTACT_SHEET_COLUMN_GAP,
+    CONTACT_SHEET_COLUMNS,
+    CONTACT_SHEET_THUMBNAIL_WIDTH,
     ComparisonConfig,
     DEFAULT_OUTPUT_ROOT,
     MapboxComparisonCamera,
+    build_all_cameras_contact_sheet,
     build_comparison_paths,
     build_image_diff,
     build_mapbox_gl_html,
@@ -437,6 +441,148 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertEqual(metrics["changed_pixel_ratio"], 0.5)
             self.assertIn("ssim_status", metrics)
 
+    def test_build_all_cameras_contact_sheet_writes_preview_grid(self):
+        try:
+            from PIL import Image
+        except ImportError:  # pragma: no cover - local dependency guard
+            self.skipTest("Pillow is not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            browser_path = root / "mapbox-gl-reference.png"
+            qgis_path = root / "qgis-vector-render.png"
+            diff_path = root / "mapbox-gl-vs-qgis-diff.png"
+            Image.new("RGB", (16, 9), (255, 255, 255)).save(browser_path)
+            Image.new("RGB", (16, 9), (128, 128, 128)).save(qgis_path)
+            Image.new("RGB", (16, 9), (255, 0, 255)).save(diff_path)
+            output_path = root / "contact-sheet.jpg"
+
+            result = build_all_cameras_contact_sheet(
+                entries=[
+                    {
+                        "camera": "test-camera",
+                        "outputs": {
+                            "browser_reference": str(browser_path),
+                            "qgis_vector_render": str(qgis_path),
+                            "diff": str(diff_path),
+                        },
+                    }
+                ],
+                output_path=output_path,
+            )
+
+            self.assertEqual(result, output_path)
+            self.assertTrue(output_path.exists())
+            expected_width = (
+                len(CONTACT_SHEET_COLUMNS) * CONTACT_SHEET_THUMBNAIL_WIDTH
+                + (len(CONTACT_SHEET_COLUMNS) - 1) * CONTACT_SHEET_COLUMN_GAP
+            )
+            with Image.open(output_path) as contact_sheet:
+                self.assertEqual(contact_sheet.width, expected_width)
+                self.assertGreater(contact_sheet.height, 180)
+
+    def test_build_all_cameras_contact_sheet_uses_optional_pillow_api(self):
+        fallback_lanczos = object()
+        resize_filters = []
+
+        class FakeImage:
+            def __init__(self, width, height):
+                self.width = width
+                self.height = height
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, _exc_type, _exc, _traceback):
+                return False
+
+            def close(self):
+                pass
+
+            def convert(self, _mode):
+                return FakeImage(self.width, self.height)
+
+            def paste(self, _image, _position):
+                pass
+
+            def resize(self, size, _resampling):
+                resize_filters.append(_resampling)
+                return FakeImage(*size)
+
+            def save(self, output_path, **_kwargs):
+                Path(output_path).write_bytes(PNG_PLACEHOLDER)
+
+        fake_pil = types.ModuleType("PIL")
+        fake_image = types.ModuleType("PIL.Image")
+        fake_image.LANCZOS = fallback_lanczos
+        fake_image.new = lambda _mode, size, _color: FakeImage(*size)
+
+        def fake_open(path):
+            if "missing" in str(path):
+                raise OSError("missing image")
+            return FakeImage(16, 9)
+
+        fake_image.open = fake_open
+        fake_draw = types.ModuleType("PIL.ImageDraw")
+        fake_draw.Draw = lambda _image: types.SimpleNamespace(text=lambda *_args, **_kwargs: None)
+        fake_font = types.ModuleType("PIL.ImageFont")
+        fake_font.truetype = lambda *_args, **_kwargs: object()
+        fake_font.load_default = lambda: object()
+        fake_pil.Image = fake_image
+        fake_pil.ImageDraw = fake_draw
+        fake_pil.ImageFont = fake_font
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "contact-sheet.jpg"
+            with patch.dict(
+                sys.modules,
+                {
+                    "PIL": fake_pil,
+                    "PIL.Image": fake_image,
+                    "PIL.ImageDraw": fake_draw,
+                    "PIL.ImageFont": fake_font,
+                },
+            ):
+                result = build_all_cameras_contact_sheet(
+                    entries=[
+                        {
+                            "camera": "test-camera",
+                            "outputs": {
+                                "browser_reference": "loaded.png",
+                                "qgis_vector_render": "missing.png",
+                            },
+                        },
+                        {"camera": "empty-camera"},
+                    ],
+                    output_path=output_path,
+                )
+
+            self.assertEqual(result, output_path)
+            self.assertEqual(output_path.read_bytes(), PNG_PLACEHOLDER)
+            self.assertIn(fallback_lanczos, resize_filters)
+
+    def test_build_all_cameras_contact_sheet_skips_placeholder_only_sheet(self):
+        try:
+            from PIL import Image as _Image  # noqa: F401
+        except ImportError:  # pragma: no cover - local dependency guard
+            self.skipTest("Pillow is not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "contact-sheet.jpg"
+
+            result = build_all_cameras_contact_sheet(
+                entries=[
+                    {
+                        "camera": "missing-camera",
+                        "outputs": {"browser_reference": str(Path(tmpdir) / "missing.png")},
+                    }
+                ],
+                output_path=output_path,
+            )
+
+            self.assertIsNone(result)
+            self.assertFalse(output_path.exists())
+
     def test_run_comparison_writes_manifest_without_token(self):
         def fake_browser_renderer(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
@@ -696,18 +842,31 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                     stderr="",
                 )
 
-            with patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run):
-                with patch("builtins.print") as print_mock:
-                    result = mapbox_outdoors_comparison.main([
-                        "--all-cameras",
-                        "--mapbox-token",
-                        "test-mapbox-token",
-                        "--output-root",
-                        str(output_root),
-                        "--skip-browser",
-                        "--skip-qgis",
-                        "--skip-diff",
-                    ])
+            contact_sheet_calls = []
+
+            def fake_contact_sheet(*, entries, output_path, **_kwargs):
+                contact_sheet_calls.append(entries)
+                output_path.write_bytes(PNG_PLACEHOLDER)
+                return output_path
+
+            with (
+                patch("qfit.validation.mapbox_outdoors_comparison.subprocess.run", side_effect=fake_run),
+                patch(
+                    "qfit.validation.mapbox_outdoors_comparison.build_all_cameras_contact_sheet",
+                    side_effect=fake_contact_sheet,
+                ),
+                patch("builtins.print") as print_mock,
+            ):
+                result = mapbox_outdoors_comparison.main([
+                    "--all-cameras",
+                    "--mapbox-token",
+                    "test-mapbox-token",
+                    "--output-root",
+                    str(output_root),
+                    "--skip-browser",
+                    "--skip-qgis",
+                    "--skip-diff",
+                ])
 
             summary_json = next((output_root / "all-cameras").glob("*/summary.json"), None)
             self.assertIsNotNone(summary_json, "all-cameras summary.json should be written")
@@ -724,11 +883,14 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(summary["cameras"][0]["outputs"]["browser_reference"].endswith("mapbox-gl-reference.png"))
         self.assertTrue(summary["cameras"][0]["outputs"]["qgis_vector_render"].endswith("qgis-vector-render.png"))
         self.assertTrue(summary["cameras"][0]["outputs"]["diff"].endswith("mapbox-gl-vs-qgis-diff.png"))
+        self.assertTrue(summary["contact_sheet"].endswith("contact-sheet.jpg"))
+        self.assertIn("test-mapbox-token", contact_sheet_calls[0][0]["outputs"]["browser_reference"])
         self.assertIn(
             "| `switzerland-alps-z5-outdoors` | passed | `metrics_available` | 5.35 | 0.1000 |",
             summary_text,
         )
         self.assertIn("## Image artifacts", summary_text)
+        self.assertIn("Contact sheet:", summary_text)
         self.assertIn("mapbox-gl-reference.png", summary_text)
         self.assertIn("qgis-vector-render.png", summary_text)
         self.assertIn("mapbox-gl-vs-qgis-diff.png", summary_text)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -14,7 +14,7 @@ import tempfile
 from collections.abc import MutableMapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Iterable, TypeAlias
+from typing import Any, Callable, Iterable, TypeAlias
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PARENT = REPO_ROOT.parent
@@ -33,6 +33,16 @@ MATRIX_SUMMARY_METRIC_KEYS = (
     "ssim_status",
 )
 MATRIX_SUMMARY_OUTPUT_KEYS = ("browser_reference", "qgis_vector_render", "diff")
+CONTACT_SHEET_FILENAME = "contact-sheet.jpg"
+CONTACT_SHEET_THUMBNAIL_WIDTH = 320
+CONTACT_SHEET_LABEL_HEIGHT = 28
+CONTACT_SHEET_ROW_GAP = 12
+CONTACT_SHEET_COLUMN_GAP = 8
+CONTACT_SHEET_COLUMNS = (
+    ("browser_reference", "Mapbox GL"),
+    ("qgis_vector_render", "QGIS"),
+    ("diff", "Diff"),
+)
 MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE = "metrics_available"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING = "manifest_missing"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE = "manifest_unreadable"
@@ -903,7 +913,12 @@ def _manifest_path_from_child_stdout(stdout: str) -> Path | None:
     return manifest_path
 
 
-def _manifest_visual_outputs(manifest: dict[str, object], *, token: str) -> dict[str, str]:
+def _manifest_visual_outputs(
+    manifest: dict[str, object],
+    *,
+    token: str,
+    redact_outputs: bool = True,
+) -> dict[str, str]:
     outputs = manifest.get("outputs")
     captured = manifest.get("captured")
     if not isinstance(outputs, dict) or not isinstance(captured, dict):
@@ -912,7 +927,8 @@ def _manifest_visual_outputs(manifest: dict[str, object], *, token: str) -> dict
     for key in MATRIX_SUMMARY_OUTPUT_KEYS:
         output_path = outputs.get(key)
         if captured.get(key) is True and output_path:
-            visual_outputs[key] = redact_sensitive_text(str(output_path), token)
+            path_text = str(output_path)
+            visual_outputs[key] = redact_sensitive_text(path_text, token) if redact_outputs else path_text
     return visual_outputs
 
 
@@ -920,6 +936,7 @@ def _manifest_artifact_status_metrics_and_outputs(
     manifest_path: Path | None,
     *,
     token: str,
+    redact_outputs: bool = True,
 ) -> tuple[str, dict[str, object], dict[str, str]]:
     if manifest_path is None:
         return MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING, {}, {}
@@ -928,7 +945,11 @@ def _manifest_artifact_status_metrics_and_outputs(
     except (OSError, json.JSONDecodeError):
         return MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE, {}, {}
     metrics = loaded.get("metrics") if isinstance(loaded, dict) else None
-    outputs = _manifest_visual_outputs(loaded, token=token) if isinstance(loaded, dict) else {}
+    outputs = (
+        _manifest_visual_outputs(loaded, token=token, redact_outputs=redact_outputs)
+        if isinstance(loaded, dict)
+        else {}
+    )
     if not isinstance(metrics, dict):
         return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}, outputs
     metric_summary = {key: metrics[key] for key in MATRIX_SUMMARY_METRIC_KEYS if key in metrics}
@@ -966,6 +987,22 @@ def _all_camera_summary_entry(
     }
 
 
+def _all_camera_contact_sheet_entry(
+    *,
+    camera: MapboxComparisonCamera,
+    manifest_path: Path | None,
+) -> dict[str, object]:
+    _artifact_status, _metrics, outputs = _manifest_artifact_status_metrics_and_outputs(
+        manifest_path,
+        token="",
+        redact_outputs=False,
+    )
+    return {
+        "camera": camera.name,
+        "outputs": outputs,
+    }
+
+
 def _format_summary_metric(metrics: dict[str, object], key: str) -> str:
     value = metrics.get(key)
     if value is None:
@@ -973,6 +1010,185 @@ def _format_summary_metric(metrics: dict[str, object], key: str) -> str:
     if isinstance(value, float):
         return f"{value:.4f}"
     return str(value)
+
+
+def _contact_sheet_image_cell(
+    *,
+    label: str,
+    path_text: str | None,
+    thumbnail_width: int,
+    label_height: int,
+    font: object,
+    image_module: object,
+    image_draw_module: object,
+):
+    thumbnail_height = int(thumbnail_width * 9 / 16)
+    source_image = None
+    if path_text:
+        try:
+            with image_module.open(Path(path_text)) as opened_image:
+                source_image = opened_image.convert("RGB")
+        except OSError:
+            source_image = None
+    if source_image is not None:
+        try:
+            thumbnail_height = max(1, int(source_image.height * (thumbnail_width / source_image.width)))
+            image = source_image.resize(
+                (thumbnail_width, thumbnail_height),
+                _contact_sheet_lanczos_filter(image_module),
+            )
+        finally:
+            source_image.close()
+    else:
+        image = image_module.new("RGB", (thumbnail_width, thumbnail_height), "#f4f4f4")
+    cell = image_module.new("RGB", (thumbnail_width, thumbnail_height + label_height), "white")
+    draw = image_draw_module.Draw(cell)
+    draw.text((6, 6), label, fill=(0, 0, 0), font=font)
+    cell.paste(image, (0, label_height))
+    image.close()
+    return cell, source_image is not None
+
+
+def _contact_sheet_lanczos_filter(image_module: object) -> object:
+    resampling = getattr(image_module, "Resampling", None)
+    if resampling is not None and hasattr(resampling, "LANCZOS"):
+        return resampling.LANCZOS
+    return getattr(image_module, "LANCZOS", 1)
+
+
+def _contact_sheet_entry_outputs(entry: dict[str, object]) -> dict[object, object]:
+    outputs = entry.get("outputs")
+    return outputs if isinstance(outputs, dict) else {}
+
+
+def _contact_sheet_row_for_entry(
+    *,
+    entry: dict[str, object],
+    font: object,
+    image_module: object,
+    image_draw_module: object,
+):
+    outputs = _contact_sheet_entry_outputs(entry)
+    if not outputs:
+        return None, False
+    camera_name = str(entry.get("camera") or "unknown")
+    cells = []
+    loaded_any_image = False
+    for output_key, label in CONTACT_SHEET_COLUMNS:
+        path_text = outputs.get(output_key)
+        cell, loaded = _contact_sheet_image_cell(
+            label=f"{camera_name} - {label}",
+            path_text=str(path_text) if path_text else None,
+            thumbnail_width=CONTACT_SHEET_THUMBNAIL_WIDTH,
+            label_height=CONTACT_SHEET_LABEL_HEIGHT,
+            font=font,
+            image_module=image_module,
+            image_draw_module=image_draw_module,
+        )
+        cells.append(cell)
+        loaded_any_image = loaded_any_image or loaded
+    row_height = max(cell.height for cell in cells)
+    row_width = len(cells) * CONTACT_SHEET_THUMBNAIL_WIDTH + (len(cells) - 1) * CONTACT_SHEET_COLUMN_GAP
+    row = image_module.new("RGB", (row_width, row_height), "white")
+    x_offset = 0
+    for cell in cells:
+        row.paste(cell, (x_offset, 0))
+        x_offset += CONTACT_SHEET_THUMBNAIL_WIDTH + CONTACT_SHEET_COLUMN_GAP
+        cell.close()
+    return row, loaded_any_image
+
+
+def _write_contact_sheet(*, row_images: list[Any], output_path: Path, image_module: object) -> Path:
+    sheet_width = max(row.width for row in row_images)
+    sheet_height = sum(row.height for row in row_images) + CONTACT_SHEET_ROW_GAP * (len(row_images) - 1)
+    sheet = image_module.new("RGB", (sheet_width, sheet_height), "white")
+    y_offset = 0
+    for row in row_images:
+        sheet.paste(row, (0, y_offset))
+        y_offset += row.height + CONTACT_SHEET_ROW_GAP
+        row.close()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(output_path, quality=90)
+    sheet.close()
+    return output_path
+
+
+def _contact_sheet_modules(
+    *,
+    image_module: object | None,
+    image_draw_module: object | None,
+    image_font_module: object | None,
+) -> tuple[object, object, object] | None:
+    if image_module is not None and image_draw_module is not None and image_font_module is not None:
+        return image_module, image_draw_module, image_font_module
+    try:
+        from PIL import Image, ImageDraw, ImageFont  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    return image_module or Image, image_draw_module or ImageDraw, image_font_module or ImageFont
+
+
+def _contact_sheet_font(image_font_module: object) -> object:
+    try:
+        return image_font_module.truetype("DejaVuSans.ttf", 14)
+    except OSError:
+        return image_font_module.load_default()
+
+
+def _contact_sheet_rows(
+    *,
+    entries: list[dict[str, object]],
+    font: object,
+    image_module: object,
+    image_draw_module: object,
+) -> tuple[list[Any], bool]:
+    row_images = []
+    loaded_any_image = False
+    for entry in entries:
+        row, loaded = _contact_sheet_row_for_entry(
+            entry=entry,
+            font=font,
+            image_module=image_module,
+            image_draw_module=image_draw_module,
+        )
+        if row is not None:
+            row_images.append(row)
+        loaded_any_image = loaded_any_image or loaded
+    return row_images, loaded_any_image
+
+
+def _close_contact_sheet_rows(row_images: list[Any]) -> None:
+    for row in row_images:
+        row.close()
+
+
+def build_all_cameras_contact_sheet(
+    *,
+    entries: list[dict[str, object]],
+    output_path: Path,
+    image_module: object | None = None,
+    image_draw_module: object | None = None,
+    image_font_module: object | None = None,
+) -> Path | None:
+    modules = _contact_sheet_modules(
+        image_module=image_module,
+        image_draw_module=image_draw_module,
+        image_font_module=image_font_module,
+    )
+    if modules is None:
+        return None
+    image_module, image_draw_module, image_font_module = modules
+    font = _contact_sheet_font(image_font_module)
+    row_images, loaded_any_image = _contact_sheet_rows(
+        entries=entries,
+        font=font,
+        image_module=image_module,
+        image_draw_module=image_draw_module,
+    )
+    if not row_images or not loaded_any_image:
+        _close_contact_sheet_rows(row_images)
+        return None
+    return _write_contact_sheet(row_images=row_images, output_path=output_path, image_module=image_module)
 
 
 def _all_cameras_summary_markdown(summary: dict[str, object]) -> str:
@@ -1005,6 +1221,8 @@ def _all_cameras_summary_markdown(summary: dict[str, object]) -> str:
             "",
             "## Image artifacts",
             "",
+            f"Contact sheet: `{summary.get('contact_sheet') or '—'}`",
+            "",
             "| Camera | Mapbox GL reference | QGIS vector render | Diff |",
             "| --- | --- | --- | --- |",
         ]
@@ -1036,6 +1254,7 @@ def _write_all_cameras_summary(
     args: argparse.Namespace,
     output_root: Path,
     entries: list[dict[str, object]],
+    contact_sheet_entries: list[dict[str, object]] | None = None,
     token: str,
 ) -> tuple[Path, Path]:
     generated_at = _utc_timestamp()
@@ -1063,6 +1282,15 @@ def _write_all_cameras_summary(
     }
     summary_json = run_dir / "summary.json"
     summary_markdown = run_dir / "summary.md"
+    contact_sheet_path = build_all_cameras_contact_sheet(
+        entries=contact_sheet_entries if contact_sheet_entries is not None else entries,
+        output_path=run_dir / CONTACT_SHEET_FILENAME,
+    )
+    summary["contact_sheet"] = (
+        redact_sensitive_text(str(contact_sheet_path), token)
+        if contact_sheet_path is not None
+        else None
+    )
     summary_json.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
     summary_markdown.write_text(_all_cameras_summary_markdown(summary), encoding="utf-8")
     return summary_json, summary_markdown
@@ -1077,6 +1305,7 @@ def _run_all_cameras_in_subprocesses(
 ) -> None:
     failures: list[str] = []
     summary_entries: list[dict[str, object]] = []
+    contact_sheet_entries: list[dict[str, object]] = []
     for camera in cameras:
         timeout_seconds = _camera_subprocess_timeout_seconds(args)
         try:
@@ -1105,6 +1334,7 @@ def _run_all_cameras_in_subprocesses(
                     token=token,
                 )
             )
+            contact_sheet_entries.append(_all_camera_contact_sheet_entry(camera=camera, manifest_path=None))
             failures.append(f"{camera.name} (timeout after {timeout_seconds:g}s)")
             print(
                 f"error: camera {camera.name} timed out after {timeout_seconds:g}s; continuing.",
@@ -1123,6 +1353,9 @@ def _run_all_cameras_in_subprocesses(
                 token=token,
             )
         )
+        contact_sheet_entries.append(
+            _all_camera_contact_sheet_entry(camera=camera, manifest_path=manifest_path)
+        )
         if completed.returncode != 0:
             failures.append(f"{camera.name} (exit {completed.returncode})")
             print(
@@ -1133,6 +1366,7 @@ def _run_all_cameras_in_subprocesses(
         args=args,
         output_root=output_root,
         entries=summary_entries,
+        contact_sheet_entries=contact_sheet_entries,
         token=token,
     )
     print(f"Matrix summary: {redact_sensitive_text(str(summary_json), token)}")


### PR DESCRIPTION
## Summary
- add an all-camera `contact-sheet.jpg` to the Mapbox Outdoors comparison matrix output
- include the contact sheet path in `summary.json` and `summary.md`
- document the contact sheet as the quick visual scan artifact for z5-z18 comparison runs

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short` (41 passed)
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_comparison.py && git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short` (2228 passed, 173 skipped, 156 subtests)
- live all-camera comparison with local QGIS-profile Mapbox token source: `debug/mapbox-outdoors-comparison/all-cameras/20260519T211746Z/summary.md`
  - 7/7 cameras passed with metrics available
  - generated `debug/mapbox-outdoors-comparison/all-cameras/20260519T211746Z/contact-sheet.jpg`

Refs #949
