### PR TITLE
Flag empty data-defined label expressions

### DIFF
--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -17,6 +17,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe,
     _apply_labeling_probes,
     _convert_style_to_labeling,
+    _data_defined_expression_issue_rows,
     _ensure_qgis_application,
     _fetch_sprite_resources,
     _geometry_generator_markdown_value,
@@ -955,7 +956,19 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             result="success",
             sprite_loaded=True,
             sprite_count=440,
-            records=[{"style_name": "contour-label"}],
+            records=[
+                {
+                    "base_style_layer_id": "contour-label",
+                    "style_name": "contour-label",
+                    "data_defined_property_details": [
+                        {
+                            "label": "ShapeSizeX (50)",
+                            "property_type": "ExpressionBasedProperty",
+                            "expression": 'CASE WHEN "shield" IN () THEN 5 ELSE 5 END',
+                        }
+                    ],
+                }
+            ],
             source_label_layers=[{"base_style_layer_id": "contour-label"}],
         )
 
@@ -969,6 +982,19 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(report["label_style_summary_by_base_layer"][0]["base_style_layer_id"], "contour-label")
         self.assertEqual(report["label_style_summary_by_base_layer"][0]["count"], 1)
         self.assertEqual(report["line_label_repeat_spacing_by_base_layer"], [])
+        self.assertEqual(
+            report["data_defined_expression_issue_rows"],
+            [
+                {
+                    "base_style_layer_id": "contour-label",
+                    "style_name": "contour-label",
+                    "property": "ShapeSizeX (50)",
+                    "property_type": "ExpressionBasedProperty",
+                    "empty_in_clause_count": 1,
+                    "expression_length": 42,
+                }
+            ],
+        )
         self.assertEqual(report["source_label_fanout_by_base_layer"][0]["base_style_layer_id"], "contour-label")
         self.assertEqual(report["source_label_fanout_by_base_layer"][0]["converted_label_styles"], 1)
         self.assertEqual(report["source_label_control_summary_by_base_layer"][0]["base_style_layer_id"], "contour-label")
@@ -976,6 +1002,47 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(report["source_label_control_omission_summary_by_base_layer"], [])
         self.assertEqual(report["source_label_unresolved_control_summary_by_base_layer"], [])
         self.assertEqual(report["source_label_layer_count"], 1)
+
+    def test_data_defined_expression_issue_rows_count_empty_in_clauses(self):
+        rows = _data_defined_expression_issue_rows(
+            [
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-2-remaining-icons-z11-plus",
+                    "data_defined_property_details": [
+                        {
+                            "label": "ShapeSizeX (50)",
+                            "property_type": "ExpressionBasedProperty",
+                            "expression": 'CASE WHEN "shield" IN () THEN 5 WHEN "shield" IN () THEN 6 ELSE 5 END',
+                        },
+                        {
+                            "label": "Priority (87)",
+                            "property_type": "ExpressionBasedProperty",
+                            "expression": 'CASE WHEN "class" IN (\'primary\') THEN 6 ELSE 3 END',
+                        },
+                    ],
+                },
+                {
+                    "base_style_layer_id": "road-label",
+                    "style_name": "road-label-z15-plus",
+                    "data_defined_property_details": [{"label": "Priority (87)", "static_value": 0}],
+                },
+            ]
+        )
+
+        self.assertEqual(
+            rows,
+            [
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-2-remaining-icons-z11-plus",
+                    "property": "ShapeSizeX (50)",
+                    "property_type": "ExpressionBasedProperty",
+                    "empty_in_clause_count": 2,
+                    "expression_length": 69,
+                }
+            ],
+        )
 
     def test_label_style_summary_groups_density_relevant_settings(self):
         rows = _label_style_summary_rows(
@@ -2087,6 +2154,16 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     ],
                 }
             ],
