### PR TITLE
Add Mapbox road path focus summary

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -47,6 +47,18 @@ def _feature(geometry_type, properties):
 
 
 class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
+    def test_top_count_labels_preserves_count_order_and_limit(self):
+        labels = road_features._top_count_labels(
+            {
+                "trail": 2,
+                "footway": 3,
+                "piste": 1,
+                "path": 4,
+            }
+        )
+
+        self.assertEqual(labels, ["path=4", "footway=3", "trail=2"])
+
     def test_resolve_mapbox_token_prefers_argument_then_environment(self):
         self.assertEqual(
             resolve_mapbox_token(

--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -1025,6 +1025,61 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("| zermatt-trails-z18-outdoors | decoded | 18.0 | 18 | 1/1 | - | 4 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |", markdown)
         self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
         self.assertIn(f'Road exit shield signatures: {{"{exit_shield_signature}":1}}', markdown)
+        self.assertIn("## Path/pedestrian focus", markdown)
+        self.assertIn(
+            '| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 1 | 1 | ["pedestrian=1"] | ["footway=1"] | ["bridge=1"] |',
+            markdown,
+        )
+        self.assertIn(f'["{path_signature}=1"] | ["{step_signature}=1"] |', markdown)
+
+    def test_build_all_camera_summary_markdown_omits_path_pedestrian_focus_for_zero_counts(self):
+        report = {
+            "generated": "2026-05-18T15:40:00+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "camera_count": 1,
+            "successful_camera_count": 1,
+            "failed_camera_count": 0,
+            "decoded_tile_count": 1,
+            "tile_count": 1,
+            "road_feature_count": 0,
+            "motorway_junction_feature_count": 0,
+            "pedestrian_polygon_candidate_count": 0,
+            "pedestrian_line_candidate_count": 0,
+            "path_line_candidate_count": 0,
+            "step_line_candidate_count": 0,
+            "oneway_arrow_candidate_count": 0,
+            "road_intersection_candidate_count": 0,
+            "level_crossing_candidate_count": 0,
+            "road_number_shield_candidate_count": 0,
+            "road_exit_shield_candidate_count": 0,
+            "cameras": [
+                {
+                    "status": "decoded",
+                    "camera": "switzerland-alps-z5-outdoors",
+                    "camera_zoom": 5.35,
+                    "tile_zoom": 5,
+                    "decoded_tile_count": 1,
+                    "failed_tile_count": 0,
+                    "tile_count": 1,
+                    "road_feature_count": 0,
+                    "motorway_junction_feature_count": 0,
+                    "pedestrian_polygon_candidate_count": 0,
+                    "pedestrian_line_candidate_count": 0,
+                    "path_line_candidate_count": 0,
+                    "step_line_candidate_count": 0,
+                    "oneway_arrow_candidate_count": 0,
+                    "road_intersection_candidate_count": 0,
+                    "level_crossing_candidate_count": 0,
+                    "road_number_shield_candidate_count": 0,
+                    "road_exit_shield_candidate_count": 0,
+                }
+            ],
+        }
+
+        markdown = build_all_camera_summary_markdown(report)
+
+        self.assertNotIn("## Path/pedestrian focus", markdown)
 
     def test_write_report_writes_json_and_markdown(self):
         report = {

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -98,6 +98,7 @@ ROAD_INTERSECTION_SIGNATURE_KEYS = ("class", "name")
 LEVEL_CROSSING_SIGNATURE_KEYS = ("class", "structure", "layer")
 ROAD_NUMBER_SHIELD_SIGNATURE_KEYS = ("class", "reflen", "shield", "shield_beta", "structure", "layer")
 ROAD_EXIT_SHIELD_SIGNATURE_KEYS = ("ref", "reflen")
+PATH_PEDESTRIAN_FOCUS_TOP_COUNT_LIMIT = 3
 
 
 @dataclass(frozen=True)
@@ -587,6 +588,26 @@ def _road_feature_table_cells(record: dict[str, object]) -> list[str]:
 
 def _markdown_table_row(cells: Iterable[object]) -> str:
     return "| " + " | ".join(_markdown_value(cell) for cell in cells) + " |"
+
+
+def _top_count_labels(value: object, *, limit: int = PATH_PEDESTRIAN_FOCUS_TOP_COUNT_LIMIT) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    counts = [(str(label), count) for label, count in value.items() if isinstance(count, int)]
+    counts.sort(key=lambda item: (-item[1], item[0]))
+    return [f"{label}={count}" for label, count in counts[:limit]]
+
+
+def _has_path_pedestrian_focus(record: dict[str, object]) -> bool:
+    return any(
+        isinstance(record.get(key), int) and record.get(key) > 0
+        for key in (
+            "pedestrian_polygon_candidate_count",
+            "pedestrian_line_candidate_count",
+            "path_line_candidate_count",
+            "step_line_candidate_count",
+        )
+    )
 
 
 def _load_original_style(config: RoadFeatureConfig, style_fetcher) -> dict[str, object]:
@@ -1080,6 +1101,40 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                 ]
             )
         )
+    focus_rows = [
+        row
+        for row in rows
+        if isinstance(row, dict) and row.get("status") == "decoded" and _has_path_pedestrian_focus(row)
+    ]
+    if focus_rows:
+        lines.extend(
+            [
+                "",
+                "## Path/pedestrian focus",
+                "",
+                "| Camera | Camera zoom | Tile zoom | Pedestrian/path polygons | Pedestrian lines | Path lines | Steps | Pedestrian line types | Path line types | Step structures | Path signatures | Step signatures |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for camera_report in focus_rows:
+            lines.append(
+                _markdown_table_row(
+                    [
+                        camera_report.get("camera"),
+                        camera_report.get("camera_zoom"),
+                        camera_report.get("tile_zoom"),
+                        camera_report.get("pedestrian_polygon_candidate_count"),
+                        camera_report.get("pedestrian_line_candidate_count"),
+                        camera_report.get("path_line_candidate_count"),
+                        camera_report.get("step_line_candidate_count"),
+                        _top_count_labels(camera_report.get("pedestrian_line_type_counts")),
+                        _top_count_labels(camera_report.get("path_line_type_counts")),
+                        _top_count_labels(camera_report.get("step_line_structure_counts")),
+                        _top_count_labels(camera_report.get("path_line_signature_counts")),
+                        _top_count_labels(camera_report.get("step_line_signature_counts")),
+                    ]
+                )
+            )
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
## Summary

- add a focused path/pedestrian section to the all-camera Mapbox Outdoors road-feature diagnostic
- show per-camera pedestrian/path/step counts plus the top signatures that drive current trail/steps comparisons
- keep the change validation-only for #949, with no production style behavior change

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- rebuilt the latest all-camera road-feature markdown from committed JSON to verify the new focus section highlights Chamonix z14 and Zermatt z18 path/step signatures

Refs #949
