### PR TITLE
chore: add contour boundary generator probe

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -185,6 +185,16 @@ python3 validation/mapbox_outdoors_comparison.py \
 
 This probe renders an extra QGIS vector-tile label rule named `contour-label-polygon-perimeter-probe`, limited to contour label candidate indices 5 and 10, with polygon geometry and curved perimeter placement. Use it to test whether QGIS can place contour labels on the polygon candidate geometry before considering a production rendering change. It is diagnostic output only; compare the browser reference, QGIS render, and diff image before treating the result as evidence for a qfit style change.
 
+To compare QGIS' polygon placement with a line-output geometry-generator approach, use the boundary-generator probe instead:
+
+```bash
+python3 validation/mapbox_outdoors_comparison.py \
+  zermatt-piste-z17-outdoors \
+  --qgis-contour-boundary-generator-label-probe
+```
+
+This renders a separate diagnostic rule named `contour-label-boundary-generator-probe` for the same contour label candidates, but labels the generated `boundary($geometry)` line output with curved line placement. Use it to check whether QGIS' line-label engine behaves better on polygon-derived contour boundaries than direct polygon perimeter placement. It is also diagnostic output only.
+
 ## Road feature diagnostic
 
 When road/path hierarchy, high-detail trail behavior, road shields, or oneway arrows are the candidate parity slice, inspect the underlying road vector-tile features before changing QGIS style preprocessing:

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -20,9 +20,14 @@ from qfit.validation.mapbox_outdoors_comparison import (
     ComparisonConfig,
     DEFAULT_OUTPUT_ROOT,
     MapboxComparisonCamera,
+    QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
+    QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER,
+    QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM,
+    QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME,
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER,
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM,
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME,
+    _append_qgis_contour_boundary_generator_label_probe,
     _append_qgis_contour_polygon_label_probe,
     build_all_cameras_contact_sheet,
     build_comparison_paths,
@@ -502,6 +507,129 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(probe_settings.repeatDistance, 0.0)
         self.assertIsNone(probe_settings.repeatDistanceUnit)
 
+    def test_append_qgis_contour_boundary_generator_label_probe_adds_line_generator_style(self):
+        class FakeQgis:
+            class GeometryType:
+                Line = "Line"
+                Polygon = "Polygon"
+
+        class FakePalLayerSettings:
+            Curved = "Curved"
+            Line = "Line"
+            constructed_sources = []
+
+            def __init__(self, source=None):
+                self.constructed_sources.append(source)
+                self.fieldName = getattr(source, "fieldName", "")
+                self.isExpression = getattr(source, "isExpression", False)
+                self.priority = getattr(source, "priority", 0)
+                self.placement = None
+                self.geometryGenerator = ""
+                self.geometryGeneratorEnabled = False
+                self.geometryGeneratorType = None
+
+        class FakeLabelingStyle:
+            def setStyleName(self, value):
+                self._style_name = value
+
+            def styleName(self):
+                return self._style_name
+
+            def setLayerName(self, value):
+                self._layer_name = value
+
+            def layerName(self):
+                return self._layer_name
+
+            def setGeometryType(self, value):
+                self._geometry_type = value
+
+            def geometryType(self):
+                return self._geometry_type
+
+            def setFilterExpression(self, value):
+                self._filter_expression = value
+
+            def filterExpression(self):
+                return self._filter_expression
+
+            def setMinZoomLevel(self, value):
+                self._min_zoom = value
+
+            def minZoomLevel(self):
+                return self._min_zoom
+
+            def setLabelSettings(self, value):
+                self._settings = value
+
+            def labelSettings(self):
+                return self._settings
+
+        class FakeLabeling:
+            def __init__(self, styles=None):
+                self._styles = list(styles or [])
+
+            def styles(self):
+                return self._styles
+
+            def setStyles(self, styles):
+                self._styles = list(styles)
+
+        class FakeLayer:
+            def __init__(self, labeling):
+                self._labeling = labeling
+                self.labels_enabled = False
+
+            def labeling(self):
+                return self._labeling
+
+            def setLabeling(self, labeling):
+                self._labeling = labeling
+
+            def setLabelsEnabled(self, value):
+                self.labels_enabled = value
+
+        source_settings = FakePalLayerSettings()
+        source_settings.priority = 6
+        source_style = FakeLabelingStyle()
+        source_style.setStyleName("contour-label")
+        source_style.setLayerName("contour")
+        source_style.setLabelSettings(source_settings)
+        layer = FakeLayer(FakeLabeling([source_style]))
+        FakePalLayerSettings.constructed_sources = []
+
+        fake_core = types.ModuleType("qgis.core")
+        fake_core.Qgis = FakeQgis
+        fake_core.QgsPalLayerSettings = FakePalLayerSettings
+        fake_core.QgsVectorTileBasicLabeling = FakeLabeling
+        fake_core.QgsVectorTileBasicLabelingStyle = FakeLabelingStyle
+
+        with patch.dict(sys.modules, {"qgis": types.ModuleType("qgis"), "qgis.core": fake_core}):
+            _append_qgis_contour_boundary_generator_label_probe(layer)
+            _append_qgis_contour_boundary_generator_label_probe(layer)
+
+        self.assertEqual(FakePalLayerSettings.constructed_sources, [None])
+        styles = layer.labeling().styles()
+        self.assertEqual(len(styles), 2)
+        self.assertTrue(layer.labels_enabled)
+        probe_style = styles[1]
+        probe_settings = probe_style.labelSettings()
+        self.assertEqual(probe_style.styleName(), QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME)
+        self.assertEqual(probe_style.layerName(), "contour")
+        self.assertEqual(probe_style.geometryType(), FakeQgis.GeometryType.Polygon)
+        self.assertEqual(probe_style.filterExpression(), QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER)
+        self.assertEqual(probe_style.minZoomLevel(), QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM)
+        self.assertEqual(probe_settings.fieldName, 'concat("ele", \' m\')')
+        self.assertTrue(probe_settings.isExpression)
+        self.assertEqual(probe_settings.placement, FakePalLayerSettings.Curved)
+        self.assertEqual(probe_settings.priority, 6)
+        self.assertEqual(
+            probe_settings.geometryGenerator,
+            QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
+        )
+        self.assertTrue(probe_settings.geometryGeneratorEnabled)
+        self.assertEqual(probe_settings.geometryGeneratorType, FakeQgis.GeometryType.Line)
+
     def test_headless_qt_platform_defaults_to_offscreen_without_overriding_callers(self):
         from qfit.validation import mapbox_outdoors_comparison
 
@@ -760,11 +888,18 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(metrics["changed_pixel_ratio"], 0.25)
         self.assertEqual(preprocessed_style, SAMPLE_STYLE)
 
-    def test_run_comparison_records_qgis_contour_polygon_label_probe_option(self):
+    def test_run_comparison_records_qgis_contour_label_probe_options(self):
         captured = {}
 
-        def fake_qgis_renderer(*, output_path, qgis_contour_polygon_label_probe, **_kwargs):
-            captured["probe"] = qgis_contour_polygon_label_probe
+        def fake_qgis_renderer(
+            *,
+            output_path,
+            qgis_contour_polygon_label_probe,
+            qgis_contour_boundary_generator_label_probe,
+            **_kwargs,
+        ):
+            captured["polygon_probe"] = qgis_contour_polygon_label_probe
+            captured["boundary_generator_probe"] = qgis_contour_boundary_generator_label_probe
             output_path.write_bytes(PNG_PLACEHOLDER)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -774,6 +909,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                     token="test-mapbox-token",
                     output_root=Path(tmpdir),
                     qgis_contour_polygon_label_probe=True,
+                    qgis_contour_boundary_generator_label_probe=True,
                     browser=False,
                     diff=False,
                     now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
@@ -783,9 +919,12 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
             manifest = json.loads(result.paths.manifest_json.read_text(encoding="utf-8"))
 
-        self.assertTrue(captured["probe"])
+        self.assertTrue(captured["polygon_probe"])
+        self.assertTrue(captured["boundary_generator_probe"])
         self.assertTrue(result.qgis_contour_polygon_label_probe)
+        self.assertTrue(result.qgis_contour_boundary_generator_label_probe)
         self.assertTrue(manifest["qgis_contour_polygon_label_probe"])
+        self.assertTrue(manifest["qgis_contour_boundary_generator_label_probe"])
 
     def test_run_comparison_passes_downloaded_style_json_to_renderers(self):
         captured_style_definitions = []
@@ -867,6 +1006,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             "/tmp/mapbox-outdoors-v12.json",
             "--skip-qgis",
             "--qgis-contour-polygon-label-probe",
+            "--qgis-contour-boundary-generator-label-probe",
             "--browser-timeout-ms",
             "5000",
         ])
