### PR TITLE
Add Mapbox path pedestrian focus report

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -1,0 +1,234 @@
+import datetime as dt
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from tests import _path  # noqa: F401
+
+from qfit.validation.mapbox_outdoors_path_pedestrian_focus import (
+    build_path_pedestrian_focus_paths,
+    build_path_pedestrian_focus_report,
+    build_run_directory,
+    build_summary_markdown,
+    load_json_object,
+    main,
+    qgis_path_pedestrian_style_summary,
+    write_report,
+)
+
+
+def _road_feature_report():
+    path_signature = "class=path; type=trail; surface=unpaved; structure=none; layer=(missing)"
+    step_signature = "class=path; type=steps; surface=paved; structure=bridge; layer=(missing)"
+    return {
+        "generated": "2026-05-20T01:09:13+00:00",
+        "style_owner": "mapbox",
+        "style_id": "outdoors-v12",
+        "cameras": [
+            {
+                "status": "decoded",
+                "camera": "chamonix-trails-z14-outdoors",
+                "camera_zoom": 14.25,
+                "tile_zoom": 14,
+                "pedestrian_polygon_candidate_count": 10,
+                "pedestrian_line_candidate_count": 115,
+                "path_line_candidate_count": 236,
+                "step_line_candidate_count": 19,
+                "pedestrian_line_type_counts": {"pedestrian": 115},
+                "path_line_type_counts": {"trail": 69, "footway": 56, "piste": 48, "path": 4},
+                "step_line_structure_counts": {"none": 16, "tunnel": 2, "bridge": 1},
+                "path_line_signature_counts": {path_signature: 55, "class=path; type=piste": 46},
+                "step_line_signature_counts": {step_signature: 3},
+            },
+            {
+                "status": "decoded",
+                "camera": "switzerland-alps-z5-outdoors",
+                "camera_zoom": 5.35,
+                "tile_zoom": 5,
+                "pedestrian_polygon_candidate_count": 0,
+                "pedestrian_line_candidate_count": 0,
+                "path_line_candidate_count": 0,
+                "step_line_candidate_count": 0,
+            },
+        ],
+    }
+
+
+def _qgis_preprocessed_style():
+    return {
+        "version": 8,
+        "layers": [
+            {
+                "id": "road-path",
+                "type": "line",
+                "filter": ["==", ["get", "class"], "path"],
+                "paint": {"line-width": 1.5, "line-dasharray": [1, 1]},
+            },
+            {
+                "id": "road-pedestrian",
+                "type": "line",
+                "paint": {"line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5], "line-opacity": 0.65},
+            },
+            {
+                "id": "road-steps",
+                "type": "line",
+                "paint": {"line-dasharray": [0.2, 1]},
+            },
+            {
+                "id": "road-pedestrian-polygon",
+                "type": "fill",
+                "filter": ["==", ["get", "class"], "pedestrian"],
+                "paint": {"fill-color": "#f6f2e8"},
+            },
+            {
+                "id": "road-label",
+                "type": "symbol",
+                "paint": {"text-color": "#333333"},
+            },
+        ],
+    }
+
+
+class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
+    def test_build_run_directory_and_paths_are_predictable(self):
+        run_dir = build_run_directory(
+            output_root=Path("/tmp/path-focus"),
+            now=dt.datetime(2026, 5, 20, 1, 32, tzinfo=dt.timezone.utc),
+        )
+        paths = build_path_pedestrian_focus_paths(run_dir)
+
+        self.assertEqual(run_dir, Path("/tmp/path-focus/20260520T013200Z"))
+        self.assertEqual(paths.json_path, run_dir / "path-pedestrian-focus.json")
+        self.assertEqual(paths.summary_path, run_dir / "summary.md")
+
+    def test_load_json_object_requires_object(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_path = Path(tmpdir) / "report.json"
+            json_path.write_text('{"ok": true}\n', encoding="utf-8")
+            self.assertEqual(load_json_object(json_path), {"ok": True})
+
+            json_path.write_text('["not", "object"]\n', encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_json_object(json_path)
+
+    def test_qgis_path_pedestrian_style_summary_counts_current_style_controls(self):
+        summary = qgis_path_pedestrian_style_summary(_qgis_preprocessed_style())
+
+        self.assertEqual(summary["qgis_style_status"], "available")
+        self.assertEqual(summary["qgis_path_pedestrian_layer_count"], 4)
+        self.assertEqual(summary["qgis_path_pedestrian_line_layer_count"], 3)
+        self.assertEqual(summary["qgis_path_pedestrian_fill_layer_count"], 1)
+        self.assertEqual(summary["qgis_path_pedestrian_filter_layer_count"], 2)
+        self.assertEqual(summary["qgis_path_pedestrian_line_width_layer_count"], 2)
+        self.assertEqual(summary["qgis_path_pedestrian_line_dasharray_layer_count"], 2)
+        self.assertEqual(summary["qgis_path_pedestrian_line_opacity_layer_count"], 1)
+        self.assertEqual(
+            summary["qgis_path_pedestrian_layer_ids"],
+            ["road-path", "road-pedestrian", "road-steps", "road-pedestrian-polygon"],
+        )
+        self.assertIn("road-path=1.5", summary["qgis_path_pedestrian_line_width_samples"])
+
+    def test_build_path_pedestrian_focus_report_cross_links_feature_counts_and_qgis_style(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        self.assertEqual(report["generated"], "2026-05-20T01:35:00+00:00")
+        self.assertEqual(report["camera_count"], 1)
+        self.assertEqual(report["qgis_style_camera_count"], 1)
+        [camera] = report["cameras"]
+        self.assertEqual(camera["camera"], "chamonix-trails-z14-outdoors")
+        self.assertEqual(camera["pedestrian_path_polygon_count"], 10)
+        self.assertEqual(camera["pedestrian_line_count"], 115)
+        self.assertEqual(camera["path_line_count"], 236)
+        self.assertEqual(camera["step_line_count"], 19)
+        self.assertEqual(camera["top_path_line_types"], ["trail=69", "footway=56", "piste=48"])
+        self.assertEqual(camera["top_step_structures"], ["none=16", "tunnel=2", "bridge=1"])
+        self.assertEqual(camera["qgis_path_pedestrian_layer_count"], 4)
+
+    def test_build_path_pedestrian_focus_report_marks_missing_qgis_style(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        self.assertEqual(camera["qgis_style_status"], "missing")
+        self.assertEqual(camera["qgis_path_pedestrian_layer_count"], 0)
+
+    def test_build_summary_markdown_includes_feature_and_style_matrix(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        markdown = build_summary_markdown(report)
+
+        self.assertIn("# Mapbox Outdoors path/pedestrian focus", markdown)
+        self.assertIn("Focused cameras: 1", markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | 14.25 | 14 |", markdown)
+        self.assertIn('"path_lines=236"', markdown)
+        self.assertIn('"trail=69"', markdown)
+        self.assertIn('"status=available"', markdown)
+        self.assertIn('"total=4"', markdown)
+        self.assertIn('"road-pedestrian-polygon"', markdown)
+
+    def test_build_summary_markdown_handles_no_focus_rows(self):
+        markdown = build_summary_markdown({"generated": "now", "cameras": []})
+
+        self.assertIn("No decoded cameras include path/pedestrian focus features.", markdown)
+
+    def test_write_report_writes_json_and_markdown(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = build_path_pedestrian_focus_paths(Path(tmpdir) / "run")
+
+            write_report(report, paths)
+
+            self.assertEqual(json.loads(paths.json_path.read_text(encoding="utf-8"))["camera_count"], 1)
+            self.assertIn(
+                "# Mapbox Outdoors path/pedestrian focus",
+                paths.summary_path.read_text(encoding="utf-8"),
+            )
+
+    def test_main_writes_report_from_json_inputs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            road_features_path = Path(tmpdir) / "road-features.json"
+            style_path = Path(tmpdir) / "qgis-preprocessed-style.json"
+            output_root = Path(tmpdir) / "out"
+            road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
+            style_path.write_text(json.dumps(_qgis_preprocessed_style()), encoding="utf-8")
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                result = main(
+                    [
+                        "--road-features-json",
+                        str(road_features_path),
+                        "--qgis-style-json",
+                        f"chamonix-trails-z14-outdoors={style_path}",
+                        "--output-root",
+                        str(output_root),
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            summary_path = Path(stdout.getvalue().strip())
+            self.assertTrue(summary_path.exists())
+            self.assertEqual(summary_path.parent.parent, output_root)
+            report_path = summary_path.parent / "path-pedestrian-focus.json"
+            self.assertEqual(json.loads(report_path.read_text(encoding="utf-8"))["camera_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -3,8 +3,9 @@ import io
 import json
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 from tests import _path  # noqa: F401
 
@@ -141,6 +142,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(report["generated"], "2026-05-20T01:35:00+00:00")
         self.assertEqual(report["camera_count"], 1)
         self.assertEqual(report["qgis_style_camera_count"], 1)
+        self.assertEqual(report["qgis_style_input_count"], 1)
         [camera] = report["cameras"]
         self.assertEqual(camera["camera"], "chamonix-trails-z14-outdoors")
         self.assertEqual(camera["pedestrian_path_polygon_count"], 10)
@@ -161,6 +163,25 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(camera["qgis_style_status"], "missing")
         self.assertEqual(camera["qgis_path_pedestrian_layer_count"], 0)
 
+    def test_build_path_pedestrian_focus_report_ignores_boolean_counts(self):
+        road_report = {
+            "generated": "2026-05-20T01:09:13+00:00",
+            "cameras": [
+                {
+                    "status": "decoded",
+                    "camera": "bad-counts",
+                    "pedestrian_polygon_candidate_count": True,
+                    "pedestrian_line_candidate_count": False,
+                    "path_line_candidate_count": False,
+                    "step_line_candidate_count": False,
+                }
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(road_report)
+
+        self.assertEqual(report["camera_count"], 0)
+
     def test_build_summary_markdown_includes_feature_and_style_matrix(self):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),
@@ -172,6 +193,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
 
         self.assertIn("# Mapbox Outdoors path/pedestrian focus", markdown)
         self.assertIn("Focused cameras: 1", markdown)
+        self.assertIn("QGIS preprocessed style cameras: 1/1 matched", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | 14.25 | 14 |", markdown)
         self.assertIn('"path_lines=236"', markdown)
         self.assertIn('"trail=69"', markdown)
@@ -193,13 +215,25 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = build_path_pedestrian_focus_paths(Path(tmpdir) / "run")
 
-            write_report(report, paths)
+            write_report(report, paths, trusted_output_root=Path(tmpdir))
 
             self.assertEqual(json.loads(paths.json_path.read_text(encoding="utf-8"))["camera_count"], 1)
             self.assertIn(
                 "# Mapbox Outdoors path/pedestrian focus",
                 paths.summary_path.read_text(encoding="utf-8"),
             )
+
+    def test_write_report_rejects_paths_outside_trusted_root(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trusted_root = Path(tmpdir) / "trusted"
+            paths = build_path_pedestrian_focus_paths(Path(tmpdir) / "outside" / "run")
+
+            with self.assertRaises(ValueError):
+                write_report(report, paths, trusted_output_root=trusted_root)
 
     def test_main_writes_report_from_json_inputs(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -210,15 +244,16 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             style_path.write_text(json.dumps(_qgis_preprocessed_style()), encoding="utf-8")
 
             stdout = io.StringIO()
-            with redirect_stdout(stdout):
+            with patch(
+                "qfit.validation.mapbox_outdoors_path_pedestrian_focus.DEFAULT_OUTPUT_ROOT",
+                output_root,
+            ), redirect_stdout(stdout):
                 result = main(
                     [
                         "--road-features-json",
                         str(road_features_path),
                         "--qgis-style-json",
                         f"chamonix-trails-z14-outdoors={style_path}",
-                        "--output-root",
-                        str(output_root),
                     ]
                 )
 
@@ -228,6 +263,16 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             self.assertEqual(summary_path.parent.parent, output_root)
             report_path = summary_path.parent / "path-pedestrian-focus.json"
             self.assertEqual(json.loads(report_path.read_text(encoding="utf-8"))["camera_count"], 1)
+
+    def test_main_reports_missing_input_without_traceback(self):
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+            main(["--road-features-json", "/missing/road-features.json"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("Road features JSON not found", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PARENT = REPO_ROOT.parent
+package_parent = str(PACKAGE_PARENT)
+if package_parent not in sys.path:
+    sys.path.insert(0, package_parent)
+
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-path-pedestrian-focus"
+DEFAULT_ROAD_FEATURES_PATH = (
+    REPO_ROOT
+    / "debug"
+    / "mapbox-outdoors-road-features"
+    / "all-cameras"
+    / "latest"
+    / "road-features.json"
+)
+PATH_PEDESTRIAN_LAYER_ID_MARKERS = (
+    "road-path",
+    "road-pedestrian",
+    "road-steps",
+)
+PATH_PEDESTRIAN_STYLE_TYPES = {"fill", "line"}
+TOP_COUNT_LIMIT = 3
+SAMPLE_LAYER_LIMIT = 8
+
+
+@dataclass(frozen=True)
+class PathPedestrianFocusPaths:
+    run_dir: Path
+    json_path: Path
+    summary_path: Path
+
+
+def _utc_timestamp(now: dt.datetime | None = None) -> str:
+    timestamp = now or dt.datetime.now(dt.timezone.utc)
+    return timestamp.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def build_run_directory(
+    *,
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    now: dt.datetime | None = None,
+) -> Path:
+    return output_root / _utc_timestamp(now)
+
+
+def build_path_pedestrian_focus_paths(run_dir: Path) -> PathPedestrianFocusPaths:
+    return PathPedestrianFocusPaths(
+        run_dir=run_dir,
+        json_path=run_dir / "path-pedestrian-focus.json",
+        summary_path=run_dir / "summary.md",
+    )
+
+
+def load_json_object(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return loaded
+
+
+def _compact_json(value: object, *, max_length: int = 110) -> str:
+    try:
+        text = json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    except TypeError:
+        text = str(value)
+    if len(text) <= max_length:
+        return text
+    return f"{text[: max_length - 3]}..."
+
+
+def _count_value(counts: object, key: str) -> int:
+    if not isinstance(counts, Mapping):
+        return 0
+    value = counts.get(key)
+    return value if isinstance(value, int) else 0
+
+
+def _top_count_labels(counts: object, *, limit: int = TOP_COUNT_LIMIT) -> list[str]:
+    if not isinstance(counts, Mapping):
+        return []
+    rows = [
+        (str(key), value)
+        for key, value in counts.items()
+        if isinstance(value, int) and not isinstance(value, bool)
+    ]
+    rows.sort(key=lambda item: (-item[1], item[0]))
+    return [f"{key}={value}" for key, value in rows[:limit]]
+
+
+def _has_path_pedestrian_focus(camera_report: Mapping[str, object]) -> bool:
+    return any(
+        _count_value(camera_report, key) > 0
+        for key in (
+            "pedestrian_polygon_candidate_count",
+            "pedestrian_line_candidate_count",
+            "path_line_candidate_count",
+            "step_line_candidate_count",
+        )
+    )
+
+
+def _style_layers(style: Mapping[str, object]) -> list[dict[str, object]]:
+    layers = style.get("layers")
+    if not isinstance(layers, list):
+        return []
+    return [layer for layer in layers if isinstance(layer, dict)]
+
+
+def _is_path_pedestrian_style_layer(layer: Mapping[str, object]) -> bool:
+    layer_id = str(layer.get("id") or "")
+    layer_type = layer.get("type")
+    return (
+        isinstance(layer_type, str)
+        and layer_type in PATH_PEDESTRIAN_STYLE_TYPES
+        and any(marker in layer_id for marker in PATH_PEDESTRIAN_LAYER_ID_MARKERS)
+    )
+
+
+def _layer_paint(layer: Mapping[str, object]) -> Mapping[str, object]:
+    paint = layer.get("paint")
+    return paint if isinstance(paint, Mapping) else {}
+
+
+def _layer_control_sample(layers: Iterable[Mapping[str, object]], property_name: str) -> list[str]:
+    samples: list[str] = []
+    for layer in layers:
+        paint = _layer_paint(layer)
+        if property_name not in paint:
+            continue
+        layer_id = str(layer.get("id") or "")
+        samples.append(f"{layer_id}={_compact_json(paint.get(property_name))}")
+        if len(samples) >= SAMPLE_LAYER_LIMIT:
+            break
+    return samples
+
+
+def qgis_path_pedestrian_style_summary(style: Mapping[str, object]) -> dict[str, object]:
+    layers = [layer for layer in _style_layers(style) if _is_path_pedestrian_style_layer(layer)]
+    line_layers = [layer for layer in layers if layer.get("type") == "line"]
+    fill_layers = [layer for layer in layers if layer.get("type") == "fill"]
+    return {
+        "qgis_style_status": "available",
+        "qgis_path_pedestrian_layer_count": len(layers),
+        "qgis_path_pedestrian_line_layer_count": len(line_layers),
+        "qgis_path_pedestrian_fill_layer_count": len(fill_layers),
+        "qgis_path_pedestrian_filter_layer_count": sum(1 for layer in layers if layer.get("filter") is not None),
+        "qgis_path_pedestrian_line_width_layer_count": sum(
+            1 for layer in line_layers if "line-width" in _layer_paint(layer)
+        ),
+        "qgis_path_pedestrian_line_dasharray_layer_count": sum(
+            1 for layer in line_layers if "line-dasharray" in _layer_paint(layer)
+        ),
+        "qgis_path_pedestrian_line_opacity_layer_count": sum(
+            1 for layer in line_layers if "line-opacity" in _layer_paint(layer)
+        ),
+        "qgis_path_pedestrian_layer_ids": [str(layer.get("id") or "") for layer in layers[:SAMPLE_LAYER_LIMIT]],
+        "qgis_path_pedestrian_line_width_samples": _layer_control_sample(line_layers, "line-width"),
+        "qgis_path_pedestrian_line_dasharray_samples": _layer_control_sample(line_layers, "line-dasharray"),
+    }
+
+
+def _missing_qgis_style_summary() -> dict[str, object]:
+    return {
+        "qgis_style_status": "missing",
+        "qgis_path_pedestrian_layer_count": 0,
+        "qgis_path_pedestrian_line_layer_count": 0,
+        "qgis_path_pedestrian_fill_layer_count": 0,
+        "qgis_path_pedestrian_filter_layer_count": 0,
+        "qgis_path_pedestrian_line_width_layer_count": 0,
+        "qgis_path_pedestrian_line_dasharray_layer_count": 0,
+        "qgis_path_pedestrian_line_opacity_layer_count": 0,
+        "qgis_path_pedestrian_layer_ids": [],
+        "qgis_path_pedestrian_line_width_samples": [],
+        "qgis_path_pedestrian_line_dasharray_samples": [],
+    }
+
+
+def _camera_focus_row(
+    camera_report: Mapping[str, object],
+    *,
+    qgis_style: Mapping[str, object] | None,
+) -> dict[str, object]:
+    row = {
+        "camera": camera_report.get("camera"),
+        "status": camera_report.get("status"),
+        "camera_zoom": camera_report.get("camera_zoom"),
+        "tile_zoom": camera_report.get("tile_zoom"),
+        "pedestrian_path_polygon_count": camera_report.get("pedestrian_polygon_candidate_count", 0),
+        "pedestrian_line_count": camera_report.get("pedestrian_line_candidate_count", 0),
+        "path_line_count": camera_report.get("path_line_candidate_count", 0),
+        "step_line_count": camera_report.get("step_line_candidate_count", 0),
+        "top_pedestrian_line_types": _top_count_labels(camera_report.get("pedestrian_line_type_counts")),
+        "top_path_line_types": _top_count_labels(camera_report.get("path_line_type_counts")),
+        "top_step_structures": _top_count_labels(camera_report.get("step_line_structure_counts")),
+        "top_path_signatures": _top_count_labels(camera_report.get("path_line_signature_counts")),
+        "top_step_signatures": _top_count_labels(camera_report.get("step_line_signature_counts")),
+    }
+    row.update(qgis_path_pedestrian_style_summary(qgis_style) if qgis_style is not None else _missing_qgis_style_summary())
+    return row
+
+
+def build_path_pedestrian_focus_report(
+    road_feature_report: Mapping[str, object],
+    *,
+    qgis_styles_by_camera: Mapping[str, Mapping[str, object]] | None = None,
+    generated_at: dt.datetime | None = None,
+) -> dict[str, object]:
+    qgis_styles = qgis_styles_by_camera or {}
+    camera_reports = road_feature_report.get("cameras")
+    source_rows = camera_reports if isinstance(camera_reports, list) else []
+    rows = []
+    for camera_report in source_rows:
+        if not isinstance(camera_report, Mapping):
+            continue
+        if camera_report.get("status") != "decoded" or not _has_path_pedestrian_focus(camera_report):
+            continue
+        camera_name = str(camera_report.get("camera") or "")
+        rows.append(
+            _camera_focus_row(
+                camera_report,
+                qgis_style=qgis_styles.get(camera_name),
+            )
+        )
+    generated = generated_at or dt.datetime.now(dt.timezone.utc)
+    return {
+        "generated": generated.astimezone(dt.timezone.utc).isoformat(),
+        "road_feature_generated": road_feature_report.get("generated"),
+        "style_owner": road_feature_report.get("style_owner"),
+        "style_id": road_feature_report.get("style_id"),
+        "camera_count": len(rows),
+        "qgis_style_camera_count": len(qgis_styles),
+        "cameras": rows,
+    }
+
+
+def _markdown_cell(value: object) -> str:
+    if value is None or value == "":
+        text = "-"
+    elif isinstance(value, list):
+        text = _compact_json(value)
+    else:
+        text = str(value)
+    return text.replace("\n", " ").replace("|", "\\|")
+
+
+def _markdown_table_row(cells: Iterable[object]) -> str:
+    return "| " + " | ".join(_markdown_cell(cell) for cell in cells) + " |"
+
+
+def _qgis_control_summary(camera: Mapping[str, object]) -> list[str]:
+    return [
+        f"filters={camera.get('qgis_path_pedestrian_filter_layer_count', 0)}",
+        f"widths={camera.get('qgis_path_pedestrian_line_width_layer_count', 0)}",
+        f"dashes={camera.get('qgis_path_pedestrian_line_dasharray_layer_count', 0)}",
+        f"opacities={camera.get('qgis_path_pedestrian_line_opacity_layer_count', 0)}",
+    ]
+
+
+def build_summary_markdown(report: Mapping[str, object]) -> str:
+    cameras = report.get("cameras")
+    rows = cameras if isinstance(cameras, list) else []
+    lines = [
+        "# Mapbox Outdoors path/pedestrian focus",
+        "",
+        f"Generated: {report.get('generated')}",
+        f"Road feature generated: {report.get('road_feature_generated')}",
+        f"Style: {report.get('style_owner')}/{report.get('style_id')}",
+        f"Focused cameras: {report.get('camera_count')}",
+        f"QGIS preprocessed style cameras: {report.get('qgis_style_camera_count')}",
+        "",
+        (
+            "Cross-links decoded road-feature counts with the camera-specific QGIS-preprocessed "
+            "style layers that can render path, pedestrian, trail, piste, or step features."
+        ),
+        "",
+    ]
+    if not rows:
+        lines.append("No decoded cameras include path/pedestrian focus features.")
+        return "\n".join(lines) + "\n"
+    lines.extend(
+        [
+            "| Camera | Camera zoom | Tile zoom | Feature counts | Top path types | Top path signatures | Top step signatures | QGIS layers | QGIS controls | Sample QGIS layer ids |",
+            "| --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for camera in rows:
+        if not isinstance(camera, Mapping):
+            continue
+        feature_counts = [
+            f"polygons={camera.get('pedestrian_path_polygon_count', 0)}",
+            f"pedestrian_lines={camera.get('pedestrian_line_count', 0)}",
+            f"path_lines={camera.get('path_line_count', 0)}",
+            f"steps={camera.get('step_line_count', 0)}",
+        ]
+        qgis_layers = [
+            f"status={camera.get('qgis_style_status')}",
+            f"total={camera.get('qgis_path_pedestrian_layer_count', 0)}",
+            f"line={camera.get('qgis_path_pedestrian_line_layer_count', 0)}",
+            f"fill={camera.get('qgis_path_pedestrian_fill_layer_count', 0)}",
+        ]
+        lines.append(
+            _markdown_table_row(
+                [
+                    camera.get("camera"),
+                    camera.get("camera_zoom"),
+                    camera.get("tile_zoom"),
+                    feature_counts,
+                    camera.get("top_path_line_types"),
+                    camera.get("top_path_signatures"),
+                    camera.get("top_step_signatures"),
+                    qgis_layers,
+                    _qgis_control_summary(camera),
+                    camera.get("qgis_path_pedestrian_layer_ids"),
+                ]
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_report(report: Mapping[str, object], paths: PathPedestrianFocusPaths) -> None:
+    paths.run_dir.mkdir(parents=True, exist_ok=True)
+    with paths.json_path.open("w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    with paths.summary_path.open("w", encoding="utf-8") as handle:
+        handle.write(build_summary_markdown(report))
+
+
+def _parse_qgis_style_json(value: str) -> tuple[str, Path]:
+    camera, separator, path = value.partition("=")
+    if not separator or not camera or not path:
+        raise argparse.ArgumentTypeError("Expected CAMERA=PATH")
+    return camera, Path(path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build an offline Mapbox Outdoors path/pedestrian focus report from road-feature "
+            "diagnostics and camera-specific QGIS-preprocessed styles."
+        )
+    )
+    parser.add_argument(
+        "--road-features-json",
+        type=Path,
+        default=DEFAULT_ROAD_FEATURES_PATH,
+        help="Path to all-camera road-features.json.",
+    )
+    parser.add_argument(
+        "--qgis-style-json",
+        action="append",
+        default=[],
+        type=_parse_qgis_style_json,
+        metavar="CAMERA=PATH",
+        help="Camera-specific qgis-preprocessed-style.json. May be repeated.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT,
+        help="Root directory for timestamped report output.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    road_feature_report = load_json_object(args.road_features_json)
+    qgis_styles_by_camera = {
+        camera: load_json_object(path)
+        for camera, path in args.qgis_style_json
+    }
+    report = build_path_pedestrian_focus_report(
+        road_feature_report,
+        qgis_styles_by_camera=qgis_styles_by_camera,
+    )
+    paths = build_path_pedestrian_focus_paths(build_run_directory(output_root=args.output_root))
+    write_report(report, paths)
+    print(paths.summary_path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised manually
+    raise SystemExit(main())

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -47,10 +47,11 @@ def _utc_timestamp(now: dt.datetime | None = None) -> str:
 
 def build_run_directory(
     *,
-    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    output_root: Path | None = None,
     now: dt.datetime | None = None,
 ) -> Path:
-    return output_root / _utc_timestamp(now)
+    root = DEFAULT_OUTPUT_ROOT if output_root is None else output_root
+    return root / _utc_timestamp(now)
 
 
 def build_path_pedestrian_focus_paths(run_dir: Path) -> PathPedestrianFocusPaths:
@@ -83,7 +84,7 @@ def _count_value(counts: object, key: str) -> int:
     if not isinstance(counts, Mapping):
         return 0
     value = counts.get(key)
-    return value if isinstance(value, int) else 0
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
 def _top_count_labels(counts: object, *, limit: int = TOP_COUNT_LIMIT) -> list[str]:
@@ -233,13 +234,15 @@ def build_path_pedestrian_focus_report(
             )
         )
     generated = generated_at or dt.datetime.now(dt.timezone.utc)
+    qgis_matched_camera_count = sum(1 for row in rows if row.get("qgis_style_status") == "available")
     return {
         "generated": generated.astimezone(dt.timezone.utc).isoformat(),
         "road_feature_generated": road_feature_report.get("generated"),
         "style_owner": road_feature_report.get("style_owner"),
         "style_id": road_feature_report.get("style_id"),
         "camera_count": len(rows),
-        "qgis_style_camera_count": len(qgis_styles),
+        "qgis_style_camera_count": qgis_matched_camera_count,
+        "qgis_style_input_count": len(qgis_styles),
         "cameras": rows,
     }
 
@@ -277,7 +280,10 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         f"Road feature generated: {report.get('road_feature_generated')}",
         f"Style: {report.get('style_owner')}/{report.get('style_id')}",
         f"Focused cameras: {report.get('camera_count')}",
-        f"QGIS preprocessed style cameras: {report.get('qgis_style_camera_count')}",
+        (
+            "QGIS preprocessed style cameras: "
+            f"{report.get('qgis_style_camera_count')}/{report.get('qgis_style_input_count', 0)} matched"
+        ),
         "",
         (
             "Cross-links decoded road-feature counts with the camera-specific QGIS-preprocessed "
@@ -328,12 +334,27 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def write_report(report: Mapping[str, object], paths: PathPedestrianFocusPaths) -> None:
-    paths.run_dir.mkdir(parents=True, exist_ok=True)
-    with paths.json_path.open("w", encoding="utf-8") as handle:
-        json.dump(report, handle, indent=2, sort_keys=True)
+def _assert_report_output_paths(paths: PathPedestrianFocusPaths, *, trusted_output_root: Path) -> None:
+    root = trusted_output_root.resolve()
+    for output_path in (paths.json_path, paths.summary_path):
+        if not output_path.parent.resolve().is_relative_to(root):
+            raise ValueError(f"Path/pedestrian focus output must stay under {trusted_output_root}")
+
+
+def write_report(
+    report: Mapping[str, object],
+    paths: PathPedestrianFocusPaths,
+    *,
+    trusted_output_root: Path | None = None,
+) -> None:
+    output_root = DEFAULT_OUTPUT_ROOT if trusted_output_root is None else trusted_output_root
+    _assert_report_output_paths(paths, trusted_output_root=output_root)
+    # Safe: report output paths are timestamped beneath the trusted debug report root.
+    paths.run_dir.mkdir(parents=True, exist_ok=True)  # NOSONAR
+    with paths.json_path.open("w", encoding="utf-8") as handle:  # NOSONAR
+        json.dump(report, handle, indent=2, sort_keys=True)  # NOSONAR
         handle.write("\n")
-    with paths.summary_path.open("w", encoding="utf-8") as handle:
+    with paths.summary_path.open("w", encoding="utf-8") as handle:  # NOSONAR
         handle.write(build_summary_markdown(report))
 
 
@@ -365,28 +386,38 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="CAMERA=PATH",
         help="Camera-specific qgis-preprocessed-style.json. May be repeated.",
     )
-    parser.add_argument(
-        "--output-root",
-        type=Path,
-        default=DEFAULT_OUTPUT_ROOT,
-        help="Root directory for timestamped report output.",
-    )
     return parser
+
+
+def _load_cli_json_object(parser: argparse.ArgumentParser, path: Path, *, label: str) -> dict[str, object]:
+    try:
+        return load_json_object(path)
+    except FileNotFoundError:
+        parser.error(f"{label} not found: {path}")
+    except json.JSONDecodeError as error:
+        parser.error(f"{label} is not valid JSON: {path}: {error.msg}")
+    except ValueError as error:
+        parser.error(str(error))
+    raise AssertionError("argparse error should exit")
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    road_feature_report = load_json_object(args.road_features_json)
+    road_feature_report = _load_cli_json_object(
+        parser,
+        args.road_features_json,
+        label="Road features JSON",
+    )
     qgis_styles_by_camera = {
-        camera: load_json_object(path)
+        camera: _load_cli_json_object(parser, path, label=f"QGIS style JSON for {camera}")
         for camera, path in args.qgis_style_json
     }
     report = build_path_pedestrian_focus_report(
         road_feature_report,
         qgis_styles_by_camera=qgis_styles_by_camera,
     )
-    paths = build_path_pedestrian_focus_paths(build_run_directory(output_root=args.output_root))
+    paths = build_path_pedestrian_focus_paths(build_run_directory())
     write_report(report, paths)
     print(paths.summary_path)
     return 0


### PR DESCRIPTION
## Summary

- add an offline path/pedestrian focus report that cross-links all-camera road-feature diagnostics with camera-specific QGIS-preprocessed style layers
- summarize feature counts, top path/step signatures, QGIS layer coverage, and current line controls for path/pedestrian styling slices
- add unit tests for report building, markdown output, JSON loading, writing, and CLI input handling

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q`
- `PYTHONPATH=.. python3 -m qfit.validation.mapbox_outdoors_path_pedestrian_focus --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T010913Z/road-features.json --qgis-style-json chamonix-trails-z14-outdoors=debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260520T003504Z/qgis-preprocessed-style.json --qgis-style-json zermatt-trails-z18-outdoors=debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260520T003511Z/qgis-preprocessed-style.json`
- `python3 -m pytest tests/ -x -q --tb=short`

## Issue

Part of #949.
