### PR TITLE
[codex] Apply high-zoom road label repeat distance

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -688,7 +688,7 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         other_style.setLabelSettings.assert_not_called()
         remaining_style.setLabelSettings.assert_not_called()
 
-    def test_line_label_repeat_distance_uses_mapbox_default_spacing(self):
+    def test_high_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         from qgis.core import Qgis
 
         labeling = MagicMock()
@@ -699,7 +699,21 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         self.service._apply_label_priority(labeling)
 
         self.assertEqual(settings.priority, 4)
-        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_high_zoom_road_label_overrides_qgis_default_repeat_distance(self):
+        from qgis.core import Qgis
+
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.repeatDistance = 250 * 25.4 / 96
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
 
@@ -872,7 +886,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         other_style.setLabelSettings.assert_not_called()
         remaining_style.setLabelSettings.assert_not_called()
 
-    def test_line_label_repeat_distance_uses_mapbox_default_spacing(self):
+    def test_high_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         labeling = MagicMock()
         style, settings = self._make_style("road", "road-label-z15-plus")
         settings.repeatDistance = 0.0
@@ -881,7 +895,19 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.service._apply_label_priority(labeling)
 
         self.assertEqual(settings.priority, 4)
-        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_high_zoom_road_label_overrides_qgis_default_repeat_distance(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.repeatDistance = 250 * 25.4 / 96
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
 

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -48,6 +48,8 @@ _SWISS_MOTORWAY_SHIELD_Z11_STYLE_MARKER = "ch-motorway-icon-z11-plus"
 _MAPBOX_SYMBOL_PIXEL_TO_MM = 25.4 / 96.0
 _MAPBOX_DEFAULT_SYMBOL_SPACING_PX = 250.0
 _ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX = 150.0
+_ROAD_LABEL_HIGH_ZOOM_SYMBOL_SPACING_PX = 400.0
+_REPEAT_DISTANCE_EPSILON_MM = 0.001
 _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "ferry-aerialway-label",
     "path-pedestrian-label",
@@ -111,6 +113,8 @@ def _label_repeat_distance(layer_name: str, style) -> float | None:
     if layer_name == "road-label":
         if style_name in {"road-label-below-z12", "road-label-z12-to-z15"}:
             return _symbol_spacing_mm(_ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX)
+        if style_name == "road-label-z15-plus":
+            return _symbol_spacing_mm(_ROAD_LABEL_HIGH_ZOOM_SYMBOL_SPACING_PX)
         return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
     if layer_name in _LINE_LABEL_REPEAT_DISTANCE_LAYERS:
         return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
@@ -147,9 +151,20 @@ def _settings_priority(settings) -> int:
     return int(priority) if isinstance(priority, (int, float)) else 0
 
 
-def _needs_repeat_distance(settings) -> bool:
+def _is_repeat_distance_close(left: float, right: float) -> bool:
+    return abs(left - right) <= _REPEAT_DISTANCE_EPSILON_MM
+
+
+def _needs_repeat_distance(settings, expected_repeat_distance: float | None = None) -> bool:
     repeat_distance = getattr(settings, "repeatDistance", 0.0)
-    return not isinstance(repeat_distance, (int, float)) or repeat_distance <= 0
+    if not isinstance(repeat_distance, (int, float)) or repeat_distance <= 0:
+        return True
+    if expected_repeat_distance is None or _is_repeat_distance_close(repeat_distance, expected_repeat_distance):
+        return False
+    return _is_repeat_distance_close(
+        repeat_distance,
+        _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX),
+    )
 
 
 def _apply_settlement_label_priority(settings, qgs_property) -> None:
@@ -179,7 +194,7 @@ def _apply_label_settings(
         if layer_name in _SETTLEMENT_LAYERS:
             _apply_settlement_label_priority(settings, qgs_property)
         changed = True
-    if repeat_distance is not None and _needs_repeat_distance(settings):
+    if repeat_distance is not None and _needs_repeat_distance(settings, repeat_distance):
         settings.repeatDistance = repeat_distance
         settings.repeatDistanceUnit = qgis.RenderUnit.Millimeters
         changed = True


### PR DESCRIPTION
## Summary
- apply the audited 400px high-zoom road-label spacing to `QgsPalLayerSettings.repeatDistance` for `road-label-z15-plus`
- override only QGIS' default 250px-derived repeat distance, while preserving existing non-default/custom repeat distances
- add regression coverage for empty/default repeat distances in both real-QGIS and mock-QGIS suites

## Evidence
- QGIS' converted label settings previously showed `road-label-z15-plus` with `qfit_layout.symbol-spacing: 400.0` but `repeat_distance: 66.1458mm`, matching the 250px default rather than the qfit high-zoom spacing.
- After this patch, live label settings show `road-label-z15-plus` with `repeat_distance: 105.8333mm` (`400 * 25.4 / 96`).
- Focused z18 comparison remained pixel-identical versus the pre-patch probe, which suggests the remaining visible repetition is likely feature segmentation/placement behavior rather than the repeat-distance field alone.

## Validation
- `python3 -m py_compile visualization/infrastructure/background_map_service.py tests/test_background_map_service.py`
- `python3 -m pytest tests/test_background_map_service.py -q --tb=short` -> 23 passed, 41 skipped
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short` -> 2275 passed, 174 skipped, 162 subtests passed
- `MAPBOX_ACCESS_TOKEN=... python3 validation/mapbox_outdoors_label_settings.py`
  - report: `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260520T051745Z/summary.md`
- `MAPBOX_ACCESS_TOKEN=... python3 validation/mapbox_outdoors_comparison.py zermatt-trails-z18-outdoors --browser-timeout-ms 120000`
  - run: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260520T051819Z/manifest.json`
  - QGIS before/after repeat-distance diff: 0 changed pixels
- `MAPBOX_ACCESS_TOKEN=... python3 validation/mapbox_outdoors_comparison.py --all-cameras --browser-timeout-ms 120000`
  - summary: `debug/mapbox-outdoors-comparison/all-cameras/20260520T052014Z/summary.md`

Fixes part of #949.
