### PR TITLE
Surface duplicate road shield refs

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -373,6 +373,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                 "LineString",
                 {
                     "class": "primary",
+                    "ref": "A1",
                     "reflen": "2",
                     "shield": "ch-primary",
                     "structure": "none",
@@ -462,6 +463,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
         self.assertEqual(record["road_number_shield_class_counts"], {"primary": 1})
         self.assertEqual(record["road_number_shield_reflen_counts"], {"2": 1})
+        self.assertEqual(record["road_number_shield_ref_counts"], {"A1": 1})
+        self.assertEqual(record["road_number_shield_duplicate_ref_counts"], {})
         self.assertEqual(record["road_number_shield_sprite_reference_counts"], {"shield:ch-primary-2": 1})
         self.assertEqual(record["road_number_shield_structure_counts"], {"none": 1})
         self.assertEqual(record["road_number_shield_layer_counts"], {"0": 1})
@@ -490,7 +493,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["sample_road_exit_shields"][0]["properties"]["ref"], "12")
         self.assertEqual(record["sample_road_label_candidates"][0]["properties"]["name"], "Bachstrasse")
 
-    def test_road_tile_record_counts_duplicate_non_empty_path_pedestrian_names(self):
+    def test_road_tile_record_counts_duplicate_non_empty_label_values(self):
         road_features = [
             _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "name": " Plaza "}),
             _feature("LineString", {"class": "pedestrian", "type": "pedestrian", "structure": "none", "name": "Plaza"}),
@@ -502,6 +505,9 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             _feature("LineString", {"class": "path", "type": "steps", "structure": "none", "name": "Steps"}),
             _feature("LineString", {"class": "street", "name": "Main Road"}),
             _feature("LineString", {"class": "street", "name": "Main Road"}),