+            "data_defined_expression_issue_rows": [
+                {
+                    "base_style_layer_id": "road-number-shield",
+                    "style_name": "road-number-shield-2-remaining-icons-z11-plus",
+                    "property": "ShapeSizeX (50)",
+                    "property_type": "ExpressionBasedProperty",
+                    "empty_in_clause_count": 2,
+                    "expression_length": 69,
+                }
+            ],
             "line_label_repeat_spacing_by_base_layer": [
                 {
                     "base_style_layer_id": "contour-label",
@@ -2259,6 +2336,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("## Road shield label placement detail", markdown)
         self.assertIn(
             '| road-number-shield-2-remaining-icons-z11-plus | 6+ | 11+ | step, [\'zoom\'], point, 11, line | line | 466.667 | Line | Horizontal | 6 | 123.472 | no | yes | no | PreventOverlap | no | yes | 2.38125 Millimeters | #1d1f25 | yes ShapeRectangle | 4.49792 x 2.64583 SizeFixed Millimeters | #ffffff 1 | #1d1f25 0.2 Millimeters | ShapeSizeX (50): ExpressionBasedProperty CASE WHEN length("ref") > 3 THEN 8 ELSE 5 END, Priority (87): StaticProperty inactive 0 |',
+            markdown,
+        )
+        self.assertIn("## Data-defined expression issues", markdown)
+        self.assertIn(
+            "| road-number-shield | road-number-shield-2-remaining-icons-z11-plus | ShapeSizeX (50) | ExpressionBasedProperty | 2 | 69 |",
             markdown,
         )
         self.assertIn("## Line label repeat spacing by base layer", markdown)

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -1004,6 +1004,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertEqual(report["source_label_layer_count"], 1)
 
     def test_data_defined_expression_issue_rows_count_empty_in_clauses(self):
+        empty_expression = (
+            'CASE WHEN "shield" IN () THEN 5 '
+            'WHEN "shield" in() THEN 6 '
+            'WHEN "shield" IN (   ) THEN 7 ELSE 5 END'
+        )
         rows = _data_defined_expression_issue_rows(
             [
                 {
@@ -1013,7 +1018,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                         {
                             "label": "ShapeSizeX (50)",
                             "property_type": "ExpressionBasedProperty",
-                            "expression": 'CASE WHEN "shield" IN () THEN 5 WHEN "shield" in () THEN 6 ELSE 5 END',
+                            "expression": empty_expression,
                         },
                         {
                             "label": "Priority (87)",
@@ -1038,8 +1043,8 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                     "style_name": "road-number-shield-2-remaining-icons-z11-plus",
                     "property": "ShapeSizeX (50)",
                     "property_type": "ExpressionBasedProperty",
-                    "empty_in_clause_count": 2,
-                    "expression_length": 69,
+                    "empty_in_clause_count": 3,
+                    "expression_length": len(empty_expression),
                 }
             ],
         )

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -1013,7 +1013,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
                         {
                             "label": "ShapeSizeX (50)",
                             "property_type": "ExpressionBasedProperty",
-                            "expression": 'CASE WHEN "shield" IN () THEN 5 WHEN "shield" IN () THEN 6 ELSE 5 END',
+                            "expression": 'CASE WHEN "shield" IN () THEN 5 WHEN "shield" in () THEN 6 ELSE 5 END',
                         },
                         {
                             "label": "Priority (87)",

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -4,6 +4,7 @@ import argparse
 import datetime as dt
 import json
 import os
+import re
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -16,6 +17,7 @@ DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-label-settings"
 DEFAULT_MAPBOX_STYLE_OWNER = "mapbox"
 DEFAULT_MAPBOX_STYLE_ID = "outdoors-v12"
 DEFAULT_QT_QPA_PLATFORM = "offscreen"
+_EMPTY_IN_CLAUSE_RE = re.compile(r"\bin\s*\(\s*\)", re.IGNORECASE)
 _BOOL_COUNT_KEY_MARKDOWN_VALUES = {"false": "no", "true": "yes"}
 _SOURCE_LABEL_LAYOUT_PROPERTIES = (
     "symbol-placement",
@@ -1539,7 +1541,9 @@ def _data_defined_expression_issue_rows(
             if not isinstance(detail, dict):
                 continue
             expression = detail.get("expression")
-            empty_in_clause_count = expression.upper().count("IN ()") if isinstance(expression, str) else 0
+            empty_in_clause_count = (
+                len(_EMPTY_IN_CLAUSE_RE.findall(expression)) if isinstance(expression, str) else 0
+            )
             if empty_in_clause_count <= 0:
                 continue
             rows.append(

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -1539,7 +1539,7 @@ def _data_defined_expression_issue_rows(
             if not isinstance(detail, dict):
                 continue
             expression = detail.get("expression")
-            empty_in_clause_count = expression.count("IN ()") if isinstance(expression, str) else 0
+            empty_in_clause_count = expression.upper().count("IN ()") if isinstance(expression, str) else 0
             if empty_in_clause_count <= 0:
                 continue
             rows.append(

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -1527,6 +1527,42 @@ def _road_shield_label_placement_rows(
     )
 
 
+def _data_defined_expression_issue_rows(
+    label_records: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for record in label_records:
+        details = record.get("data_defined_property_details")
+        if not isinstance(details, list):
+            continue
+        for detail in details:
+            if not isinstance(detail, dict):
+                continue
+            expression = detail.get("expression")
+            empty_in_clause_count = expression.count("IN ()") if isinstance(expression, str) else 0
+            if empty_in_clause_count <= 0:
+                continue
+            rows.append(
+                {
+                    "base_style_layer_id": record.get("base_style_layer_id"),
+                    "style_name": record.get("style_name"),
+                    "property": detail.get("label"),
+                    "property_type": detail.get("property_type"),
+                    "empty_in_clause_count": empty_in_clause_count,
+                    "expression_length": len(expression),
+                }
+            )
+    return sorted(
+        rows,
+        key=lambda row: (
+            -int(row["empty_in_clause_count"]),
+            _summary_key(row.get("base_style_layer_id")),
+            _summary_key(row.get("style_name")),
+            _summary_key(row.get("property")),
+        ),
+    )
+
+
 def _line_center_label_conversion_rows(
     source_label_layers: list[dict[str, object]],
     label_records: list[dict[str, object]],
@@ -1892,6 +1928,7 @@ def _label_settings_report(
         "labels": records,
         "label_style_summary_by_base_layer": _label_style_summary_rows(records),
         "road_shield_label_placement_rows": _road_shield_label_placement_rows(source_label_layer_rows, records),
+        "data_defined_expression_issue_rows": _data_defined_expression_issue_rows(records),
         "line_label_repeat_spacing_by_base_layer": _line_label_repeat_spacing_rows(source_label_layer_rows, records),
         "line_label_conversion_by_base_layer": _line_label_conversion_rows(source_label_layer_rows, records),
         "line_center_label_conversion_by_base_layer": _line_center_label_conversion_rows(
@@ -2206,6 +2243,35 @@ def _append_road_shield_label_placement_rows(lines: list[str], rows: list[object
                     row.get("background_stroke_width_unit"),
                 ),
                 keys=_data_defined_property_markdown_value(row),
+            )
+        )
+    if rows:
+        lines.append("")
+
+
+def _append_data_defined_expression_issue_rows(lines: list[str], rows: list[object]) -> None:
+    if rows:
+        lines.extend(
+            [
+                "## Data-defined expression issues",
+                "",
+                "QGIS data-defined label properties whose converted expressions include empty `IN ()` clauses.",
+                "",
+                "| Base layer | Style | Property | Type | Empty IN clauses | Expression length |",
+                "| --- | --- | --- | --- | ---: | ---: |",
+            ]
+        )
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        lines.append(
+            "| {base} | {style} | {prop} | {type} | {empty_count} | {length} |".format(
+                base=_markdown_value(row.get("base_style_layer_id")),
+                style=_markdown_value(row.get("style_name")),
+                prop=_markdown_value(row.get("property")),
+                type=_markdown_value(row.get("property_type")),
+                empty_count=_markdown_value(row.get("empty_in_clause_count")),
+                length=_markdown_value(row.get("expression_length")),
             )
         )
     if rows:
@@ -2538,6 +2604,11 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         road_shield_label_placement if isinstance(road_shield_label_placement, list) else []
     )
     _append_road_shield_label_placement_rows(lines, road_shield_label_placement_rows)
+    data_defined_expression_issues = report.get("data_defined_expression_issue_rows")
+    data_defined_expression_issue_rows = (
+        data_defined_expression_issues if isinstance(data_defined_expression_issues, list) else []
+    )
+    _append_data_defined_expression_issue_rows(lines, data_defined_expression_issue_rows)
     _append_line_label_repeat_spacing_summary(lines, line_repeat_rows)
     _append_line_label_conversion_summary(lines, line_conversion_rows)
     _append_line_center_label_conversion_summary(lines, line_center_conversion_rows)


### PR DESCRIPTION
## Summary
- Add a focused label-settings diagnostic table for data-defined label property expressions that contain empty `IN ()` clauses.
- Include the affected base layer, converted style, property label/type, empty-clause count, and expression length.
- Cover report generation and markdown rendering with tests, including case-insensitive empty-clause detection.

## Evidence
- Issue #949 follow-up after PR #1225 exposed road-shield `ShapeSizeX` expression values.
- Fresh live artifact: `debug/mapbox-outdoors-label-settings-data-defined-expression-issues/mapbox-outdoors-v12/20260520T165039Z/summary.md`.
- The artifact shows 10 affected `road-number-shield` z11-plus remaining-icon rows, with the highest empty `IN ()` count at 25 for reflen-2 remaining-icon variants.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- Live label-settings diagnostic using the local profile token source without exposing it.

Issue #949
