### PR TITLE
chore: add source-styled contour probe

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -206,6 +206,16 @@ python3 validation/mapbox_outdoors_comparison.py \
 
 This renders a diagnostic rule named `contour-label-bbox-edge-difference-probe` using `line_merge(difference(boundary($geometry), boundary(bounds($geometry))))` as the label geometry generator. It is intended to compare whether filtering rectangular/tile-edge-like boundary pieces before QGIS line labeling reduces the over-labeling seen in the broader contour probes.
 
+To repeat that geometry test with the converted production contour label text and buffer settings copied onto the probe, use the source-style variant:
+
+```bash
+python3 validation/mapbox_outdoors_comparison.py \
+  zermatt-piste-z17-outdoors \
+  --qgis-contour-bbox-edge-difference-source-style-label-probe
+```
+
+This renders a separate diagnostic rule named `contour-label-bbox-edge-difference-source-style-probe`. Use it when the visual question is whether the bbox-edge-difference geometry is still promising after matching the production `contour-label` text styling.
+
 When QGIS capture runs, inspect `qgis-label-styles.json` beside the screenshots to confirm the converted label settings and any probe geometry-generator settings that were active for the render. Use that snapshot with the preprocessed style JSON before deciding whether a diagnostic probe is safe to promote into production styling.
 
 For a table-oriented label-settings report with the same diagnostic rule appended, run:
