### PR TITLE
[codex] Report road-label feature candidates

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -28,6 +28,7 @@ from qfit.validation.mapbox_outdoors_road_features import (
     is_pedestrian_polygon_candidate,
     is_road_exit_shield_candidate,
     is_road_intersection_candidate,
+    is_road_label_candidate,
     is_road_number_shield_candidate,
     is_step_line_candidate,
     load_style_definition,
@@ -165,6 +166,16 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         sidewalk_path_line = _feature("LineString", {"class": "path", "type": "sidewalk", "structure": "none"})
         crossing_path_line = _feature("LineString", {"class": "path", "type": "crossing", "structure": "none"})
         missing_structure_path_line = _feature("LineString", {"class": "path", "type": "footway"})
+        low_zoom_major_road_label = _feature("LineString", {"class": "primary", "name": "Main Road"})
+        mid_zoom_street_road_label = _feature("LineString", {"class": "street", "name": "Main Road"})
+        high_zoom_street_road_label = _feature("LineString", {"class": "street", "name": "Main Road"})
+        high_zoom_link_road_label = _feature("LineString", {"class": "primary_link", "name": "Main Link"})
+        high_zoom_path_road_label = _feature("LineString", {"class": "path", "name": "Trail"})
+        unnamed_road_label = _feature("LineString", {"class": "street"})
+        null_name_road_label = _feature("LineString", {"class": "street", "name": None})
+        empty_name_road_label = _feature("LineString", {"class": "street", "name": "  "})
+        missing_class_road_label = _feature("LineString", {"name": "Main Road"})
+        point_road_label = _feature("Point", {"class": "street", "name": "Main Road"})
 
         self.assertTrue(is_pedestrian_polygon_candidate(pedestrian_polygon))
         self.assertTrue(is_pedestrian_polygon_candidate(path_polygon))
@@ -231,6 +242,19 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertTrue(is_path_line_candidate(crossing_path_line, tile_zoom=16))
         self.assertFalse(is_path_line_candidate(missing_structure_path_line))
         self.assertFalse(is_path_line_candidate(pedestrian_line))
+        self.assertFalse(is_road_label_candidate(low_zoom_major_road_label, tile_zoom=9))
+        self.assertTrue(is_road_label_candidate(low_zoom_major_road_label, tile_zoom=10))
+        self.assertFalse(is_road_label_candidate(mid_zoom_street_road_label, tile_zoom=11))
+        self.assertTrue(is_road_label_candidate(mid_zoom_street_road_label, tile_zoom=12))
+        self.assertTrue(is_road_label_candidate(high_zoom_street_road_label, tile_zoom=15))
+        self.assertTrue(is_road_label_candidate(high_zoom_link_road_label, tile_zoom=18))
+        self.assertFalse(is_road_label_candidate(high_zoom_path_road_label, tile_zoom=18))
+        self.assertFalse(is_road_label_candidate(unnamed_road_label, tile_zoom=18))
+        self.assertFalse(is_road_label_candidate(null_name_road_label, tile_zoom=18))
+        self.assertFalse(is_road_label_candidate(empty_name_road_label, tile_zoom=18))
+        self.assertFalse(is_road_label_candidate(missing_class_road_label, tile_zoom=18))
+        self.assertFalse(is_road_label_candidate(point_road_label, tile_zoom=18))
+        self.assertFalse(is_road_label_candidate(high_zoom_street_road_label))
 
     def test_road_tile_record_counts_pedestrian_polygons_and_line_candidates(self):
         road_features = [
@@ -247,7 +271,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": -1}),
             _feature("LineString", {"class": "path", "type": "footway", "structure": "none", "surface": "unpaved"}),
             _feature("MultiLineString", {"class": "path", "type": "steps", "structure": "none", "layer": 0, "surface": "paved"}),
-            _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
+            _feature(
+                "LineString",
+                {"class": "street", "structure": "none", "layer": 0, "name": "Bachstrasse", "oneway": "true"},
+            ),
             _feature("LineString", {"class": "motorway", "structure": "bridge", "oneway": "true"}),
             _feature("Point", {"class": "intersection", "name": "A1"}),
             _feature("Point", {"class": "level_crossing", "structure": "none", "layer": 0}),
@@ -263,7 +290,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                 },
             ),
             _feature("LineString", {"class": "service", "reflen": 2, "structure": "none"}),
-            _feature("LineString", {"class": "street", "type": "street", "structure": "none"}),
+            _feature("LineString", {"class": "street", "type": "street", "structure": "none", "name": "Bachstrasse"}),
         ]
         motorway_junction_features = [
             _feature("Point", {"ref": "12", "reflen": 2}),
@@ -295,6 +322,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["level_crossing_candidate_count"], 1)
         self.assertEqual(record["road_number_shield_candidate_count"], 1)
         self.assertEqual(record["road_exit_shield_candidate_count"], 1)
