### PR TITLE
[codex] Merge ferry route label segments

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -756,6 +756,22 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
                 self.assertAlmostEqual(settings.repeatDistance, spacing_px * 25.4 / 96)
                 style.setLabelSettings.assert_called_once_with(settings)
 
+    def test_ferry_aerialway_labels_merge_matching_line_segments(self):
+        from qgis.core import Qgis
+
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "ferry-aerialway-label")
+        settings.mergeLines = False
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertTrue(settings.mergeLines)
+        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
+        style.setLabelSettings.assert_called_once_with(settings)
+
     def test_path_pedestrian_labels_merge_matching_line_segments(self):
         from qgis.core import Qgis
 
@@ -981,6 +997,20 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
                 self.assertTrue(settings.mergeLines)
                 self.assertAlmostEqual(settings.repeatDistance, spacing_px * 25.4 / 96)
                 style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_ferry_aerialway_labels_merge_matching_line_segments(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("road", "ferry-aerialway-label")
+        settings.mergeLines = False
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertTrue(settings.mergeLines)
+        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
+        style.setLabelSettings.assert_called_once_with(settings)
 
     def test_path_pedestrian_labels_merge_matching_line_segments(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -55,6 +55,7 @@ _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "path-pedestrian-label",
 }
 _LINE_LABEL_MERGE_LAYERS = {
+    "ferry-aerialway-label",
     "path-pedestrian-label",
     "road-label",
     "waterway-label",


### PR DESCRIPTION
## Summary

- enable QGIS `mergeLines` for the Mapbox Outdoors `ferry-aerialway-label` line-label style
- preserve the existing 250 px-equivalent repeat-distance tuning for ferry/aerialway labels
- add real-QGIS and mock regression coverage for the new merge behavior

## Rendering proof

- Data: live Mapbox Outdoors z5-z18 comparison cameras using the local QGIS-profile token source; token was not printed or committed
- Artifact checked: browser Mapbox GL references, QGIS vector renders, diff images, and contact sheet
- Path checked: headless comparison harness with QGIS vector rendering
- Runtime note: local source checkout with QGIS/Qt offscreen comparison harness
- Result: all seven cameras passed with metrics available; `qgis-label-styles.json` reported `ferry-aerialway-label` with `merge_lines=true`, and contact-sheet review showed no obvious broad-scale regression

## Validation

- `python3 -m py_compile visualization/infrastructure/background_map_service.py tests/test_background_map_service.py`
- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 validation/mapbox_outdoors_comparison.py --all-cameras --browser-timeout-ms 120000`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Evidence:

- all-camera summary: `debug/mapbox-outdoors-comparison/all-cameras/20260520T075112Z/summary.md`

Issue: #949
