### PR TITLE
[codex] Summarize QGIS converter probe outcomes

### DIFF
--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -3108,6 +3108,37 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("After qfit preprocessing with sprite context: 0", qgis_section)
         self.assertIn("Sprite context warning count delta from qfit preprocessing: 9", qgis_section)
 
+    def test_audit_markdown_summarizes_probe_outcomes_near_unresolved_counts(self):
+        markdown = build_audit_markdown(
+            {
+                "style": {"label": "mapbox/outdoors-v12"},
+                "generated_at": "2026-05-18T06:05:00Z",
+                "layer_count": 0,
+                "layers": [],
+                "summary": {},
+                "qgis_converter_warnings": {
+                    "filter_expression_parse_support_probe": {
+                        "filter_expression_count": 12,
+                        "qgis_parser_supported_count": 11,
+                        "qgis_parser_unsupported_count": 1,
+                    },
+                    "with_sprite_context_probe": {
+                        "sprite_definition_count": 440,
+                        "sprite_image_loaded": True,
+                        "summary": {"count": 0},
+                    },
+                },
+            }
+        )
+        summary_section = markdown.split("### Label density candidates", 1)[0]
+
+        self.assertIn("### QGIS converter probe outcomes", summary_section)
+        self.assertIn("| `Filter parser support` | 11/12 accepted; 1 rejected |", summary_section)
+        self.assertIn(
+            "| `Runtime sprite context` | 0 warnings; 440 definitions; image loaded: yes |",
+            summary_section,
+        )
+
     def test_qgis_converter_warning_report_reuses_existing_qgis_app(self):
         existing_app = object()
         fake_qgis, fake_core, fake_app, _fake_converter = _fake_qgis_modules(

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -5921,6 +5921,7 @@ def _markdown_summary(summary: dict[str, object], qgis_converter_warnings: objec
         *_markdown_filter_signature_group_table(
             _summary_rows(summary, "qfit_unresolved_filter_expression_signatures_by_layer_group")
         ),
+        *_markdown_qgis_converter_probe_outcomes(qgis_converter_warnings),
         *_markdown_label_density_summary(summary),
         *_markdown_line_label_repetition_summary(summary),
         *_markdown_road_trail_hierarchy_summary(summary),
@@ -5933,6 +5934,46 @@ def _markdown_summary(summary: dict[str, object], qgis_converter_warnings: objec
         *_markdown_airport_special_landuse_summary(summary),
         *_markdown_qgis_converter_warnings(qgis_converter_warnings),
     ]
+
+
+def _markdown_qgis_converter_probe_outcomes(report: object) -> list[str]:
+    if not isinstance(report, dict):
+        return []
+
+    rows: list[tuple[str, str]] = []
+    filter_probe = report.get(_FILTER_PARSE_SUPPORT_PROBE_KEY)
+    if isinstance(filter_probe, dict):
+        tested = filter_probe.get("filter_expression_count", 0)
+        accepted = filter_probe.get("qgis_parser_supported_count", 0)
+        rejected = filter_probe.get("qgis_parser_unsupported_count", 0)
+        rows.append(("Filter parser support", f"{accepted}/{tested} accepted; {rejected} rejected"))
+
+    sprite_probe = report.get(_SPRITE_CONTEXT_PROBE_KEY)
+    if isinstance(sprite_probe, dict):
+        raw_summary = sprite_probe.get("summary")
+        summary = raw_summary if isinstance(raw_summary, dict) else {}
+        rows.append(
+            (
+                "Runtime sprite context",
+                (
+                    f"{summary.get('count', 0)} warnings; "
+                    f"{sprite_probe.get(_SPRITE_CONTEXT_DEFINITION_COUNT_KEY, 0)} definitions; "
+                    f"image loaded: {_markdown_yes_no(sprite_probe.get(_SPRITE_CONTEXT_IMAGE_LOADED_KEY))}"
+                ),
+            )
+        )
+
+    if not rows:
+        return []
+    lines = [
+        "### QGIS converter probe outcomes",
+        "",
+        "| Probe | Outcome |",
+        "| --- | --- |",
+    ]
+    lines.extend(f"| `{name}` | {outcome} |" for name, outcome in rows)
+    return [*lines, ""]
+
 
 def _markdown_source_filter(layer_obj: dict[str, object]) -> str:
     source_parts = [part for part in (layer_obj.get("source"), layer_obj.get("source_layer")) if part]


### PR DESCRIPTION
## Summary

- add a compact audit summary block for QGIS converter probe outcomes
- surface filter parser support and runtime sprite context status near the unresolved filter signature counts
- cover the new markdown section with a regression test

## Evidence

- Fresh live audit with local Mapbox credentials: debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260520T121416Z/audit.md
- The new section reports `501/501 accepted; 0 rejected` for filter parser support and `0 warnings; 440 definitions; image loaded: yes` for runtime sprite context

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short` (2288 passed, 180 skipped, 167 subtests)

Refs #949
