### PR TITLE
Surface road shield collision flags

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -1025,7 +1025,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "placement": "Horizontal",
                     "priority": 6,
                     "repeat_distance": 123.4722222222,
+                    "display_all": False,
                     "obstacle": True,
+                    "label_per_part": False,
                     "merge_lines": True,
                     "text_color": "#1d1f25",
                 },
@@ -1035,7 +1037,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "placement": "OverPoint",
                     "priority": 3,
                     "repeat_distance": 0.0,
+                    "display_all": False,
                     "obstacle": True,
+                    "label_per_part": False,
                     "merge_lines": False,
                     "text_color": "#1d1f25",
                 },
@@ -1055,10 +1059,14 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(below["source_zoom"], "6+")
         self.assertEqual(below["qfit_symbol_placement"], "point")
         self.assertEqual(below["priority"], 3)
+        self.assertFalse(below["display_all"])
+        self.assertFalse(below["label_per_part"])
         self.assertEqual(z11_plus["qfit_zoom"], "11+")
         self.assertEqual(z11_plus["qfit_symbol_placement"], "line")
         self.assertAlmostEqual(z11_plus["qfit_symbol_spacing"], 466.6666666667)
         self.assertEqual(z11_plus["priority"], 6)
+        self.assertFalse(z11_plus["display_all"])
+        self.assertFalse(z11_plus["label_per_part"])
         self.assertTrue(z11_plus["merge_lines"])
 
     def test_line_center_label_conversion_summary_isolates_line_center_labels(self):
@@ -1691,7 +1699,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "placement": "Horizontal",
                     "priority": 6,
                     "repeat_distance": 123.4722222222,
+                    "display_all": False,
                     "obstacle": True,
+                    "label_per_part": False,
                     "merge_lines": True,
                     "text_color": "#1d1f25",
                 }
@@ -1856,7 +1866,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
-            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | yes | yes | #1d1f25 |",
+            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | yes | #1d1f25 |",
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -1216,7 +1216,9 @@ def _road_shield_label_placement_rows(
                     "placement": label_row.get("placement"),
                     "priority": label_row.get("priority"),
                     "repeat_distance": label_row.get("repeat_distance"),
+                    "display_all": label_row.get("display_all"),
                     "obstacle": label_row.get("obstacle"),
+                    "label_per_part": label_row.get("label_per_part"),
                     "merge_lines": label_row.get("merge_lines"),
                     "text_color": label_row.get("text_color"),
                 }
@@ -1789,15 +1791,15 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 "",
                 "Focused `road-number-shield` rows for placement, repeat-distance, and collision-priority follow-up.",
                 "",
-                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Obstacle | Merge lines | Text color |",
-                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- |",
+                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Display all | Obstacle | Label/part | Merge lines | Text color |",
+                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- | --- | --- |",
             ]
         )
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {obstacle} | {merge_lines} | {text_color} |".format(
+            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {display_all} | {obstacle} | {label_per_part} | {merge_lines} | {text_color} |".format(
                 style=_markdown_value(row.get("style_name")),
                 source_zoom=_markdown_value(row.get("source_zoom")),
                 qfit_zoom=_markdown_value(row.get("qfit_zoom")),
@@ -1808,7 +1810,9 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 placement=_markdown_value(row.get("placement")),
                 priority=_markdown_value(row.get("priority")),
                 repeat=_markdown_value(row.get("repeat_distance")),
+                display_all=_markdown_value(row.get("display_all")),
                 obstacle=_markdown_value(row.get("obstacle")),
+                label_per_part=_markdown_value(row.get("label_per_part")),
                 merge_lines=_markdown_value(row.get("merge_lines")),
                 text_color=_markdown_value(row.get("text_color")),
             )


### PR DESCRIPTION
## Summary
- add `Display all` and `Label/part` to the focused road shield label placement rows
- include the same fields in the generated `Road shield label placement detail` table
- cover the focused rows and markdown output with regression tests

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings-road-shield-collision-flags-focus/mapbox-outdoors-v12/20260520T145044Z/summary.md`

Issue: #949