@@ -214,6 +224,8 @@ For a table-oriented label-settings report with the same diagnostic rule appende
 python3 validation/mapbox_outdoors_label_settings.py \
   --qgis-contour-bbox-edge-difference-label-probe
 ```
+
+Add `--qgis-contour-bbox-edge-difference-source-style-label-probe` to include the source-style variant in the same report.
 
 The report keeps the probe separate from source Mapbox layers, so the summary can distinguish converted production labels from diagnostic-only QGIS rules.
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -24,6 +24,10 @@ from qfit.validation.mapbox_outdoors_comparison import (
     QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER,
     QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM,
     QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_STYLE_NAME,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_EXPRESSION,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_FILTER,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_MIN_ZOOM,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_STYLE_NAME,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM,
@@ -32,6 +36,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM,
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME,
     _append_qgis_contour_bbox_edge_difference_label_probe,
+    _append_qgis_contour_bbox_edge_difference_source_style_label_probe,
     _append_qgis_contour_boundary_generator_label_probe,
     _append_qgis_contour_polygon_label_probe,
     _label_setting_value,
@@ -533,7 +538,8 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 self.fieldName = getattr(source, "fieldName", "")
                 self.isExpression = getattr(source, "isExpression", False)
                 self.priority = getattr(source, "priority", 0)
-                self.placement = None
+                self.sourceMarker = getattr(source, "sourceMarker", "fresh")
+                self.placement = getattr(source, "placement", None)
                 self.geometryGenerator = ""
                 self.geometryGeneratorEnabled = False
                 self.geometryGeneratorType = None
@@ -611,6 +617,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER,
                 QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM,
                 QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
+                False,
             ),
             (
                 _append_qgis_contour_bbox_edge_difference_label_probe,
@@ -618,13 +625,26 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER,
                 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM,
                 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION,
+                False,
+            ),
+            (
+                _append_qgis_contour_bbox_edge_difference_source_style_label_probe,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_STYLE_NAME,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_FILTER,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_MIN_ZOOM,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_EXPRESSION,
+                True,
             ),
         ]
 
-        for append_probe, style_name, filter_expression, min_zoom, geometry_generator in cases:
+        for append_probe, style_name, filter_expression, min_zoom, geometry_generator, copies_source in cases:
             with self.subTest(style_name=style_name):
                 source_settings = FakePalLayerSettings()
                 source_settings.priority = 6
+                source_settings.fieldName = '"ele"'
+                source_settings.isExpression = False
+                source_settings.placement = "SourceCurved"
+                source_settings.sourceMarker = "copied"
                 source_style = FakeLabelingStyle()
                 source_style.setStyleName("contour-label")
                 source_style.setLayerName("contour")
@@ -636,7 +656,10 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                     append_probe(layer)
                     append_probe(layer)
 
-                self.assertEqual(FakePalLayerSettings.constructed_sources, [None])
+                self.assertEqual(
+                    FakePalLayerSettings.constructed_sources,
+                    [source_settings] if copies_source else [None],
+                )
                 styles = layer.labeling().styles()
                 self.assertEqual(len(styles), 2)
                 self.assertTrue(layer.labels_enabled)
@@ -651,11 +674,183 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 self.assertTrue(probe_settings.isExpression)
                 self.assertEqual(probe_settings.placement, FakePalLayerSettings.Curved)
                 self.assertEqual(probe_settings.priority, 6)
+                self.assertEqual(probe_settings.sourceMarker, "copied" if copies_source else "fresh")
                 self.assertEqual(probe_settings.geometryGenerator, geometry_generator)
                 self.assertTrue(probe_settings.geometryGeneratorEnabled)
                 self.assertEqual(probe_settings.geometryGeneratorType, FakeQgis.GeometryType.Line)
 
+    def test_append_qgis_contour_bbox_edge_difference_source_style_probe_copies_source_settings(self):
+        class FakeQgis:
+            class GeometryType:
+                Line = "Line"
+                Polygon = "Polygon"
+
+        class FakePalLayerSettings:
+            Curved = "Curved"
+            Line = "Line"
+            constructed_sources = []
+
+            def __init__(self, source=None):
+                self.constructed_sources.append(source)
+                self.fieldName = getattr(source, "fieldName", "")
+                self.isExpression = getattr(source, "isExpression", False)
+                self.priority = getattr(source, "priority", 0)
+                self.placement = getattr(source, "placement", None)
+                self.repeatDistance = getattr(source, "repeatDistance", 0.0)
+                self.geometryGenerator = getattr(source, "geometryGenerator", "")
+                self.geometryGeneratorEnabled = getattr(source, "geometryGeneratorEnabled", False)
+                self.geometryGeneratorType = getattr(source, "geometryGeneratorType", None)
+
+        class FakeLabelingStyle:
+            def setStyleName(self, value):
+                self._style_name = value
+
+            def styleName(self):
+                return self._style_name
+
+            def setLayerName(self, value):
+                self._layer_name = value
+
+            def layerName(self):
+                return self._layer_name
+
+            def setGeometryType(self, value):
+                self._geometry_type = value
+
+            def geometryType(self):
+                return self._geometry_type
+
+            def setFilterExpression(self, value):
+                self._filter_expression = value
+
+            def filterExpression(self):
+                return self._filter_expression
+
+            def setMinZoomLevel(self, value):
+                self._min_zoom = value
+
+            def minZoomLevel(self):
+                return self._min_zoom
+
+            def setLabelSettings(self, value):
+                self._settings = value
+
+            def labelSettings(self):
+                return self._settings
+
+        class FakeLabeling:
+            def __init__(self, styles=None):
+                self._styles = list(styles or [])
+
+            def styles(self):
+                return self._styles
+
+            def setStyles(self, styles):
+                self._styles = list(styles)
+
+        class FakeLayer:
+            def __init__(self, labeling):
+                self._labeling = labeling
+                self.labels_enabled = False
+
+            def labeling(self):
+                return self._labeling
+
+            def setLabeling(self, labeling):
+                self._labeling = labeling
+
+            def setLabelsEnabled(self, value):
+                self.labels_enabled = value
+
+        source_settings = FakePalLayerSettings()
+        source_settings.fieldName = '"ele"'
+        source_settings.isExpression = False
+        source_settings.priority = 2
+        source_settings.placement = FakePalLayerSettings.Curved
+        source_settings.repeatDistance = 66.1458333333
+        source_style = FakeLabelingStyle()
+        source_style.setStyleName("contour-label")
+        source_style.setLayerName("contour")
+        source_style.setLabelSettings(source_settings)
+        layer = FakeLayer(FakeLabeling([source_style]))
+        FakePalLayerSettings.constructed_sources = []
+
+        fake_core = types.ModuleType("qgis.core")
+        fake_core.Qgis = FakeQgis
+        fake_core.QgsPalLayerSettings = FakePalLayerSettings
+        fake_core.QgsVectorTileBasicLabeling = FakeLabeling
+        fake_core.QgsVectorTileBasicLabelingStyle = FakeLabelingStyle
+
+        with patch.dict(sys.modules, {"qgis": types.ModuleType("qgis"), "qgis.core": fake_core}):
+            _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
+            _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
+
+        self.assertEqual(FakePalLayerSettings.constructed_sources, [source_settings])
+        styles = layer.labeling().styles()
+        self.assertEqual(len(styles), 2)
+        self.assertTrue(layer.labels_enabled)
+        probe_style = styles[1]
+        probe_settings = probe_style.labelSettings()
+        self.assertEqual(probe_style.styleName(), QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_STYLE_NAME)
+        self.assertEqual(probe_style.layerName(), "contour")
+        self.assertEqual(probe_style.geometryType(), FakeQgis.GeometryType.Polygon)
+        self.assertEqual(
+            probe_style.filterExpression(),
+            QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_FILTER,
+        )
+        self.assertEqual(probe_style.minZoomLevel(), QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_MIN_ZOOM)
+        self.assertEqual(probe_settings.fieldName, 'concat("ele", \' m\')')
+        self.assertTrue(probe_settings.isExpression)
+        self.assertEqual(probe_settings.placement, FakePalLayerSettings.Curved)
+        self.assertEqual(probe_settings.priority, 3)
+        self.assertAlmostEqual(probe_settings.repeatDistance, 66.1458333333)
+        self.assertEqual(
+            probe_settings.geometryGenerator,
+            QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_EXPRESSION,
+        )
+        self.assertTrue(probe_settings.geometryGeneratorEnabled)
+        self.assertEqual(probe_settings.geometryGeneratorType, FakeQgis.GeometryType.Line)
+
     def test_qgis_label_styles_snapshot_captures_probe_settings(self):
+        class FakeColor:
+            def __init__(self, name):
+                self._name = name
+
+            def name(self):
+                return self._name
+
+        class FakeTextBuffer:
+            def enabled(self):
+                return True
+
+            def size(self):
+                return 0.5291666667
+
+            def sizeUnit(self):
+                return "Millimeters"
+
+            def color(self):
+                return FakeColor("#dcdcd4")
+
+            def opacity(self):
+                return 0.75
+
+        class FakeTextFormat:
+            def size(self):
+                return 2.5135416667
+
+            def sizeUnit(self):
+                return "Millimeters"
+
+            def color(self):
+                return FakeColor("#626250")
+
+            def opacity(self):
+                return 0.9
+
+            def buffer(self):
+                return FakeTextBuffer()
+
         class FakeSettings:
             fieldName = 'concat("ele", \' m\')'
             isExpression = True
@@ -666,6 +861,9 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             geometryGenerator = QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION
             geometryGeneratorEnabled = True
             geometryGeneratorType = "Line"
+
+            def format(self):
+                return FakeTextFormat()
 
         class FakeStyle:
             def styleName(self):
@@ -716,6 +914,15 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 "geometry_generator": QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION,
                 "geometry_generator_enabled": True,
                 "geometry_generator_type": "Line",
+                "text_size": 2.5135416667,
+                "text_size_unit": "Millimeters",
+                "text_color": "#626250",
+                "text_opacity": 0.9,
+                "buffer_enabled": True,
+                "buffer_size": 0.5291666667,
+                "buffer_size_unit": "Millimeters",
+                "buffer_color": "#dcdcd4",
+                "buffer_opacity": 0.75,
             },
         }])
 
@@ -1054,11 +1261,15 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             qgis_contour_polygon_label_probe,
             qgis_contour_boundary_generator_label_probe,
             qgis_contour_bbox_edge_difference_label_probe,
+            qgis_contour_bbox_edge_difference_source_style_label_probe,
             **_kwargs,
         ):
             captured["polygon_probe"] = qgis_contour_polygon_label_probe
             captured["boundary_generator_probe"] = qgis_contour_boundary_generator_label_probe
             captured["bbox_edge_difference_probe"] = qgis_contour_bbox_edge_difference_label_probe
+            captured["bbox_edge_difference_source_style_probe"] = (
+                qgis_contour_bbox_edge_difference_source_style_label_probe
+            )
             output_path.write_bytes(PNG_PLACEHOLDER)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1070,6 +1281,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                     qgis_contour_polygon_label_probe=True,
                     qgis_contour_boundary_generator_label_probe=True,
                     qgis_contour_bbox_edge_difference_label_probe=True,
+                    qgis_contour_bbox_edge_difference_source_style_label_probe=True,
                     browser=False,
                     diff=False,
                     now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
@@ -1082,12 +1294,15 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(captured["polygon_probe"])
         self.assertTrue(captured["boundary_generator_probe"])
         self.assertTrue(captured["bbox_edge_difference_probe"])
+        self.assertTrue(captured["bbox_edge_difference_source_style_probe"])
         self.assertTrue(result.qgis_contour_polygon_label_probe)
         self.assertTrue(result.qgis_contour_boundary_generator_label_probe)
         self.assertTrue(result.qgis_contour_bbox_edge_difference_label_probe)
+        self.assertTrue(result.qgis_contour_bbox_edge_difference_source_style_label_probe)
         self.assertTrue(manifest["qgis_contour_polygon_label_probe"])
         self.assertTrue(manifest["qgis_contour_boundary_generator_label_probe"])
         self.assertTrue(manifest["qgis_contour_bbox_edge_difference_label_probe"])
+        self.assertTrue(manifest["qgis_contour_bbox_edge_difference_source_style_label_probe"])
 
     def test_run_comparison_passes_downloaded_style_json_to_renderers(self):
         captured_style_definitions = []
@@ -1171,6 +1386,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             "--qgis-contour-polygon-label-probe",
             "--qgis-contour-boundary-generator-label-probe",
             "--qgis-contour-bbox-edge-difference-label-probe",
+            "--qgis-contour-bbox-edge-difference-source-style-label-probe",
             "--browser-timeout-ms",
             "5000",
         ])
@@ -1183,6 +1399,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(args.qgis_contour_polygon_label_probe)
         self.assertTrue(args.qgis_contour_boundary_generator_label_probe)
         self.assertTrue(args.qgis_contour_bbox_edge_difference_label_probe)
+        self.assertTrue(args.qgis_contour_bbox_edge_difference_source_style_label_probe)
         self.assertEqual(args.browser_timeout_ms, 5000)
 
     def test_main_all_cameras_runs_full_inspection_matrix(self):
@@ -1210,6 +1427,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                         "--qgis-contour-polygon-label-probe",
                         "--qgis-contour-boundary-generator-label-probe",
                         "--qgis-contour-bbox-edge-difference-label-probe",
+                        "--qgis-contour-bbox-edge-difference-source-style-label-probe",
                         "--skip-diff",
                         "--browser-timeout-ms",
                         "5000",
@@ -1228,6 +1446,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertIn("--qgis-contour-polygon-label-probe", command)
             self.assertIn("--qgis-contour-boundary-generator-label-probe", command)
             self.assertIn("--qgis-contour-bbox-edge-difference-label-probe", command)
+            self.assertIn("--qgis-contour-bbox-edge-difference-source-style-label-probe", command)
             self.assertIn("--skip-diff", command)
             self.assertEqual(kwargs["env"]["MAPBOX_ACCESS_TOKEN"], "test-mapbox-token")
             self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -13,6 +13,7 @@ from tests import _path  # noqa: F401
 from qfit.validation.mapbox_outdoors_label_settings import (
     LabelSettingsConfig,
     _append_qgis_contour_bbox_edge_difference_label_probe,
+    _append_qgis_contour_bbox_edge_difference_source_style_label_probe,
     _apply_labeling_probes,
     _convert_style_to_labeling,
     _ensure_qgis_application,
@@ -442,60 +443,79 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual([record["base_style_layer_id"] for record in records], ["road-label", "waterway-label"])
         self.assertEqual(_postprocessed_label_records(None, fake_apply_label_priority), [])
 
-    def test_apply_labeling_probes_appends_bbox_edge_probe_when_requested(self):
+    def test_apply_labeling_probes_appends_bbox_edge_probes_when_requested(self):
         original_labeling = FakeLabeling([])
-        updated_labeling = FakeLabeling([])
+        first_updated_labeling = FakeLabeling([])
+        second_updated_labeling = FakeLabeling([])
         seen = {}
 
         def fake_append_probe(layer):
             seen["before"] = layer.labeling()
-            layer.setLabeling(updated_labeling)
+            layer.setLabeling(first_updated_labeling)
             layer.setLabelsEnabled(True)
             seen["labels_enabled_called"] = True
+
+        def fake_append_source_style_probe(layer):
+            seen["source_before"] = layer.labeling()
+            layer.setLabeling(second_updated_labeling)
 
         with mock.patch(
             "qfit.validation.mapbox_outdoors_label_settings._append_qgis_contour_bbox_edge_difference_label_probe",
             side_effect=fake_append_probe,
         ) as append_probe:
-            result = _apply_labeling_probes(
-                original_labeling,
-                LabelSettingsConfig(
-                    token="token",
-                    output_root=Path("/tmp"),
-                    qgis_contour_bbox_edge_difference_label_probe=True,
-                ),
-            )
+            with mock.patch(
+                "qfit.validation.mapbox_outdoors_label_settings."
+                "_append_qgis_contour_bbox_edge_difference_source_style_label_probe",
+                side_effect=fake_append_source_style_probe,
+            ) as append_source_style_probe:
+                result = _apply_labeling_probes(
+                    original_labeling,
+                    LabelSettingsConfig(
+                        token="token",
+                        output_root=Path("/tmp"),
+                        qgis_contour_bbox_edge_difference_label_probe=True,
+                        qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                    ),
+                )
 
         append_probe.assert_called_once()
+        append_source_style_probe.assert_called_once()
         self.assertIs(seen["before"], original_labeling)
+        self.assertIs(seen["source_before"], first_updated_labeling)
         self.assertTrue(seen["labels_enabled_called"])
-        self.assertIs(result, updated_labeling)
+        self.assertIs(result, second_updated_labeling)
 
     def test_apply_labeling_probes_skips_when_disabled_or_missing_labeling(self):
         labeling = FakeLabeling([])
         with mock.patch(
             "qfit.validation.mapbox_outdoors_label_settings._append_qgis_contour_bbox_edge_difference_label_probe"
         ) as append_probe:
-            self.assertIs(
-                _apply_labeling_probes(
-                    labeling,
-                    LabelSettingsConfig(token="token", output_root=Path("/tmp")),
-                ),
-                labeling,
-            )
-            self.assertIs(
-                _apply_labeling_probes(
-                    None,
-                    LabelSettingsConfig(
-                        token="token",
-                        output_root=Path("/tmp"),
-                        qgis_contour_bbox_edge_difference_label_probe=True,
+            with mock.patch(
+                "qfit.validation.mapbox_outdoors_label_settings."
+                "_append_qgis_contour_bbox_edge_difference_source_style_label_probe"
+            ) as append_source_style_probe:
+                self.assertIs(
+                    _apply_labeling_probes(
+                        labeling,
+                        LabelSettingsConfig(token="token", output_root=Path("/tmp")),
                     ),
-                ),
-                None,
-            )
+                    labeling,
+                )
+                self.assertIs(
+                    _apply_labeling_probes(
+                        None,
+                        LabelSettingsConfig(
+                            token="token",
+                            output_root=Path("/tmp"),
+                            qgis_contour_bbox_edge_difference_label_probe=True,
+                            qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                        ),
+                    ),
+                    None,
+                )
 
         append_probe.assert_not_called()
+        append_source_style_probe.assert_not_called()
 
     def test_append_qgis_contour_bbox_edge_difference_label_probe_delegates_to_comparison_helper(self):
         layer = object()
@@ -503,6 +523,16 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "qfit.validation.mapbox_outdoors_comparison._append_qgis_contour_bbox_edge_difference_label_probe"
         ) as append_probe:
             _append_qgis_contour_bbox_edge_difference_label_probe(layer)
+
+        append_probe.assert_called_once_with(layer)
+
+    def test_append_qgis_contour_bbox_edge_difference_source_style_probe_delegates_to_comparison_helper(self):
+        layer = object()
+        with mock.patch(
+            "qfit.validation.mapbox_outdoors_comparison."
+            "_append_qgis_contour_bbox_edge_difference_source_style_label_probe"
+        ) as append_probe:
+            _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
 
         append_probe.assert_called_once_with(layer)
 
@@ -1096,6 +1126,27 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             )
             layer.setLabelsEnabled(True)
 
+        def fake_append_source_style_probe(layer):
+            class FakeProbeSettings(FakeSettings):
+                geometryGenerator = bbox_expression
+                geometryGeneratorEnabled = True
+                geometryGeneratorType = SimpleNamespace(name="Line")
+
+            styles = list(layer.labeling().styles())
+            layer.setLabeling(
+                FakeLabeling(
+                    [
+                        *styles,
+                        FakeLabelStyle(
+                            style_name="contour-label-bbox-edge-difference-source-style-probe",
+                            layer_name="contour",
+                            settings=FakeProbeSettings(),
+                            geometry_type=SimpleNamespace(name="Polygon"),
+                        ),
+                    ]
+                )
+            )
+
         modules = {
             **_fake_qgis_modules(),
             "qfit.visualization.infrastructure.background_map_service": _fake_background_map_service_module(),
@@ -1140,22 +1191,30 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                             "qfit.validation.mapbox_outdoors_label_settings._append_qgis_contour_bbox_edge_difference_label_probe",
                             side_effect=fake_append_probe,
                         ) as append_probe:
-                            report = collect_label_settings(
-                                LabelSettingsConfig(
-                                    token="token",
-                                    output_root=Path("/tmp"),
-                                    qgis_contour_bbox_edge_difference_label_probe=True,
+                            with mock.patch(
+                                "qfit.validation.mapbox_outdoors_label_settings."
+                                "_append_qgis_contour_bbox_edge_difference_source_style_label_probe",
+                                side_effect=fake_append_source_style_probe,
+                            ) as append_source_style_probe:
+                                report = collect_label_settings(
+                                    LabelSettingsConfig(
+                                        token="token",
+                                        output_root=Path("/tmp"),
+                                        qgis_contour_bbox_edge_difference_label_probe=True,
+                                        qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                                    )
                                 )
-                            )
 
         fetch_style.assert_called_once_with("token", "mapbox", "outdoors-v12")
         fetch_sprites.assert_called_once()
         append_probe.assert_called_once()
+        append_source_style_probe.assert_called_once()
         self.assertEqual(report["qgis_converter_result"], "success")
         self.assertEqual(report["sprite_definition_count"], 1)
         self.assertFalse(report["sprite_context_loaded"])
         self.assertTrue(report["qgis_contour_bbox_edge_difference_label_probe"])
-        self.assertEqual(report["label_count"], 2)
+        self.assertTrue(report["qgis_contour_bbox_edge_difference_source_style_label_probe"])
+        self.assertEqual(report["label_count"], 3)
         labels_by_style = {row["style_name"]: row for row in report["labels"]}
         self.assertEqual(labels_by_style["road-label-z15-plus"]["base_style_layer_id"], "road-label")
         self.assertEqual(
@@ -1165,6 +1224,10 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(
             labels_by_style["contour-label-bbox-edge-difference-probe"]["geometry_type"],
             "Polygon",
+        )
+        self.assertEqual(
+            labels_by_style["contour-label-bbox-edge-difference-source-style-probe"]["geometry_generator"],
+            bbox_expression,
         )
         self.assertEqual(report["source_label_layer_count"], 1)
         self.assertEqual(report["source_label_fanout_by_base_layer"][0]["base_style_layer_id"], "road-label")
@@ -1180,6 +1243,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "sprite_context_loaded": True,
             "sprite_definition_count": 440,
             "qgis_contour_bbox_edge_difference_label_probe": True,
+            "qgis_contour_bbox_edge_difference_source_style_label_probe": True,
             "label_count": 1,
             "label_style_summary_by_base_layer": [
                 {
@@ -1318,6 +1382,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("Converted label styles: 1", markdown)
         self.assertIn("Sprite context loaded: yes", markdown)
         self.assertIn("Bbox-edge contour label probe: yes", markdown)
+        self.assertIn("Bbox-edge source-style contour label probe: yes", markdown)
         self.assertIn("## Label style summary by base layer", markdown)
         self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
         self.assertIn("## Line label repeat spacing by base layer", markdown)
@@ -1479,6 +1544,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                         str(output_root),
                         "--no-sprite-context",
                         "--qgis-contour-bbox-edge-difference-label-probe",
+                        "--qgis-contour-bbox-edge-difference-source-style-label-probe",
                     ]
                 )
 
@@ -1487,6 +1553,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             self.assertEqual(collect.call_args.args[0].style_json_path, style_path)
             self.assertFalse(collect.call_args.args[0].include_sprite_context)
             self.assertTrue(collect.call_args.args[0].qgis_contour_bbox_edge_difference_label_probe)
+            self.assertTrue(
+                collect.call_args.args[0].qgis_contour_bbox_edge_difference_source_style_label_probe
+            )
             self.assertEqual(len(list(output_root.glob("mapbox-outdoors-v12/*/summary.md"))), 1)
 
 

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -56,6 +56,18 @@ QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION = (
 )
 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER = QGIS_CONTOUR_POLYGON_LABEL_PROBE_FILTER
 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM = QGIS_CONTOUR_POLYGON_LABEL_PROBE_MIN_ZOOM
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_STYLE_NAME = (
+    "contour-label-bbox-edge-difference-source-style-probe"
+)
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_EXPRESSION = (
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION
+)
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_FILTER = (
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER
+)
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_MIN_ZOOM = (
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM
+)
 MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE = "metrics_available"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING = "manifest_missing"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE = "manifest_unreadable"
@@ -196,6 +208,7 @@ class ComparisonConfig:
     qgis_contour_polygon_label_probe: bool = False
     qgis_contour_boundary_generator_label_probe: bool = False
     qgis_contour_bbox_edge_difference_label_probe: bool = False
+    qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False
     browser: bool = True
     qgis: bool = True
     diff: bool = True
@@ -214,6 +227,7 @@ class ComparisonResult:
     qgis_contour_polygon_label_probe: bool = False
     qgis_contour_boundary_generator_label_probe: bool = False
     qgis_contour_bbox_edge_difference_label_probe: bool = False
+    qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False
     image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
     style_json_path: str | None = None
 
@@ -324,6 +338,9 @@ def _redacted_manifest(
         ),
         "qgis_contour_bbox_edge_difference_label_probe": (
             result.qgis_contour_bbox_edge_difference_label_probe
+        ),
+        "qgis_contour_bbox_edge_difference_source_style_label_probe": (
+            result.qgis_contour_bbox_edge_difference_source_style_label_probe
         ),
         "captured": {
             "browser_reference": result.browser_captured,
@@ -588,6 +605,29 @@ def _label_setting_value(settings: object | None, name: str) -> object:
         return None
 
 
+def _color_name(value: object) -> object:
+    name = _method_value(value, "name")
+    return name if isinstance(name, str) else None
+
+
+def _qgis_label_format_snapshot(settings: object | None) -> dict[str, object]:
+    text_format = _method_value(settings, "format") if settings is not None else None
+    buffer = _method_value(text_format, "buffer") if text_format is not None else None
+    text_color = _method_value(text_format, "color") if text_format is not None else None
+    buffer_color = _method_value(buffer, "color") if buffer is not None else None
+    return {
+        "text_size": _method_value(text_format, "size") if text_format is not None else None,
+        "text_size_unit": _label_value(_method_value(text_format, "sizeUnit")) if text_format is not None else None,
+        "text_color": _color_name(text_color),
+        "text_opacity": _method_value(text_format, "opacity") if text_format is not None else None,
+        "buffer_enabled": _method_value(buffer, "enabled") if buffer is not None else None,
+        "buffer_size": _method_value(buffer, "size") if buffer is not None else None,
+        "buffer_size_unit": _label_value(_method_value(buffer, "sizeUnit")) if buffer is not None else None,
+        "buffer_color": _color_name(buffer_color),
+        "buffer_opacity": _method_value(buffer, "opacity") if buffer is not None else None,
+    }
+
+
 def qgis_label_styles_snapshot(layer: object) -> list[dict[str, object]]:
     """Return a token-free diagnostic snapshot of QGIS vector-tile label rules."""
 
@@ -613,6 +653,7 @@ def qgis_label_styles_snapshot(layer: object) -> list[dict[str, object]]:
                 "geometry_generator": _label_setting_value(settings, "geometryGenerator"),
                 "geometry_generator_enabled": _label_setting_value(settings, "geometryGeneratorEnabled"),
                 "geometry_generator_type": _label_setting_value(settings, "geometryGeneratorType"),
+                **_qgis_label_format_snapshot(settings),
             },
         })
     return snapshots
@@ -672,6 +713,7 @@ def _append_qgis_contour_line_generator_label_probe(
     geometry_generator: str,
     filter_expression: str,
     min_zoom: int,
+    copy_source_settings: bool = False,
 ) -> None:
     from qgis.core import (  # type: ignore[import-not-found] # noqa: PLC0415
         QgsPalLayerSettings,
@@ -691,7 +733,10 @@ def _append_qgis_contour_line_generator_label_probe(
             source_settings = _method_value(style, "labelSettings")
             break
 
-    settings = QgsPalLayerSettings()
+    if copy_source_settings and source_settings is not None:
+        settings = QgsPalLayerSettings(source_settings)
+    else:
+        settings = QgsPalLayerSettings()
     settings.fieldName = 'concat("ele", \' m\')'
     settings.isExpression = True
     settings.placement = getattr(QgsPalLayerSettings, "Curved", QgsPalLayerSettings.Line)
@@ -734,6 +779,17 @@ def _append_qgis_contour_bbox_edge_difference_label_probe(layer: object) -> None
     )
 
 
+def _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer: object) -> None:
+    _append_qgis_contour_line_generator_label_probe(
+        layer,
+        style_name=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_STYLE_NAME,
+        geometry_generator=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_EXPRESSION,
+        filter_expression=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_FILTER,
+        min_zoom=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_MIN_ZOOM,
+        copy_source_settings=True,
+    )
+
+
 def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     *,
     camera: MapboxComparisonCamera,
@@ -745,6 +801,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     qgis_contour_polygon_label_probe: bool = False,
     qgis_contour_boundary_generator_label_probe: bool = False,
     qgis_contour_bbox_edge_difference_label_probe: bool = False,
+    qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False,
 ) -> None:
     _ensure_package_parent_on_path()
     _ensure_headless_qt_platform()
@@ -821,6 +878,8 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
             _append_qgis_contour_boundary_generator_label_probe(layer)
         if qgis_contour_bbox_edge_difference_label_probe:
             _append_qgis_contour_bbox_edge_difference_label_probe(layer)
+        if qgis_contour_bbox_edge_difference_source_style_label_probe:
+            _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
         if qgis_label_styles_path is not None:
             write_qgis_label_styles_snapshot(layer=layer, output_path=qgis_label_styles_path, token=token)
 
@@ -951,6 +1010,9 @@ def run_comparison(
             qgis_contour_bbox_edge_difference_label_probe=(
                 config.qgis_contour_bbox_edge_difference_label_probe
             ),
+            qgis_contour_bbox_edge_difference_source_style_label_probe=(
+                config.qgis_contour_bbox_edge_difference_source_style_label_probe
+            ),
         )
         qgis_captured = True
         qgis_preprocessed_style_captured = paths.qgis_preprocessed_style_json.exists()
@@ -978,6 +1040,9 @@ def run_comparison(
         ),
         qgis_contour_bbox_edge_difference_label_probe=(
             config.qgis_contour_bbox_edge_difference_label_probe
+        ),
+        qgis_contour_bbox_edge_difference_source_style_label_probe=(
+            config.qgis_contour_bbox_edge_difference_source_style_label_probe
         ),
         image_metrics=image_metrics,
         style_json_path=str(config.style_json_path) if config.style_json_path is not None else None,
@@ -1067,6 +1132,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--qgis-contour-bbox-edge-difference-source-style-label-probe",
+        action="store_true",
+        help=(
+            "Append a diagnostic bbox-edge-difference contour-label style that copies "
+            "the converted production contour label text settings before rendering. "
+            "Use only for #949 visual probes."
+        ),
+    )
+    parser.add_argument(
         "--skip-diff",
         action="store_true",
         help="Skip diff image generation.",
@@ -1118,6 +1192,9 @@ def _comparison_config(
         qgis_contour_bbox_edge_difference_label_probe=(
             args.qgis_contour_bbox_edge_difference_label_probe
         ),
+        qgis_contour_bbox_edge_difference_source_style_label_probe=(
+            args.qgis_contour_bbox_edge_difference_source_style_label_probe
+        ),
         browser=not args.skip_browser,
         qgis=not args.skip_qgis,
         diff=not args.skip_diff,
@@ -1165,6 +1242,8 @@ def _single_camera_subprocess_command(
         command.append("--qgis-contour-boundary-generator-label-probe")
     if args.qgis_contour_bbox_edge_difference_label_probe:
         command.append("--qgis-contour-bbox-edge-difference-label-probe")
+    if args.qgis_contour_bbox_edge_difference_source_style_label_probe:
+        command.append("--qgis-contour-bbox-edge-difference-source-style-label-probe")
     if args.skip_diff:
         command.append("--skip-diff")
     command.extend(["--browser-timeout-ms", str(args.browser_timeout_ms)])

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -88,6 +88,7 @@ class LabelSettingsConfig:
     style_json_path: Path | None = None
     include_sprite_context: bool = True
     qgis_contour_bbox_edge_difference_label_probe: bool = False
+    qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False
     now: dt.datetime | None = None
 
 
@@ -419,6 +420,12 @@ def _postprocessed_label_records(labeling: object | None, apply_label_priority) 
     if labeling is None:
         return []
     apply_label_priority(labeling)
+    return _sorted_label_records(labeling)
+
+
+def _sorted_label_records(labeling: object | None) -> list[dict[str, object]]:
+    if labeling is None:
+        return []
     return sorted(
         _iter_label_records(labeling),
         key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
@@ -450,11 +457,22 @@ def _append_qgis_contour_bbox_edge_difference_label_probe(layer: object) -> None
     append_probe(layer)
 
 
+def _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer: object) -> None:
+    from qfit.validation.mapbox_outdoors_comparison import (  # noqa: PLC0415
+        _append_qgis_contour_bbox_edge_difference_source_style_label_probe as append_probe,
+    )
+
+    append_probe(layer)
+
+
 def _apply_labeling_probes(labeling: object | None, config: LabelSettingsConfig) -> object | None:
-    if labeling is None or not config.qgis_contour_bbox_edge_difference_label_probe:
+    if labeling is None:
         return labeling
     layer = _LabelingProbeLayer(labeling)
-    _append_qgis_contour_bbox_edge_difference_label_probe(layer)
+    if config.qgis_contour_bbox_edge_difference_label_probe:
+        _append_qgis_contour_bbox_edge_difference_label_probe(layer)
+    if config.qgis_contour_bbox_edge_difference_source_style_label_probe:
+        _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
     return layer.labeling()
 
 
@@ -984,6 +1002,9 @@ def _label_settings_report(
         "qgis_contour_bbox_edge_difference_label_probe": (
             config.qgis_contour_bbox_edge_difference_label_probe
         ),
+        "qgis_contour_bbox_edge_difference_source_style_label_probe": (
+            config.qgis_contour_bbox_edge_difference_source_style_label_probe
+        ),
         "label_count": len(records),
         "labels": records,
         "label_style_summary_by_base_layer": _label_style_summary_rows(records),
@@ -1031,8 +1052,10 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             sprite_resources,
             (QgsMapBoxGlStyleConversionContext, QgsMapBoxGlStyleConverter, Qgis),
         )
+        if labeling is not None:
+            apply_mapbox_label_priority(labeling)
         labeling = _apply_labeling_probes(labeling, config)
-        records = _postprocessed_label_records(labeling, apply_mapbox_label_priority)
+        records = _sorted_label_records(labeling)
         source_label_layers = source_label_layer_records(original_style, qfit_style, records)
         return _label_settings_report(
             config=config,
@@ -1392,6 +1415,8 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Sprite context loaded: {_markdown_value(report.get('sprite_context_loaded'))}",
         f"Sprite definitions: {_markdown_value(report.get('sprite_definition_count'))}",
         f"Bbox-edge contour label probe: {_markdown_value(report.get('qgis_contour_bbox_edge_difference_label_probe'))}",
+        "Bbox-edge source-style contour label probe: "
+        f"{_markdown_value(report.get('qgis_contour_bbox_edge_difference_source_style_label_probe'))}",
         "",
     ]
     _append_label_style_summary(lines, summary_rows)
@@ -1427,6 +1452,14 @@ def build_parser() -> argparse.ArgumentParser:
             "line_merge(difference(boundary($geometry), boundary(bounds($geometry))))."
         ),
     )
+    parser.add_argument(
+        "--qgis-contour-bbox-edge-difference-source-style-label-probe",
+        action="store_true",
+        help=(
+            "Append the bbox-edge contour probe after copying the converted production "
+            "contour label text settings."
+        ),
+    )
     return parser
 
 
@@ -1441,6 +1474,9 @@ def main(argv: list[str] | None = None) -> int:
         style_json_path=args.style_json,
         include_sprite_context=not args.no_sprite_context,
         qgis_contour_bbox_edge_difference_label_probe=args.qgis_contour_bbox_edge_difference_label_probe,
+        qgis_contour_bbox_edge_difference_source_style_label_probe=(
+            args.qgis_contour_bbox_edge_difference_source_style_label_probe
+        ),
     )
     paths = build_label_settings_paths(
         build_run_directory(


### PR DESCRIPTION
## Summary

- add a source-styled bbox-edge-difference contour label probe that copies the converted production contour label text/buffer settings
- record richer QGIS label style snapshots, including text and buffer details, beside comparison renders
- expose the source-styled probe in the label-settings diagnostic and docs

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_label_settings.py`
- `git diff --check`
- live QGIS-only `zermatt-piste-z17-outdoors` comparison with `--qgis-contour-bbox-edge-difference-source-style-label-probe --skip-browser --skip-diff`
- live label-settings diagnostic with `--qgis-contour-bbox-edge-difference-source-style-label-probe`
- live all-camera QGIS-only matrix with `--qgis-contour-bbox-edge-difference-source-style-label-probe --skip-browser --skip-diff`
- `python3 -m pytest tests/ -x -q --tb=short`

## Issue

Part of #949.
