### PR TITLE
Address road shield coverage review feedback

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -119,6 +119,16 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             ),
             [],
         )
+        self.assertEqual(
+            road_features._markdown_road_shield_sprite_reference_coverage(
+                {
+                    "road_number_shield_sprite_reference_coverage": {
+                        "observed_road_number_shield_sprite_reference_count": True
+                    }
+                }
+            ),
+            [],
+        )
 
     def test_road_number_shield_sprite_reference_coverage_markdown_lists_missing_refs(self):
         lines = road_features._markdown_road_shield_sprite_reference_coverage(
@@ -1337,7 +1347,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn(f'Road label signatures: {{"{road_label_signature}":2}}', markdown)
         self.assertIn("## Road shield sprite reference coverage", markdown)
         self.assertIn("- Observed road-number shield sprite refs: 1", markdown)
-        self.assertIn("Observed road-number shield sprite refs missing from qfit config: none", markdown)
+        self.assertIn("- Observed road-number shield sprite refs missing from qfit config: none", markdown)
         self.assertIn("## Path/pedestrian focus", markdown)
         self.assertIn(
             '| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 1 | 1 | ["pedestrian=1"] | ["footway=1"] | ["bridge=1"] | ["Promenade=2"] | ["Trail=2"] | ["Kirchsteig=2"] |',

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -806,7 +806,7 @@ def _markdown_road_shield_sprite_reference_coverage(report: dict[str, object]) -
     if not isinstance(coverage, dict):
         return []
     observed_count = coverage.get("observed_road_number_shield_sprite_reference_count")
-    if not isinstance(observed_count, int) or observed_count <= 0:
+    if not isinstance(observed_count, int) or isinstance(observed_count, bool) or observed_count <= 0:
         return []
     missing = list(coverage.get("observed_road_number_shield_sprite_references_missing_from_qfit_config") or [])
     lines = [
@@ -822,7 +822,7 @@ def _markdown_road_shield_sprite_reference_coverage(report: dict[str, object]) -
         "",
     ]
     if not missing:
-        return [*lines, "Observed road-number shield sprite refs missing from qfit config: none", ""]
+        return [*lines, "- Observed road-number shield sprite refs missing from qfit config: none", ""]
     return [
         *lines,
         "### Observed road-number shield sprite refs missing from qfit config",


### PR DESCRIPTION
## Summary
- address Greptile feedback from #1213 on the road shield sprite coverage markdown
- render the no-missing-refs line as a bullet for consistent formatting
- reject boolean observed counts in the coverage markdown guard and cover that path with tests

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Issue: #949
