### PR TITLE
[codex] Improve Outdoors path route visibility

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -649,7 +649,14 @@ _PATH_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES = (
 )
 _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 18.0
 _PATH_LOW_ZOOM_LINE_WIDTH_LAYER_PREFIXES = ("road-path-below-z16",)
+_PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_LAYER_PREFIXES = (
+    "road-path-bg-below-z16",
+    "bridge-path-bg-below-z16",
+)
 _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 14.0
+# The z14 Chamonix comparison showed Outdoors path casings reading too faintly
+# in QGIS after px-to-mm conversion; keep this as a modest casing-only boost.
+_PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.25
 _PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.5
 _PEDESTRIAN_LINE_WIDTH_LAYER_IDS = {
     "bridge-pedestrian",
@@ -667,15 +674,20 @@ _PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, 
     ("z16-plus", 16.0, None, 17.0),
 )
 _PATH_TRAIL_LINE_WIDTH_LAYER_IDS = {
+    "bridge-path-cycleway-piste",
     "bridge-path-trail",
+    "road-path-cycleway-piste",
     "road-path-trail",
+    "tunnel-path-cycleway-piste",
     "tunnel-path-trail",
 }
 _PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("below-z16", None, 16.0, 15.0),
     ("z16-plus", 16.0, None, 18.0),
 )
-_PATH_TRAIL_LINE_WIDTH_QGIS_SCALE = 1.35
+# Shared by trail and cycleway/piste overlays so outdoor route strokes remain
+# legible against contour/landcover-heavy Mapbox Outdoors scenes.
+_PATH_TRAIL_LINE_WIDTH_QGIS_SCALE = 1.6
 _ROAD_STEPS_LINE_STYLE_LAYER_IDS = {
     "road-steps",
     "road-steps-bg",
@@ -2596,10 +2608,24 @@ def _should_sample_path_low_zoom_line_width(layer_id: object, prop: str, maxzoom
     return normalized == "road-path" and layer_maxzoom is not None and layer_maxzoom <= _PATH_TYPE_FILTER_SPLIT_ZOOM
 
 
+def _should_sample_path_low_zoom_background_line_width(layer_id: object, prop: str) -> bool:
+    if prop != "line-width":
+        return False
+    normalized = str(layer_id or "")
+    return any(
+        normalized == prefix or normalized.startswith(f"{prefix}-")
+        for prefix in _PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_LAYER_PREFIXES
+    )
+
+
 def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: object, maxzoom: object) -> float | None:
     high_zoom_path_width = False
+    low_zoom_path_background_width = False
     if _should_sample_path_low_zoom_line_width(layer_id, prop, maxzoom):
         target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+    elif _should_sample_path_low_zoom_background_line_width(layer_id, prop):
+        target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+        low_zoom_path_background_width = True
     elif _should_sample_path_high_zoom_line_width(layer_id, prop, minzoom):
         target_sample_zoom = _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
         high_zoom_path_width = True
@@ -2615,6 +2641,8 @@ def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: o
         and _path_background_line_color_base_layer_id(layer_id) is not None
     ):
         width *= _PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
+    if width is not None and low_zoom_path_background_width:
+        width *= _PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
     return width
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5323,6 +5323,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
         low_width_mm = 1 * mapbox_config._MAPBOX_PIXEL_TO_MM
