### PR TITLE
chore: add high-zoom contour probe

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -216,6 +216,16 @@ python3 validation/mapbox_outdoors_comparison.py \
 
 This renders a separate diagnostic rule named `contour-label-bbox-edge-difference-source-style-probe`. Use it when the visual question is whether the bbox-edge-difference geometry is still promising after matching the production `contour-label` text styling.
 
+To test the same source-styled probe without enabling it in the z14 cameras where it can over-label slopes, use the high-zoom variant:
+
+```bash
+python3 validation/mapbox_outdoors_comparison.py \
+  zermatt-piste-z17-outdoors \
+  --qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe
+```
+
+This renders `contour-label-bbox-edge-difference-source-style-high-zoom-probe`, with the diagnostic rule's minimum QGIS zoom raised to 17. Use it to compare a tightly gated production candidate against the broad source-style probe; it remains diagnostic output only.
+
 When QGIS capture runs, inspect `qgis-label-styles.json` beside the screenshots to confirm the converted label settings and any probe geometry-generator settings that were active for the render. Use that snapshot with the preprocessed style JSON before deciding whether a diagnostic probe is safe to promote into production styling.
 
 For a table-oriented label-settings report with the same diagnostic rule appended, run:
@@ -225,7 +235,7 @@ python3 validation/mapbox_outdoors_label_settings.py \
   --qgis-contour-bbox-edge-difference-label-probe
 ```
 
-Add `--qgis-contour-bbox-edge-difference-source-style-label-probe` to include the source-style variant in the same report.
+Add `--qgis-contour-bbox-edge-difference-source-style-label-probe` or `--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe` to include source-style variants in the same report.
 
 The report keeps the probe separate from source Mapbox layers, so the summary can distinguish converted production labels from diagnostic-only QGIS rules.
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -28,6 +28,10 @@ from qfit.validation.mapbox_outdoors_comparison import (
     QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_FILTER,
     QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_MIN_ZOOM,
     QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_STYLE_NAME,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_EXPRESSION,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_FILTER,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_MIN_ZOOM,
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_STYLE_NAME,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_EXPRESSION,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_FILTER,
     QGIS_CONTOUR_BOUNDARY_GENERATOR_LABEL_PROBE_MIN_ZOOM,
@@ -37,6 +41,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     QGIS_CONTOUR_POLYGON_LABEL_PROBE_STYLE_NAME,
     _append_qgis_contour_bbox_edge_difference_label_probe,
     _append_qgis_contour_bbox_edge_difference_source_style_label_probe,
+    _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe,
     _append_qgis_contour_boundary_generator_label_probe,
     _append_qgis_contour_polygon_label_probe,
     _label_setting_value,
@@ -633,6 +638,14 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_FILTER,
                 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_MIN_ZOOM,
                 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_EXPRESSION,
+                True,
+            ),
+            (
+                _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_STYLE_NAME,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_FILTER,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_MIN_ZOOM,
+                QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_EXPRESSION,
                 True,
             ),
         ]
@@ -1262,6 +1275,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             qgis_contour_boundary_generator_label_probe,
             qgis_contour_bbox_edge_difference_label_probe,
             qgis_contour_bbox_edge_difference_source_style_label_probe,
+            qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe,
             **_kwargs,
         ):
             captured["polygon_probe"] = qgis_contour_polygon_label_probe
@@ -1269,6 +1283,9 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             captured["bbox_edge_difference_probe"] = qgis_contour_bbox_edge_difference_label_probe
             captured["bbox_edge_difference_source_style_probe"] = (
                 qgis_contour_bbox_edge_difference_source_style_label_probe
+            )
+            captured["bbox_edge_difference_source_style_high_zoom_probe"] = (
+                qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
             )
             output_path.write_bytes(PNG_PLACEHOLDER)
 
@@ -1282,6 +1299,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                     qgis_contour_boundary_generator_label_probe=True,
                     qgis_contour_bbox_edge_difference_label_probe=True,
                     qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                    qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=True,
                     browser=False,
                     diff=False,
                     now=dt.datetime(2026, 5, 10, 19, 45, tzinfo=dt.timezone.utc),
@@ -1295,14 +1313,17 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(captured["boundary_generator_probe"])
         self.assertTrue(captured["bbox_edge_difference_probe"])
         self.assertTrue(captured["bbox_edge_difference_source_style_probe"])
+        self.assertTrue(captured["bbox_edge_difference_source_style_high_zoom_probe"])
         self.assertTrue(result.qgis_contour_polygon_label_probe)
         self.assertTrue(result.qgis_contour_boundary_generator_label_probe)
         self.assertTrue(result.qgis_contour_bbox_edge_difference_label_probe)
         self.assertTrue(result.qgis_contour_bbox_edge_difference_source_style_label_probe)
+        self.assertTrue(result.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe)
         self.assertTrue(manifest["qgis_contour_polygon_label_probe"])
         self.assertTrue(manifest["qgis_contour_boundary_generator_label_probe"])
         self.assertTrue(manifest["qgis_contour_bbox_edge_difference_label_probe"])
         self.assertTrue(manifest["qgis_contour_bbox_edge_difference_source_style_label_probe"])
+        self.assertTrue(manifest["qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe"])
 
     def test_run_comparison_passes_downloaded_style_json_to_renderers(self):
         captured_style_definitions = []
@@ -1387,6 +1408,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             "--qgis-contour-boundary-generator-label-probe",
             "--qgis-contour-bbox-edge-difference-label-probe",
             "--qgis-contour-bbox-edge-difference-source-style-label-probe",
+            "--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe",
             "--browser-timeout-ms",
             "5000",
         ])
@@ -1400,6 +1422,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(args.qgis_contour_boundary_generator_label_probe)
         self.assertTrue(args.qgis_contour_bbox_edge_difference_label_probe)
         self.assertTrue(args.qgis_contour_bbox_edge_difference_source_style_label_probe)
+        self.assertTrue(args.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe)
         self.assertEqual(args.browser_timeout_ms, 5000)
 
     def test_main_all_cameras_runs_full_inspection_matrix(self):
@@ -1428,6 +1451,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                         "--qgis-contour-boundary-generator-label-probe",
                         "--qgis-contour-bbox-edge-difference-label-probe",
                         "--qgis-contour-bbox-edge-difference-source-style-label-probe",
+                        "--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe",
                         "--skip-diff",
                         "--browser-timeout-ms",
                         "5000",
@@ -1447,6 +1471,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             self.assertIn("--qgis-contour-boundary-generator-label-probe", command)
             self.assertIn("--qgis-contour-bbox-edge-difference-label-probe", command)
             self.assertIn("--qgis-contour-bbox-edge-difference-source-style-label-probe", command)
+            self.assertIn("--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe", command)
             self.assertIn("--skip-diff", command)
             self.assertEqual(kwargs["env"]["MAPBOX_ACCESS_TOKEN"], "test-mapbox-token")
             self.assertEqual(kwargs["cwd"], mapbox_outdoors_comparison.REPO_ROOT)

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -14,6 +14,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     LabelSettingsConfig,
     _append_qgis_contour_bbox_edge_difference_label_probe,
     _append_qgis_contour_bbox_edge_difference_source_style_label_probe,
+    _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe,
     _apply_labeling_probes,
     _convert_style_to_labeling,
     _ensure_qgis_application,
@@ -447,6 +448,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         original_labeling = FakeLabeling([])
         first_updated_labeling = FakeLabeling([])
         second_updated_labeling = FakeLabeling([])
+        third_updated_labeling = FakeLabeling([])
         seen = {}
 
         def fake_append_probe(layer):
@@ -459,6 +461,10 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             seen["source_before"] = layer.labeling()
             layer.setLabeling(second_updated_labeling)
 
+        def fake_append_source_style_high_zoom_probe(layer):
+            seen["source_high_zoom_before"] = layer.labeling()
+            layer.setLabeling(third_updated_labeling)
+
         with mock.patch(
             "qfit.validation.mapbox_outdoors_label_settings._append_qgis_contour_bbox_edge_difference_label_probe",
             side_effect=fake_append_probe,
@@ -468,22 +474,30 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                 "_append_qgis_contour_bbox_edge_difference_source_style_label_probe",
                 side_effect=fake_append_source_style_probe,
             ) as append_source_style_probe:
-                result = _apply_labeling_probes(
-                    original_labeling,
-                    LabelSettingsConfig(
-                        token="token",
-                        output_root=Path("/tmp"),
-                        qgis_contour_bbox_edge_difference_label_probe=True,
-                        qgis_contour_bbox_edge_difference_source_style_label_probe=True,
-                    ),
-                )
+                with mock.patch(
+                    "qfit.validation.mapbox_outdoors_label_settings."
+                    "_append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe",
+                    side_effect=fake_append_source_style_high_zoom_probe,
+                ) as append_source_style_high_zoom_probe:
+                    result = _apply_labeling_probes(
+                        original_labeling,
+                        LabelSettingsConfig(
+                            token="token",
+                            output_root=Path("/tmp"),
+                            qgis_contour_bbox_edge_difference_label_probe=True,
+                            qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                            qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=True,
+                        ),
+                    )
 
         append_probe.assert_called_once()
         append_source_style_probe.assert_called_once()
+        append_source_style_high_zoom_probe.assert_called_once()
         self.assertIs(seen["before"], original_labeling)
         self.assertIs(seen["source_before"], first_updated_labeling)
+        self.assertIs(seen["source_high_zoom_before"], second_updated_labeling)
         self.assertTrue(seen["labels_enabled_called"])
-        self.assertIs(result, second_updated_labeling)
+        self.assertIs(result, third_updated_labeling)
 
     def test_apply_labeling_probes_skips_when_disabled_or_missing_labeling(self):
         labeling = FakeLabeling([])
@@ -494,28 +508,34 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                 "qfit.validation.mapbox_outdoors_label_settings."
                 "_append_qgis_contour_bbox_edge_difference_source_style_label_probe"
             ) as append_source_style_probe:
-                self.assertIs(
-                    _apply_labeling_probes(
-                        labeling,
-                        LabelSettingsConfig(token="token", output_root=Path("/tmp")),
-                    ),
-                    labeling,
-                )
-                self.assertIs(
-                    _apply_labeling_probes(
-                        None,
-                        LabelSettingsConfig(
-                            token="token",
-                            output_root=Path("/tmp"),
-                            qgis_contour_bbox_edge_difference_label_probe=True,
-                            qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                with mock.patch(
+                    "qfit.validation.mapbox_outdoors_label_settings."
+                    "_append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe"
+                ) as append_source_style_high_zoom_probe:
+                    self.assertIs(
+                        _apply_labeling_probes(
+                            labeling,
+                            LabelSettingsConfig(token="token", output_root=Path("/tmp")),
                         ),
-                    ),
-                    None,
-                )
+                        labeling,
+                    )
+                    self.assertIs(
+                        _apply_labeling_probes(
+                            None,
+                            LabelSettingsConfig(
+                                token="token",
+                                output_root=Path("/tmp"),
+                                qgis_contour_bbox_edge_difference_label_probe=True,
+                                qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                                qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=True,
+                            ),
+                        ),
+                        None,
+                    )
 
         append_probe.assert_not_called()
         append_source_style_probe.assert_not_called()
+        append_source_style_high_zoom_probe.assert_not_called()
 
     def test_append_qgis_contour_bbox_edge_difference_label_probe_delegates_to_comparison_helper(self):
         layer = object()
@@ -533,6 +553,16 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "_append_qgis_contour_bbox_edge_difference_source_style_label_probe"
         ) as append_probe:
             _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
+
+        append_probe.assert_called_once_with(layer)
+
+    def test_append_qgis_contour_bbox_edge_difference_source_style_high_zoom_probe_delegates_to_comparison_helper(self):
+        layer = object()
+        with mock.patch(
+            "qfit.validation.mapbox_outdoors_comparison."
+            "_append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe"
+        ) as append_probe:
+            _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe(layer)
 
         append_probe.assert_called_once_with(layer)
 
@@ -1147,6 +1177,27 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                 )
             )
 
+        def fake_append_source_style_high_zoom_probe(layer):
+            class FakeProbeSettings(FakeSettings):
+                geometryGenerator = bbox_expression
+                geometryGeneratorEnabled = True
+                geometryGeneratorType = SimpleNamespace(name="Line")
+
+            styles = list(layer.labeling().styles())
+            layer.setLabeling(
+                FakeLabeling(
+                    [
+                        *styles,
+                        FakeLabelStyle(
+                            style_name="contour-label-bbox-edge-difference-source-style-high-zoom-probe",
+                            layer_name="contour",
+                            settings=FakeProbeSettings(),
+                            geometry_type=SimpleNamespace(name="Polygon"),
+                        ),
+                    ]
+                )
+            )
+
         modules = {
             **_fake_qgis_modules(),
             "qfit.visualization.infrastructure.background_map_service": _fake_background_map_service_module(),
@@ -1196,25 +1247,33 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                                 "_append_qgis_contour_bbox_edge_difference_source_style_label_probe",
                                 side_effect=fake_append_source_style_probe,
                             ) as append_source_style_probe:
-                                report = collect_label_settings(
-                                    LabelSettingsConfig(
-                                        token="token",
-                                        output_root=Path("/tmp"),
-                                        qgis_contour_bbox_edge_difference_label_probe=True,
-                                        qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                                with mock.patch(
+                                    "qfit.validation.mapbox_outdoors_label_settings."
+                                    "_append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe",
+                                    side_effect=fake_append_source_style_high_zoom_probe,
+                                ) as append_source_style_high_zoom_probe:
+                                    report = collect_label_settings(
+                                        LabelSettingsConfig(
+                                            token="token",
+                                            output_root=Path("/tmp"),
+                                            qgis_contour_bbox_edge_difference_label_probe=True,
+                                            qgis_contour_bbox_edge_difference_source_style_label_probe=True,
+                                            qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=True,
+                                        )
                                     )
-                                )
 
         fetch_style.assert_called_once_with("token", "mapbox", "outdoors-v12")
         fetch_sprites.assert_called_once()
         append_probe.assert_called_once()
         append_source_style_probe.assert_called_once()
+        append_source_style_high_zoom_probe.assert_called_once()
         self.assertEqual(report["qgis_converter_result"], "success")
         self.assertEqual(report["sprite_definition_count"], 1)
         self.assertFalse(report["sprite_context_loaded"])
         self.assertTrue(report["qgis_contour_bbox_edge_difference_label_probe"])
         self.assertTrue(report["qgis_contour_bbox_edge_difference_source_style_label_probe"])
-        self.assertEqual(report["label_count"], 3)
+        self.assertTrue(report["qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe"])
+        self.assertEqual(report["label_count"], 4)
         labels_by_style = {row["style_name"]: row for row in report["labels"]}
         self.assertEqual(labels_by_style["road-label-z15-plus"]["base_style_layer_id"], "road-label")
         self.assertEqual(
@@ -1227,6 +1286,12 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         self.assertEqual(
             labels_by_style["contour-label-bbox-edge-difference-source-style-probe"]["geometry_generator"],
+            bbox_expression,
+        )
+        self.assertEqual(
+            labels_by_style["contour-label-bbox-edge-difference-source-style-high-zoom-probe"][
+                "geometry_generator"
+            ],
             bbox_expression,
         )
         self.assertEqual(report["source_label_layer_count"], 1)
@@ -1244,6 +1309,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "sprite_definition_count": 440,
             "qgis_contour_bbox_edge_difference_label_probe": True,
             "qgis_contour_bbox_edge_difference_source_style_label_probe": True,
+            "qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe": True,
             "label_count": 1,
             "label_style_summary_by_base_layer": [
                 {
@@ -1383,6 +1449,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("Sprite context loaded: yes", markdown)
         self.assertIn("Bbox-edge contour label probe: yes", markdown)
         self.assertIn("Bbox-edge source-style contour label probe: yes", markdown)
+        self.assertIn("Bbox-edge source-style high-zoom contour label probe: yes", markdown)
         self.assertIn("## Label style summary by base layer", markdown)
         self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
         self.assertIn("## Line label repeat spacing by base layer", markdown)
@@ -1545,6 +1612,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                         "--no-sprite-context",
                         "--qgis-contour-bbox-edge-difference-label-probe",
                         "--qgis-contour-bbox-edge-difference-source-style-label-probe",
+                        "--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe",
                     ]
                 )
 
@@ -1556,6 +1624,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             self.assertTrue(
                 collect.call_args.args[0].qgis_contour_bbox_edge_difference_source_style_label_probe
             )
+            config = collect.call_args.args[0]
+            self.assertTrue(config.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe)
             self.assertEqual(len(list(output_root.glob("mapbox-outdoors-v12/*/summary.md"))), 1)
 
 

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -68,6 +68,16 @@ QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_FILTER = (
 QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_LABEL_PROBE_MIN_ZOOM = (
     QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_MIN_ZOOM
 )
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_STYLE_NAME = (
+    "contour-label-bbox-edge-difference-source-style-high-zoom-probe"
+)
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_EXPRESSION = (
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION
+)
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_FILTER = (
+    QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_FILTER
+)
+QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_MIN_ZOOM = 17
 MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE = "metrics_available"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING = "manifest_missing"
 MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE = "manifest_unreadable"
@@ -209,6 +219,7 @@ class ComparisonConfig:
     qgis_contour_boundary_generator_label_probe: bool = False
     qgis_contour_bbox_edge_difference_label_probe: bool = False
     qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False
+    qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe: bool = False
     browser: bool = True
     qgis: bool = True
     diff: bool = True
@@ -228,6 +239,7 @@ class ComparisonResult:
     qgis_contour_boundary_generator_label_probe: bool = False
     qgis_contour_bbox_edge_difference_label_probe: bool = False
     qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False
+    qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe: bool = False
     image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
     style_json_path: str | None = None
 
@@ -341,6 +353,9 @@ def _redacted_manifest(
         ),
         "qgis_contour_bbox_edge_difference_source_style_label_probe": (
             result.qgis_contour_bbox_edge_difference_source_style_label_probe
+        ),
+        "qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe": (
+            result.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
         ),
         "captured": {
             "browser_reference": result.browser_captured,
@@ -790,6 +805,17 @@ def _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer: ob
     )
 
 
+def _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe(layer: object) -> None:
+    _append_qgis_contour_line_generator_label_probe(
+        layer,
+        style_name=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_STYLE_NAME,
+        geometry_generator=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_EXPRESSION,
+        filter_expression=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_FILTER,
+        min_zoom=QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_SOURCE_STYLE_HIGH_ZOOM_LABEL_PROBE_MIN_ZOOM,
+        copy_source_settings=True,
+    )
+
+
 def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     *,
     camera: MapboxComparisonCamera,
@@ -802,6 +828,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     qgis_contour_boundary_generator_label_probe: bool = False,
     qgis_contour_bbox_edge_difference_label_probe: bool = False,
     qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False,
+    qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe: bool = False,
 ) -> None:
     _ensure_package_parent_on_path()
     _ensure_headless_qt_platform()
@@ -880,6 +907,8 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
             _append_qgis_contour_bbox_edge_difference_label_probe(layer)
         if qgis_contour_bbox_edge_difference_source_style_label_probe:
             _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
+        if qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe:
+            _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe(layer)
         if qgis_label_styles_path is not None:
             write_qgis_label_styles_snapshot(layer=layer, output_path=qgis_label_styles_path, token=token)
 
@@ -1013,6 +1042,9 @@ def run_comparison(
             qgis_contour_bbox_edge_difference_source_style_label_probe=(
                 config.qgis_contour_bbox_edge_difference_source_style_label_probe
             ),
+            qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=(
+                config.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
+            ),
         )
         qgis_captured = True
         qgis_preprocessed_style_captured = paths.qgis_preprocessed_style_json.exists()
@@ -1043,6 +1075,9 @@ def run_comparison(
         ),
         qgis_contour_bbox_edge_difference_source_style_label_probe=(
             config.qgis_contour_bbox_edge_difference_source_style_label_probe
+        ),
+        qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=(
+            config.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
         ),
         image_metrics=image_metrics,
         style_json_path=str(config.style_json_path) if config.style_json_path is not None else None,
@@ -1141,6 +1176,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe",
+        action="store_true",
+        help=(
+            "Append the source-styled bbox-edge-difference contour-label probe only "
+            "from QGIS zoom 17 upward. Use to validate whether the source-styled "
+            "candidate avoids the z14 contour-label clutter seen in broad probes."
+        ),
+    )
+    parser.add_argument(
         "--skip-diff",
         action="store_true",
         help="Skip diff image generation.",
@@ -1195,6 +1239,9 @@ def _comparison_config(
         qgis_contour_bbox_edge_difference_source_style_label_probe=(
             args.qgis_contour_bbox_edge_difference_source_style_label_probe
         ),
+        qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=(
+            args.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
+        ),
         browser=not args.skip_browser,
         qgis=not args.skip_qgis,
         diff=not args.skip_diff,
@@ -1244,6 +1291,8 @@ def _single_camera_subprocess_command(
         command.append("--qgis-contour-bbox-edge-difference-label-probe")
     if args.qgis_contour_bbox_edge_difference_source_style_label_probe:
         command.append("--qgis-contour-bbox-edge-difference-source-style-label-probe")
+    if args.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe:
+        command.append("--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe")
     if args.skip_diff:
         command.append("--skip-diff")
     command.extend(["--browser-timeout-ms", str(args.browser_timeout_ms)])

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -89,6 +89,7 @@ class LabelSettingsConfig:
     include_sprite_context: bool = True
     qgis_contour_bbox_edge_difference_label_probe: bool = False
     qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False
+    qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe: bool = False
     now: dt.datetime | None = None
 
 
@@ -465,6 +466,14 @@ def _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer: ob
     append_probe(layer)
 
 
+def _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe(layer: object) -> None:
+    from qfit.validation.mapbox_outdoors_comparison import (  # noqa: PLC0415
+        _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe as append_probe,
+    )
+
+    append_probe(layer)
+
+
 def _apply_labeling_probes(labeling: object | None, config: LabelSettingsConfig) -> object | None:
     if labeling is None:
         return labeling
@@ -473,6 +482,8 @@ def _apply_labeling_probes(labeling: object | None, config: LabelSettingsConfig)
         _append_qgis_contour_bbox_edge_difference_label_probe(layer)
     if config.qgis_contour_bbox_edge_difference_source_style_label_probe:
         _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
+    if config.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe:
+        _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe(layer)
     return layer.labeling()
 
 
@@ -1005,6 +1016,9 @@ def _label_settings_report(
         "qgis_contour_bbox_edge_difference_source_style_label_probe": (
             config.qgis_contour_bbox_edge_difference_source_style_label_probe
         ),
+        "qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe": (
+            config.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
+        ),
         "label_count": len(records),
         "labels": records,
         "label_style_summary_by_base_layer": _label_style_summary_rows(records),
@@ -1417,6 +1431,8 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Bbox-edge contour label probe: {_markdown_value(report.get('qgis_contour_bbox_edge_difference_label_probe'))}",
         "Bbox-edge source-style contour label probe: "
         f"{_markdown_value(report.get('qgis_contour_bbox_edge_difference_source_style_label_probe'))}",
+        "Bbox-edge source-style high-zoom contour label probe: "
+        f"{_markdown_value(report.get('qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe'))}",
         "",
     ]
     _append_label_style_summary(lines, summary_rows)
@@ -1460,6 +1476,14 @@ def build_parser() -> argparse.ArgumentParser:
             "contour label text settings."
         ),
     )
+    parser.add_argument(
+        "--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe",
+        action="store_true",
+        help=(
+            "Append the source-styled bbox-edge contour probe with the diagnostic "
+            "minimum zoom raised to 17."
+        ),
+    )
     return parser
 
 
@@ -1476,6 +1500,9 @@ def main(argv: list[str] | None = None) -> int:
         qgis_contour_bbox_edge_difference_label_probe=args.qgis_contour_bbox_edge_difference_label_probe,
         qgis_contour_bbox_edge_difference_source_style_label_probe=(
             args.qgis_contour_bbox_edge_difference_source_style_label_probe
+        ),
+        qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=(
+            args.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
         ),
     )
     paths = build_label_settings_paths(


### PR DESCRIPTION
## Summary
- add an opt-in source-styled bbox-edge-difference contour label probe gated to QGIS zoom 17+
- wire the high-zoom probe through the comparison harness, all-camera subprocess flow, and label-settings diagnostic
- document the new diagnostic path and add focused parser/helper/report tests

## Evidence
- Broad source-styled probe improved z17 but over-labeled Chamonix z14, so this slice keeps the probe diagnostic and tightens the zoom gate instead of changing production styling.
- Live high-zoom matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260520T001812Z/summary.md`
- Live label-settings diagnostic: `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260520T001718Z/summary.md`
- Visual read: z14 Chamonix clutter from the broad source-styled probe is removed/reduced while z17 behavior remains comparable.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_comparison.py validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_label_settings.py`
- `python3 -m pytest -q --tb=short`
- `git diff --check`
- Live all-camera Mapbox/QGIS comparison with `--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe`
