### PR TITLE
chore: add contour bbox-edge difference probe

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -195,6 +195,16 @@ python3 validation/mapbox_outdoors_comparison.py \
 
 This renders a separate diagnostic rule named `contour-label-boundary-generator-probe` for the same contour label candidates, but labels the generated `boundary($geometry)` line output with curved line placement. Use it to check whether QGIS' line-label engine behaves better on polygon-derived contour boundaries than direct polygon perimeter placement. It is also diagnostic output only.
 
+To test whether removing obvious polygon bounding-box edges improves the contour-label candidate geometry, use the bbox-edge-difference probe:
+
+```bash
+python3 validation/mapbox_outdoors_comparison.py \
+  zermatt-piste-z17-outdoors \
+  --qgis-contour-bbox-edge-difference-label-probe
+```
+
+This renders a diagnostic rule named `contour-label-bbox-edge-difference-probe` using `line_merge(difference(boundary($geometry), boundary(bounds($geometry))))` as the label geometry generator. It is intended to compare whether filtering rectangular/tile-edge-like boundary pieces before QGIS line labeling reduces the over-labeling seen in the broader contour probes.
+
 ## Road feature diagnostic
 
 When road/path hierarchy, high-detail trail behavior, road shields, or oneway arrows are the candidate parity slice, inspect the underlying road vector-tile features before changing QGIS style preprocessing:

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -20,6 +20,10 @@ from qfit.validation.mapbox_outdoors_comparison import (
     ComparisonConfig,
     DEFAULT_OUTPUT_ROOT,
     MapboxComparisonCamera,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_STYLE_NAME,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM,
@@ -27,6 +31,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER,
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM,
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME,
+    _append_qgis_contour_bbox_edge_difference_label_probe,
     _append_qgis_contour_boundary_generator_label_probe,
     _append_qgis_contour_polygon_label_probe,
     build_all_cameras_contact_sheet,
@@ -507,7 +512,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(probe_settings.repeatDistance, 0.0)
         self.assertIsNone(probe_settings.repeatDistanceUnit)
 
-    def test_append_qgis_contour_boundary_generator_label_probe_adds_line_generator_style(self):
+    def test_append_qgis_contour_line_generator_label_probes_add_line_generator_style(self):
         class FakeQgis:
             class GeometryType:
                 Line = "Line"
@@ -589,46 +594,61 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             def setLabelsEnabled(self, value):
                 self.labels_enabled = value
 
-        source_settings = FakePalLayerSettings()
-        source_settings.priority = 6
-        source_style = FakeLabelingStyle()
-        source_style.setStyleName("contour-label")
-        source_style.setLayerName("contour")
-        source_style.setLabelSettings(source_settings)
-        layer = FakeLayer(FakeLabeling([source_style]))
-        FakePalLayerSettings.constructed_sources = []
-
         fake_core = types.ModuleType("qgis.core")
         fake_core.Qgis = FakeQgis
         fake_core.QgsPalLayerSettings = FakePalLayerSettings
         fake_core.QgsVectorTileBasicLabeling = FakeLabeling
         fake_core.QgsVectorTileBasicLabelingStyle = FakeLabelingStyle
+        cases = [
+            (
+                _append_qgis_contour_boundary_generator_label_probe,
+                QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME,
+                QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER,
+                QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM,
+                QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
+            ),
+            (
+                _append_qgis_contour_bbox_edge_difference_label_probe,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_STYLE_NAME,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION,
+            ),
+        ]
 
-        with patch.dict(sys.modules, {"qgis": types.ModuleType("qgis"), "qgis.core": fake_core}):
-            _append_qgis_contour_boundary_generator_label_probe(layer)
-            _append_qgis_contour_boundary_generator_label_probe(layer)
+        for append_probe, style_name, filter_expression, min_zoom, geometry_generator in cases:
+            with self.subTest(style_name=style_name):
+                source_settings = FakePalLayerSettings()
+                source_settings.priority = 6
+                source_style = FakeLabelingStyle()
+                source_style.setStyleName("contour-label")
+                source_style.setLayerName("contour")
+                source_style.setLabelSettings(source_settings)
+                layer = FakeLayer(FakeLabeling([source_style]))
+                FakePalLayerSettings.constructed_sources = []
 
-        self.assertEqual(FakePalLayerSettings.constructed_sources, [None])
-        styles = layer.labeling().styles()
-        self.assertEqual(len(styles), 2)
-        self.assertTrue(layer.labels_enabled)
-        probe_style = styles[1]
-        probe_settings = probe_style.labelSettings()
-        self.assertEqual(probe_style.styleName(), QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME)
-        self.assertEqual(probe_style.layerName(), "contour")
-        self.assertEqual(probe_style.geometryType(), FakeQgis.GeometryType.Polygon)
-        self.assertEqual(probe_style.filterExpression(), QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER)
-        self.assertEqual(probe_style.minZoomLevel(), QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM)
-        self.assertEqual(probe_settings.fieldName, 'concat("ele", \' m\')')
-        self.assertTrue(probe_settings.isExpression)
-        self.assertEqual(probe_settings.placement, FakePalLayerSettings.Curved)
-        self.assertEqual(probe_settings.priority, 6)
-        self.assertEqual(
-            probe_settings.geometryGenerator,
-            QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
-        )
-        self.assertTrue(probe_settings.geometryGeneratorEnabled)
-        self.assertEqual(probe_settings.geometryGeneratorType, FakeQgis.GeometryType.Line)
+                with patch.dict(sys.modules, {"qgis": types.ModuleType("qgis"), "qgis.core": fake_core}):
+                    append_probe(layer)
+                    append_probe(layer)
+
+                self.assertEqual(FakePalLayerSettings.constructed_sources, [None])
+                styles = layer.labeling().styles()
+                self.assertEqual(len(styles), 2)
+                self.assertTrue(layer.labels_enabled)
+                probe_style = styles[1]
+                probe_settings = probe_style.labelSettings()
+                self.assertEqual(probe_style.styleName(), style_name)
+                self.assertEqual(probe_style.layerName(), "contour")
+                self.assertEqual(probe_style.geometryType(), FakeQgis.GeometryType.Polygon)
+                self.assertEqual(probe_style.filterExpression(), filter_expression)
+                self.assertEqual(probe_style.minZoomLevel(), min_zoom)
+                self.assertEqual(probe_settings.fieldName, 'concat("ele", \' m\')')
+                self.assertTrue(probe_settings.isExpression)
+                self.assertEqual(probe_settings.placement, FakePalLayerSettings.Curved)
+                self.assertEqual(probe_settings.priority, 6)
+                self.assertEqual(probe_settings.geometryGenerator, geometry_generator)
+                self.assertTrue(probe_settings.geometryGeneratorEnabled)
+                self.assertEqual(probe_settings.geometryGeneratorType, FakeQgis.GeometryType.Line)
 
     def test_headless_qt_platform_defaults_to_offscreen_without_overriding_callers(self):
         from qfit.validation import mapbox_outdoors_comparison
@@ -896,10 +916,12 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             output_path,
             qgis_contour_polygon_label_probe,
             qgis_contour_boundary_generator_label_probe,
+            qgis_contour_bbox_edge_difference_label_probe,
             **_kwargs,
         ):
             captured["polygon_probe"] = qgis_contour_polygon_label_probe
             captured["boundary_generator_probe"] = qgis_contour_boundary_generator_label_probe
