### PR TITLE
[codex] Expose label merge flags in comparison snapshots

### DIFF
--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -871,6 +871,8 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             priority = 6
             repeatDistance = 0.0
             repeatDistanceUnit = None
+            labelPerPart = False
+            mergeLines = True
             geometryGenerator = QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION
             geometryGeneratorEnabled = True
             geometryGeneratorType = "Line"
@@ -924,6 +926,8 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                 "priority": 6,
                 "repeat_distance": 0.0,
                 "repeat_distance_unit": None,
+                "label_per_part": False,
+                "merge_lines": True,
                 "geometry_generator": QGIS_CONTOUR_BBOX_EDGE_DIFFERENCE_LABEL_PROBE_EXPRESSION,
                 "geometry_generator_enabled": True,
                 "geometry_generator_type": "Line",

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -665,6 +665,8 @@ def qgis_label_styles_snapshot(layer: object) -> list[dict[str, object]]:
                 "priority": _label_setting_value(settings, "priority"),
                 "repeat_distance": _label_setting_value(settings, "repeatDistance"),
                 "repeat_distance_unit": _label_setting_value(settings, "repeatDistanceUnit"),
+                "label_per_part": _label_setting_value(settings, "labelPerPart"),
+                "merge_lines": _label_setting_value(settings, "mergeLines"),
                 "geometry_generator": _label_setting_value(settings, "geometryGenerator"),
                 "geometry_generator_enabled": _label_setting_value(settings, "geometryGeneratorEnabled"),
                 "geometry_generator_type": _label_setting_value(settings, "geometryGeneratorType"),


### PR DESCRIPTION
## Summary

- include `labelPerPart` and `mergeLines` in the token-free QGIS label-style snapshot emitted by the Mapbox Outdoors comparison harness
- cover the new snapshot fields in the existing comparison snapshot regression test

## Validation

- `python3 -m py_compile validation/mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_comparison.py`
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Issue: #949
