### PR TITLE
Report road shield geometry types

### DIFF
--- a/tests/test_mapbox_outdoors_road_features.py
+++ b/tests/test_mapbox_outdoors_road_features.py
@@ -463,6 +463,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         )
         self.assertEqual(record["road_number_shield_class_counts"], {"primary": 1})
         self.assertEqual(record["road_number_shield_reflen_counts"], {"2": 1})
+        self.assertEqual(record["road_number_shield_geometry_type_counts"], {"LineString": 1})
         self.assertEqual(record["road_number_shield_ref_counts"], {"A1": 1})
         self.assertEqual(record["road_number_shield_duplicate_ref_counts"], {})
         self.assertEqual(record["road_number_shield_sprite_reference_counts"], {"shield:ch-primary-2": 1})
@@ -727,6 +728,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["level_crossing_signature_counts"], {})
         self.assertEqual(report["road_number_shield_class_counts"], {})
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
+        self.assertEqual(report["road_number_shield_geometry_type_counts"], {})
         self.assertEqual(report["road_number_shield_sprite_reference_counts"], {})
         self.assertEqual(
             report["road_number_shield_sprite_reference_coverage"],
@@ -942,6 +944,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertEqual(report["level_crossing_signature_counts"], {})
         self.assertEqual(report["road_number_shield_class_counts"], {})
         self.assertEqual(report["road_number_shield_reflen_counts"], {})
+        self.assertEqual(report["road_number_shield_geometry_type_counts"], {})
         self.assertEqual(report["road_number_shield_sprite_reference_counts"], {})
         self.assertEqual(report["road_number_shield_structure_counts"], {})
         self.assertEqual(report["road_number_shield_layer_counts"], {})
@@ -1040,6 +1043,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "level_crossing_signature_counts": {level_crossing_signature: 1},
             "road_number_shield_class_counts": {"primary": 1},
             "road_number_shield_reflen_counts": {"2": 1},
+            "road_number_shield_geometry_type_counts": {"LineString": 1},
             "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
             "road_number_shield_sprite_reference_coverage": {
                 "configured_road_number_shield_sprite_count": len(
@@ -1116,6 +1120,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "level_crossing_signature_counts": {level_crossing_signature: 1},
                     "road_number_shield_class_counts": {"primary": 1},
                     "road_number_shield_reflen_counts": {"2": 1},
+                    "road_number_shield_geometry_type_counts": {"LineString": 1},
                     "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
                     "road_number_shield_structure_counts": {"none": 1},
                     "road_number_shield_layer_counts": {"0": 1},
@@ -1171,6 +1176,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn(f'Level crossing signatures: {{"{level_crossing_signature}":1}}', markdown)
         self.assertIn('Road number shield class counts: {"primary":1}', markdown)
         self.assertIn('Road number shield reflen counts: {"2":1}', markdown)
+        self.assertIn('Road number shield geometry types: {"LineString":1}', markdown)
         self.assertIn('Road number shield sprite references: {"shield:ch-primary-2":1}', markdown)
         self.assertIn('Road number shield structure counts: {"none":1}', markdown)
         self.assertIn('Road number shield layer counts: {"0":1}', markdown)
@@ -1252,6 +1258,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
             "level_crossing_signature_counts": {level_crossing_signature: 1},
             "road_number_shield_class_counts": {"primary": 1},
             "road_number_shield_reflen_counts": {"2": 1},
+            "road_number_shield_geometry_type_counts": {"LineString": 1},
             "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
             "road_number_shield_sprite_reference_coverage": {
                 "configured_road_number_shield_sprite_count": len(
@@ -1323,6 +1330,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
                     "level_crossing_signature_counts": {level_crossing_signature: 1},
                     "road_number_shield_class_counts": {"primary": 1},
                     "road_number_shield_reflen_counts": {"2": 1},
+                    "road_number_shield_geometry_type_counts": {"LineString": 1},
                     "road_number_shield_sprite_reference_counts": {"shield:ch-primary-2": 1},
                     "road_number_shield_structure_counts": {"none": 1},
                     "road_number_shield_layer_counts": {"0": 1},
@@ -1364,7 +1372,7 @@ class MapboxOutdoorsRoadFeatureTests(unittest.TestCase):
         self.assertIn(f'["{path_signature}=1"] | ["{step_signature}=1"] |', markdown)
         self.assertIn("## Road label/shield focus", markdown)
         self.assertIn(
-            f'| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 2 | ["primary=1"] | ["2=1"] | [] | ["shield:ch-primary-2=1"] | ["{shield_signature}=1"] | ["2=1"] | ["street=2"] | ["Bachstrasse=2"] |',
+            f'| zermatt-trails-z18-outdoors | 18.0 | 18 | 1 | 1 | 2 | ["primary=1"] | ["2=1"] | ["LineString=1"] | [] | ["shield:ch-primary-2=1"] | ["{shield_signature}=1"] | ["2=1"] | ["street=2"] | ["Bachstrasse=2"] |',
             markdown,
         )
 

--- a/validation/mapbox_outdoors_road_features.py
+++ b/validation/mapbox_outdoors_road_features.py
@@ -547,6 +547,7 @@ def road_tile_record(
         ),
         "road_number_shield_class_counts": _count_by_property(road_number_shields, "class"),
         "road_number_shield_reflen_counts": _count_by_property(road_number_shields, "reflen"),
+        "road_number_shield_geometry_type_counts": _count_geometry_types(road_number_shields),
         "road_number_shield_ref_counts": road_number_shield_ref_counts,
         "road_number_shield_duplicate_ref_counts": _duplicate_count_map(road_number_shield_ref_counts),
         "road_number_shield_sprite_reference_counts": _count_road_number_shield_sprite_references(
@@ -654,6 +655,7 @@ _SUMMARY_COUNT_MAP_FIELDS = (
     ("Level crossing signatures", "level_crossing_signature_counts"),
     ("Road number shield class counts", "road_number_shield_class_counts"),
     ("Road number shield reflen counts", "road_number_shield_reflen_counts"),
+    ("Road number shield geometry types", "road_number_shield_geometry_type_counts"),
     ("Road number shield duplicate refs", "road_number_shield_duplicate_ref_counts"),
     ("Road number shield sprite references", "road_number_shield_sprite_reference_counts"),
     ("Road number shield structure counts", "road_number_shield_structure_counts"),
@@ -710,6 +712,7 @@ _ROAD_FEATURE_TABLE_FIELDS = (
     ("Level crossing signatures", "level_crossing_signature_counts", "---"),
     ("Shield classes", "road_number_shield_class_counts", "---"),
     ("Shield reflens", "road_number_shield_reflen_counts", "---"),
+    ("Shield geometries", "road_number_shield_geometry_type_counts", "---"),
     ("Duplicate shield refs", "road_number_shield_duplicate_ref_counts", "---"),
     ("Shield sprite refs", "road_number_shield_sprite_reference_counts", "---"),
     ("Shield structures", "road_number_shield_structure_counts", "---"),
@@ -1146,6 +1149,10 @@ def collect_all_camera_road_feature_report(
             camera_reports,
             "road_number_shield_reflen_counts",
         ),
+        "road_number_shield_geometry_type_counts": _combined_record_counts(
+            camera_reports,
+            "road_number_shield_geometry_type_counts",
+        ),
         "road_number_shield_sprite_reference_counts": road_number_shield_sprite_reference_counts,
         "road_number_shield_sprite_reference_coverage": _road_number_shield_sprite_reference_coverage(
             road_number_shield_sprite_reference_counts
@@ -1300,8 +1307,8 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                 "",
                 "## Road label/shield focus",
                 "",
-                "| Camera | Camera zoom | Tile zoom | Road number shields | Road exit shields | Road labels | Shield classes | Shield reflens | Duplicate shield refs | Shield sprite refs | Shield signatures | Exit shield reflens | Road label classes | Duplicate road labels |",
-                "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
+                "| Camera | Camera zoom | Tile zoom | Road number shields | Road exit shields | Road labels | Shield classes | Shield reflens | Shield geometries | Duplicate shield refs | Shield sprite refs | Shield signatures | Exit shield reflens | Road label classes | Duplicate road labels |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
         for camera_report in road_focus_rows:
@@ -1316,6 +1323,7 @@ def build_all_camera_summary_markdown(report: dict[str, object]) -> str:
                         camera_report.get("road_label_candidate_count"),
                         _top_count_labels(camera_report.get("road_number_shield_class_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_reflen_counts")),
+                        _top_count_labels(camera_report.get("road_number_shield_geometry_type_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_duplicate_ref_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_sprite_reference_counts")),
                         _top_count_labels(camera_report.get("road_number_shield_signature_counts")),


### PR DESCRIPTION
## Summary

- add road-number shield geometry-type counts to the road feature diagnostic
- surface shield geometries in the all-camera road table and road label/shield focus table
- cover the new per-tile, aggregate, and markdown output fields in tests

## Evidence

This follows the duplicate-ref slice in #1217 and the live Lausanne visual comparison. The repeated `D 1005` shields at z10 are coming from low-zoom road shield candidates, so the diagnostic needs to show whether those candidates are point- or line-derived before changing placement or repeat-distance behavior.

Fresh live artifact: `debug/mapbox-outdoors-road-features-shield-geometry-focus/all-cameras/20260520T143559Z/summary.md`

Key observations from that artifact:

- all road-number shield candidates across the z5-z18 camera set are now split by geometry: `Point=528`, `MultiLineString=7`
- `lausanne-lavaux-z10-outdoors` has `Point=240` road-number shield candidates, including duplicate refs such as `D 1005=10`
- z14 road shield rows are line-derived (`geneva-airport-motorway-z14-outdoors`: `MultiLineString=6`; `chamonix-trails-z14-outdoors`: `MultiLineString=1`)

That points the next #949 decision toward low-zoom point-shield density/collision behavior for the Lake Geneva duplicate-shield issue, not only z11-plus line repeat-distance tuning.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- live all-camera road feature diagnostic with the local Mapbox token loaded only into the command environment

Issue: #949