@@ -877,6 +1017,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(args.style_json, Path("/tmp/mapbox-outdoors-v12.json"))
         self.assertTrue(args.skip_qgis)
         self.assertTrue(args.qgis_contour_polygon_label_probe)
+        self.assertTrue(args.qgis_contour_boundary_generator_label_probe)
         self.assertEqual(args.browser_timeout_ms, 5000)
 
     def test_main_all_cameras_runs_full_inspection_matrix(self):
@@ -902,6 +1043,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                         str(output_root),
                         "--skip-browser",
                         "--qgis-contour-polygon-label-probe",
+                        "--qgis-contour-boundary-generator-label-probe",
                         "--skip-diff",
                         "--browser-timeout-ms",
                         "5000",
@@ -918,6 +1060,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertIn(str(output_root), command)
             self.assertIn("--skip-browser", command)
             self.assertIn("--qgis-contour-polygon-label-probe", command)
+            self.assertIn("--qgis-contour-boundary-generator-label-probe", command)
             self.assertIn("--skip-diff", command)
             self.assertEqual(kwargs["env"]["MAPBOX_ACCESS_TOKEN"], "test-mapbox-token")
             self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -46,6 +46,10 @@ CONTACT_SHEET_COLUMNS = (
 QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME = "contour-label-polygon-perimeter-probe"
 QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER = '("index" = 5 OR "index" = 10)'
 QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM = 11
+QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME = "contour-label-boundary-generator-probe"
+QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION = "boundary($geometry)"
+QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER = QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER
+QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM = QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM
 MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE = "metrics_available"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING = "manifest_missing"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE = "manifest_unreadable"
@@ -183,6 +187,7 @@ class ComparisonConfig:
     output_root: Path
     style_json_path: Path | None = None
     qgis_contour_polygon_label_probe: bool = False
+    qgis_contour_boundary_generator_label_probe: bool = False
     browser: bool = True
     qgis: bool = True
     diff: bool = True
@@ -198,6 +203,7 @@ class ComparisonResult:
     diff_captured: bool
     qgis_preprocessed_style_captured: bool = False
     qgis_contour_polygon_label_probe: bool = False
+    qgis_contour_boundary_generator_label_probe: bool = False
     image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
     style_json_path: str | None = None
 
@@ -301,6 +307,9 @@ def _redacted_manifest(
         },
         "style_json_path": result.style_json_path,
         "qgis_contour_polygon_label_probe": result.qgis_contour_polygon_label_probe,
+        "qgis_contour_boundary_generator_label_probe": (
+            result.qgis_contour_boundary_generator_label_probe
+        ),
         "captured": {
             "browser_reference": result.browser_captured,
             "qgis_vector_render": result.qgis_captured,
@@ -585,6 +594,51 @@ def _append_qgis_contour_polygon_label_probe(layer: object) -> None:
     layer.setLabelsEnabled(True)
 
 
+def _append_qgis_contour_boundary_generator_label_probe(layer: object) -> None:
+    from qgis.core import (  # type: ignore[import-not-found] # noqa: PLC0415
+        QgsPalLayerSettings,
+        QgsVectorTileBasicLabeling,
+        QgsVectorTileBasicLabelingStyle,
+        Qgis,
+    )
+
+    labeling = _method_value(layer, "labeling")
+    styles = list(_method_value(labeling, "styles") or [])
+    if any(
+        _method_text(style, "styleName") == QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME
+        for style in styles
+    ):
+        return
+
+    source_settings = None
+    for style in styles:
+        if _is_contour_label_style(style):
+            source_settings = _method_value(style, "labelSettings")
+            break
+
+    settings = QgsPalLayerSettings()
+    settings.fieldName = 'concat("ele", \' m\')'
+    settings.isExpression = True
+    settings.placement = getattr(QgsPalLayerSettings, "Curved", QgsPalLayerSettings.Line)
+    settings.priority = max(3, _settings_priority(source_settings))
+    settings.geometryGenerator = QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION
+    settings.geometryGeneratorEnabled = True
+    settings.geometryGeneratorType = Qgis.GeometryType.Line
+
+    probe_style = QgsVectorTileBasicLabelingStyle()
+    probe_style.setStyleName(QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME)
+    probe_style.setLayerName("contour")
+    probe_style.setGeometryType(Qgis.GeometryType.Polygon)
+    probe_style.setFilterExpression(QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER)
+    probe_style.setMinZoomLevel(QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM)
+    probe_style.setLabelSettings(settings)
+
+    updated_labeling = QgsVectorTileBasicLabeling()
+    updated_labeling.setStyles([*styles, probe_style])
+    layer.setLabeling(updated_labeling)
+    layer.setLabelsEnabled(True)
+
+
 def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     *,
     camera: MapboxComparisonCamera,
@@ -593,6 +647,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     style_definition: dict[str, object] | None = None,
     qgis_preprocessed_style_path: Path | None = None,
     qgis_contour_polygon_label_probe: bool = False,
+    qgis_contour_boundary_generator_label_probe: bool = False,
 ) -> None:
     _ensure_package_parent_on_path()
     _ensure_headless_qt_platform()
@@ -665,6 +720,8 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
         BackgroundMapService()._apply_mapbox_gl_style(layer, simplified_style, sprite_resources=sprite_resources)
         if qgis_contour_polygon_label_probe:
             _append_qgis_contour_polygon_label_probe(layer)
+        if qgis_contour_boundary_generator_label_probe:
+            _append_qgis_contour_boundary_generator_label_probe(layer)
 
         destination_crs = QgsCoordinateReferenceSystem("EPSG:3857")
         settings = QgsMapSettings()
@@ -785,6 +842,9 @@ def run_comparison(
             style_definition=style_definition,
             qgis_preprocessed_style_path=paths.qgis_preprocessed_style_json,
             qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
+            qgis_contour_boundary_generator_label_probe=(
+                config.qgis_contour_boundary_generator_label_probe
+            ),
         )
         qgis_captured = True
         qgis_preprocessed_style_captured = paths.qgis_preprocessed_style_json.exists()
@@ -805,6 +865,9 @@ def run_comparison(
         diff_captured=diff_captured,
         qgis_preprocessed_style_captured=qgis_preprocessed_style_captured,
         qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
+        qgis_contour_boundary_generator_label_probe=(
+            config.qgis_contour_boundary_generator_label_probe
+        ),
         image_metrics=image_metrics,
         style_json_path=str(config.style_json_path) if config.style_json_path is not None else None,
     )
@@ -876,6 +939,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--qgis-contour-boundary-generator-label-probe",
+        action="store_true",
+        help=(
+            "Append a diagnostic QGIS contour-label style using a boundary($geometry) "
+            "line geometry generator before rendering. Use only for #949 visual probes."
+        ),
+    )
+    parser.add_argument(
         "--skip-diff",
         action="store_true",
         help="Skip diff image generation.",
@@ -921,6 +992,9 @@ def _comparison_config(
         output_root=output_root,
         style_json_path=args.style_json,
         qgis_contour_polygon_label_probe=args.qgis_contour_polygon_label_probe,
+        qgis_contour_boundary_generator_label_probe=(
+            args.qgis_contour_boundary_generator_label_probe
+        ),
         browser=not args.skip_browser,
         qgis=not args.skip_qgis,
         diff=not args.skip_diff,
@@ -964,6 +1038,8 @@ def _single_camera_subprocess_command(
         command.append("--skip-qgis")
     if args.qgis_contour_polygon_label_probe:
         command.append("--qgis-contour-polygon-label-probe")
+    if args.qgis_contour_boundary_generator_label_probe:
+        command.append("--qgis-contour-boundary-generator-label-probe")
     if args.skip_diff:
         command.append("--skip-diff")
     command.extend(["--browser-timeout-ms", str(args.browser_timeout_ms)])


### PR DESCRIPTION
## Summary

- add a diagnostic QGIS contour label probe that uses `boundary($geometry)` as a line geometry generator
- record the new probe flag in comparison manifests and propagate it through all-camera child runs
- document when to compare the boundary-generator probe against the polygon/perimeter probe

## Evidence

This is a #949 validation aid, not a production style change. QGIS documentation supports geometry-generator label geometry output, and the existing style diagnostics already record `boundary($geometry)` label settings, so this adds a small harness probe to compare that approach directly.

Live artifacts generated with the local QGIS-profile Mapbox token source, without printing or committing the token:

- z17 Zermatt single run: `debug/mapbox-outdoors-comparison/zermatt-piste-z17-outdoors/20260519T225659Z/manifest.json`
- all-camera matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260519T225813Z/summary.md`
- all-camera contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260519T225813Z/contact-sheet.jpg`

The all-camera run passed 7/7 cameras with metrics available. z17 Zermatt metrics were changed ratio `0.9984`, mean delta `0.0112`, RMS delta `0.0598`; z18 Zermatt metrics were changed ratio `0.9981`, mean delta `0.0321`, RMS delta `0.0924`.

Visual read: the boundary-generator probe successfully renders labels through QGIS' line-label path, but it still over-labels the contour candidate geometry. The z17 render shows repeated low-elevation row labels plus vertical edge-like labels, so this is negative evidence against promoting a broad boundary-generator rule directly into production rendering.

Refs #949.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_comparison.py`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- live `python3 validation/mapbox_outdoors_comparison.py zermatt-piste-z17-outdoors --qgis-contour-boundary-generator-label-probe`
- live `python3 validation/mapbox_outdoors_comparison.py --all-cameras --qgis-contour-boundary-generator-label-probe`
