### PR TITLE
[codex] Include path focus input artifacts

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -436,6 +436,28 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
 
         self.assertIn("No decoded cameras include path/pedestrian focus features.", markdown)
 
+    def test_build_summary_markdown_includes_input_artifacts(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+            input_artifacts={
+                "road_features_json": "debug/roads/road-features.json",
+                "comparison_summary_jsons": ["debug/comparison/summary.json"],
+                "qgis_style_cameras": ["chamonix-trails-z14-outdoors"],
+            },
+        )
+
+        markdown = build_summary_markdown(report)
+
+        self.assertEqual(
+            report["input_artifacts"]["road_features_json"],
+            "debug/roads/road-features.json",
+        )
+        self.assertIn("Road features input: `debug/roads/road-features.json`", markdown)
+        self.assertIn("Comparison summary inputs: `debug/comparison/summary.json`", markdown)
+        self.assertIn("QGIS style input cameras: `chamonix-trails-z14-outdoors`", markdown)
+
     def test_build_summary_markdown_ignores_non_mapping_visible_details(self):
         markdown = build_summary_markdown(
             {
@@ -508,7 +530,12 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             self.assertTrue(summary_path.exists())
             self.assertEqual(summary_path.parent.parent, output_root)
             report_path = summary_path.parent / "path-pedestrian-focus.json"
-            self.assertEqual(json.loads(report_path.read_text(encoding="utf-8"))["camera_count"], 1)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["camera_count"], 1)
+            self.assertEqual(
+                report["input_artifacts"]["qgis_style_cameras"],
+                ["chamonix-trails-z14-outdoors"],
+            )
 
     def test_main_loads_qgis_styles_from_comparison_summary(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -560,6 +587,11 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertEqual(report["qgis_style_camera_count"], 1)
             self.assertEqual(report["qgis_style_input_count"], 1)
+            self.assertEqual(
+                report["input_artifacts"]["comparison_summary_jsons"],
+                [str(comparison_summary_path)],
+            )
+            self.assertEqual(report["input_artifacts"]["qgis_style_cameras"], ["chamonix-trails-z14-outdoors"])
 
     def test_main_reports_missing_input_without_traceback(self):
         stderr = io.StringIO()

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -459,6 +459,22 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("Comparison summary inputs: `debug/comparison/summary.json`", markdown)
         self.assertIn("QGIS style input cameras: `chamonix-trails-z14-outdoors`", markdown)
 
+    def test_build_report_serializes_path_input_artifacts(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+            input_artifacts={
+                "road_features_json": Path("/tmp/road-features.json"),
+                "comparison_summary_jsons": [Path("/tmp/comparison/summary.json")],
+                "nested": {"style": Path("/tmp/qgis-preprocessed-style.json")},
+            },
+        )
+
+        json.dumps(report)
+        self.assertEqual(report["input_artifacts"]["road_features_json"], "/tmp/road-features.json")
+        self.assertEqual(report["input_artifacts"]["comparison_summary_jsons"], ["/tmp/comparison/summary.json"])
+        self.assertEqual(report["input_artifacts"]["nested"], {"style": "/tmp/qgis-preprocessed-style.json"})
+
     def test_build_summary_markdown_ignores_non_mapping_visible_details(self):
         markdown = build_summary_markdown(
             {

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import io
 import json
+import os
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -535,6 +536,33 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             self.assertEqual(
                 report["input_artifacts"]["qgis_style_cameras"],
                 ["chamonix-trails-z14-outdoors"],
+            )
+
+    def test_main_records_resolved_external_relative_input_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            road_features_path = root / "road-features.json"
+            output_root = root / "out"
+            road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
+
+            stdout = io.StringIO()
+            previous_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                with patch(
+                    "qfit.validation.mapbox_outdoors_path_pedestrian_focus.DEFAULT_OUTPUT_ROOT",
+                    output_root,
+                ), redirect_stdout(stdout):
+                    result = main(["--road-features-json", road_features_path.name])
+            finally:
+                os.chdir(previous_cwd)
+
+            self.assertEqual(result, 0)
+            report_path = Path(stdout.getvalue().strip()).parent / "path-pedestrian-focus.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                report["input_artifacts"]["road_features_json"],
+                str(road_features_path.resolve()),
             )
 
     def test_main_loads_qgis_styles_from_comparison_summary(self):

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -741,7 +741,7 @@ def _display_input_path(path: Path) -> str:
     try:
         return str(resolved.relative_to(REPO_ROOT))
     except ValueError:
-        return str(path)
+        return str(resolved)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -398,6 +398,7 @@ def build_path_pedestrian_focus_report(
     *,
     qgis_styles_by_camera: Mapping[str, Mapping[str, object]] | None = None,
     generated_at: dt.datetime | None = None,
+    input_artifacts: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     qgis_styles = qgis_styles_by_camera or {}
     camera_reports = road_feature_report.get("cameras")
@@ -417,7 +418,7 @@ def build_path_pedestrian_focus_report(
         )
     generated = generated_at or dt.datetime.now(dt.timezone.utc)
     qgis_matched_camera_count = sum(1 for row in rows if row.get("qgis_style_status") == "available")
-    return {
+    report = {
         "generated": generated.astimezone(dt.timezone.utc).isoformat(),
         "road_feature_generated": road_feature_report.get("generated"),
         "style_owner": road_feature_report.get("style_owner"),
@@ -427,6 +428,9 @@ def build_path_pedestrian_focus_report(
         "qgis_style_input_count": len(qgis_styles),
         "cameras": rows,
     }
+    if input_artifacts is not None:
+        report["input_artifacts"] = dict(input_artifacts)
+    return report
 
 
 def _markdown_cell(value: object) -> str:
@@ -477,6 +481,29 @@ def _qgis_stroke_samples(camera: Mapping[str, object]) -> list[str]:
     if isinstance(dash_samples, list):
         samples.extend(str(sample) for sample in dash_samples[:2])
     return samples
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if item is not None]
+
+
+def _input_artifact_markdown_lines(report: Mapping[str, object]) -> list[str]:
+    input_artifacts = report.get("input_artifacts")
+    if not isinstance(input_artifacts, Mapping):
+        return []
+    lines: list[str] = []
+    road_features_json = input_artifacts.get("road_features_json")
+    if isinstance(road_features_json, str) and road_features_json:
+        lines.append(f"Road features input: `{road_features_json}`")
+    comparison_summary_jsons = _string_list(input_artifacts.get("comparison_summary_jsons"))
+    if comparison_summary_jsons:
+        lines.append(f"Comparison summary inputs: `{', '.join(comparison_summary_jsons)}`")
+    qgis_style_cameras = _string_list(input_artifacts.get("qgis_style_cameras"))
+    if qgis_style_cameras:
+        lines.append(f"QGIS style input cameras: `{', '.join(qgis_style_cameras)}`")
+    return lines
 
 
 def _detail_zoom_band(detail: Mapping[str, object]) -> str:
@@ -550,16 +577,24 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
             f"{report.get('qgis_style_camera_count')}/{report.get('qgis_style_input_count', 0)} matched"
         ),
         "",
-        (
-            "Cross-links decoded road-feature counts with the camera-specific QGIS-preprocessed "
-            "style layers that can render path, pedestrian, trail, piste, or step features."
-        ),
-        (
-            "Visible QGIS counts apply the camera zoom to style-layer minzoom/maxzoom, "
-            "so zoom-banded preprocessing can be reviewed against the layers active in each camera."
-        ),
-        "",
     ]
+    input_lines = _input_artifact_markdown_lines(report)
+    if input_lines:
+        lines.extend(input_lines)
+        lines.append("")
+    lines.extend(
+        [
+            (
+                "Cross-links decoded road-feature counts with the camera-specific QGIS-preprocessed "
+                "style layers that can render path, pedestrian, trail, piste, or step features."
+            ),
+            (
+                "Visible QGIS counts apply the camera zoom to style-layer minzoom/maxzoom, "
+                "so zoom-banded preprocessing can be reviewed against the layers active in each camera."
+            ),
+            "",
+        ]
+    )
     if not rows:
         lines.append("No decoded cameras include path/pedestrian focus features.")
         return "\n".join(lines) + "\n"
@@ -701,6 +736,14 @@ def _qgis_style_paths_from_cli_comparison_summary(
     raise AssertionError("argparse error should exit")
 
 
+def _display_input_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -722,6 +765,11 @@ def main(argv: list[str] | None = None) -> int:
     report = build_path_pedestrian_focus_report(
         road_feature_report,
         qgis_styles_by_camera=qgis_styles_by_camera,
+        input_artifacts={
+            "road_features_json": _display_input_path(args.road_features_json),
+            "comparison_summary_jsons": [_display_input_path(path) for path in args.comparison_summary_json],
+            "qgis_style_cameras": sorted(qgis_style_paths_by_camera),
+        },
     )
     paths = build_path_pedestrian_focus_paths(build_run_directory())
     write_report(report, paths)

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -393,6 +393,22 @@ def _camera_focus_row(
     return row
 
 
+def _json_safe_artifact_value(value: object) -> object:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe_artifact_value(child) for key, child in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_safe_artifact_value(child) for child in value]
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    return str(value)
+
+
+def _json_safe_artifacts(input_artifacts: Mapping[str, object]) -> dict[str, object]:
+    return {str(key): _json_safe_artifact_value(value) for key, value in input_artifacts.items()}
+
+
 def build_path_pedestrian_focus_report(
     road_feature_report: Mapping[str, object],
     *,
@@ -429,7 +445,7 @@ def build_path_pedestrian_focus_report(
         "cameras": rows,
     }
     if input_artifacts is not None:
-        report["input_artifacts"] = dict(input_artifacts)
+        report["input_artifacts"] = _json_safe_artifacts(input_artifacts)
     return report
 
 


### PR DESCRIPTION
## Summary
- add input-artifact metadata to the Mapbox Outdoors path/pedestrian focus report JSON
- show the road-feature input, comparison-summary inputs, and discovered QGIS style cameras at the top of the Markdown report
- keep token values and per-style absolute artifact paths out of repo-local reports while making refreshed #949 validation runs easier to trace
- resolve external relative inputs to absolute paths and normalize artifact values before JSON output

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short` (23 passed)
- `python3 -m py_compile validation/mapbox_outdoors_path_pedestrian_focus.py tests/test_mapbox_outdoors_path_pedestrian_focus.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T040127Z/road-features.json --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/20260520T040116Z/summary.json`
- generated report: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T041756Z/summary.md`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short` (2273 passed, 173 skipped, 162 subtests passed)

Refs #949