### PR TITLE
[codex] Soften mid-zoom road labels

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -739,10 +739,11 @@ _ROAD_LABEL_FILTER_ZOOM_STEP_ENTRIES: tuple[tuple[int, object], ...] = (
     (4, _ROAD_LABEL_MID_ZOOM_CLASS_FILTER),
     (6, _ROAD_LABEL_HIGH_ZOOM_CLASS_FILTER),
 )
+_ROAD_LABEL_MID_ZOOM_SUFFIX = "z12-to-z15"
 _ROAD_LABEL_HIGH_ZOOM_SUFFIX = "z15-plus"
 _ROAD_LABEL_FILTER_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, object], ...] = (
     ("below-z12", None, 12.0, _ROAD_LABEL_LOW_ZOOM_CLASS_FILTER),
-    ("z12-to-z15", 12.0, 15.0, _ROAD_LABEL_MID_ZOOM_CLASS_FILTER),
+    (_ROAD_LABEL_MID_ZOOM_SUFFIX, 12.0, 15.0, _ROAD_LABEL_MID_ZOOM_CLASS_FILTER),
     (_ROAD_LABEL_HIGH_ZOOM_SUFFIX, 15.0, None, _ROAD_LABEL_HIGH_ZOOM_CLASS_FILTER),
 )
 _ROAD_LABEL_FILTER_ZOOM_VARIANT_IDS = {
@@ -750,6 +751,7 @@ _ROAD_LABEL_FILTER_ZOOM_VARIANT_IDS = {
 }
 _ROAD_LABEL_HIGH_ZOOM_SYMBOL_SPACING = 400.0
 _ROAD_LABEL_HIGH_ZOOM_TEXT_COLOR = "hsl(0, 0%, 38%)"
+_ROAD_LABEL_MID_ZOOM_TEXT_COLOR = _ROAD_LABEL_HIGH_ZOOM_TEXT_COLOR
 _PATH_BACKGROUND_LINE_COLOR_EXPRESSION = [
     "match",
     ["get", "type"],
@@ -2034,6 +2036,12 @@ def _apply_high_zoom_road_label_style(variant: dict[str, object]) -> None:
         variant_paint["text-color"] = _ROAD_LABEL_HIGH_ZOOM_TEXT_COLOR
 
 
+def _apply_mid_zoom_road_label_style(variant: dict[str, object]) -> None:
+    variant_paint = variant.setdefault("paint", {})
+    if isinstance(variant_paint, dict):
+        variant_paint["text-color"] = _ROAD_LABEL_MID_ZOOM_TEXT_COLOR
+
+
 def _road_label_filter_layer_variant(
     layer: dict[str, object],
     filter_value: list[object],
@@ -2050,6 +2058,8 @@ def _road_label_filter_layer_variant(
         clause_index,
         class_filter,
     )
+    if suffix == _ROAD_LABEL_MID_ZOOM_SUFFIX:
+        _apply_mid_zoom_road_label_style(variant)
     if suffix == _ROAD_LABEL_HIGH_ZOOM_SUFFIX:
         _apply_high_zoom_road_label_style(variant)
     return variant

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2283,6 +2283,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             by_id["road-label-z15-plus"]["paint"]["text-color"],
             mapbox_config._ROAD_LABEL_HIGH_ZOOM_TEXT_COLOR,
         )
+        self.assertEqual(
+            by_id["road-label-z12-to-z15"]["paint"]["text-color"],
+            mapbox_config._ROAD_LABEL_MID_ZOOM_TEXT_COLOR,
+        )
+        self.assertNotIn("paint", by_id["road-label-below-z12"])
         for layer in by_id.values():
             self.assertEqual(layer["layout"]["text-field"], ["get", "name"])
             self.assertEqual(layer["layout"]["text-size"], 10.0)


### PR DESCRIPTION
## Summary

- use the existing muted road-label text color for the z12-to-z15 Mapbox Outdoors road-label split
- keep the lower zoom road-label styling unchanged and preserve the existing z15-plus spacing/color override

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live all-camera Mapbox Outdoors comparison: `debug/mapbox-outdoors-comparison-road-label-mid-grey-all/all-cameras/20260520T113756Z/summary.md`

## Visual notes

- The z14 Geneva airport/motorway camera improved from the latest main checkpoint's mean/RMS deltas of 0.0643/0.1200 to 0.0613/0.1077.
- The z14 Chamonix trails camera improved from 0.0368/0.0844 to 0.0353/0.0765.
- z5, z8, z10, z17, and z18 stayed effectively unchanged because the slice only affects the z12-to-z15 road-label split.

Refs #949
