### PR TITLE
Name road shield background enums

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -29,6 +29,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _postprocessed_label_records,
     _qgis_duplicate_label_controls,
     _qgis_pal_layer_property_names_by_value,
+    _qgis_text_background_enum_names_by_field,
     _road_shield_label_placement_rows,
     _source_label_control_omission_summary_rows,
     _source_label_control_summary_rows,
@@ -95,17 +96,23 @@ class FakeTextBuffer:
 
 
 class FakeTextBackground:
+    def __init__(self, *, type_value=None, size_type_value=None):
+        self._type_value = type_value if type_value is not None else SimpleNamespace(name="ShapeRectangle")
+        self._size_type_value = (
+            size_type_value if size_type_value is not None else SimpleNamespace(name="SizeFixed")
+        )
+
     def enabled(self):
         return True
 
     def type(self):
-        return SimpleNamespace(name="ShapeRectangle")
+        return self._type_value
 
     def size(self):
         return FakeSize(4.4979166667, 2.6458333333)
 
     def sizeType(self):
-        return SimpleNamespace(name="SizeFixed")
+        return self._size_type_value
 
     def sizeUnit(self):
         return SimpleNamespace(name="Millimeters")
@@ -127,6 +134,9 @@ class FakeTextBackground:
 
 
 class FakeTextFormat:
+    def __init__(self, *, background=None):
+        self._background = background if background is not None else FakeTextBackground()
+
     def size(self):
         return 2.5135416667
 
@@ -143,7 +153,7 @@ class FakeTextFormat:
         return FakeTextBuffer()
 
     def background(self):
-        return FakeTextBackground()
+        return self._background
 
 
 class FakePlacementSettings:
@@ -247,6 +257,15 @@ class FakeQgsPalLayerSettings:
     Priority = Property(87)
 
 
+class FakeQgsTextBackgroundSettings:
+    ShapeRectangle = 0
+    ShapeMarkerSymbol = 5
+    ShapeType = object()
+    SizeBuffer = 0
+    SizeFixed = 1
+    SizeType = object()
+
+
 class FakeConversionContext:
     last_instance = None
 
@@ -303,6 +322,7 @@ def _fake_qgis_modules():
     core_module.QgsMapBoxGlStyleConversionContext = FakeConversionContext
     core_module.QgsMapBoxGlStyleConverter = FakeConverter
     core_module.QgsPalLayerSettings = FakeQgsPalLayerSettings
+    core_module.QgsTextBackgroundSettings = FakeQgsTextBackgroundSettings
     core_module.Qgis = SimpleNamespace(RenderUnit=SimpleNamespace(Millimeters="millimeters"))
     qgis_module.core = core_module
     return {"qgis": qgis_module, "qgis.core": core_module}
@@ -458,6 +478,37 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(names[50], "ShapeSizeX")
         self.assertEqual(names[87], "Priority")
 
+    def test_qgis_text_background_enum_names_by_field_reports_runtime_enum_names(self):
+        names = _qgis_text_background_enum_names_by_field(FakeQgsTextBackgroundSettings)
+
+        self.assertEqual(names["type"][0], "ShapeRectangle")
+        self.assertEqual(names["type"][5], "ShapeMarkerSymbol")
+        self.assertEqual(names["size_type"][0], "SizeBuffer")
+        self.assertEqual(names["size_type"][1], "SizeFixed")
+
+    def test_label_settings_record_decodes_numeric_background_enums(self):
+        class NumericBackgroundSettings(FakeSettings):
+            def format(self):
+                return FakeTextFormat(
+                    background=FakeTextBackground(
+                        type_value=5,
+                        size_type_value=1,
+                    )
+                )
+
+        record = label_settings_record(
+            FakeStyle(style_name="road-number-shield-2-remaining-icons-z11-plus", layer_name="road"),
+            NumericBackgroundSettings(),
+            {50: "ShapeSizeX"},
+            {
+                "type": {5: "ShapeMarkerSymbol"},
+                "size_type": {1: "SizeFixed"},
+            },
+        )
+
+        self.assertEqual(record["background_type"], "ShapeMarkerSymbol")
+        self.assertEqual(record["background_size_type"], "SizeFixed")
+
     def test_load_original_style_uses_fixture_or_live_fetcher(self):
         config = LabelSettingsConfig(token=None, output_root=Path("/tmp"))
         with self.assertRaises(ValueError):
@@ -555,6 +606,32 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual([record["base_style_layer_id"] for record in records], ["road-label", "waterway-label"])
         self.assertEqual(records[0]["data_defined_property_names"], ["ShapeSizeX", "Priority"])
         self.assertEqual(_postprocessed_label_records(None, fake_apply_label_priority), [])
