### PR TITLE
[codex] Split Mapbox step line styles by zoom

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2725,16 +2725,18 @@ def _road_steps_line_style_controls(
     line_width: object,
     line_dasharray: object,
     sampled_zoom: float,
-) -> dict[str, object]:
+) -> dict[str, object] | None:
     controls: dict[str, object] = {}
     if isinstance(line_width, list):
         line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
-        if line_width_mm is not None:
-            controls["line-width"] = line_width_mm
+        if line_width_mm is None:
+            return None
+        controls["line-width"] = line_width_mm
     if isinstance(line_dasharray, list):
         dasharray = _extract_line_dasharray_literal(line_dasharray, target_zoom=sampled_zoom)
-        if dasharray is not None:
-            controls["line-dasharray"] = dasharray
+        if dasharray is None:
+            return None
+        controls["line-dasharray"] = dasharray
     return controls
 
 
@@ -2791,7 +2793,7 @@ def _road_steps_line_style_layer_variants(layer: dict[str, object]) -> list[dict
             line_dasharray=line_dasharray,
             sampled_zoom=sampled_zoom,
         )
-        if controls:
+        if controls is not None:
             variants.append(
                 _road_steps_line_style_variant(
                     layer,

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2720,6 +2720,41 @@ def _split_pedestrian_line_width_layers_for_qgis(layers: object) -> object:
     )
 
 
+def _road_steps_line_style_controls(
+    *,
+    line_width: object,
+    line_dasharray: object,
+    sampled_zoom: float,
+) -> dict[str, object]:
+    controls: dict[str, object] = {}
+    if isinstance(line_width, list):
+        line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
+        if line_width_mm is not None:
+            controls["line-width"] = line_width_mm
+    if isinstance(line_dasharray, list):
+        dasharray = _extract_line_dasharray_literal(line_dasharray, target_zoom=sampled_zoom)
+        if dasharray is not None:
+            controls["line-dasharray"] = dasharray
+    return controls
+
+
+def _road_steps_line_style_variant(
+    layer: dict[str, object],
+    *,
+    suffix: str,
+    zoom_band: tuple[float | None, float | None],
+    controls: dict[str, object],
+) -> dict[str, object]:
+    layer_id = str(layer.get("id") or "")
+    variant = copy.deepcopy(layer)
+    variant["id"] = f"{layer_id}-{suffix}"
+    _set_zoom_bounds(variant, *zoom_band)
+    variant_paint = variant["paint"]
+    assert isinstance(variant_paint, dict)
+    variant_paint.update(controls)
+    return variant
+
+
 def _road_steps_line_style_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited step line styles into static QGIS zoom bands."""
     layer_id = str(layer.get("id") or "")
@@ -2751,20 +2786,20 @@ def _road_steps_line_style_layer_variants(layer: dict[str, object]) -> list[dict
         if sampled_zoom is None:
             continue
 
-        variant = copy.deepcopy(layer)
-        variant["id"] = f"{layer_id}-{suffix}"
-        _set_zoom_bounds(variant, *effective_zoom_band)
-        variant_paint = variant["paint"]
-        assert isinstance(variant_paint, dict)
-        if isinstance(line_width, list):
-            line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
-            if line_width_mm is not None:
-                variant_paint["line-width"] = line_width_mm
-        if isinstance(line_dasharray, list):
-            dasharray = _extract_line_dasharray_literal(line_dasharray, target_zoom=sampled_zoom)
-            if dasharray is not None:
-                variant_paint["line-dasharray"] = dasharray
-        variants.append(variant)
+        controls = _road_steps_line_style_controls(
+            line_width=line_width,
+            line_dasharray=line_dasharray,
+            sampled_zoom=sampled_zoom,
+        )
+        if controls:
+            variants.append(
+                _road_steps_line_style_variant(
+                    layer,
+                    suffix=suffix,
+                    zoom_band=effective_zoom_band,
+                    controls=controls,
+                )
+            )
     return variants or None
 
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -676,6 +676,16 @@ _PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, 
     ("z16-plus", 16.0, None, 18.0),
 )
 _PATH_TRAIL_LINE_WIDTH_QGIS_SCALE = 1.35
+_ROAD_STEPS_LINE_STYLE_LAYER_IDS = {
+    "road-steps",
+    "road-steps-bg",
+}
+_ROAD_STEPS_LINE_STYLE_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
+    ("below-z15", None, 15.0, 14.0),
+    ("z15-to-z16", 15.0, 16.0, 15.0),
+    ("z16-to-z17", 16.0, 17.0, 16.0),
+    ("z17-plus", 17.0, None, 17.0),
+)
 _PATH_BACKGROUND_LINE_COLOR_LAYER_IDS = {
     "bridge-path-bg",
     "road-path-bg",
@@ -2438,6 +2448,14 @@ def _path_trail_line_width_base_layer_id(layer_id: object) -> str | None:
     )
 
 
+def _road_steps_line_style_base_layer_id(layer_id: object) -> str | None:
+    return _line_width_zoom_band_base_layer_id(
+        layer_id,
+        layer_ids=_ROAD_STEPS_LINE_STYLE_LAYER_IDS,
+        zoom_bands=_ROAD_STEPS_LINE_STYLE_ZOOM_BANDS,
+    )
+
+
 def _regional_major_road_width_base_layer_id(layer_id: object) -> str | None:
     normalized = str(layer_id or "")
     for suffix, _band_minzoom, _band_maxzoom in _REGIONAL_MAJOR_ROAD_WIDTH_BANDS:
@@ -2518,6 +2536,7 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
         _path_background_line_color_base_layer_id(layer_id),
         _path_trail_line_width_base_layer_id(layer_id),
         _pedestrian_line_width_base_layer_id(layer_id),
+        _road_steps_line_style_base_layer_id(layer_id),
     ):
         if resolved_layer_id is not None:
             return resolved_layer_id
@@ -2698,6 +2717,61 @@ def _split_pedestrian_line_width_layers_for_qgis(layers: object) -> object:
     return _split_line_width_zoom_band_layers_for_qgis(
         layers,
         variants_for_layer=_pedestrian_line_width_layer_variants,
+    )
+
+
+def _road_steps_line_style_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split audited step line styles into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    paint = layer.get("paint")
+    if (
+        layer_id not in _ROAD_STEPS_LINE_STYLE_LAYER_IDS
+        or layer.get("type") != "line"
+        or not isinstance(paint, dict)
+    ):
+        return None
+    line_width = paint.get("line-width")
+    line_dasharray = paint.get("line-dasharray")
+    if not isinstance(line_width, list) and not isinstance(line_dasharray, list):
+        return None
+
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, band_minzoom, band_maxzoom, target_zoom in _ROAD_STEPS_LINE_STYLE_ZOOM_BANDS:
+        effective_zoom_band = _effective_zoom_band(
+            existing_minzoom,
+            existing_maxzoom,
+            band_minzoom,
+            band_maxzoom,
+        )
+        if effective_zoom_band is None:
+            continue
+        sampled_zoom = _zoom_in_layer_range(target_zoom, *effective_zoom_band)
+        if sampled_zoom is None:
+            continue
+
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        _set_zoom_bounds(variant, *effective_zoom_band)
+        variant_paint = variant["paint"]
+        assert isinstance(variant_paint, dict)
+        if isinstance(line_width, list):
+            line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
+            if line_width_mm is not None:
+                variant_paint["line-width"] = line_width_mm
+        if isinstance(line_dasharray, list):
+            dasharray = _extract_line_dasharray_literal(line_dasharray, target_zoom=sampled_zoom)
+            if dasharray is not None:
+                variant_paint["line-dasharray"] = dasharray
+        variants.append(variant)
+    return variants or None
+
+
+def _split_road_steps_line_style_layers_for_qgis(layers: object) -> object:
+    return _split_line_width_zoom_band_layers_for_qgis(
+        layers,
+        variants_for_layer=_road_steps_line_style_layer_variants,
     )
 
 
@@ -5888,6 +5962,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_path_background_line_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_trail_line_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_pedestrian_line_width_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_road_steps_line_style_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_gate_label_icon_image_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5628,6 +5628,115 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             pedestrian_low_mm,
         )
 
+    def test_road_steps_line_styles_split_high_zoom_widths_and_dashes(self):
+        steps_width = [
+            "interpolate",
+            ["exponential", 1.5],
+            ["zoom"],
+            15,
+            1,
+            16,
+            1.6,
+            18,
+            6,
+        ]
+        steps_bg_width = [
+            "interpolate",
+            ["exponential", 1.5],
+            ["zoom"],
+            15,
+            2,
+            17,
+            4.6,
+            18,
+            7,
+        ]
+        steps_dasharray = [
+            "step",
+            ["zoom"],
+            ["literal", [1, 0]],
+            15,
+            ["literal", [1.75, 1]],
+            16,
+            ["literal", [1, 0.75]],
+            17,
+            ["literal", [0.3, 0.3]],
+        ]
+        style = {
+            "layers": [
+                {
+                    "id": "road-steps",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-width": copy.deepcopy(steps_width),
+                        "line-dasharray": copy.deepcopy(steps_dasharray),
+                    },
+                },
+                {
+                    "id": "road-steps-bg",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {
+                        "line-color": "hsl(35, 80%, 48%)",
+                        "line-width": copy.deepcopy(steps_bg_width),
+                    },
+                },
+                {
+                    "id": "road-path",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {"line-width": copy.deepcopy(steps_width)},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [
+                "road-steps-below-z15",
+                "road-steps-z15-to-z16",
+                "road-steps-z16-to-z17",
+                "road-steps-z17-plus",
+                "road-steps-bg-below-z15",
+                "road-steps-bg-z15-to-z16",
+                "road-steps-bg-z16-to-z17",
+                "road-steps-bg-z17-plus",
+                "road-path",
+            ],
+        )
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+
+        self.assertEqual(by_id["road-steps-below-z15"]["paint"]["line-dasharray"], [1, 0])
+        self.assertEqual(by_id["road-steps-z15-to-z16"]["paint"]["line-dasharray"], [1.75, 1])
+        self.assertEqual(by_id["road-steps-z16-to-z17"]["paint"]["line-dasharray"], [1, 0.75])
+        self.assertEqual(by_id["road-steps-z17-plus"]["paint"]["line-dasharray"], [0.3, 0.3])
+        self.assertAlmostEqual(
+            by_id["road-steps-z17-plus"]["paint"]["line-width"],
+            (
+                mapbox_config._extract_zoom_scalar_size_at_zoom(steps_width, 17.0)
+                * mapbox_config._MAPBOX_PIXEL_TO_MM
+            ),
+        )
+        self.assertAlmostEqual(
+            by_id["road-steps-bg-z17-plus"]["paint"]["line-width"],
+            4.6 * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
+        self.assertEqual(by_id["road-steps-below-z15"]["minzoom"], 14)
+        self.assertEqual(by_id["road-steps-below-z15"]["maxzoom"], 15.0)
+        self.assertEqual(by_id["road-steps-z17-plus"]["minzoom"], 17.0)
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-steps-z17-plus"),
+            "road-steps",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-steps-bg-z17-plus"),
+            "road-steps-bg",
+        )
+
     def test_filter_simplification_splits_poi_filterrank_filter_by_zoom_band(self):
         class_rank_match = [
             "match",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5737,6 +5737,45 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             "road-steps-bg",
         )
 
+    def test_road_steps_line_style_keeps_layer_unsplit_when_dasharray_is_unsupported(self):
+        steps_width = [
+            "interpolate",
+            ["exponential", 1.5],
+            ["zoom"],
+            15,
+            1,
+            16,
+            1.6,
+        ]
+        unsupported_dasharray = ["get", "dash"]
+        style = {
+            "layers": [
+                {
+                    "id": "road-steps",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {
+                        "line-width": copy.deepcopy(steps_width),
+                        "line-dasharray": unsupported_dasharray,
+                    },
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        layer = result["layers"][0]
+        self.assertEqual(layer["id"], "road-steps")
+        self.assertEqual(layer["paint"]["line-dasharray"], unsupported_dasharray)
+        self.assertAlmostEqual(
+            layer["paint"]["line-width"],
+            (
+                mapbox_config._extract_zoom_scalar_size_at_zoom(steps_width, 14.0)
+                * mapbox_config._MAPBOX_PIXEL_TO_MM
+            ),
+        )
+
     def test_filter_simplification_splits_poi_filterrank_filter_by_zoom_band(self):
         class_rank_match = [
             "match",


### PR DESCRIPTION
## Summary
- Split Mapbox Outdoors `road-steps` and `road-steps-bg` QGIS preprocessing into static z15/z16/z17 zoom bands.
- Preserve high-zoom step dash arrays and widths instead of sampling the low-zoom solid style for every zoom.
- Keep qfit-created step style variants mapped back to their source Mapbox layer ids.

## Evidence
- #949 road-feature diagnostic `debug/mapbox-outdoors-road-features/all-cameras/20260520T010913Z/summary.md` shows step candidates in the focused path/pedestrian cameras, including Chamonix z14 and Zermatt z18.
- Live comparison artifacts generated without printing or storing the local Mapbox token:
  - `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260520T021912Z/manifest.json`
  - `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260520T021917Z/manifest.json`
  - `debug/mapbox-outdoors-path-pedestrian-focus/20260520T022050Z/summary.md`
- Chamonix z14 QGIS output was unchanged; Zermatt z18 changed only localized step pixels while the preprocessed style now exposes the z17+ dash/width controls.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m py_compile mapbox_config.py tests/test_mapbox_config.py`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`