### PR TITLE
Add road shield sprite reference focus

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -60,6 +60,24 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
 
         self.assertEqual(labels, ["path=4", "footway=3", "trail=2"])
 
+    def test_road_number_shield_sprite_references_prefer_beta_then_shield(self):
+        counts = road_features._count_road_number_shield_sprite_references(
+            [
+                _feature("LineString", {"shield_beta": "it-motorway", "shield": "default", "reflen": 2}),
+                _feature("LineString", {"shield": "rectangle-red", "reflen": "4"}),
+                _feature("LineString", {"shield": "  ", "reflen": 3}),
+                _feature("LineString", {"shield": "rectangle-yellow"}),
+            ]
+        )
+
+        self.assertEqual(
+            counts,
+            {
+                "shield:rectangle-red-4": 1,
+                "shield_beta:it-motorway-2": 1,
+            },
+        )
+
     def test_resolve_mapbox_token_prefers_argument_then_environment(self):
         self.assertEqual(
             resolve_mapbox_token(
@@ -372,6 +390,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
         self.assertEqual(record["road_number_shield_class_counts"], {"primary": 1})
         self.assertEqual(record["road_number_shield_reflen_counts"], {"2": 1})
+        self.assertEqual(record["road_number_shield_sprite_reference_counts"], {"shield:ch-primary-2": 1})
         self.assertEqual(record["road_number_shield_structure_counts"], {"none": 1})
         self.assertEqual(record["road_number_shield_layer_counts"], {"0": 1})
         self.assertEqual(
@@ -628,6 +647,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["level_crossing_signature_counts"], {})
         self.assertEqual(report["road_number_shield_class_counts"], {})
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
+        self.assertEqual(report["road_number_shield_sprite_reference_counts"], {})
         self.assertEqual(report["road_number_shield_structure_counts"], {})
         self.assertEqual(report["road_number_shield_layer_counts"], {})
         self.assertEqual(report["road_exit_shield_reflen_counts"], {})
@@ -831,6 +851,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["level_crossing_signature_counts"], {})
         self.assertEqual(report["road_number_shield_class_counts"], {})
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
+        self.assertEqual(report["road_number_shield_sprite_reference_counts"], {})
         self.assertEqual(report["road_number_shield_structure_counts"], {})
         self.assertEqual(report["road_number_shield_layer_counts"], {})
         self.assertEqual(report["road_exit_shield_reflen_counts"], {})
@@ -928,6 +949,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "level_crossing_signature_counts": {level_crossing_signature: 1},
             "road_number_shield_class_counts": {"primary": 1},
             "road_number_shield_reflen_counts": {"2": 1},
+            "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
             "road_number_shield_structure_counts": {"none": 1},
             "road_number_shield_layer_counts": {"0": 1},
             "road_number_shield_signature_counts": {shield_signature: 1},
@@ -995,6 +1017,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "level_crossing_signature_counts": {level_crossing_signature: 1},
                     "road_number_shield_class_counts": {"primary": 1},
                     "road_number_shield_reflen_counts": {"2": 1},
+                    "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
                     "road_number_shield_structure_counts": {"none": 1},
                     "road_number_shield_layer_counts": {"0": 1},
                     "road_number_shield_signature_counts": {shield_signature: 1},
@@ -1049,6 +1072,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn(f'Level crossing signatures: {{"{level_crossing_signature}":1}}', markdown)
         self.assertIn('Road number shield class counts: {"primary":1}', markdown)
         self.assertIn('Road number shield reflen counts: {"2":1}', markdown)
+        self.assertIn('Road number shield sprite references: {"shield:ch-primary-2":1}', markdown)
         self.assertIn('Road number shield structure counts: {"none":1}', markdown)
         self.assertIn('Road number shield layer counts: {"0":1}', markdown)
         self.assertIn(f'Road number shield signatures: {{"{shield_signature}":1}}', markdown)
@@ -1129,6 +1153,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "level_crossing_signature_counts": {level_crossing_signature: 1},
             "road_number_shield_class_counts": {"primary": 1},
             "road_number_shield_reflen_counts": {"2": 1},
+            "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
             "road_number_shield_structure_counts": {"none": 1},
             "road_number_shield_layer_counts": {"0": 1},
             "road_number_shield_signature_counts": {shield_signature: 1},
@@ -1191,6 +1216,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "level_crossing_signature_counts": {level_crossing_signature: 1},
                     "road_number_shield_class_counts": {"primary": 1},
                     "road_number_shield_reflen_counts": {"2": 1},
+                    "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
                     "road_number_shield_structure_counts": {"none": 1},
                     "road_number_shield_layer_counts": {"0": 1},
                     "road_number_shield_signature_counts": {shield_signature: 1},
@@ -1228,7 +1254,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn(f'["{path_signature}=1"] | ["{step_signature}=1"] |', markdown)
         self.assertIn("## Road label/shield focus", markdown)
         self.assertIn(
-            f'| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 2 | ["primary=1"] | ["2=1"] | ["{shield_signature}=1"] | ["2=1"] | ["street=2"] | ["Bachstrasse=2"] |',
+            f'| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 2 | ["primary=1"] | ["2=1"] | ["shield:ch-primary-2=1"] | ["{shield_signature}=1"] | ["2=1"] | ["street=2"] | ["Bachstrasse=2"] |',
             markdown,
         )
 

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -330,6 +330,28 @@ def _count_non_empty_string_property(features: Iterable[dict[str, object]], key:
     return dict(sorted(counts.items()))
 
 
+def _road_number_shield_sprite_reference(feature: dict[str, object]) -> str | None:
+    properties = _feature_properties(feature)
+    reflen = _property_count_label(properties.get("reflen", MISSING_VALUE)).strip()
+    if not reflen or reflen == MISSING_VALUE:
+        return None
+    for field_name in ("shield_beta", "shield"):
+        value = properties.get(field_name)
+        if isinstance(value, str) and value.strip():
+            return f"{field_name}:{value.strip()}-{reflen}"
+    return None
+
+
+def _count_road_number_shield_sprite_references(features: Iterable[dict[str, object]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for feature in features:
+        reference = _road_number_shield_sprite_reference(feature)
+        if reference is None:
+            continue
+        counts[reference] = counts.get(reference, 0) + 1
+    return dict(sorted(counts.items()))
+
+
 def _duplicate_count_map(counts: object) -> dict[str, int]:
     if not isinstance(counts, dict):
         return {}
@@ -481,6 +503,9 @@ def road_tile_record(
         ),
         "road_number_shield_class_counts": _count_by_property(road_number_shields, "class"),
         "road_number_shield_reflen_counts": _count_by_property(road_number_shields, "reflen"),
+        "road_number_shield_sprite_reference_counts": _count_road_number_shield_sprite_references(
+            road_number_shields
+        ),
         "road_number_shield_structure_counts": _count_by_property(road_number_shields, "structure"),
         "road_number_shield_layer_counts": _count_by_property(road_number_shields, "layer"),
         "road_number_shield_signature_counts": _count_property_signatures(
@@ -583,6 +608,7 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("Level crossing signatures", "level_crossing_signature_counts"),
     ("Road number shield class counts", "road_number_shield_class_counts"),
     ("Road number shield reflen counts", "road_number_shield_reflen_counts"),
+    ("Road number shield sprite references", "road_number_shield_sprite_reference_counts"),
     ("Road number shield structure counts", "road_number_shield_structure_counts"),
     ("Road number shield layer counts", "road_number_shield_layer_counts"),
     ("Road number shield signatures", "road_number_shield_signature_counts"),
@@ -637,6 +663,7 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Level crossing signatures", "level_crossing_signature_counts", "---"),
     ("Shield classes", "road_number_shield_class_counts", "---"),
     ("Shield reflens", "road_number_shield_reflen_counts", "---"),
+    ("Shield sprite refs", "road_number_shield_sprite_reference_counts", "---"),
     ("Shield structures", "road_number_shield_structure_counts", "---"),
     ("Shield layers", "road_number_shield_layer_counts", "---"),
     ("Shield signatures", "road_number_shield_signature_counts", "---"),
@@ -1029,6 +1056,10 @@ def collect_all_camera_road_feature_report(
             camera_reports,
             "road_number_shield_reflen_counts",
         ),
+        "road_number_shield_sprite_reference_counts": _combined_record_counts(
+            camera_reports,
+            "road_number_shield_sprite_reference_counts",
+        ),
         "road_number_shield_structure_counts": _combined_record_counts(
             camera_reports,
             "road_number_shield_structure_counts",
@@ -1177,8 +1208,8 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                 "",
                 "## Road label/shield focus",
                 "",
-                "| Camera | Camera zoom | Tile zoom | Road number shields | Road exit shields | Road labels | Shield classes | Shield reflens | Shield signatures | Exit shield reflens | Road label classes | Duplicate road labels |",
-                "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- |",
+                "| Camera | Camera zoom | Tile zoom | Road number shields | Road exit shields | Road labels | Shield classes | Shield reflens | Shield sprite refs | Shield signatures | Exit shield reflens | Road label classes | Duplicate road labels |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
         for camera_report in road_focus_rows:
@@ -1193,6 +1224,7 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                         camera_report.get("road_label_candidate_count"),
                         _top_count_labels(camera_report.get("road_number_shield_class_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_reflen_counts")),
+                        _top_count_labels(camera_report.get("road_number_shield_sprite_reference_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_signature_counts")),
                         _top_count_labels(camera_report.get("road_exit_shield_reflen_counts")),
                         _top_count_labels(camera_report.get("road_label_class_counts")),


### PR DESCRIPTION
## Summary
- add observed road-number shield sprite reference counts to the road feature diagnostic
- include the top shield sprite refs in the all-camera Road label/shield focus table
- cover beta-vs-shield preference and summary output with tests

## Evidence
- fresh live all-camera road-feature diagnostic: debug/mapbox-outdoors-road-features-shield-sprite-reference-focus/all-cameras/20260520T130642Z/summary.md
- the artifact surfaces high-demand references such as shield:rectangle-red-4, shield:ch-motorway-2, and shield_beta:it-motorway-2 by camera

## Validation
- python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Issue: #949