### PR TITLE
[codex] Keep full path focus layer ids

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -292,6 +292,25 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             summary["qgis_path_pedestrian_line_dasharray_layer_count"],
         )
 
+    def test_qgis_style_summary_keeps_full_layer_id_lists(self):
+        style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": f"road-path-test-{index}",
+                    "type": "line",
+                    "paint": {"line-width": index + 1},
+                }
+                for index in range(10)
+            ],
+        }
+
+        summary = qgis_path_pedestrian_style_summary(style)
+
+        expected_ids = [f"road-path-test-{index}" for index in range(10)]
+        self.assertEqual(summary["qgis_path_pedestrian_layer_ids"], expected_ids)
+        self.assertEqual(summary["qgis_path_pedestrian_visible_layer_ids"], expected_ids)
+
     def test_build_path_pedestrian_focus_report_cross_links_feature_counts_and_qgis_style(self):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -277,10 +277,8 @@ def qgis_path_pedestrian_style_summary(
             visible_line_layers,
             "line-opacity",
         ),
-        "qgis_path_pedestrian_layer_ids": [str(layer.get("id") or "") for layer in layers[:SAMPLE_LAYER_LIMIT]],
-        "qgis_path_pedestrian_visible_layer_ids": [
-            str(layer.get("id") or "") for layer in visible_layers[:SAMPLE_LAYER_LIMIT]
-        ],
+        "qgis_path_pedestrian_layer_ids": [str(layer.get("id") or "") for layer in layers],
+        "qgis_path_pedestrian_visible_layer_ids": [str(layer.get("id") or "") for layer in visible_layers],
         "qgis_path_pedestrian_line_width_samples": _layer_control_sample(line_layers, "line-width"),
         "qgis_path_pedestrian_line_color_samples": _layer_control_sample(line_layers, "line-color"),
         "qgis_path_pedestrian_fill_color_samples": _layer_control_sample(fill_layers, "fill-color"),


### PR DESCRIPTION
## Summary
- keep complete QGIS path/pedestrian layer-id lists in the focus report JSON instead of sampling the first eight ids
- leave Markdown compacting unchanged, so the table stays readable while the JSON artifact can audit every active layer
- add regression coverage for layer-id lists beyond the sample display limit

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_path_pedestrian_focus.py tests/test_mapbox_outdoors_path_pedestrian_focus.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T010913Z/road-features.json --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/20260520T003516Z/summary.json`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Generated report: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T031655Z/summary.md`

Refs #949