+            captured["bbox_edge_difference_probe"] = qgis_contour_bbox_edge_difference_label_probe
             output_path.write_bytes(PNG_PLACEHOLDER)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -910,6 +932,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                     output_root=Path(tmpdir),
                     qgis_contour_polygon_label_probe=True,
                     qgis_contour_boundary_generator_label_probe=True,
+                    qgis_contour_bbox_edge_difference_label_probe=True,
                     browser=False,
                     diff=False,
                     now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
@@ -921,10 +944,13 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
         self.assertTrue(captured["polygon_probe"])
         self.assertTrue(captured["boundary_generator_probe"])
+        self.assertTrue(captured["bbox_edge_difference_probe"])
         self.assertTrue(result.qgis_contour_polygon_label_probe)
         self.assertTrue(result.qgis_contour_boundary_generator_label_probe)
+        self.assertTrue(result.qgis_contour_bbox_edge_difference_label_probe)
         self.assertTrue(manifest["qgis_contour_polygon_label_probe"])
         self.assertTrue(manifest["qgis_contour_boundary_generator_label_probe"])
+        self.assertTrue(manifest["qgis_contour_bbox_edge_difference_label_probe"])
 
     def test_run_comparison_passes_downloaded_style_json_to_renderers(self):
         captured_style_definitions = []
