### PR TITLE
Surface road shield data-defined keys

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -1091,6 +1091,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "label_per_part": False,
                     "merge_lines": True,
                     "text_color": "#1d1f25",
+                    "data_defined_property_keys": [50],
+                    "data_defined_property_labels": ["ShapeSizeX (50)"],
                 },
                 {
                     "style_name": "road-number-shield-2-remaining-icons-below-z11",
@@ -1135,6 +1137,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(z11_plus["overlap_handling"], "PreventOverlap")
         self.assertFalse(z11_plus["label_per_part"])
         self.assertTrue(z11_plus["merge_lines"])
+        self.assertEqual(z11_plus["data_defined_property_keys"], [50])
+        self.assertEqual(z11_plus["data_defined_property_labels"], ["ShapeSizeX (50)"])
 
     def test_line_center_label_conversion_summary_isolates_line_center_labels(self):
         rows = _line_center_label_conversion_rows(
@@ -1785,6 +1789,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "label_per_part": False,
                     "merge_lines": True,
                     "text_color": "#1d1f25",
+                    "data_defined_property_keys": [50],
+                    "data_defined_property_labels": ["ShapeSizeX (50)"],
                 }
             ],
             "line_label_repeat_spacing_by_base_layer": [
@@ -1958,7 +1964,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
-            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | #1d1f25 |",
+            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | #1d1f25 | ShapeSizeX (50) |",
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -1327,6 +1327,8 @@ def _road_shield_label_placement_rows(
                     "label_per_part": label_row.get("label_per_part"),
                     "merge_lines": label_row.get("merge_lines"),
                     "text_color": label_row.get("text_color"),
+                    "data_defined_property_keys": label_row.get("data_defined_property_keys"),
+                    "data_defined_property_labels": label_row.get("data_defined_property_labels"),
                 }
             )
     return sorted(
@@ -1926,15 +1928,15 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 "",
                 "Focused `road-number-shield` rows for placement, repeat-distance, and collision-priority follow-up.",
                 "",
-                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Display all | Obstacle | Degraded placement | Overlap handling | Label/part | Merge lines | Text color |",
-                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |",
+                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Display all | Obstacle | Degraded placement | Overlap handling | Label/part | Merge lines | Text color | Data-defined keys |",
+                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {display_all} | {obstacle} | {allow_degraded} | {overlap} | {label_per_part} | {merge_lines} | {text_color} |".format(
+            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {display_all} | {obstacle} | {allow_degraded} | {overlap} | {label_per_part} | {merge_lines} | {text_color} | {keys} |".format(
                 style=_markdown_value(row.get("style_name")),
                 source_zoom=_markdown_value(row.get("source_zoom")),
                 qfit_zoom=_markdown_value(row.get("qfit_zoom")),
@@ -1952,6 +1954,7 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 label_per_part=_markdown_value(row.get("label_per_part")),
                 merge_lines=_markdown_value(row.get("merge_lines")),
                 text_color=_markdown_value(row.get("text_color")),
+                keys=_data_defined_property_markdown_value(row),
             )
         )
     if rows:


### PR DESCRIPTION
## Summary
- add decoded data-defined property keys to the focused road shield label placement table
- preserve the existing focused placement/collision fields while showing whether converted shield rows carry data-defined overrides
- cover the focused row and markdown output in label-settings tests

## Evidence
- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings-road-shield-data-defined-detail/mapbox-outdoors-v12/20260520T153511Z/summary.md`
- The focused `road-number-shield` placement table now shows z11-plus remaining-icon shield rows with `ShapeSizeX (50)` beside placement, repeat distance, collision, and merge-lines fields.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Issue: #949
