### PR TITLE
[codex] Merge road label segments

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -693,11 +693,13 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
 
         labeling = MagicMock()
         style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.mergeLines = False
         settings.repeatDistance = 0.0
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
+        self.assertTrue(settings.mergeLines)
         self.assertEqual(settings.priority, 4)
         self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
@@ -708,11 +710,13 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
 
         labeling = MagicMock()
         style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.mergeLines = False
         settings.repeatDistance = 250 * 25.4 / 96
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
+        self.assertTrue(settings.mergeLines)
         self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
@@ -720,11 +724,13 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
     def test_low_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         labeling = MagicMock()
         style, settings = self._make_style("road", "road-label-z12-to-z15")
+        settings.mergeLines = False
         settings.repeatDistance = 0.0
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
+        self.assertTrue(settings.mergeLines)
         self.assertEqual(settings.priority, 4)
         self.assertAlmostEqual(settings.repeatDistance, 150 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
@@ -905,11 +911,13 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
     def test_high_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         labeling = MagicMock()
         style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.mergeLines = False
         settings.repeatDistance = 0.0
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
+        self.assertTrue(settings.mergeLines)
         self.assertEqual(settings.priority, 4)
         self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
@@ -918,11 +926,13 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
     def test_high_zoom_road_label_overrides_qgis_default_repeat_distance(self):
         labeling = MagicMock()
         style, settings = self._make_style("road", "road-label-z15-plus")
+        settings.mergeLines = False
         settings.repeatDistance = 250 * 25.4 / 96
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
+        self.assertTrue(settings.mergeLines)
         self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
@@ -930,11 +940,13 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
     def test_low_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         labeling = MagicMock()
         style, settings = self._make_style("road", "road-label-below-z12")
+        settings.mergeLines = False
         settings.repeatDistance = 0.0
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
+        self.assertTrue(settings.mergeLines)
         self.assertEqual(settings.priority, 4)
         self.assertAlmostEqual(settings.repeatDistance, 150 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -56,6 +56,7 @@ _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
 }
 _LINE_LABEL_MERGE_LAYERS = {
     "path-pedestrian-label",
+    "road-label",
 }
 # Representative-zoom values from mapbox_config's waterway-label spacing
 # expression after qfit splits it into static QGIS zoom bands.  The z17+


### PR DESCRIPTION
## Summary
- Enable QGIS `mergeLines` for Mapbox `road-label` styles so connected same-name road segments are merged before label placement.
- Keep the existing road-label priority and repeat-distance tuning unchanged.
- Tighten real/mock background-map tests to verify high-zoom road labels now merge matching line segments.

## Evidence
- QGIS docs describe `mergeLines` as merging connected line features with identical label text before label placement.
- The #949 all-camera road-feature diagnostic showed repeated road-label candidate names across the Geneva/Chamonix cameras, even after repeat-distance tuning.
- Live label-settings audit after this change reports all three `road-label` styles as Curved with `merge lines = yes` while preserving repeat distances `39.6875`/`105.833` mm.
- Live Geneva z14 visual comparison produced Mapbox, QGIS, and diff artifacts at `debug/mapbox-outdoors-comparison/geneva-airport-motorway-z14-outdoors/20260520T070550Z/`; the QGIS render is nonblank and road-label styles still render.

## Tests
- `git diff --check`
- `python3 -m py_compile visualization/infrastructure/background_map_service.py tests/test_background_map_service.py`
- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
