### PR TITLE
[codex] Merge waterway label segments

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -738,11 +738,13 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
     def test_waterway_label_repeat_distance_uses_split_symbol_spacing(self):
         labeling = MagicMock()
         style, settings = self._make_style("natural_label", "waterway-label-z17-plus")
+        settings.mergeLines = False
         settings.repeatDistance = 0.0
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
+        self.assertTrue(settings.mergeLines)
         self.assertAlmostEqual(settings.repeatDistance, 600 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 
@@ -954,11 +956,13 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
     def test_waterway_label_repeat_distance_uses_split_symbol_spacing(self):
         labeling = MagicMock()
         style, settings = self._make_style("natural_label", "waterway-label-z17-plus")
+        settings.mergeLines = False
         settings.repeatDistance = 0.0
         labeling.styles.return_value = [style]
 
         self.service._apply_label_priority(labeling)
 
+        self.assertTrue(settings.mergeLines)
         self.assertAlmostEqual(settings.repeatDistance, 600 * 25.4 / 96)
         style.setLabelSettings.assert_called_once_with(settings)
 

--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -736,17 +736,25 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_waterway_label_repeat_distance_uses_split_symbol_spacing(self):
-        labeling = MagicMock()
-        style, settings = self._make_style("natural_label", "waterway-label-z17-plus")
-        settings.mergeLines = False
-        settings.repeatDistance = 0.0
-        labeling.styles.return_value = [style]
+        cases = [
+            ("waterway-label-z13-to-z15", 250),
+            ("waterway-label-z15-to-z17", 325),
+            ("waterway-label-z17-plus", 600),
+        ]
 
-        self.service._apply_label_priority(labeling)
+        for style_name, spacing_px in cases:
+            with self.subTest(style_name=style_name):
+                labeling = MagicMock()
+                style, settings = self._make_style("natural_label", style_name)
+                settings.mergeLines = False
+                settings.repeatDistance = 0.0
+                labeling.styles.return_value = [style]
 
-        self.assertTrue(settings.mergeLines)
-        self.assertAlmostEqual(settings.repeatDistance, 600 * 25.4 / 96)
-        style.setLabelSettings.assert_called_once_with(settings)
+                self.service._apply_label_priority(labeling)
+
+                self.assertTrue(settings.mergeLines)
+                self.assertAlmostEqual(settings.repeatDistance, spacing_px * 25.4 / 96)
+                style.setLabelSettings.assert_called_once_with(settings)
 
     def test_path_pedestrian_labels_merge_matching_line_segments(self):
         from qgis.core import Qgis
@@ -954,17 +962,25 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         style.setLabelSettings.assert_called_once_with(settings)
 
     def test_waterway_label_repeat_distance_uses_split_symbol_spacing(self):
-        labeling = MagicMock()
-        style, settings = self._make_style("natural_label", "waterway-label-z17-plus")
-        settings.mergeLines = False
-        settings.repeatDistance = 0.0
-        labeling.styles.return_value = [style]
+        cases = [
+            ("waterway-label-z13-to-z15", 250),
+            ("waterway-label-z15-to-z17", 325),
+            ("waterway-label-z17-plus", 600),
+        ]
 
-        self.service._apply_label_priority(labeling)
+        for style_name, spacing_px in cases:
+            with self.subTest(style_name=style_name):
+                labeling = MagicMock()
+                style, settings = self._make_style("natural_label", style_name)
+                settings.mergeLines = False
+                settings.repeatDistance = 0.0
+                labeling.styles.return_value = [style]
 
-        self.assertTrue(settings.mergeLines)
-        self.assertAlmostEqual(settings.repeatDistance, 600 * 25.4 / 96)
-        style.setLabelSettings.assert_called_once_with(settings)
+                self.service._apply_label_priority(labeling)
+
+                self.assertTrue(settings.mergeLines)
+                self.assertAlmostEqual(settings.repeatDistance, spacing_px * 25.4 / 96)
+                style.setLabelSettings.assert_called_once_with(settings)
 
     def test_path_pedestrian_labels_merge_matching_line_segments(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -57,6 +57,7 @@ _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
 _LINE_LABEL_MERGE_LAYERS = {
     "path-pedestrian-label",
     "road-label",
+    "waterway-label",
 }
 # Representative-zoom values from mapbox_config's waterway-label spacing
 # expression after qfit splits it into static QGIS zoom bands.  The z17+


### PR DESCRIPTION
## Summary

- enable QGIS `mergeLines` for the Mapbox Outdoors `waterway-label` zoom-band styles
- keep existing waterway repeat-distance tuning and label priorities unchanged
- extend background-map label-setting regression coverage for the new waterway merge behavior

## Rendering proof

- Data: live Mapbox Outdoors z5-z18 comparison cameras using the local QGIS-profile token source; token was not printed or committed
- Artifact checked: browser Mapbox GL references, QGIS vector renders, diff images, and contact sheet
- Path checked: headless comparison harness with QGIS vector rendering
- Runtime note: local source checkout with QGIS/Qt offscreen comparison harness
- Result: all seven cameras passed with metrics available; QGIS renders were nonblank, and contact-sheet review showed no obvious broad-scale regression

## Validation

- `python3 -m py_compile visualization/infrastructure/background_map_service.py tests/test_background_map_service.py`
- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 validation/mapbox_outdoors_comparison.py zermatt-trails-z18-outdoors --skip-browser --skip-diff --browser-timeout-ms 120000`
- `python3 validation/mapbox_outdoors_comparison.py --all-cameras --browser-timeout-ms 120000`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Evidence:

- z18 probe: `debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260520T073535Z/manifest.json`
- all-camera summary: `debug/mapbox-outdoors-comparison/all-cameras/20260520T073642Z/summary.md`

Issue: #949
