### PR TITLE
Name QGIS label property keys

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -28,6 +28,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _load_original_style,
     _postprocessed_label_records,
     _qgis_duplicate_label_controls,
+    _qgis_pal_layer_property_names_by_value,
     _road_shield_label_placement_rows,
     _source_label_control_omission_summary_rows,
     _source_label_control_summary_rows,
@@ -192,7 +193,11 @@ class FakeQgsApplication:
 
 
 class FakeQgsPalLayerSettings:
-    pass
+    class Property(int):
+        pass
+
+    ShapeSizeX = Property(50)
+    Priority = Property(87)
 
 
 class FakeConversionContext:
@@ -319,6 +324,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         record = label_settings_record(
             FakeStyle(style_name="road-label-z15-plus", layer_name="road"),
             FakeSettings(),
+            {50: "ShapeSizeX", 87: "Priority"},
         )
 
         self.assertEqual(record["style_name"], "road-label-z15-plus")
@@ -355,6 +361,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertFalse(record["allow_degraded_placement"])
         self.assertEqual(record["overlap_handling"], "PreventOverlap")
         self.assertEqual(record["data_defined_property_keys"], [50, 87])
+        self.assertEqual(record["data_defined_property_names"], ["ShapeSizeX", "Priority"])
+        self.assertEqual(record["data_defined_property_labels"], ["ShapeSizeX (50)", "Priority (87)"])
 
     def test_ensure_qgis_application_reuses_or_creates_application(self):
         existing_app = FakeQgsApplication([], False)
@@ -386,6 +394,12 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertTrue(controls["remove_duplicate_labels"])
         self.assertTrue(controls["remove_duplicate_label_distance"])
         self.assertFalse(controls["label_margin_distance"])
+
+    def test_qgis_pal_layer_property_names_by_value_reports_enum_names(self):
+        names = _qgis_pal_layer_property_names_by_value(FakeQgsPalLayerSettings)
+
+        self.assertEqual(names[50], "ShapeSizeX")
+        self.assertEqual(names[87], "Priority")
 
     def test_load_original_style_uses_fixture_or_live_fetcher(self):
         config = LabelSettingsConfig(token=None, output_root=Path("/tmp"))
@@ -1689,6 +1703,10 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         labels_by_style = {row["style_name"]: row for row in report["labels"]}
         self.assertEqual(labels_by_style["road-label-z15-plus"]["base_style_layer_id"], "road-label")
         self.assertEqual(
+            labels_by_style["road-label-z15-plus"]["data_defined_property_labels"],
+            ["ShapeSizeX (50)", "Priority (87)"],
+        )
+        self.assertEqual(
             labels_by_style["contour-label-bbox-edge-difference-probe"]["geometry_generator"],
             bbox_expression,
         )
@@ -1894,7 +1912,9 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "buffer_size_unit": "Millimeters",
                     "buffer_color": "#dcdcd4",
                     "buffer_opacity": 0.75,
-                    "data_defined_property_keys": ["pipe|key"],
+                    "data_defined_property_keys": [50, 87],
+                    "data_defined_property_names": ["ShapeSizeX", "Priority"],
+                    "data_defined_property_labels": ["ShapeSizeX (50)", "Priority (87)"],
                 }
             ],
             "source_label_layers": [
@@ -1984,7 +2004,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("#626250", markdown)
         self.assertIn("#dcdcd4", markdown)
         self.assertIn("25/-25", markdown)
-        self.assertIn("pipe\\|key", markdown)
+        self.assertIn("ShapeSizeX (50), Priority (87)", markdown)
         self.assertIn("## Source Mapbox label controls", markdown)
         self.assertIn("Source label layers: 1", markdown)
         self.assertIn("| contour-label | contour-label | contour-label | contour | 12+", markdown)

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -324,7 +324,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         record = label_settings_record(
             FakeStyle(style_name="road-label-z15-plus", layer_name="road"),
             FakeSettings(),
-            {50: "ShapeSizeX", 87: "Priority"},
+            {50: "ShapeSizeX"},
         )
 
         self.assertEqual(record["style_name"], "road-label-z15-plus")
@@ -361,8 +361,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertFalse(record["allow_degraded_placement"])
         self.assertEqual(record["overlap_handling"], "PreventOverlap")
         self.assertEqual(record["data_defined_property_keys"], [50, 87])
-        self.assertEqual(record["data_defined_property_names"], ["ShapeSizeX", "Priority"])
-        self.assertEqual(record["data_defined_property_labels"], ["ShapeSizeX (50)", "Priority (87)"])
+        self.assertEqual(record["data_defined_property_names"], ["ShapeSizeX", "87"])
+        self.assertEqual(record["data_defined_property_labels"], ["ShapeSizeX (50)", "87"])
 
     def test_ensure_qgis_application_reuses_or_creates_application(self):
         existing_app = FakeQgsApplication([], False)
@@ -490,11 +490,13 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                 ]
             ),
             fake_apply_label_priority,
