### PR TITLE
Add Mapbox path pedestrian style audit

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -858,6 +858,13 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         "paint": {"line-color": "#88aa77"},
                     },
                     {
+                        "id": "road-no-hiking",
+                        "type": "line",
+                        "source-layer": "road",
+                        "filter": ["!=", ["get", "type"], "hiking"],
+                        "paint": {"line-color": "#cccccc"},
+                    },
+                    {
                         "id": "path-pedestrian-label",
                         "type": "symbol",
                         "source-layer": "road",
@@ -924,6 +931,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         )[0]
         self.assertNotIn("hidden-road-path` |", path_pedestrian_section)
         self.assertNotIn("landuse-path-outline` |", path_pedestrian_section)
+        self.assertNotIn("road-no-hiking` |", path_pedestrian_section)
         self.assertNotIn("path-pedestrian-label` |", path_pedestrian_section)
 
     def test_build_style_audit_reports_terrain_landcover_palette_candidates(self):

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -852,6 +852,12 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
                         "paint": {"line-color": "#cccccc"},
                     },
                     {
+                        "id": "landuse-path-outline",
+                        "type": "line",
+                        "source-layer": "landuse",
+                        "paint": {"line-color": "#88aa77"},
+                    },
+                    {
                         "id": "path-pedestrian-label",
                         "type": "symbol",
                         "source-layer": "road",
@@ -917,6 +923,7 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             1,
         )[0]
         self.assertNotIn("hidden-road-path` |", path_pedestrian_section)
+        self.assertNotIn("landuse-path-outline` |", path_pedestrian_section)
         self.assertNotIn("path-pedestrian-label` |", path_pedestrian_section)
 
     def test_build_style_audit_reports_terrain_landcover_palette_candidates(self):

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -803,6 +803,122 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertNotIn("filter<br>paint.line-opacity", markdown)
         self.assertNotIn("hidden-road` |", markdown)
 
