### PR TITLE
fix: enable high-zoom contour labels

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -1005,6 +1005,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         appended_style.setLabelSettings.assert_called_once_with(copied_settings)
         self.assertEqual(copied_settings.fieldName, "concat(\"ele\", ' m')")
         self.assertTrue(copied_settings.isExpression)
+        self.assertEqual(copied_settings.placement, _qstub.QgsPalLayerSettings.Curved)
         self.assertEqual(copied_settings.priority, 3)
         self.assertEqual(
             copied_settings.geometryGenerator,

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -974,6 +974,80 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.assertTrue(settings.isExpression)
         style.setLabelSettings.assert_called_once_with(settings)
 
+    def test_contour_label_appends_high_zoom_bbox_edge_style(self):
+        labeling = MagicMock()
+        source_style, source_settings = self._make_style("contour", "contour-label")
+        source_settings.fieldName = '"ele"'
+        source_settings.isExpression = True
+        source_settings.priority = 2
+        labeling.styles.return_value = [source_style]
+        copied_settings = SimpleNamespace()
+        appended_style = MagicMock()
+        _qstub.QgsPalLayerSettings.reset_mock(return_value=True, side_effect=True)
+        _qstub.QgsPalLayerSettings.return_value = copied_settings
+        _qstub.QgsVectorTileBasicLabelingStyle.reset_mock(return_value=True, side_effect=True)
+        _qstub.QgsVectorTileBasicLabelingStyle.return_value = appended_style
+
+        self.service._apply_label_priority(labeling)
+
+        _qstub.QgsPalLayerSettings.assert_called_once_with(source_settings)
+        appended_style.setStyleName.assert_called_once_with(
+            _mock_bms_mod._CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_STYLE_NAME
+        )
+        appended_style.setLayerName.assert_called_once_with("contour")
+        appended_style.setGeometryType.assert_called_once_with(_qstub.Qgis.GeometryType.Polygon)
+        appended_style.setFilterExpression.assert_called_once_with(
+            _mock_bms_mod._CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_FILTER
+        )
+        appended_style.setMinZoomLevel.assert_called_once_with(
+            _mock_bms_mod._CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_MIN_ZOOM
+        )
+        appended_style.setLabelSettings.assert_called_once_with(copied_settings)
+        self.assertEqual(copied_settings.fieldName, "concat(\"ele\", ' m')")
+        self.assertTrue(copied_settings.isExpression)
+        self.assertEqual(copied_settings.priority, 3)
+        self.assertEqual(
+            copied_settings.geometryGenerator,
+            _mock_bms_mod._CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_EXPRESSION,
+        )
+        self.assertTrue(copied_settings.geometryGeneratorEnabled)
+        self.assertEqual(copied_settings.geometryGeneratorType, _qstub.Qgis.GeometryType.Line)
+        labeling.setStyles.assert_called_once_with([source_style, appended_style])
+
+    def test_custom_contour_label_field_does_not_append_high_zoom_bbox_edge_style(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("contour", "contour-label")
+        settings.fieldName = '"height_ft"'
+        settings.isExpression = True
+        labeling.styles.return_value = [style]
+        _qstub.QgsPalLayerSettings.reset_mock(return_value=True, side_effect=True)
+        _qstub.QgsVectorTileBasicLabelingStyle.reset_mock(return_value=True, side_effect=True)
+
+        self.service._apply_label_priority(labeling)
+
+        _qstub.QgsPalLayerSettings.assert_not_called()
+        _qstub.QgsVectorTileBasicLabelingStyle.assert_not_called()
+        labeling.setStyles.assert_not_called()
+
+    def test_existing_high_zoom_bbox_edge_style_is_not_duplicated(self):
+        labeling = MagicMock()
+        source_style, source_settings = self._make_style("contour", "contour-label")
+        source_settings.fieldName = "concat(\"ele\", ' m')"
+        source_settings.isExpression = True
+        existing_style, _existing_settings = self._make_style(
+            "contour",
+            _mock_bms_mod._CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_STYLE_NAME,
+        )
+        labeling.styles.return_value = [source_style, existing_style]
+        _qstub.QgsPalLayerSettings.reset_mock(return_value=True, side_effect=True)
+        _qstub.QgsVectorTileBasicLabelingStyle.reset_mock(return_value=True, side_effect=True)
+
+        self.service._apply_label_priority(labeling)
+
+        _qstub.QgsPalLayerSettings.assert_not_called()
+        _qstub.QgsVectorTileBasicLabelingStyle.assert_not_called()
+        labeling.setStyles.assert_not_called()
+
     def test_custom_contour_label_field_is_left_unchanged(self):
         labeling = MagicMock()
         style, settings = self._make_style("contour", "contour-label")

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -61,8 +61,17 @@ _WATERWAY_LABEL_REPEAT_DISTANCE_PX_BY_STYLE_MARKER = {
     "z15-to-z17": 325.0,
     "z17-plus": 600.0,
 }
+_CONTOUR_LABEL_LAYER_ID = "contour-label"
 _CONTOUR_LABEL_ELEVATION_FIELD_EXPRESSION = '"ele"'
 _CONTOUR_LABEL_EXPRESSION = "concat(\"ele\", ' m')"
+_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_STYLE_NAME = (
+    "contour-label-bbox-edge-difference-z17-plus"
+)
+_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_EXPRESSION = (
+    "line_merge(difference(boundary($geometry), boundary(bounds($geometry))))"
+)
+_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_FILTER = '("index" = 5 OR "index" = 10)'
+_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_MIN_ZOOM = 17
 
 
 def _label_style_mapbox_layer_id(style) -> str:
@@ -116,12 +125,26 @@ def _label_repeat_distance(layer_name: str, style) -> float | None:
 
 def _label_field_expression(layer_name: str, settings) -> str | None:
     if (
-        layer_name == "contour-label"
+        layer_name == _CONTOUR_LABEL_LAYER_ID
         and getattr(settings, "fieldName", "") == _CONTOUR_LABEL_ELEVATION_FIELD_EXPRESSION
         and getattr(settings, "isExpression", False)
     ):
         return _CONTOUR_LABEL_EXPRESSION
     return None
+
+
+def _is_contour_elevation_label(settings) -> bool:
+    field_name = getattr(settings, "fieldName", "")
+    return bool(
+        getattr(settings, "isExpression", False)
+        and field_name
+        in {_CONTOUR_LABEL_ELEVATION_FIELD_EXPRESSION, _CONTOUR_LABEL_EXPRESSION}
+    )
+
+
+def _settings_priority(settings) -> int:
+    priority = getattr(settings, "priority", 0)
+    return int(priority) if isinstance(priority, (int, float)) else 0
 
 
 def _needs_repeat_distance(settings) -> bool:
@@ -170,9 +193,63 @@ def _apply_label_settings(
     return changed
 
 
+def _append_high_zoom_contour_bbox_edge_label_style(
+    styles: list,
+    *,
+    qgs_pal_layer_settings,
+    qgs_vector_tile_labeling_style,
+    qgis,
+) -> bool:
+    if any(
+        _label_style_name(style) == _CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_STYLE_NAME
+        for style in styles
+    ):
+        return False
+
+    source_settings = None
+    for style in styles:
+        if _label_style_mapbox_layer_id(style) != _CONTOUR_LABEL_LAYER_ID:
+            continue
+        source_settings = style.labelSettings()
+        break
+    if source_settings is None or not _is_contour_elevation_label(source_settings):
+        return False
+
+    try:
+        settings = qgs_pal_layer_settings(source_settings)
+    except (RuntimeError, TypeError):
+        return False
+    settings.fieldName = _CONTOUR_LABEL_EXPRESSION
+    settings.isExpression = True
+    settings.placement = getattr(
+        qgs_pal_layer_settings,
+        "Curved",
+        qgs_pal_layer_settings.Line,
+    )
+    settings.priority = max(3, _settings_priority(source_settings))
+    settings.geometryGenerator = _CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_EXPRESSION
+    settings.geometryGeneratorEnabled = True
+    settings.geometryGeneratorType = qgis.GeometryType.Line
+
+    style = qgs_vector_tile_labeling_style()
+    style.setStyleName(_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_STYLE_NAME)
+    style.setLayerName("contour")
+    style.setGeometryType(qgis.GeometryType.Polygon)
+    style.setFilterExpression(_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_FILTER)
+    style.setMinZoomLevel(_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_MIN_ZOOM)
+    style.setLabelSettings(settings)
+    styles.append(style)
+    return True
+
+
 def apply_mapbox_label_priority(labeling) -> None:
     try:
-        from qgis.core import QgsProperty, Qgis  # noqa: PLC0415
+        from qgis.core import (  # noqa: PLC0415
+            QgsPalLayerSettings,
+            QgsProperty,
+            QgsVectorTileBasicLabelingStyle,
+            Qgis,
+        )
 
         styles = list(labeling.styles())
         changed = False
@@ -180,7 +257,11 @@ def apply_mapbox_label_priority(labeling) -> None:
             layer_name = _label_style_mapbox_layer_id(style)
             priority = _label_priority(layer_name, style)
             repeat_distance = _label_repeat_distance(layer_name, style)
-            if priority is None and repeat_distance is None and layer_name != "contour-label":
+            if (
+                priority is None
+                and repeat_distance is None
+                and layer_name != _CONTOUR_LABEL_LAYER_ID
+            ):
                 continue
             settings = style.labelSettings()
             if settings is None:
@@ -199,6 +280,13 @@ def apply_mapbox_label_priority(labeling) -> None:
             ):
                 style.setLabelSettings(settings)
                 changed = True
+        if _append_high_zoom_contour_bbox_edge_label_style(
+            styles,
+            qgs_pal_layer_settings=QgsPalLayerSettings,
+            qgs_vector_tile_labeling_style=QgsVectorTileBasicLabelingStyle,
+            qgis=Qgis,
+        ):
+            changed = True
         if changed:
             labeling.setStyles(styles)
     except (RuntimeError, AttributeError):

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -224,7 +224,7 @@ def _append_high_zoom_contour_bbox_edge_label_style(
     settings.placement = getattr(
         qgs_pal_layer_settings,
         "Curved",
-        qgs_pal_layer_settings.Line,
+        getattr(qgs_pal_layer_settings, "Line", None),
     )
     settings.priority = max(3, _settings_priority(source_settings))
     settings.geometryGenerator = _CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_EXPRESSION


### PR DESCRIPTION
## Summary
- add a production z17+ contour label style that copies the converted `contour-label` settings
- route label placement through `line_merge(difference(boundary($geometry), boundary(bounds($geometry))))` to avoid obvious bbox/tile-edge contour label artifacts
- keep the original contour-label style intact and add coverage for idempotency and unsupported/custom contour label fields

## Evidence
- Builds on the diagnostic high-zoom probe from #1175, which avoided the z14 Chamonix clutter seen in the broader source-styled probe while preserving z17 contour behavior.
- Live label-settings report with no diagnostic flags: `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260520T003423Z/summary.md`
- Live all-camera comparison with no diagnostic flags: `debug/mapbox-outdoors-comparison/all-cameras/20260520T003516Z/summary.md`
- The production branch matches the diagnostic high-zoom contact sheet: z14 Chamonix does not regain the contour-label clutter, and z17 Zermatt contour labels remain active.

## Validation
- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 -m pytest tests/test_background_map_service.py tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest -q --tb=short`
- `git diff --check`
- Live all-camera Mapbox/QGIS comparison with no diagnostic flags
