### PR TITLE
Report road shield overlap controls

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -27,6 +27,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _line_label_repeat_spacing_rows,
     _load_original_style,
     _postprocessed_label_records,
+    _qgis_duplicate_label_controls,
     _road_shield_label_placement_rows,
     _source_label_control_omission_summary_rows,
     _source_label_control_summary_rows,
@@ -97,6 +98,14 @@ class FakeTextFormat:
         return FakeTextBuffer()
 
 
+class FakePlacementSettings:
+    def allowDegradedPlacement(self):
+        return False
+
+    def overlapHandling(self):
+        return SimpleNamespace(name="PreventOverlap")
+
+
 class FakeStyle:
     def __init__(self, *, style_name, layer_name, geometry_type=None):
         self._style_name = style_name
@@ -156,6 +165,9 @@ class FakeSettings:
     def format(self):
         return FakeTextFormat()
 
+    def placementSettings(self):
+        return FakePlacementSettings()
+
 
 class FakeQgsApplication:
     _instance = None
@@ -177,6 +189,10 @@ class FakeQgsApplication:
     def exitQgis(self):
         self.exited = True
         type(self)._instance = None
+
+
+class FakeQgsPalLayerSettings:
+    pass
 
 
 class FakeConversionContext:
@@ -234,6 +250,7 @@ def _fake_qgis_modules():
     core_module.QgsApplication = FakeQgsApplication
     core_module.QgsMapBoxGlStyleConversionContext = FakeConversionContext
     core_module.QgsMapBoxGlStyleConverter = FakeConverter
+    core_module.QgsPalLayerSettings = FakeQgsPalLayerSettings
     core_module.Qgis = SimpleNamespace(RenderUnit=SimpleNamespace(Millimeters="millimeters"))
     qgis_module.core = core_module
     return {"qgis": qgis_module, "qgis.core": core_module}
@@ -335,6 +352,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["buffer_size_unit"], "Millimeters")
         self.assertEqual(record["buffer_color"], "#dcdcd4")
         self.assertEqual(record["buffer_opacity"], 0.75)
+        self.assertFalse(record["allow_degraded_placement"])
+        self.assertEqual(record["overlap_handling"], "PreventOverlap")
         self.assertEqual(record["data_defined_property_keys"], [50, 87])
 
     def test_ensure_qgis_application_reuses_or_creates_application(self):
@@ -352,6 +371,21 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertTrue(created)
         self.assertTrue(app.initialized)
         self.assertIs(FakeQgsApplication.instance(), app)
+
+    def test_qgis_duplicate_label_controls_report_runtime_support(self):
+        class FakeQgis:
+            QGIS_VERSION = "3.44.0"
+
+        class FakePalLayerSettings:
+            RemoveDuplicateLabels = 1
+            RemoveDuplicateLabelDistance = 2
+
+        controls = _qgis_duplicate_label_controls(FakePalLayerSettings, FakeQgis)
+
+        self.assertEqual(controls["qgis_version"], "3.44.0")
+        self.assertTrue(controls["remove_duplicate_labels"])
+        self.assertTrue(controls["remove_duplicate_label_distance"])
+        self.assertFalse(controls["label_margin_distance"])
 
     def test_load_original_style_uses_fixture_or_live_fetcher(self):
         config = LabelSettingsConfig(token=None, output_root=Path("/tmp"))
@@ -689,6 +723,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(report["qgis_converter_result"], "success")
         self.assertTrue(report["sprite_context_loaded"])
         self.assertEqual(report["sprite_definition_count"], 440)
+        self.assertEqual(report["qgis_duplicate_label_controls"], {})
         self.assertEqual(report["label_count"], 1)
         self.assertEqual(report["label_style_summary_by_base_layer"][0]["base_style_layer_id"], "contour-label")
         self.assertEqual(report["label_style_summary_by_base_layer"][0]["count"], 1)
@@ -713,6 +748,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distance": 39.6875,
                     "display_all": False,
                     "obstacle": True,
+                    "allow_degraded_placement": False,
+                    "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": False,
                 },
@@ -725,6 +762,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distance": 66.1458333333,
                     "display_all": False,
                     "obstacle": True,
+                    "allow_degraded_placement": False,
+                    "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": False,
                 },
@@ -737,6 +776,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distance": 0.0,
                     "display_all": False,
                     "obstacle": True,
+                    "allow_degraded_placement": False,
+                    "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": False,
                 },
@@ -750,6 +791,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(road_row["priorities"], {"4": 2})
         self.assertEqual(road_row["repeat_distances"], {"39.6875": 1, "66.1458": 1})
         self.assertEqual(road_row["display_all"], {"false": 2})
