### PR TITLE
[codex] Merge road shield line segments

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -671,22 +671,30 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
             "road",
             "road-number-shield-2-beta-ch-motorway-icon-z11-plus",
         )
-        other_style, _other_settings = self._make_style(
+        swiss_settings.mergeLines = False
+        other_style, other_settings = self._make_style(
             "road",
             "road-number-shield-2-beta-ch-motorway-icon-below-z11",
         )
-        remaining_style, _remaining_settings = self._make_style(
+        other_settings.mergeLines = False
+        remaining_style, remaining_settings = self._make_style(
             "road",
             "road-number-shield-2-beta-remaining-icons-z11-plus",
         )
+        remaining_settings.mergeLines = False
+        remaining_priority = remaining_settings.priority
         labeling.styles.return_value = [swiss_style, other_style, remaining_style]
 
         self.service._apply_label_priority(labeling)
 
         self.assertEqual(swiss_settings.priority, 6)
+        self.assertEqual(remaining_settings.priority, remaining_priority)
+        self.assertTrue(swiss_settings.mergeLines)
+        self.assertFalse(other_settings.mergeLines)
+        self.assertTrue(remaining_settings.mergeLines)
         swiss_style.setLabelSettings.assert_called_once_with(swiss_settings)
         other_style.setLabelSettings.assert_not_called()
-        remaining_style.setLabelSettings.assert_not_called()
+        remaining_style.setLabelSettings.assert_called_once_with(remaining_settings)
 
     def test_high_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         from qgis.core import Qgis
@@ -937,22 +945,30 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
             "road",
             "road-number-shield-2-beta-ch-motorway-icon-z11-plus",
         )
-        other_style, _other_settings = self._make_style(
+        swiss_settings.mergeLines = False
+        other_style, other_settings = self._make_style(
             "road",
             "road-number-shield-2-beta-ch-motorway-icon-below-z11",
         )
-        remaining_style, _remaining_settings = self._make_style(
+        other_settings.mergeLines = False
+        remaining_style, remaining_settings = self._make_style(
             "road",
             "road-number-shield-2-beta-remaining-icons-z11-plus",
         )
+        remaining_settings.mergeLines = False
+        remaining_priority = remaining_settings.priority
         labeling.styles.return_value = [swiss_style, other_style, remaining_style]
 
         self.service._apply_label_priority(labeling)
 
         self.assertEqual(swiss_settings.priority, 6)
+        self.assertEqual(remaining_settings.priority, remaining_priority)
+        self.assertTrue(swiss_settings.mergeLines)
+        self.assertFalse(other_settings.mergeLines)
+        self.assertTrue(remaining_settings.mergeLines)
         swiss_style.setLabelSettings.assert_called_once_with(swiss_settings)
         other_style.setLabelSettings.assert_not_called()
-        remaining_style.setLabelSettings.assert_not_called()
+        remaining_style.setLabelSettings.assert_called_once_with(remaining_settings)
 
     def test_high_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -134,7 +134,9 @@ def _label_repeat_distance(layer_name: str, style) -> float | None:
     return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
 
 
-def _label_merge_lines(layer_name: str) -> bool | None:
+def _label_merge_lines(layer_name: str, style) -> bool | None:
+    if layer_name == "road-number-shield" and "z11-plus" in _label_style_name(style):
+        return True
     if layer_name in _LINE_LABEL_MERGE_LAYERS:
         return True
     return None
@@ -289,7 +291,7 @@ def apply_mapbox_label_priority(labeling) -> None:
             layer_name = _label_style_mapbox_layer_id(style)
             priority = _label_priority(layer_name, style)
             repeat_distance = _label_repeat_distance(layer_name, style)
-            merge_lines = _label_merge_lines(layer_name)
+            merge_lines = _label_merge_lines(layer_name, style)
             if (
                 priority is None
                 and repeat_distance is None


### PR DESCRIPTION
## Summary

- Enable `mergeLines` for high-zoom Mapbox Outdoors `road-number-shield` line styles so shield labels are evaluated on merged road geometry instead of individual vector-tile line segments.
- Keep below-z11 shield styles unchanged, and preserve the existing Swiss motorway shield priority rule without promoting remaining shield styles.
- Extend the label-priority tests to cover the new merge behavior in both real-QGIS and mock paths.

Part of #949.

## Validation

- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `MAPBOX_ACCESS_TOKEN=... python3 validation/mapbox_outdoors_comparison.py --all-cameras --browser-timeout-ms 120000`
  - all 7 camera runs passed
  - report: `debug/mapbox-outdoors-comparison/all-cameras/20260520T082132Z/summary.md`
  - contact sheet: `debug/mapbox-outdoors-comparison/all-cameras/20260520T082132Z/contact-sheet.jpg`
  - Geneva z14 label snapshot confirms all 14 `road-number-shield` `z11-plus` styles have `merge_lines=True`, while below-z11 point shield styles remain unmerged.
