### PR TITLE
[codex] Report line label conversion settings

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -22,6 +22,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _geometry_generator_markdown_value,
     _label_settings_report,
     _label_style_summary_rows,
+    _line_label_conversion_rows,
     _line_label_repeat_spacing_rows,
     _load_original_style,
     _postprocessed_label_records,
@@ -29,6 +30,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _source_label_control_summary_rows,
     _source_label_fanout_summary_rows,
     _source_label_unresolved_control_summary_rows,
+    _symbol_placement_includes_line,
     build_label_settings_paths,
     build_run_directory,
     build_summary_markdown,
@@ -849,6 +851,167 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(rows[0]["repeat_distances"], {"66.1458": 1})
         self.assertEqual(rows[0]["qfit_symbol_spacing_to_repeat_distances"], {"(missing) -> 66.1458": 2})
 
+    def test_line_label_conversion_summary_includes_shields_and_line_center_labels(self):
+        rows = _line_label_conversion_rows(
+            [
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-z11-plus",
+                    "qfit_style_layer_id": "road-number-shield-z11-plus",
+                    "layout": {"symbol-placement": "line"},
+                    "qfit_layout": {"symbol-placement": "line", "icon-image": "default-2"},
+                },
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-below-z11",
+                    "qfit_style_layer_id": "road-number-shield-below-z11",
+                    "layout": {"symbol-placement": ["step", ["zoom"], "point", 11, "line"]},
+                    "qfit_layout": {"symbol-placement": "point", "icon-image": "default-2"},
+                },
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-low-zoom",
+                    "qfit_style_layer_id": "road-number-shield-low-zoom",
+                    "maxzoom": 11,
+                    "layout": {"symbol-placement": ["step", ["zoom"], "point", 11, "line"]},
+                    "qfit_layout": {"symbol-placement": "point", "icon-image": "default-2"},
+                },
+                {
+                    "base_style_layer_id": "ferry-aerialway-label",
+                    "style_name": "ferry-aerialway-label",
+                    "qfit_style_layer_id": "ferry-aerialway-label",
+                    "layout": {"symbol-placement": ["literal", "line"]},
+                    "qfit_layout": {"symbol-placement": "point"},
+                },
+                {
+                    "base_style_layer_id": "water-line-label",
+                    "style_name": "water-line-label",
+                    "qfit_style_layer_id": "water-line-label",
+                    "layout": {"symbol-placement": "line-center"},
+                    "qfit_layout": {"symbol-placement": "line-center"},
+                },
+                {
+                    "base_style_layer_id": "poi-label",
+                    "style_name": "poi-label",
+                    "qfit_style_layer_id": "poi-label",
+                    "layout": {
+                        "symbol-placement": [
+                            "match",
+                            ["get", "class"],
+                            "line",
+                            "point",
+                            "point",
+                        ]
+                    },
+                    "qfit_layout": {"symbol-placement": "point"},
+                },
+            ],
+            [
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-z11-plus",
+                    "geometry_type": "Line",
+                    "placement": "Horizontal",
+                    "repeat_distance": 0.0,
+                    "label_per_part": False,
+                    "merge_lines": True,
+                },
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-below-z11",
+                    "geometry_type": "Point",
+                    "placement": "OverPoint",
+                    "repeat_distance": 0.0,
+                    "label_per_part": False,
+                    "merge_lines": False,
+                },
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-low-zoom",
+                    "geometry_type": "Point",
+                    "placement": "OverPoint",
+                    "repeat_distance": 0.0,
+                    "label_per_part": False,
+                    "merge_lines": False,
+                },
+                {
+                    "base_style_layer_id": "ferry-aerialway-label",
+                    "style_name": "ferry-aerialway-label",
+                    "geometry_type": "Line",
+                    "placement": "Curved",
+                    "repeat_distance": 66.1458333333,
+                    "label_per_part": False,
+                    "merge_lines": True,
+                },
+                {
+                    "base_style_layer_id": "water-line-label",
+                    "style_name": "water-line-label",
+                    "geometry_type": "Point",
+                    "placement": "OverPoint",
+                    "repeat_distance": 0.0,
+                    "label_per_part": False,
+                    "merge_lines": False,
+                },
+                {
+                    "base_style_layer_id": "poi-label",
+                    "style_name": "poi-label",
+                    "geometry_type": "Point",
+                    "placement": "OverPoint",
+                    "repeat_distance": 0.0,
+                    "label_per_part": False,
+                    "merge_lines": False,
+                },
+            ],
+        )
+
+        self.assertEqual(
+            [row["base_style_layer_id"] for row in rows],
+            ["road-number-shield", "ferry-aerialway-label", "water-line-label"],
+        )
+        shield_row = rows[0]
+        self.assertEqual(shield_row["source_label_rows"], 2)
+        self.assertEqual(shield_row["converted_label_styles"], 2)
+        self.assertEqual(shield_row["qfit_symbol_placements"], {"line": 1, "point": 1})
+        self.assertEqual(shield_row["converted_geometry_types"], {"Line": 1, "Point": 1})
+        self.assertEqual(shield_row["converted_placements"], {"Horizontal": 1, "OverPoint": 1})
+        self.assertEqual(shield_row["repeat_distances"], {"0": 1})
+        self.assertEqual(shield_row["merge_lines"], {"false": 1, "true": 1})
+        ferry_row = rows[1]
+        self.assertEqual(ferry_row["source_symbol_placements"], {'["literal","line"]': 1})
+        self.assertEqual(ferry_row["repeat_distances"], {"66.1458": 1})
+        water_row = rows[2]
+        self.assertEqual(water_row["source_symbol_placements"], {"line-center": 1})
+        self.assertEqual(water_row["converted_geometry_types"], {"Point": 1})
+        self.assertEqual(water_row["converted_placements"], {"OverPoint": 1})
+        self.assertEqual(water_row["repeat_distances"], {})
+        self.assertEqual(water_row["merge_lines"], {"false": 1})
+
+    def test_symbol_placement_line_detection_uses_expression_outputs_and_zoom_bounds(self):
+        self.assertTrue(_symbol_placement_includes_line(["literal", "line"]))
+        self.assertTrue(
+            _symbol_placement_includes_line(["coalesce", ["get", "placement"], "line-center"])
+        )
+        self.assertTrue(
+            _symbol_placement_includes_line(
+                ["let", "placement", "line", ["var", "placement"]]
+            )
+        )
+        self.assertFalse(
+            _symbol_placement_includes_line(
+                ["match", ["get", "class"], "line", "point", "point"]
+            )
+        )
+        self.assertFalse(
+            _symbol_placement_includes_line(
+                ["step", ["zoom"], "point", 11, "line"], max_zoom=11
+            )
+        )
+        self.assertTrue(
+            _symbol_placement_includes_line(
+                ["step", ["zoom"], "point", 11, "line"], min_zoom=11
+            )
+        )
+
     def test_source_label_fanout_summary_groups_qfit_style_expansion(self):
         rows = _source_label_fanout_summary_rows(
             [
@@ -1343,6 +1506,21 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "zero_repeat_distance_count": 1,
                 }
             ],