+        path_background_low_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(line_width, 14.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+            * mapbox_config._PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
+        )
         path_core_low_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(line_width, 14.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
@@ -5335,7 +5340,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path-z16-plus"]["paint"]["line-width"], high_width_mm)
-        self.assertAlmostEqual(by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"], low_width_mm)
+        self.assertAlmostEqual(
+            by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"],
+            path_background_low_width_mm,
+        )
         self.assertAlmostEqual(
             by_id["road-path-bg-z16-plus-outdoor"]["paint"]["line-width"],
             high_background_width_mm,
@@ -5515,6 +5523,77 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 15.0)
                 * mapbox_config._MAPBOX_PIXEL_TO_MM
             ),
+        )
+
+    def test_path_cycleway_piste_line_width_splits_high_zoom_widths(self):
+        cycleway_piste_width = ["interpolate", ["exponential", 1.5], ["zoom"], 15, 1, 18, 4]
+        style = {
+            "layers": [
+                {
+                    "id": "road-path-cycleway-piste",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-width": copy.deepcopy(cycleway_piste_width),
+                        "line-dasharray": [10, 0],
+                    },
+                },
+                {
+                    "id": "bridge-path-cycleway-piste",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {"line-width": copy.deepcopy(cycleway_piste_width)},
+                },
+                {
+                    "id": "tunnel-path-cycleway-piste",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {"line-width": copy.deepcopy(cycleway_piste_width)},
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(
+            [layer["id"] for layer in result["layers"]],
+            [
+                "road-path-cycleway-piste-below-z16",
+                "road-path-cycleway-piste-z16-plus",
+                "bridge-path-cycleway-piste-below-z16",
+                "bridge-path-cycleway-piste-z16-plus",
+                "tunnel-path-cycleway-piste-below-z16",
+                "tunnel-path-cycleway-piste-z16-plus",
+            ],
+        )
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(cycleway_piste_width, 15.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+            * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
+        )
+        high_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(cycleway_piste_width, 18.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+            * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
+        )
+
+        self.assertAlmostEqual(
+            by_id["road-path-cycleway-piste-below-z16"]["paint"]["line-width"],
+            low_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["road-path-cycleway-piste-z16-plus"]["paint"]["line-width"],
+            high_width_mm,
+        )
+        self.assertEqual(by_id["road-path-cycleway-piste-below-z16"]["paint"]["line-dasharray"], [10, 0])
+        self.assertEqual(by_id["road-path-cycleway-piste-below-z16"]["maxzoom"], 16.0)
+        self.assertEqual(by_id["road-path-cycleway-piste-z16-plus"]["minzoom"], 16.0)
+        self.assertEqual(by_id["bridge-path-cycleway-piste-below-z16"]["minzoom"], 14)
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-cycleway-piste-z16-plus"),
+            "road-path-cycleway-piste",
         )
 
     def test_pedestrian_line_width_splits_high_zoom_widths(self):

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5345,6 +5345,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             path_background_low_width_mm,
         )
         self.assertAlmostEqual(
+            by_id["bridge-path-bg-below-z16-outdoor"]["paint"]["line-width"],
+            path_background_low_width_mm,
+        )
+        self.assertAlmostEqual(
             by_id["road-path-bg-z16-plus-outdoor"]["paint"]["line-width"],
             high_background_width_mm,
         )
@@ -5585,6 +5589,22 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertAlmostEqual(
             by_id["road-path-cycleway-piste-z16-plus"]["paint"]["line-width"],
+            high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-path-cycleway-piste-below-z16"]["paint"]["line-width"],
+            low_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-path-cycleway-piste-z16-plus"]["paint"]["line-width"],
+            high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["tunnel-path-cycleway-piste-below-z16"]["paint"]["line-width"],
+            low_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["tunnel-path-cycleway-piste-z16-plus"]["paint"]["line-width"],
             high_width_mm,
         )
         self.assertEqual(by_id["road-path-cycleway-piste-below-z16"]["paint"]["line-dasharray"], [10, 0])


### PR DESCRIPTION
## Summary
- modestly widen low-zoom Mapbox Outdoors path background/casing layers for QGIS so z14 trail/path routes read more clearly against dense terrain and landcover
- split cycleway/piste path overlay widths into the same below-z16 / z16-plus bands used by trail overlays
- keep the change scoped to path-route visibility preprocessing and preserve existing path filters/dash patterns

## Validation
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short` (209 passed)
- `python3 -m py_compile mapbox_config.py tests/test_mapbox_config.py`
- `MAPBOX_ACCESS_TOKEN=... python3 validation/mapbox_outdoors_comparison.py --all-cameras --browser-timeout-ms 120000`
- generated comparison matrix: `debug/mapbox-outdoors-comparison/all-cameras/20260520T043058Z/summary.md`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T040127Z/road-features.json --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/20260520T043058Z/summary.json`
- generated focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T043105Z/summary.md`
- visual review: Chamonix z14 path/trail legibility is modestly improved; all-camera contact sheet showed no obvious z5-z18 regression
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short` (2274 passed, 173 skipped, 162 subtests passed)

Refs #949
