### PR TITLE
Show data-defined label property values

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -29,6 +29,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _postprocessed_label_records,
     _qgis_duplicate_label_controls,
     _qgis_pal_layer_property_names_by_value,
+    _qgis_property_type_names_by_value,
     _qgis_text_background_enum_names_by_field,
     _road_shield_label_placement_rows,
     _source_label_control_omission_summary_rows,
@@ -51,11 +52,47 @@ from qfit.validation.mapbox_outdoors_label_settings import (
 
 
 class FakeProperties:
-    def __init__(self, keys):
+    def __init__(self, keys, properties=None):
         self._keys = keys
+        self._properties = properties or {}
 
     def propertyKeys(self):
         return self._keys
+
+    def property(self, key):
+        return self._properties.get(key)
+
+
+class FakeProperty:
+    def __init__(
+        self,
+        *,
+        property_type,
+        active=True,
+        expression="",
+        field="",
+        static_value=None,
+    ):
+        self._property_type = property_type
+        self._active = active
+        self._expression = expression
+        self._field = field
+        self._static_value = static_value
+
+    def propertyType(self):
+        return self._property_type
+
+    def isActive(self):
+        return self._active
+
+    def expressionString(self):
+        return self._expression
+
+    def field(self):
+        return self._field
+
+    def staticValue(self):
+        return self._static_value
 
 
 class FakeColor:
@@ -218,7 +255,16 @@ class FakeSettings:
     overrunDistanceUnit = SimpleNamespace(name="Millimeters")
 
     def dataDefinedProperties(self):
-        return FakeProperties([87, 50])
+        return FakeProperties(
+            [87, 50],
+            {
+                50: FakeProperty(
+                    property_type=3,
+                    expression='CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END',
+                ),
+                87: FakeProperty(property_type=1, static_value=6),
+            },
+        )
 
     def format(self):
         return FakeTextFormat()
@@ -264,6 +310,13 @@ class FakeQgsTextBackgroundSettings:
     SizeBuffer = 0
     SizeFixed = 1
     SizeType = object()
+
+
+class FakeQgsProperty:
+    InvalidProperty = 0
+    StaticProperty = 1
+    FieldBasedProperty = 2
+    ExpressionBasedProperty = 3
 
 
 class FakeConversionContext:
@@ -322,6 +375,7 @@ def _fake_qgis_modules():
     core_module.QgsMapBoxGlStyleConversionContext = FakeConversionContext
     core_module.QgsMapBoxGlStyleConverter = FakeConverter
     core_module.QgsPalLayerSettings = FakeQgsPalLayerSettings
+    core_module.QgsProperty = FakeQgsProperty
     core_module.QgsTextBackgroundSettings = FakeQgsTextBackgroundSettings
     core_module.Qgis = SimpleNamespace(RenderUnit=SimpleNamespace(Millimeters="millimeters"))
     qgis_module.core = core_module
@@ -392,6 +446,10 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             FakeStyle(style_name="road-label-z15-plus", layer_name="road"),
             FakeSettings(),
             {50: "ShapeSizeX"},
+            property_type_names_by_value={
+                1: "StaticProperty",
+                3: "ExpressionBasedProperty",
+            },
         )
 
         self.assertEqual(record["style_name"], "road-label-z15-plus")
@@ -440,6 +498,31 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(record["data_defined_property_keys"], [50, 87])
         self.assertEqual(record["data_defined_property_names"], ["ShapeSizeX", "87"])
         self.assertEqual(record["data_defined_property_labels"], ["ShapeSizeX (50)", "87"])
+        self.assertEqual(
+            record["data_defined_property_details"],
+            [
+                {
+                    "key": 50,
+                    "name": "ShapeSizeX",
+                    "label": "ShapeSizeX (50)",
+                    "active": True,
+                    "property_type": "ExpressionBasedProperty",
+                    "expression": 'CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END',
+                    "field": None,
+                    "static_value": None,
+                },
+                {
+                    "key": 87,
+                    "name": "87",
+                    "label": "87",
+                    "active": True,
+                    "property_type": "StaticProperty",
+                    "expression": None,
+                    "field": None,
+                    "static_value": 6,
+                },
+            ],
+        )
 
     def test_ensure_qgis_application_reuses_or_creates_application(self):
         existing_app = FakeQgsApplication([], False)
