### PR TITLE
[codex] Include path focus layer details

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -269,6 +269,13 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             detail["id"] for detail in summary["qgis_path_pedestrian_visible_layer_details"]
         ]
         self.assertEqual(visible_detail_ids, ["road-path", "road-steps", "road-pedestrian-polygon"])
+        visible_details_by_id = {
+            detail["id"]: detail for detail in summary["qgis_path_pedestrian_visible_layer_details"]
+        }
+        self.assertEqual(visible_details_by_id["road-path"]["type"], "line")
+        self.assertEqual(visible_details_by_id["road-path"]["line-width"], 1.5)
+        self.assertEqual(visible_details_by_id["road-pedestrian-polygon"]["type"], "fill")
+        self.assertEqual(visible_details_by_id["road-pedestrian-polygon"]["fill-opacity"], 0.4)
         self.assertIn("road-path=1.5", summary["qgis_path_pedestrian_line_width_samples"])
         self.assertIn('road-path="#d8c6a3"', summary["qgis_path_pedestrian_line_color_samples"])
         self.assertIn('road-pedestrian-polygon="#f6f2e8"', summary["qgis_path_pedestrian_fill_color_samples"])

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -93,7 +93,7 @@ def _qgis_preprocessed_style():
                 "type": "fill",
                 "minzoom": 14,
                 "filter": ["==", ["get", "class"], "pedestrian"],
-                "paint": {"fill-color": "#f6f2e8"},
+                "paint": {"fill-color": "#f6f2e8", "fill-opacity": 0.4},
             },
             {
                 "id": "road-label",
@@ -263,6 +263,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(details_by_id["road-path"]["line-width"], 1.5)
         self.assertEqual(details_by_id["road-path"]["line-color"], "#d8c6a3")
         self.assertEqual(details_by_id["road-path"]["line-dasharray"], [1, 1])
+        self.assertEqual(details_by_id["road-pedestrian-polygon"]["fill-color"], "#f6f2e8")
+        self.assertEqual(details_by_id["road-pedestrian-polygon"]["fill-opacity"], 0.4)
         visible_detail_ids = [
             detail["id"] for detail in summary["qgis_path_pedestrian_visible_layer_details"]
         ]

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -255,6 +255,18 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             summary["qgis_path_pedestrian_visible_layer_ids"],
             ["road-path", "road-steps", "road-pedestrian-polygon"],
         )
+        details_by_id = {detail["id"]: detail for detail in summary["qgis_path_pedestrian_layer_details"]}
+        self.assertEqual(details_by_id["road-path"]["type"], "line")
+        self.assertEqual(details_by_id["road-path"]["minzoom"], 12)
+        self.assertEqual(details_by_id["road-path"]["maxzoom"], 16)
+        self.assertEqual(details_by_id["road-path"]["filter"], ["==", ["get", "class"], "path"])
+        self.assertEqual(details_by_id["road-path"]["line-width"], 1.5)
+        self.assertEqual(details_by_id["road-path"]["line-color"], "#d8c6a3")
+        self.assertEqual(details_by_id["road-path"]["line-dasharray"], [1, 1])
+        visible_detail_ids = [
+            detail["id"] for detail in summary["qgis_path_pedestrian_visible_layer_details"]
+        ]
+        self.assertEqual(visible_detail_ids, ["road-path", "road-steps", "road-pedestrian-polygon"])
         self.assertIn("road-path=1.5", summary["qgis_path_pedestrian_line_width_samples"])
         self.assertIn('road-path="#d8c6a3"', summary["qgis_path_pedestrian_line_color_samples"])
         self.assertIn('road-pedestrian-polygon="#f6f2e8"', summary["qgis_path_pedestrian_fill_color_samples"])
@@ -310,6 +322,14 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         expected_ids = [f"road-path-test-{index}" for index in range(10)]
         self.assertEqual(summary["qgis_path_pedestrian_layer_ids"], expected_ids)
         self.assertEqual(summary["qgis_path_pedestrian_visible_layer_ids"], expected_ids)
