### PR TITLE
[codex] Approximate Mapbox line-center labels

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -137,6 +137,21 @@ def _make_layer_node(layer_name, layer_cls=None):
     return node, layer
 
 
+def _make_line_label_settings(
+    *,
+    line_anchor_percent=0.0,
+    anchor_text_point=None,
+    anchor_type=None,
+    anchor_clipping=None,
+):
+    settings = MagicMock()
+    settings.lineAnchorPercent.return_value = line_anchor_percent
+    settings.anchorTextPoint.return_value = anchor_text_point
+    settings.anchorType.return_value = anchor_type
+    settings.anchorClipping.return_value = anchor_clipping
+    return settings
+
+
 # ===========================================================================
 # Suite 1 — real-QGIS (skipped when QGIS unavailable)
 # ===========================================================================
@@ -783,6 +798,40 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
                 self.assertAlmostEqual(settings.repeatDistance, spacing_px * 25.4 / 96)
                 style.setLabelSettings.assert_called_once_with(settings)
 
+    def test_line_center_labels_use_strict_center_line_anchor(self):
+        from qgis.core import QgsLabelLineSettings, Qgis
+
+        cases = [
+            ("natural_label", "natural-line-label", 4),
+            ("natural_label", "water-line-label-ocean-name", 6),
+        ]
+        for layer_name, style_name, priority in cases:
+            with self.subTest(style_name=style_name):
+                labeling = MagicMock()
+                style, settings = self._make_style(layer_name, style_name)
+                settings.placement = Qgis.LabelPlacement.OverPoint
+                line_settings = _make_line_label_settings()
+                settings.lineSettings.return_value = line_settings
+                labeling.styles.return_value = [style]
+
+                self.service._apply_label_priority(labeling)
+
+                self.assertEqual(settings.priority, priority)
+                self.assertEqual(settings.placement, Qgis.LabelPlacement.Line)
+                style.setGeometryType.assert_called_once_with(Qgis.GeometryType.Line)
+                line_settings.setLineAnchorPercent.assert_called_once_with(0.5)
+                line_settings.setAnchorTextPoint.assert_called_once_with(
+                    QgsLabelLineSettings.AnchorTextPoint.CenterOfText
+                )
+                line_settings.setAnchorType.assert_called_once_with(
+                    QgsLabelLineSettings.AnchorType.Strict
+                )
+                line_settings.setAnchorClipping.assert_called_once_with(
+                    QgsLabelLineSettings.AnchorClipping.UseEntireLine
+                )
+                settings.setLineSettings.assert_called_once_with(line_settings)
+                style.setLabelSettings.assert_called_once_with(settings)
+
     def test_ferry_aerialway_labels_merge_matching_line_segments(self):
         from qgis.core import Qgis
 
@@ -1068,6 +1117,38 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
                 self.assertTrue(settings.mergeLines)
                 self.assertAlmostEqual(settings.repeatDistance, spacing_px * 25.4 / 96)