+            _feature("LineString", {"class": "primary", "ref": "D 1005", "reflen": 5, "shield": "rectangle-yellow", "len": 3000}),
+            _feature("LineString", {"class": "primary", "ref": " D 1005 ", "reflen": 5, "shield": "rectangle-yellow", "len": 3500}),
+            _feature("LineString", {"class": "primary", "ref": "   ", "reflen": 5, "shield": "rectangle-yellow", "len": 4000}),
         ]
 
         record = road_tile_record(
@@ -517,6 +523,8 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(record["path_line_duplicate_name_counts"], {"Trail": 2})
         self.assertEqual(record["step_line_name_counts"], {"Steps": 2})
         self.assertEqual(record["step_line_duplicate_name_counts"], {"Steps": 2})
+        self.assertEqual(record["road_number_shield_ref_counts"], {"D 1005": 2})
+        self.assertEqual(record["road_number_shield_duplicate_ref_counts"], {"D 1005": 2})
         self.assertEqual(record["road_label_name_counts"], {"Main Road": 2})
         self.assertEqual(record["road_label_duplicate_name_counts"], {"Main Road": 2})
 
@@ -1356,7 +1364,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn(f'["{path_signature}=1"] | ["{step_signature}=1"] |', markdown)
         self.assertIn("## Road label/shield focus", markdown)
         self.assertIn(
-            f'| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 2 | ["primary=1"] | ["2=1"] | ["shield:ch-primary-2=1"] | ["{shield_signature}=1"] | ["2=1"] | ["street=2"] | ["Bachstrasse=2"] |',
+            f'| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 2 | ["primary=1"] | ["2=1"] | [] | ["shield:ch-primary-2=1"] | ["{shield_signature}=1"] | ["2=1"] | ["street=2"] | ["Bachstrasse=2"] |',
             markdown,
         )
 

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -480,6 +480,7 @@ def road_tile_record(
     pedestrian_line_name_counts = _count_non_empty_string_property(pedestrian_lines, "name")
     path_line_name_counts = _count_non_empty_string_property(path_lines, "name")
     step_line_name_counts = _count_non_empty_string_property(step_lines, "name")
+    road_number_shield_ref_counts = _count_non_empty_string_property(road_number_shields, "ref")
     road_label_name_counts = _count_non_empty_string_property(road_label_lines, "name")
     return {
         **tile,
@@ -546,6 +547,8 @@ def road_tile_record(
         ),
         "road_number_shield_class_counts": _count_by_property(road_number_shields, "class"),
         "road_number_shield_reflen_counts": _count_by_property(road_number_shields, "reflen"),
+        "road_number_shield_ref_counts": road_number_shield_ref_counts,
+        "road_number_shield_duplicate_ref_counts": _duplicate_count_map(road_number_shield_ref_counts),
         "road_number_shield_sprite_reference_counts": _count_road_number_shield_sprite_references(
             road_number_shields
         ),
@@ -651,6 +654,7 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("Level crossing signatures", "level_crossing_signature_counts"),
     ("Road number shield class counts", "road_number_shield_class_counts"),
     ("Road number shield reflen counts", "road_number_shield_reflen_counts"),
+    ("Road number shield duplicate refs", "road_number_shield_duplicate_ref_counts"),
     ("Road number shield sprite references", "road_number_shield_sprite_reference_counts"),
     ("Road number shield structure counts", "road_number_shield_structure_counts"),
     ("Road number shield layer counts", "road_number_shield_layer_counts"),
@@ -706,6 +710,7 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Level crossing signatures", "level_crossing_signature_counts", "---"),
     ("Shield classes", "road_number_shield_class_counts", "---"),
     ("Shield reflens", "road_number_shield_reflen_counts", "---"),
+    ("Duplicate shield refs", "road_number_shield_duplicate_ref_counts", "---"),
     ("Shield sprite refs", "road_number_shield_sprite_reference_counts", "---"),
     ("Shield structures", "road_number_shield_structure_counts", "---"),
     ("Shield layers", "road_number_shield_layer_counts", "---"),
@@ -733,6 +738,7 @@ _NAME_COUNT_FIELD_PAIRS = (
     ("pedestrian_line_name_counts", "pedestrian_line_duplicate_name_counts"),
     ("path_line_name_counts", "path_line_duplicate_name_counts"),
     ("step_line_name_counts", "step_line_duplicate_name_counts"),
+    ("road_number_shield_ref_counts", "road_number_shield_duplicate_ref_counts"),
     ("road_label_name_counts", "road_label_duplicate_name_counts"),
 )
 _DUPLICATE_NAME_COUNT_FIELDS = frozenset(duplicate_key for _name_key, duplicate_key in _NAME_COUNT_FIELD_PAIRS)
@@ -1294,8 +1300,8 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                 "",
                 "## Road label/shield focus",
                 "",
-                "| Camera | Camera zoom | Tile zoom | Road number shields | Road exit shields | Road labels | Shield classes | Shield reflens | Shield sprite refs | Shield signatures | Exit shield reflens | Road label classes | Duplicate road labels |",
-                "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |",
+                "| Camera | Camera zoom | Tile zoom | Road number shields | Road exit shields | Road labels | Shield classes | Shield reflens | Duplicate shield refs | Shield sprite refs | Shield signatures | Exit shield reflens | Road label classes | Duplicate road labels |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
         for camera_report in road_focus_rows:
@@ -1310,6 +1316,7 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                         camera_report.get("road_label_candidate_count"),
                         _top_count_labels(camera_report.get("road_number_shield_class_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_reflen_counts")),
+                        _top_count_labels(camera_report.get("road_number_shield_duplicate_ref_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_sprite_reference_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_signature_counts")),
                         _top_count_labels(camera_report.get("road_exit_shield_reflen_counts")),


### PR DESCRIPTION
## Summary

- add road-number shield `ref` counts and duplicate-ref counts to the Mapbox Outdoors road feature diagnostic
- surface duplicate shield refs in the all-camera road feature table and road label/shield focus table
- add regression coverage for normalized duplicate shield refs while ignoring blank refs

## Evidence

Issue #949 visual validation showed repeated road shields around the south Lake Geneva shore, including `D 1005`, suggesting a density/collision question rather than only a sprite mapping question. The refreshed live diagnostic artifact at `debug/mapbox-outdoors-road-features-duplicate-shield-ref-focus/all-cameras/20260520T142249Z/summary.md` now reports:

- `Road number shield duplicate refs` across the decoded camera set, including `D 1005=10`
- focused per-camera duplicate shield refs, for example `lausanne-lavaux-z10-outdoors` top duplicates `9=35`, `1=28`, `12=18`

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- live all-camera road feature diagnostic with the local Mapbox token loaded only into the command environment

Issue: #949
