### PR TITLE
[codex] Add high-zoom path casing underlay

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -775,6 +775,18 @@ _PATH_BACKGROUND_LINE_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
         "hsl(60, 1%, 64%)",
     ),
 )
+_PATH_HIGH_ZOOM_PALE_CASING_LAYER_IDS = {
+    "bridge-path-bg-z16-plus-outdoor",
+    "bridge-path-bg-z16-plus-remaining",
+    "bridge-pedestrian-case-z16-plus",
+    "road-path-bg-z16-plus-outdoor",
+    "road-path-bg-z16-plus-remaining",
+    "road-pedestrian-case-z16-plus",
+}
+_PATH_HIGH_ZOOM_PALE_CASING_SUFFIX = "pale-casing"
+_PATH_HIGH_ZOOM_PALE_CASING_COLOR = "hsl(0, 0%, 98%)"
+_PATH_HIGH_ZOOM_PALE_CASING_WIDTH_MM = 3.0
+_PATH_HIGH_ZOOM_PALE_CASING_OPACITY = 1.0
 _PATH_TYPE_FILTER_LOW_ZOOM_TYPES = ["steps", "sidewalk", "crossing"]
 _PATH_TYPE_FILTER_LOW_ZOOM_INVERTED_MATCH = [
     "!",
@@ -2152,6 +2164,36 @@ def _split_path_background_line_color_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _path_high_zoom_pale_casing_layer_variant(layer: dict[str, object]) -> dict[str, object] | None:
+    """Add a pale underlay behind selected high-zoom path and pedestrian casings."""
+    layer_id = str(layer.get("id") or "")
+    if layer_id not in _PATH_HIGH_ZOOM_PALE_CASING_LAYER_IDS or layer.get("type") != "line":
+        return None
+    variant = copy.deepcopy(layer)
+    variant["id"] = f"{layer_id}-{_PATH_HIGH_ZOOM_PALE_CASING_SUFFIX}"
+    variant["paint"] = {
+        "line-width": _PATH_HIGH_ZOOM_PALE_CASING_WIDTH_MM,
+        "line-color": _PATH_HIGH_ZOOM_PALE_CASING_COLOR,
+        "line-opacity": _PATH_HIGH_ZOOM_PALE_CASING_OPACITY,
+    }
+    return variant
+
+
+def _add_path_high_zoom_pale_casing_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variant = _path_high_zoom_pale_casing_layer_variant(layer)
+        if variant is not None:
+            expanded_layers.append(variant)
+        expanded_layers.append(layer)
+    return expanded_layers
+
+
 def _numeric_match_filter_with_offset(value: object, offset: float) -> object | None:
     if not isinstance(value, list) or len(value) < 5 or value[0] != "match" or (len(value) - 3) % 2 != 0:
         return None
@@ -2477,6 +2519,20 @@ def _path_background_line_color_base_layer_id(layer_id: object) -> str | None:
     return None
 
 
+def _path_high_zoom_pale_casing_base_layer_id(layer_id: object) -> str | None:
+    normalized = str(layer_id or "")
+    casing_suffix = f"-{_PATH_HIGH_ZOOM_PALE_CASING_SUFFIX}"
+    if not normalized.endswith(casing_suffix):
+        return None
+    cased_layer_id = normalized[: -len(casing_suffix)]
+    if cased_layer_id not in _PATH_HIGH_ZOOM_PALE_CASING_LAYER_IDS:
+        return None
+    path_background_base_layer_id = _path_background_line_color_base_layer_id(cased_layer_id)
+    if path_background_base_layer_id is not None:
+        return path_background_base_layer_id
+    return _pedestrian_line_width_base_layer_id(cased_layer_id)
+
+
 def _line_width_zoom_band_base_layer_id(
     layer_id: object,
     *,
@@ -2597,6 +2653,7 @@ def base_mapbox_style_layer_id_for_qfit(layer_id: object) -> str:
         _landcover_fill_opacity_base_layer_id(layer_id),
         _landuse_fill_opacity_base_layer_id(layer_id),
         _path_background_line_color_base_layer_id(layer_id),
+        _path_high_zoom_pale_casing_base_layer_id(layer_id),
         _path_trail_line_width_base_layer_id(layer_id),
         _pedestrian_line_width_base_layer_id(layer_id),
         _road_steps_line_style_base_layer_id(layer_id),
@@ -6056,7 +6113,8 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     survive QGIS conversion, rewrites a few semantics-preserving filter shapes,
     snapshots selected zoom-dependent filters at a representative layer zoom that
     QGIS can parse, splits visible hillshade, landcover, landuse, waterway,
-    path background, and road class colors into static class layers, and collapses
+    path background, and road class colors into static class layers, adds
+    high-zoom pale path/pedestrian casings for Outdoors parity, and collapses
     Mapbox font stacks to a QGIS-safe local fallback to avoid
     warning spam from proprietary Mapbox font
     family names.
@@ -6078,6 +6136,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_path_background_line_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_path_trail_line_width_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_pedestrian_line_width_layers_for_qgis(style.get("layers"))
+    style["layers"] = _add_path_high_zoom_pale_casing_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_steps_line_style_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_poi_label_filter_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_label_icon_visibility_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5179,13 +5179,17 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-path-bg-below-z16-outdoor",
                 "road-path-bg-below-z16-remaining",
                 "road-path-bg-z16-plus-piste",
+                "road-path-bg-z16-plus-outdoor-pale-casing",
                 "road-path-bg-z16-plus-outdoor",
+                "road-path-bg-z16-plus-remaining-pale-casing",
                 "road-path-bg-z16-plus-remaining",
                 "bridge-path-bg-below-z16-piste",
                 "bridge-path-bg-below-z16-outdoor",
                 "bridge-path-bg-below-z16-remaining",
                 "bridge-path-bg-z16-plus-piste",
+                "bridge-path-bg-z16-plus-outdoor-pale-casing",
                 "bridge-path-bg-z16-plus-outdoor",
+                "bridge-path-bg-z16-plus-remaining-pale-casing",
                 "bridge-path-bg-z16-plus-remaining",
             ],
         )
