### PR TITLE
fix: tokenize road shield icon layers

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1790,20 +1790,16 @@ def _is_road_number_shield_icon_image(expr: object) -> bool:
     )
 
 
-def _road_shield_icon_match(
-    field_name: str,
+def _road_shield_sprite_bases(
     reflen: int,
     excluded_sprite_bases: Iterable[str] = (),
-) -> list[object]:
-    fallback = f"default-{reflen}"
+) -> tuple[str, ...]:
     excluded = set(excluded_sprite_bases)
-    values = tuple(value for value in _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen] if value not in excluded)
-    return [
-        "match",
-        ["get", field_name],
-        *(item for value in values for item in (value, f"{value}-{reflen}")),
-        fallback,
-    ]
+    return tuple(value for value in _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen] if value not in excluded)
+
+
+def _road_shield_icon_token(field_name: str, reflen: int) -> str:
+    return f"{{{field_name}}}-{reflen}"
 
 
 def _road_shield_reflen_filter(reflen: int) -> list[object]:
@@ -1831,19 +1827,23 @@ def _road_shield_literal_icon_filter(field_name: str, sprite_base: str) -> list[
     return ["==", ["get", field_name], sprite_base]
 
 
-def _road_shield_remaining_icon_filter(field_name: str, sprite_bases: tuple[str, ...]) -> list[object]:
+def _road_shield_known_icon_filter(field_name: str, sprite_bases: tuple[str, ...]) -> list[object]:
+    return ["match", ["get", field_name], list(sprite_bases), True, False]
+
+
+def _road_shield_default_icon_filter(field_name: str, sprite_bases: tuple[str, ...]) -> list[object]:
     return ["match", ["get", field_name], list(sprite_bases), False, True]
 
 
-def _road_shield_literal_icon_layer_variants(
+def _road_shield_icon_layer_variants(
     layer: dict[str, object],
     *,
     field_name: str,
     reflen: int,
 ) -> list[dict[str, object]]:
     literal_bases = _road_shield_literal_icon_bases(reflen)
-    if not literal_bases:
-        return [layer]
+    token_bases = _road_shield_sprite_bases(reflen, literal_bases)
+    fallback_filter_bases = _road_shield_sprite_bases(reflen)
 
     variants: list[dict[str, object]] = []
     for sprite_base in literal_bases:
@@ -1859,18 +1859,25 @@ def _road_shield_literal_icon_layer_variants(
             paint["text-color"] = _ROAD_SHIELD_LITERAL_ICON_TEXT_COLORS[sprite_base]
         variants.append(literal_layer)
 
-    remaining_layer = copy.deepcopy(layer)
-    remaining_layer["id"] = f"{layer['id']}-remaining-icons"
-    remaining_layer["filter"] = _with_additional_filter_clauses(
+    # QGIS converts tokenized icon-image strings into valid field equality
+    # expressions, while large match lists can produce empty IN clauses.
+    token_layer = copy.deepcopy(layer)
+    token_layer["id"] = f"{layer['id']}-known-icons"
+    token_layer["filter"] = _with_additional_filter_clauses(
         layer.get("filter"),
-        _road_shield_remaining_icon_filter(field_name, literal_bases),
+        _road_shield_known_icon_filter(field_name, token_bases),
     )
-    remaining_layer["layout"]["icon-image"] = _road_shield_icon_match(
-        field_name,
-        reflen,
-        literal_bases,
+    token_layer["layout"]["icon-image"] = _road_shield_icon_token(field_name, reflen)
+    variants.append(token_layer)
+
+    fallback_layer = copy.deepcopy(layer)
+    fallback_layer["id"] = f"{layer['id']}-default-icon"
+    fallback_layer["filter"] = _with_additional_filter_clauses(
+        layer.get("filter"),
+        _road_shield_default_icon_filter(field_name, fallback_filter_bases),
     )
-    variants.append(remaining_layer)
+    fallback_layer["layout"]["icon-image"] = f"default-{reflen}"
+    variants.append(fallback_layer)
     return variants
 
 
@@ -2314,9 +2321,8 @@ def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[st
             _road_shield_reflen_filter(reflen),
             ["has", "shield_beta"],
         )
-        beta_layer["layout"]["icon-image"] = _road_shield_icon_match("shield_beta", reflen)
         variants.extend(
-            _road_shield_literal_icon_layer_variants(
+            _road_shield_icon_layer_variants(
                 beta_layer,
                 field_name="shield_beta",
                 reflen=reflen,
@@ -2330,9 +2336,8 @@ def _road_number_shield_layer_variants(layer: dict[str, object]) -> list[dict[st
             _road_shield_reflen_filter(reflen),
             ["!", ["has", "shield_beta"]],
         )
-        shield_layer["layout"]["icon-image"] = _road_shield_icon_match("shield", reflen)
         variants.extend(
-            _road_shield_literal_icon_layer_variants(
+            _road_shield_icon_layer_variants(
                 shield_layer,
                 field_name="shield",
                 reflen=reflen,

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -1689,7 +1689,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             ],
         ]
 
-    def test_road_number_shield_icon_case_expands_to_reflen_sprite_matches(self):
+    def test_road_number_shield_icon_case_expands_to_reflen_tokenized_sprite_layers(self):
         shield_icon = self._road_number_shield_icon_case()
         style = {
             "layers": [
@@ -1717,19 +1717,29 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             [
                 "before",
                 "road-number-shield-2-beta-ch-motorway-icon",
-                "road-number-shield-2-beta-remaining-icons",
+                "road-number-shield-2-beta-known-icons",
+                "road-number-shield-2-beta-default-icon",
                 "road-number-shield-2-ch-motorway-icon",
-                "road-number-shield-2-remaining-icons",
+                "road-number-shield-2-known-icons",
+                "road-number-shield-2-default-icon",
                 "road-number-shield-3-beta-ch-motorway-icon",
-                "road-number-shield-3-beta-remaining-icons",
+                "road-number-shield-3-beta-known-icons",
+                "road-number-shield-3-beta-default-icon",
                 "road-number-shield-3-ch-motorway-icon",
-                "road-number-shield-3-remaining-icons",
-                "road-number-shield-4-beta",
-                "road-number-shield-4",
-                "road-number-shield-5-beta",
-                "road-number-shield-5",
-                "road-number-shield-6-beta",
-                "road-number-shield-6",
+                "road-number-shield-3-known-icons",
+                "road-number-shield-3-default-icon",
+                "road-number-shield-4-beta-known-icons",
+                "road-number-shield-4-beta-default-icon",
+                "road-number-shield-4-known-icons",
+                "road-number-shield-4-default-icon",
+                "road-number-shield-5-beta-known-icons",
+                "road-number-shield-5-beta-default-icon",
+                "road-number-shield-5-known-icons",
+                "road-number-shield-5-default-icon",
+                "road-number-shield-6-beta-known-icons",
+                "road-number-shield-6-beta-default-icon",
+                "road-number-shield-6-known-icons",
+                "road-number-shield-6-default-icon",
                 "after",
             ],
         )
@@ -1780,66 +1790,76 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(beta_layer["layout"]["icon-image"], "ch-motorway-2")
         self.assertEqual(beta_layer["paint"]["text-color"], "hsl(0, 0%, 100%)")
 
-        remaining_beta_layer = by_id["road-number-shield-2-beta-remaining-icons"]
+        known_beta_layer = by_id["road-number-shield-2-beta-known-icons"]
+        expected_known_beta_values = [
+            base for base in mapbox_config._ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[2] if base != "ch-motorway"
+        ]
         self.assertEqual(
-            remaining_beta_layer["filter"][-2:],
+            known_beta_layer["filter"][-2:],
             [
                 ["has", "shield_beta"],
-                ["match", ["get", "shield_beta"], ["ch-motorway"], False, True],
+                ["match", ["get", "shield_beta"], expected_known_beta_values, True, False],
             ],
         )
-        self.assertEqual(
-            remaining_beta_layer["layout"]["icon-image"][:2],
-            ["match", ["get", "shield_beta"]],
-        )
-        self.assertNotIn("ch-motorway", remaining_beta_layer["layout"]["icon-image"])
-        self.assertNotIn("ch-motorway-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("gr-motorway-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("au-national-highway-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("cl-highway-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("hu-main-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("md-main-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("pk-national-highway-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("qa-main-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("sa-highway-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("th-highway-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertIn("us-highway-2", remaining_beta_layer["layout"]["icon-image"])
-        self.assertEqual(remaining_beta_layer["layout"]["icon-image"][-1], "default-2")
+        self.assertEqual(known_beta_layer["layout"]["icon-image"], "{shield_beta}-2")
+        self.assertNotIn("ch-motorway", known_beta_layer["filter"][-1][2])
+        self.assertIn("gr-motorway", known_beta_layer["filter"][-1][2])
+        self.assertIn("au-national-highway", known_beta_layer["filter"][-1][2])
+        self.assertIn("cl-highway", known_beta_layer["filter"][-1][2])
+        self.assertIn("hu-main", known_beta_layer["filter"][-1][2])
+        self.assertIn("md-main", known_beta_layer["filter"][-1][2])
+        self.assertIn("pk-national-highway", known_beta_layer["filter"][-1][2])
+        self.assertIn("qa-main", known_beta_layer["filter"][-1][2])
+        self.assertIn("sa-highway", known_beta_layer["filter"][-1][2])
+        self.assertIn("th-highway", known_beta_layer["filter"][-1][2])
+        self.assertIn("us-highway", known_beta_layer["filter"][-1][2])
 
-        shield_layer = by_id["road-number-shield-2-remaining-icons"]
+        fallback_beta_layer = by_id["road-number-shield-2-beta-default-icon"]
+        self.assertEqual(
+            fallback_beta_layer["filter"][-2:],
+            [
+                ["has", "shield_beta"],
+                [
+                    "match",
+                    ["get", "shield_beta"],
+                    list(mapbox_config._ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[2]),
+                    False,
+                    True,
+                ],
+            ],
+        )
+        self.assertEqual(fallback_beta_layer["layout"]["icon-image"], "default-2")
+
+        shield_layer = by_id["road-number-shield-2-known-icons"]
         self.assertEqual(
             shield_layer["filter"][-3:],
             [
                 ["match", ["get", "reflen"], 2, True, "2", True, False],
                 ["!", ["has", "shield_beta"]],
-                ["match", ["get", "shield"], ["ch-motorway"], False, True],
+                ["match", ["get", "shield"], expected_known_beta_values, True, False],
             ],
         )
-        self.assertEqual(shield_layer["layout"]["icon-image"][:2], ["match", ["get", "shield"]])
-        self.assertNotIn("ch-motorway", shield_layer["layout"]["icon-image"])
-        self.assertNotIn("ch-motorway-2", shield_layer["layout"]["icon-image"])
-        self.assertIn("rectangle-yellow-2", shield_layer["layout"]["icon-image"])
+        self.assertEqual(shield_layer["layout"]["icon-image"], "{shield}-2")
+        self.assertNotIn("ch-motorway", shield_layer["filter"][-1][2])
+        self.assertIn("rectangle-yellow", shield_layer["filter"][-1][2])
+        self.assertEqual(by_id["road-number-shield-2-default-icon"]["layout"]["icon-image"], "default-2")
         self.assertEqual(by_id["road-number-shield-3-ch-motorway-icon"]["layout"]["icon-image"], "ch-motorway-3")
-        self.assertNotIn(
-            "ch-motorway",
-            by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"],
-        )
-        self.assertNotIn(
-            "ch-motorway-3",
-            by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"],
-        )
-        self.assertIn("au-national-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
-        self.assertIn("cl-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
-        self.assertIn("md-main-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
-        self.assertIn("pk-national-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
-        self.assertIn("qa-main-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
-        self.assertIn("sa-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
-        self.assertIn("us-highway-3", by_id["road-number-shield-3-beta-remaining-icons"]["layout"]["icon-image"])
-        self.assertIn("md-main-4", by_id["road-number-shield-4-beta"]["layout"]["icon-image"])
-        self.assertIn("qa-main-4", by_id["road-number-shield-4-beta"]["layout"]["icon-image"])
-        self.assertIn("th-highway-4", by_id["road-number-shield-4-beta"]["layout"]["icon-image"])
-        self.assertIn("us-highway-4", by_id["road-number-shield-4-beta"]["layout"]["icon-image"])
-        self.assertIn("hu-main-5", by_id["road-number-shield-5-beta"]["layout"]["icon-image"])
+        self.assertEqual(by_id["road-number-shield-3-beta-known-icons"]["layout"]["icon-image"], "{shield_beta}-3")
+        self.assertNotIn("ch-motorway", by_id["road-number-shield-3-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("au-national-highway", by_id["road-number-shield-3-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("cl-highway", by_id["road-number-shield-3-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("md-main", by_id["road-number-shield-3-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("pk-national-highway", by_id["road-number-shield-3-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("qa-main", by_id["road-number-shield-3-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("sa-highway", by_id["road-number-shield-3-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("us-highway", by_id["road-number-shield-3-beta-known-icons"]["filter"][-1][2])
+        self.assertEqual(by_id["road-number-shield-4-beta-known-icons"]["layout"]["icon-image"], "{shield_beta}-4")
+        self.assertIn("md-main", by_id["road-number-shield-4-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("qa-main", by_id["road-number-shield-4-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("th-highway", by_id["road-number-shield-4-beta-known-icons"]["filter"][-1][2])
+        self.assertIn("us-highway", by_id["road-number-shield-4-beta-known-icons"]["filter"][-1][2])
+        self.assertEqual(by_id["road-number-shield-5-beta-known-icons"]["layout"]["icon-image"], "{shield_beta}-5")
+        self.assertIn("hu-main", by_id["road-number-shield-5-beta-known-icons"]["filter"][-1][2])
         self.assertEqual(result["layers"][-1]["layout"]["icon-image"], shield_icon)
 
     def test_road_number_shield_point_layers_stay_visible_below_z11(self):
@@ -1882,7 +1902,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 28)
+        self.assertEqual(len(result["layers"]), 48)
         by_id = {layer["id"]: layer for layer in result["layers"]}
         low_layer = by_id["road-number-shield-2-beta-ch-motorway-icon-below-z11"]
         self.assertEqual(low_layer["maxzoom"], 11.0)
@@ -1945,14 +1965,26 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertIn(["has", "shield_beta"], high_layer["filter"])
         self.assertIn(["==", ["get", "shield_beta"], "ch-motorway"], high_layer["filter"])
-        remaining_low_layer = by_id["road-number-shield-2-beta-remaining-icons-below-z11"]
+        known_low_layer = by_id["road-number-shield-2-beta-known-icons-below-z11"]
+        expected_known_beta_values = [
+            base for base in mapbox_config._ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[2] if base != "ch-motorway"
+        ]
         self.assertIn(
-            ["match", ["get", "shield_beta"], ["ch-motorway"], False, True],
-            remaining_low_layer["filter"],
+            ["match", ["get", "shield_beta"], expected_known_beta_values, True, False],
+            known_low_layer["filter"],
         )
-        self.assertEqual(
-            remaining_low_layer["layout"]["icon-image"][:2],
-            ["match", ["get", "shield_beta"]],
+        self.assertEqual(known_low_layer["layout"]["icon-image"], "{shield_beta}-2")
+        fallback_low_layer = by_id["road-number-shield-2-beta-default-icon-below-z11"]
+        self.assertEqual(fallback_low_layer["layout"]["icon-image"], "default-2")
+        self.assertIn(
+            [
+                "match",
+                ["get", "shield_beta"],
+                list(mapbox_config._ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[2]),
+                False,
+                True,
+            ],
+            fallback_low_layer["filter"],
         )
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit(

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -1751,6 +1751,19 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertEqual(outputs, ["gr-motorway-2", "rectangle-yellow-2"])
         self.assertNotIn("ch-motorway-2", outputs)
 
+    def test_road_shield_token_outputs_preserve_empty_known_icon_filter(self):
+        outputs = mapbox_outdoors_style_audit._qfit_road_number_shield_sprite_outputs(
+            [
+                {
+                    "id": "road-number-shield-2-known-icons",
+                    "layout": {"icon-image": "{shield}-2"},
+                    "filter": ["match", ["get", "shield"], [], True, False],
+                },
+            ]
+        )
+
+        self.assertEqual(outputs, [])
+
     def test_build_style_audit_reports_route_overlay_candidates(self):
         audit = build_style_audit(
             {

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -1726,6 +1726,31 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         self.assertIn("| zz-main-2 |", markdown)
         self.assertIn("#### Live motorway-exit sprites handled separately", markdown)
 
+    def test_road_shield_token_outputs_follow_known_icon_filter(self):
+        outputs = mapbox_outdoors_style_audit._qfit_road_number_shield_sprite_outputs(
+            [
+                {
+                    "id": "road-number-shield-2-beta-known-icons",
+                    "layout": {"icon-image": "{shield_beta}-2"},
+                    "filter": [
+                        "all",
+                        ["match", ["get", "reflen"], 2, True, "2", True, False],
+                        ["has", "shield_beta"],
+                        [
+                            "match",
+                            ["get", "shield_beta"],
+                            ["gr-motorway", "rectangle-yellow"],
+                            True,
+                            False,
+                        ],
+                    ],
+                },
+            ]
+        )
+
+        self.assertEqual(outputs, ["gr-motorway-2", "rectangle-yellow-2"])
+        self.assertNotIn("ch-motorway-2", outputs)
+
     def test_build_style_audit_reports_route_overlay_candidates(self):
         audit = build_style_audit(
             {

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -1200,9 +1200,9 @@ def _match_expression_string_outputs(expr: object) -> list[str]:
     return sorted({str(output) for output in outputs if isinstance(output, str)})
 
 
-def _road_number_shield_token_filter_bases(expr: object, field_name: str) -> list[str]:
+def _road_number_shield_token_filter_bases(expr: object, field_name: str) -> list[str] | None:
     if not isinstance(expr, list) or not expr:
-        return []
+        return None
     if (
         len(expr) == 5
         and expr[0] == "match"
@@ -1214,9 +1214,9 @@ def _road_number_shield_token_filter_bases(expr: object, field_name: str) -> lis
         return sorted({str(value) for value in expr[2] if isinstance(value, str)})
     for item in expr[1:]:
         bases = _road_number_shield_token_filter_bases(item, field_name)
-        if bases:
+        if bases is not None:
             return bases
-    return []
+    return None
 
 
 def _icon_image_string_outputs(expr: object, layer_filter: object = None) -> list[str]:
@@ -1227,7 +1227,7 @@ def _icon_image_string_outputs(expr: object, layer_filter: object = None) -> lis
             reflen = int(token_match.group("reflen"))
             configured_bases = set(_ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen])
             filter_bases = _road_number_shield_token_filter_bases(layer_filter, field_name)
-            bases = filter_bases or sorted(configured_bases)
+            bases = filter_bases if filter_bases is not None else sorted(configured_bases)
             return sorted(
                 f"{base}-{reflen}"
                 for base in bases

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -232,6 +232,7 @@ _ROAD_NUMBER_SHIELD_SPRITE_NAME_RE = re.compile(
     r"^(?:default|rectangle-(?:blue|green|red|white|yellow)|"
     r"[a-z]{2}-(?:highway|main|motorway|national-highway)(?:-toll)?)-[2-6]$"
 )
+_ROAD_NUMBER_SHIELD_ICON_TOKEN_RE = re.compile(r"^\{shield(?:_beta)?\}-(?P<reflen>[2-6])$")
 _MOTORWAY_EXIT_SPRITE_NAME_RE = re.compile(r"^motorway-exit-[1-9]$")
 _TERRAIN_LANDCOVER_LAYER_TYPES = frozenset({"fill", "line"})
 _TERRAIN_LANDCOVER_CONTROL_PROPERTIES = (
@@ -1201,6 +1202,13 @@ def _match_expression_string_outputs(expr: object) -> list[str]:
 
 def _icon_image_string_outputs(expr: object) -> list[str]:
     if isinstance(expr, str) and expr:
+        token_match = _ROAD_NUMBER_SHIELD_ICON_TOKEN_RE.match(expr)
+        if token_match is not None:
+            reflen = int(token_match.group("reflen"))
+            return sorted(
+                f"{base}-{reflen}"
+                for base in _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen]
+            )
         return [expr]
     return _match_expression_string_outputs(expr)
 

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -232,7 +232,7 @@ _ROAD_NUMBER_SHIELD_SPRITE_NAME_RE = re.compile(
     r"^(?:default|rectangle-(?:blue|green|red|white|yellow)|"
     r"[a-z]{2}-(?:highway|main|motorway|national-highway)(?:-toll)?)-[2-6]$"
 )
-_ROAD_NUMBER_SHIELD_ICON_TOKEN_RE = re.compile(r"^\{shield(?:_beta)?\}-(?P<reflen>[2-6])$")
+_ROAD_NUMBER_SHIELD_ICON_TOKEN_RE = re.compile(r"^\{(?P<field>shield(?:_beta)?)\}-(?P<reflen>[2-6])$")
 _MOTORWAY_EXIT_SPRITE_NAME_RE = re.compile(r"^motorway-exit-[1-9]$")
 _TERRAIN_LANDCOVER_LAYER_TYPES = frozenset({"fill", "line"})
 _TERRAIN_LANDCOVER_CONTROL_PROPERTIES = (
@@ -1200,14 +1200,38 @@ def _match_expression_string_outputs(expr: object) -> list[str]:
     return sorted({str(output) for output in outputs if isinstance(output, str)})
 
 
-def _icon_image_string_outputs(expr: object) -> list[str]:
+def _road_number_shield_token_filter_bases(expr: object, field_name: str) -> list[str]:
+    if not isinstance(expr, list) or not expr:
+        return []
+    if (
+        len(expr) == 5
+        and expr[0] == "match"
+        and expr[1] == ["get", field_name]
+        and isinstance(expr[2], list)
+        and expr[3] is True
+        and expr[4] is False
+    ):
+        return sorted({str(value) for value in expr[2] if isinstance(value, str)})
+    for item in expr[1:]:
+        bases = _road_number_shield_token_filter_bases(item, field_name)
+        if bases:
+            return bases
+    return []
+
+
+def _icon_image_string_outputs(expr: object, layer_filter: object = None) -> list[str]:
     if isinstance(expr, str) and expr:
         token_match = _ROAD_NUMBER_SHIELD_ICON_TOKEN_RE.match(expr)
         if token_match is not None:
+            field_name = token_match.group("field")
             reflen = int(token_match.group("reflen"))
+            configured_bases = set(_ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen])
+            filter_bases = _road_number_shield_token_filter_bases(layer_filter, field_name)
+            bases = filter_bases or sorted(configured_bases)
             return sorted(
                 f"{base}-{reflen}"
-                for base in _ROAD_SHIELD_SPRITE_BASES_BY_REFLEN[reflen]
+                for base in bases
+                if base in configured_bases
             )
         return [expr]
     return _match_expression_string_outputs(expr)
@@ -1221,7 +1245,7 @@ def _qfit_road_number_shield_sprite_outputs(simplified_layers: list[dict[str, ob
         layout = layer.get("layout")
         if not isinstance(layout, dict):
             continue
-        outputs.update(_icon_image_string_outputs(layout.get("icon-image")))
+        outputs.update(_icon_image_string_outputs(layout.get("icon-image"), layer.get("filter")))
     return sorted(outputs)
 
 


### PR DESCRIPTION
## Summary
- Split road-number-shield dynamic `match` icon layers into tokenized known-icon layers plus explicit static `default-*` fallback layers.
- Keep the existing literal `ch-motorway` split so Swiss motorway shields retain white text.
- Teach the Mapbox Outdoors style audit to expand `{shield}` / `{shield_beta}` icon tokens back into configured road-shield sprite coverage.

## Evidence
- Live label-settings artifact: `debug/mapbox-outdoors-label-settings-road-shield-tokenized-icons/mapbox-outdoors-v12/20260520T171135Z/summary.md`.
- In that artifact, road-number-shield now has 48 split styles and no road-number-shield rows in the empty `IN ()` data-defined-expression table; only the pre-existing settlement-subdivision-label row remains.
- QGIS converter source/docs show tokenized sprite names are handled through field equality properties, avoiding the `match`-list path that produced empty `IN ()` clauses.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_style_audit.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
