### PR TITLE
[codex] Merge path pedestrian label segments

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -741,15 +741,19 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_path_pedestrian_labels_merge_matching_line_segments(self):
+        from qgis.core import Qgis
+
         labeling = MagicMock()
         style, settings = self._make_style("road", "path-pedestrian-label")
         settings.mergeLines = False
+        settings.repeatDistance = 0.0
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
         self.assertTrue(settings.mergeLines)
         self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_contour_label_appends_metre_suffix_without_repeat_distance(self):
@@ -950,12 +954,14 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         labeling = MagicMock()
         style, settings = self._make_style("road", "path-pedestrian-label")
         settings.mergeLines = False
+        settings.repeatDistance = 0.0
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
         self.assertTrue(settings.mergeLines)
         self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_existing_line_label_repeat_distance_is_preserved(self):

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -740,6 +740,18 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         self.assertAlmostEqual(settings.repeatDistance, 600 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 
+    def test_path_pedestrian_labels_merge_matching_line_segments(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "path-pedestrian-label")
+        settings.mergeLines = False
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertTrue(settings.mergeLines)
+        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        style.setLabelSettings.assert_called_once_with(settings)
+
     def test_contour_label_appends_metre_suffix_without_repeat_distance(self):
         labeling = MagicMock()
         style, settings = self._make_style("contour", "contour-label")
@@ -932,6 +944,18 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.service._apply_label_priority(labeling)
 
         self.assertAlmostEqual(settings.repeatDistance, 600 * 25.4 / 96)
+        style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_path_pedestrian_labels_merge_matching_line_segments(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "path-pedestrian-label")
+        settings.mergeLines = False
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertTrue(settings.mergeLines)
+        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_existing_line_label_repeat_distance_is_preserved(self):

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -54,6 +54,9 @@ _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "ferry-aerialway-label",
     "path-pedestrian-label",
 }
+_LINE_LABEL_MERGE_LAYERS = {
+    "path-pedestrian-label",
+}
 # Representative-zoom values from mapbox_config's waterway-label spacing
 # expression after qfit splits it into static QGIS zoom bands.  The z17+
 # value is wider than Mapbox's raw 400 px spacing because QGIS repeats labels
@@ -127,6 +130,12 @@ def _label_repeat_distance(layer_name: str, style) -> float | None:
     return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
 
 
+def _label_merge_lines(layer_name: str) -> bool | None:
+    if layer_name in _LINE_LABEL_MERGE_LAYERS:
+        return True
+    return None
+
+
 def _label_field_expression(layer_name: str, settings) -> str | None:
     if (
         layer_name == _CONTOUR_LABEL_LAYER_ID
@@ -184,6 +193,7 @@ def _apply_label_settings(
     layer_name: str,
     priority: int | None,
     repeat_distance: float | None,
+    merge_lines: bool | None,
     field_expression: str | None,
     qgs_property,
     qgis,
@@ -197,6 +207,9 @@ def _apply_label_settings(
     if repeat_distance is not None and _needs_repeat_distance(settings, repeat_distance):
         settings.repeatDistance = repeat_distance
         settings.repeatDistanceUnit = qgis.RenderUnit.Millimeters
+        changed = True
+    if merge_lines is not None and getattr(settings, "mergeLines", None) != merge_lines:
+        settings.mergeLines = merge_lines
         changed = True
     if field_expression is not None and (
         getattr(settings, "fieldName", "") != field_expression
@@ -272,9 +285,11 @@ def apply_mapbox_label_priority(labeling) -> None:
             layer_name = _label_style_mapbox_layer_id(style)
             priority = _label_priority(layer_name, style)
             repeat_distance = _label_repeat_distance(layer_name, style)
+            merge_lines = _label_merge_lines(layer_name)
             if (
                 priority is None
                 and repeat_distance is None
+                and merge_lines is None
                 and layer_name != _CONTOUR_LABEL_LAYER_ID
             ):
                 continue
@@ -282,13 +297,14 @@ def apply_mapbox_label_priority(labeling) -> None:
             if settings is None:
                 continue
             field_expression = _label_field_expression(layer_name, settings)
-            if priority is None and repeat_distance is None and field_expression is None:
+            if priority is None and repeat_distance is None and merge_lines is None and field_expression is None:
                 continue
             if _apply_label_settings(
                 settings,
                 layer_name=layer_name,
                 priority=priority,
                 repeat_distance=repeat_distance,
+                merge_lines=merge_lines,
                 field_expression=field_expression,
                 qgs_property=QgsProperty,
                 qgis=Qgis,


### PR DESCRIPTION
## Summary
- Enable QGIS `mergeLines` for the Mapbox `path-pedestrian-label` style only.
- Keep the existing Mapbox 250 px-equivalent repeat distance for that label layer.
- Add real/mock background-map tests that verify matching path/pedestrian line segments are merged before label placement.

## Evidence
- QGIS docs describe `mergeLines` as merging connected line features with identical label text before label placement.
- PR #1193 live diagnostics showed the z18 Zermatt repeated labels come from path/pedestrian/step line feature segmentation, while `road_label_candidate_count=0` for that camera.
- Live label-settings audit after this change reports `path-pedestrian-label` as Curved with repeat distance 66.1458 mm and `merge_lines={"true":1}`.
- Live zermatt-trails-z18 visual comparison produced Mapbox, QGIS, and diff artifacts at `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260520T064808Z/`; the QGIS render is nonblank and still renders path/pedestrian labels.

## Tests
- git diff --check
- python3 -m py_compile visualization/infrastructure/background_map_service.py tests/test_background_map_service.py
- python3 -m pytest tests/test_background_map_service.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #949