### PR TITLE
fix: scalarize hidden subdivision label spacing

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -812,6 +812,8 @@ _NAME_EN_FALLBACK_TEXT_FIELD_EXPRESSION = [
 ]
 _SETTLEMENT_MAJOR_LABEL_LAYER_ID = "settlement-major-label"
 _SETTLEMENT_MINOR_LABEL_LAYER_ID = "settlement-minor-label"
+_SETTLEMENT_SUBDIVISION_LABEL_LAYER_ID = "settlement-subdivision-label"
+_SETTLEMENT_SUBDIVISION_TEXT_LETTER_SPACING = 0.05
 _SETTLEMENT_MINOR_SYMBOLRANK_FILTER_ZOOM_STEP = [
     "step",
     ["zoom"],
@@ -6194,7 +6196,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
         "water-line-label": 11.0,
         "water-point-label": 12.0,
         "airport-label": 11.0,
-        "settlement-subdivision-label": 8.0,
+        _SETTLEMENT_SUBDIVISION_LABEL_LAYER_ID: 8.0,
         "settlement-minor-label": 10.0,
         "settlement-major-label": 14.0,
         "state-label": 13.0,
@@ -6214,7 +6216,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     _SETTLEMENT_FILTERS: dict[str, object] = {
         "settlement-major-label": ["match", ["get", "type"], ["city"], True, False],
         "settlement-minor-label": ["match", ["get", "type"], ["town"], True, False],
-        "settlement-subdivision-label": None,
+        _SETTLEMENT_SUBDIVISION_LABEL_LAYER_ID: None,
     }
 
     for layer in style.get("layers", []):
@@ -6225,8 +6227,16 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
         settlement_filter = _SETTLEMENT_FILTERS.get(base_layer_id, "NOTSET")
         if settlement_filter != "NOTSET":
             if settlement_filter is None:
-                layer["layout"] = layer.get("layout", {})
-                layer["layout"]["visibility"] = "none"
+                layout = layer.get("layout")
+                if not isinstance(layout, dict):
+                    layout = {}
+                    layer["layout"] = layout
+                layout["visibility"] = "none"
+                if (
+                    base_layer_id == _SETTLEMENT_SUBDIVISION_LABEL_LAYER_ID
+                    and isinstance(layout.get("text-letter-spacing"), list)
+                ):
+                    layout["text-letter-spacing"] = _SETTLEMENT_SUBDIVISION_TEXT_LETTER_SPACING
             else:
                 existing_filter = layer.get("filter")
                 if existing_filter:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2385,6 +2385,41 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(style["layers"][0]["filter"], major_filter)
         self.assertEqual(style["layers"][1]["filter"], minor_filter)
 
+    def test_filter_simplification_scalarizes_hidden_settlement_subdivision_letter_spacing(self):
+        letter_spacing = ["match", ["get", "type"], "suburb", 0.15, 0.05]
+        style = {
+            "layers": [
+                {
+                    "id": "settlement-subdivision-label",
+                    "type": "symbol",
+                    "layout": {
+                        "text-letter-spacing": letter_spacing,
+                    },
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        layout = result["layers"][0]["layout"]
+        self.assertEqual(layout["visibility"], "none")
+        self.assertEqual(layout["text-letter-spacing"], 0.05)
+        self.assertEqual(style["layers"][0]["layout"]["text-letter-spacing"], letter_spacing)
+
+    def test_filter_simplification_hides_settlement_subdivision_without_layout(self):
+        style = {
+            "layers": [
+                {
+                    "id": "settlement-subdivision-label",
+                    "type": "symbol",
+                },
+            ]
+        }
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"][0]["layout"], {"visibility": "none"})
+
     def _settlement_dot_icon_layout(self):
         return {
             "symbol-sort-key": ["get", "symbolrank"],


### PR DESCRIPTION
## Summary
- Scalarize `settlement-subdivision-label` text-letter-spacing when qfit suppresses that layer for QGIS.
- Keep the layer hidden, but avoid handing QGIS a data-defined `match` expression that converts to an empty `IN ()` label property.
- Add a regression test for the hidden subdivision label spacing simplification.

## Evidence
- Live label-settings artifact: `debug/mapbox-outdoors-label-settings-settlement-letter-spacing/mapbox-outdoors-v12/20260520T173221Z/summary.md`.
- The live diagnostic now reports 0 data-defined label expressions with empty `IN ()` clauses.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949
