### PR TITLE
Add road label shield focus summary

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -1226,8 +1226,13 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             markdown,
         )
         self.assertIn(f'["{path_signature}=1"] | ["{step_signature}=1"] |', markdown)
+        self.assertIn("## Road label/shield focus", markdown)
+        self.assertIn(
+            '| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 2 | ["primary=1"] | ["2=1"] | ["2=1"] | ["street=2"] | ["Bachstrasse=2"] |',
+            markdown,
+        )
 
-    def test_build_all_camera_summary_markdown_omits_path_pedestrian_focus_for_zero_counts(self):
+    def test_build_all_camera_summary_markdown_omits_focus_sections_for_zero_counts(self):
         report = {
             "generated": "2026-05-18T15:40:00+00:00",
             "style_owner": "mapbox",
@@ -1248,6 +1253,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "level_crossing_candidate_count": 0,
             "road_number_shield_candidate_count": 0,
             "road_exit_shield_candidate_count": 0,
+            "road_label_candidate_count": 0,
             "cameras": [
                 {
                     "status": "decoded",
@@ -1268,6 +1274,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "level_crossing_candidate_count": 0,
                     "road_number_shield_candidate_count": 0,
                     "road_exit_shield_candidate_count": 0,
+                    "road_label_candidate_count": 0,
                 }
             ],
         }
@@ -1275,6 +1282,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         markdown = build_all_camera_summary_markdown(report)
 
         self.assertNotIn("## Path/pedestrian focus", markdown)
+        self.assertNotIn("## Road label/shield focus", markdown)
 
     def test_write_report_writes_json_and_markdown(self):
         report = {

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -103,7 +103,7 @@ LEVEL_CROSSING_SIGNATURE_KEYS = ("class", "structure", "layer")
 ROAD_NUMBER_SHIELD_SIGNATURE_KEYS = ("class", "reflen", "shield", "shield_beta", "structure", "layer")
 ROAD_EXIT_SHIELD_SIGNATURE_KEYS = ("ref", "reflen")
 ROAD_LABEL_SIGNATURE_KEYS = ("class", "type", "structure", "layer")
-PATH_PEDESTRIAN_FOCUS_TOP_COUNT_LIMIT = 3
+FOCUS_TOP_COUNT_LIMIT = 3
 
 
 @dataclass(frozen=True)
@@ -723,7 +723,7 @@ def _markdown_table_row(cells: Iterable[object]) -> str:
     return "| " + " | ".join(_markdown_value(cell) for cell in cells) + " |"
 
 
-def _top_count_labels(value: object, *, limit: int = PATH_PEDESTRIAN_FOCUS_TOP_COUNT_LIMIT) -> list[str]:
+def _top_count_labels(value: object, *, limit: int = FOCUS_TOP_COUNT_LIMIT) -> list[str]:
     if not isinstance(value, dict):
         return []
     counts = [(str(label), count) for label, count in value.items() if isinstance(count, int)]
@@ -739,6 +739,17 @@ def _has_path_pedestrian_focus(record: dict[str, object]) -> bool:
             "pedestrian_line_candidate_count",
             "path_line_candidate_count",
             "step_line_candidate_count",
+        )
+    )
+
+
+def _has_road_label_shield_focus(record: dict[str, object]) -> bool:
+    return any(
+        isinstance(record.get(key), int) and record.get(key) > 0
+        for key in (
+            "road_number_shield_candidate_count",
+            "road_exit_shield_candidate_count",
+            "road_label_candidate_count",
         )
     )
 
@@ -1152,6 +1163,39 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                         _top_count_labels(camera_report.get("step_line_duplicate_name_counts")),
                         _top_count_labels(camera_report.get("path_line_signature_counts")),
                         _top_count_labels(camera_report.get("step_line_signature_counts")),
+                    ]
+                )
+            )
+    road_focus_rows = [
+        row
+        for row in rows
+        if isinstance(row, dict) and row.get("status") == "decoded" and _has_road_label_shield_focus(row)
+    ]
+    if road_focus_rows:
+        lines.extend(
+            [
+                "",
+                "## Road label/shield focus",
+                "",
+                "| Camera | Camera zoom | Tile zoom | Road number shields | Road exit shields | Road labels | Shield classes | Shield reflens | Exit shield reflens | Road label classes | Duplicate road labels |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for camera_report in road_focus_rows:
+            lines.append(
+                _markdown_table_row(
+                    [
+                        camera_report.get("camera"),
+                        camera_report.get("camera_zoom"),
+                        camera_report.get("tile_zoom"),
+                        camera_report.get("road_number_shield_candidate_count"),
+                        camera_report.get("road_exit_shield_candidate_count"),
+                        camera_report.get("road_label_candidate_count"),
+                        _top_count_labels(camera_report.get("road_number_shield_class_counts")),
+                        _top_count_labels(camera_report.get("road_number_shield_reflen_counts")),
+                        _top_count_labels(camera_report.get("road_exit_shield_reflen_counts")),
+                        _top_count_labels(camera_report.get("road_label_class_counts")),
+                        _top_count_labels(camera_report.get("road_label_duplicate_name_counts")),
                     ]
                 )
             )


### PR DESCRIPTION
## Summary
- Adds an all-camera road label/shield focus table to the Mapbox Outdoors road feature diagnostic summary.
- Highlights per-camera road number shields, exit shields, road label counts, top shield classes/reflens, top road label classes, and duplicate road labels.
- Keeps the slice limited to validation reporting for issue #949's current road-label/shield investigation bucket.

## Validation
- python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- MAPBOX_ACCESS_TOKEN=... python3 validation/mapbox_outdoors_road_features.py --all-cameras --output-root debug/mapbox-outdoors-road-features-road-label-shield-focus

Generated diagnostic artifact: debug/mapbox-outdoors-road-features-road-label-shield-focus/all-cameras/20260520T123955Z/summary.md

Closes no issue; contributes to #949.
