### PR TITLE
Repeat Mapbox road shields on line labels

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -696,6 +696,25 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         other_style.setLabelSettings.assert_not_called()
         remaining_style.setLabelSettings.assert_called_once_with(remaining_settings)
 
+    def test_road_number_shield_z11_plus_repeat_distance_uses_audited_spacing(self):
+        from qgis.core import Qgis
+
+        labeling = MagicMock()
+        style, settings = self._make_style(
+            "road",
+            "road-number-shield-2-beta-remaining-icons-z11-plus",
+        )
+        settings.mergeLines = False
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertTrue(settings.mergeLines)
+        self.assertAlmostEqual(settings.repeatDistance, (1400.0 / 3.0) * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
+        style.setLabelSettings.assert_called_once_with(settings)
+
     def test_high_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         from qgis.core import Qgis
 
@@ -969,6 +988,23 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         swiss_style.setLabelSettings.assert_called_once_with(swiss_settings)
         other_style.setLabelSettings.assert_not_called()
         remaining_style.setLabelSettings.assert_called_once_with(remaining_settings)
+
+    def test_road_number_shield_z11_plus_repeat_distance_uses_audited_spacing(self):
+        labeling = MagicMock()
+        style, settings = self._make_style(
+            "road",
+            "road-number-shield-2-beta-remaining-icons-z11-plus",
+        )
+        settings.mergeLines = False
+        settings.repeatDistance = 0.0
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertTrue(settings.mergeLines)
+        self.assertAlmostEqual(settings.repeatDistance, (1400.0 / 3.0) * 25.4 / 96)
+        self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
+        style.setLabelSettings.assert_called_once_with(settings)
 
     def test_high_zoom_road_label_repeat_distance_uses_audited_spacing(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -49,6 +49,7 @@ _MAPBOX_SYMBOL_PIXEL_TO_MM = 25.4 / 96.0
 _MAPBOX_DEFAULT_SYMBOL_SPACING_PX = 250.0
 _ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX = 150.0
 _ROAD_LABEL_HIGH_ZOOM_SYMBOL_SPACING_PX = 400.0
+_ROAD_NUMBER_SHIELD_Z11_PLUS_SYMBOL_SPACING_PX = 1400.0 / 3.0
 _REPEAT_DISTANCE_EPSILON_MM = 0.001
 _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "ferry-aerialway-label",
@@ -117,6 +118,8 @@ def _symbol_spacing_mm(pixels: float) -> float:
 
 def _label_repeat_distance(layer_name: str, style) -> float | None:
     style_name = _label_style_name(style)
+    if layer_name == "road-number-shield" and "z11-plus" in style_name:
+        return _symbol_spacing_mm(_ROAD_NUMBER_SHIELD_Z11_PLUS_SYMBOL_SPACING_PX)
     if layer_name == "road-label":
         if style_name in {"road-label-below-z12", "road-label-z12-to-z15"}:
             return _symbol_spacing_mm(_ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX)


### PR DESCRIPTION
## Summary

- Apply the audited z11+ Mapbox road-number-shield symbol spacing as a QGIS label repeat distance for line shield styles.
- Keep below-z11 point shield styles at QGIS' zero repeat distance.
- Add real-QGIS and mock-QGIS regression coverage for the z11+ shield repeat setting.

## Validation

- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 validation/mapbox_outdoors_label_settings.py`
  - Confirmed `road-number-shield` has `0=14, 123.472=14` repeat distances, and line-placement rows show `123.472=14`.
- `python3 validation/mapbox_outdoors_comparison.py geneva-airport-motorway-z14-outdoors`
  - Captured browser reference, QGIS render, diff, manifest, and `qgis-label-styles.json`.
  - Confirmed all z11+ `road-number-shield-*` line styles have `repeat_distance=123.47222222222223`; below-z11 point styles remain `0.0`.

Part of #949.
