### PR TITLE
Surface road shield background settings

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -65,6 +65,18 @@ class FakeColor:
         return self._name
 
 
+class FakeSize:
+    def __init__(self, width, height):
+        self._width = width
+        self._height = height
+
+    def width(self):
+        return self._width
+
+    def height(self):
+        return self._height
+
+
 class FakeTextBuffer:
     def enabled(self):
         return True
@@ -82,6 +94,38 @@ class FakeTextBuffer:
         return 0.75
 
 
+class FakeTextBackground:
+    def enabled(self):
+        return True
+
+    def type(self):
+        return SimpleNamespace(name="ShapeRectangle")
+
+    def size(self):
+        return FakeSize(4.4979166667, 2.6458333333)
+
+    def sizeType(self):
+        return SimpleNamespace(name="SizeFixed")
+
+    def sizeUnit(self):
+        return SimpleNamespace(name="Millimeters")
+
+    def fillColor(self):
+        return FakeColor("#ffffff")
+
+    def strokeColor(self):
+        return FakeColor("#1d1f25")
+
+    def strokeWidth(self):
+        return 0.2
+
+    def strokeWidthUnit(self):
+        return SimpleNamespace(name="Millimeters")
+
+    def opacity(self):
+        return 1.0
+
+
 class FakeTextFormat:
     def size(self):
         return 2.5135416667
@@ -97,6 +141,9 @@ class FakeTextFormat:
 
     def buffer(self):
         return FakeTextBuffer()
+
+    def background(self):
+        return FakeTextBackground()
 
 
 class FakePlacementSettings:
@@ -358,6 +405,16 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["buffer_size_unit"], "Millimeters")
         self.assertEqual(record["buffer_color"], "#dcdcd4")
         self.assertEqual(record["buffer_opacity"], 0.75)
+        self.assertTrue(record["background_enabled"])
+        self.assertEqual(record["background_type"], "ShapeRectangle")
+        self.assertEqual(record["background_size"], {"width": 4.4979166667, "height": 2.6458333333})
+        self.assertEqual(record["background_size_type"], "SizeFixed")
+        self.assertEqual(record["background_size_unit"], "Millimeters")
+        self.assertEqual(record["background_fill_color"], "#ffffff")
+        self.assertEqual(record["background_stroke_color"], "#1d1f25")
+        self.assertEqual(record["background_stroke_width"], 0.2)
+        self.assertEqual(record["background_stroke_width_unit"], "Millimeters")
+        self.assertEqual(record["background_opacity"], 1.0)
         self.assertFalse(record["allow_degraded_placement"])
         self.assertEqual(record["overlap_handling"], "PreventOverlap")
         self.assertEqual(record["data_defined_property_keys"], [50, 87])
@@ -1090,7 +1147,19 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": True,
+                    "text_size": 2.38125,
+                    "text_size_unit": "Millimeters",
                     "text_color": "#1d1f25",
+                    "background_enabled": True,
+                    "background_type": "ShapeRectangle",
+                    "background_size": {"width": 4.4979166667, "height": 2.6458333333},
+                    "background_size_type": "SizeFixed",
+                    "background_size_unit": "Millimeters",
+                    "background_fill_color": "#ffffff",
+                    "background_stroke_color": "#1d1f25",
+                    "background_stroke_width": 0.2,
+                    "background_stroke_width_unit": "Millimeters",
+                    "background_opacity": 1.0,
                     "data_defined_property_keys": [50],
                     "data_defined_property_labels": ["ShapeSizeX (50)"],
                 },
@@ -1137,6 +1206,13 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(z11_plus["overlap_handling"], "PreventOverlap")
         self.assertFalse(z11_plus["label_per_part"])
         self.assertTrue(z11_plus["merge_lines"])
+        self.assertAlmostEqual(z11_plus["text_size"], 2.38125)
+        self.assertEqual(z11_plus["text_size_unit"], "Millimeters")
+        self.assertEqual(z11_plus["background_type"], "ShapeRectangle")
+        self.assertEqual(z11_plus["background_size"], {"width": 4.4979166667, "height": 2.6458333333})
+        self.assertEqual(z11_plus["background_fill_color"], "#ffffff")
+        self.assertEqual(z11_plus["background_stroke_color"], "#1d1f25")
+        self.assertEqual(z11_plus["background_stroke_width"], 0.2)
         self.assertEqual(z11_plus["data_defined_property_keys"], [50])
         self.assertEqual(z11_plus["data_defined_property_labels"], ["ShapeSizeX (50)"])
 
