### PR TITLE
Promote z11 road shield label priority

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -680,7 +680,7 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         self.assertEqual(updated_style.layerName(), "poi_label")
         self.assertEqual(updated_style.labelSettings().priority, 5)
 
-    def test_priority_promotes_swiss_motorway_shields_without_promoting_other_shields(self):
+    def test_priority_promotes_z11_plus_road_shields_without_promoting_below_z11(self):
         labeling = MagicMock()
         swiss_style, swiss_settings = self._make_style(
             "road",
@@ -697,13 +697,12 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
             "road-number-shield-2-beta-remaining-icons-z11-plus",
         )
         remaining_settings.mergeLines = False
-        remaining_priority = remaining_settings.priority
         labeling.styles.return_value = [swiss_style, other_style, remaining_style]
 
         self.service._apply_label_priority(labeling)
 
         self.assertEqual(swiss_settings.priority, 6)
-        self.assertEqual(remaining_settings.priority, remaining_priority)
+        self.assertEqual(remaining_settings.priority, 6)
         self.assertTrue(swiss_settings.mergeLines)
         self.assertFalse(other_settings.mergeLines)
         self.assertTrue(remaining_settings.mergeLines)
@@ -1035,7 +1034,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
                 self.assertEqual(settings.priority, expected_priority)
                 style.setLabelSettings.assert_called_once_with(settings)
 
-    def test_priority_promotes_swiss_motorway_shields_without_promoting_other_shields(self):
+    def test_priority_promotes_z11_plus_road_shields_without_promoting_below_z11(self):
         labeling = MagicMock()
         swiss_style, swiss_settings = self._make_style(
             "road",
@@ -1052,13 +1051,12 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
             "road-number-shield-2-beta-remaining-icons-z11-plus",
         )
         remaining_settings.mergeLines = False
-        remaining_priority = remaining_settings.priority
         labeling.styles.return_value = [swiss_style, other_style, remaining_style]
 
         self.service._apply_label_priority(labeling)
 
         self.assertEqual(swiss_settings.priority, 6)
-        self.assertEqual(remaining_settings.priority, remaining_priority)
+        self.assertEqual(remaining_settings.priority, 6)
         self.assertTrue(swiss_settings.mergeLines)
         self.assertFalse(other_settings.mergeLines)
         self.assertTrue(remaining_settings.mergeLines)

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -43,8 +43,8 @@ _LABEL_PRIORITIES = {
     "airport-label": 8,
 }
 _SETTLEMENT_LAYERS = {"settlement-major-label", "settlement-minor-label"}
-_SWISS_MOTORWAY_SHIELD_PRIORITY = 6
-_SWISS_MOTORWAY_SHIELD_Z11_STYLE_MARKER = "ch-motorway-icon-z11-plus"
+_ROAD_NUMBER_SHIELD_Z11_PLUS_PRIORITY = 6
+_ROAD_NUMBER_SHIELD_Z11_PLUS_STYLE_MARKER = "z11-plus"
 _MAPBOX_SYMBOL_PIXEL_TO_MM = 25.4 / 96.0
 _MAPBOX_DEFAULT_SYMBOL_SPACING_PX = 250.0
 _ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX = 150.0
@@ -109,9 +109,9 @@ def _label_style_name(style) -> str:
 def _label_priority(layer_name: str, style) -> int | None:
     if (
         layer_name == "road-number-shield"
-        and _SWISS_MOTORWAY_SHIELD_Z11_STYLE_MARKER in _label_style_name(style)
+        and _ROAD_NUMBER_SHIELD_Z11_PLUS_STYLE_MARKER in _label_style_name(style)
     ):
-        return _SWISS_MOTORWAY_SHIELD_PRIORITY
+        return _ROAD_NUMBER_SHIELD_Z11_PLUS_PRIORITY
     return _LABEL_PRIORITIES.get(layer_name)
 
 

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -121,7 +121,7 @@ def _symbol_spacing_mm(pixels: float) -> float:
 
 def _label_repeat_distance(layer_name: str, style) -> float | None:
     style_name = _label_style_name(style)
-    if layer_name == "road-number-shield" and "z11-plus" in style_name:
+    if layer_name == "road-number-shield" and _ROAD_NUMBER_SHIELD_Z11_PLUS_STYLE_MARKER in style_name:
         return _symbol_spacing_mm(_ROAD_NUMBER_SHIELD_Z11_PLUS_SYMBOL_SPACING_PX)
     if layer_name == "road-label":
         if style_name in {"road-label-below-z12", "road-label-z12-to-z15"}:
@@ -141,7 +141,10 @@ def _label_repeat_distance(layer_name: str, style) -> float | None:
 
 
 def _label_merge_lines(layer_name: str, style) -> bool | None:
-    if layer_name == "road-number-shield" and "z11-plus" in _label_style_name(style):
+    if (
+        layer_name == "road-number-shield"
+        and _ROAD_NUMBER_SHIELD_Z11_PLUS_STYLE_MARKER in _label_style_name(style)
+    ):
         return True
     if layer_name in _LINE_LABEL_MERGE_LAYERS:
         return True


### PR DESCRIPTION
## Summary
- promote every z11-plus road-number-shield label style to the road-shield priority, not only Swiss motorway shield styles
- rename the priority constants to describe the generic z11-plus road shield rule
- update real and mock background map service tests so below-z11 point shields stay unpromoted while z11-plus line shields are promoted

## Evidence
- Live label-settings artifact: `debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260520T133751Z/summary.md`
- That artifact reports road-number-shield split into 28 converted styles: 14 point styles at priority 3 and 14 line z11-plus styles at priority 6 after this branch.
- Branch all-camera visual comparison artifact: `debug/mapbox-outdoors-comparison-road-shield-z11-priority/all-cameras/20260520T133917Z/summary.md`
- The branch Lausanne label snapshot promotes all 14 z11-plus road-number-shield styles to priority 6; the same baseline camera snapshot had only 4 of 14 z11-plus road shield styles at priority 6.

## Validation
- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- live all-camera Mapbox Outdoors comparison with local token, token excluded from artifacts

Issue: #949