+        self.assertEqual(road_row["allow_degraded_placement"], {"false": 2})
+        self.assertEqual(road_row["overlap_handling"], {"PreventOverlap": 2})
 
     def test_line_label_repeat_spacing_summary_highlights_missing_spacing_and_zero_repeat(self):
         rows = _line_label_repeat_spacing_rows(
@@ -1027,6 +1070,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distance": 123.4722222222,
                     "display_all": False,
                     "obstacle": True,
+                    "allow_degraded_placement": False,
+                    "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": True,
                     "text_color": "#1d1f25",
@@ -1039,6 +1084,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distance": 0.0,
                     "display_all": False,
                     "obstacle": True,
+                    "allow_degraded_placement": False,
+                    "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": False,
                     "text_color": "#1d1f25",
@@ -1060,12 +1107,16 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(below["qfit_symbol_placement"], "point")
         self.assertEqual(below["priority"], 3)
         self.assertFalse(below["display_all"])
+        self.assertFalse(below["allow_degraded_placement"])
+        self.assertEqual(below["overlap_handling"], "PreventOverlap")
         self.assertFalse(below["label_per_part"])
         self.assertEqual(z11_plus["qfit_zoom"], "11+")
         self.assertEqual(z11_plus["qfit_symbol_placement"], "line")
         self.assertAlmostEqual(z11_plus["qfit_symbol_spacing"], 466.6666666667)
         self.assertEqual(z11_plus["priority"], 6)
         self.assertFalse(z11_plus["display_all"])
+        self.assertFalse(z11_plus["allow_degraded_placement"])
+        self.assertEqual(z11_plus["overlap_handling"], "PreventOverlap")
         self.assertFalse(z11_plus["label_per_part"])
         self.assertTrue(z11_plus["merge_lines"])
 
@@ -1668,6 +1719,12 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "generated": "2026-05-18T08:22:00+00:00",
             "sprite_context_loaded": True,
             "sprite_definition_count": 440,
+            "qgis_duplicate_label_controls": {
+                "qgis_version": "3.34.4-Prizren",
+                "remove_duplicate_labels": False,
+                "remove_duplicate_label_distance": False,
+                "label_margin_distance": False,
+            },
             "qgis_contour_bbox_edge_difference_label_probe": True,
             "qgis_contour_bbox_edge_difference_source_style_label_probe": True,
             "qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe": True,
@@ -1683,6 +1740,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distances": {"0": 1},
                     "display_all": {"false": 1},
                     "obstacle": {"true": 1},
+                    "allow_degraded_placement": {"false": 1},
+                    "overlap_handling": {"PreventOverlap": 1},
                     "label_per_part": {"false": 1},
                     "merge_lines": {"false": 1},
                 }
@@ -1701,6 +1760,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "repeat_distance": 123.4722222222,
                     "display_all": False,
                     "obstacle": True,
+                    "allow_degraded_placement": False,
+                    "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": True,
                     "text_color": "#1d1f25",
@@ -1813,6 +1874,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "display_all": False,
                     "obstacle": True,
                     "placement_flags": 1,
+                    "allow_degraded_placement": False,
+                    "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": False,
                     "geometry_generator": "boundary($geometry)",
@@ -1859,14 +1922,21 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("# Mapbox Outdoors QGIS label settings — mapbox/outdoors-v12", markdown)
         self.assertIn("Converted label styles: 1", markdown)
         self.assertIn("Sprite context loaded: yes", markdown)
+        self.assertIn(
+            "QGIS duplicate-label controls: QGIS 3.34.4-Prizren; remove_duplicate_labels=no; remove_duplicate_label_distance=no; label_margin_distance=no",
+            markdown,
+        )
         self.assertIn("Bbox-edge contour label probe: yes", markdown)
         self.assertIn("Bbox-edge source-style contour label probe: yes", markdown)
         self.assertIn("Bbox-edge source-style high-zoom contour label probe: yes", markdown)
         self.assertIn("## Label style summary by base layer", markdown)
-        self.assertIn("| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | no=1 |", markdown)
+        self.assertIn(
+            "| contour-label | 1 | contour=1 | Line=1 | 3=1 | Line=1 | 0=1 | no=1 | yes=1 | no=1 | PreventOverlap=1 | no=1 | no=1 |",
+            markdown,
+        )
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
-            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | yes | #1d1f25 |",
+            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | #1d1f25 |",
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -72,6 +72,11 @@ _SOURCE_LABEL_PAINT_PROPERTIES = (
 )
 _LINE_SYMBOL_PLACEMENTS = frozenset({"line", "line-center"})
 _LINE_CENTER_SYMBOL_PLACEMENTS = frozenset({"line-center"})