+        self.assertEqual(record["road_label_candidate_count"], 2)
         self.assertEqual(record["pedestrian_polygon_class_counts"], {"path": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_type_counts"], {"footway": 1, "pedestrian": 1})
         self.assertEqual(record["pedestrian_polygon_structure_counts"], {"none": 2})
@@ -351,6 +379,16 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
         self.assertEqual(record["road_exit_shield_reflen_counts"], {"2": 1})
         self.assertEqual(record["road_exit_shield_signature_counts"], {"ref=12; reflen=2": 1})
+        self.assertEqual(record["road_label_class_counts"], {"street": 2})
+        self.assertEqual(record["road_label_name_counts"], {"Bachstrasse": 2})
+        self.assertEqual(record["road_label_duplicate_name_counts"], {"Bachstrasse": 2})
+        self.assertEqual(
+            record["road_label_signature_counts"],
+            {
+                "class=street; type=(missing); structure=none; layer=0": 1,
+                "class=street; type=street; structure=none; layer=(missing)": 1,
+            },
+        )
         self.assertEqual(record["sample_pedestrian_polygons"][0]["properties"]["class"], "pedestrian")
         self.assertEqual(record["sample_step_lines"][0]["properties"]["type"], "steps")
         self.assertEqual(record["sample_oneway_arrow_lines"][0]["properties"]["oneway"], "true")
@@ -358,6 +396,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["sample_level_crossings"][0]["properties"]["class"], "level_crossing")
         self.assertEqual(record["sample_road_number_shields"][0]["properties"]["shield"], "ch-primary")
         self.assertEqual(record["sample_road_exit_shields"][0]["properties"]["ref"], "12")
+        self.assertEqual(record["sample_road_label_candidates"][0]["properties"]["name"], "Bachstrasse")
 
     def test_road_tile_record_accepts_flat_layer_lists_and_summarizes_irregular_features(self):
         road_features = [
@@ -459,7 +498,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                             "LineString",
                             {"class": "path", "type": "steps", "structure": "bridge", "surface": "paved"},
                         ),
-                        _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
+                        _feature(
+                            "LineString",
+                            {"class": "street", "structure": "none", "layer": 0, "name": "Main Road", "oneway": "true"},
+                        ),
                     ]
                 },
                 "motorway_junction": {
@@ -490,6 +532,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["level_crossing_candidate_count"], 0)
         self.assertEqual(report["road_number_shield_candidate_count"], 0)
         self.assertEqual(report["road_exit_shield_candidate_count"], 0)
+        self.assertEqual(report["road_label_candidate_count"], 0)
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 1})
         self.assertEqual(report["pedestrian_polygon_structure_counts"], {"none": 1})
         self.assertEqual(report["pedestrian_polygon_layer_counts"], {"0": 1})
@@ -532,6 +575,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["road_number_shield_structure_counts"], {})
         self.assertEqual(report["road_number_shield_layer_counts"], {})
         self.assertEqual(report["road_exit_shield_reflen_counts"], {})
+        self.assertEqual(report["road_label_class_counts"], {})
+        self.assertEqual(report["road_label_name_counts"], {})
+        self.assertEqual(report["road_label_duplicate_name_counts"], {})
+        self.assertEqual(report["road_label_signature_counts"], {})
         self.assertEqual(len(calls), 1)
         self.assertIn("mapbox.mapbox-streets-v8/0/0/0.mvt", calls[0])
 
@@ -626,7 +673,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                         "LineString",
                         {"class": "path", "type": "steps", "structure": "tunnel", "surface": "paved"},
                     ),
-                    _feature("LineString", {"class": "street", "structure": "none", "layer": 0, "oneway": "true"}),
+                    _feature(
+                        "LineString",
+                        {"class": "street", "structure": "none", "layer": 0, "name": "Main Road", "oneway": "true"},
+                    ),
                 ],
                 "motorway_junction": [_feature("Point", {"ref": "12", "reflen": 2})],
             }
@@ -656,6 +706,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["level_crossing_candidate_count"], 0)
         self.assertEqual(report["road_number_shield_candidate_count"], 0)
         self.assertEqual(report["road_exit_shield_candidate_count"], 0)
+        self.assertEqual(report["road_label_candidate_count"], 0)
         self.assertEqual(report["road_geometry_type_counts"], {"LineString": 8, "Polygon": 2})
         self.assertEqual(report["pedestrian_polygon_class_counts"], {"pedestrian": 2})
         self.assertEqual(report["pedestrian_polygon_type_counts"], {"pedestrian": 2})
@@ -702,6 +753,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["road_number_shield_structure_counts"], {})
         self.assertEqual(report["road_number_shield_layer_counts"], {})
         self.assertEqual(report["road_exit_shield_reflen_counts"], {})