@@ -5198,6 +5202,27 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             for suffix in ("piste", "outdoor", "remaining"):
                 self.assertEqual(by_id[f"{layer_id}-below-z16-{suffix}"]["maxzoom"], 16.0)
                 self.assertEqual(by_id[f"{layer_id}-z16-plus-{suffix}"]["minzoom"], 16.0)
+            for suffix in ("outdoor", "remaining"):
+                cased_layer = by_id[f"{layer_id}-z16-plus-{suffix}-pale-casing"]
+                target_layer = by_id[f"{layer_id}-z16-plus-{suffix}"]
+                self.assertEqual(cased_layer["filter"], target_layer["filter"])
+                self.assertEqual(cased_layer["minzoom"], 16.0)
+                self.assertNotIn("maxzoom", cased_layer)
+                self.assertEqual(
+                    cased_layer["paint"],
+                    {
+                        "line-width": 3.0,
+                        "line-color": "hsl(0, 0%, 98%)",
+                        "line-opacity": 1.0,
+                    },
+                )
+                self.assertEqual(
+                    mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                        f"{layer_id}-z16-plus-{suffix}-pale-casing"
+                    ),
+                    layer_id,
+                )
+            self.assertNotIn(f"{layer_id}-z16-plus-piste-pale-casing", by_id)
         self.assertEqual(by_id["road-path-bg-below-z16-piste"]["minzoom"], 12)
         self.assertEqual(by_id["bridge-path-bg-below-z16-piste"]["minzoom"], 14)
         expected_below_z16_outdoor_filter = [
@@ -5271,6 +5296,57 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "bridge-path-bg-below-z16-piste")
         self.assertEqual(result[3]["id"], "bridge-path-bg-below-z16-outdoor")
         self.assertEqual(result[4]["id"], "bridge-path-bg-below-z16-remaining")