+    def test_build_style_audit_reports_path_pedestrian_hierarchy_candidates(self):
+        audit = build_style_audit(
+            {
+                "version": 8,
+                "layers": [
+                    {
+                        "id": "road-primary",
+                        "type": "line",
+                        "source-layer": "road",
+                        "minzoom": 5,
+                        "filter": ["==", ["get", "class"], "primary"],
+                        "paint": {"line-color": "#ffffff", "line-width": 2},
+                    },
+                    {
+                        "id": "road-path-trail",
+                        "type": "line",
+                        "source-layer": "road",
+                        "minzoom": 12,
+                        "filter": [
+                            "all",
+                            ["==", ["geometry-type"], "LineString"],
+                            ["match", ["get", "type"], ["piste", "trail"], True, False],
+                        ],
+                        "layout": {"line-join": "round"},
+                        "paint": {
+                            "line-color": ["match", ["get", "type"], "trail", "#8b7d45", "#c88a2a"],
+                            "line-dasharray": [1, 2],
+                            "line-width": ["interpolate", ["linear"], ["zoom"], 12, 0.7, 16, 1.5],
+                        },
+                    },
+                    {
+                        "id": "road-pedestrian-polygon-fill",
+                        "type": "fill",
+                        "source-layer": "road",
+                        "minzoom": 14,
+                        "filter": ["==", ["get", "class"], "pedestrian"],
+                        "paint": {
+                            "fill-color": ["match", ["get", "class"], "pedestrian", "#eeeeee", "#ffffff"],
+                            "fill-opacity": ["interpolate", ["linear"], ["zoom"], 14, 0, 16, 1],
+                        },
+                    },
+                    {
+                        "id": "hidden-road-path",
+                        "type": "line",
+                        "source-layer": "road",
+                        "layout": {"visibility": "none"},
+                        "paint": {"line-color": "#cccccc"},
+                    },
+                    {
+                        "id": "path-pedestrian-label",
+                        "type": "symbol",
+                        "source-layer": "road",
+                        "layout": {"symbol-placement": "line", "text-field": ["get", "name"]},
+                    },
+                ],
+            }
+        )
+
+        candidates = audit["summary"]["path_pedestrian_hierarchy_candidates"]
+        self.assertEqual(
+            [candidate["layer"] for candidate in candidates],
+            ["road-pedestrian-polygon-fill", "road-path-trail"],
+        )
+        fill_candidate, line_candidate = candidates
+        self.assertEqual(fill_candidate["path_pedestrian_markers"], ["pedestrian"])
+        self.assertEqual(fill_candidate["path_pedestrian_marker"], "pedestrian")
+        self.assertEqual(line_candidate["path_pedestrian_markers"], ["path", "piste", "trail"])
+        self.assertEqual(line_candidate["zoom_band"], "z≥12")
+        self.assertEqual(line_candidate["filter_operator_signature"], "==, all, geometry-type, get, match")
+        self.assertEqual(
+            line_candidate["road_trail_control_properties"],
+            [
+                "filter",
+                "layout.line-join",
+                "paint.line-color",
+                "paint.line-dasharray",
+                "paint.line-width",
+            ],
+        )
+        self.assertEqual(
+            audit["summary"]["path_pedestrian_hierarchy_candidates_by_marker"],
+            [
+                {"path_pedestrian_marker": "path", "count": 1},
+                {"path_pedestrian_marker": "pedestrian", "count": 1},
+                {"path_pedestrian_marker": "piste", "count": 1},
+                {"path_pedestrian_marker": "trail", "count": 1},
+            ],
+        )
+        self.assertEqual(
+            audit["summary"]["path_pedestrian_hierarchy_candidates_by_type"],
+            [{"type": "fill", "count": 1}, {"type": "line", "count": 1}],
+        )
+        self.assertIn(
+            {"property": "paint.line-width", "count": 1},
+            audit["summary"]["path_pedestrian_hierarchy_simplified_by_property"],
+        )
+        self.assertEqual(
+            audit["summary"]["path_pedestrian_hierarchy_qgis_dependent_by_property"],
+            [
+                {"property": "filter", "count": 2},
+                {"property": "paint.fill-opacity", "count": 1},
+            ],
+        )
+
+        markdown = build_audit_markdown(audit)
+        self.assertIn("### Path/pedestrian hierarchy candidates", markdown)
+        self.assertIn("#### Path/pedestrian hierarchy candidates QGIS-dependent controls", markdown)
+        self.assertIn("| `path, piste, trail` | `road-path-trail` | `line` | `road` | z≥12 |", markdown)
+        self.assertIn("| `pedestrian` | `road-pedestrian-polygon-fill` | `fill` | `road` | z≥14 |", markdown)
+        path_pedestrian_section = markdown.split("### Path/pedestrian hierarchy candidates", 1)[1].split(
+            "### Terrain/landcover palette candidates",
+            1,
+        )[0]
+        self.assertNotIn("hidden-road-path` |", path_pedestrian_section)
+        self.assertNotIn("path-pedestrian-label` |", path_pedestrian_section)
+
     def test_build_style_audit_reports_terrain_landcover_palette_candidates(self):
         audit = build_style_audit(
             {

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -209,6 +209,9 @@ _PATH_PEDESTRIAN_HIERARCHY_MARKERS = (
     "platform",
     "corridor",
 )
+_PATH_PEDESTRIAN_HIERARCHY_NEGATION_PREFIXES = frozenset(
+    {"except", "exclude", "excluded", "excluding", "no", "non", "not", "without"}
+)
 _ROUTE_OVERLAY_LAYER_TYPES = frozenset({"line", "symbol"})
 _ROUTE_OVERLAY_TEXT_PAINT_PROPERTIES = (
     "paint.text-color",
@@ -1048,26 +1051,79 @@ def _road_trail_hierarchy_control_properties(layer: dict[str, object]) -> list[s
     return _control_properties(layer, _ROAD_TRAIL_HIERARCHY_CONTROL_PROPERTIES, include_filter=True)
 
 
-def _path_pedestrian_hierarchy_filter_search_text(layer: dict[str, object]) -> str:
-    filter_value = _qgis_filter_value(layer)
-    if filter_value is None:
-        return ""
-    return json.dumps(filter_value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+def _ordered_path_pedestrian_hierarchy_markers(markers: Iterable[str]) -> list[str]:
+    found = set(markers)
+    return [marker for marker in _PATH_PEDESTRIAN_HIERARCHY_MARKERS if marker in found]
 
 
-def _path_pedestrian_hierarchy_search_text(layer: dict[str, object]) -> str:
-    return " ".join(
-        (
-            str(layer.get("id") or ""),
-            str(layer.get("source_layer") or ""),
-            _path_pedestrian_hierarchy_filter_search_text(layer),
-        )
-    ).replace("-", "_").lower()
+def _path_pedestrian_hierarchy_text_markers(value: object) -> list[str]:
+    tokens = [token for token in re.split(r"[^a-z0-9]+", str(value).lower()) if token]
+    markers = [
+        token
+        for index, token in enumerate(tokens)
+        if token in _PATH_PEDESTRIAN_HIERARCHY_MARKERS
+        and (index == 0 or tokens[index - 1] not in _PATH_PEDESTRIAN_HIERARCHY_NEGATION_PREFIXES)
+    ]
+    return _ordered_path_pedestrian_hierarchy_markers(markers)
+
+
+def _path_pedestrian_hierarchy_filter_label_markers(value: object) -> list[str]:
+    if isinstance(value, list):
+        markers: list[str] = []
+        for item in value:
+            markers.extend(_path_pedestrian_hierarchy_filter_label_markers(item))
+        return _ordered_path_pedestrian_hierarchy_markers(markers)
+    if isinstance(value, str):
+        return _path_pedestrian_hierarchy_text_markers(value)
+    return []
+
+
+def _path_pedestrian_hierarchy_filter_output_is_truthy(value: object) -> bool:
+    return value is True or (
+        isinstance(value, str) and value.lower() in {"1", "true", "yes"}
+    )
+
+
+def _path_pedestrian_hierarchy_positive_match_markers(value: list[object]) -> list[str]:
+    markers: list[str] = []
+    for label_index in range(2, len(value) - 1, 2):
+        if _path_pedestrian_hierarchy_filter_output_is_truthy(value[label_index + 1]):
+            markers.extend(_path_pedestrian_hierarchy_filter_label_markers(value[label_index]))
+    return _ordered_path_pedestrian_hierarchy_markers(markers)
+
+
+def _path_pedestrian_hierarchy_positive_filter_markers(value: object) -> list[str]:
+    if not isinstance(value, list) or not value:
+        return []
+    operator = value[0]
+    if operator in {"!", "!=", "!in", "none", "not"}:
+        return []
+    if operator in {"all", "any"}:
+        markers: list[str] = []
+        for item in value[1:]:
+            markers.extend(_path_pedestrian_hierarchy_positive_filter_markers(item))
+        return _ordered_path_pedestrian_hierarchy_markers(markers)
+    if operator == "==":
+        return _path_pedestrian_hierarchy_filter_label_markers(value[2:])
+    if operator == "in":
+        return _path_pedestrian_hierarchy_filter_label_markers(value[2:])
+    if operator == "match":
+        return _path_pedestrian_hierarchy_positive_match_markers(value)
+    if operator == "case":
+        markers = []
+        for predicate_index in range(1, len(value) - 1, 2):
+            if _path_pedestrian_hierarchy_filter_output_is_truthy(value[predicate_index + 1]):
+                markers.extend(_path_pedestrian_hierarchy_positive_filter_markers(value[predicate_index]))
+        return _ordered_path_pedestrian_hierarchy_markers(markers)
+    return []
 
 
 def _path_pedestrian_hierarchy_markers(layer: dict[str, object]) -> list[str]:
-    search_text = _path_pedestrian_hierarchy_search_text(layer)
-    return [marker for marker in _PATH_PEDESTRIAN_HIERARCHY_MARKERS if marker in search_text]
+    markers = [
+        *_path_pedestrian_hierarchy_text_markers(layer.get("id") or ""),
+        *_path_pedestrian_hierarchy_positive_filter_markers(_qgis_filter_value(layer)),
+    ]
+    return _ordered_path_pedestrian_hierarchy_markers(markers)
 
 
 def _is_path_pedestrian_hierarchy_candidate_layer(layer: dict[str, object]) -> bool:

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -1456,23 +1456,35 @@ def _road_trail_hierarchy_candidate_rows(layers: list[dict[str, object]]) -> lis
     for layer in layers:
         if not _is_road_trail_hierarchy_candidate_layer(layer):
             continue
-        controls = _road_trail_hierarchy_control_properties(layer)
-        if not controls:
-            continue
-        control_set = set(controls)
-        rows.append(
-            {
-                "layer": str(layer.get("id") or ""),
-                "type": str(layer.get("type") or ""),
-                "source_layer": str(layer.get("source_layer") or ""),
-                "zoom_band": str(layer.get("zoom_band") or _ALL_ZOOMS_BAND),
-                _FILTER_OPERATOR_SIGNATURE_KEY: _operator_signature(_qgis_filter_value(layer)),
-                _ROAD_TRAIL_CONTROL_PROPERTIES_KEY: controls,
-                _QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY: _qfit_simplified_control_properties(layer, control_set),
-                _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY: _qgis_dependent_control_properties(layer, control_set),
-            }
-        )
+        row = _road_trail_hierarchy_candidate_row(layer)
+        if row is not None:
+            rows.append(row)
     return sorted(rows, key=lambda row: (str(row["type"]), str(row["layer"])))
+
+
+def _road_trail_hierarchy_candidate_row(
+    layer: dict[str, object],
+    *,
+    markers: list[str] | None = None,
+) -> dict[str, object] | None:
+    controls = _road_trail_hierarchy_control_properties(layer)
+    if not controls:
+        return None
+    control_set = set(controls)
+    row: dict[str, object] = {
+        "layer": str(layer.get("id") or ""),
+        "type": str(layer.get("type") or ""),
+        "source_layer": str(layer.get("source_layer") or ""),
+        "zoom_band": str(layer.get("zoom_band") or _ALL_ZOOMS_BAND),
+        _FILTER_OPERATOR_SIGNATURE_KEY: _operator_signature(_qgis_filter_value(layer)),
+        _ROAD_TRAIL_CONTROL_PROPERTIES_KEY: controls,
+        _QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY: _qfit_simplified_control_properties(layer, control_set),
+        _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY: _qgis_dependent_control_properties(layer, control_set),
+    }
+    if markers is not None:
+        row[_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY] = ", ".join(markers)
+        row[_PATH_PEDESTRIAN_HIERARCHY_MARKERS_KEY] = markers
+    return row
 
 
 def _path_pedestrian_hierarchy_candidate_rows(layers: list[dict[str, object]]) -> list[dict[str, object]]:
@@ -1480,25 +1492,10 @@ def _path_pedestrian_hierarchy_candidate_rows(layers: list[dict[str, object]]) -
     for layer in layers:
         if not _is_path_pedestrian_hierarchy_candidate_layer(layer):
             continue
-        controls = _road_trail_hierarchy_control_properties(layer)
-        if not controls:
-            continue
-        control_set = set(controls)
         markers = _path_pedestrian_hierarchy_markers(layer)
-        rows.append(
-            {
-                "layer": str(layer.get("id") or ""),
-                "type": str(layer.get("type") or ""),
-                "source_layer": str(layer.get("source_layer") or ""),
-                _PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY: ", ".join(markers),
-                _PATH_PEDESTRIAN_HIERARCHY_MARKERS_KEY: markers,
-                "zoom_band": str(layer.get("zoom_band") or _ALL_ZOOMS_BAND),
-                _FILTER_OPERATOR_SIGNATURE_KEY: _operator_signature(_qgis_filter_value(layer)),
-                _ROAD_TRAIL_CONTROL_PROPERTIES_KEY: controls,
-                _QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY: _qfit_simplified_control_properties(layer, control_set),
-                _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY: _qgis_dependent_control_properties(layer, control_set),
-            }
-        )
+        row = _road_trail_hierarchy_candidate_row(layer, markers=markers)
+        if row is not None:
+            rows.append(row)
     return sorted(rows, key=lambda row: (str(row["type"]), str(row["layer"])))
 
 
@@ -2056,32 +2053,39 @@ def _count_row_values(rows: list[dict[str, object]], key: str) -> list[dict[str,
     ]
 
 
-def _count_route_overlay_markers(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+def _count_multi_value_rows(
+    rows: list[dict[str, object]],
+    *,
+    values_key: str,
+    output_key: str,
+) -> list[dict[str, object]]:
     counts: Counter[str] = Counter()
     for row in rows:
-        values = row.get(_ROUTE_OVERLAY_MARKERS_KEY)
+        values = row.get(values_key)
         if not isinstance(values, list):
             continue
         counts.update(str(value) for value in values if value)
     return [
-        {_ROUTE_OVERLAY_MARKER_KEY: name, "count": count}
+        {output_key: name, "count": count}
         for name, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
         if name
     ]
+
+
+def _count_route_overlay_markers(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    return _count_multi_value_rows(
+        rows,
+        values_key=_ROUTE_OVERLAY_MARKERS_KEY,
+        output_key=_ROUTE_OVERLAY_MARKER_KEY,
+    )
 
 
 def _count_path_pedestrian_hierarchy_markers(rows: list[dict[str, object]]) -> list[dict[str, object]]:
-    counts: Counter[str] = Counter()
-    for row in rows:
-        values = row.get(_PATH_PEDESTRIAN_HIERARCHY_MARKERS_KEY)
-        if not isinstance(values, list):
-            continue
-        counts.update(str(value) for value in values if value)
-    return [
-        {_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY: name, "count": count}
-        for name, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
-        if name
-    ]
+    return _count_multi_value_rows(
+        rows,
+        values_key=_PATH_PEDESTRIAN_HIERARCHY_MARKERS_KEY,
+        output_key=_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY,
+    )
 
 
 def _filter_parse_signature_summary(rows: list[dict[str, object]]) -> list[dict[str, object]]:
@@ -3952,67 +3956,38 @@ def _markdown_road_trail_hierarchy_candidate_table(
     rows: list[dict[str, object]],
     *,
     empty: str = "—",
+    leading_label: str | None = None,
+    leading_key: str | None = None,
 ) -> list[str]:
     if not rows:
         return [empty, ""]
-    lines = [
-        (
-            "| Layer | Type | Source layer | Zoom | Filter operators | Road/trail controls | "
-            "Simplified/substituted by qfit | QGIS-dependent controls |"
-        ),
-        _MARKDOWN_TYPED_CANDIDATE_SEPARATOR,
+    headers = [
+        "Layer",
+        "Type",
+        "Source layer",
+        "Zoom",
+        "Filter operators",
+        "Road/trail controls",
+        "Simplified/substituted by qfit",
+        "QGIS-dependent controls",
     ]
+    if leading_label is not None:
+        headers.insert(0, leading_label)
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _header in headers) + " |"]
     for row in rows:
-        lines.append(
-            (
-                _MARKDOWN_TYPED_CANDIDATE_ROW_PREFIX
-                + _MARKDOWN_TYPED_CANDIDATE_ROW_SUFFIX
-            ).format(
-                layer=row.get("layer", ""),
-                layer_type=row.get("type", ""),
-                source_layer=row.get("source_layer", ""),
-                zoom=row.get("zoom_band", _ALL_ZOOMS_BAND),
-                filter_operators=row.get(_FILTER_OPERATOR_SIGNATURE_KEY, _NO_OPERATOR_SIGNATURE),
-                controls=_markdown_list(list(row.get(_ROAD_TRAIL_CONTROL_PROPERTIES_KEY) or [])),
-                simplified=_markdown_list(list(row.get(_QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY) or [])),
-                unresolved=_markdown_list(list(row.get(_QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY) or [])),
-            )
-        )
-    lines.append("")
-    return lines
-
-
-def _markdown_path_pedestrian_hierarchy_candidate_table(
-    rows: list[dict[str, object]],
-    *,
-    empty: str = "—",
-) -> list[str]:
-    if not rows:
-        return [empty, ""]
-    lines = [
-        (
-            "| Markers | Layer | Type | Source layer | Zoom | Filter operators | Road/trail controls | "
-            "Simplified/substituted by qfit | QGIS-dependent controls |"
-        ),
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
-    ]
-    for row in rows:
-        lines.append(
-            (
-                "| `{markers}` | `{layer}` | `{layer_type}` | `{source_layer}` | {zoom} | "
-                "`{filter_operators}` | {controls} | {simplified} | {unresolved} |"
-            ).format(
-                markers=row.get(_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY, ""),
-                layer=row.get("layer", ""),
-                layer_type=row.get("type", ""),
-                source_layer=row.get("source_layer", ""),
-                zoom=row.get("zoom_band", _ALL_ZOOMS_BAND),
-                filter_operators=row.get(_FILTER_OPERATOR_SIGNATURE_KEY, _NO_OPERATOR_SIGNATURE),
-                controls=_markdown_list(list(row.get(_ROAD_TRAIL_CONTROL_PROPERTIES_KEY) or [])),
-                simplified=_markdown_list(list(row.get(_QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY) or [])),
-                unresolved=_markdown_list(list(row.get(_QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY) or [])),
-            )
-        )
+        cells = [
+            f"`{row.get('layer', '')}`",
+            f"`{row.get('type', '')}`",
+            f"`{row.get('source_layer', '')}`",
+            str(row.get("zoom_band", _ALL_ZOOMS_BAND)),
+            f"`{row.get(_FILTER_OPERATOR_SIGNATURE_KEY, _NO_OPERATOR_SIGNATURE)}`",
+            _markdown_list(list(row.get(_ROAD_TRAIL_CONTROL_PROPERTIES_KEY) or [])),
+            _markdown_list(list(row.get(_QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY) or [])),
+            _markdown_list(list(row.get(_QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY) or [])),
+        ]
+        if leading_key is not None:
+            cells.insert(0, f"`{row.get(leading_key, '')}`")
+        lines.append("| " + " | ".join(cells) + " |")
     lines.append("")
     return lines
 
@@ -5613,8 +5588,10 @@ def _markdown_path_pedestrian_hierarchy_summary(summary: dict[str, object]) -> l
         "#### Path/pedestrian hierarchy candidates QGIS-dependent controls",
         "",
         *_markdown_count_table(_summary_rows(summary, _PATH_PEDESTRIAN_HIERARCHY_QGIS_DEPENDENT_BY_PROPERTY_KEY)),
-        *_markdown_path_pedestrian_hierarchy_candidate_table(
-            _summary_rows(summary, _PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_KEY)
+        *_markdown_road_trail_hierarchy_candidate_table(
+            _summary_rows(summary, _PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_KEY),
+            leading_label="Markers",
+            leading_key=_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY,
         ),
     ]
 

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -47,6 +47,13 @@ _ROAD_TRAIL_HIERARCHY_CANDIDATES_BY_TYPE_KEY = "road_trail_hierarchy_candidates_
 _ROAD_TRAIL_HIERARCHY_SIMPLIFIED_BY_PROPERTY_KEY = "road_trail_hierarchy_simplified_by_property"
 _ROAD_TRAIL_HIERARCHY_QGIS_DEPENDENT_BY_PROPERTY_KEY = "road_trail_hierarchy_qgis_dependent_by_property"
 _ROAD_TRAIL_CONTROL_PROPERTIES_KEY = "road_trail_control_properties"
+_PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_KEY = "path_pedestrian_hierarchy_candidates"
+_PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_BY_MARKER_KEY = "path_pedestrian_hierarchy_candidates_by_marker"
+_PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_BY_TYPE_KEY = "path_pedestrian_hierarchy_candidates_by_type"
+_PATH_PEDESTRIAN_HIERARCHY_SIMPLIFIED_BY_PROPERTY_KEY = "path_pedestrian_hierarchy_simplified_by_property"
+_PATH_PEDESTRIAN_HIERARCHY_QGIS_DEPENDENT_BY_PROPERTY_KEY = "path_pedestrian_hierarchy_qgis_dependent_by_property"
+_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY = "path_pedestrian_marker"
+_PATH_PEDESTRIAN_HIERARCHY_MARKERS_KEY = "path_pedestrian_markers"
 _TERRAIN_LANDCOVER_CANDIDATES_KEY = "terrain_landcover_palette_candidates"
 _TERRAIN_LANDCOVER_CANDIDATES_BY_SOURCE_LAYER_KEY = "terrain_landcover_palette_candidates_by_source_layer"
 _TERRAIN_LANDCOVER_CANDIDATES_BY_TYPE_KEY = "terrain_landcover_palette_candidates_by_type"
@@ -189,6 +196,18 @@ _ROAD_TRAIL_HIERARCHY_CONTROL_PROPERTIES = (
     "paint.line-pattern",
     "paint.line-translate",
     "paint.line-width",
+)
+_PATH_PEDESTRIAN_HIERARCHY_MARKERS = (
+    "pedestrian",
+    "path",
+    "footway",
+    "cycleway",
+    "piste",
+    "trail",
+    "hiking",
+    "steps",
+    "platform",
+    "corridor",
 )
 _ROUTE_OVERLAY_LAYER_TYPES = frozenset({"line", "symbol"})
 _ROUTE_OVERLAY_TEXT_PAINT_PROPERTIES = (
@@ -1029,6 +1048,32 @@ def _road_trail_hierarchy_control_properties(layer: dict[str, object]) -> list[s
     return _control_properties(layer, _ROAD_TRAIL_HIERARCHY_CONTROL_PROPERTIES, include_filter=True)
 
 
+def _path_pedestrian_hierarchy_filter_search_text(layer: dict[str, object]) -> str:
+    filter_value = _qgis_filter_value(layer)
+    if filter_value is None:
+        return ""
+    return json.dumps(filter_value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _path_pedestrian_hierarchy_search_text(layer: dict[str, object]) -> str:
+    return " ".join(
+        (
+            str(layer.get("id") or ""),
+            str(layer.get("source_layer") or ""),
+            _path_pedestrian_hierarchy_filter_search_text(layer),
+        )
+    ).replace("-", "_").lower()
+
+
+def _path_pedestrian_hierarchy_markers(layer: dict[str, object]) -> list[str]:
+    search_text = _path_pedestrian_hierarchy_search_text(layer)
+    return [marker for marker in _PATH_PEDESTRIAN_HIERARCHY_MARKERS if marker in search_text]
+
+
+def _is_path_pedestrian_hierarchy_candidate_layer(layer: dict[str, object]) -> bool:
+    return _is_road_trail_hierarchy_candidate_layer(layer) and bool(_path_pedestrian_hierarchy_markers(layer))
+
+
 def _is_terrain_landcover_candidate_layer(layer: dict[str, object]) -> bool:
     return (
         str(layer.get("group") or "") == "terrain/landcover"
@@ -1420,6 +1465,33 @@ def _road_trail_hierarchy_candidate_rows(layers: list[dict[str, object]]) -> lis
                 "layer": str(layer.get("id") or ""),
                 "type": str(layer.get("type") or ""),
                 "source_layer": str(layer.get("source_layer") or ""),
+                "zoom_band": str(layer.get("zoom_band") or _ALL_ZOOMS_BAND),
+                _FILTER_OPERATOR_SIGNATURE_KEY: _operator_signature(_qgis_filter_value(layer)),
+                _ROAD_TRAIL_CONTROL_PROPERTIES_KEY: controls,
+                _QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY: _qfit_simplified_control_properties(layer, control_set),
+                _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY: _qgis_dependent_control_properties(layer, control_set),
+            }
+        )
+    return sorted(rows, key=lambda row: (str(row["type"]), str(row["layer"])))
+
+
+def _path_pedestrian_hierarchy_candidate_rows(layers: list[dict[str, object]]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for layer in layers:
+        if not _is_path_pedestrian_hierarchy_candidate_layer(layer):
+            continue
+        controls = _road_trail_hierarchy_control_properties(layer)
+        if not controls:
+            continue
+        control_set = set(controls)
+        markers = _path_pedestrian_hierarchy_markers(layer)
+        rows.append(
+            {
+                "layer": str(layer.get("id") or ""),
+                "type": str(layer.get("type") or ""),
+                "source_layer": str(layer.get("source_layer") or ""),
+                _PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY: ", ".join(markers),
+                _PATH_PEDESTRIAN_HIERARCHY_MARKERS_KEY: markers,
                 "zoom_band": str(layer.get("zoom_band") or _ALL_ZOOMS_BAND),
                 _FILTER_OPERATOR_SIGNATURE_KEY: _operator_signature(_qgis_filter_value(layer)),
                 _ROAD_TRAIL_CONTROL_PROPERTIES_KEY: controls,
@@ -1993,6 +2065,20 @@ def _count_route_overlay_markers(rows: list[dict[str, object]]) -> list[dict[str
         counts.update(str(value) for value in values if value)
     return [
         {_ROUTE_OVERLAY_MARKER_KEY: name, "count": count}
+        for name, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        if name
+    ]
+
+
+def _count_path_pedestrian_hierarchy_markers(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    counts: Counter[str] = Counter()
+    for row in rows:
+        values = row.get(_PATH_PEDESTRIAN_HIERARCHY_MARKERS_KEY)
+        if not isinstance(values, list):
+            continue
+        counts.update(str(value) for value in values if value)
+    return [
+        {_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY: name, "count": count}
         for name, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
         if name
     ]
@@ -3422,6 +3508,7 @@ def build_style_audit(
     label_density_candidates = _label_density_candidate_rows(layers)
     line_label_repetition_candidates = _line_label_repetition_candidate_rows(layers)
     road_trail_hierarchy_candidates = _road_trail_hierarchy_candidate_rows(layers)
+    path_pedestrian_hierarchy_candidates = _path_pedestrian_hierarchy_candidate_rows(layers)
     terrain_landcover_candidates = _terrain_landcover_candidate_rows(layers)
     water_flow_candidates = _water_flow_candidate_rows(layers)
     icon_sprite_candidates = _icon_sprite_candidate_rows(layers)
@@ -3521,6 +3608,22 @@ def build_style_audit(
                 _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY,
             ),
             _ROAD_TRAIL_HIERARCHY_CANDIDATES_KEY: road_trail_hierarchy_candidates,
+            _PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_BY_MARKER_KEY: _count_path_pedestrian_hierarchy_markers(
+                path_pedestrian_hierarchy_candidates,
+            ),
+            _PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_BY_TYPE_KEY: _count_rows_by_key(
+                path_pedestrian_hierarchy_candidates,
+                "type",
+            ),
+            _PATH_PEDESTRIAN_HIERARCHY_SIMPLIFIED_BY_PROPERTY_KEY: _count_row_values(
+                path_pedestrian_hierarchy_candidates,
+                _QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY,
+            ),
+            _PATH_PEDESTRIAN_HIERARCHY_QGIS_DEPENDENT_BY_PROPERTY_KEY: _count_row_values(
+                path_pedestrian_hierarchy_candidates,
+                _QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY,
+            ),
+            _PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_KEY: path_pedestrian_hierarchy_candidates,
             _TERRAIN_LANDCOVER_CANDIDATES_BY_SOURCE_LAYER_KEY: _count_rows_by_key(
                 terrain_landcover_candidates,
                 "source_layer",
@@ -3865,6 +3968,41 @@ def _markdown_road_trail_hierarchy_candidate_table(
                 _MARKDOWN_TYPED_CANDIDATE_ROW_PREFIX
                 + _MARKDOWN_TYPED_CANDIDATE_ROW_SUFFIX
             ).format(
+                layer=row.get("layer", ""),
+                layer_type=row.get("type", ""),
+                source_layer=row.get("source_layer", ""),
+                zoom=row.get("zoom_band", _ALL_ZOOMS_BAND),
+                filter_operators=row.get(_FILTER_OPERATOR_SIGNATURE_KEY, _NO_OPERATOR_SIGNATURE),
+                controls=_markdown_list(list(row.get(_ROAD_TRAIL_CONTROL_PROPERTIES_KEY) or [])),
+                simplified=_markdown_list(list(row.get(_QFIT_SIMPLIFIED_CONTROL_PROPERTIES_KEY) or [])),
+                unresolved=_markdown_list(list(row.get(_QGIS_DEPENDENT_CONTROL_PROPERTIES_KEY) or [])),
+            )
+        )
+    lines.append("")
+    return lines
+
+
+def _markdown_path_pedestrian_hierarchy_candidate_table(
+    rows: list[dict[str, object]],
+    *,
+    empty: str = "—",
+) -> list[str]:
+    if not rows:
+        return [empty, ""]
+    lines = [
+        (
+            "| Markers | Layer | Type | Source layer | Zoom | Filter operators | Road/trail controls | "
+            "Simplified/substituted by qfit | QGIS-dependent controls |"
+        ),
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            (
+                "| `{markers}` | `{layer}` | `{layer_type}` | `{source_layer}` | {zoom} | "
+                "`{filter_operators}` | {controls} | {simplified} | {unresolved} |"
+            ).format(
+                markers=row.get(_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY, ""),
                 layer=row.get("layer", ""),
                 layer_type=row.get("type", ""),
                 source_layer=row.get("source_layer", ""),
@@ -5449,6 +5587,38 @@ def _markdown_road_trail_hierarchy_summary(summary: dict[str, object]) -> list[s
     ]
 
 
+def _markdown_path_pedestrian_hierarchy_summary(summary: dict[str, object]) -> list[str]:
+    return [
+        "### Path/pedestrian hierarchy candidates",
+        "",
+        (
+            "Visible road source line and fill layers matching path, pedestrian, footway, cycleway, piste, "
+            "trail, hiking, steps, platform, or corridor markers. Use this diagnostic with live road-feature "
+            "counts before changing path, pedestrian, trail, piste, or step styling."
+        ),
+        "",
+        *_markdown_named_count_table(
+            _summary_rows(summary, _PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_BY_MARKER_KEY),
+            key=_PATH_PEDESTRIAN_HIERARCHY_MARKER_KEY,
+            label="Marker",
+        ),
+        *_markdown_named_count_table(
+            _summary_rows(summary, _PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_BY_TYPE_KEY),
+            key="type",
+            label=_MARKDOWN_LAYER_TYPE_LABEL,
+        ),
+        "#### Path/pedestrian hierarchy candidates simplified/substituted by qfit",
+        "",
+        *_markdown_count_table(_summary_rows(summary, _PATH_PEDESTRIAN_HIERARCHY_SIMPLIFIED_BY_PROPERTY_KEY)),
+        "#### Path/pedestrian hierarchy candidates QGIS-dependent controls",
+        "",
+        *_markdown_count_table(_summary_rows(summary, _PATH_PEDESTRIAN_HIERARCHY_QGIS_DEPENDENT_BY_PROPERTY_KEY)),
+        *_markdown_path_pedestrian_hierarchy_candidate_table(
+            _summary_rows(summary, _PATH_PEDESTRIAN_HIERARCHY_CANDIDATES_KEY)
+        ),
+    ]
+
+
 def _markdown_terrain_landcover_summary(summary: dict[str, object]) -> list[str]:
     return [
         "### Terrain/landcover palette candidates",
@@ -5709,6 +5879,7 @@ def _markdown_summary(summary: dict[str, object], qgis_converter_warnings: objec
         *_markdown_label_density_summary(summary),
         *_markdown_line_label_repetition_summary(summary),
         *_markdown_road_trail_hierarchy_summary(summary),
+        *_markdown_path_pedestrian_hierarchy_summary(summary),
         *_markdown_terrain_landcover_summary(summary),
         *_markdown_water_flow_summary(summary),
         *_markdown_icon_sprite_summary(summary),

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -1071,7 +1071,12 @@ def _path_pedestrian_hierarchy_markers(layer: dict[str, object]) -> list[str]:
 
 
 def _is_path_pedestrian_hierarchy_candidate_layer(layer: dict[str, object]) -> bool:
-    return _is_road_trail_hierarchy_candidate_layer(layer) and bool(_path_pedestrian_hierarchy_markers(layer))
+    source_layer = str(layer.get("source_layer") or "").replace("-", "_").lower()
+    return (
+        source_layer == "road"
+        and _is_road_trail_hierarchy_candidate_layer(layer)
+        and bool(_path_pedestrian_hierarchy_markers(layer))
+    )
 
 
 def _is_terrain_landcover_candidate_layer(layer: dict[str, object]) -> bool:


### PR DESCRIPTION
## Summary

- Adds a focused `Path/pedestrian hierarchy candidates` section to the Mapbox Outdoors style audit.
- Narrows the broad road/trail audit to visible road-source line/fill layers matching path, pedestrian, footway, cycleway, piste, trail, hiking, steps, platform, or corridor markers.
- Reports marker/type counts, qfit-simplified controls, QGIS-dependent controls, and candidate rows so #949 road/path work can compare feature-density evidence against the relevant Mapbox style layers.

## Evidence

Live audit generated with the local QGIS-profile Mapbox token source without printing or storing the token:

- `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260520T012831Z/audit.md`
- New focused section found 23 path/pedestrian hierarchy candidates: 21 line layers and 2 fill layers.
- Marker counts: `path=13`, `pedestrian=7`, `steps=5`, `piste=5`, `cycleway=3`, `hiking=3`, `trail=3`.
- QGIS-dependent controls: `filter=23`; qfit already simplifies `paint.line-width` on 21 candidates and `paint.line-dasharray` on 12.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_style_audit.py tests/test_mapbox_outdoors_style_audit.py`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- Fresh live style-audit run against Mapbox Outdoors v12 using the local token environment only

Issue: #949