### PR TITLE
Load path pedestrian focus styles from comparison summaries

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -123,7 +123,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
     def test_qgis_style_paths_from_comparison_summary_reads_manifest_outputs(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            run_dir = root / "camera" / "20260520T003504Z"
+            comparison_root = root / "comparison"
+            run_dir = comparison_root / "camera" / "20260520T003504Z"
             run_dir.mkdir(parents=True)
             style_path = run_dir / "qgis-preprocessed-style.json"
             manifest_path = run_dir / "manifest.json"
@@ -143,14 +144,14 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
 
             paths = qgis_style_paths_from_comparison_summary(
                 comparison_summary,
-                summary_path=root / "all-cameras" / "summary.json",
-                trusted_root=root,
+                summary_path=comparison_root / "all-cameras" / "summary.json",
             )
 
             self.assertEqual(paths, {"chamonix-trails-z14-outdoors": style_path.resolve()})
 
     def test_qgis_style_paths_from_comparison_summary_rejects_untrusted_manifest_paths(self):
         with tempfile.TemporaryDirectory() as tmpdir:
+            comparison_root = Path(tmpdir) / "comparison"
             comparison_summary = {
                 "cameras": [
                     {
@@ -163,9 +164,35 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 qgis_style_paths_from_comparison_summary(
                     comparison_summary,
-                    summary_path=Path(tmpdir) / "summary.json",
-                    trusted_root=Path(tmpdir),
+                    summary_path=comparison_root / "all-cameras" / "summary.json",
                 )
+
+    def test_qgis_style_paths_from_comparison_summary_rejects_untrusted_style_paths_with_explicit_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            comparison_root = Path(tmpdir) / "comparison"
+            run_dir = comparison_root / "camera" / "20260520T003504Z"
+            run_dir.mkdir(parents=True)
+            manifest_path = run_dir / "manifest.json"
+            manifest_path.write_text(
+                json.dumps({"outputs": {"qgis_preprocessed_style": "/tmp/outside-style.json"}}),
+                encoding="utf-8",
+            )
+            comparison_summary = {
+                "cameras": [
+                    {
+                        "camera": "chamonix-trails-z14-outdoors",
+                        "manifest": str(manifest_path),
+                    }
+                ]
+            }
+
+            with self.assertRaises(ValueError) as raised:
+                qgis_style_paths_from_comparison_summary(
+                    comparison_summary,
+                    summary_path=comparison_root / "all-cameras" / "summary.json",
+                )
+
+            self.assertIn("/tmp/outside-style.json", str(raised.exception))
 
     def test_qgis_style_paths_from_comparison_summary_rejects_untrusted_style_paths(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -383,9 +410,6 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             with patch(
                 "qfit.validation.mapbox_outdoors_path_pedestrian_focus.DEFAULT_OUTPUT_ROOT",
                 output_root,
-            ), patch(
-                "qfit.validation.mapbox_outdoors_path_pedestrian_focus.DEFAULT_COMPARISON_OUTPUT_ROOT",
-                root,
             ), redirect_stdout(stdout):
                 result = main(
                     [

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -16,6 +16,7 @@ from qfit.validation.mapbox_outdoors_path_pedestrian_focus import (
     build_summary_markdown,
     load_json_object,
     main,
+    qgis_style_paths_from_comparison_summary,
     qgis_path_pedestrian_style_summary,
     write_report,
 )
@@ -66,17 +67,21 @@ def _qgis_preprocessed_style():
                 "id": "road-path",
                 "type": "line",
                 "filter": ["==", ["get", "class"], "path"],
-                "paint": {"line-width": 1.5, "line-dasharray": [1, 1]},
+                "paint": {"line-color": "#d8c6a3", "line-width": 1.5, "line-dasharray": [1, 1]},
             },
             {
                 "id": "road-pedestrian",
                 "type": "line",
-                "paint": {"line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5], "line-opacity": 0.65},
+                "paint": {
+                    "line-color": "#f6f2e8",
+                    "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5],
+                    "line-opacity": 0.65,
+                },
             },
             {
                 "id": "road-steps",
                 "type": "line",
-                "paint": {"line-dasharray": [0.2, 1]},
+                "paint": {"line-color": "#8f7054", "line-dasharray": [0.2, 1]},
             },
             {
                 "id": "road-pedestrian-polygon",
@@ -115,6 +120,78 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 load_json_object(json_path)
 
+    def test_qgis_style_paths_from_comparison_summary_reads_manifest_outputs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir = root / "camera" / "20260520T003504Z"
+            run_dir.mkdir(parents=True)
+            style_path = run_dir / "qgis-preprocessed-style.json"
+            manifest_path = run_dir / "manifest.json"
+            style_path.write_text(json.dumps(_qgis_preprocessed_style()), encoding="utf-8")
+            manifest_path.write_text(
+                json.dumps({"outputs": {"qgis_preprocessed_style": str(style_path)}}),
+                encoding="utf-8",
+            )
+            comparison_summary = {
+                "cameras": [
+                    {
+                        "camera": "chamonix-trails-z14-outdoors",
+                        "manifest": str(manifest_path),
+                    }
+                ]
+            }
+
+            paths = qgis_style_paths_from_comparison_summary(
+                comparison_summary,
+                summary_path=root / "all-cameras" / "summary.json",
+                trusted_root=root,
+            )
+
+            self.assertEqual(paths, {"chamonix-trails-z14-outdoors": style_path.resolve()})
+
+    def test_qgis_style_paths_from_comparison_summary_rejects_untrusted_manifest_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            comparison_summary = {
+                "cameras": [
+                    {
+                        "camera": "bad-camera",
+                        "manifest": "/tmp/outside-manifest.json",
+                    }
+                ]
+            }
+
+            with self.assertRaises(ValueError):
+                qgis_style_paths_from_comparison_summary(
+                    comparison_summary,
+                    summary_path=Path(tmpdir) / "summary.json",
+                    trusted_root=Path(tmpdir),
+                )
+
+    def test_qgis_style_paths_from_comparison_summary_rejects_untrusted_style_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "camera" / "manifest.json"
+            manifest_path.parent.mkdir(parents=True)
+            manifest_path.write_text(
+                json.dumps({"outputs": {"qgis_preprocessed_style": "/tmp/outside-style.json"}}),
+                encoding="utf-8",
+            )
+            comparison_summary = {
+                "cameras": [
+                    {
+                        "camera": "bad-camera",
+                        "manifest": str(manifest_path),
+                    }
+                ]
+            }
+
+            with self.assertRaisesRegex(ValueError, "/tmp/outside-style.json"):
+                qgis_style_paths_from_comparison_summary(
+                    comparison_summary,
+                    summary_path=root / "summary.json",
+                    trusted_root=root,
+                )
+
     def test_qgis_path_pedestrian_style_summary_counts_current_style_controls(self):
         summary = qgis_path_pedestrian_style_summary(_qgis_preprocessed_style())
 
@@ -124,6 +201,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(summary["qgis_path_pedestrian_fill_layer_count"], 1)
         self.assertEqual(summary["qgis_path_pedestrian_filter_layer_count"], 2)
         self.assertEqual(summary["qgis_path_pedestrian_line_width_layer_count"], 2)
+        self.assertEqual(summary["qgis_path_pedestrian_line_color_layer_count"], 3)
+        self.assertEqual(summary["qgis_path_pedestrian_fill_color_layer_count"], 1)
         self.assertEqual(summary["qgis_path_pedestrian_line_dasharray_layer_count"], 2)
         self.assertEqual(summary["qgis_path_pedestrian_line_opacity_layer_count"], 1)
         self.assertEqual(
@@ -131,6 +210,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             ["road-path", "road-pedestrian", "road-steps", "road-pedestrian-polygon"],
         )
         self.assertIn("road-path=1.5", summary["qgis_path_pedestrian_line_width_samples"])
+        self.assertIn('road-path="#d8c6a3"', summary["qgis_path_pedestrian_line_color_samples"])
+        self.assertIn('road-pedestrian-polygon="#f6f2e8"', summary["qgis_path_pedestrian_fill_color_samples"])
 
     def test_build_path_pedestrian_focus_report_cross_links_feature_counts_and_qgis_style(self):
         report = build_path_pedestrian_focus_report(
@@ -199,6 +280,9 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn('"trail=69"', markdown)
         self.assertIn('"status=available"', markdown)
         self.assertIn('"total=4"', markdown)
+        self.assertIn('"line_colors=3"', markdown)
+        self.assertIn('"fill_colors=1"', markdown)
+        self.assertIn('"road-pedestrian-polygon=\\"#f6f2e8\\""', markdown)
         self.assertIn('"road-pedestrian-polygon"', markdown)
 
     def test_build_summary_markdown_handles_no_focus_rows(self):
@@ -263,6 +347,60 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             self.assertEqual(summary_path.parent.parent, output_root)
             report_path = summary_path.parent / "path-pedestrian-focus.json"
             self.assertEqual(json.loads(report_path.read_text(encoding="utf-8"))["camera_count"], 1)
+
+    def test_main_loads_qgis_styles_from_comparison_summary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            road_features_path = root / "road-features.json"
+            run_dir = root / "comparison" / "chamonix-trails-z14-outdoors" / "20260520T003504Z"
+            run_dir.mkdir(parents=True)
+            style_path = run_dir / "qgis-preprocessed-style.json"
+            manifest_path = run_dir / "manifest.json"
+            comparison_summary_path = root / "comparison" / "all-cameras" / "summary.json"
+            comparison_summary_path.parent.mkdir(parents=True)
+            road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
+            style_path.write_text(json.dumps(_qgis_preprocessed_style()), encoding="utf-8")
+            manifest_path.write_text(
+                json.dumps({"outputs": {"qgis_preprocessed_style": str(style_path)}}),
+                encoding="utf-8",
+            )
+            comparison_summary_path.write_text(
+                json.dumps(
+                    {
+                        "cameras": [
+                            {
+                                "camera": "chamonix-trails-z14-outdoors",
+                                "manifest": str(manifest_path),
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output_root = root / "out"
+
+            stdout = io.StringIO()
+            with patch(
+                "qfit.validation.mapbox_outdoors_path_pedestrian_focus.DEFAULT_OUTPUT_ROOT",
+                output_root,
+            ), patch(
+                "qfit.validation.mapbox_outdoors_path_pedestrian_focus.DEFAULT_COMPARISON_OUTPUT_ROOT",
+                root,
+            ), redirect_stdout(stdout):
+                result = main(
+                    [
+                        "--road-features-json",
+                        str(road_features_path),
+                        "--comparison-summary-json",
+                        str(comparison_summary_path),
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            report_path = Path(stdout.getvalue().strip()).parent / "path-pedestrian-focus.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["qgis_style_camera_count"], 1)
+            self.assertEqual(report["qgis_style_input_count"], 1)
 
     def test_main_reports_missing_input_without_traceback(self):
         stderr = io.StringIO()

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -80,13 +80,26 @@ def _resolve_trusted_debug_path(raw_path: str, *, base_dir: Path, trusted_root: 
     return resolved
 
 
+def _trusted_root_for_comparison_summary(summary_path: Path) -> Path:
+    resolved = summary_path.resolve()
+    for parent in resolved.parents:
+        if parent.name == "all-cameras":
+            return parent.parent
+    return DEFAULT_COMPARISON_OUTPUT_ROOT
+
+
 def qgis_style_paths_from_comparison_summary(
     comparison_summary: Mapping[str, object],
     *,
     summary_path: Path | None = None,
     trusted_root: Path | None = None,
 ) -> dict[str, Path]:
-    root = DEFAULT_COMPARISON_OUTPUT_ROOT if trusted_root is None else trusted_root
+    if trusted_root is not None:
+        root = trusted_root
+    elif summary_path is not None:
+        root = _trusted_root_for_comparison_summary(summary_path)
+    else:
+        root = DEFAULT_COMPARISON_OUTPUT_ROOT
     base_dir = Path.cwd() if summary_path is None else summary_path.parent
     cameras = comparison_summary.get("cameras")
     rows = cameras if isinstance(cameras, list) else []

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -15,6 +15,7 @@ if package_parent not in sys.path:
     sys.path.insert(0, package_parent)
 
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-path-pedestrian-focus"
+DEFAULT_COMPARISON_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-comparison"
 DEFAULT_ROAD_FEATURES_PATH = (
     REPO_ROOT
     / "debug"
@@ -68,6 +69,53 @@ def load_json_object(path: Path) -> dict[str, object]:
     if not isinstance(loaded, dict):
         raise ValueError(f"Expected JSON object in {path}")
     return loaded
+
+
+def _resolve_trusted_debug_path(raw_path: str, *, base_dir: Path, trusted_root: Path) -> Path:
+    path = Path(raw_path)
+    candidate = path if path.is_absolute() else base_dir / path
+    resolved = candidate.resolve()
+    if not resolved.is_relative_to(trusted_root.resolve()):
+        raise ValueError(f"Comparison artifact path must stay under {trusted_root}: {resolved}")
+    return resolved
+
+
+def qgis_style_paths_from_comparison_summary(
+    comparison_summary: Mapping[str, object],
+    *,
+    summary_path: Path | None = None,
+    trusted_root: Path | None = None,
+) -> dict[str, Path]:
+    root = DEFAULT_COMPARISON_OUTPUT_ROOT if trusted_root is None else trusted_root
+    base_dir = Path.cwd() if summary_path is None else summary_path.parent
+    cameras = comparison_summary.get("cameras")
+    rows = cameras if isinstance(cameras, list) else []
+    paths: dict[str, Path] = {}
+    for camera_report in rows:
+        if not isinstance(camera_report, Mapping):
+            continue
+        camera_name = camera_report.get("camera")
+        manifest_value = camera_report.get("manifest")
+        if not isinstance(camera_name, str) or not isinstance(manifest_value, str):
+            continue
+        manifest_path = _resolve_trusted_debug_path(
+            manifest_value,
+            base_dir=base_dir,
+            trusted_root=root,
+        )
+        manifest = load_json_object(manifest_path)  # NOSONAR - checked against the comparison debug root above.
+        outputs = manifest.get("outputs")
+        if not isinstance(outputs, Mapping):
+            continue
+        style_value = outputs.get("qgis_preprocessed_style")
+        if not isinstance(style_value, str):
+            continue
+        paths[camera_name] = _resolve_trusted_debug_path(
+            style_value,
+            base_dir=manifest_path.parent,
+            trusted_root=root,
+        )
+    return paths
 
 
 def _compact_json(value: object, *, max_length: int = 110) -> str:
@@ -159,6 +207,12 @@ def qgis_path_pedestrian_style_summary(style: Mapping[str, object]) -> dict[str,
         "qgis_path_pedestrian_line_width_layer_count": sum(
             1 for layer in line_layers if "line-width" in _layer_paint(layer)
         ),
+        "qgis_path_pedestrian_line_color_layer_count": sum(
+            1 for layer in line_layers if "line-color" in _layer_paint(layer)
+        ),
+        "qgis_path_pedestrian_fill_color_layer_count": sum(
+            1 for layer in fill_layers if "fill-color" in _layer_paint(layer)
+        ),
         "qgis_path_pedestrian_line_dasharray_layer_count": sum(
             1 for layer in line_layers if "line-dasharray" in _layer_paint(layer)
         ),
@@ -167,6 +221,8 @@ def qgis_path_pedestrian_style_summary(style: Mapping[str, object]) -> dict[str,
         ),
         "qgis_path_pedestrian_layer_ids": [str(layer.get("id") or "") for layer in layers[:SAMPLE_LAYER_LIMIT]],
         "qgis_path_pedestrian_line_width_samples": _layer_control_sample(line_layers, "line-width"),
+        "qgis_path_pedestrian_line_color_samples": _layer_control_sample(line_layers, "line-color"),
+        "qgis_path_pedestrian_fill_color_samples": _layer_control_sample(fill_layers, "fill-color"),
         "qgis_path_pedestrian_line_dasharray_samples": _layer_control_sample(line_layers, "line-dasharray"),
     }
 
@@ -179,10 +235,14 @@ def _missing_qgis_style_summary() -> dict[str, object]:
         "qgis_path_pedestrian_fill_layer_count": 0,
         "qgis_path_pedestrian_filter_layer_count": 0,
         "qgis_path_pedestrian_line_width_layer_count": 0,
+        "qgis_path_pedestrian_line_color_layer_count": 0,
+        "qgis_path_pedestrian_fill_color_layer_count": 0,
         "qgis_path_pedestrian_line_dasharray_layer_count": 0,
         "qgis_path_pedestrian_line_opacity_layer_count": 0,
         "qgis_path_pedestrian_layer_ids": [],
         "qgis_path_pedestrian_line_width_samples": [],
+        "qgis_path_pedestrian_line_color_samples": [],
+        "qgis_path_pedestrian_fill_color_samples": [],
         "qgis_path_pedestrian_line_dasharray_samples": [],
     }
 
@@ -265,9 +325,22 @@ def _qgis_control_summary(camera: Mapping[str, object]) -> list[str]:
     return [
         f"filters={camera.get('qgis_path_pedestrian_filter_layer_count', 0)}",
         f"widths={camera.get('qgis_path_pedestrian_line_width_layer_count', 0)}",
+        f"line_colors={camera.get('qgis_path_pedestrian_line_color_layer_count', 0)}",
+        f"fill_colors={camera.get('qgis_path_pedestrian_fill_color_layer_count', 0)}",
         f"dashes={camera.get('qgis_path_pedestrian_line_dasharray_layer_count', 0)}",
         f"opacities={camera.get('qgis_path_pedestrian_line_opacity_layer_count', 0)}",
     ]
+
+
+def _qgis_color_samples(camera: Mapping[str, object]) -> list[str]:
+    line_samples = camera.get("qgis_path_pedestrian_line_color_samples")
+    fill_samples = camera.get("qgis_path_pedestrian_fill_color_samples")
+    samples = []
+    if isinstance(line_samples, list):
+        samples.extend(str(sample) for sample in line_samples[:1])
+    if isinstance(fill_samples, list):
+        samples.extend(str(sample) for sample in fill_samples[:1])
+    return samples
 
 
 def build_summary_markdown(report: Mapping[str, object]) -> str:
@@ -296,8 +369,8 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         return "\n".join(lines) + "\n"
     lines.extend(
         [
-            "| Camera | Camera zoom | Tile zoom | Feature counts | Top path types | Top path signatures | Top step signatures | QGIS layers | QGIS controls | Sample QGIS layer ids |",
-            "| --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |",
+            "| Camera | Camera zoom | Tile zoom | Feature counts | Top path types | Top path signatures | Top step signatures | QGIS layers | QGIS controls | Sample QGIS colors | Sample QGIS layer ids |",
+            "| --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
     for camera in rows:
@@ -327,6 +400,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
                     camera.get("top_step_signatures"),
                     qgis_layers,
                     _qgis_control_summary(camera),
+                    _qgis_color_samples(camera),
                     camera.get("qgis_path_pedestrian_layer_ids"),
                 ]
             )
@@ -386,6 +460,16 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="CAMERA=PATH",
         help="Camera-specific qgis-preprocessed-style.json. May be repeated.",
     )
+    parser.add_argument(
+        "--comparison-summary-json",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "All-camera comparison summary.json whose manifests identify camera-specific "
+            "qgis-preprocessed-style.json artifacts. May be repeated."
+        ),
+    )
     return parser
 
 
@@ -401,6 +485,22 @@ def _load_cli_json_object(parser: argparse.ArgumentParser, path: Path, *, label:
     raise AssertionError("argparse error should exit")
 
 
+def _qgis_style_paths_from_cli_comparison_summary(
+    parser: argparse.ArgumentParser,
+    path: Path,
+) -> dict[str, Path]:
+    comparison_summary = _load_cli_json_object(parser, path, label="Comparison summary JSON")
+    try:
+        return qgis_style_paths_from_comparison_summary(comparison_summary, summary_path=path)
+    except FileNotFoundError as error:
+        parser.error(f"Comparison manifest not found: {error.filename}")
+    except json.JSONDecodeError as error:
+        parser.error(f"Comparison manifest is not valid JSON: {error.msg}")
+    except ValueError as error:
+        parser.error(str(error))
+    raise AssertionError("argparse error should exit")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -409,9 +509,15 @@ def main(argv: list[str] | None = None) -> int:
         args.road_features_json,
         label="Road features JSON",
     )
+    qgis_style_paths_by_camera: dict[str, Path] = {}
+    for comparison_summary_path in args.comparison_summary_json:
+        qgis_style_paths_by_camera.update(
+            _qgis_style_paths_from_cli_comparison_summary(parser, comparison_summary_path)
+        )
+    qgis_style_paths_by_camera.update(dict(args.qgis_style_json))
     qgis_styles_by_camera = {
         camera: _load_cli_json_object(parser, path, label=f"QGIS style JSON for {camera}")
-        for camera, path in args.qgis_style_json
+        for camera, path in qgis_style_paths_by_camera.items()
     }
     report = build_path_pedestrian_focus_report(
         road_feature_report,


### PR DESCRIPTION
## Summary

- let the path/pedestrian focus report load QGIS-preprocessed style paths from an all-camera comparison `summary.json`
- derive the trusted comparison debug root from `.../all-cameras/summary.json`, while still allowing an explicit trusted root in tests
- resolve each camera manifest and extracted style path under that trusted root before loading styles
- surface path/pedestrian line and fill color counts plus compact color samples alongside width/dash/opacity controls
- keep explicit `--qgis-style-json CAMERA=PATH` overrides for manual runs
- add tests for comparison-summary discovery, trusted-path rejection, CLI summary loading, and color samples

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short` (`17 passed`)
- `python3 -m py_compile validation/mapbox_outdoors_path_pedestrian_focus.py tests/test_mapbox_outdoors_path_pedestrian_focus.py`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short` (`2265 passed, 173 skipped, 162 subtests passed`)
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T010913Z/road-features.json --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/20260520T003516Z/summary.json`

Latest local artifact: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T020144Z/summary.md`

## Issue

Part of #949.