+
+    def test_postprocessed_label_records_forwards_background_enum_names(self):
+        class NumericBackgroundSettings(FakeSettings):
+            def format(self):
+                return FakeTextFormat(background=FakeTextBackground(type_value=5, size_type_value=1))
+
+        records = _postprocessed_label_records(
+            FakeLabeling(
+                [
+                    FakeLabelStyle(
+                        style_name="road-number-shield-2-remaining-icons-z11-plus",
+                        layer_name="road",
+                        settings=NumericBackgroundSettings(),
+                    ),
+                ]
+            ),
+            fake_apply_label_priority,
+            {50: "ShapeSizeX", 87: "Priority"},
+            {
+                "type": {5: "ShapeMarkerSymbol"},
+                "size_type": {1: "SizeFixed"},
+            },
+        )
+
+        self.assertEqual(records[0]["background_type"], "ShapeMarkerSymbol")
+        self.assertEqual(records[0]["background_size_type"], "SizeFixed")
 
     def test_apply_labeling_probes_appends_bbox_edge_probes_when_requested(self):
         original_labeling = FakeLabeling([])

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -267,11 +267,18 @@ def _method_value(obj: object, method_name: str) -> object:
         return None
 
 
-def _enum_name(value: object) -> object:
+def _enum_name(value: object, names_by_value: dict[int, str] | None = None) -> object:
     name = getattr(value, "name", None)
     if isinstance(name, str):
         return name
-    return str(value) if value is not None else None
+    if value is None:
+        return None
+    try:
+        int_value = int(value)
+    except (TypeError, ValueError):
+        return str(value)
+    mapped_name = (names_by_value or {}).get(int_value)
+    return mapped_name if mapped_name is not None else str(value)
 
 
 def _settings_value(settings: object, name: str) -> object:
@@ -295,18 +302,28 @@ def _size_dimensions(value: object) -> dict[str, object] | None:
     return {"width": width, "height": height}
 
 
-def _label_background_record(text_format: object) -> dict[str, object]:
+def _label_background_record(
+    text_format: object,
+    background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
+) -> dict[str, object]:
     background = _method_value(text_format, "background") if text_format is not None else None
     fill_color = _method_value(background, "fillColor") if background is not None else None
     stroke_color = _method_value(background, "strokeColor") if background is not None else None
+    enum_names = background_enum_names_by_field or {}
     return {
         "background_enabled": _method_value(background, "enabled") if background is not None else None,
-        "background_type": _enum_name(_method_value(background, "type")) if background is not None else None,
+        "background_type": (
+            _enum_name(_method_value(background, "type"), enum_names.get("type"))
+            if background is not None
+            else None
+        ),
         "background_size": (
             _size_dimensions(_method_value(background, "size")) if background is not None else None
         ),
         "background_size_type": (
-            _enum_name(_method_value(background, "sizeType")) if background is not None else None
+            _enum_name(_method_value(background, "sizeType"), enum_names.get("size_type"))
+            if background is not None
+            else None
         ),
         "background_size_unit": (
             _enum_name(_method_value(background, "sizeUnit")) if background is not None else None
@@ -323,7 +340,10 @@ def _label_background_record(text_format: object) -> dict[str, object]:
     }
 
 
-def _label_format_record(settings: object) -> dict[str, object]:
+def _label_format_record(
+    settings: object,
+    background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
+) -> dict[str, object]:
     text_format = _method_value(settings, "format")
     buffer = _method_value(text_format, "buffer") if text_format is not None else None
     text_color = _method_value(text_format, "color") if text_format is not None else None
@@ -338,7 +358,7 @@ def _label_format_record(settings: object) -> dict[str, object]:
         "buffer_size_unit": _enum_name(_method_value(buffer, "sizeUnit")) if buffer is not None else None,
         "buffer_color": _color_name(buffer_color),
         "buffer_opacity": _method_value(buffer, "opacity") if buffer is not None else None,
-        **_label_background_record(text_format),
+        **_label_background_record(text_format, background_enum_names_by_field),
     }
 
 
@@ -382,6 +402,34 @@ def _qgis_pal_layer_property_names_by_value(qgs_pal_layer_settings: object) -> d
     return names
 
 
