### PR TITLE
Focus road shield label placement diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -27,6 +27,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _line_label_repeat_spacing_rows,
     _load_original_style,
     _postprocessed_label_records,
+    _road_shield_label_placement_rows,
     _source_label_control_omission_summary_rows,
     _source_label_control_summary_rows,
     _source_label_fanout_summary_rows,
@@ -988,6 +989,77 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(water_row["repeat_distances"], {"0": 1})
         self.assertEqual(water_row["merge_lines"], {"false": 1})
 
+    def test_road_shield_label_placement_rows_focus_converted_shields(self):
+        rows = _road_shield_label_placement_rows(
+            [
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-2-remaining-icons-z11-plus",
+                    "qfit_style_layer_id": "road-number-shield-2-remaining-icons-z11-plus",
+                    "minzoom": 6,
+                    "qfit_minzoom": 11,
+                    "layout": {"symbol-placement": ["step", ["zoom"], "point", 11, "line"]},
+                    "qfit_layout": {"symbol-placement": "line", "symbol-spacing": 466.6666666667},
+                },
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-2-remaining-icons-below-z11",
+                    "qfit_style_layer_id": "road-number-shield-2-remaining-icons-below-z11",
+                    "minzoom": 6,
+                    "qfit_minzoom": 6,
+                    "qfit_maxzoom": 11,
+                    "layout": {"symbol-placement": ["step", ["zoom"], "point", 11, "line"]},
+                    "qfit_layout": {"symbol-placement": "point"},
+                },
+                {
+                    "base_style_layer_id": "road-label",
+                    "style_name": "road-label-z15-plus",
+                    "qfit_style_layer_id": "road-label-z15-plus",
+                    "qfit_layout": {"symbol-placement": "line"},
+                },
+            ],
+            [
+                {
+                    "style_name": "road-number-shield-2-remaining-icons-z11-plus",
+                    "geometry_type": "Line",
+                    "placement": "Horizontal",
+                    "priority": 6,
+                    "repeat_distance": 123.4722222222,
+                    "obstacle": True,
+                    "merge_lines": True,
+                    "text_color": "#1d1f25",
+                },
+                {
+                    "style_name": "road-number-shield-2-remaining-icons-below-z11",
+                    "geometry_type": "Point",
+                    "placement": "OverPoint",
+                    "priority": 3,
+                    "repeat_distance": 0.0,
+                    "obstacle": True,
+                    "merge_lines": False,
+                    "text_color": "#1d1f25",
+                },
+                {"style_name": "road-label-z15-plus"},
+            ],
+        )
+
+        self.assertEqual(
+            [row["style_name"] for row in rows],
+            [
+                "road-number-shield-2-remaining-icons-below-z11",
+                "road-number-shield-2-remaining-icons-z11-plus",
+            ],
+        )
+        below, z11_plus = rows
+        self.assertEqual(below["qfit_zoom"], "6 to 11")
+        self.assertEqual(below["qfit_symbol_placement"], "point")
+        self.assertEqual(below["priority"], 3)
+        self.assertEqual(z11_plus["qfit_zoom"], "11+")
+        self.assertEqual(z11_plus["qfit_symbol_placement"], "line")
+        self.assertAlmostEqual(z11_plus["qfit_symbol_spacing"], 466.6666666667)
+        self.assertEqual(z11_plus["priority"], 6)
+        self.assertTrue(z11_plus["merge_lines"])
+
     def test_line_center_label_conversion_summary_isolates_line_center_labels(self):
         rows = _line_center_label_conversion_rows(
             [
@@ -1606,6 +1678,22 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "merge_lines": {"false": 1},
                 }
             ],
