### PR TITLE
chore: add contour polygon label probe

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -175,6 +175,16 @@ debug/mapbox-outdoors-contour-features/all-cameras/<UTC timestamp>/
 
 Use the aggregate table to check whether contour-label candidates are line-compatible, polygon-only, or absent across the z5-z18 comparison matrix. Per-camera status and error columns keep the batch useful when one camera fails before tile-level diagnostics can be collected. A polygon-only result means a Mapbox `symbol-spacing` or QGIS line-repeat tweak is not enough by itself; follow-up work should stay focused on QGIS vector-tile polygon/perimeter-label behavior or a separately validated contour-boundary overlay. The diagnostic also classifies polygon candidates as rectangular or non-rectangular so perimeter-label probes can distinguish likely tile/source-boundary polygons from shapes that might plausibly follow contour boundaries.
 
+When the contour diagnostic reports polygon-only label candidates, the screenshot harness can append a diagnostic-only QGIS polygon/perimeter label style for the `contour` source layer before rendering:
+
+```bash
+python3 validation/mapbox_outdoors_comparison.py \
+  zermatt-piste-z17-outdoors \
+  --qgis-contour-polygon-label-probe
+```
+
+This probe renders an extra QGIS vector-tile label rule named `contour-label-polygon-perimeter-probe`, limited to contour label candidate indices 5 and 10, with polygon geometry and curved perimeter placement. Use it to test whether QGIS can place contour labels on the polygon candidate geometry before considering a production rendering change. It is diagnostic output only; compare the browser reference, QGIS render, and diff image before treating the result as evidence for a qfit style change.
+
 ## Road feature diagnostic
 
 When road/path hierarchy, high-detail trail behavior, road shields, or oneway arrows are the candidate parity slice, inspect the underlying road vector-tile features before changing QGIS style preprocessing:

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -20,6 +20,10 @@ from qfit.validation.mapbox_outdoors_comparison import (
     ComparisonConfig,
     DEFAULT_OUTPUT_ROOT,
     MapboxComparisonCamera,
+    QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER,
+    QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM,
+    QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME,
+    _append_qgis_contour_polygon_label_probe,
     build_all_cameras_contact_sheet,
     build_comparison_paths,
     build_image_diff,
@@ -380,6 +384,124 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertTrue(preprocessed_style["metadata"]["qfit-preprocessed"])
             self.assertNotIn("test-mapbox-token", preprocessed_style_text)
 
+    def test_append_qgis_contour_polygon_label_probe_adds_polygon_perimeter_style(self):
+        class FakeQgis:
+            class GeometryType:
+                Polygon = "Polygon"
+
+            class RenderUnit:
+                Millimeters = "Millimeters"
+
+        class FakePalLayerSettings:
+            PerimeterCurved = "PerimeterCurved"
+            constructed_sources = []
+
+            def __init__(self, source=None):
+                self.constructed_sources.append(source)
+                self.fieldName = getattr(source, "fieldName", "")
+                self.isExpression = getattr(source, "isExpression", False)
+                self.priority = getattr(source, "priority", 0)
+                self.repeatDistance = getattr(source, "repeatDistance", 0.0)
+                self.repeatDistanceUnit = getattr(source, "repeatDistanceUnit", None)
+
+        class FakeLabelingStyle:
+            def setStyleName(self, value):
+                self._style_name = value
+
+            def styleName(self):
+                return self._style_name
+
+            def setLayerName(self, value):
+                self._layer_name = value
+
+            def layerName(self):
+                return self._layer_name
+
+            def setGeometryType(self, value):
+                self._geometry_type = value
+
+            def geometryType(self):
+                return self._geometry_type
+
+            def setFilterExpression(self, value):
+                self._filter_expression = value
+
+            def filterExpression(self):
+                return self._filter_expression
+
+            def setMinZoomLevel(self, value):
+                self._min_zoom = value
+
+            def minZoomLevel(self):
+                return self._min_zoom
+
+            def setLabelSettings(self, value):
+                self._settings = value
+
+            def labelSettings(self):
+                return self._settings
+
+        class FakeLabeling:
+            def __init__(self, styles=None):
+                self._styles = list(styles or [])
+
+            def styles(self):
+                return self._styles
+
+            def setStyles(self, styles):
+                self._styles = list(styles)
+
+        class FakeLayer:
+            def __init__(self, labeling):
+                self._labeling = labeling
+                self.labels_enabled = False
+
+            def labeling(self):
+                return self._labeling
+
+            def setLabeling(self, labeling):
+                self._labeling = labeling
+
+            def setLabelsEnabled(self, value):
+                self.labels_enabled = value
+
+        source_settings = FakePalLayerSettings()
+        source_settings.priority = 7
+        source_style = FakeLabelingStyle()
+        source_style.setStyleName("contour-label")
+        source_style.setLayerName("contour")
+        source_style.setLabelSettings(source_settings)
+        layer = FakeLayer(FakeLabeling([source_style]))
+        FakePalLayerSettings.constructed_sources = []
+
+        fake_core = types.ModuleType("qgis.core")
+        fake_core.Qgis = FakeQgis
+        fake_core.QgsPalLayerSettings = FakePalLayerSettings
+        fake_core.QgsVectorTileBasicLabeling = FakeLabeling
+        fake_core.QgsVectorTileBasicLabelingStyle = FakeLabelingStyle
+
+        with patch.dict(sys.modules, {"qgis": types.ModuleType("qgis"), "qgis.core": fake_core}):
+            _append_qgis_contour_polygon_label_probe(layer)
+            _append_qgis_contour_polygon_label_probe(layer)
+
+        self.assertEqual(FakePalLayerSettings.constructed_sources, [None])
+        styles = layer.labeling().styles()
+        self.assertEqual(len(styles), 2)
+        self.assertTrue(layer.labels_enabled)
+        probe_style = styles[1]
+        probe_settings = probe_style.labelSettings()
+        self.assertEqual(probe_style.styleName(), QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME)
+        self.assertEqual(probe_style.layerName(), "contour")
+        self.assertEqual(probe_style.geometryType(), FakeQgis.GeometryType.Polygon)
+        self.assertEqual(probe_style.filterExpression(), QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER)
+        self.assertEqual(probe_style.minZoomLevel(), QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM)
+        self.assertEqual(probe_settings.fieldName, 'concat("ele", \' m\')')
+        self.assertTrue(probe_settings.isExpression)
+        self.assertEqual(probe_settings.placement, FakePalLayerSettings.PerimeterCurved)
+        self.assertEqual(probe_settings.priority, 7)
+        self.assertEqual(probe_settings.repeatDistance, 0.0)
+        self.assertIsNone(probe_settings.repeatDistanceUnit)
+
     def test_headless_qt_platform_defaults_to_offscreen_without_overriding_callers(self):
         from qfit.validation import mapbox_outdoors_comparison
 
@@ -638,6 +760,33 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(metrics["changed_pixel_ratio"], 0.25)
         self.assertEqual(preprocessed_style, SAMPLE_STYLE)
 
+    def test_run_comparison_records_qgis_contour_polygon_label_probe_option(self):
+        captured = {}
+
+        def fake_qgis_renderer(*, output_path, qgis_contour_polygon_label_probe, **_kwargs):
+            captured["probe"] = qgis_contour_polygon_label_probe
+            output_path.write_bytes(PNG_PLACEHOLDER)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_comparison(
+                ComparisonConfig(
+                    camera=CAMERAS["zermatt-piste-z17-outdoors"],
+                    token="test-mapbox-token",
+                    output_root=Path(tmpdir),
+                    qgis_contour_polygon_label_probe=True,
+                    browser=False,
+                    diff=False,
+                    now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
+                ),
+                qgis_renderer=fake_qgis_renderer,
+            )
+
+            manifest = json.loads(result.paths.manifest_json.read_text(encoding="utf-8"))
+
+        self.assertTrue(captured["probe"])
+        self.assertTrue(result.qgis_contour_polygon_label_probe)
+        self.assertTrue(manifest["qgis_contour_polygon_label_probe"])
+
     def test_run_comparison_passes_downloaded_style_json_to_renderers(self):
         captured_style_definitions = []
 
@@ -717,6 +866,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             "--style-json",
             "/tmp/mapbox-outdoors-v12.json",
             "--skip-qgis",
+            "--qgis-contour-polygon-label-probe",
             "--browser-timeout-ms",
             "5000",
         ])