@@ -1007,6 +1033,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             "--skip-qgis",
             "--qgis-contour-polygon-label-probe",
             "--qgis-contour-boundary-generator-label-probe",
+            "--qgis-contour-bbox-edge-difference-label-probe",
             "--browser-timeout-ms",
             "5000",
         ])
@@ -1018,6 +1045,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(args.skip_qgis)
         self.assertTrue(args.qgis_contour_polygon_label_probe)
         self.assertTrue(args.qgis_contour_boundary_generator_label_probe)
+        self.assertTrue(args.qgis_contour_bbox_edge_difference_label_probe)
         self.assertEqual(args.browser_timeout_ms, 5000)
 
     def test_main_all_cameras_runs_full_inspection_matrix(self):
@@ -1044,6 +1072,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                         "--skip-browser",
                         "--qgis-contour-polygon-label-probe",
                         "--qgis-contour-boundary-generator-label-probe",
+                        "--qgis-contour-bbox-edge-difference-label-probe",
                         "--skip-diff",
                         "--browser-timeout-ms",
                         "5000",
@@ -1061,6 +1090,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertIn("--skip-browser", command)
             self.assertIn("--qgis-contour-polygon-label-probe", command)
             self.assertIn("--qgis-contour-boundary-generator-label-probe", command)
+            self.assertIn("--qgis-contour-bbox-edge-difference-label-probe", command)
             self.assertIn("--skip-diff", command)
             self.assertEqual(kwargs["env"]["MAPBOX_ACCESS_TOKEN"], "test-mapbox-token")
             self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -50,6 +50,12 @@ QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME = "contour-label-boundary
 QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION = "boundary($geometry)"
 QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER = QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER
 QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM = QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_STYLE_NAME = "contour-label-bbox-edge-difference-probe"
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION = (
+    "line_merge(difference(boundary($geometry), boundary(bounds($geometry))))"
+)
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER = QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM = QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM
 MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE = "metrics_available"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING = "manifest_missing"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE = "manifest_unreadable"
@@ -188,6 +194,7 @@ class ComparisonConfig:
     style_json_path: Path | None = None
     qgis_contour_polygon_label_probe: bool = False
     qgis_contour_boundary_generator_label_probe: bool = False
+    qgis_contour_bbox_edge_difference_label_probe: bool = False
     browser: bool = True
     qgis: bool = True
     diff: bool = True
@@ -204,6 +211,7 @@ class ComparisonResult:
     qgis_preprocessed_style_captured: bool = False
     qgis_contour_polygon_label_probe: bool = False
     qgis_contour_boundary_generator_label_probe: bool = False
+    qgis_contour_bbox_edge_difference_label_probe: bool = False
     image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
     style_json_path: str | None = None
 
