### PR TITLE
Handle Mapbox contact sheet font fallback

### DIFF
--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -483,6 +483,8 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
     def test_build_all_cameras_contact_sheet_uses_optional_pillow_api(self):
         fallback_lanczos = object()
+        default_font = object()
+        drawn_fonts = []
         resize_filters = []
 
         class FakeImage:
@@ -524,10 +526,16 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
         fake_image.open = fake_open
         fake_draw = types.ModuleType("PIL.ImageDraw")
-        fake_draw.Draw = lambda _image: types.SimpleNamespace(text=lambda *_args, **_kwargs: None)
+        fake_draw.Draw = lambda _image: types.SimpleNamespace(
+            text=lambda *_args, **kwargs: drawn_fonts.append(kwargs.get("font"))
+        )
         fake_font = types.ModuleType("PIL.ImageFont")
-        fake_font.truetype = lambda *_args, **_kwargs: object()
-        fake_font.load_default = lambda: object()
+
+        def fake_truetype(*_args, **_kwargs):
+            raise ImportError("_imagingft")
+
+        fake_font.truetype = fake_truetype
+        fake_font.load_default = lambda: default_font
         fake_pil.Image = fake_image
         fake_pil.ImageDraw = fake_draw
         fake_pil.ImageFont = fake_font
@@ -559,6 +567,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
             self.assertEqual(result, output_path)
             self.assertEqual(output_path.read_bytes(), PNG_PLACEHOLDER)
+            self.assertIn(default_font, drawn_fonts)
             self.assertIn(fallback_lanczos, resize_filters)
 
     def test_build_all_cameras_contact_sheet_skips_placeholder_only_sheet(self):

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -1131,7 +1131,7 @@ def _contact_sheet_modules(
 def _contact_sheet_font(image_font_module: object) -> object:
     try:
         return image_font_module.truetype("DejaVuSans.ttf", 14)
-    except OSError:
+    except (ImportError, OSError):
         return image_font_module.load_default()
 
 


### PR DESCRIPTION
## Summary
- broaden the contact-sheet font fallback to handle Pillow builds without FreeType support
- cover the fallback path in the fake-Pillow contact-sheet test

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short` (41 passed)
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_comparison.py && git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short` (2228 passed, 173 skipped, 156 subtests)

Addresses Codex feedback from #1166.
Refs #949