@@ -485,6 +568,14 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(names["type"][5], "ShapeMarkerSymbol")
         self.assertEqual(names["size_type"][0], "SizeBuffer")
         self.assertEqual(names["size_type"][1], "SizeFixed")
+
+    def test_qgis_property_type_names_by_value_reports_enum_names(self):
+        names = _qgis_property_type_names_by_value(FakeQgsProperty)
+
+        self.assertEqual(names[0], "InvalidProperty")
+        self.assertEqual(names[1], "StaticProperty")
+        self.assertEqual(names[2], "FieldBasedProperty")
+        self.assertEqual(names[3], "ExpressionBasedProperty")
 
     def test_label_settings_record_decodes_numeric_background_enums(self):
         class NumericBackgroundSettings(FakeSettings):
@@ -1239,6 +1330,18 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "background_opacity": 1.0,
                     "data_defined_property_keys": [50],
                     "data_defined_property_labels": ["ShapeSizeX (50)"],
+                    "data_defined_property_details": [
+                        {
+                            "key": 50,
+                            "name": "ShapeSizeX",
+                            "label": "ShapeSizeX (50)",
+                            "active": True,
+                            "property_type": "ExpressionBasedProperty",
+                            "expression": 'CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END',
+                            "field": None,
+                            "static_value": None,
+                        }
+                    ],
                 },
                 {
                     "style_name": "road-number-shield-2-remaining-icons-below-z11",
@@ -1292,6 +1395,10 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(z11_plus["background_stroke_width"], 0.2)
         self.assertEqual(z11_plus["data_defined_property_keys"], [50])
         self.assertEqual(z11_plus["data_defined_property_labels"], ["ShapeSizeX (50)"])
+        self.assertEqual(
+            z11_plus["data_defined_property_details"][0]["expression"],
+            'CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END',
+        )
 
     def test_line_center_label_conversion_summary_isolates_line_center_labels(self):
         rows = _line_center_label_conversion_rows(
@@ -1956,6 +2063,18 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "background_opacity": 1.0,
                     "data_defined_property_keys": [50],
                     "data_defined_property_labels": ["ShapeSizeX (50)"],
+                    "data_defined_property_details": [
+                        {
+                            "key": 50,
+                            "name": "ShapeSizeX",
+                            "label": "ShapeSizeX (50)",
+                            "active": True,
+                            "property_type": "ExpressionBasedProperty",
+                            "expression": 'CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END',
+                            "field": None,
+                            "static_value": None,
+                        }
+                    ],
                 }
             ],
             "line_label_repeat_spacing_by_base_layer": [
@@ -2129,7 +2248,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
-            "| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, ['zoom'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | 2.38125 Millimeters | #1d1f25 | yes ShapeRectangle | 4.49792 x 2.64583 SizeFixed Millimeters | #ffffff 1 | #1d1f25 0.2 Millimeters | ShapeSizeX (50) |",
+            '| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, [\'zoom\'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | 2.38125 Millimeters | #1d1f25 | yes ShapeRectangle | 4.49792 x 2.64583 SizeFixed Millimeters | #ffffff 1 | #1d1f25 0.2 Millimeters | ShapeSizeX (50): ExpressionBasedProperty CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END |',
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -2078,7 +2078,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                             "key": 87,
                             "name": "Priority",
                             "label": "Priority (87)",
-                            "active": True,
+                            "active": False,
                             "property_type": "StaticProperty",
                             "expression": None,
                             "field": None,
@@ -2258,7 +2258,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
-            '| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, [\'zoom\'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | 2.38125 Millimeters | #1d1f25 | yes ShapeRectangle | 4.49792 x 2.64583 SizeFixed Millimeters | #ffffff 1 | #1d1f25 0.2 Millimeters | ShapeSizeX (50): ExpressionBasedProperty CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END, Priority (87): StaticProperty 0 |',
+            '| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, [\'zoom\'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | 2.38125 Millimeters | #1d1f25 | yes ShapeRectangle | 4.49792 x 2.64583 SizeFixed Millimeters | #ffffff 1 | #1d1f25 0.2 Millimeters | ShapeSizeX (50): ExpressionBasedProperty CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END, Priority (87): StaticProperty inactive 0 |',
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -2061,8 +2061,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "background_stroke_width": 0.2,
                     "background_stroke_width_unit": "Millimeters",
                     "background_opacity": 1.0,
-                    "data_defined_property_keys": [50],
-                    "data_defined_property_labels": ["ShapeSizeX (50)"],
+                    "data_defined_property_keys": [50, 87],
+                    "data_defined_property_labels": ["ShapeSizeX (50)", "Priority (87)"],
                     "data_defined_property_details": [
                         {
                             "key": 50,
@@ -2073,7 +2073,17 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                             "expression": 'CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END',
                             "field": None,
                             "static_value": None,
-                        }
+                        },
+                        {
+                            "key": 87,
+                            "name": "Priority",
+                            "label": "Priority (87)",
+                            "active": True,
+                            "property_type": "StaticProperty",
+                            "expression": None,
+                            "field": None,
+                            "static_value": 0,
+                        },
                     ],
                 }
             ],
@@ -2248,7 +2258,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         )
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
-            '| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, [\'zoom\'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | 2.38125 Millimeters | #1d1f25 | yes ShapeRectangle | 4.49792 x 2.64583 SizeFixed Millimeters | #ffffff 1 | #1d1f25 0.2 Millimeters | ShapeSizeX (50): ExpressionBasedProperty CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END |',
+            '| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, [\'zoom\'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | 2.38125 Millimeters | #1d1f25 | yes ShapeRectangle | 4.49792 x 2.64583 SizeFixed Millimeters | #ffffff 1 | #1d1f25 0.2 Millimeters | ShapeSizeX (50): ExpressionBasedProperty CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END, Priority (87): StaticProperty 0 |',
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -2013,6 +2013,16 @@ def _geometry_generator_markdown_value(row: dict[str, object]) -> str:
     )
 
 
+def _data_defined_property_detail_value(detail: dict[str, object]) -> object:
+    expression = detail.get("expression")
+    if expression not in (None, ""):
+        return expression
+    field = detail.get("field")
+    if field not in (None, ""):
+        return field
+    return detail.get("static_value")
+
+
 def _data_defined_property_markdown_value(row: dict[str, object]) -> str:
     details = row.get("data_defined_property_details")
     if isinstance(details, list) and details:
@@ -2023,7 +2033,7 @@ def _data_defined_property_markdown_value(row: dict[str, object]) -> str:
             label = _markdown_value(detail.get("label"))
             parts = [
                 _markdown_value(detail.get("property_type")),
-                _markdown_value(detail.get("expression") or detail.get("field") or detail.get("static_value")),
+                _markdown_value(_data_defined_property_detail_value(detail)),
             ]
             rendered_parts = [part for part in parts if part != "—"]
             rendered_details.append(f"{label}: {' '.join(rendered_parts)}" if rendered_parts else label)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -389,6 +389,16 @@ def _data_defined_property_keys(settings: object) -> list[object]:
         return list(keys)
 
 
+def _collection_property(properties: object, key: object) -> object:
+    method = getattr(properties, "property", None)
+    if not callable(method):
+        return None
+    try:
+        return method(key)
+    except (AttributeError, RuntimeError, TypeError):
+        return None
+
+
 def _qgis_pal_layer_property_names_by_value(qgs_pal_layer_settings: object) -> dict[int, str]:
     property_type = getattr(qgs_pal_layer_settings, "Property", None)
     names: dict[int, str] = {}
@@ -430,6 +440,16 @@ def _qgis_text_background_enum_names_by_field(qgs_text_background_settings: obje
     }
 
 