@@ -309,6 +317,9 @@ def _redacted_manifest(
         "qgis_contour_polygon_label_probe": result.qgis_contour_polygon_label_probe,
         "qgis_contour_boundary_generator_label_probe": (
             result.qgis_contour_boundary_generator_label_probe
+        ),
+        "qgis_contour_bbox_edge_difference_label_probe": (
+            result.qgis_contour_bbox_edge_difference_label_probe
         ),
         "captured": {
             "browser_reference": result.browser_captured,
@@ -594,7 +605,14 @@ def _append_qgis_contour_polygon_label_probe(layer: object) -> None:
     layer.setLabelsEnabled(True)
 
 
-def _append_qgis_contour_boundary_generator_label_probe(layer: object) -> None:
+def _append_qgis_contour_line_generator_label_probe(
+    layer: object,
+    *,
+    style_name: str,
+    geometry_generator: str,
+    filter_expression: str,
+    min_zoom: int,
+) -> None:
     from qgis.core import (  # type: ignore[import-not-found] # noqa: PLC0415
         QgsPalLayerSettings,
         QgsVectorTileBasicLabeling,
@@ -604,10 +622,7 @@ def _append_qgis_contour_boundary_generator_label_probe(layer: object) -> None:
 
     labeling = _method_value(layer, "labeling")
     styles = list(_method_value(labeling, "styles") or [])
-    if any(
-        _method_text(style, "styleName") == QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME
-        for style in styles
-    ):
+    if any(_method_text(style, "styleName") == style_name for style in styles):
         return
 
     source_settings = None
@@ -621,22 +636,42 @@ def _append_qgis_contour_boundary_generator_label_probe(layer: object) -> None:
     settings.isExpression = True
     settings.placement = getattr(QgsPalLayerSettings, "Curved", QgsPalLayerSettings.Line)
     settings.priority = max(3, _settings_priority(source_settings))
-    settings.geometryGenerator = QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION
+    settings.geometryGenerator = geometry_generator
     settings.geometryGeneratorEnabled = True
     settings.geometryGeneratorType = Qgis.GeometryType.Line
 
     probe_style = QgsVectorTileBasicLabelingStyle()
-    probe_style.setStyleName(QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME)
+    probe_style.setStyleName(style_name)
     probe_style.setLayerName("contour")
     probe_style.setGeometryType(Qgis.GeometryType.Polygon)
-    probe_style.setFilterExpression(QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER)
-    probe_style.setMinZoomLevel(QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM)
+    probe_style.setFilterExpression(filter_expression)
+    probe_style.setMinZoomLevel(min_zoom)
     probe_style.setLabelSettings(settings)
 
     updated_labeling = QgsVectorTileBasicLabeling()
     updated_labeling.setStyles([*styles, probe_style])
     layer.setLabeling(updated_labeling)
     layer.setLabelsEnabled(True)
+
+
+def _append_qgis_contour_boundary_generator_label_probe(layer: object) -> None:
+    _append_qgis_contour_line_generator_label_probe(
+        layer,
+        style_name=QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_STYLE_NAME,
+        geometry_generator=QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
+        filter_expression=QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER,
+        min_zoom=QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM,
+    )
+
+
+def _append_qgis_contour_bbox_edge_difference_label_probe(layer: object) -> None:
+    _append_qgis_contour_line_generator_label_probe(
+        layer,
+        style_name=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_STYLE_NAME,
+        geometry_generator=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION,
+        filter_expression=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER,
+        min_zoom=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM,
+    )
 
 
 def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
@@ -648,6 +683,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     qgis_preprocessed_style_path: Path | None = None,
     qgis_contour_polygon_label_probe: bool = False,
     qgis_contour_boundary_generator_label_probe: bool = False,
+    qgis_contour_bbox_edge_difference_label_probe: bool = False,
 ) -> None:
     _ensure_package_parent_on_path()
     _ensure_headless_qt_platform()
@@ -722,6 +758,8 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
             _append_qgis_contour_polygon_label_probe(layer)
         if qgis_contour_boundary_generator_label_probe:
             _append_qgis_contour_boundary_generator_label_probe(layer)
+        if qgis_contour_bbox_edge_difference_label_probe:
+            _append_qgis_contour_bbox_edge_difference_label_probe(layer)
 
         destination_crs = QgsCoordinateReferenceSystem("EPSG:3857")
         settings = QgsMapSettings()
@@ -845,6 +883,9 @@ def run_comparison(
             qgis_contour_boundary_generator_label_probe=(
                 config.qgis_contour_boundary_generator_label_probe
             ),
+            qgis_contour_bbox_edge_difference_label_probe=(
+                config.qgis_contour_bbox_edge_difference_label_probe
+            ),
         )
         qgis_captured = True
         qgis_preprocessed_style_captured = paths.qgis_preprocessed_style_json.exists()
@@ -867,6 +908,9 @@ def run_comparison(
         qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
         qgis_contour_boundary_generator_label_probe=(
             config.qgis_contour_boundary_generator_label_probe
+        ),
+        qgis_contour_bbox_edge_difference_label_probe=(
+            config.qgis_contour_bbox_edge_difference_label_probe
         ),
         image_metrics=image_metrics,
         style_json_path=str(config.style_json_path) if config.style_json_path is not None else None,
@@ -947,6 +991,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--qgis-contour-bbox-edge-difference-label-probe",
+        action="store_true",
+        help=(
+            "Append a diagnostic QGIS contour-label style using "
+            "line_merge(difference(boundary($geometry), boundary(bounds($geometry)))) "
+            "before rendering. Use only for #949 visual probes."
+        ),
+    )
+    parser.add_argument(
         "--skip-diff",
         action="store_true",
         help="Skip diff image generation.",
@@ -995,6 +1048,9 @@ def _comparison_config(
         qgis_contour_boundary_generator_label_probe=(
             args.qgis_contour_boundary_generator_label_probe
         ),
+        qgis_contour_bbox_edge_difference_label_probe=(
+            args.qgis_contour_bbox_edge_difference_label_probe
+        ),
         browser=not args.skip_browser,
         qgis=not args.skip_qgis,
         diff=not args.skip_diff,
@@ -1040,6 +1096,8 @@ def _single_camera_subprocess_command(
         command.append("--qgis-contour-polygon-label-probe")
     if args.qgis_contour_boundary_generator_label_probe:
         command.append("--qgis-contour-boundary-generator-label-probe")
+    if args.qgis_contour_bbox_edge_difference_label_probe:
+        command.append("--qgis-contour-bbox-edge-difference-label-probe")
     if args.skip_diff:
         command.append("--skip-diff")
     command.extend(["--browser-timeout-ms", str(args.browser_timeout_ms)])


### PR DESCRIPTION
## Summary

- add a diagnostic QGIS contour label probe using `line_merge(difference(boundary($geometry), boundary(bounds($geometry))))`
- share the line geometry-generator probe construction between the plain boundary and bbox-edge-difference probes
- record and propagate the new flag through manifests, single-camera runs, and all-camera child runs

## Evidence

This is a #949 validation aid, not a production style change. It makes the ad hoc bbox-edge-difference probe repeatable in the comparison harness so it can be compared with the polygon/perimeter and plain `boundary($geometry)` probes.

Live artifacts generated with the local QGIS-profile Mapbox token source, without printing or committing the token:

- z17 Zermatt single run: `debug/mapbox-outdoors-comparison/zermatt-piste-z17-outdoors/20260519T231701Z/manifest.json`
- all-camera matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260519T231757Z/summary.md`
- all-camera contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260519T231757Z/contact-sheet.jpg`

The all-camera run passed 7/7 cameras with metrics available. z17 Zermatt metrics were changed ratio `0.9983`, mean delta `0.0073`, RMS delta `0.0418`; z18 Zermatt metrics were changed ratio `0.9981`, mean delta `0.0310`, RMS delta `0.0904`.

Visual read: the z17 probe removes the worst vertical edge-like contour labels and is a stronger candidate than the broad polygon/perimeter or plain boundary-generator probes. It still remains diagnostic-only because placement differs from Mapbox GL and needs comparison before any production style change.

Refs #949.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_comparison.py`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- live `python3 validation/mapbox_outdoors_comparison.py zermatt-piste-z17-outdoors --qgis-contour-bbox-edge-difference-label-probe`
- live `python3 validation/mapbox_outdoors_comparison.py --all-cameras --qgis-contour-bbox-edge-difference-label-probe`