@@ -1788,7 +1864,19 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "overlap_handling": "PreventOverlap",
                     "label_per_part": False,
                     "merge_lines": True,
+                    "text_size": 2.38125,
+                    "text_size_unit": "Millimeters",
                     "text_color": "#1d1f25",
+                    "background_enabled": True,
+                    "background_type": "ShapeRectangle",
+                    "background_size": {"width": 4.4979166667, "height": 2.6458333333},
+                    "background_size_type": "SizeFixed",
+                    "background_size_unit": "Millimeters",
+                    "background_fill_color": "#ffffff",
+                    "background_stroke_color": "#1d1f25",
+                    "background_stroke_width": 0.2,
+                    "background_stroke_width_unit": "Millimeters",
+                    "background_opacity": 1.0,
                     "data_defined_property_keys": [50],
                     "data_defined_property_labels": ["ShapeSizeX (50)"],
                 }
@@ -1964,7 +2052,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
-            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | #1d1f25 | ShapeSizeX (50) |",
+            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | 2.38125 Millimeters | #1d1f25 | yes ShapeRectangle | 4.49792 x 2.64583 SizeFixed Millimeters | #ffffff 1 | #1d1f25 0.2 Millimeters | ShapeSizeX (50) |",
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -287,6 +287,42 @@ def _color_name(value: object) -> object:
     return name if isinstance(name, str) else None
 
 
+def _size_dimensions(value: object) -> dict[str, object] | None:
+    width = _method_value(value, "width")
+    height = _method_value(value, "height")
+    if width is None and height is None:
+        return None
+    return {"width": width, "height": height}
+
+
+def _label_background_record(text_format: object) -> dict[str, object]:
+    background = _method_value(text_format, "background") if text_format is not None else None
+    fill_color = _method_value(background, "fillColor") if background is not None else None
+    stroke_color = _method_value(background, "strokeColor") if background is not None else None
+    return {
+        "background_enabled": _method_value(background, "enabled") if background is not None else None,
+        "background_type": _enum_name(_method_value(background, "type")) if background is not None else None,
+        "background_size": (
+            _size_dimensions(_method_value(background, "size")) if background is not None else None
+        ),
+        "background_size_type": (
+            _enum_name(_method_value(background, "sizeType")) if background is not None else None
+        ),
+        "background_size_unit": (
+            _enum_name(_method_value(background, "sizeUnit")) if background is not None else None
+        ),
+        "background_fill_color": _color_name(fill_color),
+        "background_stroke_color": _color_name(stroke_color),
+        "background_stroke_width": (
+            _method_value(background, "strokeWidth") if background is not None else None
+        ),
+        "background_stroke_width_unit": (
+            _enum_name(_method_value(background, "strokeWidthUnit")) if background is not None else None
+        ),
+        "background_opacity": _method_value(background, "opacity") if background is not None else None,
+    }
+
+
 def _label_format_record(settings: object) -> dict[str, object]:
     text_format = _method_value(settings, "format")
     buffer = _method_value(text_format, "buffer") if text_format is not None else None
@@ -302,6 +338,7 @@ def _label_format_record(settings: object) -> dict[str, object]:
         "buffer_size_unit": _enum_name(_method_value(buffer, "sizeUnit")) if buffer is not None else None,
         "buffer_color": _color_name(buffer_color),
         "buffer_opacity": _method_value(buffer, "opacity") if buffer is not None else None,
+        **_label_background_record(text_format),
     }
 
 
@@ -1326,7 +1363,19 @@ def _road_shield_label_placement_rows(
                     "overlap_handling": label_row.get("overlap_handling"),
                     "label_per_part": label_row.get("label_per_part"),
                     "merge_lines": label_row.get("merge_lines"),
+                    "text_size": label_row.get("text_size"),
+                    "text_size_unit": label_row.get("text_size_unit"),
                     "text_color": label_row.get("text_color"),
+                    "background_enabled": label_row.get("background_enabled"),
+                    "background_type": label_row.get("background_type"),
+                    "background_size": label_row.get("background_size"),
+                    "background_size_type": label_row.get("background_size_type"),
+                    "background_size_unit": label_row.get("background_size_unit"),
+                    "background_fill_color": label_row.get("background_fill_color"),
+                    "background_stroke_color": label_row.get("background_stroke_color"),
+                    "background_stroke_width": label_row.get("background_stroke_width"),
+                    "background_stroke_width_unit": label_row.get("background_stroke_width_unit"),
+                    "background_opacity": label_row.get("background_opacity"),
                     "data_defined_property_keys": label_row.get("data_defined_property_keys"),
                     "data_defined_property_labels": label_row.get("data_defined_property_labels"),
                 }