+            "road_shield_label_placement_rows": [
+                {
+                    "style_name": "road-number-shield-2-remaining-icons-z11-plus",
+                    "qfit_zoom": "11+",
+                    "source_symbol_placement": ["step", ["zoom"], "point", 11, "line"],
+                    "qfit_symbol_placement": "line",
+                    "qfit_symbol_spacing": 466.6666666667,
+                    "geometry_type": "Line",
+                    "placement": "Horizontal",
+                    "priority": 6,
+                    "repeat_distance": 123.4722222222,
+                    "obstacle": True,
+                    "merge_lines": True,
+                    "text_color": "#1d1f25",
+                }
+            ],
             "line_label_repeat_spacing_by_base_layer": [
                 {
                     "base_style_layer_id": "contour-label",
@@ -1764,6 +1852,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("Bbox-edge source-style high-zoom contour label probe: yes", markdown)
         self.assertIn("## Label style summary by base layer", markdown)
         self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
+        self.assertIn("## Road shield label placement detail", markdown)
+        self.assertIn(
+            "| road-number-shield-2-remaining-icons-z11-plus | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | yes | yes | #1d1f25 |",
+            markdown,
+        )
         self.assertIn("## Line label repeat spacing by base layer", markdown)
         self.assertIn(
             "| contour-label | 1 | 1 | 1 | (missing)=1 | (missing)=1 | 0=1 | (missing) -> 0=1 | Curved=1 | contour-label=1 |",

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -1052,6 +1052,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         below, z11_plus = rows
         self.assertEqual(below["qfit_zoom"], "6 to 11")
+        self.assertEqual(below["source_zoom"], "6+")
         self.assertEqual(below["qfit_symbol_placement"], "point")
         self.assertEqual(below["priority"], 3)
         self.assertEqual(z11_plus["qfit_zoom"], "11+")
@@ -1681,6 +1682,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "road_shield_label_placement_rows": [
                 {
                     "style_name": "road-number-shield-2-remaining-icons-z11-plus",
+                    "source_zoom": "6+",
                     "qfit_zoom": "11+",
                     "source_symbol_placement": ["step", ["zoom"], "point", 11, "line"],
                     "qfit_symbol_placement": "line",
@@ -1854,7 +1856,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
-            "| road-number-shield-2-remaining-icons-z11-plus | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | yes | yes | #1d1f25 |",
+            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | yes | yes | #1d1f25 |",
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -1789,16 +1789,17 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 "",
                 "Focused `road-number-shield` rows for placement, repeat-distance, and collision-priority follow-up.",
                 "",
-                "| Style | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Obstacle | Merge lines | Text color |",
-                "| --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- |",
+                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Obstacle | Merge lines | Text color |",
+                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- |",
             ]
         )
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {style} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {obstacle} | {merge_lines} | {text_color} |".format(
+            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {obstacle} | {merge_lines} | {text_color} |".format(
                 style=_markdown_value(row.get("style_name")),
+                source_zoom=_markdown_value(row.get("source_zoom")),
                 qfit_zoom=_markdown_value(row.get("qfit_zoom")),
                 source_placement=_markdown_value(row.get("source_symbol_placement")),
                 qfit_placement=_markdown_value(row.get("qfit_symbol_placement")),

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -1188,6 +1188,48 @@ def _label_conversion_rows(
     )
 
 
+def _road_shield_label_placement_rows(
+    source_label_layers: list[dict[str, object]],
+    label_records: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    labels_by_style = _label_records_by_style(label_records)
+    rows: list[dict[str, object]] = []
+    for source_row in source_label_layers:
+        if not isinstance(source_row, dict) or _base_style_layer_id(source_row) != "road-number-shield":
+            continue
+        matched_labels = _matched_label_records_for_source_row(source_row, labels_by_style)
+        for label_row in matched_labels or [{}]:
+            rows.append(
+                {
+                    "style_name": source_row.get("style_name"),
+                    "qfit_style_layer_id": source_row.get("qfit_style_layer_id"),
+                    "source_zoom": _zoom_range_key(source_row.get("minzoom"), source_row.get("maxzoom")),
+                    "qfit_zoom": (
+                        _zoom_range_key(source_row.get("qfit_minzoom"), source_row.get("qfit_maxzoom"))
+                        if source_row.get("qfit_style_layer_id") is not None
+                        else None
+                    ),
+                    "source_symbol_placement": _section_control(source_row, "layout", "symbol-placement"),
+                    "qfit_symbol_placement": _section_control(source_row, "qfit_layout", "symbol-placement"),
+                    "qfit_symbol_spacing": _section_control(source_row, "qfit_layout", "symbol-spacing"),
+                    "geometry_type": label_row.get("geometry_type"),
+                    "placement": label_row.get("placement"),
+                    "priority": label_row.get("priority"),
+                    "repeat_distance": label_row.get("repeat_distance"),
+                    "obstacle": label_row.get("obstacle"),
+                    "merge_lines": label_row.get("merge_lines"),
+                    "text_color": label_row.get("text_color"),
+                }
+            )
+    return sorted(
+        rows,
+        key=lambda row: (
+            _summary_key(row.get("style_name")),
+            _summary_key(row.get("qfit_zoom")),
+        ),
+    )
+
+
 def _line_center_label_conversion_rows(
     source_label_layers: list[dict[str, object]],
     label_records: list[dict[str, object]],
@@ -1550,6 +1592,7 @@ def _label_settings_report(
         "label_count": len(records),
         "labels": records,
         "label_style_summary_by_base_layer": _label_style_summary_rows(records),
+        "road_shield_label_placement_rows": _road_shield_label_placement_rows(source_label_layer_rows, records),
         "line_label_repeat_spacing_by_base_layer": _line_label_repeat_spacing_rows(source_label_layer_rows, records),
         "line_label_conversion_by_base_layer": _line_label_conversion_rows(source_label_layer_rows, records),
         "line_center_label_conversion_by_base_layer": _line_center_label_conversion_rows(
@@ -1735,6 +1778,41 @@ def _append_line_label_repeat_spacing_summary(lines: list[str], summary_rows: li
                     styles=_count_map_markdown_value(row.get("style_names")),
                 )
             )
+        lines.append("")
+
+
+def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object]) -> None:
+    if rows:
+        lines.extend(
+            [
+                "## Road shield label placement detail",
+                "",
+                "Focused `road-number-shield` rows for placement, repeat-distance, and collision-priority follow-up.",
+                "",
+                "| Style | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Obstacle | Merge lines | Text color |",
+                "| --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- |",
+            ]
+        )
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        lines.append(
+            "| {style} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {obstacle} | {merge_lines} | {text_color} |".format(
+                style=_markdown_value(row.get("style_name")),
+                qfit_zoom=_markdown_value(row.get("qfit_zoom")),
+                source_placement=_markdown_value(row.get("source_symbol_placement")),
+                qfit_placement=_markdown_value(row.get("qfit_symbol_placement")),
+                qfit_spacing=_markdown_value(row.get("qfit_symbol_spacing")),
+                geometry=_markdown_value(row.get("geometry_type")),
+                placement=_markdown_value(row.get("placement")),
+                priority=_markdown_value(row.get("priority")),
+                repeat=_markdown_value(row.get("repeat_distance")),
+                obstacle=_markdown_value(row.get("obstacle")),
+                merge_lines=_markdown_value(row.get("merge_lines")),
+                text_color=_markdown_value(row.get("text_color")),
+            )
+        )
+    if rows:
         lines.append("")
 
 
@@ -2055,6 +2133,11 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         "",
     ]
     _append_label_style_summary(lines, summary_rows)
+    road_shield_label_placement = report.get("road_shield_label_placement_rows")
+    road_shield_label_placement_rows = (
+        road_shield_label_placement if isinstance(road_shield_label_placement, list) else []
+    )
+    _append_road_shield_label_placement_rows(lines, road_shield_label_placement_rows)
     _append_line_label_repeat_spacing_summary(lines, line_repeat_rows)
     _append_line_label_conversion_summary(lines, line_conversion_rows)
     _append_line_center_label_conversion_summary(lines, line_center_conversion_rows)


### PR DESCRIPTION
## Summary
- add a focused road-number-shield placement detail section to the Mapbox Outdoors label-settings report
- include per-style QGIS zoom, source/QGIS placement, symbol spacing, geometry, converted placement, priority, repeat distance, obstacle, merge-line, and text color fields
- cover the focused row builder and markdown output with tests

## Evidence
- Live label-settings artifact: debug/mapbox-outdoors-label-settings/mapbox-outdoors-v12/20260520T135911Z/summary.md
- The new section shows 28 road-number-shield rows: 14 below-z11 point styles at priority 3 and 14 z11-plus line styles at priority 6, all with repeat distance 123.472 mm, obstacle=yes, and merge lines=yes for the z11-plus styles.
- This directly supports the next #949 road-shield visual/collision pass after PR #1215 promoted z11-plus road shield priority.

## Validation
- python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- Live diagnostic smoke: MAPBOX_ACCESS_TOKEN from the local QGIS profile, then python3 validation/mapbox_outdoors_label_settings.py

Issue: #949