+        self.assertEqual(report["road_label_class_counts"], {})
+        self.assertEqual(report["road_label_name_counts"], {})
+        self.assertEqual(report["road_label_duplicate_name_counts"], {})
+        self.assertEqual(report["road_label_signature_counts"], {})
         self.assertEqual(style_calls, [("token", "mapbox", "outdoors-v12")])
         self.assertEqual(
             [camera_report["camera"] for camera_report in report["cameras"]],
@@ -739,6 +794,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         level_crossing_signature = "class=level_crossing; structure=none; layer=0"
         shield_signature = "class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0"
         exit_shield_signature = "ref=12; reflen=2"
+        road_label_signature = "class=street; type=street; structure=none; layer=0"
         report = {
             "generated": "2026-05-18T14:12:00+00:00",
             "style_owner": "mapbox",
@@ -758,6 +814,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "level_crossing_candidate_count": 1,
             "road_number_shield_candidate_count": 1,
             "road_exit_shield_candidate_count": 1,
+            "road_label_candidate_count": 2,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
@@ -792,6 +849,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "road_number_shield_signature_counts": {shield_signature: 1},
             "road_exit_shield_reflen_counts": {"2": 1},
             "road_exit_shield_signature_counts": {exit_shield_signature: 1},
+            "road_label_class_counts": {"street": 2},
+            "road_label_name_counts": {"Bachstrasse": 2},
+            "road_label_duplicate_name_counts": {"Bachstrasse": 2},
+            "road_label_signature_counts": {road_label_signature: 2},
             "sample_pedestrian_polygons": [{"properties": {"class": "pedestrian"}}],
             "sample_pedestrian_lines": [{"properties": {"class": "pedestrian"}}],
             "sample_path_lines": [{"properties": {"class": "path"}}],
@@ -801,6 +862,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "sample_level_crossings": [{"properties": {"class": "level_crossing"}}],
             "sample_road_number_shields": [{"properties": {"class": "primary", "shield": "ch-primary"}}],
             "sample_road_exit_shields": [{"properties": {"ref": "12", "reflen": 2}}],
+            "sample_road_label_candidates": [{"properties": {"class": "street", "name": "Bachstrasse"}}],
             "tiles": [
                 "ignore-me",
                 {
@@ -819,6 +881,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "level_crossing_candidate_count": 1,
                     "road_number_shield_candidate_count": 1,
                     "road_exit_shield_candidate_count": 1,
+                    "road_label_candidate_count": 2,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
@@ -853,6 +916,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "road_number_shield_signature_counts": {shield_signature: 1},
                     "road_exit_shield_reflen_counts": {"2": 1},
                     "road_exit_shield_signature_counts": {exit_shield_signature: 1},
+                    "road_label_class_counts": {"street": 2},
+                    "road_label_name_counts": {"Bachstrasse": 2},
+                    "road_label_duplicate_name_counts": {"Bachstrasse": 2},
+                    "road_label_signature_counts": {road_label_signature: 2},
                 }
             ],
         }
@@ -868,6 +935,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("Level crossing candidates: 1", markdown)
         self.assertIn("Road number shield candidates: 1", markdown)
         self.assertIn("Road exit shield candidates: 1", markdown)
+        self.assertIn("Road label candidates: 2", markdown)
         self.assertIn('Pedestrian polygon structure counts: {"none":1}', markdown)
         self.assertIn('Pedestrian polygon layer counts: {"0":1}', markdown)
         self.assertIn('Pedestrian polygon surface counts: {"paved":1}', markdown)
@@ -899,6 +967,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn(f'Road number shield signatures: {{"{shield_signature}":1}}', markdown)
         self.assertIn('Road exit shield reflen counts: {"2":1}', markdown)
         self.assertIn(f'Road exit shield signatures: {{"{exit_shield_signature}":1}}', markdown)
+        self.assertIn('Road label duplicate names: {"Bachstrasse":2}', markdown)
+        self.assertIn(f'Road label signatures: {{"{road_label_signature}":2}}', markdown)
         self.assertIn("## Sample pedestrian/path polygon candidates", markdown)
         self.assertIn("## Sample pedestrian line candidates", markdown)
         self.assertIn("## Sample path line candidates", markdown)
@@ -908,6 +978,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("## Sample level crossing candidates", markdown)
         self.assertIn("## Sample road number shield candidates", markdown)
         self.assertIn("## Sample road exit shield candidates", markdown)
+        self.assertIn("## Sample road label candidates", markdown)
 
     def test_build_all_camera_summary_markdown_includes_camera_rows(self):
         pedestrian_signature = "class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0"
@@ -917,6 +988,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         level_crossing_signature = "class=level_crossing; structure=none; layer=0"
         shield_signature = "class=primary; reflen=2; shield=ch-primary; shield_beta=(missing); structure=none; layer=0"
         exit_shield_signature = "ref=12; reflen=2"
+        road_label_signature = "class=street; type=street; structure=none; layer=0"
         report = {
             "generated": "2026-05-18T15:40:00+00:00",
             "style_owner": "mapbox",
@@ -937,6 +1009,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "level_crossing_candidate_count": 1,
             "road_number_shield_candidate_count": 1,
             "road_exit_shield_candidate_count": 1,
+            "road_label_candidate_count": 2,
             "pedestrian_polygon_type_counts": {"pedestrian": 1},
             "pedestrian_polygon_structure_counts": {"none": 1},
             "pedestrian_polygon_layer_counts": {"0": 1},
@@ -971,6 +1044,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "road_number_shield_signature_counts": {shield_signature: 1},
             "road_exit_shield_reflen_counts": {"2": 1},
             "road_exit_shield_signature_counts": {exit_shield_signature: 1},
+            "road_label_class_counts": {"street": 2},
+            "road_label_name_counts": {"Bachstrasse": 2},
+            "road_label_duplicate_name_counts": {"Bachstrasse": 2},
+            "road_label_signature_counts": {road_label_signature: 2},
             "cameras": [
                 {
                     "status": "decoded",
@@ -991,6 +1068,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "level_crossing_candidate_count": 1,
                     "road_number_shield_candidate_count": 1,
                     "road_exit_shield_candidate_count": 1,
+                    "road_label_candidate_count": 2,
                     "pedestrian_polygon_type_counts": {"pedestrian": 1},
                     "pedestrian_polygon_structure_counts": {"none": 1},
                     "pedestrian_polygon_layer_counts": {"0": 1},
@@ -1025,6 +1103,10 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "road_number_shield_signature_counts": {shield_signature: 1},
                     "road_exit_shield_reflen_counts": {"2": 1},
                     "road_exit_shield_signature_counts": {exit_shield_signature: 1},
+                    "road_label_class_counts": {"street": 2},
+                    "road_label_name_counts": {"Bachstrasse": 2},
+                    "road_label_duplicate_name_counts": {"Bachstrasse": 2},
+                    "road_label_signature_counts": {road_label_signature: 2},
                 }
             ],
         }
@@ -1034,9 +1116,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn("# Mapbox Outdoors road feature diagnostic - all cameras", markdown)
         self.assertIn("Cameras: 1", markdown)
         self.assertIn('Camera statuses: {"decoded":1}', markdown)
-        self.assertIn("| zermatt-trails-z18-outdoors | decoded | 18.0 | 18 | 1/1 | - | 4 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |", markdown)
+        self.assertIn(
+            "| zermatt-trails-z18-outdoors | decoded | 18.0 | 18 | 1/1 | - | 4 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 2 |",
+            markdown,
+        )
         self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
         self.assertIn(f'Road exit shield signatures: {{"{exit_shield_signature}":1}}', markdown)
+        self.assertIn('Road label duplicate names: {"Bachstrasse":2}', markdown)
+        self.assertIn(f'Road label signatures: {{"{road_label_signature}":2}}', markdown)
         self.assertIn("## Path/pedestrian focus", markdown)
         self.assertIn(
             '| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 1 | 1 | ["pedestrian=1"] | ["footway=1"] | ["bridge=1"] |',

--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -252,7 +252,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertFalse(is_road_label_candidate(unnamed_road_label, tile_zoom=18))
         self.assertFalse(is_road_label_candidate(null_name_road_label, tile_zoom=18))
         self.assertFalse(is_road_label_candidate(empty_name_road_label, tile_zoom=18))
-        self.assertFalse(is_road_label_candidate(missing_class_road_label, tile_zoom=18))
+        self.assertFalse(is_road_label_candidate(missing_class_road_label, tile_zoom=14))
+        self.assertTrue(is_road_label_candidate(missing_class_road_label, tile_zoom=18))
         self.assertFalse(is_road_label_candidate(point_road_label, tile_zoom=18))
         self.assertFalse(is_road_label_candidate(high_zoom_street_road_label))
 

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -65,6 +65,10 @@ ROAD_NUMBER_SHIELD_EXCLUDED_CLASSES = {"pedestrian", "service"}
 ROAD_NUMBER_SHIELD_LINE_LENGTH_MIN = 2500.0
 ROAD_EXIT_SHIELD_MIN_ZOOM = 14
 ROAD_EXIT_SHIELD_MAX_REFLEN = 9
+ROAD_LABEL_MIN_ZOOM = 10
+ROAD_LABEL_LOW_ZOOM_CLASSES = {"motorway", "trunk", "primary", "secondary", "tertiary"}
+ROAD_LABEL_MID_ZOOM_CLASSES = ROAD_LABEL_LOW_ZOOM_CLASSES | {"street", "street_limited", "track"}
+ROAD_LABEL_HIGH_ZOOM_EXCLUDED_CLASSES = {"path", "pedestrian", "golf", "ferry", "aerialway"}
 ONEWAY_ARROW_BLUE_CLASSES = {
     "primary",
     "primary_link",
@@ -98,6 +102,7 @@ ROAD_INTERSECTION_SIGNATURE_KEYS = ("class", "name")
 LEVEL_CROSSING_SIGNATURE_KEYS = ("class", "structure", "layer")
 ROAD_NUMBER_SHIELD_SIGNATURE_KEYS = ("class", "reflen", "shield", "shield_beta", "structure", "layer")
 ROAD_EXIT_SHIELD_SIGNATURE_KEYS = ("ref", "reflen")
+ROAD_LABEL_SIGNATURE_KEYS = ("class", "type", "structure", "layer")
 PATH_PEDESTRIAN_FOCUS_TOP_COUNT_LIMIT = 3
 
 
@@ -271,6 +276,25 @@ def is_road_exit_shield_candidate(feature: dict[str, object], *, tile_zoom: int 
     )
 
 
+def is_road_label_candidate(feature: dict[str, object], *, tile_zoom: int | None = None) -> bool:
+    properties = _feature_properties(feature)
+    road_name = properties.get("name")
+    road_class = properties.get("class")
+    if (
+        tile_zoom is None
+        or tile_zoom < ROAD_LABEL_MIN_ZOOM
+        or not isinstance(road_name, str)
+        or not road_name.strip()
+        or _geometry_type(feature) not in LINE_GEOMETRY_TYPES
+    ):
+        return False
+    if tile_zoom < 12:
+        return road_class in ROAD_LABEL_LOW_ZOOM_CLASSES
+    if tile_zoom < 15:
+        return road_class in ROAD_LABEL_MID_ZOOM_CLASSES
+    return road_class is not None and road_class not in ROAD_LABEL_HIGH_ZOOM_EXCLUDED_CLASSES
+
+
 def _property_count_label(value: object) -> str:
     if isinstance(value, (dict, list)):
         value = json.dumps(value, sort_keys=True, separators=(",", ":"))
@@ -291,6 +315,17 @@ def _count_by_property(features: Iterable[dict[str, object]], key: str) -> dict[
         normalized = _property_count_label(_feature_properties(feature).get(key, MISSING_VALUE))
         counts[normalized] = counts.get(normalized, 0) + 1
     return dict(sorted(counts.items()))
+
+
+def _duplicate_count_map(counts: object) -> dict[str, int]:
+    if not isinstance(counts, dict):
+        return {}
+    duplicates = {
+        str(label): count
+        for label, count in counts.items()
+        if isinstance(count, int) and not isinstance(count, bool) and count > 1
+    }
+    return dict(sorted(duplicates.items()))
 
 
 def _count_property_signatures(
@@ -361,6 +396,10 @@ def road_tile_record(
         for feature in motorway_junction_features
         if is_road_exit_shield_candidate(feature, tile_zoom=tile.get("z"))
     ]
+    road_label_lines = [
+        feature for feature in road_features if is_road_label_candidate(feature, tile_zoom=tile.get("z"))
+    ]
+    road_label_name_counts = _count_by_property(road_label_lines, "name")
     return {
         **tile,
         "status": "decoded",
@@ -376,6 +415,7 @@ def road_tile_record(
         "level_crossing_candidate_count": len(level_crossings),
         "road_number_shield_candidate_count": len(road_number_shields),
         "road_exit_shield_candidate_count": len(road_exit_shields),
+        "road_label_candidate_count": len(road_label_lines),
         "road_geometry_type_counts": _count_geometry_types(road_features),
         "pedestrian_polygon_class_counts": _count_by_property(pedestrian_polygons, "class"),
         "pedestrian_polygon_type_counts": _count_by_property(pedestrian_polygons, "type"),
@@ -430,6 +470,10 @@ def road_tile_record(
             road_exit_shields,
             ROAD_EXIT_SHIELD_SIGNATURE_KEYS,
         ),
+        "road_label_class_counts": _count_by_property(road_label_lines, "class"),
+        "road_label_name_counts": road_label_name_counts,
+        "road_label_duplicate_name_counts": _duplicate_count_map(road_label_name_counts),
+        "road_label_signature_counts": _count_property_signatures(road_label_lines, ROAD_LABEL_SIGNATURE_KEYS),
         "sample_pedestrian_polygons": [
             _feature_sample(tile, feature) for feature in pedestrian_polygons[:MAX_SAMPLE_FEATURES]
         ],
@@ -452,6 +496,9 @@ def road_tile_record(
         ],
         "sample_road_exit_shields": [
             _feature_sample(tile, feature) for feature in road_exit_shields[:MAX_SAMPLE_FEATURES]
+        ],
+        "sample_road_label_candidates": [
+            _feature_sample(tile, feature) for feature in road_label_lines[:MAX_SAMPLE_FEATURES]
         ],
     }
 
@@ -479,6 +526,7 @@ _SUMMARY_COUNT_FIELDS = (
     ("Level crossing candidates", "level_crossing_candidate_count"),
     ("Road number shield candidates", "road_number_shield_candidate_count"),
     ("Road exit shield candidates", "road_exit_shield_candidate_count"),
+    ("Road label candidates", "road_label_candidate_count"),
 )
 _SUMMARY_COUNT_MAP_FIELDS = (
     ("Pedestrian polygon type counts", "pedestrian_polygon_type_counts"),
@@ -515,6 +563,9 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("Road number shield signatures", "road_number_shield_signature_counts"),
     ("Road exit shield reflen counts", "road_exit_shield_reflen_counts"),
     ("Road exit shield signatures", "road_exit_shield_signature_counts"),
+    ("Road label classes", "road_label_class_counts"),
+    ("Road label duplicate names", "road_label_duplicate_name_counts"),
+    ("Road label signatures", "road_label_signature_counts"),
 )
 _ROAD_FEATURE_TABLE_FIELDS = (
     ("Road", "road_feature_count", "---:"),
@@ -528,6 +579,7 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Level crossings", "level_crossing_candidate_count", "---:"),
     ("Road number shields", "road_number_shield_candidate_count", "---:"),
     ("Road exit shields", "road_exit_shield_candidate_count", "---:"),
+    ("Road labels", "road_label_candidate_count", "---:"),
     ("Polygon types", "pedestrian_polygon_type_counts", "---"),
     ("Polygon structures", "pedestrian_polygon_structure_counts", "---"),
     ("Polygon layers", "pedestrian_polygon_layer_counts", "---"),
@@ -562,7 +614,45 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Shield signatures", "road_number_shield_signature_counts", "---"),
     ("Exit shield reflens", "road_exit_shield_reflen_counts", "---"),
     ("Exit shield signatures", "road_exit_shield_signature_counts", "---"),
+    ("Road label classes", "road_label_class_counts", "---"),
+    ("Duplicate road labels", "road_label_duplicate_name_counts", "---"),
+    ("Road label signatures", "road_label_signature_counts", "---"),
 )
+_SAMPLE_FEATURE_SECTIONS = (
+    ("Sample pedestrian/path polygon candidates", "sample_pedestrian_polygons"),
+    ("Sample pedestrian line candidates", "sample_pedestrian_lines"),
+    ("Sample path line candidates", "sample_path_lines"),
+    ("Sample step line candidates", "sample_step_lines"),
+    ("Sample one-way arrow candidates", "sample_oneway_arrow_lines"),
+    ("Sample road intersection candidates", "sample_road_intersections"),
+    ("Sample level crossing candidates", "sample_level_crossings"),
+    ("Sample road number shield candidates", "sample_road_number_shields"),
+    ("Sample road exit shield candidates", "sample_road_exit_shields"),
+    ("Sample road label candidates", "sample_road_label_candidates"),
+)
+_SAMPLE_FEATURE_KEYS = tuple(key for _heading, key in _SAMPLE_FEATURE_SECTIONS)
+
+
+def _candidate_count_report_fields(records: Iterable[dict[str, object]]) -> dict[str, int]:
+    return {key: _sum_reports(records, key) for _label, key in _SUMMARY_COUNT_FIELDS}
+
+
+def _count_map_report_fields(records: Iterable[dict[str, object]]) -> dict[str, object]:
+    record_list = list(records)
+    road_label_name_counts = _combined_record_counts(record_list, "road_label_name_counts")
+    fields = {
+        key: _combined_record_counts(record_list, key)
+        for _label, key in _SUMMARY_COUNT_MAP_FIELDS
+        if key != "road_label_duplicate_name_counts"
+    }
+    fields["road_label_name_counts"] = road_label_name_counts
+    fields["road_label_duplicate_name_counts"] = _duplicate_count_map(road_label_name_counts)
+    return fields
+
+
+def _sample_report_fields(records: Iterable[dict[str, object]]) -> dict[str, list[dict[str, object]]]:
+    record_list = list(records)
+    return {key: _combined_samples(record_list, key) for key in _SAMPLE_FEATURE_KEYS}
 
 
 def _feature_summary_lines(report: dict[str, object]) -> list[str]:
@@ -677,6 +767,7 @@ def _all_camera_row(report: dict[str, object]) -> dict[str, object]:
     }
     for _label, key, _alignment in _ROAD_FEATURE_TABLE_FIELDS:
         row[key] = report.get(key)
+    row["road_label_name_counts"] = report.get("road_label_name_counts")
     return row
 
 
@@ -733,123 +824,11 @@ def collect_road_feature_report(
         "tile_count": len(tile_records),
         "decoded_tile_count": decoded_tile_count,
         "failed_tile_count": len(tile_records) - decoded_tile_count,
-        "road_feature_count": sum(int(tile.get("road_feature_count") or 0) for tile in tile_records),
-        "motorway_junction_feature_count": sum(
-            int(tile.get("motorway_junction_feature_count") or 0) for tile in tile_records
-        ),
-        "pedestrian_polygon_candidate_count": sum(
-            int(tile.get("pedestrian_polygon_candidate_count") or 0) for tile in tile_records
-        ),
-        "pedestrian_line_candidate_count": sum(
-            int(tile.get("pedestrian_line_candidate_count") or 0) for tile in tile_records
-        ),
-        "path_line_candidate_count": sum(int(tile.get("path_line_candidate_count") or 0) for tile in tile_records),
-        "step_line_candidate_count": sum(int(tile.get("step_line_candidate_count") or 0) for tile in tile_records),
-        "oneway_arrow_candidate_count": sum(
-            int(tile.get("oneway_arrow_candidate_count") or 0) for tile in tile_records
-        ),
-        "road_intersection_candidate_count": sum(
-            int(tile.get("road_intersection_candidate_count") or 0) for tile in tile_records
-        ),
-        "level_crossing_candidate_count": sum(
-            int(tile.get("level_crossing_candidate_count") or 0) for tile in tile_records
-        ),
-        "road_number_shield_candidate_count": sum(
-            int(tile.get("road_number_shield_candidate_count") or 0) for tile in tile_records
-        ),
-        "road_exit_shield_candidate_count": sum(
-            int(tile.get("road_exit_shield_candidate_count") or 0) for tile in tile_records
-        ),
+        **_candidate_count_report_fields(tile_records),
         "road_geometry_type_counts": _combined_record_counts(tile_records, "road_geometry_type_counts"),
-        "pedestrian_polygon_class_counts": _combined_record_counts(
-            tile_records,
-            "pedestrian_polygon_class_counts",
-        ),
-        "pedestrian_polygon_type_counts": _combined_record_counts(
-            tile_records,
-            "pedestrian_polygon_type_counts",
-        ),
-        "pedestrian_polygon_structure_counts": _combined_record_counts(
-            tile_records,
-            "pedestrian_polygon_structure_counts",
-        ),
-        "pedestrian_polygon_layer_counts": _combined_record_counts(
-            tile_records,
-            "pedestrian_polygon_layer_counts",
-        ),
-        "pedestrian_polygon_surface_counts": _combined_record_counts(
-            tile_records,
-            "pedestrian_polygon_surface_counts",
-        ),
-        "pedestrian_polygon_signature_counts": _combined_record_counts(
-            tile_records,
-            "pedestrian_polygon_signature_counts",
-        ),
-        "pedestrian_line_type_counts": _combined_record_counts(tile_records, "pedestrian_line_type_counts"),
-        "pedestrian_line_structure_counts": _combined_record_counts(
-            tile_records,
-            "pedestrian_line_structure_counts",
-        ),
-        "pedestrian_line_layer_counts": _combined_record_counts(tile_records, "pedestrian_line_layer_counts"),
-        "pedestrian_line_surface_counts": _combined_record_counts(tile_records, "pedestrian_line_surface_counts"),
-        "pedestrian_line_signature_counts": _combined_record_counts(
-            tile_records,
-            "pedestrian_line_signature_counts",
-        ),
-        "path_line_type_counts": _combined_record_counts(tile_records, "path_line_type_counts"),
-        "path_line_structure_counts": _combined_record_counts(tile_records, "path_line_structure_counts"),
-        "path_line_layer_counts": _combined_record_counts(tile_records, "path_line_layer_counts"),
-        "path_line_surface_counts": _combined_record_counts(tile_records, "path_line_surface_counts"),
-        "path_line_signature_counts": _combined_record_counts(tile_records, "path_line_signature_counts"),
-        "step_line_structure_counts": _combined_record_counts(tile_records, "step_line_structure_counts"),
-        "step_line_layer_counts": _combined_record_counts(tile_records, "step_line_layer_counts"),
-        "step_line_surface_counts": _combined_record_counts(tile_records, "step_line_surface_counts"),
-        "step_line_signature_counts": _combined_record_counts(tile_records, "step_line_signature_counts"),
-        "oneway_arrow_class_counts": _combined_record_counts(tile_records, "oneway_arrow_class_counts"),
-        "oneway_arrow_structure_counts": _combined_record_counts(tile_records, "oneway_arrow_structure_counts"),
-        "oneway_arrow_layer_counts": _combined_record_counts(tile_records, "oneway_arrow_layer_counts"),
-        "road_intersection_name_counts": _combined_record_counts(tile_records, "road_intersection_name_counts"),
-        "road_intersection_signature_counts": _combined_record_counts(
-            tile_records,
-            "road_intersection_signature_counts",
-        ),
-        "level_crossing_structure_counts": _combined_record_counts(tile_records, "level_crossing_structure_counts"),
-        "level_crossing_layer_counts": _combined_record_counts(tile_records, "level_crossing_layer_counts"),
-        "level_crossing_signature_counts": _combined_record_counts(
-            tile_records,
-            "level_crossing_signature_counts",
-        ),
-        "road_number_shield_class_counts": _combined_record_counts(tile_records, "road_number_shield_class_counts"),
-        "road_number_shield_reflen_counts": _combined_record_counts(
-            tile_records,
-            "road_number_shield_reflen_counts",
-        ),
-        "road_number_shield_structure_counts": _combined_record_counts(
-            tile_records,
-            "road_number_shield_structure_counts",
-        ),
-        "road_number_shield_layer_counts": _combined_record_counts(tile_records, "road_number_shield_layer_counts"),
-        "road_number_shield_signature_counts": _combined_record_counts(
-            tile_records,
-            "road_number_shield_signature_counts",
-        ),
-        "road_exit_shield_reflen_counts": _combined_record_counts(
-            tile_records,
-            "road_exit_shield_reflen_counts",
-        ),
-        "road_exit_shield_signature_counts": _combined_record_counts(
-            tile_records,
-            "road_exit_shield_signature_counts",
-        ),
-        "sample_pedestrian_polygons": _combined_samples(tile_records, "sample_pedestrian_polygons"),
-        "sample_pedestrian_lines": _combined_samples(tile_records, "sample_pedestrian_lines"),
-        "sample_path_lines": _combined_samples(tile_records, "sample_path_lines"),
-        "sample_step_lines": _combined_samples(tile_records, "sample_step_lines"),
-        "sample_oneway_arrow_lines": _combined_samples(tile_records, "sample_oneway_arrow_lines"),
-        "sample_road_intersections": _combined_samples(tile_records, "sample_road_intersections"),
-        "sample_level_crossings": _combined_samples(tile_records, "sample_level_crossings"),
-        "sample_road_number_shields": _combined_samples(tile_records, "sample_road_number_shields"),
-        "sample_road_exit_shields": _combined_samples(tile_records, "sample_road_exit_shields"),
+        "pedestrian_polygon_class_counts": _combined_record_counts(tile_records, "pedestrian_polygon_class_counts"),
+        **_count_map_report_fields(tile_records),
+        **_sample_report_fields(tile_records),
         "tiles": tile_records,
     }
 
@@ -917,6 +896,7 @@ def collect_all_camera_road_feature_report(
         "level_crossing_candidate_count": _sum_reports(camera_reports, "level_crossing_candidate_count"),
         "road_number_shield_candidate_count": _sum_reports(camera_reports, "road_number_shield_candidate_count"),
         "road_exit_shield_candidate_count": _sum_reports(camera_reports, "road_exit_shield_candidate_count"),
+        "road_label_candidate_count": _sum_reports(camera_reports, "road_label_candidate_count"),
         "road_geometry_type_counts": _combined_record_counts(camera_reports, "road_geometry_type_counts"),
         "pedestrian_polygon_class_counts": _combined_record_counts(
             camera_reports,
@@ -1013,6 +993,12 @@ def collect_all_camera_road_feature_report(
             camera_reports,
             "road_exit_shield_signature_counts",
         ),
+        "road_label_class_counts": _combined_record_counts(camera_reports, "road_label_class_counts"),
+        "road_label_name_counts": _combined_record_counts(camera_reports, "road_label_name_counts"),
+        "road_label_duplicate_name_counts": _duplicate_count_map(
+            _combined_record_counts(camera_reports, "road_label_name_counts")
+        ),
+        "road_label_signature_counts": _combined_record_counts(camera_reports, "road_label_signature_counts"),
         "cameras": camera_reports,
     }
 
@@ -1036,18 +1022,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         if not isinstance(tile, dict):
             continue
         lines.append(_markdown_table_row([tile.get("z"), tile.get("x"), tile.get("y"), tile.get("status"), *_road_feature_table_cells(tile)]))
-    sample_sections = (
-        ("Sample pedestrian/path polygon candidates", "sample_pedestrian_polygons"),
-        ("Sample pedestrian line candidates", "sample_pedestrian_lines"),
-        ("Sample path line candidates", "sample_path_lines"),
-        ("Sample step line candidates", "sample_step_lines"),
-        ("Sample one-way arrow candidates", "sample_oneway_arrow_lines"),
-        ("Sample road intersection candidates", "sample_road_intersections"),
-        ("Sample level crossing candidates", "sample_level_crossings"),
-        ("Sample road number shield candidates", "sample_road_number_shields"),
-        ("Sample road exit shield candidates", "sample_road_exit_shields"),
-    )
-    for heading, key in sample_sections:
+    for heading, key in _SAMPLE_FEATURE_SECTIONS:
         samples = report.get(key)
         sample_rows = samples if isinstance(samples, list) else []
         if sample_rows:

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -292,7 +292,7 @@ def is_road_label_candidate(feature: dict[str, object], *, tile_zoom: int | None
         return road_class in ROAD_LABEL_LOW_ZOOM_CLASSES
     if tile_zoom < 15:
         return road_class in ROAD_LABEL_MID_ZOOM_CLASSES
-    return road_class is not None and road_class not in ROAD_LABEL_HIGH_ZOOM_EXCLUDED_CLASSES
+    return road_class not in ROAD_LABEL_HIGH_ZOOM_EXCLUDED_CLASSES
 
 
 def _property_count_label(value: object) -> str:
@@ -869,6 +869,7 @@ def collect_all_camera_road_feature_report(
             continue
         camera_reports.append(_all_camera_row(report))
     status_counts = _all_camera_status_counts(camera_reports)
+    road_label_name_counts = _combined_record_counts(camera_reports, "road_label_name_counts")
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
@@ -994,10 +995,8 @@ def collect_all_camera_road_feature_report(
             "road_exit_shield_signature_counts",
         ),
         "road_label_class_counts": _combined_record_counts(camera_reports, "road_label_class_counts"),
-        "road_label_name_counts": _combined_record_counts(camera_reports, "road_label_name_counts"),
-        "road_label_duplicate_name_counts": _duplicate_count_map(
-            _combined_record_counts(camera_reports, "road_label_name_counts")
-        ),
+        "road_label_name_counts": road_label_name_counts,
+        "road_label_duplicate_name_counts": _duplicate_count_map(road_label_name_counts),
         "road_label_signature_counts": _combined_record_counts(camera_reports, "road_label_signature_counts"),
         "cameras": camera_reports,
     }


### PR DESCRIPTION
## Summary

- Add Mapbox Outdoors road-feature diagnostic coverage for `road-label` source candidates.
- Report candidate counts, classes, duplicate label names, signatures, and samples in the JSON/Markdown output.
- Use the audited `road-label` zoom/class filter bands so #949 can separate road-label density from path/pedestrian label density.
- Align the high-zoom diagnostic predicate with the Mapbox `match` default so named, classless line features are counted instead of dropped.

## Evidence

Live z18 Zermatt diagnostic generated after the review fix:

- `debug/mapbox-outdoors-road-features/zermatt-trails-z18-outdoors/20260520T061722Z/summary.md`
- Result: `road_label_candidate_count` is `0` for that camera, while the existing pedestrian/path samples contain repeated visible names such as `Englischer Viertel`.
- Implication: the current Zermatt z18 repetition probe is probably exercising `path-pedestrian-label`/line-feature segmentation rather than the Mapbox `road-label` layer itself.

## Validation

- `git diff --check`
- `python3 -m py_compile validation/mapbox_outdoors_road_features.py tests/test_mapbox_outdoors_road_features.py`
- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q` -> 24 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2275 passed, 174 skipped, 162 subtests passed
- live diagnostic above was generated with the local Mapbox token source; token was not printed or stored

Refs #949