+            {50: "ShapeSizeX", 87: "Priority"},
         )
 
         self.assertEqual(FakeBackgroundMapService.applied_count, 1)
         self.assertIsInstance(FakeBackgroundMapService.labeling, FakeLabeling)
         self.assertEqual([record["base_style_layer_id"] for record in records], ["road-label", "waterway-label"])
+        self.assertEqual(records[0]["data_defined_property_names"], ["ShapeSizeX", "Priority"])
         self.assertEqual(_postprocessed_label_records(None, fake_apply_label_priority), [])
 
     def test_apply_labeling_probes_appends_bbox_edge_probes_when_requested(self):

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -332,13 +332,62 @@ def _data_defined_property_keys(settings: object) -> list[object]:
         return list(keys)
 
 
-def label_settings_record(style: object, settings: object) -> dict[str, object]:
+def _qgis_pal_layer_property_names_by_value(qgs_pal_layer_settings: object) -> dict[int, str]:
+    property_type = getattr(qgs_pal_layer_settings, "Property", None)
+    names: dict[int, str] = {}
+    for name, value in vars(qgs_pal_layer_settings).items():
+        try:
+            if property_type is not None and not isinstance(value, property_type):
+                continue
+            names[int(value)] = name
+        except (TypeError, ValueError):
+            continue
+    return names
+
+
+def _data_defined_property_names(
+    keys: list[object],
+    property_names_by_value: dict[int, str] | None,
+) -> list[str]:
+    names: list[str] = []
+    for key in keys:
+        try:
+            name = (property_names_by_value or {}).get(int(key))
+        except (TypeError, ValueError):
+            continue
+        if name is not None:
+            names.append(name)
+    return names
+
+
+def _data_defined_property_labels(
+    keys: list[object],
+    property_names_by_value: dict[int, str] | None,
+) -> list[str]:
+    labels: list[str] = []
+    for key in keys:
+        try:
+            int_key = int(key)
+        except (TypeError, ValueError):
+            labels.append(str(key))
+            continue
+        name = (property_names_by_value or {}).get(int_key)
+        labels.append(f"{name} ({int_key})" if name is not None else str(int_key))
+    return labels
+
+
+def label_settings_record(
+    style: object,
+    settings: object,
+    property_names_by_value: dict[int, str] | None = None,
+) -> dict[str, object]:
     _ensure_package_parent_on_path()
     from qfit.mapbox_config import base_mapbox_style_layer_id_for_qfit
 
     style_name = _method_value(style, "styleName")
     layer_name = _method_value(style, "layerName")
     style_name_text = style_name if isinstance(style_name, str) else ""
+    data_defined_property_keys = _data_defined_property_keys(settings)
     return {
         "style_name": style_name_text,
         "base_style_layer_id": base_mapbox_style_layer_id_for_qfit(style_name_text),
@@ -364,16 +413,27 @@ def label_settings_record(style: object, settings: object) -> dict[str, object]:
         "overrun_distance_unit": _settings_value(settings, "overrunDistanceUnit"),
         **_label_format_record(settings),
         **_label_placement_record(settings),
-        "data_defined_property_keys": _data_defined_property_keys(settings),
+        "data_defined_property_keys": data_defined_property_keys,
+        "data_defined_property_names": _data_defined_property_names(
+            data_defined_property_keys,
+            property_names_by_value,
+        ),
+        "data_defined_property_labels": _data_defined_property_labels(
+            data_defined_property_keys,
+            property_names_by_value,
+        ),
     }
 
 