@@ -1795,6 +1844,16 @@ def _compound_markdown_value(*values: object, separator: str = " ") -> str:
     return separator.join(rendered_values)
 
 
+def _size_markdown_value(size: object, *context: object) -> str:
+    if not isinstance(size, dict):
+        return _compound_markdown_value(size, *context)
+    width = size.get("width")
+    height = size.get("height")
+    if width is None and height is None:
+        return _compound_markdown_value(None, *context)
+    return _compound_markdown_value(f"{_markdown_value(width)} x {_markdown_value(height)}", *context)
+
+
 def _geometry_generator_markdown_value(row: dict[str, object]) -> str:
     if row.get("geometry_generator_enabled") is False:
         return "no"
@@ -1928,15 +1987,15 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 "",
                 "Focused `road-number-shield` rows for placement, repeat-distance, and collision-priority follow-up.",
                 "",
-                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Display all | Obstacle | Degraded placement | Overlap handling | Label/part | Merge lines | Text color | Data-defined keys |",
-                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
+                "| Style | Source zoom | QGIS zoom | Source placement | QGIS style placement | QGIS symbol spacing | Geometry | Converted placement | Priority | Repeat distance | Display all | Obstacle | Degraded placement | Overlap handling | Label/part | Merge lines | Text size | Text color | Background | Background size | Background fill / opacity | Background stroke | Data-defined keys |",
+                "| --- | --- | --- | --- | --- | ---: | --- | --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
     for row in rows:
         if not isinstance(row, dict):
             continue
         lines.append(
-            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {display_all} | {obstacle} | {allow_degraded} | {overlap} | {label_per_part} | {merge_lines} | {text_color} | {keys} |".format(
+            "| {style} | {source_zoom} | {qfit_zoom} | {source_placement} | {qfit_placement} | {qfit_spacing} | {geometry} | {placement} | {priority} | {repeat} | {display_all} | {obstacle} | {allow_degraded} | {overlap} | {label_per_part} | {merge_lines} | {text_size} | {text_color} | {background} | {background_size} | {background_fill} | {background_stroke} | {keys} |".format(
                 style=_markdown_value(row.get("style_name")),
                 source_zoom=_markdown_value(row.get("source_zoom")),
                 qfit_zoom=_markdown_value(row.get("qfit_zoom")),
@@ -1953,7 +2012,23 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                 overlap=_markdown_value(row.get("overlap_handling")),
                 label_per_part=_markdown_value(row.get("label_per_part")),
                 merge_lines=_markdown_value(row.get("merge_lines")),
+                text_size=_compound_markdown_value(row.get("text_size"), row.get("text_size_unit")),
                 text_color=_markdown_value(row.get("text_color")),
+                background=_compound_markdown_value(row.get("background_enabled"), row.get("background_type")),
+                background_size=_size_markdown_value(
+                    row.get("background_size"),
+                    row.get("background_size_type"),
+                    row.get("background_size_unit"),
+                ),
+                background_fill=_compound_markdown_value(
+                    row.get("background_fill_color"),
+                    row.get("background_opacity"),
+                ),
+                background_stroke=_compound_markdown_value(
+                    row.get("background_stroke_color"),
+                    row.get("background_stroke_width"),
+                    row.get("background_stroke_width_unit"),
+                ),
                 keys=_data_defined_property_markdown_value(row),
             )
         )


### PR DESCRIPTION
## Summary
- record QGIS text-background settings in the Mapbox Outdoors label-settings diagnostic
- surface road-shield text size, background shape state, shape size, fill/opacity, and stroke beside placement/collision fields
- cover the structured road-shield row and focused markdown output in tests

## Evidence
- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings-road-shield-background-detail/mapbox-outdoors-v12/20260520T155226Z/summary.md`
- The focused `road-number-shield` placement table now shows z11-plus remaining-icon shield rows with QGIS background dimensions such as `5 x 4`, `7 x 4`, `8 x 4`, `10 x 4`, and `12 x 4` alongside `ShapeSizeX (50)`.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Issue: #949