+            "line_label_conversion_by_base_layer": [
+                {
+                    "base_style_layer_id": "contour-label",
+                    "source_label_rows": 1,
+                    "converted_label_styles": 1,
+                    "source_symbol_placements": {"line": 1},
+                    "qfit_symbol_placements": {"line": 1},
+                    "converted_geometry_types": {"Line": 1},
+                    "converted_placements": {"Curved": 1},
+                    "repeat_distances": {"0": 1},
+                    "label_per_part": {"false": 1},
+                    "merge_lines": {"true": 1},
+                    "style_names": {"contour-label": 1},
+                }
+            ],
             "source_label_fanout_by_base_layer": [
                 {
                     "base_style_layer_id": "contour-label",
@@ -1458,6 +1636,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("## Line label repeat spacing by base layer", markdown)
         self.assertIn(
             "| contour-label | 1 | 1 | 1 | (missing)=1 | (missing)=1 | 0=1 | (missing) -> 0=1 | Curved=1 | contour-label=1 |",
+            markdown,
+        )
+        self.assertIn("## Line-placement label conversion by base layer", markdown)
+        self.assertIn(
+            "| contour-label | 1 | 1 | line=1 | line=1 | Line=1 | Curved=1 | 0=1 | no=1 | yes=1 | contour-label=1 |",
             markdown,
         )
         self.assertIn("## Source label fan-out by base layer", markdown)

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -991,6 +991,13 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertTrue(
             _symbol_placement_includes_line(["coalesce", ["get", "placement"], "line-center"])
         )
+        self.assertFalse(_symbol_placement_includes_line(["coalesce", "point", "line"]))
+        self.assertFalse(
+            _symbol_placement_includes_line(["coalesce", ["literal", "point"], "line-center"])
+        )
+        self.assertTrue(
+            _symbol_placement_includes_line(["coalesce", ["literal", None], "line-center"])
+        )
         self.assertTrue(
             _symbol_placement_includes_line(
                 ["let", "placement", "line", ["var", "placement"]]

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -559,6 +559,214 @@ def _is_line_label_source_row(row: dict[str, object]) -> bool:
     )
 
 
+def _numeric_row_zoom_bounds(
+    row: dict[str, object], *, min_key: str, max_key: str
+) -> tuple[float, float]:
+    minzoom = row.get(min_key)
+    maxzoom = row.get(max_key)
+    min_zoom = float(minzoom) if isinstance(minzoom, (int, float)) else 0.0
+    max_zoom = float(maxzoom) if isinstance(maxzoom, (int, float)) else float("inf")
+    return min_zoom, max_zoom
+
+
+def _zoom_expression(value: object) -> bool:
+    return isinstance(value, list) and value == ["zoom"]
+
+
+def _zoom_ranges_overlap(start: float, end: float, layer_min: float, layer_max: float) -> bool:
+    return start < layer_max and layer_min < end
+
+
+def _symbol_placement_zoom_step_includes_line(
+    value: list[object],
+    *,
+    min_zoom: float,
+    max_zoom: float,
+    bindings: dict[str, object],
+) -> bool | None:
+    if len(value) < 3 or not _zoom_expression(value[1]):
+        return None
+    active_start = float("-inf")
+    active_value = value[2]
+    for index in range(3, len(value) - 1, 2):
+        stop = value[index]
+        if not isinstance(stop, (int, float)):
+            return None
+        active_end = float(stop)
+        if _zoom_ranges_overlap(
+            active_start, active_end, min_zoom, max_zoom
+        ) and _symbol_placement_includes_line(
+            active_value,
+            min_zoom=max(min_zoom, active_start),
+            max_zoom=min(max_zoom, active_end),
+            bindings=bindings,
+        ):
+            return True
+        active_start = active_end
+        active_value = value[index + 1]
+    return _zoom_ranges_overlap(
+        active_start, float("inf"), min_zoom, max_zoom
+    ) and _symbol_placement_includes_line(
+        active_value,
+        min_zoom=max(min_zoom, active_start),
+        max_zoom=max_zoom,
+        bindings=bindings,
+    )
+
+
+def _symbol_placement_output_indexes(value: list[object]) -> Iterable[int] | None:
+    operator = value[0]
+    if operator == "interpolate":
+        return range(4, len(value), 2)
+    if operator == "case" and len(value) >= 4:
+        return [*range(2, len(value) - 1, 2), len(value) - 1]
+    if operator == "match" and len(value) >= 4:
+        return [*range(3, len(value) - 1, 2), len(value) - 1]
+    if operator == "coalesce":
+        return range(1, len(value))
+    return None
+
+
+def _symbol_placement_outputs_include_line(
+    value: list[object],
+    output_indexes: Iterable[int],
+    *,
+    min_zoom: float,
+    max_zoom: float,
+    bindings: dict[str, object],
+) -> bool:
+    return any(
+        _symbol_placement_includes_line(
+            value[index],
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            bindings=bindings,
+        )
+        for index in output_indexes
+    )
+
+
+def _literal_symbol_placement_includes_line(
+    value: list[object], *, min_zoom: float, max_zoom: float, bindings: dict[str, object]
+) -> bool:
+    return len(value) == 2 and _symbol_placement_includes_line(
+        value[1],
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        bindings=bindings,
+    )
+
+
+def _variable_symbol_placement_includes_line(
+    value: list[object], *, min_zoom: float, max_zoom: float, bindings: dict[str, object]
+) -> bool:
+    if len(value) != 2 or not isinstance(value[1], str):
+        return False
+    return _symbol_placement_includes_line(
+        bindings.get(value[1]),
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        bindings=bindings,
+    )
+
+
+def _let_symbol_placement_includes_line(
+    value: list[object], *, min_zoom: float, max_zoom: float, bindings: dict[str, object]
+) -> bool:
+    let_bindings = dict(bindings)
+    for index in range(1, len(value) - 1, 2):
+        variable_name = value[index]
+        if isinstance(variable_name, str) and index + 1 < len(value):
+            let_bindings[variable_name] = value[index + 1]
+    return _symbol_placement_includes_line(
+        value[-1],
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        bindings=let_bindings,
+    )
+
+
+def _step_symbol_placement_includes_line(
+    value: list[object], *, min_zoom: float, max_zoom: float, bindings: dict[str, object]
+) -> bool:
+    step_result = _symbol_placement_zoom_step_includes_line(
+        value,
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        bindings=bindings,
+    )
+    if step_result is not None:
+        return step_result
+    return _symbol_placement_outputs_include_line(
+        value,
+        range(2, len(value), 2),
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        bindings=bindings,
+    )
+
+
+def _symbol_placement_includes_line(
+    value: object,
+    *,
+    min_zoom: float = 0.0,
+    max_zoom: float = float("inf"),
+    bindings: dict[str, object] | None = None,
+) -> bool:
+    expression_bindings = bindings or {}
+    if isinstance(value, str):
+        return value in {"line", "line-center"}
+    if not isinstance(value, list) or not value:
+        return False
+
+    operator = value[0]
+    if operator == "literal":
+        return _literal_symbol_placement_includes_line(
+            value, min_zoom=min_zoom, max_zoom=max_zoom, bindings=expression_bindings
+        )
+    if operator == "var":
+        return _variable_symbol_placement_includes_line(
+            value, min_zoom=min_zoom, max_zoom=max_zoom, bindings=expression_bindings
+        )
+    if operator == "let" and len(value) >= 2:
+        return _let_symbol_placement_includes_line(
+            value, min_zoom=min_zoom, max_zoom=max_zoom, bindings=expression_bindings
+        )
+    if operator == "step":
+        return _step_symbol_placement_includes_line(
+            value, min_zoom=min_zoom, max_zoom=max_zoom, bindings=expression_bindings
+        )
+
+    output_indexes = _symbol_placement_output_indexes(value)
+    if output_indexes is None:
+        return False
+    return _symbol_placement_outputs_include_line(
+        value,
+        output_indexes,
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        bindings=expression_bindings,
+    )
+
+
+def _is_line_placement_source_row(row: dict[str, object]) -> bool:
+    source_min_zoom, source_max_zoom = _numeric_row_zoom_bounds(
+        row, min_key="minzoom", max_key="maxzoom"
+    )
+    qfit_min_zoom, qfit_max_zoom = _numeric_row_zoom_bounds(
+        row, min_key="qfit_minzoom", max_key="qfit_maxzoom"
+    )
+    return _symbol_placement_includes_line(
+        _section_control(row, "layout", "symbol-placement"),
+        min_zoom=source_min_zoom,
+        max_zoom=source_max_zoom,
+    ) or _symbol_placement_includes_line(
+        _section_control(row, "qfit_layout", "symbol-placement"),
+        min_zoom=qfit_min_zoom,
+        max_zoom=qfit_max_zoom,
+    )
+
+
 def _line_label_record_for_repeat(row: dict[str, object]) -> bool:
     placement = row.get("placement")
     return row.get("geometry_type") == "Line" or placement in {"Curved", "Line", "Horizontal"}
@@ -688,6 +896,56 @@ def _line_label_repeat_spacing_rows(
             -int(row["zero_repeat_distance_count"]),
             -int(row["missing_qfit_symbol_spacing"]),
             -int(row["converted_line_label_styles"]),
+            str(row["base_style_layer_id"]),
+        ),
+    )
+
+
+def _line_label_conversion_rows(
+    source_label_layers: list[dict[str, object]],
+    label_records: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    grouped: dict[str, list[tuple[dict[str, object], list[dict[str, object]]]]] = defaultdict(list)
+    labels_by_style = _label_records_by_style(label_records)
+    for row in source_label_layers:
+        if not isinstance(row, dict) or not _is_line_placement_source_row(row):
+            continue
+        base_layer = _base_style_layer_id(row)
+        if base_layer:
+            grouped[base_layer].append((row, _matched_label_records_for_source_row(row, labels_by_style)))
+
+    rows: list[dict[str, object]] = []
+    for base_layer, grouped_rows in grouped.items():
+        source_rows = [row for row, _labels in grouped_rows]
+        converted_rows = _deduplicated_label_records(
+            record for _row, labels in grouped_rows for record in labels
+        )
+        rows.append(
+            {
+                "base_style_layer_id": base_layer,
+                "source_label_rows": len(source_rows),
+                "converted_label_styles": len(converted_rows),
+                "source_symbol_placements": _sorted_count_map(
+                    _section_control(row, "layout", "symbol-placement") for row in source_rows
+                ),
+                "qfit_symbol_placements": _sorted_count_map(
+                    _section_control(row, "qfit_layout", "symbol-placement") for row in source_rows
+                ),
+                "converted_geometry_types": _sorted_count_map(row.get("geometry_type") for row in converted_rows),
+                "converted_placements": _sorted_count_map(row.get("placement") for row in converted_rows),
+                "repeat_distances": _sorted_count_map(
+                    row.get("repeat_distance") for row in converted_rows if _line_label_record_for_repeat(row)
+                ),
+                "label_per_part": _sorted_count_map(row.get("label_per_part") for row in converted_rows),
+                "merge_lines": _sorted_count_map(row.get("merge_lines") for row in converted_rows),
+                "style_names": _sorted_count_map(row.get("style_name") for row in source_rows),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda row: (
+            -int(row["source_label_rows"]),
+            -int(row["converted_label_styles"]),
             str(row["base_style_layer_id"]),
         ),
     )
@@ -1044,6 +1302,7 @@ def _label_settings_report(
         "labels": records,
         "label_style_summary_by_base_layer": _label_style_summary_rows(records),
         "line_label_repeat_spacing_by_base_layer": _line_label_repeat_spacing_rows(source_label_layer_rows, records),
+        "line_label_conversion_by_base_layer": _line_label_conversion_rows(source_label_layer_rows, records),
         "source_label_fanout_by_base_layer": _source_label_fanout_summary_rows(source_label_layer_rows, records),
         "source_label_control_summary_by_base_layer": _source_label_control_summary_rows(source_label_layer_rows),
         "source_label_control_omission_summary_by_base_layer": _source_label_control_omission_summary_rows(
@@ -1221,6 +1480,37 @@ def _append_line_label_repeat_spacing_summary(lines: list[str], summary_rows: li
                     repeat=_count_map_markdown_value(row.get("repeat_distances")),
                     spacing_to_repeat=_count_map_markdown_value(row.get("qfit_symbol_spacing_to_repeat_distances")),
                     placements=_count_map_markdown_value(row.get("placements")),
+                    styles=_count_map_markdown_value(row.get("style_names")),
+                )
+            )
+        lines.append("")
+
+
+def _append_line_label_conversion_summary(lines: list[str], summary_rows: list[object]) -> None:
+    if summary_rows:
+        lines.extend(
+            [
+                "## Line-placement label conversion by base layer",
+                "",
+                "| Base layer | Source rows | Converted styles | Source placement | QGIS style placement | Converted geometry | Converted placement | Repeat distances | Label/part | Merge lines | Styles |",
+                "| --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for row in summary_rows:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "| {base} | {source_rows} | {converted} | {source_placement} | {qfit_placement} | {geometry} | {placement} | {repeat} | {label_per_part} | {merge_lines} | {styles} |".format(
+                    base=_markdown_value(row.get("base_style_layer_id")),
+                    source_rows=_markdown_value(row.get("source_label_rows")),
+                    converted=_markdown_value(row.get("converted_label_styles")),
+                    source_placement=_count_map_markdown_value(row.get("source_symbol_placements")),
+                    qfit_placement=_count_map_markdown_value(row.get("qfit_symbol_placements")),
+                    geometry=_count_map_markdown_value(row.get("converted_geometry_types")),
+                    placement=_count_map_markdown_value(row.get("converted_placements")),
+                    repeat=_count_map_markdown_value(row.get("repeat_distances")),
+                    label_per_part=_count_map_markdown_value(row.get("label_per_part")),
+                    merge_lines=_count_map_markdown_value(row.get("merge_lines")),
                     styles=_count_map_markdown_value(row.get("style_names")),
                 )
             )
@@ -1429,6 +1719,8 @@ def build_summary_markdown(report: dict[str, object]) -> str:
     summary_rows = label_summary if isinstance(label_summary, list) else []
     line_repeat_summary = report.get("line_label_repeat_spacing_by_base_layer")
     line_repeat_rows = line_repeat_summary if isinstance(line_repeat_summary, list) else []
+    line_conversion_summary = report.get("line_label_conversion_by_base_layer")
+    line_conversion_rows = line_conversion_summary if isinstance(line_conversion_summary, list) else []
     source_fanout_summary = report.get("source_label_fanout_by_base_layer")
     source_fanout_rows = source_fanout_summary if isinstance(source_fanout_summary, list) else []
     source_control_summary = report.get("source_label_control_summary_by_base_layer")
@@ -1459,6 +1751,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
     ]
     _append_label_style_summary(lines, summary_rows)
     _append_line_label_repeat_spacing_summary(lines, line_repeat_rows)
+    _append_line_label_conversion_summary(lines, line_conversion_rows)
     _append_source_label_fanout_summary(lines, source_fanout_rows)
     _append_source_label_control_summary(lines, source_control_rows)
     _append_source_label_control_omission_summary(lines, source_control_omission_rows)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -688,17 +688,59 @@ def _variable_symbol_placement_includes_line(
 def _let_symbol_placement_includes_line(
     value: list[object], *, min_zoom: float, max_zoom: float, bindings: dict[str, object]
 ) -> bool:
+    return _symbol_placement_includes_line(
+        value[-1],
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        bindings=_symbol_placement_let_bindings(value, bindings),
+    )
+
+
+def _symbol_placement_let_bindings(
+    value: list[object],
+    bindings: dict[str, object],
+) -> dict[str, object]:
     let_bindings = dict(bindings)
     for index in range(1, len(value) - 1, 2):
         variable_name = value[index]
         if isinstance(variable_name, str) and index + 1 < len(value):
             let_bindings[variable_name] = value[index + 1]
-    return _symbol_placement_includes_line(
-        value[-1],
-        min_zoom=min_zoom,
-        max_zoom=max_zoom,
-        bindings=let_bindings,
+    return let_bindings
+
+
+def _literal_symbol_placement_value_is_known_non_null(
+    value: list[object], *, bindings: dict[str, object]
+) -> bool:
+    return len(value) == 2 and value[1] is not None
+
+
+def _variable_symbol_placement_value_is_known_non_null(
+    value: list[object], *, bindings: dict[str, object]
+) -> bool:
+    if len(value) != 2 or not isinstance(value[1], str):
+        return False
+    return _symbol_placement_value_is_known_non_null(
+        bindings.get(value[1]),
+        bindings=bindings,
     )
+
+
+def _let_symbol_placement_value_is_known_non_null(
+    value: list[object], *, bindings: dict[str, object]
+) -> bool:
+    if len(value) < 2:
+        return False
+    return _symbol_placement_value_is_known_non_null(
+        value[-1],
+        bindings=_symbol_placement_let_bindings(value, bindings),
+    )
+
+
+_SYMBOL_PLACEMENT_NON_NULL_TESTERS = {
+    "literal": _literal_symbol_placement_value_is_known_non_null,
+    "var": _variable_symbol_placement_value_is_known_non_null,
+    "let": _let_symbol_placement_value_is_known_non_null,
+}
 
 
 def _symbol_placement_value_is_known_non_null(
@@ -713,25 +755,8 @@ def _symbol_placement_value_is_known_non_null(
     if not isinstance(value, list) or not value:
         return True
 
-    operator = value[0]
-    if operator == "literal":
-        return len(value) == 2 and value[1] is not None
-    if operator == "var" and len(value) == 2 and isinstance(value[1], str):
-        return _symbol_placement_value_is_known_non_null(
-            bindings.get(value[1]),
-            bindings=bindings,
-        )
-    if operator == "let" and len(value) >= 2:
-        let_bindings = dict(bindings)
-        for index in range(1, len(value) - 1, 2):
-            variable_name = value[index]
-            if isinstance(variable_name, str) and index + 1 < len(value):
-                let_bindings[variable_name] = value[index + 1]
-        return _symbol_placement_value_is_known_non_null(
-            value[-1],
-            bindings=let_bindings,
-        )
-    return False
+    tester = _SYMBOL_PLACEMENT_NON_NULL_TESTERS.get(value[0])
+    return tester(value, bindings=bindings) if tester else False
 
 
 def _coalesce_symbol_placement_includes_line(

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -614,17 +614,32 @@ def _symbol_placement_zoom_step_includes_line(
     )
 
 
+def _interpolate_symbol_placement_output_indexes(value: list[object]) -> Iterable[int]:
+    return range(4, len(value), 2)
+
+
+def _case_symbol_placement_output_indexes(value: list[object]) -> Iterable[int] | None:
+    if len(value) < 4:
+        return None
+    return [*range(2, len(value) - 1, 2), len(value) - 1]
+
+
+def _match_symbol_placement_output_indexes(value: list[object]) -> Iterable[int] | None:
+    if len(value) < 4:
+        return None
+    return [*range(3, len(value) - 1, 2), len(value) - 1]
+
+
+_SYMBOL_PLACEMENT_OUTPUT_INDEXERS = {
+    "interpolate": _interpolate_symbol_placement_output_indexes,
+    "case": _case_symbol_placement_output_indexes,
+    "match": _match_symbol_placement_output_indexes,
+}
+
+
 def _symbol_placement_output_indexes(value: list[object]) -> Iterable[int] | None:
-    operator = value[0]
-    if operator == "interpolate":
-        return range(4, len(value), 2)
-    if operator == "case" and len(value) >= 4:
-        return [*range(2, len(value) - 1, 2), len(value) - 1]
-    if operator == "match" and len(value) >= 4:
-        return [*range(3, len(value) - 1, 2), len(value) - 1]
-    if operator == "coalesce":
-        return range(1, len(value))
-    return None
+    output_indexer = _SYMBOL_PLACEMENT_OUTPUT_INDEXERS.get(value[0])
+    return output_indexer(value) if output_indexer else None
 
 
 def _symbol_placement_outputs_include_line(
@@ -686,6 +701,55 @@ def _let_symbol_placement_includes_line(
     )
 
 
+def _symbol_placement_value_is_known_non_null(
+    value: object,
+    *,
+    bindings: dict[str, object],
+) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return True
+    if not isinstance(value, list) or not value:
+        return True
+
+    operator = value[0]
+    if operator == "literal":
+        return len(value) == 2 and value[1] is not None
+    if operator == "var" and len(value) == 2 and isinstance(value[1], str):
+        return _symbol_placement_value_is_known_non_null(
+            bindings.get(value[1]),
+            bindings=bindings,
+        )
+    if operator == "let" and len(value) >= 2:
+        let_bindings = dict(bindings)
+        for index in range(1, len(value) - 1, 2):
+            variable_name = value[index]
+            if isinstance(variable_name, str) and index + 1 < len(value):
+                let_bindings[variable_name] = value[index + 1]
+        return _symbol_placement_value_is_known_non_null(
+            value[-1],
+            bindings=let_bindings,
+        )
+    return False
+
+
+def _coalesce_symbol_placement_includes_line(
+    value: list[object], *, min_zoom: float, max_zoom: float, bindings: dict[str, object]
+) -> bool:
+    for candidate in value[1:]:
+        if _symbol_placement_includes_line(
+            candidate,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            bindings=bindings,
+        ):
+            return True
+        if _symbol_placement_value_is_known_non_null(candidate, bindings=bindings):
+            return False
+    return False
+
+
 def _step_symbol_placement_includes_line(
     value: list[object], *, min_zoom: float, max_zoom: float, bindings: dict[str, object]
 ) -> bool:
@@ -734,6 +798,10 @@ def _symbol_placement_includes_line(
         )
     if operator == "step":
         return _step_symbol_placement_includes_line(
+            value, min_zoom=min_zoom, max_zoom=max_zoom, bindings=expression_bindings
+        )
+    if operator == "coalesce":
+        return _coalesce_symbol_placement_includes_line(
             value, min_zoom=min_zoom, max_zoom=max_zoom, bindings=expression_bindings
         )
 


### PR DESCRIPTION
## Summary

- Add a label-settings report section that groups line-placement label conversions by base Mapbox layer, including road shields and line-center labels that are outside the repeat-spacing table.
- Detect line placement from supported Mapbox `symbol-placement` expression outputs and from qfit placement, without treating expression match labels such as `"line"` as placement values.
- Honor row zoom bounds when interpreting zoom-step placement so unreachable line branches do not count.
- Keep repeat-distance diagnostics limited to converted line labels where QGIS repeat spacing applies.

## Validation

- `python3 -m py_compile validation/mapbox_outdoors_label_settings.py tests/test_mapbox_outdoors_label_settings.py`
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `MAPBOX_ACCESS_TOKEN=... python3 validation/mapbox_outdoors_label_settings.py`
- Report artifact: `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260520T092425Z/summary.md`



