### PR TITLE
Compare observed road shield sprite refs

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -78,6 +78,68 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             },
         )
 
+    def test_road_number_shield_sprite_reference_coverage_flags_unconfigured_observed_refs(self):
+        configured_count = len(road_features._configured_road_number_shield_sprite_names())
+
+        coverage = road_features._road_number_shield_sprite_reference_coverage(
+            {
+                "shield:ch-motorway-2": 3,
+                "shield:rectangle-red-4": 1,
+                "shield_beta:zz-main-2": 1,
+                "invalid-reference": 2,
+                "shield:rectangle-yellow-3": True,
+            }
+        )
+
+        self.assertEqual(
+            coverage,
+            {
+                "configured_road_number_shield_sprite_count": configured_count,
+                "observed_road_number_shield_sprite_reference_count": 3,
+                "observed_road_number_shield_sprite_reference_count_covered_by_qfit_config": 2,
+                "observed_road_number_shield_sprite_references_missing_from_qfit_config": [
+                    "shield_beta:zz-main-2"
+                ],
+            },
+        )
+
+    def test_road_number_shield_sprite_reference_coverage_handles_empty_inputs(self):
+        coverage = road_features._road_number_shield_sprite_reference_coverage(None)
+
+        self.assertEqual(coverage["observed_road_number_shield_sprite_reference_count"], 0)
+        self.assertEqual(
+            coverage["observed_road_number_shield_sprite_references_missing_from_qfit_config"],
+            [],
+        )
+        self.assertIsNone(road_features._road_number_shield_sprite_name_from_reference(2))
+        self.assertEqual(road_features._markdown_road_shield_sprite_reference_coverage({}), [])
+        self.assertEqual(
+            road_features._markdown_road_shield_sprite_reference_coverage(
+                {"road_number_shield_sprite_reference_coverage": coverage}
+            ),
+            [],
+        )
+
+    def test_road_number_shield_sprite_reference_coverage_markdown_lists_missing_refs(self):
+        lines = road_features._markdown_road_shield_sprite_reference_coverage(
+            {
+                "road_number_shield_sprite_reference_coverage": {
+                    "configured_road_number_shield_sprite_count": len(
+                        road_features._configured_road_number_shield_sprite_names()
+                    ),
+                    "observed_road_number_shield_sprite_reference_count": 1,
+                    "observed_road_number_shield_sprite_reference_count_covered_by_qfit_config": 0,
+                    "observed_road_number_shield_sprite_references_missing_from_qfit_config": [
+                        "shield_beta:zz-main-2"
+                    ],
+                }
+            }
+        )
+
+        markdown = "\n".join(lines)
+        self.assertIn("### Observed road-number shield sprite refs missing from qfit config", markdown)
+        self.assertIn("| shield_beta:zz-main-2 |", markdown)
+
     def test_resolve_mapbox_token_prefers_argument_then_environment(self):
         self.assertEqual(
             resolve_mapbox_token(
@@ -648,6 +710,17 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["road_number_shield_class_counts"], {})
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
         self.assertEqual(report["road_number_shield_sprite_reference_counts"], {})
+        self.assertEqual(
+            report["road_number_shield_sprite_reference_coverage"],
+            {
+                "configured_road_number_shield_sprite_count": len(
+                    road_features._configured_road_number_shield_sprite_names()
+                ),
+                "observed_road_number_shield_sprite_reference_count": 0,
+                "observed_road_number_shield_sprite_reference_count_covered_by_qfit_config": 0,
+                "observed_road_number_shield_sprite_references_missing_from_qfit_config": [],
+            },
+        )
         self.assertEqual(report["road_number_shield_structure_counts"], {})
         self.assertEqual(report["road_number_shield_layer_counts"], {})
         self.assertEqual(report["road_exit_shield_reflen_counts"], {})
@@ -950,6 +1023,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "road_number_shield_class_counts": {"primary": 1},
             "road_number_shield_reflen_counts": {"2": 1},
             "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
+            "road_number_shield_sprite_reference_coverage": {
+                "configured_road_number_shield_sprite_count": len(
+                    road_features._configured_road_number_shield_sprite_names()
+                ),
+                "observed_road_number_shield_sprite_reference_count": 1,
+                "observed_road_number_shield_sprite_reference_count_covered_by_qfit_config": 1,
+                "observed_road_number_shield_sprite_references_missing_from_qfit_config": [],
+            },
             "road_number_shield_structure_counts": {"none": 1},
             "road_number_shield_layer_counts": {"0": 1},
             "road_number_shield_signature_counts": {shield_signature: 1},
@@ -1154,6 +1235,14 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "road_number_shield_class_counts": {"primary": 1},
             "road_number_shield_reflen_counts": {"2": 1},
             "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
+            "road_number_shield_sprite_reference_coverage": {
+                "configured_road_number_shield_sprite_count": len(
+                    road_features._configured_road_number_shield_sprite_names()
+                ),
+                "observed_road_number_shield_sprite_reference_count": 1,
+                "observed_road_number_shield_sprite_reference_count_covered_by_qfit_config": 1,
+                "observed_road_number_shield_sprite_references_missing_from_qfit_config": [],
+            },
             "road_number_shield_structure_counts": {"none": 1},
             "road_number_shield_layer_counts": {"0": 1},
             "road_number_shield_signature_counts": {shield_signature: 1},
@@ -1246,6 +1335,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn('Step line duplicate names: {"Kirchsteig":2}', markdown)
         self.assertIn('Road label duplicate names: {"Bachstrasse":2}', markdown)
         self.assertIn(f'Road label signatures: {{"{road_label_signature}":2}}', markdown)
+        self.assertIn("## Road shield sprite reference coverage", markdown)
+        self.assertIn("- Observed road-number shield sprite refs: 1", markdown)
+        self.assertIn("Observed road-number shield sprite refs missing from qfit config: none", markdown)
         self.assertIn("## Path/pedestrian focus", markdown)
         self.assertIn(
             '| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 1 | 1 | ["pedestrian=1"] | ["footway=1"] | ["bridge=1"] | ["Promenade=2"] | ["Trail=2"] | ["Kirchsteig=2"] |',

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -352,6 +352,49 @@ def _count_road_number_shield_sprite_references(features: Iterable[dict[str, obj
     return dict(sorted(counts.items()))
 
 
+def _configured_road_number_shield_sprite_names() -> set[str]:
+    return {
+        f"{base}-{reflen}"
+        for reflen, bases in mapbox_config._ROAD_SHIELD_SPRITE_BASES_BY_REFLEN.items()
+        for base in bases
+    }
+
+
+def _road_number_shield_sprite_name_from_reference(reference: object) -> str | None:
+    if not isinstance(reference, str):
+        return None
+    _field_name, separator, sprite_name = reference.partition(":")
+    normalized = sprite_name.strip()
+    if not separator or not normalized:
+        return None
+    return normalized
+
+
+def _road_number_shield_sprite_reference_coverage(reference_counts: object) -> dict[str, object]:
+    configured = _configured_road_number_shield_sprite_names()
+    observed_references = [
+        str(reference)
+        for reference, count in (reference_counts.items() if isinstance(reference_counts, dict) else ())
+        if isinstance(count, int)
+        and not isinstance(count, bool)
+        and count > 0
+        and _road_number_shield_sprite_name_from_reference(reference) is not None
+    ]
+    missing = [
+        reference
+        for reference in observed_references
+        if _road_number_shield_sprite_name_from_reference(reference) not in configured
+    ]
+    return {
+        "configured_road_number_shield_sprite_count": len(configured),
+        "observed_road_number_shield_sprite_reference_count": len(observed_references),
+        "observed_road_number_shield_sprite_reference_count_covered_by_qfit_config": (
+            len(observed_references) - len(missing)
+        ),
+        "observed_road_number_shield_sprite_references_missing_from_qfit_config": sorted(missing),
+    }
+
+
 def _duplicate_count_map(counts: object) -> dict[str, int]:
     if not isinstance(counts, dict):
         return {}
@@ -758,6 +801,39 @@ def _top_count_labels(value: object, *, limit: int = FOCUS_TOP_COUNT_LIMIT) -> l
     return [f"{label}={count}" for label, count in counts[:limit]]
 
 
+def _markdown_road_shield_sprite_reference_coverage(report: dict[str, object]) -> list[str]:
+    coverage = report.get("road_number_shield_sprite_reference_coverage")
+    if not isinstance(coverage, dict):
+        return []
+    observed_count = coverage.get("observed_road_number_shield_sprite_reference_count")
+    if not isinstance(observed_count, int) or observed_count <= 0:
+        return []
+    missing = list(coverage.get("observed_road_number_shield_sprite_references_missing_from_qfit_config") or [])
+    lines = [
+        "",
+        "## Road shield sprite reference coverage",
+        "",
+        f"- qfit configured road-number shield sprites: {coverage.get('configured_road_number_shield_sprite_count')}",
+        f"- Observed road-number shield sprite refs: {observed_count}",
+        (
+            "- Observed refs covered by qfit config: "
+            f"{coverage.get('observed_road_number_shield_sprite_reference_count_covered_by_qfit_config')}"
+        ),
+        "",
+    ]
+    if not missing:
+        return [*lines, "Observed road-number shield sprite refs missing from qfit config: none", ""]
+    return [
+        *lines,
+        "### Observed road-number shield sprite refs missing from qfit config",
+        "",
+        "| Reference |",
+        "| --- |",
+        *(f"| {_markdown_value(reference)} |" for reference in missing),
+        "",
+    ]
+
+
 def _has_path_pedestrian_focus(record: dict[str, object]) -> bool:
     return any(
         isinstance(record.get(key), int) and record.get(key) > 0
@@ -888,6 +964,7 @@ def collect_road_feature_report(
     ]
     decoded_tile_count = sum(1 for tile in tile_records if tile.get("status") == "decoded")
     generated = config.now or dt.datetime.now(dt.timezone.utc)
+    count_map_fields = _count_map_report_fields(tile_records)
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
@@ -909,7 +986,10 @@ def collect_road_feature_report(
         **_candidate_count_report_fields(tile_records),
         "road_geometry_type_counts": _combined_record_counts(tile_records, "road_geometry_type_counts"),
         "pedestrian_polygon_class_counts": _combined_record_counts(tile_records, "pedestrian_polygon_class_counts"),
-        **_count_map_report_fields(tile_records),
+        **count_map_fields,
+        "road_number_shield_sprite_reference_coverage": _road_number_shield_sprite_reference_coverage(
+            count_map_fields.get("road_number_shield_sprite_reference_counts")
+        ),
         **_sample_report_fields(tile_records),
         "tiles": tile_records,
     }
@@ -952,6 +1032,10 @@ def collect_all_camera_road_feature_report(
         camera_reports.append(_all_camera_row(report))
     status_counts = _all_camera_status_counts(camera_reports)
     name_count_fields = _combined_name_count_fields(camera_reports)
+    road_number_shield_sprite_reference_counts = _combined_record_counts(
+        camera_reports,
+        "road_number_shield_sprite_reference_counts",
+    )
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
@@ -1056,9 +1140,9 @@ def collect_all_camera_road_feature_report(
             camera_reports,
             "road_number_shield_reflen_counts",
         ),
-        "road_number_shield_sprite_reference_counts": _combined_record_counts(
-            camera_reports,
-            "road_number_shield_sprite_reference_counts",
+        "road_number_shield_sprite_reference_counts": road_number_shield_sprite_reference_counts,
+        "road_number_shield_sprite_reference_coverage": _road_number_shield_sprite_reference_coverage(
+            road_number_shield_sprite_reference_counts
         ),
         "road_number_shield_structure_counts": _combined_record_counts(
             camera_reports,
@@ -1097,6 +1181,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Tile zoom: {report.get('tile_zoom')}",
         f"Tiles: {report.get('decoded_tile_count')}/{report.get('tile_count')} decoded",
         *_feature_summary_lines(report),
+        *_markdown_road_shield_sprite_reference_coverage(report),
         "",
         *_markdown_table_header((("z", "---:"), ("x", "---:"), ("y", "---:"), ("Status", "---"))),
     ]
@@ -1128,6 +1213,7 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
         f"Camera statuses: {_markdown_value(_all_camera_status_counts(rows))}",
         f"Tiles: {report.get('decoded_tile_count')}/{report.get('tile_count')} decoded",
         *_feature_summary_lines(report),
+        *_markdown_road_shield_sprite_reference_coverage(report),
         "",
         *_markdown_table_header(
             (


### PR DESCRIPTION
## Summary
- add road shield sprite-reference coverage to the road feature diagnostic
- compare observed road-number shield sprite refs against qfit configured shield sprite outputs
- include the coverage result in generated markdown and cover empty/missing branches with tests

## Evidence
- fresh live all-camera road-feature diagnostic: `debug/mapbox-outdoors-road-features-shield-sprite-coverage-focus/all-cameras/20260520T132106Z/summary.md`
- the artifact reports 20 observed road-number shield sprite refs, all 20 covered by qfit config, with no observed refs missing from qfit config

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Issue: #949
