### PR TITLE
[codex] Tune path pedestrian label spacing

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -887,7 +887,7 @@ class ApplyLabelPriorityRealTests(unittest.TestCase):
         self.service._apply_label_priority(labeling)
 
         self.assertTrue(settings.mergeLines)
-        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         self.assertEqual(settings.repeatDistanceUnit, Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
 
@@ -1227,7 +1227,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.service._apply_label_priority(labeling)
 
         self.assertTrue(settings.mergeLines)
-        self.assertAlmostEqual(settings.repeatDistance, 250 * 25.4 / 96)
+        self.assertAlmostEqual(settings.repeatDistance, 400 * 25.4 / 96)
         self.assertEqual(settings.repeatDistanceUnit, _qstub.Qgis.RenderUnit.Millimeters)
         style.setLabelSettings.assert_called_once_with(settings)
 

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -50,12 +50,12 @@ _MAPBOX_DEFAULT_SYMBOL_SPACING_PX = 250.0
 _ROAD_LABEL_LOW_ZOOM_SYMBOL_SPACING_PX = 150.0
 _ROAD_LABEL_HIGH_ZOOM_SYMBOL_SPACING_PX = 400.0
 _ROAD_NUMBER_SHIELD_Z11_PLUS_SYMBOL_SPACING_PX = 1400.0 / 3.0
+_PATH_PEDESTRIAN_LABEL_SYMBOL_SPACING_PX = 400.0
 _REPEAT_DISTANCE_EPSILON_MM = 0.001
 _LINE_CENTER_ANCHOR_PERCENT = 0.5
 _LINE_CENTER_ANCHOR_PERCENT_EPSILON = 0.000001
 _LINE_LABEL_REPEAT_DISTANCE_LAYERS = {
     "ferry-aerialway-label",
-    "path-pedestrian-label",
 }
 _LINE_LABEL_MERGE_LAYERS = {
     "contour-label",
@@ -129,6 +129,8 @@ def _label_repeat_distance(layer_name: str, style) -> float | None:
         if style_name == "road-label-z15-plus":
             return _symbol_spacing_mm(_ROAD_LABEL_HIGH_ZOOM_SYMBOL_SPACING_PX)
         return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
+    if layer_name == "path-pedestrian-label":
+        return _symbol_spacing_mm(_PATH_PEDESTRIAN_LABEL_SYMBOL_SPACING_PX)
     if layer_name in _LINE_LABEL_REPEAT_DISTANCE_LAYERS:
         return _symbol_spacing_mm(_MAPBOX_DEFAULT_SYMBOL_SPACING_PX)
     if layer_name != "waterway-label":


### PR DESCRIPTION
## Summary

- widen QGIS repeat distance for `path-pedestrian-label` from the default 250 px to 400 px
- keep ferry/aerialway label spacing on the existing 250 px default
- update real-QGIS and mock-QGIS label-priority tests for the path/pedestrian spacing behavior

## Evidence

This follows the #949 path/pedestrian focus refresh, where high-zoom Zermatt pedestrian/path labels were concentrated in repeated names while QGIS 3.34 reported no duplicate-label controls.

Live label-settings diagnostic after the change:
- `debug/mapbox-outdoors-label-settings-path-pedestrian-spacing/mapbox-outdoors-v12/20260520T181640Z/summary.md`
- `path-pedestrian-label` repeat distance is now `105.833` mm (400 px)
- `ferry-aerialway-label` remains `66.1458` mm (250 px)

Live all-camera comparison after the change:
- `debug/mapbox-outdoors-comparison-path-pedestrian-label-spacing-all/all-cameras/20260520T181842Z/summary.md`
- z18 Zermatt improved: normalized mean delta `0.030789201 -> 0.030457584`, normalized RMS `0.089858543 -> 0.088493455`
- z10 Lausanne and z17 Zermatt-piste moved slightly better
- Chamonix z14 and Valais/Geneva z8 were unchanged
- z5 Switzerland and Geneva z14 moved slightly worse by very small metric deltas, with no obvious contact-sheet break

## Validation

- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
