### PR TITLE
[codex] Avoid redundant line-center anchor writes

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -832,6 +832,34 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
                 settings.setLineSettings.assert_called_once_with(line_settings)
                 style.setLabelSettings.assert_called_once_with(settings)
 
+    def test_line_center_placement_change_does_not_reset_unchanged_anchor(self):
+        from qgis.core import QgsLabelLineSettings, Qgis
+
+        labeling = MagicMock()
+        style, settings = self._make_style("natural_label", "natural-line-label")
+        style.geometryType.return_value = Qgis.GeometryType.Line
+        settings.priority = 4
+        settings.placement = Qgis.LabelPlacement.OverPoint
+        line_settings = _make_line_label_settings(
+            line_anchor_percent=0.5,
+            anchor_text_point=QgsLabelLineSettings.AnchorTextPoint.CenterOfText,
+            anchor_type=QgsLabelLineSettings.AnchorType.Strict,
+            anchor_clipping=QgsLabelLineSettings.AnchorClipping.UseEntireLine,
+        )
+        settings.lineSettings.return_value = line_settings
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.placement, Qgis.LabelPlacement.Line)
+        line_settings.setLineAnchorPercent.assert_not_called()
+        line_settings.setAnchorTextPoint.assert_not_called()
+        line_settings.setAnchorType.assert_not_called()
+        line_settings.setAnchorClipping.assert_not_called()
+        settings.setLineSettings.assert_not_called()
+        style.setGeometryType.assert_not_called()
+        style.setLabelSettings.assert_called_once_with(settings)
+
     def test_ferry_aerialway_labels_merge_matching_line_segments(self):
         from qgis.core import Qgis
 
@@ -1150,6 +1178,32 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
                 )
                 settings.setLineSettings.assert_called_once_with(line_settings)
                 style.setLabelSettings.assert_called_once_with(settings)
+
+    def test_line_center_placement_change_does_not_reset_unchanged_anchor(self):
+        labeling = MagicMock()
+        style, settings = self._make_style("natural_label", "natural-line-label")
+        style.geometryType.return_value = _qstub.Qgis.GeometryType.Line
+        settings.priority = 4
+        settings.placement = _qstub.Qgis.LabelPlacement.OverPoint
+        line_settings = _make_line_label_settings(
+            line_anchor_percent=0.5,
+            anchor_text_point=_qstub.QgsLabelLineSettings.AnchorTextPoint.CenterOfText,
+            anchor_type=_qstub.QgsLabelLineSettings.AnchorType.Strict,
+            anchor_clipping=_qstub.QgsLabelLineSettings.AnchorClipping.UseEntireLine,
+        )
+        settings.lineSettings.return_value = line_settings
+        labeling.styles.return_value = [style]
+
+        self.service._apply_label_priority(labeling)
+
+        self.assertEqual(settings.placement, _qstub.Qgis.LabelPlacement.Line)
+        line_settings.setLineAnchorPercent.assert_not_called()
+        line_settings.setAnchorTextPoint.assert_not_called()
+        line_settings.setAnchorType.assert_not_called()
+        line_settings.setAnchorClipping.assert_not_called()
+        settings.setLineSettings.assert_not_called()
+        style.setGeometryType.assert_not_called()
+        style.setLabelSettings.assert_called_once_with(settings)
 
     def test_ferry_aerialway_labels_merge_matching_line_segments(self):
         labeling = MagicMock()

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -241,36 +241,37 @@ def _apply_label_settings(
 
 
 def _apply_line_center_label_placement(settings, qgs_label_line_settings, qgis) -> bool:
-    changed = False
+    placement_changed = False
     if getattr(settings, "placement", None) != qgis.LabelPlacement.Line:
         settings.placement = qgis.LabelPlacement.Line
-        changed = True
+        placement_changed = True
 
     try:
         line_settings = settings.lineSettings()
     except (AttributeError, RuntimeError, TypeError):
-        return changed
+        return placement_changed
+    line_settings_changed = False
     if _needs_line_center_anchor_percent(line_settings):
         line_settings.setLineAnchorPercent(_LINE_CENTER_ANCHOR_PERCENT)
-        changed = True
+        line_settings_changed = True
     if (
         line_settings.anchorTextPoint()
         != qgs_label_line_settings.AnchorTextPoint.CenterOfText
     ):
         line_settings.setAnchorTextPoint(qgs_label_line_settings.AnchorTextPoint.CenterOfText)
-        changed = True
+        line_settings_changed = True
     if line_settings.anchorType() != qgs_label_line_settings.AnchorType.Strict:
         line_settings.setAnchorType(qgs_label_line_settings.AnchorType.Strict)
-        changed = True
+        line_settings_changed = True
     if (
         line_settings.anchorClipping()
         != qgs_label_line_settings.AnchorClipping.UseEntireLine
     ):
         line_settings.setAnchorClipping(qgs_label_line_settings.AnchorClipping.UseEntireLine)
-        changed = True
-    if changed:
+        line_settings_changed = True
+    if line_settings_changed:
         settings.setLineSettings(line_settings)
-    return changed
+    return placement_changed or line_settings_changed
 
 
 def _apply_line_center_label_geometry(style, qgis) -> bool:


### PR DESCRIPTION
## Summary

- Split line-center label placement changes from line anchor changes so unchanged `QgsLabelLineSettings` copies are not written back.
- Add real-QGIS and mock regression coverage for the placement-only path flagged by Greptile on #1205.

## Validation

- python3 -m py_compile visualization/infrastructure/background_map_service.py tests/test_background_map_service.py
- python3 -m pytest tests/test_background_map_service.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- git diff --check

Addresses Greptile feedback on #1205.