+                style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_line_center_labels_use_strict_center_line_anchor(self):
+        cases = [
+            ("natural_label", "natural-line-label", 4),
+            ("natural_label", "water-line-label-ocean-name", 6),
+        ]
+        for layer_name, style_name, priority in cases:
+            with self.subTest(style_name=style_name):
+                labeling = MagicMock()
+                style, settings = self._make_style(layer_name, style_name)
+                settings.placement = _qstub.Qgis.LabelPlacement.OverPoint
+                line_settings = _make_line_label_settings()
+                settings.lineSettings.return_value = line_settings
+                labeling.styles.return_value = [style]
+
+                self.service._apply_label_priority(labeling)
+
+                self.assertEqual(settings.priority, priority)
+                self.assertEqual(settings.placement, _qstub.Qgis.LabelPlacement.Line)
+                style.setGeometryType.assert_called_once_with(_qstub.Qgis.GeometryType.Line)
+                line_settings.setLineAnchorPercent.assert_called_once_with(0.5)
+                line_settings.setAnchorTextPoint.assert_called_once_with(
+                    _qstub.QgsLabelLineSettings.AnchorTextPoint.CenterOfText
+                )
+                line_settings.setAnchorType.assert_called_once_with(
+                    _qstub.QgsLabelLineSettings.AnchorType.Strict
+                )
+                line_settings.setAnchorClipping.assert_called_once_with(
+                    _qstub.QgsLabelLineSettings.AnchorClipping.UseEntireLine
+                )
+                settings.setLineSettings.assert_called_once_with(line_settings)
                 style.setLabelSettings.assert_called_once_with(settings)
 
     def test_ferry_aerialway_labels_merge_matching_line_segments(self):

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -948,8 +948,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                 {
                     "base_style_layer_id": "water-line-label",
                     "style_name": "water-line-label",
-                    "geometry_type": "Point",
-                    "placement": "OverPoint",
+                    "geometry_type": "Line",
+                    "placement": "Line",
                     "repeat_distance": 0.0,
                     "label_per_part": False,
                     "merge_lines": False,
@@ -983,9 +983,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(ferry_row["repeat_distances"], {"66.1458": 1})
         water_row = rows[2]
         self.assertEqual(water_row["source_symbol_placements"], {"line-center": 1})
-        self.assertEqual(water_row["converted_geometry_types"], {"Point": 1})
-        self.assertEqual(water_row["converted_placements"], {"OverPoint": 1})
-        self.assertEqual(water_row["repeat_distances"], {})
+        self.assertEqual(water_row["converted_geometry_types"], {"Line": 1})
+        self.assertEqual(water_row["converted_placements"], {"Line": 1})
+        self.assertEqual(water_row["repeat_distances"], {"0": 1})
         self.assertEqual(water_row["merge_lines"], {"false": 1})
 
     def test_line_center_label_conversion_summary_isolates_line_center_labels(self):
@@ -1028,8 +1028,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                 {
                     "base_style_layer_id": "water-line-label",
                     "style_name": "water-line-label-ocean-name",
-                    "geometry_type": "Point",
-                    "placement": "OverPoint",
+                    "geometry_type": "Line",
+                    "placement": "Line",
                     "repeat_distance": 0.0,
                     "label_per_part": False,
                     "merge_lines": False,
@@ -1037,8 +1037,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                 {
                     "base_style_layer_id": "natural-line-label",
                     "style_name": "natural-line-label",
-                    "geometry_type": "Point",
-                    "placement": "OverPoint",
+                    "geometry_type": "Line",
+                    "placement": "Line",
                     "repeat_distance": 0.0,
                     "label_per_part": False,
                     "merge_lines": False,
@@ -1072,9 +1072,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(water_row["source_layers"], {"natural_label": 1})
         self.assertEqual(water_row["source_symbol_placements"], {"line-center": 1})
         self.assertEqual(water_row["qfit_symbol_placements"], {"line-center": 1})
-        self.assertEqual(water_row["converted_geometry_types"], {"Point": 1})
-        self.assertEqual(water_row["converted_placements"], {"OverPoint": 1})
-        self.assertEqual(water_row["repeat_distances"], {})
+        self.assertEqual(water_row["converted_geometry_types"], {"Line": 1})
+        self.assertEqual(water_row["converted_placements"], {"Line": 1})
+        self.assertEqual(water_row["repeat_distances"], {"0": 1})
         self.assertEqual(water_row["merge_lines"], {"false": 1})
 
     def test_symbol_placement_line_detection_uses_expression_outputs_and_zoom_bounds(self):
@@ -1644,9 +1644,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "source_layers": {"natural_label": 1},
                     "source_symbol_placements": {"line-center": 1},
                     "qfit_symbol_placements": {"line-center": 1},
-                    "converted_geometry_types": {"Point": 1},
-                    "converted_placements": {"OverPoint": 1},
-                    "repeat_distances": {},
+                    "converted_geometry_types": {"Line": 1},
+                    "converted_placements": {"Line": 1},
+                    "repeat_distances": {"0": 1},
                     "label_per_part": {"false": 1},
                     "merge_lines": {"false": 1},
                     "style_names": {"water-line-label": 1},
@@ -1780,7 +1780,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             markdown,
         )
         self.assertIn(
-            "| water-line-label | 1 | 1 | natural_label=1 | line-center=1 | line-center=1 | Point=1 | OverPoint=1 | — | no=1 | no=1 | water-line-label=1 |",
+            "| water-line-label | 1 | 1 | natural_label=1 | line-center=1 | line-center=1 | Line=1 | Line=1 | 0=1 | no=1 | no=1 | water-line-label=1 |",
             markdown,
         )
         self.assertIn("## Source label fan-out by base layer", markdown)

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -51,6 +51,8 @@ _ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX = 150.0
 _ROAD_LABEL_HIGH_ZOOM_SYMBOL_SPACING_PX = 400.0
 _ROAD_NUMBER_SHIELD_Z11_PLUS_SYMBOL_SPACING_PX = 1400.0 / 3.0
 _REPEAT_DISTANCE_EPSILON_MM = 0.001
+_LINE_CENTER_ANCHOR_PERCENT = 0.5
+_LINE_CENTER_ANCHOR_PERCENT_EPSILON = 0.000001
 _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "ferry-aerialway-label",
     "path-pedestrian-label",
@@ -62,6 +64,7 @@ _LINE_LABEL_MERGE_LAYERS = {
     "road-label",
     "waterway-label",
 }
+_LINE_CENTER_LABEL_LAYERS = {"natural-line-label", "water-line-label"}
 # Representative-zoom values from mapbox_config's waterway-label spacing
 # expression after qfit splits it into static QGIS zoom bands.  The z17+
 # value is wider than Mapbox's raw 400 px spacing because QGIS repeats labels
@@ -185,6 +188,13 @@ def _needs_repeat_distance(settings, expected_repeat_distance: float | None = No
     )
 
 
+def _needs_line_center_anchor_percent(line_settings) -> bool:
+    line_anchor_percent = line_settings.lineAnchorPercent()
+    return not isinstance(line_anchor_percent, (int, float)) or abs(
+        line_anchor_percent - _LINE_CENTER_ANCHOR_PERCENT
+    ) > _LINE_CENTER_ANCHOR_PERCENT_EPSILON
+
+
 def _apply_settlement_label_priority(settings, qgs_property) -> None:
     dd_props = settings.dataDefinedProperties()
     dd_props.setProperty(
@@ -228,6 +238,147 @@ def _apply_label_settings(
         settings.isExpression = True
         changed = True
     return changed
+
+
+def _apply_line_center_label_placement(settings, qgs_label_line_settings, qgis) -> bool:
+    changed = False
+    if getattr(settings, "placement", None) != qgis.LabelPlacement.Line:
+        settings.placement = qgis.LabelPlacement.Line
+        changed = True
+
+    try:
+        line_settings = settings.lineSettings()
+    except (AttributeError, RuntimeError, TypeError):
+        return changed
+    if _needs_line_center_anchor_percent(line_settings):
+        line_settings.setLineAnchorPercent(_LINE_CENTER_ANCHOR_PERCENT)
+        changed = True
+    if (
+        line_settings.anchorTextPoint()
+        != qgs_label_line_settings.AnchorTextPoint.CenterOfText
+    ):
+        line_settings.setAnchorTextPoint(qgs_label_line_settings.AnchorTextPoint.CenterOfText)
+        changed = True
+    if line_settings.anchorType() != qgs_label_line_settings.AnchorType.Strict:
+        line_settings.setAnchorType(qgs_label_line_settings.AnchorType.Strict)
+        changed = True
+    if (
+        line_settings.anchorClipping()
+        != qgs_label_line_settings.AnchorClipping.UseEntireLine
+    ):
+        line_settings.setAnchorClipping(qgs_label_line_settings.AnchorClipping.UseEntireLine)
+        changed = True
+    if changed:
+        settings.setLineSettings(line_settings)
+    return changed
+
+
+def _apply_line_center_label_geometry(style, qgis) -> bool:
+    try:
+        geometry_type = style.geometryType()
+    except (AttributeError, RuntimeError, TypeError):
+        geometry_type = None
+    if geometry_type == qgis.GeometryType.Line:
+        return False
+    set_geometry_type = getattr(style, "setGeometryType", None)
+    if not callable(set_geometry_type):
+        return False
+    try:
+        set_geometry_type(qgis.GeometryType.Line)
+    except (RuntimeError, TypeError):
+        return False
+    return True
+
+
+def _has_label_postprocess(
+    *,
+    layer_name: str,
+    priority: int | None,
+    repeat_distance: float | None,
+    merge_lines: bool | None,
+    is_line_center_label: bool,
+) -> bool:
+    return (
+        priority is not None
+        or repeat_distance is not None
+        or merge_lines is not None
+        or is_line_center_label
+        or layer_name == _CONTOUR_LABEL_LAYER_ID
+    )
+
+
+def _has_label_settings_postprocess(
+    *,
+    priority: int | None,
+    repeat_distance: float | None,
+    merge_lines: bool | None,
+    field_expression: str | None,
+    is_line_center_label: bool,
+) -> bool:
+    return (
+        priority is not None
+        or repeat_distance is not None
+        or merge_lines is not None
+        or field_expression is not None
+        or is_line_center_label
+    )
+
+
+def _apply_mapbox_label_style(
+    style,
+    *,
+    qgs_label_line_settings,
+    qgs_property,
+    qgis,
+) -> bool:
+    layer_name = _label_style_mapbox_layer_id(style)
+    priority = _label_priority(layer_name, style)
+    repeat_distance = _label_repeat_distance(layer_name, style)
+    merge_lines = _label_merge_lines(layer_name, style)
+    is_line_center_label = layer_name in _LINE_CENTER_LABEL_LAYERS
+    if not _has_label_postprocess(
+        layer_name=layer_name,
+        priority=priority,
+        repeat_distance=repeat_distance,
+        merge_lines=merge_lines,
+        is_line_center_label=is_line_center_label,
+    ):
+        return False
+
+    settings = style.labelSettings()
+    if settings is None:
+        return False
+
+    field_expression = _label_field_expression(layer_name, settings)
+    if not _has_label_settings_postprocess(
+        priority=priority,
+        repeat_distance=repeat_distance,
+        merge_lines=merge_lines,
+        field_expression=field_expression,
+        is_line_center_label=is_line_center_label,
+    ):
+        return False
+
+    style_changed = _apply_label_settings(
+        settings,
+        layer_name=layer_name,
+        priority=priority,
+        repeat_distance=repeat_distance,
+        merge_lines=merge_lines,
+        field_expression=field_expression,
+        qgs_property=qgs_property,
+        qgis=qgis,
+    )
+    geometry_changed = False
+    if is_line_center_label:
+        style_changed = (
+            _apply_line_center_label_placement(settings, qgs_label_line_settings, qgis)
+            or style_changed
+        )
+        geometry_changed = _apply_line_center_label_geometry(style, qgis)
+    if style_changed:
+        style.setLabelSettings(settings)
+    return style_changed or geometry_changed
 
 
 def _append_high_zoom_contour_bbox_edge_label_style(
@@ -282,6 +433,7 @@ def _append_high_zoom_contour_bbox_edge_label_style(
 def apply_mapbox_label_priority(labeling) -> None:
     try:
         from qgis.core import (  # noqa: PLC0415
+            QgsLabelLineSettings,
             QgsPalLayerSettings,
             QgsProperty,
             QgsVectorTileBasicLabelingStyle,
@@ -291,35 +443,12 @@ def apply_mapbox_label_priority(labeling) -> None:
         styles = list(labeling.styles())
         changed = False
         for style in styles:
-            layer_name = _label_style_mapbox_layer_id(style)
-            priority = _label_priority(layer_name, style)
-            repeat_distance = _label_repeat_distance(layer_name, style)
-            merge_lines = _label_merge_lines(layer_name, style)
-            if (
-                priority is None
-                and repeat_distance is None
-                and merge_lines is None
-                and layer_name != _CONTOUR_LABEL_LAYER_ID
-            ):
-                continue
-            settings = style.labelSettings()
-            if settings is None:
-                continue
-            field_expression = _label_field_expression(layer_name, settings)
-            if priority is None and repeat_distance is None and merge_lines is None and field_expression is None:
-                continue
-            if _apply_label_settings(
-                settings,
-                layer_name=layer_name,
-                priority=priority,
-                repeat_distance=repeat_distance,
-                merge_lines=merge_lines,
-                field_expression=field_expression,
+            changed = _apply_mapbox_label_style(
+                style,
+                qgs_label_line_settings=QgsLabelLineSettings,
                 qgs_property=QgsProperty,
                 qgis=Qgis,
-            ):
-                style.setLabelSettings(settings)
-                changed = True
+            ) or changed
         if _append_high_zoom_contour_bbox_edge_label_style(
             styles,
             qgs_pal_layer_settings=QgsPalLayerSettings,


### PR DESCRIPTION
## Summary

- Set Mapbox line-center natural and water labels to QGIS line geometry with line placement.
- Anchor those labels strictly at the line midpoint with centered text, matching Mapbox line-center intent more closely than OverPoint conversion.
- Update #949 label-audit expectations so line-center rows report Line geometry/placement instead of Point/OverPoint.

## Evidence

- Official Mapbox style spec treats symbol-placement line-center as a line symbol placement.
- QGIS QgsLabelLineSettings exposes a strict anchor type, center text anchor point, visible/entire line clipping, and 50% line anchor support.
- Live Lausanne/Lavaux comparison: line-center styles converted from geometry/placement 0/1 to 1/2; branch vs main changed 427 pixels, mean channel delta improved from 11.3677607060 to 11.3671545139, RMS improved from 22.1636094579 to 22.1625551743.
- Live Valais/Geneva comparison: line-center styles converted from 0/1 to 1/2 with no QGIS pixel delta versus main.

## Validation

- python3 -m py_compile visualization/infrastructure/background_map_service.py tests/test_background_map_service.py tests/test_mapbox_outdoors_label_settings.py
- python3 -m pytest tests/test_background_map_service.py tests/test_mapbox_outdoors_label_settings.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- git diff --check

Fixes part of #949