### PR TITLE
[codex] Report path label duplicate names

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -43,6 +43,9 @@ def _road_feature_report():
                 "pedestrian_line_type_counts": {"pedestrian": 115},
                 "path_line_type_counts": {"trail": 69, "footway": 56, "piste": 48, "path": 4},
                 "step_line_structure_counts": {"none": 16, "tunnel": 2, "bridge": 1},
+                "pedestrian_line_duplicate_name_counts": {"Englischer Viertel": 5},
+                "path_line_duplicate_name_counts": {"Hofmattweg": 3},
+                "step_line_duplicate_name_counts": {"Kirchsteig": 2},
                 "path_line_signature_counts": {path_signature: 55, "class=path; type=piste": 46},
                 "step_line_signature_counts": {step_signature: 3},
             },
@@ -360,6 +363,9 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(camera["step_line_count"], 19)
         self.assertEqual(camera["top_path_line_types"], ["trail=69", "footway=56", "piste=48"])
         self.assertEqual(camera["top_step_structures"], ["none=16", "tunnel=2", "bridge=1"])
+        self.assertEqual(camera["top_pedestrian_line_duplicate_names"], ["Englischer Viertel=5"])
+        self.assertEqual(camera["top_path_line_duplicate_names"], ["Hofmattweg=3"])
+        self.assertEqual(camera["top_step_line_duplicate_names"], ["Kirchsteig=2"])
         self.assertEqual(camera["qgis_path_pedestrian_layer_count"], 4)
         self.assertEqual(camera["qgis_path_pedestrian_visible_layer_count"], 3)
 
@@ -409,10 +415,14 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("Focused cameras: 1", markdown)
         self.assertIn("QGIS preprocessed style cameras: 1/1 matched", markdown)
         self.assertIn("Top pedestrian types", markdown)
+        self.assertIn("Duplicate pedestrian labels", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | 14.25 | 14 |", markdown)
         self.assertIn('"path_lines=236"', markdown)
         self.assertIn('"pedestrian=115"', markdown)
         self.assertIn('"trail=69"', markdown)
+        self.assertIn('"Englischer Viertel=5"', markdown)
+        self.assertIn('"Hofmattweg=3"', markdown)
+        self.assertIn('"Kirchsteig=2"', markdown)
         self.assertIn('"status=available"', markdown)
         self.assertIn('"total=4"', markdown)
         self.assertIn('"visible=3"', markdown)

--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -399,6 +399,36 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["sample_road_exit_shields"][0]["properties"]["ref"], "12")
         self.assertEqual(record["sample_road_label_candidates"][0]["properties"]["name"], "Bachstrasse")
 