+
+    def test_path_high_zoom_pale_casing_helper_inserts_only_selected_layers(self):
+        unchanged_layers = "not-a-layer-list"
+        selected_layer = {
+            "id": "road-pedestrian-case-z16-plus",
+            "type": "line",
+            "minzoom": 16,
+            "filter": ["==", ["get", "class"], "pedestrian"],
+            "paint": {"line-width": 2.4, "line-color": "hsl(60, 10%, 70%)"},
+        }
+        mixed_layers = [
+            "not-a-layer",
+            {"id": "road-path-bg-z16-plus-piste", "type": "line"},
+            selected_layer,
+        ]
+
+        self.assertIs(
+            mapbox_config._add_path_high_zoom_pale_casing_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._add_path_high_zoom_pale_casing_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "road-path-bg-z16-plus-piste")
+        self.assertEqual(result[2]["id"], "road-pedestrian-case-z16-plus-pale-casing")
+        self.assertEqual(result[2]["filter"], selected_layer["filter"])
+        self.assertEqual(
+            result[2]["paint"],
+            {
+                "line-width": 3.0,
+                "line-color": "hsl(0, 0%, 98%)",
+                "line-opacity": 1.0,
+            },
+        )
+        self.assertEqual(result[3]["id"], "road-pedestrian-case-z16-plus")
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-case-z16-plus-pale-casing"),
+            "road-pedestrian-case",
+        )
+        self.assertEqual(
+            mapbox_config._path_high_zoom_pale_casing_base_layer_id(
+                "road-path-bg-z16-plus-outdoor-pale-casing"
+            ),
+            "road-path-bg",
+        )
+        self.assertEqual(
+            mapbox_config._path_high_zoom_pale_casing_base_layer_id(
+                "road-pedestrian-case-z16-plus-pale-casing"
+            ),
+            "road-pedestrian-case",
+        )
 
     def test_path_line_width_uses_split_zoom_band_samples(self):
         path_filter = [
@@ -5691,6 +5767,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-pedestrian-below-z16",
                 "road-pedestrian-z16-plus",
                 "road-pedestrian-case-below-z16",
+                "road-pedestrian-case-z16-plus-pale-casing",
                 "road-pedestrian-case-z16-plus",
                 "bridge-pedestrian-below-z16",
                 "bridge-pedestrian-z16-plus",
@@ -5723,6 +5800,18 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             by_id["road-pedestrian-case-z16-plus"]["paint"]["line-width"],
             case_high_mm,
         )
+        self.assertEqual(
+            by_id["road-pedestrian-case-z16-plus-pale-casing"]["paint"],
+            {
+                "line-width": 3.0,
+                "line-color": "hsl(0, 0%, 98%)",
+                "line-opacity": 1.0,
+            },
+        )
+        self.assertEqual(
+            by_id["road-pedestrian-case-z16-plus-pale-casing"].get("filter"),
+            by_id["road-pedestrian-case-z16-plus"].get("filter"),
+        )
         self.assertGreater(case_high_mm, pedestrian_high_mm)
         self.assertEqual(by_id["road-pedestrian-below-z16"]["maxzoom"], 16.0)
         self.assertEqual(by_id["road-pedestrian-z16-plus"]["minzoom"], 16.0)
@@ -5733,6 +5822,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-case-z16-plus"),
+            "road-pedestrian-case",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                "road-pedestrian-case-z16-plus-pale-casing"
+            ),
             "road-pedestrian-case",
         )
         self.assertAlmostEqual(


### PR DESCRIPTION
## Summary

- add a pale QGIS-only underlay behind selected high-zoom path/pedestrian casing layers
- keep piste casing unchanged and preserve the existing path/pedestrian foreground styling
- map the generated pale-casing variants back to their original Mapbox layer ids in the audit helpers

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- Clean committed-state full suite: `PYTHONPATH=<clean-worktree-parent> python3 -m pytest tests/ -x -q --tb=short`
- Live all-camera Mapbox Outdoors comparison: `debug/mapbox-outdoors-comparison-high-zoom-path-casing-all/all-cameras/20260520T115724Z/summary.md`

## Visual notes

- `zermatt-trails-z18-outdoors` improved from the latest #1207 baseline mean/RMS deltas of 0.0311/0.0905 to 0.0308/0.0901.
- On the pixels changed by this slice in `zermatt-trails-z18-outdoors`, mean delta improved from 0.18174250 to 0.16933688.
- z5, z8, z14, and z17 cameras stayed unchanged in QGIS output; z10 retained the existing tiny road-label-only delta from the previous slice.

Refs #949