+_QGIS_DUPLICATE_LABEL_CONTROL_PROPERTIES = (
+    ("remove_duplicate_labels", "RemoveDuplicateLabels"),
+    ("remove_duplicate_label_distance", "RemoveDuplicateLabelDistance"),
+    ("label_margin_distance", "LabelMarginDistance"),
+)
 
 
 @dataclass(frozen=True)
@@ -300,6 +305,22 @@ def _label_format_record(settings: object) -> dict[str, object]:
     }
 
 
+def _label_placement_record(settings: object) -> dict[str, object]:
+    placement_settings = _method_value(settings, "placementSettings")
+    return {
+        "allow_degraded_placement": (
+            _method_value(placement_settings, "allowDegradedPlacement")
+            if placement_settings is not None
+            else None
+        ),
+        "overlap_handling": (
+            _enum_name(_method_value(placement_settings, "overlapHandling"))
+            if placement_settings is not None
+            else None
+        ),
+    }
+
+
 def _data_defined_property_keys(settings: object) -> list[object]:
     properties = _method_value(settings, "dataDefinedProperties")
     keys = _method_value(properties, "propertyKeys") if properties is not None else None
@@ -342,6 +363,7 @@ def label_settings_record(style: object, settings: object) -> dict[str, object]:
         "overrun_distance": _settings_value(settings, "overrunDistance"),
         "overrun_distance_unit": _settings_value(settings, "overrunDistanceUnit"),
         **_label_format_record(settings),
+        **_label_placement_record(settings),
         "data_defined_property_keys": _data_defined_property_keys(settings),
     }
 
@@ -379,6 +401,16 @@ def _ensure_qgis_application(qgs_application):
         app = qgs_application([], False)
         app.initQgis()
     return app, created_app
+
+
+def _qgis_duplicate_label_controls(qgs_pal_layer_settings, qgis_api) -> dict[str, object]:
+    return {
+        "qgis_version": getattr(qgis_api, "QGIS_VERSION", None),
+        **{
+            key: hasattr(qgs_pal_layer_settings, property_name)
+            for key, property_name in _QGIS_DUPLICATE_LABEL_CONTROL_PROPERTIES
+        },
+    }
 
 
 def _load_original_style(config: LabelSettingsConfig, fetch_mapbox_style_definition) -> dict[str, object]:
@@ -542,6 +574,10 @@ def _label_style_summary_rows(records: list[dict[str, object]]) -> list[dict[str
                 "repeat_distances": _sorted_count_map(row.get("repeat_distance") for row in layer_records),
                 "display_all": _sorted_count_map(row.get("display_all") for row in layer_records),
                 "obstacle": _sorted_count_map(row.get("obstacle") for row in layer_records),
+                "allow_degraded_placement": _sorted_count_map(
+                    row.get("allow_degraded_placement") for row in layer_records
+                ),
+                "overlap_handling": _sorted_count_map(row.get("overlap_handling") for row in layer_records),
                 "label_per_part": _sorted_count_map(row.get("label_per_part") for row in layer_records),
                 "merge_lines": _sorted_count_map(row.get("merge_lines") for row in layer_records),
             }
@@ -1218,6 +1254,8 @@ def _road_shield_label_placement_rows(
                     "repeat_distance": label_row.get("repeat_distance"),
                     "display_all": label_row.get("display_all"),
                     "obstacle": label_row.get("obstacle"),
+                    "allow_degraded_placement": label_row.get("allow_degraded_placement"),
+                    "overlap_handling": label_row.get("overlap_handling"),
                     "label_per_part": label_row.get("label_per_part"),
                     "merge_lines": label_row.get("merge_lines"),
                     "text_color": label_row.get("text_color"),
@@ -1572,6 +1610,7 @@ def _label_settings_report(
     sprite_count: int,
     records: list[dict[str, object]],
     source_label_layers: list[dict[str, object]] | None = None,
+    qgis_duplicate_label_controls: dict[str, object] | None = None,
 ) -> dict[str, object]:
     source_label_layer_rows = source_label_layers or []
     return {
@@ -1582,6 +1621,7 @@ def _label_settings_report(
         "sprite_context_requested": config.include_sprite_context,
         "sprite_context_loaded": sprite_loaded,
         "sprite_definition_count": sprite_count,
+        "qgis_duplicate_label_controls": qgis_duplicate_label_controls or {},
         "qgis_contour_bbox_edge_difference_label_probe": (
             config.qgis_contour_bbox_edge_difference_label_probe
         ),
@@ -1621,6 +1661,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             QgsApplication,
             QgsMapBoxGlStyleConversionContext,
             QgsMapBoxGlStyleConverter,
+            QgsPalLayerSettings,
             Qgis,
         )
     except ImportError as exc:  # pragma: no cover - depends on optional PyQGIS runtime
@@ -1655,6 +1696,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             sprite_count=sprite_count,
             records=records,
             source_label_layers=source_label_layers,
+            qgis_duplicate_label_controls=_qgis_duplicate_label_controls(QgsPalLayerSettings, Qgis),
         )
     finally:
         if created_app:
@@ -1718,6 +1760,19 @@ def _count_map_markdown_value(value: object) -> str:
     )
 
 
+def _qgis_duplicate_label_controls_markdown_value(value: object) -> str:
+    if not isinstance(value, dict) or not value:
+        return "—"
+    controls = [
+        f"{key}={_markdown_value(value.get(key))}"
+        for key, _property_name in _QGIS_DUPLICATE_LABEL_CONTROL_PROPERTIES
+    ]
+    qgis_version = value.get("qgis_version")
+    if qgis_version:
+        controls.insert(0, f"QGIS {_markdown_value(qgis_version)}")
+    return "; ".join(controls)
+
+
 def _zoom_range_markdown_value(minzoom: object, maxzoom: object) -> str:
     return _zoom_range_value(minzoom, maxzoom, _markdown_value)
 
@@ -1728,15 +1783,15 @@ def _append_label_style_summary(lines: list[str], summary_rows: list[object]) ->
             [
                 "## Label style summary by base layer",
                 "",
-                "| Base layer | Count | Source layers | Geometry | Priorities | Placements | Repeat distances | Display all | Obstacle | Label/part | Merge lines |",
-                "| --- | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+                "| Base layer | Count | Source layers | Geometry | Priorities | Placements | Repeat distances | Display all | Obstacle | Degraded placement | Overlap handling | Label/part | Merge lines |",
+                "| --- | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
         for row in summary_rows:
             if not isinstance(row, dict):
                 continue
             lines.append(
-                "| {base} | {count} | {source_layers} | {geometry} | {priorities} | {placements} | {repeat} | {display_all} | {obstacle} | {label_per_part} | {merge_lines} |".format(
+                "| {base} | {count} | {source_layers} | {geometry} | {priorities} | {placements} | {repeat} | {display_all} | {obstacle} | {allow_degraded} | {overlap} | {label_per_part} | {merge_lines} |".format(
                     base=_markdown_value(row.get("base_style_layer_id")),
                     count=_markdown_value(row.get("count")),
                     source_layers=_count_map_markdown_value(row.get("source_layers")),
@@ -1746,6 +1801,8 @@ def _append_label_style_summary(lines: list[str], summary_rows: list[object]) ->
                     repeat=_count_map_markdown_value(row.get("repeat_distances")),
                     display_all=_count_map_markdown_value(row.get("display_all")),
                     obstacle=_count_map_markdown_value(row.get("obstacle")),
+                    allow_degraded=_count_map_markdown_value(row.get("allow_degraded_placement")),
+                    overlap=_count_map_markdown_value(row.get("overlap_handling")),
                     label_per_part=_count_map_markdown_value(row.get("label_per_part")),
                     merge_lines=_count_map_markdown_value(row.get("merge_lines")),
                 )
@@ -1791,15 +1848,15 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 "",
                 "Focused `road-number-shield` rows for placement, repeat-distance, and collision-priority follow-up.",
                 "",
-                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Display all | Obstacle | Label/part | Merge lines | Text color |",
-                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- | --- | --- |",
+                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Display all | Obstacle | Degraded placement | Overlap handling | Label/part | Merge lines | Text color |",
+                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {display_all} | {obstacle} | {label_per_part} | {merge_lines} | {text_color} |".format(
+            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {display_all} | {obstacle} | {allow_degraded} | {overlap} | {label_per_part} | {merge_lines} | {text_color} |".format(
                 style=_markdown_value(row.get("style_name")),
                 source_zoom=_markdown_value(row.get("source_zoom")),
                 qfit_zoom=_markdown_value(row.get("qfit_zoom")),
@@ -1812,6 +1869,8 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 repeat=_markdown_value(row.get("repeat_distance")),
                 display_all=_markdown_value(row.get("display_all")),
                 obstacle=_markdown_value(row.get("obstacle")),
+                allow_degraded=_markdown_value(row.get("allow_degraded_placement")),
+                overlap=_markdown_value(row.get("overlap_handling")),
                 label_per_part=_markdown_value(row.get("label_per_part")),
                 merge_lines=_markdown_value(row.get("merge_lines")),
                 text_color=_markdown_value(row.get("text_color")),
@@ -2012,15 +2071,15 @@ def _append_converted_label_rows(lines: list[str], rows: list[object]) -> None:
         [
             "## Converted QGIS label styles",
             "",
-            "| Base layer | Style | Source layer | Geometry | Field | Expr | Priority | Placement | Placement flags | Repeat distance | Repeat unit | Display all | Obstacle | Text size | Text color | Text opacity | Buffer | Buffer size | Buffer color | Buffer opacity | Label/part | Merge lines | Geometry generator | Curve angles | Overrun | Data-defined keys |",
-            "| --- | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | --- | --- | --- | ---: | --- | ---: | --- | ---: | --- | ---: | --- | --- | --- | --- | --- | --- |",
+            "| Base layer | Style | Source layer | Geometry | Field | Expr | Priority | Placement | Placement flags | Repeat distance | Repeat unit | Display all | Obstacle | Degraded placement | Overlap handling | Text size | Text color | Text opacity | Buffer | Buffer size | Buffer color | Buffer opacity | Label/part | Merge lines | Geometry generator | Curve angles | Overrun | Data-defined keys |",
+            "| --- | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: | --- | --- | --- | --- | --- | ---: | --- | ---: | --- | ---: | --- | ---: | --- | --- | --- | --- | --- | --- |",
         ]
     )
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {base} | {style} | {source} | {geometry} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {text_size} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {generator} | {curve_angles} | {overrun} | {keys} |".format(
+            "| {base} | {style} | {source} | {geometry} | {field} | {expr} | {priority} | {placement} | {placement_flags} | {repeat} | {unit} | {display_all} | {obstacle} | {allow_degraded} | {overlap} | {text_size} | {text_color} | {text_opacity} | {buffer_enabled} | {buffer_size} | {buffer_color} | {buffer_opacity} | {label_per_part} | {merge_lines} | {generator} | {curve_angles} | {overrun} | {keys} |".format(
                 base=_markdown_value(row.get("base_style_layer_id")),
                 style=_markdown_value(row.get("style_name")),
                 source=_markdown_value(row.get("source_layer")),
@@ -2034,6 +2093,8 @@ def _append_converted_label_rows(lines: list[str], rows: list[object]) -> None:
                 unit=_markdown_value(row.get("repeat_distance_unit")),
                 display_all=_markdown_value(row.get("display_all")),
                 obstacle=_markdown_value(row.get("obstacle")),
+                allow_degraded=_markdown_value(row.get("allow_degraded_placement")),
+                overlap=_markdown_value(row.get("overlap_handling")),
                 text_size=_compound_markdown_value(row.get("text_size"), row.get("text_size_unit")),
                 text_color=_markdown_value(row.get("text_color")),
                 text_opacity=_markdown_value(row.get("text_opacity")),
@@ -2130,6 +2191,8 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"Converted label styles: {report.get('label_count', len(rows))}",
         f"Sprite context loaded: {_markdown_value(report.get('sprite_context_loaded'))}",
         f"Sprite definitions: {_markdown_value(report.get('sprite_definition_count'))}",
+        "QGIS duplicate-label controls: "
+        f"{_qgis_duplicate_label_controls_markdown_value(report.get('qgis_duplicate_label_controls'))}",
         f"Bbox-edge contour label probe: {_markdown_value(report.get('qgis_contour_bbox_edge_difference_label_probe'))}",
         "Bbox-edge source-style contour label probe: "
         f"{_markdown_value(report.get('qgis_contour_bbox_edge_difference_source_style_label_probe'))}",


### PR DESCRIPTION
## Summary
- add QGIS label placement overlap fields to the label-settings diagnostic output
- surface the same overlap controls in the focused road shield placement table
- report whether the running QGIS exposes duplicate-label property keys used by newer duplicate-label controls

## Evidence
- QGIS API docs list `LabelMarginDistance`, `RemoveDuplicateLabels`, and `RemoveDuplicateLabelDistance` as label properties added in QGIS 3.44: https://qgis.org/pyqgis/master/core/QgsPalLayerSettings.html
- Live diagnostic on this runtime reports QGIS `3.34.4-Prizren` with those duplicate-label property keys unavailable, while road shield labels use `PreventOverlap` and disallow degraded placement.
- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings-road-shield-overlap-capability/mapbox-outdoors-v12/20260520T150534Z/summary.md`

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Issue: #949