+def _qgis_property_type_names_by_value(qgs_property: object) -> dict[int, str]:
+    names: dict[int, str] = {}
+    for name in ("InvalidProperty", "StaticProperty", "FieldBasedProperty", "ExpressionBasedProperty"):
+        try:
+            names[int(getattr(qgs_property, name))] = name
+        except (AttributeError, TypeError, ValueError):
+            continue
+    return names
+
+
 def _data_defined_property_names(
     keys: list[object],
     property_names_by_value: dict[int, str] | None,
@@ -462,11 +482,51 @@ def _data_defined_property_labels(
     return labels
 
 
+def _json_safe_property_value(value: object) -> object:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
+def _data_defined_property_details(
+    settings: object,
+    keys: list[object],
+    property_names_by_value: dict[int, str] | None,
+    property_type_names_by_value: dict[int, str] | None,
+) -> list[dict[str, object]]:
+    properties = _method_value(settings, "dataDefinedProperties")
+    details: list[dict[str, object]] = []
+    for key in keys:
+        detail = {
+            "key": key,
+            "name": _data_defined_property_names([key], property_names_by_value)[0],
+            "label": _data_defined_property_labels([key], property_names_by_value)[0],
+        }
+        property_value = _collection_property(properties, key) if properties is not None else None
+        if property_value is not None:
+            property_type = _method_value(property_value, "propertyType")
+            expression = _method_value(property_value, "expressionString")
+            field = _method_value(property_value, "field")
+            static_value = _method_value(property_value, "staticValue")
+            detail.update(
+                {
+                    "active": _method_value(property_value, "isActive"),
+                    "property_type": _enum_name(property_type, property_type_names_by_value),
+                    "expression": expression if isinstance(expression, str) and expression else None,
+                    "field": field if isinstance(field, str) and field else None,
+                    "static_value": _json_safe_property_value(static_value),
+                }
+            )
+        details.append(detail)
+    return details
+
+
 def label_settings_record(
     style: object,
     settings: object,
     property_names_by_value: dict[int, str] | None = None,
     background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
+    property_type_names_by_value: dict[int, str] | None = None,
 ) -> dict[str, object]:
     _ensure_package_parent_on_path()
     from qfit.mapbox_config import base_mapbox_style_layer_id_for_qfit
@@ -509,6 +569,12 @@ def label_settings_record(
             data_defined_property_keys,
             property_names_by_value,
         ),
+        "data_defined_property_details": _data_defined_property_details(
+            settings,
+            data_defined_property_keys,
+            property_names_by_value,
+            property_type_names_by_value,
+        ),
     }
 
 
@@ -516,6 +582,7 @@ def _iter_label_records(
     labeling: object,
     property_names_by_value: dict[int, str] | None = None,
     background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
+    property_type_names_by_value: dict[int, str] | None = None,
 ) -> Iterable[dict[str, object]]:
     for style in _method_value(labeling, "styles") or []:
         settings = _method_value(style, "labelSettings")
@@ -526,6 +593,7 @@ def _iter_label_records(
             settings,
             property_names_by_value,
             background_enum_names_by_field,
+            property_type_names_by_value,
         )
 
 
@@ -609,22 +677,34 @@ def _postprocessed_label_records(
     apply_label_priority,
     property_names_by_value: dict[int, str] | None = None,
     background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
+    property_type_names_by_value: dict[int, str] | None = None,
 ) -> list[dict[str, object]]:
     if labeling is None:
         return []
     apply_label_priority(labeling)
-    return _sorted_label_records(labeling, property_names_by_value, background_enum_names_by_field)
+    return _sorted_label_records(
+        labeling,
+        property_names_by_value,
+        background_enum_names_by_field,
+        property_type_names_by_value,
+    )
 
 
 def _sorted_label_records(
     labeling: object | None,
     property_names_by_value: dict[int, str] | None = None,
     background_enum_names_by_field: dict[str, dict[int, str]] | None = None,
+    property_type_names_by_value: dict[int, str] | None = None,
 ) -> list[dict[str, object]]:
     if labeling is None:
         return []
     return sorted(
-        _iter_label_records(labeling, property_names_by_value, background_enum_names_by_field),
+        _iter_label_records(
+            labeling,
+            property_names_by_value,
+            background_enum_names_by_field,
+            property_type_names_by_value,
+        ),
         key=lambda row: (str(row.get("base_style_layer_id") or ""), str(row.get("style_name") or "")),
     )
 
@@ -1435,6 +1515,7 @@ def _road_shield_label_placement_rows(
                     "background_opacity": label_row.get("background_opacity"),
                     "data_defined_property_keys": label_row.get("data_defined_property_keys"),
                     "data_defined_property_labels": label_row.get("data_defined_property_labels"),
+                    "data_defined_property_details": label_row.get("data_defined_property_details"),
                 }
             )
     return sorted(
@@ -1838,6 +1919,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             QgsMapBoxGlStyleConversionContext,
             QgsMapBoxGlStyleConverter,
             QgsPalLayerSettings,
+            QgsProperty,
             QgsTextBackgroundSettings,
             Qgis,
         )