+        self.assertEqual(
+            [detail["id"] for detail in summary["qgis_path_pedestrian_layer_details"]],
+            expected_ids,
+        )
+        self.assertEqual(
+            [detail["line-width"] for detail in summary["qgis_path_pedestrian_layer_details"]],
+            list(range(1, 11)),
+        )
 
     def test_build_path_pedestrian_focus_report_cross_links_feature_counts_and_qgis_style(self):
         report = build_path_pedestrian_focus_report(
@@ -344,6 +364,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(camera["qgis_path_pedestrian_layer_count"], 0)
         self.assertEqual(camera["qgis_path_pedestrian_visible_layer_count"], 0)
         self.assertEqual(camera["qgis_path_pedestrian_visible_filter_layer_count"], 0)
+        self.assertEqual(camera["qgis_path_pedestrian_layer_details"], [])
+        self.assertEqual(camera["qgis_path_pedestrian_visible_layer_details"], [])
 
     def test_build_path_pedestrian_focus_report_ignores_boolean_counts(self):
         road_report = {

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -36,6 +36,7 @@ PATH_PEDESTRIAN_DETAIL_PAINT_KEYS = (
     "line-dasharray",
     "line-opacity",
     "fill-color",
+    "fill-opacity",
 )
 TOP_COUNT_LIMIT = 3
 SAMPLE_LAYER_LIMIT = 8

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -30,6 +30,13 @@ PATH_PEDESTRIAN_LAYER_ID_MARKERS = (
     "road-steps",
 )
 PATH_PEDESTRIAN_STYLE_TYPES = {"fill", "line"}
+PATH_PEDESTRIAN_DETAIL_PAINT_KEYS = (
+    "line-width",
+    "line-color",
+    "line-dasharray",
+    "line-opacity",
+    "fill-color",
+)
 TOP_COUNT_LIMIT = 3
 SAMPLE_LAYER_LIMIT = 8
 
@@ -229,6 +236,22 @@ def _style_control_count(layers: Iterable[Mapping[str, object]], property_name: 
     return sum(1 for layer in layers if property_name in _layer_paint(layer))
 
 
+def _layer_detail(layer: Mapping[str, object]) -> dict[str, object]:
+    detail = {
+        "id": str(layer.get("id") or ""),
+        "type": layer.get("type"),
+    }
+    for key in ("minzoom", "maxzoom", "filter"):
+        value = layer.get(key)
+        if value is not None:
+            detail[key] = value
+    paint = _layer_paint(layer)
+    for key in PATH_PEDESTRIAN_DETAIL_PAINT_KEYS:
+        if key in paint:
+            detail[key] = paint[key]
+    return detail
+
+
 def qgis_path_pedestrian_style_summary(
     style: Mapping[str, object],
     *,
@@ -279,6 +302,8 @@ def qgis_path_pedestrian_style_summary(
         ),
         "qgis_path_pedestrian_layer_ids": [str(layer.get("id") or "") for layer in layers],
         "qgis_path_pedestrian_visible_layer_ids": [str(layer.get("id") or "") for layer in visible_layers],
+        "qgis_path_pedestrian_layer_details": [_layer_detail(layer) for layer in layers],
+        "qgis_path_pedestrian_visible_layer_details": [_layer_detail(layer) for layer in visible_layers],
         "qgis_path_pedestrian_line_width_samples": _layer_control_sample(line_layers, "line-width"),
         "qgis_path_pedestrian_line_color_samples": _layer_control_sample(line_layers, "line-color"),
         "qgis_path_pedestrian_fill_color_samples": _layer_control_sample(fill_layers, "fill-color"),
@@ -325,6 +350,8 @@ def _missing_qgis_style_summary() -> dict[str, object]:
         "qgis_path_pedestrian_visible_line_opacity_layer_count": 0,
         "qgis_path_pedestrian_layer_ids": [],
         "qgis_path_pedestrian_visible_layer_ids": [],
+        "qgis_path_pedestrian_layer_details": [],
+        "qgis_path_pedestrian_visible_layer_details": [],
         "qgis_path_pedestrian_line_width_samples": [],
         "qgis_path_pedestrian_line_color_samples": [],
         "qgis_path_pedestrian_fill_color_samples": [],


### PR DESCRIPTION
## Summary
- add full QGIS path/pedestrian layer detail records to the focus report JSON
- include layer id, type, zoom bounds, filter, and relevant stroke/fill paint controls for all matched and camera-visible layers
- include fill opacity as well as line opacity in per-layer detail records
- keep Markdown unchanged while making the JSON artifact trace camera-active controls back to specific generated QGIS layer variants

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_path_pedestrian_focus.py tests/test_mapbox_outdoors_path_pedestrian_focus.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T010913Z/road-features.json --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/20260520T003516Z/summary.json`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Generated report: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T033431Z/summary.md`

Refs #949