-def _iter_label_records(labeling: object) -> Iterable[dict[str, object]]:
+def _iter_label_records(
+    labeling: object,
+    property_names_by_value: dict[int, str] | None = None,
+) -> Iterable[dict[str, object]]:
     for style in _method_value(labeling, "styles") or []:
         settings = _method_value(style, "labelSettings")
         if settings is None:
             continue
-        yield label_settings_record(style, settings)
+        yield label_settings_record(style, settings, property_names_by_value)
 
 
 def _apply_sprite_context(ctx: object, sprite_resources: object | None) -> bool:
@@ -458,11 +518,14 @@ def _postprocessed_label_records(labeling: object | None, apply_label_priority) 
     return _sorted_label_records(labeling)
 
 
-def _sorted_label_records(labeling: object | None) -> list[dict[str, object]]:
+def _sorted_label_records(
+    labeling: object | None,
+    property_names_by_value: dict[int, str] | None = None,
+) -> list[dict[str, object]]:
     if labeling is None:
         return []
     return sorted(
-        _iter_label_records(labeling),
+        _iter_label_records(labeling, property_names_by_value),
         key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
     )
 
@@ -1687,7 +1750,10 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
         if labeling is not None:
             apply_mapbox_label_priority(labeling)
         labeling = _apply_labeling_probes(labeling, config)
-        records = _sorted_label_records(labeling)
+        records = _sorted_label_records(
+            labeling,
+            _qgis_pal_layer_property_names_by_value(QgsPalLayerSettings),
+        )
         source_label_layers = source_label_layer_records(original_style, qfit_style, records)
         return _label_settings_report(
             config=config,
@@ -1737,6 +1803,13 @@ def _geometry_generator_markdown_value(row: dict[str, object]) -> str:
         row.get("geometry_generator_type"),
         row.get("geometry_generator"),
     )
+
+
+def _data_defined_property_markdown_value(row: dict[str, object]) -> str:
+    labels = row.get("data_defined_property_labels")
+    if isinstance(labels, list) and labels:
+        return _markdown_value(labels)
+    return _markdown_value(row.get("data_defined_property_keys"))
 
 
 def _json_markdown_value(value: object) -> str:
@@ -2114,7 +2187,7 @@ def _append_converted_label_rows(lines: list[str], rows: list[object]) -> None:
                     row.get("overrun_distance"),
                     row.get("overrun_distance_unit"),
                 ),
-                keys=_markdown_value(row.get("data_defined_property_keys")),
+                keys=_data_defined_property_markdown_value(row),
             )
         )
 

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -352,11 +352,12 @@ def _data_defined_property_names(
     names: list[str] = []
     for key in keys:
         try:
-            name = (property_names_by_value or {}).get(int(key))
+            int_key = int(key)
         except (TypeError, ValueError):
+            names.append(str(key))
             continue
-        if name is not None:
-            names.append(name)
+        name = (property_names_by_value or {}).get(int_key)
+        names.append(name if name is not None else str(int_key))
     return names
 
 
@@ -511,11 +512,15 @@ def _convert_style_to_labeling(qfit_style: dict[str, object], sprite_resources: 
     return result, converter.labeling(), sprite_loaded
 
 
-def _postprocessed_label_records(labeling: object | None, apply_label_priority) -> list[dict[str, object]]:
+def _postprocessed_label_records(
+    labeling: object | None,
+    apply_label_priority,
+    property_names_by_value: dict[int, str] | None = None,
+) -> list[dict[str, object]]:
     if labeling is None:
         return []
     apply_label_priority(labeling)
-    return _sorted_label_records(labeling)
+    return _sorted_label_records(labeling, property_names_by_value)
 
 
 def _sorted_label_records(


### PR DESCRIPTION
## Summary
- decode QGIS `QgsPalLayerSettings.Property` enum values in the label-settings diagnostic
- keep the raw data-defined property keys in JSON while adding aligned names and markdown labels such as `ShapeSizeX (50)`
- make road-shield and settlement label data-defined properties easier to audit without manually mapping integers

## Evidence
- Previous live reports showed road shield converted labels with opaque data-defined key `50`.
- Fresh live diagnostic now renders those rows as `ShapeSizeX (50)` and settlement rows as `OffsetQuad (77), Priority (87)`.
- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings-data-defined-property-names/mapbox-outdoors-v12/20260520T152505Z/summary.md`

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Issue: #949
