### PR TITLE
[codex] Add visible path detail appendix

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -436,6 +436,22 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
 
         self.assertIn("No decoded cameras include path/pedestrian focus features.", markdown)
 
+    def test_build_summary_markdown_ignores_non_mapping_visible_details(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "now",
+                "cameras": [
+                    {
+                        "camera": "bad-details",
+                        "qgis_path_pedestrian_visible_layer_details": ["not-a-detail"],
+                    }
+                ],
+            }
+        )
+
+        self.assertIn("| bad-details |", markdown)
+        self.assertNotIn("## Visible QGIS layer details", markdown)
+
     def test_write_report_writes_json_and_markdown(self):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -424,6 +424,12 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn('"road-path=[1,1]"', markdown)
         self.assertIn('"road-pedestrian-polygon=\\"#f6f2e8\\""', markdown)
         self.assertIn('"road-pedestrian-polygon"', markdown)
+        self.assertIn("## Visible QGIS layer details", markdown)
+        self.assertIn("### chamonix-trails-z14-outdoors", markdown)
+        self.assertIn("| road-path | line | 12<=z<16 |", markdown)
+        self.assertIn('"line-width=1.5"', markdown)
+        self.assertIn('"line-dasharray=[1,1]"', markdown)
+        self.assertIn("| road-pedestrian-polygon | fill | z>=14 |", markdown)
 
     def test_build_summary_markdown_handles_no_focus_rows(self):
         markdown = build_summary_markdown({"generated": "now", "cameras": []})

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -507,9 +507,10 @@ def _visible_detail_markdown_lines(cameras: Iterable[object]) -> list[str]:
             continue
         details = camera.get("qgis_path_pedestrian_visible_layer_details")
         detail_rows = details if isinstance(details, list) else []
-        if not detail_rows:
+        mapping_rows = [detail for detail in detail_rows if isinstance(detail, Mapping)]
+        if not mapping_rows:
             continue
-        detail_row_count += len(detail_rows)
+        detail_row_count += len(mapping_rows)
         lines.extend(
             [
                 f"### {camera.get('camera')}",
@@ -518,9 +519,7 @@ def _visible_detail_markdown_lines(cameras: Iterable[object]) -> list[str]:
                 "| --- | --- | --- | --- | --- |",
             ]
         )
-        for detail in detail_rows:
-            if not isinstance(detail, Mapping):
-                continue
+        for detail in mapping_rows:
             lines.append(
                 _markdown_table_row(
                     [

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -479,6 +479,63 @@ def _qgis_stroke_samples(camera: Mapping[str, object]) -> list[str]:
     return samples
 
 
+def _detail_zoom_band(detail: Mapping[str, object]) -> str:
+    minzoom = detail.get("minzoom")
+    maxzoom = detail.get("maxzoom")
+    if minzoom is None and maxzoom is None:
+        return "all"
+    if minzoom is None:
+        return f"z<{maxzoom}"
+    if maxzoom is None:
+        return f"z>={minzoom}"
+    return f"{minzoom}<=z<{maxzoom}"
+
+
+def _detail_paint_controls(detail: Mapping[str, object]) -> list[str]:
+    return [
+        f"{key}={_compact_json(detail.get(key))}"
+        for key in PATH_PEDESTRIAN_DETAIL_PAINT_KEYS
+        if key in detail
+    ]
+
+
+def _visible_detail_markdown_lines(cameras: Iterable[object]) -> list[str]:
+    lines = ["", "## Visible QGIS layer details", ""]
+    detail_row_count = 0
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        details = camera.get("qgis_path_pedestrian_visible_layer_details")
+        detail_rows = details if isinstance(details, list) else []
+        if not detail_rows:
+            continue
+        detail_row_count += len(detail_rows)
+        lines.extend(
+            [
+                f"### {camera.get('camera')}",
+                "",
+                "| Layer | Type | Zoom band | Paint controls | Filter |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for detail in detail_rows:
+            if not isinstance(detail, Mapping):
+                continue
+            lines.append(
+                _markdown_table_row(
+                    [
+                        detail.get("id"),
+                        detail.get("type"),
+                        _detail_zoom_band(detail),
+                        _detail_paint_controls(detail),
+                        detail.get("filter"),
+                    ]
+                )
+            )
+        lines.append("")
+    return lines if detail_row_count else []
+
+
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     cameras = report.get("cameras")
     rows = cameras if isinstance(cameras, list) else []
@@ -548,6 +605,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
                 ]
             )
         )
+    lines.extend(_visible_detail_markdown_lines(rows))
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
## Summary
- add a visible QGIS layer detail appendix to the Mapbox Outdoors path/pedestrian focus Markdown report
- show each camera-visible layer id, type, zoom band, paint controls, and compact filter next to the existing feature/style matrix
- keep the JSON artifact shape and production rendering behavior unchanged while making active Chamonix/Zermatt controls easier to compare before the next styling slice
- skip malformed/non-mapping visible-detail rows before rendering camera detail tables

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m py_compile validation/mapbox_outdoors_path_pedestrian_focus.py tests/test_mapbox_outdoors_path_pedestrian_focus.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T010913Z/road-features.json --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/20260520T003516Z/summary.json`
- generated report: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T035624Z/summary.md`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949