+def _qgis_prefixed_enum_names_by_value(enum_owner: object, prefix: str, ignored_names: set[str]) -> dict[int, str]:
+    # QGIS enum values within one prefix are expected to be unique; collisions keep the later class attr.
+    names: dict[int, str] = {}
+    for name, value in vars(enum_owner).items():
+        if name in ignored_names or not name.startswith(prefix):
+            continue
+        try:
+            names[int(value)] = name
+        except (TypeError, ValueError):
+            continue
+    return names
+
+
+def _qgis_text_background_enum_names_by_field(qgs_text_background_settings: object) -> dict[str, dict[int, str]]:
+    return {
+        "type": _qgis_prefixed_enum_names_by_value(
+            qgs_text_background_settings,
+            "Shape",
+            {"ShapeType"},
+        ),
+        "size_type": _qgis_prefixed_enum_names_by_value(
+            qgs_text_background_settings,
+            "Size",
+            {"SizeType"},
+        ),
+    }
+
+
 def _data_defined_property_names(
     keys: list[object],
     property_names_by_value: dict[int, str] | None,
@@ -418,6 +466,7 @@ def label_settings_record(
     style: object,
     settings: object,
     property_names_by_value: dict[int, str] | None = None,
+    background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
 ) -> dict[str, object]:
     _ensure_package_parent_on_path()
     from qfit.mapbox_config import base_mapbox_style_layer_id_for_qfit
@@ -449,7 +498,7 @@ def label_settings_record(
         "max_curved_char_angle_out": _settings_value(settings, "maxCurvedCharAngleOut"),
         "overrun_distance": _settings_value(settings, "overrunDistance"),
         "overrun_distance_unit": _settings_value(settings, "overrunDistanceUnit"),
-        **_label_format_record(settings),
+        **_label_format_record(settings, background_enum_names_by_field),
         **_label_placement_record(settings),
         "data_defined_property_keys": data_defined_property_keys,
         "data_defined_property_names": _data_defined_property_names(
@@ -466,12 +515,18 @@ def label_settings_record(
 def _iter_label_records(
     labeling: object,
     property_names_by_value: dict[int, str] | None = None,
+    background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
 ) -> Iterable[dict[str, object]]:
     for style in _method_value(labeling, "styles") or []:
         settings = _method_value(style, "labelSettings")
         if settings is None:
             continue
-        yield label_settings_record(style, settings, property_names_by_value)
+        yield label_settings_record(
+            style,
+            settings,
+            property_names_by_value,
+            background_enum_names_by_field,
+        )
 
 
 def _apply_sprite_context(ctx: object, sprite_resources: object | None) -> bool:
@@ -553,21 +608,23 @@ def _postprocessed_label_records(
     labeling: object | None,
     apply_label_priority,
     property_names_by_value: dict[int, str] | None = None,
+    background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
 ) -> list[dict[str, object]]:
     if labeling is None:
         return []
     apply_label_priority(labeling)
-    return _sorted_label_records(labeling, property_names_by_value)
+    return _sorted_label_records(labeling, property_names_by_value, background_enum_names_by_field)
 
 
 def _sorted_label_records(
     labeling: object | None,
     property_names_by_value: dict[int, str] | None = None,
+    background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
 ) -> list[dict[str, object]]:
     if labeling is None:
         return []
     return sorted(
-        _iter_label_records(labeling, property_names_by_value),
+        _iter_label_records(labeling, property_names_by_value, background_enum_names_by_field),
         key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
     )
 
@@ -1781,6 +1838,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             QgsMapBoxGlStyleConversionContext,
             QgsMapBoxGlStyleConverter,
             QgsPalLayerSettings,
+            QgsTextBackgroundSettings,
             Qgis,
         )
     except ImportError as exc:  # pragma: no cover - depends on optional PyQGIS runtime
@@ -1809,6 +1867,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
         records = _sorted_label_records(
             labeling,
             _qgis_pal_layer_property_names_by_value(QgsPalLayerSettings),
+            _qgis_text_background_enum_names_by_field(QgsTextBackgroundSettings),
         )
         source_label_layers = source_label_layer_records(original_style, qfit_style, records)
         return _label_settings_report(


### PR DESCRIPTION
## Summary
- decode QGIS text-background type and size-type enum integers in the Mapbox Outdoors label-settings diagnostic
- keep existing enum-name handling for PyQGIS objects that already expose `.name`
- cover runtime enum map extraction, numeric background decoding, and postprocessed label-record forwarding in tests

## Evidence
- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings-road-shield-background-enum-labels/mapbox-outdoors-v12/20260520T160024Z/summary.md`
- The focused `road-number-shield` table now reports background values such as `yes ShapeMarkerSymbol` and `5 x 4 SizeFixed Millimeters` instead of opaque numeric `5` / `1` values.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Issue: #949