@@ -726,6 +876,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(args.output_root, "/tmp/qfit-mapbox")
         self.assertEqual(args.style_json, Path("/tmp/mapbox-outdoors-v12.json"))
         self.assertTrue(args.skip_qgis)
+        self.assertTrue(args.qgis_contour_polygon_label_probe)
         self.assertEqual(args.browser_timeout_ms, 5000)
 
     def test_main_all_cameras_runs_full_inspection_matrix(self):
@@ -750,6 +901,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                         "--output-root",
                         str(output_root),
                         "--skip-browser",
+                        "--qgis-contour-polygon-label-probe",
                         "--skip-diff",
                         "--browser-timeout-ms",
                         "5000",
@@ -765,6 +917,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertIn("/tmp/mapbox-outdoors-v12.json", command)
             self.assertIn(str(output_root), command)
             self.assertIn("--skip-browser", command)
+            self.assertIn("--qgis-contour-polygon-label-probe", command)
             self.assertIn("--skip-diff", command)
             self.assertEqual(kwargs["env"]["MAPBOX_ACCESS_TOKEN"], "test-mapbox-token")
             self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -43,6 +43,9 @@ CONTACT_SHEET_COLUMNS = (
     ("qgis_vector_render", "QGIS"),
     ("diff", "Diff"),
 )
+QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME = "contour-label-polygon-perimeter-probe"
+QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER = '("index" = 5 OR "index" = 10)'
+QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM = 11
 MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE = "metrics_available"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING = "manifest_missing"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE = "manifest_unreadable"
@@ -179,6 +182,7 @@ class ComparisonConfig:
     token: str
     output_root: Path
     style_json_path: Path | None = None
+    qgis_contour_polygon_label_probe: bool = False
     browser: bool = True
     qgis: bool = True
     diff: bool = True
@@ -193,6 +197,7 @@ class ComparisonResult:
     qgis_captured: bool
     diff_captured: bool
     qgis_preprocessed_style_captured: bool = False
+    qgis_contour_polygon_label_probe: bool = False
     image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
     style_json_path: str | None = None
 
@@ -295,6 +300,7 @@ def _redacted_manifest(
             "qgis_preprocessed_style": str(result.paths.qgis_preprocessed_style_json),
         },
         "style_json_path": result.style_json_path,
+        "qgis_contour_polygon_label_probe": result.qgis_contour_polygon_label_probe,
         "captured": {
             "browser_reference": result.browser_captured,
             "qgis_vector_render": result.qgis_captured,
@@ -506,6 +512,79 @@ def is_valid_qgis_vector_tile_layer(*, layer: object, vector_tile_layer_type: ty
     return isinstance(layer, vector_tile_layer_type) and bool(layer.isValid())
 
 
+def _method_value(obj: object, method_name: str) -> object:
+    method = getattr(obj, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        return method()
+    except (AttributeError, RuntimeError, TypeError):
+        return None
+
+
+def _method_text(obj: object, method_name: str) -> str:
+    value = _method_value(obj, method_name)
+    return value if isinstance(value, str) else ""
+
+
+def _is_contour_label_style(style: object) -> bool:
+    return (
+        _method_text(style, "layerName") == "contour"
+        and _method_text(style, "styleName").startswith("contour-label")
+    )
+
+
+def _settings_priority(settings: object | None) -> int:
+    priority = getattr(settings, "priority", 0)
+    if isinstance(priority, bool):
+        return 0
+    if isinstance(priority, (int, float)):
+        return int(priority)
+    return 0
+
+
+def _append_qgis_contour_polygon_label_probe(layer: object) -> None:
+    from qgis.core import (  # type: ignore[import-not-found] # noqa: PLC0415
+        QgsPalLayerSettings,
+        QgsVectorTileBasicLabeling,
+        QgsVectorTileBasicLabelingStyle,
+        Qgis,
+    )
+
+    labeling = _method_value(layer, "labeling")
+    styles = list(_method_value(labeling, "styles") or [])
+    if any(_method_text(style, "styleName") == QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME for style in styles):
+        return
+
+    source_settings = None
+    for style in styles:
+        if _is_contour_label_style(style):
+            source_settings = _method_value(style, "labelSettings")
+            break
+
+    # Keep the probe as an independent polygon label rule.  Copying QGIS'
+    # converted line-label settings into a polygon rule can crash local
+    # PyQGIS during render cleanup.
+    settings = QgsPalLayerSettings()
+    settings.fieldName = 'concat("ele", \' m\')'
+    settings.isExpression = True
+    settings.placement = QgsPalLayerSettings.PerimeterCurved
+    settings.priority = max(3, _settings_priority(source_settings))
+
+    probe_style = QgsVectorTileBasicLabelingStyle()
+    probe_style.setStyleName(QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME)
+    probe_style.setLayerName("contour")
+    probe_style.setGeometryType(Qgis.GeometryType.Polygon)
+    probe_style.setFilterExpression(QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER)
+    probe_style.setMinZoomLevel(QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM)
+    probe_style.setLabelSettings(settings)
+
+    updated_labeling = QgsVectorTileBasicLabeling()
+    updated_labeling.setStyles([*styles, probe_style])
+    layer.setLabeling(updated_labeling)
+    layer.setLabelsEnabled(True)
+
+
 def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     *,
     camera: MapboxComparisonCamera,
@@ -513,6 +592,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     output_path: Path,
     style_definition: dict[str, object] | None = None,
     qgis_preprocessed_style_path: Path | None = None,
+    qgis_contour_polygon_label_probe: bool = False,
 ) -> None:
     _ensure_package_parent_on_path()
     _ensure_headless_qt_platform()
@@ -583,6 +663,8 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
         if not is_valid_qgis_vector_tile_layer(layer=layer, vector_tile_layer_type=QgsVectorTileLayer):
             raise RuntimeError("QGIS did not create a valid Mapbox vector tile layer.")
         BackgroundMapService()._apply_mapbox_gl_style(layer, simplified_style, sprite_resources=sprite_resources)
+        if qgis_contour_polygon_label_probe:
+            _append_qgis_contour_polygon_label_probe(layer)
 
         destination_crs = QgsCoordinateReferenceSystem("EPSG:3857")
         settings = QgsMapSettings()
@@ -702,6 +784,7 @@ def run_comparison(
             output_path=paths.qgis_png,
             style_definition=style_definition,
             qgis_preprocessed_style_path=paths.qgis_preprocessed_style_json,
+            qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
         )
         qgis_captured = True
         qgis_preprocessed_style_captured = paths.qgis_preprocessed_style_json.exists()
@@ -721,6 +804,7 @@ def run_comparison(
         qgis_captured=qgis_captured,
         diff_captured=diff_captured,
         qgis_preprocessed_style_captured=qgis_preprocessed_style_captured,
+        qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
         image_metrics=image_metrics,
         style_json_path=str(config.style_json_path) if config.style_json_path is not None else None,
     )
@@ -784,6 +868,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Skip the native QGIS vector-tile screenshot.",
     )
     parser.add_argument(
+        "--qgis-contour-polygon-label-probe",
+        action="store_true",
+        help=(
+            "Append a diagnostic QGIS polygon/perimeter contour-label style before rendering. "
+            "Use only for #949 visual probes, not production parity claims."
+        ),
+    )
+    parser.add_argument(
         "--skip-diff",
         action="store_true",
         help="Skip diff image generation.",
@@ -828,6 +920,7 @@ def _comparison_config(
         token=token,
         output_root=output_root,
         style_json_path=args.style_json,
+        qgis_contour_polygon_label_probe=args.qgis_contour_polygon_label_probe,
         browser=not args.skip_browser,
         qgis=not args.skip_qgis,
         diff=not args.skip_diff,
@@ -869,6 +962,8 @@ def _single_camera_subprocess_command(
         command.append("--skip-browser")
     if args.skip_qgis:
         command.append("--skip-qgis")
+    if args.qgis_contour_polygon_label_probe:
+        command.append("--qgis-contour-polygon-label-probe")
     if args.skip_diff:
         command.append("--skip-diff")
     command.extend(["--browser-timeout-ms", str(args.browser_timeout_ms)])


### PR DESCRIPTION
Refs #949.

## Summary

- Add a diagnostic `--qgis-contour-polygon-label-probe` mode to the Mapbox Outdoors comparison harness.
- Append a QGIS polygon/perimeter contour-label rule during probe renders and record the probe flag in the manifest.
- Use fresh polygon label settings for the probe instead of cloning QGIS' converted line-label settings, which crashed local PyQGIS during render cleanup.
- Document how to use the probe after contour diagnostics report polygon-only label candidates.

## Live evidence

Generated with the local QGIS-profile Mapbox token source without printing or committing the token:

- z17 Zermatt probe: `debug/mapbox-outdoors-comparison/zermatt-piste-z17-outdoors/20260519T221625Z/manifest.json`
- all-camera probe matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260519T221750Z/summary.md`
- contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260519T221750Z/contact-sheet.jpg`

The probe path is operational: 7/7 cameras passed with metrics available. Visual review shows this is not a production rendering fix yet: QGIS can generate contour labels on the polygon/perimeter candidates, but z17/z18 output is too dense and artifact-prone compared with the Mapbox GL reference.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_comparison.py`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`