### PR TITLE
[codex] Report label spacing repeat mappings

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -814,6 +814,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(waterway_row["zero_repeat_distance_count"], 0)
         self.assertEqual(waterway_row["qfit_symbol_spacings"], {"400": 1})
         self.assertEqual(waterway_row["repeat_distances"], {"66.1458": 1})
+        self.assertEqual(waterway_row["qfit_symbol_spacing_to_repeat_distances"], {"400 -> 66.1458": 1})
 
     def test_line_label_repeat_spacing_summary_deduplicates_shared_label_records(self):
         rows = _line_label_repeat_spacing_rows(
@@ -846,6 +847,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(rows[0]["source_label_rows"], 2)
         self.assertEqual(rows[0]["converted_line_label_styles"], 1)
         self.assertEqual(rows[0]["repeat_distances"], {"66.1458": 1})
+        self.assertEqual(rows[0]["qfit_symbol_spacing_to_repeat_distances"], {"(missing) -> 66.1458": 2})
 
     def test_source_label_fanout_summary_groups_qfit_style_expansion(self):
         rows = _source_label_fanout_summary_rows(
@@ -1335,6 +1337,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "source_symbol_spacings": {"(missing)": 1},
                     "qfit_symbol_spacings": {"(missing)": 1},
                     "repeat_distances": {"0": 1},
+                    "qfit_symbol_spacing_to_repeat_distances": {"(missing) -> 0": 1},
                     "placements": {"Curved": 1},
                     "style_names": {"contour-label": 1},
                     "zero_repeat_distance_count": 1,
@@ -1454,7 +1457,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
         self.assertIn("## Line label repeat spacing by base layer", markdown)
         self.assertIn(
-            "| contour-label | 1 | 1 | 1 | (missing)=1 | (missing)=1 | 0=1 | Curved=1 | contour-label=1 |",
+            "| contour-label | 1 | 1 | 1 | (missing)=1 | (missing)=1 | 0=1 | (missing) -> 0=1 | Curved=1 | contour-label=1 |",
             markdown,
         )
         self.assertIn("## Source label fan-out by base layer", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -625,10 +625,23 @@ def _repeat_label_records(
     )
 
 
+def _qfit_symbol_spacing_repeat_pairs(
+    grouped_rows: list[tuple[dict[str, object], list[dict[str, object]]]],
+) -> dict[str, int]:
+    return _sorted_count_map(
+        f"{_summary_key(_section_control(row, 'qfit_layout', 'symbol-spacing'))} -> "
+        f"{_summary_key(record.get('repeat_distance'))}"
+        for row, labels in grouped_rows
+        for record in labels
+        if _line_label_record_for_repeat(record)
+    )
+
+
 def _line_label_repeat_spacing_row(
     base_layer: str,
     source_rows: list[dict[str, object]],
     line_label_rows: list[dict[str, object]],
+    grouped_rows: list[tuple[dict[str, object], list[dict[str, object]]]],
 ) -> dict[str, object]:
     return {
         "base_style_layer_id": base_layer,
@@ -646,6 +659,7 @@ def _line_label_repeat_spacing_row(
             _section_control(row, "qfit_layout", "symbol-spacing") for row in source_rows
         ),
         "repeat_distances": _sorted_count_map(row.get("repeat_distance") for row in line_label_rows),
+        "qfit_symbol_spacing_to_repeat_distances": _qfit_symbol_spacing_repeat_pairs(grouped_rows),
         "placements": _sorted_count_map(row.get("placement") for row in line_label_rows),
         "style_names": _sorted_count_map(row.get("style_name") for row in source_rows),
         "zero_repeat_distance_count": sum(1 for row in line_label_rows if row.get("repeat_distance") == 0),
@@ -660,7 +674,14 @@ def _line_label_repeat_spacing_rows(
     rows = []
     for base_layer, grouped_rows in grouped.items():
         source_rows = [row for row, _labels in grouped_rows]
-        rows.append(_line_label_repeat_spacing_row(base_layer, source_rows, _repeat_label_records(grouped_rows)))
+        rows.append(
+            _line_label_repeat_spacing_row(
+                base_layer,
+                source_rows,
+                _repeat_label_records(grouped_rows),
+                grouped_rows,
+            )
+        )
     return sorted(
         rows,
         key=lambda row: (
@@ -1182,15 +1203,15 @@ def _append_line_label_repeat_spacing_summary(lines: list[str], summary_rows: li
             [
                 "## Line label repeat spacing by base layer",
                 "",
-                "| Base layer | Source rows | Converted line styles | Missing QGIS symbol-spacing | Source symbol-spacing | QGIS symbol-spacing | QGIS repeat distances | QGIS placements | Styles |",
-                "| --- | ---: | ---: | ---: | --- | --- | --- | --- | --- |",
+                "| Base layer | Source rows | Converted line styles | Missing QGIS symbol-spacing | Source symbol-spacing | QGIS symbol-spacing | QGIS repeat distances | QGIS spacing to repeat | QGIS placements | Styles |",
+                "| --- | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- |",
             ]
         )
         for row in summary_rows:
             if not isinstance(row, dict):
                 continue
             lines.append(
-                "| {base} | {source_rows} | {converted} | {missing_spacing} | {source_spacing} | {qfit_spacing} | {repeat} | {placements} | {styles} |".format(
+                "| {base} | {source_rows} | {converted} | {missing_spacing} | {source_spacing} | {qfit_spacing} | {repeat} | {spacing_to_repeat} | {placements} | {styles} |".format(
                     base=_markdown_value(row.get("base_style_layer_id")),
                     source_rows=_markdown_value(row.get("source_label_rows")),
                     converted=_markdown_value(row.get("converted_line_label_styles")),
@@ -1198,6 +1219,7 @@ def _append_line_label_repeat_spacing_summary(lines: list[str], summary_rows: li
                     source_spacing=_count_map_markdown_value(row.get("source_symbol_spacings")),
                     qfit_spacing=_count_map_markdown_value(row.get("qfit_symbol_spacings")),
                     repeat=_count_map_markdown_value(row.get("repeat_distances")),
+                    spacing_to_repeat=_count_map_markdown_value(row.get("qfit_symbol_spacing_to_repeat_distances")),
                     placements=_count_map_markdown_value(row.get("placements")),
                     styles=_count_map_markdown_value(row.get("style_names")),
                 )


### PR DESCRIPTION
## Summary

- add a `QGIS spacing to repeat` column to the Mapbox Outdoors label-settings diagnostic
- preserve the existing aggregate symbol-spacing and repeat-distance columns while adding the per-style mapping needed for #949 label-density probes
- cover the new mapping in the summary row and Markdown tests

## Validation

- `git diff --check`
- `python3 -m py_compile validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_label_settings.py`
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short` - 34 passed
- `python3 -m pytest tests/ -x -q --tb=short` - 2275 passed, 174 skipped, 162 subtests passed
- live label-settings diagnostic generated at `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260520T053943Z/summary.md`

The new diagnostic makes it explicit when a QGIS symbol-spacing value maps to an unexpected repeat distance, which is the next useful investigation thread for #949 after the ineffective high-zoom road-label spacing probe.

Refs #949.