+    def test_road_tile_record_counts_duplicate_non_empty_path_pedestrian_names(self):
+        road_features = [
+            _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "name": " Plaza "}),
+            _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "name": "Plaza"}),
+            _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "name": None}),
+            _feature("LineString", {"class": "path", "type": "footway", "structure": "none", "name": "Trail"}),
+            _feature("LineString", {"class": "path", "type": "footway", "structure": "none", "name": "Trail"}),
+            _feature("LineString", {"class": "path", "type": "footway", "structure": "none", "name": "   "}),
+            _feature("LineString", {"class": "path", "type": "steps", "structure": "none", "name": "Steps"}),
+            _feature("LineString", {"class": "path", "type": "steps", "structure": "none", "name": "Steps"}),
+            _feature("LineString", {"class": "street", "name": "Main Road"}),
+            _feature("LineString", {"class": "street", "name": "Main Road"}),
+        ]
+
+        record = road_tile_record(
+            tile={"z": 18, "x": 136712, "y": 93238},
+            tile_url_template="https://example.test/{z}/{x}/{y}.mvt",
+            tile_fetcher=lambda _url: gzip.compress(b"tile"),
+            tile_decoder=lambda _payload: {"road": {"features": road_features}},
+        )
+
+        self.assertEqual(record["pedestrian_line_name_counts"], {"Plaza": 2})
+        self.assertEqual(record["pedestrian_line_duplicate_name_counts"], {"Plaza": 2})
+        self.assertEqual(record["path_line_name_counts"], {"Trail": 2})
+        self.assertEqual(record["path_line_duplicate_name_counts"], {"Trail": 2})
+        self.assertEqual(record["step_line_name_counts"], {"Steps": 2})
+        self.assertEqual(record["step_line_duplicate_name_counts"], {"Steps": 2})
+        self.assertEqual(record["road_label_name_counts"], {"Main Road": 2})
+        self.assertEqual(record["road_label_duplicate_name_counts"], {"Main Road": 2})
+
     def test_road_tile_record_accepts_flat_layer_lists_and_summarizes_irregular_features(self):
         road_features = [
             {
@@ -489,15 +519,34 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                         ),
                         _feature(
                             "LineString",
-                            {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": 0, "surface": "paved"},
+                            {
+                                "class": "pedestrian",
+                                "type": "pedestrian",
+                                "structure": "none",
+                                "layer": 0,
+                                "surface": "paved",
+                                "name": "Promenade",
+                            },
                         ),
                         _feature(
                             "LineString",
-                            {"class": "path", "type": "footway", "structure": "none", "surface": "unpaved"},
+                            {
+                                "class": "path",
+                                "type": "footway",
+                                "structure": "none",
+                                "surface": "unpaved",
+                                "name": "Trail",
+                            },
                         ),
                         _feature(
                             "LineString",
-                            {"class": "path", "type": "steps", "structure": "bridge", "surface": "paved"},
+                            {
+                                "class": "path",
+                                "type": "steps",
+                                "structure": "bridge",
+                                "surface": "paved",
+                                "name": "Kirchsteig",
+                            },
                         ),
                         _feature(
                             "LineString",
@@ -544,6 +593,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
         self.assertEqual(report["pedestrian_line_structure_counts"], {"none": 1})
         self.assertEqual(report["pedestrian_line_layer_counts"], {"0": 1})
+        self.assertEqual(report["pedestrian_line_name_counts"], {"Promenade": 1})
+        self.assertEqual(report["pedestrian_line_duplicate_name_counts"], {})
         self.assertEqual(
             report["pedestrian_line_signature_counts"],
             {"class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0": 1},
@@ -552,6 +603,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["path_line_structure_counts"], {"none": 1})
         self.assertEqual(report["path_line_layer_counts"], {"(missing)": 1})
         self.assertEqual(report["path_line_surface_counts"], {"unpaved": 1})
+        self.assertEqual(report["path_line_name_counts"], {"Trail": 1})
+        self.assertEqual(report["path_line_duplicate_name_counts"], {})
         self.assertEqual(
             report["path_line_signature_counts"],
             {"class=path; type=footway; surface=unpaved; structure=none; layer=(missing)": 1},
@@ -559,6 +612,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["step_line_structure_counts"], {"bridge": 1})
         self.assertEqual(report["step_line_layer_counts"], {"(missing)": 1})
         self.assertEqual(report["step_line_surface_counts"], {"paved": 1})
+        self.assertEqual(report["step_line_name_counts"], {"Kirchsteig": 1})
+        self.assertEqual(report["step_line_duplicate_name_counts"], {})
         self.assertEqual(
             report["step_line_signature_counts"],
             {"class=path; type=steps; surface=paved; structure=bridge; layer=(missing)": 1},
@@ -664,15 +719,34 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     ),
                     _feature(
                         "LineString",
-                        {"class": "pedestrian", "type": "pedestrian", "structure": "none", "layer": 0, "surface": "paved"},
+                        {
+                            "class": "pedestrian",
+                            "type": "pedestrian",
+                            "structure": "none",
+                            "layer": 0,
+                            "surface": "paved",
+                            "name": "Promenade",
+                        },
                     ),
                     _feature(
                         "LineString",
-                        {"class": "path", "type": "footway", "structure": "none", "surface": "unpaved"},
+                        {
+                            "class": "path",
+                            "type": "footway",
+                            "structure": "none",
+                            "surface": "unpaved",
+                            "name": "Trail",
+                        },
                     ),
                     _feature(
                         "LineString",
-                        {"class": "path", "type": "steps", "structure": "tunnel", "surface": "paved"},
+                        {
+                            "class": "path",
+                            "type": "steps",
+                            "structure": "tunnel",
+                            "surface": "paved",
+                            "name": "Kirchsteig",
+                        },
                     ),
                     _feature(
                         "LineString",
@@ -722,6 +796,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["pedestrian_line_structure_counts"], {"none": 2})
         self.assertEqual(report["pedestrian_line_layer_counts"], {"0": 2})
         self.assertEqual(report["pedestrian_line_surface_counts"], {"paved": 2})
+        self.assertEqual(report["pedestrian_line_name_counts"], {"Promenade": 2})
+        self.assertEqual(report["pedestrian_line_duplicate_name_counts"], {"Promenade": 2})
         self.assertEqual(
             report["pedestrian_line_signature_counts"],
             {"class=pedestrian; type=pedestrian; surface=paved; structure=none; layer=0": 2},
@@ -730,6 +806,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["path_line_structure_counts"], {"none": 2})
         self.assertEqual(report["path_line_layer_counts"], {"(missing)": 2})
         self.assertEqual(report["path_line_surface_counts"], {"unpaved": 2})
+        self.assertEqual(report["path_line_name_counts"], {"Trail": 2})
+        self.assertEqual(report["path_line_duplicate_name_counts"], {"Trail": 2})
         self.assertEqual(
             report["path_line_signature_counts"],
             {"class=path; type=footway; surface=unpaved; structure=none; layer=(missing)": 2},
@@ -737,6 +815,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["step_line_structure_counts"], {"tunnel": 2})
         self.assertEqual(report["step_line_layer_counts"], {"(missing)": 2})
         self.assertEqual(report["step_line_surface_counts"], {"paved": 2})
+        self.assertEqual(report["step_line_name_counts"], {"Kirchsteig": 2})
+        self.assertEqual(report["step_line_duplicate_name_counts"], {"Kirchsteig": 2})
         self.assertEqual(
             report["step_line_signature_counts"],
             {"class=path; type=steps; surface=paved; structure=tunnel; layer=(missing)": 2},
@@ -825,15 +905,18 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "pedestrian_line_structure_counts": {"none": 1},
             "pedestrian_line_layer_counts": {"0": 1},
             "pedestrian_line_surface_counts": {"paved": 1},
+            "pedestrian_line_duplicate_name_counts": {"Promenade": 2},
             "pedestrian_line_signature_counts": {pedestrian_signature: 1},
             "path_line_type_counts": {"footway": 1},
             "path_line_structure_counts": {"none": 1},
             "path_line_layer_counts": {"(missing)": 1},
             "path_line_surface_counts": {"unpaved": 1},
+            "path_line_duplicate_name_counts": {"Trail": 2},
             "path_line_signature_counts": {path_signature: 1},
             "step_line_structure_counts": {"none": 1},
             "step_line_layer_counts": {"0": 1},
             "step_line_surface_counts": {"paved": 1},
+            "step_line_duplicate_name_counts": {"Kirchsteig": 2},
             "step_line_signature_counts": {step_signature: 1},
             "oneway_arrow_class_counts": {"street": 1},
             "oneway_arrow_structure_counts": {"none": 1},
@@ -944,14 +1027,17 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn('Pedestrian line structure counts: {"none":1}', markdown)
         self.assertIn('Pedestrian line layer counts: {"0":1}', markdown)
         self.assertIn('Pedestrian line surface counts: {"paved":1}', markdown)
+        self.assertIn('Pedestrian line duplicate names: {"Promenade":2}', markdown)
         self.assertIn(f'Pedestrian line signatures: {{"{pedestrian_signature}":1}}', markdown)
         self.assertIn('Path line structure counts: {"none":1}', markdown)
         self.assertIn('Path line layer counts: {"(missing)":1}', markdown)
         self.assertIn('Path line surface counts: {"unpaved":1}', markdown)
+        self.assertIn('Path line duplicate names: {"Trail":2}', markdown)
         self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
         self.assertIn('Step line structure counts: {"none":1}', markdown)
         self.assertIn('Step line layer counts: {"0":1}', markdown)
         self.assertIn('Step line surface counts: {"paved":1}', markdown)
+        self.assertIn('Step line duplicate names: {"Kirchsteig":2}', markdown)
         self.assertIn(f'Step line signatures: {{"{step_signature}":1}}', markdown)
         self.assertIn('One-way arrow class counts: {"street":1}', markdown)
         self.assertIn('One-way arrow structure counts: {"none":1}', markdown)
@@ -1020,15 +1106,18 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "pedestrian_line_structure_counts": {"none": 1},
             "pedestrian_line_layer_counts": {"0": 1},
             "pedestrian_line_surface_counts": {"paved": 1},
+            "pedestrian_line_duplicate_name_counts": {"Promenade": 2},
             "pedestrian_line_signature_counts": {pedestrian_signature: 1},
             "path_line_type_counts": {"footway": 1},
             "path_line_structure_counts": {"none": 1},
             "path_line_layer_counts": {"(missing)": 1},
             "path_line_surface_counts": {"unpaved": 1},
+            "path_line_duplicate_name_counts": {"Trail": 2},
             "path_line_signature_counts": {path_signature: 1},
             "step_line_structure_counts": {"bridge": 1},
             "step_line_layer_counts": {"(missing)": 1},
             "step_line_surface_counts": {"paved": 1},
+            "step_line_duplicate_name_counts": {"Kirchsteig": 2},
             "step_line_signature_counts": {step_signature: 1},
             "oneway_arrow_class_counts": {"street": 1},
             "oneway_arrow_structure_counts": {"none": 1},
@@ -1079,15 +1168,18 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "pedestrian_line_structure_counts": {"none": 1},
                     "pedestrian_line_layer_counts": {"0": 1},
                     "pedestrian_line_surface_counts": {"paved": 1},
+                    "pedestrian_line_duplicate_name_counts": {"Promenade": 2},
                     "pedestrian_line_signature_counts": {pedestrian_signature: 1},
                     "path_line_type_counts": {"footway": 1},
                     "path_line_structure_counts": {"none": 1},
                     "path_line_layer_counts": {"(missing)": 1},
                     "path_line_surface_counts": {"unpaved": 1},
+                    "path_line_duplicate_name_counts": {"Trail": 2},
                     "path_line_signature_counts": {path_signature: 1},
                     "step_line_structure_counts": {"bridge": 1},
                     "step_line_layer_counts": {"(missing)": 1},
                     "step_line_surface_counts": {"paved": 1},
+                    "step_line_duplicate_name_counts": {"Kirchsteig": 2},
                     "step_line_signature_counts": {step_signature: 1},
                     "oneway_arrow_class_counts": {"street": 1},
                     "oneway_arrow_structure_counts": {"none": 1},
@@ -1123,11 +1215,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
         self.assertIn(f'Path line signatures: {{"{path_signature}":1}}', markdown)
         self.assertIn(f'Road exit shield signatures: {{"{exit_shield_signature}":1}}', markdown)
+        self.assertIn('Pedestrian line duplicate names: {"Promenade":2}', markdown)
+        self.assertIn('Path line duplicate names: {"Trail":2}', markdown)
+        self.assertIn('Step line duplicate names: {"Kirchsteig":2}', markdown)
         self.assertIn('Road label duplicate names: {"Bachstrasse":2}', markdown)
         self.assertIn(f'Road label signatures: {{"{road_label_signature}":2}}', markdown)
         self.assertIn("## Path/pedestrian focus", markdown)
         self.assertIn(
-            '| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 1 | 1 | ["pedestrian=1"] | ["footway=1"] | ["bridge=1"] |',
+            '| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 1 | 1 | ["pedestrian=1"] | ["footway=1"] | ["bridge=1"] | ["Promenade=2"] | ["Trail=2"] | ["Kirchsteig=2"] |',
             markdown,
         )
         self.assertIn(f'["{path_signature}=1"] | ["{step_signature}=1"] |', markdown)

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -381,6 +381,11 @@ def _camera_focus_row(
         "top_pedestrian_line_types": _top_count_labels(camera_report.get("pedestrian_line_type_counts")),
         "top_path_line_types": _top_count_labels(camera_report.get("path_line_type_counts")),
         "top_step_structures": _top_count_labels(camera_report.get("step_line_structure_counts")),
+        "top_pedestrian_line_duplicate_names": _top_count_labels(
+            camera_report.get("pedestrian_line_duplicate_name_counts")
+        ),
+        "top_path_line_duplicate_names": _top_count_labels(camera_report.get("path_line_duplicate_name_counts")),
+        "top_step_line_duplicate_names": _top_count_labels(camera_report.get("step_line_duplicate_name_counts")),
         "top_path_signatures": _top_count_labels(camera_report.get("path_line_signature_counts")),
         "top_step_signatures": _top_count_labels(camera_report.get("step_line_signature_counts")),
     }
@@ -616,8 +621,8 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         return "\n".join(lines) + "\n"
     lines.extend(
         [
-            "| Camera | Camera zoom | Tile zoom | Feature counts | Top pedestrian types | Top path types | Top path signatures | Top step signatures | QGIS layers | QGIS controls | Sample visible QGIS strokes | Sample visible QGIS colors | Sample visible QGIS layer ids |",
-            "| --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+            "| Camera | Camera zoom | Tile zoom | Feature counts | Top pedestrian types | Top path types | Duplicate pedestrian labels | Duplicate path labels | Duplicate step labels | Top path signatures | Top step signatures | QGIS layers | QGIS controls | Sample visible QGIS strokes | Sample visible QGIS colors | Sample visible QGIS layer ids |",
+            "| --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
     for camera in rows:
@@ -645,6 +650,9 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
                     feature_counts,
                     camera.get("top_pedestrian_line_types"),
                     camera.get("top_path_line_types"),
+                    camera.get("top_pedestrian_line_duplicate_names"),
+                    camera.get("top_path_line_duplicate_names"),
+                    camera.get("top_step_line_duplicate_names"),
                     camera.get("top_path_signatures"),
                     camera.get("top_step_signatures"),
                     qgis_layers,

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -317,6 +317,19 @@ def _count_by_property(features: Iterable[dict[str, object]], key: str) -> dict[
     return dict(sorted(counts.items()))
 
 
+def _count_non_empty_string_property(features: Iterable[dict[str, object]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for feature in features:
+        value = _feature_properties(feature).get(key)
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip()
+        if not normalized:
+            continue
+        counts[normalized] = counts.get(normalized, 0) + 1
+    return dict(sorted(counts.items()))
+
+
 def _duplicate_count_map(counts: object) -> dict[str, int]:
     if not isinstance(counts, dict):
         return {}
@@ -399,7 +412,10 @@ def road_tile_record(
     road_label_lines = [
         feature for feature in road_features if is_road_label_candidate(feature, tile_zoom=tile.get("z"))
     ]
-    road_label_name_counts = _count_by_property(road_label_lines, "name")
+    pedestrian_line_name_counts = _count_non_empty_string_property(pedestrian_lines, "name")
+    path_line_name_counts = _count_non_empty_string_property(path_lines, "name")
+    step_line_name_counts = _count_non_empty_string_property(step_lines, "name")
+    road_label_name_counts = _count_non_empty_string_property(road_label_lines, "name")
     return {
         **tile,
         "status": "decoded",
@@ -430,6 +446,8 @@ def road_tile_record(
         "pedestrian_line_structure_counts": _count_by_property(pedestrian_lines, "structure"),
         "pedestrian_line_layer_counts": _count_by_property(pedestrian_lines, "layer"),
         "pedestrian_line_surface_counts": _count_by_property(pedestrian_lines, "surface"),
+        "pedestrian_line_name_counts": pedestrian_line_name_counts,
+        "pedestrian_line_duplicate_name_counts": _duplicate_count_map(pedestrian_line_name_counts),
         "pedestrian_line_signature_counts": _count_property_signatures(
             pedestrian_lines,
             ROAD_FEATURE_SIGNATURE_KEYS,
@@ -438,10 +456,14 @@ def road_tile_record(
         "path_line_structure_counts": _count_by_property(path_lines, "structure"),
         "path_line_layer_counts": _count_by_property(path_lines, "layer"),
         "path_line_surface_counts": _count_by_property(path_lines, "surface"),
+        "path_line_name_counts": path_line_name_counts,
+        "path_line_duplicate_name_counts": _duplicate_count_map(path_line_name_counts),
         "path_line_signature_counts": _count_property_signatures(path_lines, ROAD_FEATURE_SIGNATURE_KEYS),
         "step_line_structure_counts": _count_by_property(step_lines, "structure"),
         "step_line_layer_counts": _count_by_property(step_lines, "layer"),
         "step_line_surface_counts": _count_by_property(step_lines, "surface"),
+        "step_line_name_counts": step_line_name_counts,
+        "step_line_duplicate_name_counts": _duplicate_count_map(step_line_name_counts),
         "step_line_signature_counts": _count_property_signatures(step_lines, ROAD_FEATURE_SIGNATURE_KEYS),
         "oneway_arrow_class_counts": _count_by_property(oneway_arrow_lines, "class"),
         "oneway_arrow_structure_counts": _count_by_property(oneway_arrow_lines, "structure"),
@@ -538,15 +560,18 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("Pedestrian line structure counts", "pedestrian_line_structure_counts"),
     ("Pedestrian line layer counts", "pedestrian_line_layer_counts"),
     ("Pedestrian line surface counts", "pedestrian_line_surface_counts"),
+    ("Pedestrian line duplicate names", "pedestrian_line_duplicate_name_counts"),
     ("Pedestrian line signatures", "pedestrian_line_signature_counts"),
     ("Path line type counts", "path_line_type_counts"),
     ("Path line structure counts", "path_line_structure_counts"),
     ("Path line layer counts", "path_line_layer_counts"),
     ("Path line surface counts", "path_line_surface_counts"),
+    ("Path line duplicate names", "path_line_duplicate_name_counts"),
     ("Path line signatures", "path_line_signature_counts"),
     ("Step line structure counts", "step_line_structure_counts"),
     ("Step line layer counts", "step_line_layer_counts"),
     ("Step line surface counts", "step_line_surface_counts"),
+    ("Step line duplicate names", "step_line_duplicate_name_counts"),
     ("Step line signatures", "step_line_signature_counts"),
     ("One-way arrow class counts", "oneway_arrow_class_counts"),
     ("One-way arrow structure counts", "oneway_arrow_structure_counts"),
@@ -589,15 +614,18 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Pedestrian line structures", "pedestrian_line_structure_counts", "---"),
     ("Pedestrian line layers", "pedestrian_line_layer_counts", "---"),
     ("Pedestrian line surfaces", "pedestrian_line_surface_counts", "---"),
+    ("Duplicate pedestrian line labels", "pedestrian_line_duplicate_name_counts", "---"),
     ("Pedestrian line signatures", "pedestrian_line_signature_counts", "---"),
     ("Path line types", "path_line_type_counts", "---"),
     ("Path line structures", "path_line_structure_counts", "---"),
     ("Path line layers", "path_line_layer_counts", "---"),
     ("Path line surfaces", "path_line_surface_counts", "---"),
+    ("Duplicate path line labels", "path_line_duplicate_name_counts", "---"),
     ("Path line signatures", "path_line_signature_counts", "---"),
     ("Step structures", "step_line_structure_counts", "---"),
     ("Step layers", "step_line_layer_counts", "---"),
     ("Step surfaces", "step_line_surface_counts", "---"),
+    ("Duplicate step line labels", "step_line_duplicate_name_counts", "---"),
     ("Step signatures", "step_line_signature_counts", "---"),
     ("One-way arrow classes", "oneway_arrow_class_counts", "---"),
     ("One-way arrow structures", "oneway_arrow_structure_counts", "---"),
@@ -631,6 +659,13 @@ _SAMPLE_FEATURE_SECTIONS = (
     ("Sample road label candidates", "sample_road_label_candidates"),
 )
 _SAMPLE_FEATURE_KEYS = tuple(key for _heading, key in _SAMPLE_FEATURE_SECTIONS)
+_NAME_COUNT_FIELD_PAIRS = (
+    ("pedestrian_line_name_counts", "pedestrian_line_duplicate_name_counts"),
+    ("path_line_name_counts", "path_line_duplicate_name_counts"),
+    ("step_line_name_counts", "step_line_duplicate_name_counts"),
+    ("road_label_name_counts", "road_label_duplicate_name_counts"),
+)
+_DUPLICATE_NAME_COUNT_FIELDS = frozenset(duplicate_key for _name_key, duplicate_key in _NAME_COUNT_FIELD_PAIRS)
 
 
 def _candidate_count_report_fields(records: Iterable[dict[str, object]]) -> dict[str, int]:
@@ -639,14 +674,22 @@ def _candidate_count_report_fields(records: Iterable[dict[str, object]]) -> dict
 
 def _count_map_report_fields(records: Iterable[dict[str, object]]) -> dict[str, object]:
     record_list = list(records)
-    road_label_name_counts = _combined_record_counts(record_list, "road_label_name_counts")
     fields = {
         key: _combined_record_counts(record_list, key)
         for _label, key in _SUMMARY_COUNT_MAP_FIELDS
-        if key != "road_label_duplicate_name_counts"
+        if key not in _DUPLICATE_NAME_COUNT_FIELDS
     }
-    fields["road_label_name_counts"] = road_label_name_counts
-    fields["road_label_duplicate_name_counts"] = _duplicate_count_map(road_label_name_counts)
+    fields.update(_combined_name_count_fields(record_list))
+    return fields
+
+
+def _combined_name_count_fields(records: Iterable[dict[str, object]]) -> dict[str, object]:
+    record_list = list(records)
+    fields: dict[str, object] = {}
+    for name_key, duplicate_key in _NAME_COUNT_FIELD_PAIRS:
+        name_counts = _combined_record_counts(record_list, name_key)
+        fields[name_key] = name_counts
+        fields[duplicate_key] = _duplicate_count_map(name_counts)
     return fields
 
 
@@ -767,7 +810,8 @@ def _all_camera_row(report: dict[str, object]) -> dict[str, object]:
     }
     for _label, key, _alignment in _ROAD_FEATURE_TABLE_FIELDS:
         row[key] = report.get(key)
-    row["road_label_name_counts"] = report.get("road_label_name_counts")
+    for name_key, _duplicate_key in _NAME_COUNT_FIELD_PAIRS:
+        row[name_key] = report.get(name_key)
     return row
 
 
@@ -869,7 +913,7 @@ def collect_all_camera_road_feature_report(
             continue
         camera_reports.append(_all_camera_row(report))
     status_counts = _all_camera_status_counts(camera_reports)
-    road_label_name_counts = _combined_record_counts(camera_reports, "road_label_name_counts")
+    name_count_fields = _combined_name_count_fields(camera_reports)
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
@@ -995,8 +1039,7 @@ def collect_all_camera_road_feature_report(
             "road_exit_shield_signature_counts",
         ),
         "road_label_class_counts": _combined_record_counts(camera_reports, "road_label_class_counts"),
-        "road_label_name_counts": road_label_name_counts,
-        "road_label_duplicate_name_counts": _duplicate_count_map(road_label_name_counts),
+        **name_count_fields,
         "road_label_signature_counts": _combined_record_counts(camera_reports, "road_label_signature_counts"),
         "cameras": camera_reports,
     }
@@ -1086,8 +1129,8 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                 "",
                 "## Path/pedestrian focus",
                 "",
-                "| Camera | Camera zoom | Tile zoom | Pedestrian/path polygons | Pedestrian lines | Path lines | Steps | Pedestrian line types | Path line types | Step structures | Path signatures | Step signatures |",
-                "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- |",
+                "| Camera | Camera zoom | Tile zoom | Pedestrian/path polygons | Pedestrian lines | Path lines | Steps | Pedestrian line types | Path line types | Step structures | Duplicate pedestrian labels | Duplicate path labels | Duplicate step labels | Path signatures | Step signatures |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
         for camera_report in focus_rows:
@@ -1104,6 +1147,9 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                         _top_count_labels(camera_report.get("pedestrian_line_type_counts")),
                         _top_count_labels(camera_report.get("path_line_type_counts")),
                         _top_count_labels(camera_report.get("step_line_structure_counts")),
+                        _top_count_labels(camera_report.get("pedestrian_line_duplicate_name_counts")),
+                        _top_count_labels(camera_report.get("path_line_duplicate_name_counts")),
+                        _top_count_labels(camera_report.get("step_line_duplicate_name_counts")),
                         _top_count_labels(camera_report.get("path_line_signature_counts")),
                         _top_count_labels(camera_report.get("step_line_signature_counts")),
                     ]


### PR DESCRIPTION
## Summary

- Add non-empty name-count and duplicate-name reporting for pedestrian, path, and step line candidates alongside road-label duplicates.
- Surface duplicate path/pedestrian/step labels in the all-camera road-feature table and path/pedestrian focus report.
- Preserve raw name counts through all-camera aggregation so duplicate counts include repeated feature segments across tiles and cameras.

## Evidence

- Live all-camera road-feature diagnostic: `debug/mapbox-outdoors-road-features/all-cameras/20260520T063426Z/summary.md`
- Live path/pedestrian focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T063505Z/summary.md`
- Result: `zermatt-trails-z18-outdoors` still has `road_label_candidate_count=0`, while duplicate pedestrian labels include `Englischer Viertel=17`, `Bachstrasse=13`, and `Uferweg=10`; duplicate path labels include `Brunnmattgasse=8`, `Getwing=8`, and `Hofmattweg=8`; duplicate step labels include `Brunnmattgasse=4`.
- Implication: the remaining z18 repetition problem is observable in path/pedestrian feature segmentation, not only in the Mapbox `road-label` layer.

## Validation

- `git diff --check`
- `python3 -m py_compile validation/mapbox_outdoors_road_features.py validation/mapbox_outdoors_path_pedestrian_focus.py tests/test_mapbox_outdoors_road_features.py tests/test_mapbox_outdoors_path_pedestrian_focus.py`
- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short` -> 48 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2276 passed, 174 skipped, 162 subtests passed
- live diagnostics above were generated with the local Mapbox token source; token was not printed or stored

Refs #949