@@ -1868,6 +1950,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             labeling,
             _qgis_pal_layer_property_names_by_value(QgsPalLayerSettings),
             _qgis_text_background_enum_names_by_field(QgsTextBackgroundSettings),
+            _qgis_property_type_names_by_value(QgsProperty),
         )
         source_label_layers = source_label_layer_records(original_style, qfit_style, records)
         return _label_settings_report(
@@ -1931,6 +2014,21 @@ def _geometry_generator_markdown_value(row: dict[str, object]) -> str:
 
 
 def _data_defined_property_markdown_value(row: dict[str, object]) -> str:
+    details = row.get("data_defined_property_details")
+    if isinstance(details, list) and details:
+        rendered_details: list[str] = []
+        for detail in details:
+            if not isinstance(detail, dict):
+                continue
+            label = _markdown_value(detail.get("label"))
+            parts = [
+                _markdown_value(detail.get("property_type")),
+                _markdown_value(detail.get("expression") or detail.get("field") or detail.get("static_value")),
+            ]
+            rendered_parts = [part for part in parts if part != "—"]
+            rendered_details.append(f"{label}: {' '.join(rendered_parts)}" if rendered_parts else label)
+        if rendered_details:
+            return ", ".join(rendered_details)
     labels = row.get("data_defined_property_labels")
     if isinstance(labels, list) and labels:
         return _markdown_value(labels)

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -2033,6 +2033,7 @@ def _data_defined_property_markdown_value(row: dict[str, object]) -> str:
             label = _markdown_value(detail.get("label"))
             parts = [
                 _markdown_value(detail.get("property_type")),
+                "inactive" if detail.get("active") is False else "—",
                 _markdown_value(_data_defined_property_detail_value(detail)),
             ]
             rendered_parts = [part for part in parts if part != "—"]

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -2023,21 +2023,29 @@ def _data_defined_property_detail_value(detail: dict[str, object]) -> object:
     return detail.get("static_value")
 
 
+def _data_defined_property_detail_markdown_value(detail: object) -> str | None:
+    if not isinstance(detail, dict):
+        return None
+    label = _markdown_value(detail.get("label"))
+    parts = [
+        _markdown_value(detail.get("property_type")),
+        "inactive" if detail.get("active") is False else "—",
+        _markdown_value(_data_defined_property_detail_value(detail)),
+    ]
+    rendered_parts = [part for part in parts if part != "—"]
+    if rendered_parts:
+        return f"{label}: {' '.join(rendered_parts)}"
+    return label
+
+
 def _data_defined_property_markdown_value(row: dict[str, object]) -> str:
     details = row.get("data_defined_property_details")
     if isinstance(details, list) and details:
-        rendered_details: list[str] = []
-        for detail in details:
-            if not isinstance(detail, dict):
-                continue
-            label = _markdown_value(detail.get("label"))
-            parts = [
-                _markdown_value(detail.get("property_type")),
-                "inactive" if detail.get("active") is False else "—",
-                _markdown_value(_data_defined_property_detail_value(detail)),
-            ]
-            rendered_parts = [part for part in parts if part != "—"]
-            rendered_details.append(f"{label}: {' '.join(rendered_parts)}" if rendered_parts else label)
+        rendered_details = [
+            rendered
+            for detail in details
+            if (rendered := _data_defined_property_detail_markdown_value(detail)) is not None
+        ]
         if rendered_details:
             return ", ".join(rendered_details)
     labels = row.get("data_defined_property_labels")


### PR DESCRIPTION
## Summary
- include QGIS data-defined label property details in the Mapbox Outdoors label-settings diagnostic
- surface property type plus expression/field/static value in focused road-shield and converted-label markdown rows
- cover property-type enum naming, structured data-defined property details, and markdown rendering in tests

## Evidence
- Live diagnostic artifact: `debug/mapbox-outdoors-label-settings-road-shield-data-defined-values/mapbox-outdoors-v12/20260520T161815Z/summary.md`
- The focused `road-number-shield` table now shows `ShapeSizeX (50): ExpressionBasedProperty ...` for z11-plus remaining-icon shield rows, exposing the QGIS width expression behind the previous key-only diagnostic.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Issue: #949
