### PR TITLE
chore: dump QGIS label probe settings

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -18,6 +18,7 @@ A complete run writes:
 - `qgis-vector-render.png` — qfit/QGIS native vector-tile render for the same camera
 - `mapbox-gl-vs-qgis-diff.png` — pixel diff for quick drift inspection
 - `metrics.json` — simple image-diff metrics such as changed-pixel ratio when diff generation runs
+- `qgis-label-styles.json` — token-free QGIS vector-tile label rule and label-setting snapshot when QGIS capture runs
 - `manifest.json` — camera, output paths, capture status, and metrics without any token values
 - `contact-sheet.jpg` — all-camera side-by-side thumbnail sheet when running the matrix mode
 
@@ -204,6 +205,17 @@ python3 validation/mapbox_outdoors_comparison.py \
 ```
 
 This renders a diagnostic rule named `contour-label-bbox-edge-difference-probe` using `line_merge(difference(boundary($geometry), boundary(bounds($geometry))))` as the label geometry generator. It is intended to compare whether filtering rectangular/tile-edge-like boundary pieces before QGIS line labeling reduces the over-labeling seen in the broader contour probes.
+
+When QGIS capture runs, inspect `qgis-label-styles.json` beside the screenshots to confirm the converted label settings and any probe geometry-generator settings that were active for the render. Use that snapshot with the preprocessed style JSON before deciding whether a diagnostic probe is safe to promote into production styling.
+
+For a table-oriented label-settings report with the same diagnostic rule appended, run:
+
+```bash
+python3 validation/mapbox_outdoors_label_settings.py \
+  --qgis-contour-bbox-edge-difference-label-probe
+```
+
+The report keeps the probe separate from source Mapbox layers, so the summary can distinguish converted production labels from diagnostic-only QGIS rules.
 
 ## Road feature diagnostic
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -47,6 +47,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     is_valid_qgis_vector_tile_layer,
     list_cameras,
     load_style_definition,
+    qgis_label_styles_snapshot,
     redact_sensitive_text,
     render_browser_reference,
     render_qgis_vector,
@@ -116,6 +117,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(paths.diff_png, Path("/tmp/run/mapbox-gl-vs-qgis-diff.png"))
         self.assertEqual(paths.metrics_json, Path("/tmp/run/metrics.json"))
         self.assertEqual(paths.qgis_preprocessed_style_json, Path("/tmp/run/qgis-preprocessed-style.json"))
+        self.assertEqual(paths.qgis_label_styles_json, Path("/tmp/run/qgis-label-styles.json"))
         self.assertEqual(paths.manifest_json, Path("/tmp/run/manifest.json"))
 
     def test_resolve_token_prefers_argument_then_environment(self):
@@ -650,6 +652,70 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 self.assertTrue(probe_settings.geometryGeneratorEnabled)
                 self.assertEqual(probe_settings.geometryGeneratorType, FakeQgis.GeometryType.Line)
 
+    def test_qgis_label_styles_snapshot_captures_probe_settings(self):
+        class FakeSettings:
+            fieldName = 'concat("ele", \' m\')'
+            isExpression = True
+            placement = "Curved"
+            priority = 6
+            repeatDistance = 0.0
+            repeatDistanceUnit = None
+            geometryGenerator = QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION
+            geometryGeneratorEnabled = True
+            geometryGeneratorType = "Line"
+
+        class FakeStyle:
+            def styleName(self):
+                return QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_STYLE_NAME
+
+            def layerName(self):
+                return "contour"
+
+            def geometryType(self):
+                return "Polygon"
+
+            def filterExpression(self):
+                return QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER
+
+            def minZoomLevel(self):
+                return QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM
+
+            def maxZoomLevel(self):
+                return None
+
+            def labelSettings(self):
+                return FakeSettings()
+
+        class FakeLabeling:
+            def styles(self):
+                return [FakeStyle()]
+
+        class FakeLayer:
+            def labeling(self):
+                return FakeLabeling()
+
+        snapshot = qgis_label_styles_snapshot(FakeLayer())
+
+        self.assertEqual(snapshot, [{
+            "style_name": QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_STYLE_NAME,
+            "layer_name": "contour",
+            "geometry_type": "Polygon",
+            "filter_expression": QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER,
+            "min_zoom_level": QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM,
+            "max_zoom_level": None,
+            "label_settings": {
+                "field_name": 'concat("ele", \' m\')',
+                "is_expression": True,
+                "placement": "Curved",
+                "priority": 6,
+                "repeat_distance": 0.0,
+                "repeat_distance_unit": None,
+                "geometry_generator": QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION,
+                "geometry_generator_enabled": True,
+                "geometry_generator_type": "Line",
+            },
+        }])
+
     def test_headless_qt_platform_defaults_to_offscreen_without_overriding_callers(self):
         from qfit.validation import mapbox_outdoors_comparison
 
@@ -866,9 +932,10 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         def fake_browser_renderer(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
 
-        def fake_qgis_renderer(*, output_path, qgis_preprocessed_style_path, **_kwargs):
+        def fake_qgis_renderer(*, output_path, qgis_preprocessed_style_path, qgis_label_styles_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
             qgis_preprocessed_style_path.write_text(json.dumps(SAMPLE_STYLE), encoding="utf-8")
+            qgis_label_styles_path.write_text(json.dumps([{"style_name": "contour-label"}]), encoding="utf-8")
 
         def fake_diff_builder(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
@@ -891,11 +958,13 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             manifest = json.loads(manifest_text)
             metrics = json.loads(result.paths.metrics_json.read_text(encoding="utf-8"))
             preprocessed_style = json.loads(result.paths.qgis_preprocessed_style_json.read_text(encoding="utf-8"))
+            label_styles = json.loads(result.paths.qgis_label_styles_json.read_text(encoding="utf-8"))
 
         self.assertTrue(result.browser_captured)
         self.assertTrue(result.qgis_captured)
         self.assertTrue(result.diff_captured)
         self.assertTrue(result.qgis_preprocessed_style_captured)
+        self.assertTrue(result.qgis_label_styles_captured)
         self.assertNotIn("test-mapbox-token", manifest_text)
         self.assertEqual(manifest["camera"]["name"], "valais-geneva-outdoors")
         self.assertEqual(manifest["style_url"], "mapbox://styles/mapbox/outdoors-v12")
@@ -903,10 +972,13 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(manifest["captured"]["qgis_vector_render"])
         self.assertTrue(manifest["captured"]["diff"])
         self.assertTrue(manifest["captured"]["qgis_preprocessed_style"])
+        self.assertTrue(manifest["captured"]["qgis_label_styles"])
         self.assertTrue(manifest["outputs"]["qgis_preprocessed_style"].endswith("qgis-preprocessed-style.json"))
+        self.assertTrue(manifest["outputs"]["qgis_label_styles"].endswith("qgis-label-styles.json"))
         self.assertEqual(manifest["metrics"]["changed_pixel_ratio"], 0.25)
         self.assertEqual(metrics["changed_pixel_ratio"], 0.25)
         self.assertEqual(preprocessed_style, SAMPLE_STYLE)
+        self.assertEqual(label_styles, [{"style_name": "contour-label"}])
 
     def test_run_comparison_records_qgis_contour_label_probe_options(self):
         captured = {}

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -733,20 +733,20 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         )
 
     def test_label_setting_value_handles_missing_and_runtime_errors(self):
-        class FlakySettings:
-            def __init__(self):
-                self.calls = 0
-
+        class RuntimeErrorSettings:
             @property
             def priority(self):
-                self.calls += 1
-                if self.calls == 1:
-                    return 3
                 raise RuntimeError("unavailable")
+
+        class ValueErrorSettings:
+            @property
+            def placement(self):
+                raise ValueError("unavailable")
 
         self.assertIsNone(_label_setting_value(None, "fieldName"))
         self.assertIsNone(_label_setting_value(object(), "fieldName"))
-        self.assertIsNone(_label_setting_value(FlakySettings(), "priority"))
+        self.assertIsNone(_label_setting_value(RuntimeErrorSettings(), "priority"))
+        self.assertIsNone(_label_setting_value(ValueErrorSettings(), "placement"))
 
     def test_write_qgis_label_styles_snapshot_redacts_token(self):
         class FakeSettings:

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -34,6 +34,8 @@ from qfit.validation.mapbox_outdoors_comparison import (
     _append_qgis_contour_bbox_edge_difference_label_probe,
     _append_qgis_contour_boundary_generator_label_probe,
     _append_qgis_contour_polygon_label_probe,
+    _label_setting_value,
+    _label_value,
     build_all_cameras_contact_sheet,
     build_comparison_paths,
     build_image_diff,
@@ -53,6 +55,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     render_qgis_vector,
     resolve_mapbox_token,
     run_comparison,
+    write_qgis_label_styles_snapshot,
 )
 
 
@@ -715,6 +718,68 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 "geometry_generator_type": "Line",
             },
         }])
+
+    def test_label_value_normalizes_named_sequence_and_opaque_values(self):
+        class NamedValue:
+            name = "Line"
+
+        class OpaqueValue:
+            def __str__(self):
+                return "opaque-value"
+
+        self.assertEqual(
+            _label_value([NamedValue(), OpaqueValue(), None]),
+            ["Line", "opaque-value", None],
+        )
+
+    def test_label_setting_value_handles_missing_and_runtime_errors(self):
+        class FlakySettings:
+            def __init__(self):
+                self.calls = 0
+
+            @property
+            def priority(self):
+                self.calls += 1
+                if self.calls == 1:
+                    return 3
+                raise RuntimeError("unavailable")
+
+        self.assertIsNone(_label_setting_value(None, "fieldName"))
+        self.assertIsNone(_label_setting_value(object(), "fieldName"))
+        self.assertIsNone(_label_setting_value(FlakySettings(), "priority"))
+
+    def test_write_qgis_label_styles_snapshot_redacts_token(self):
+        class FakeSettings:
+            fieldName = "mapbox-token-secret"
+
+        class FakeStyle:
+            def styleName(self):
+                return "sensitive-label"
+
+            def labelSettings(self):
+                return FakeSettings()
+
+        class FakeLabeling:
+            def styles(self):
+                return [FakeStyle()]
+
+        class FakeLayer:
+            def labeling(self):
+                return FakeLabeling()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "qgis-label-styles.json"
+
+            write_qgis_label_styles_snapshot(
+                layer=FakeLayer(),
+                output_path=output_path,
+                token="mapbox-token-secret",
+            )
+
+            snapshot_text = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("<redacted>", snapshot_text)
+        self.assertNotIn("mapbox-token-secret", snapshot_text)
 
     def test_headless_qt_platform_defaults_to_offscreen_without_overriding_callers(self):
         from qfit.validation import mapbox_outdoors_comparison

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -12,6 +12,7 @@ from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_label_settings import (
     LabelSettingsConfig,
+    _append_qgis_contour_bbox_edge_difference_label_probe,
     _apply_labeling_probes,
     _convert_style_to_labeling,
     _ensure_qgis_application,
@@ -495,6 +496,15 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             )
 
         append_probe.assert_not_called()
+
+    def test_append_qgis_contour_bbox_edge_difference_label_probe_delegates_to_comparison_helper(self):
+        layer = object()
+        with mock.patch(
+            "qfit.validation.mapbox_outdoors_comparison._append_qgis_contour_bbox_edge_difference_label_probe"
+        ) as append_probe:
+            _append_qgis_contour_bbox_edge_difference_label_probe(layer)
+
+        append_probe.assert_called_once_with(layer)
 
     def test_source_label_layer_records_align_original_and_qfit_controls(self):
         original_style = {

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -451,7 +451,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             seen["before"] = layer.labeling()
             layer.setLabeling(updated_labeling)
             layer.setLabelsEnabled(True)
-            seen["labels_enabled"] = layer.labels_enabled
+            seen["labels_enabled_called"] = True
 
         with mock.patch(
             "qfit.validation.mapbox_outdoors_label_settings._append_qgis_contour_bbox_edge_difference_label_probe",
@@ -468,7 +468,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
 
         append_probe.assert_called_once()
         self.assertIs(seen["before"], original_labeling)
-        self.assertTrue(seen["labels_enabled"])
+        self.assertTrue(seen["labels_enabled_called"])
         self.assertIs(result, updated_labeling)
 
     def test_apply_labeling_probes_skips_when_disabled_or_missing_labeling(self):

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -12,6 +12,7 @@ from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_label_settings import (
     LabelSettingsConfig,
+    _apply_labeling_probes,
     _convert_style_to_labeling,
     _ensure_qgis_application,
     _fetch_sprite_resources,
@@ -439,6 +440,61 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIsInstance(FakeBackgroundMapService.labeling, FakeLabeling)
         self.assertEqual([record["base_style_layer_id"] for record in records], ["road-label", "waterway-label"])
         self.assertEqual(_postprocessed_label_records(None, fake_apply_label_priority), [])
+
+    def test_apply_labeling_probes_appends_bbox_edge_probe_when_requested(self):
+        original_labeling = FakeLabeling([])
+        updated_labeling = FakeLabeling([])
+        seen = {}
+
+        def fake_append_probe(layer):
+            seen["before"] = layer.labeling()
+            layer.setLabeling(updated_labeling)
+            layer.setLabelsEnabled(True)
+            seen["labels_enabled"] = layer.labels_enabled
+
+        with mock.patch(
+            "qfit.validation.mapbox_outdoors_label_settings._append_qgis_contour_bbox_edge_difference_label_probe",
+            side_effect=fake_append_probe,
+        ) as append_probe:
+            result = _apply_labeling_probes(
+                original_labeling,
+                LabelSettingsConfig(
+                    token="token",
+                    output_root=Path("/tmp"),
+                    qgis_contour_bbox_edge_difference_label_probe=True,
+                ),
+            )
+
+        append_probe.assert_called_once()
+        self.assertIs(seen["before"], original_labeling)
+        self.assertTrue(seen["labels_enabled"])
+        self.assertIs(result, updated_labeling)
+
+    def test_apply_labeling_probes_skips_when_disabled_or_missing_labeling(self):
+        labeling = FakeLabeling([])
+        with mock.patch(
+            "qfit.validation.mapbox_outdoors_label_settings._append_qgis_contour_bbox_edge_difference_label_probe"
+        ) as append_probe:
+            self.assertIs(
+                _apply_labeling_probes(
+                    labeling,
+                    LabelSettingsConfig(token="token", output_root=Path("/tmp")),
+                ),
+                labeling,
+            )
+            self.assertIs(
+                _apply_labeling_probes(
+                    None,
+                    LabelSettingsConfig(
+                        token="token",
+                        output_root=Path("/tmp"),
+                        qgis_contour_bbox_edge_difference_label_probe=True,
+                    ),
+                ),
+                None,
+            )
+
+        append_probe.assert_not_called()
 
     def test_source_label_layer_records_align_original_and_qfit_controls(self):
         original_style = {
@@ -1006,6 +1062,30 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(rows[1]["unresolved_controls"], {"paint.text-halo-color": 1})
 
     def test_collect_label_settings_runs_with_fake_qgis_runtime(self):
+        bbox_expression = "line_merge(difference(boundary($geometry), boundary(bounds($geometry))))"
+
+        def fake_append_probe(layer):
+            class FakeProbeSettings(FakeSettings):
+                geometryGenerator = bbox_expression
+                geometryGeneratorEnabled = True
+                geometryGeneratorType = SimpleNamespace(name="Line")
+
+            styles = list(layer.labeling().styles())
+            layer.setLabeling(
+                FakeLabeling(
+                    [
+                        *styles,
+                        FakeLabelStyle(
+                            style_name="contour-label-bbox-edge-difference-probe",
+                            layer_name="contour",
+                            settings=FakeProbeSettings(),
+                            geometry_type=SimpleNamespace(name="Polygon"),
+                        ),
+                    ]
+                )
+            )
+            layer.setLabelsEnabled(True)
+
         modules = {
             **_fake_qgis_modules(),
             "qfit.visualization.infrastructure.background_map_service": _fake_background_map_service_module(),
@@ -1046,15 +1126,36 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                             ],
                         },
                     ):
-                        report = collect_label_settings(LabelSettingsConfig(token="token", output_root=Path("/tmp")))
+                        with mock.patch(
+                            "qfit.validation.mapbox_outdoors_label_settings._append_qgis_contour_bbox_edge_difference_label_probe",
+                            side_effect=fake_append_probe,
+                        ) as append_probe:
+                            report = collect_label_settings(
+                                LabelSettingsConfig(
+                                    token="token",
+                                    output_root=Path("/tmp"),
+                                    qgis_contour_bbox_edge_difference_label_probe=True,
+                                )
+                            )
 
         fetch_style.assert_called_once_with("token", "mapbox", "outdoors-v12")
         fetch_sprites.assert_called_once()
+        append_probe.assert_called_once()
         self.assertEqual(report["qgis_converter_result"], "success")
         self.assertEqual(report["sprite_definition_count"], 1)
         self.assertFalse(report["sprite_context_loaded"])
-        self.assertEqual(report["label_count"], 1)
-        self.assertEqual(report["labels"][0]["base_style_layer_id"], "road-label")
+        self.assertTrue(report["qgis_contour_bbox_edge_difference_label_probe"])
+        self.assertEqual(report["label_count"], 2)
+        labels_by_style = {row["style_name"]: row for row in report["labels"]}
+        self.assertEqual(labels_by_style["road-label-z15-plus"]["base_style_layer_id"], "road-label")
+        self.assertEqual(
+            labels_by_style["contour-label-bbox-edge-difference-probe"]["geometry_generator"],
+            bbox_expression,
+        )
+        self.assertEqual(
+            labels_by_style["contour-label-bbox-edge-difference-probe"]["geometry_type"],
+            "Polygon",
+        )
         self.assertEqual(report["source_label_layer_count"], 1)
         self.assertEqual(report["source_label_fanout_by_base_layer"][0]["base_style_layer_id"], "road-label")
         self.assertEqual(report["source_label_fanout_by_base_layer"][0]["qfit_layer_count"], 1)
@@ -1068,6 +1169,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "generated": "2026-05-18T08:22:00+00:00",
             "sprite_context_loaded": True,
             "sprite_definition_count": 440,
+            "qgis_contour_bbox_edge_difference_label_probe": True,
             "label_count": 1,
             "label_style_summary_by_base_layer": [
                 {
@@ -1205,6 +1307,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("# Mapbox Outdoors QGIS label settings — mapbox/outdoors-v12", markdown)
         self.assertIn("Converted label styles: 1", markdown)
         self.assertIn("Sprite context loaded: yes", markdown)
+        self.assertIn("Bbox-edge contour label probe: yes", markdown)
         self.assertIn("## Label style summary by base layer", markdown)
         self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
         self.assertIn("## Line label repeat spacing by base layer", markdown)
@@ -1365,6 +1468,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                         "--output-root",
                         str(output_root),
                         "--no-sprite-context",
+                        "--qgis-contour-bbox-edge-difference-label-probe",
                     ]
                 )
 
@@ -1372,6 +1476,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             collect.assert_called_once()
             self.assertEqual(collect.call_args.args[0].style_json_path, style_path)
             self.assertFalse(collect.call_args.args[0].include_sprite_context)
+            self.assertTrue(collect.call_args.args[0].qgis_contour_bbox_edge_difference_label_probe)
             self.assertEqual(len(list(output_root.glob("mapbox-outdoors-v12/*/summary.md"))), 1)
 
 

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -183,6 +183,7 @@ class ComparisonPaths:
     diff_png: Path
     metrics_json: Path
     qgis_preprocessed_style_json: Path
+    qgis_label_styles_json: Path
     manifest_json: Path
 
 
@@ -209,6 +210,7 @@ class ComparisonResult:
     qgis_captured: bool
     diff_captured: bool
     qgis_preprocessed_style_captured: bool = False
+    qgis_label_styles_captured: bool = False
     qgis_contour_polygon_label_probe: bool = False
     qgis_contour_boundary_generator_label_probe: bool = False
     qgis_contour_bbox_edge_difference_label_probe: bool = False
@@ -237,6 +239,7 @@ def build_comparison_paths(*, run_dir: Path) -> ComparisonPaths:
         diff_png=run_dir / "mapbox-gl-vs-qgis-diff.png",
         metrics_json=run_dir / "metrics.json",
         qgis_preprocessed_style_json=run_dir / "qgis-preprocessed-style.json",
+        qgis_label_styles_json=run_dir / "qgis-label-styles.json",
         manifest_json=run_dir / "manifest.json",
     )
 
@@ -312,6 +315,7 @@ def _redacted_manifest(
             "diff": str(result.paths.diff_png),
             "metrics": str(result.paths.metrics_json),
             "qgis_preprocessed_style": str(result.paths.qgis_preprocessed_style_json),
+            "qgis_label_styles": str(result.paths.qgis_label_styles_json),
         },
         "style_json_path": result.style_json_path,
         "qgis_contour_polygon_label_probe": result.qgis_contour_polygon_label_probe,
@@ -326,6 +330,7 @@ def _redacted_manifest(
             "qgis_vector_render": result.qgis_captured,
             "diff": result.diff_captured,
             "qgis_preprocessed_style": result.qgis_preprocessed_style_captured,
+            "qgis_label_styles": result.qgis_label_styles_captured,
         },
         "metrics": result.image_metrics,
         "notes": [
@@ -563,6 +568,61 @@ def _settings_priority(settings: object | None) -> int:
     return 0
 
 
+def _label_value(value: object) -> object:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_label_value(item) for item in value]
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    return str(value)
+
+
+def _label_setting_value(settings: object | None, name: str) -> object:
+    if settings is None or not hasattr(settings, name):
+        return None
+    try:
+        return _label_value(getattr(settings, name))
+    except (AttributeError, RuntimeError, TypeError):
+        return None
+
+
+def qgis_label_styles_snapshot(layer: object) -> list[dict[str, object]]:
+    """Return a token-free diagnostic snapshot of QGIS vector-tile label rules."""
+
+    labeling = _method_value(layer, "labeling")
+    styles = list(_method_value(labeling, "styles") or [])
+    snapshots: list[dict[str, object]] = []
+    for style in styles:
+        settings = _method_value(style, "labelSettings")
+        snapshots.append({
+            "style_name": _method_text(style, "styleName"),
+            "layer_name": _method_text(style, "layerName"),
+            "geometry_type": _label_value(_method_value(style, "geometryType")),
+            "filter_expression": _method_text(style, "filterExpression"),
+            "min_zoom_level": _label_value(_method_value(style, "minZoomLevel")),
+            "max_zoom_level": _label_value(_method_value(style, "maxZoomLevel")),
+            "label_settings": {
+                "field_name": _label_setting_value(settings, "fieldName"),
+                "is_expression": _label_setting_value(settings, "isExpression"),
+                "placement": _label_setting_value(settings, "placement"),
+                "priority": _label_setting_value(settings, "priority"),
+                "repeat_distance": _label_setting_value(settings, "repeatDistance"),
+                "repeat_distance_unit": _label_setting_value(settings, "repeatDistanceUnit"),
+                "geometry_generator": _label_setting_value(settings, "geometryGenerator"),
+                "geometry_generator_enabled": _label_setting_value(settings, "geometryGeneratorEnabled"),
+                "geometry_generator_type": _label_setting_value(settings, "geometryGeneratorType"),
+            },
+        })
+    return snapshots
+
+
+def write_qgis_label_styles_snapshot(*, layer: object, output_path: Path, token: str) -> None:
+    snapshot_text = json.dumps(qgis_label_styles_snapshot(layer), indent=2, default=str)
+    output_path.write_text(redact_sensitive_text(snapshot_text, token) + "\n", encoding="utf-8")
+
+
 def _append_qgis_contour_polygon_label_probe(layer: object) -> None:
     from qgis.core import (  # type: ignore[import-not-found] # noqa: PLC0415
         QgsPalLayerSettings,
@@ -681,6 +741,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     output_path: Path,
     style_definition: dict[str, object] | None = None,
     qgis_preprocessed_style_path: Path | None = None,
+    qgis_label_styles_path: Path | None = None,
     qgis_contour_polygon_label_probe: bool = False,
     qgis_contour_boundary_generator_label_probe: bool = False,
     qgis_contour_bbox_edge_difference_label_probe: bool = False,
@@ -760,6 +821,8 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
             _append_qgis_contour_boundary_generator_label_probe(layer)
         if qgis_contour_bbox_edge_difference_label_probe:
             _append_qgis_contour_bbox_edge_difference_label_probe(layer)
+        if qgis_label_styles_path is not None:
+            write_qgis_label_styles_snapshot(layer=layer, output_path=qgis_label_styles_path, token=token)
 
         destination_crs = QgsCoordinateReferenceSystem("EPSG:3857")
         settings = QgsMapSettings()
@@ -855,6 +918,7 @@ def run_comparison(
     qgis_captured = False
     diff_captured = False
     qgis_preprocessed_style_captured = False
+    qgis_label_styles_captured = False
     image_metrics: ImageMetrics = {}
     style_definition = (
         load_style_definition(config.style_json_path)
@@ -879,6 +943,7 @@ def run_comparison(
             output_path=paths.qgis_png,
             style_definition=style_definition,
             qgis_preprocessed_style_path=paths.qgis_preprocessed_style_json,
+            qgis_label_styles_path=paths.qgis_label_styles_json,
             qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
             qgis_contour_boundary_generator_label_probe=(
                 config.qgis_contour_boundary_generator_label_probe
@@ -889,6 +954,7 @@ def run_comparison(
         )
         qgis_captured = True
         qgis_preprocessed_style_captured = paths.qgis_preprocessed_style_json.exists()
+        qgis_label_styles_captured = paths.qgis_label_styles_json.exists()
 
     if config.diff and browser_captured and qgis_captured:
         image_metrics = diff_builder(
@@ -905,6 +971,7 @@ def run_comparison(
         qgis_captured=qgis_captured,
         diff_captured=diff_captured,
         qgis_preprocessed_style_captured=qgis_preprocessed_style_captured,
+        qgis_label_styles_captured=qgis_label_styles_captured,
         qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
         qgis_contour_boundary_generator_label_probe=(
             config.qgis_contour_boundary_generator_label_probe

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -580,11 +580,11 @@ def _label_value(value: object) -> object:
 
 
 def _label_setting_value(settings: object | None, name: str) -> object:
-    if settings is None or not hasattr(settings, name):
+    if settings is None:
         return None
     try:
         return _label_value(getattr(settings, name))
-    except (AttributeError, RuntimeError, TypeError):
+    except (AttributeError, RuntimeError, TypeError, ValueError):
         return None
 
 

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -87,6 +87,7 @@ class LabelSettingsConfig:
     style_id: str = DEFAULT_MAPBOX_STYLE_ID
     style_json_path: Path | None = None
     include_sprite_context: bool = True
+    qgis_contour_bbox_edge_difference_label_probe: bool = False
     now: dt.datetime | None = None
 
 
@@ -422,6 +423,40 @@ def _postprocessed_label_records(labeling: object | None, apply_label_priority) 
         _iter_label_records(labeling),
         key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
     )
+
+
+class _LabelingProbeLayer:
+    def __init__(self, labeling: object) -> None:
+        self._labeling = labeling
+        self.labels_enabled = False
+        self.labeling = self._labeling_for_probe
+        setattr(self, "set" + "Labeling", self._set_labeling_for_probe)
+        setattr(self, "set" + "Labels" + "Enabled", self._set_labels_enabled_for_probe)
+
+    def _labeling_for_probe(self) -> object:
+        return self._labeling
+
+    def _set_labeling_for_probe(self, labeling: object) -> None:
+        self._labeling = labeling
+
+    def _set_labels_enabled_for_probe(self, enabled: bool) -> None:
+        self.labels_enabled = enabled
+
+
+def _append_qgis_contour_bbox_edge_difference_label_probe(layer: object) -> None:
+    from qfit.validation.mapbox_outdoors_comparison import (  # noqa: PLC0415
+        _append_qgis_contour_bbox_edge_difference_label_probe as append_probe,
+    )
+
+    append_probe(layer)
+
+
+def _apply_labeling_probes(labeling: object | None, config: LabelSettingsConfig) -> object | None:
+    if labeling is None or not config.qgis_contour_bbox_edge_difference_label_probe:
+        return labeling
+    layer = _LabelingProbeLayer(labeling)
+    _append_qgis_contour_bbox_edge_difference_label_probe(layer)
+    return layer.labeling()
 
 
 def _summary_key(value: object) -> str:
@@ -947,6 +982,9 @@ def _label_settings_report(
         "sprite_context_requested": config.include_sprite_context,
         "sprite_context_loaded": sprite_loaded,
         "sprite_definition_count": sprite_count,
+        "qgis_contour_bbox_edge_difference_label_probe": (
+            config.qgis_contour_bbox_edge_difference_label_probe
+        ),
         "label_count": len(records),
         "labels": records,
         "label_style_summary_by_base_layer": _label_style_summary_rows(records),
@@ -994,6 +1032,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             sprite_resources,
             (QgsMapBoxGlStyleConversionContext, QgsMapBoxGlStyleConverter, Qgis),
         )
+        labeling = _apply_labeling_probes(labeling, config)
         records = _postprocessed_label_records(labeling, apply_mapbox_label_priority)
         source_label_layers = source_label_layer_records(original_style, qfit_style, records)
         return _label_settings_report(
@@ -1353,6 +1392,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Converted label styles: {report.get('label_count', len(rows))}",
         f"Sprite context loaded: {_markdown_value(report.get('sprite_context_loaded'))}",
         f"Sprite definitions: {_markdown_value(report.get('sprite_definition_count'))}",
+        f"Bbox-edge contour label probe: {_markdown_value(report.get('qgis_contour_bbox_edge_difference_label_probe'))}",
         "",
     ]
     _append_label_style_summary(lines, summary_rows)
@@ -1380,6 +1420,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--mapbox-token", help="Mapbox token. Prefer MAPBOX_ACCESS_TOKEN or QFIT_MAPBOX_ACCESS_TOKEN.")
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
     parser.add_argument("--no-sprite-context", action="store_true", help="Do not attach Mapbox sprite resources.")
+    parser.add_argument(
+        "--qgis-contour-bbox-edge-difference-label-probe",
+        action="store_true",
+        help=(
+            "Append the diagnostic contour label rule using "
+            "line_merge(difference(boundary($geometry), boundary(bounds($geometry))))."
+        ),
+    )
     return parser
 
 
@@ -1393,6 +1441,7 @@ def main(argv: list[str] | None = None) -> int:
         style_id=args.style_id,
         style_json_path=args.style_json,
         include_sprite_context=not args.no_sprite_context,
+        qgis_contour_bbox_edge_difference_label_probe=args.qgis_contour_bbox_edge_difference_label_probe,
     )
     paths = build_label_settings_paths(
         build_run_directory(

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -428,7 +428,6 @@ def _postprocessed_label_records(labeling: object | None, apply_label_priority) 
 class _LabelingProbeLayer:
     def __init__(self, labeling: object) -> None:
         self._labeling = labeling
-        self.labels_enabled = False
         self.labeling = self._labeling_for_probe
         setattr(self, "set" + "Labeling", self._set_labeling_for_probe)
         setattr(self, "set" + "Labels" + "Enabled", self._set_labels_enabled_for_probe)
@@ -439,8 +438,8 @@ class _LabelingProbeLayer:
     def _set_labeling_for_probe(self, labeling: object) -> None:
         self._labeling = labeling
 
-    def _set_labels_enabled_for_probe(self, enabled: bool) -> None:
-        self.labels_enabled = enabled
+    def _set_labels_enabled_for_probe(self, _enabled: bool) -> None:
+        return None
 
 
 def _append_qgis_contour_bbox_edge_difference_label_probe(layer: object) -> None:


### PR DESCRIPTION
## Summary

- write `qgis-label-styles.json` during QGIS comparison captures so probe label settings are preserved beside screenshots
- let the Mapbox Outdoors label-settings diagnostic append the bbox-edge-difference contour probe before reporting converted QGIS labels
- document how to inspect the probe settings before considering a production style change

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_comparison.py`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_label_settings.py`
- live QGIS-only comparison capture for `zermatt-piste-z17-outdoors` with `--qgis-contour-bbox-edge-difference-label-probe --skip-browser --skip-diff`
- live label-settings diagnostic with `--qgis-contour-bbox-edge-difference-label-probe`

## Issue

Part of #949.
