### PR TITLE
test: add Mapbox comparison delta report

### DIFF
--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -161,9 +161,14 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
             )
 
             stdout = io.StringIO()
+
+            def fake_run_directory(*, output_root=None, now=None):
+                self.assertIsNone(now)
+                return Path(output_root) / "20260520T185100Z"
+
             with patch(
-                "qfit.validation.mapbox_outdoors_comparison_delta._utc_timestamp",
-                return_value="20260520T185100Z",
+                "qfit.validation.mapbox_outdoors_comparison_delta._build_timestamped_run_directory",
+                side_effect=fake_run_directory,
             ):
                 with redirect_stdout(stdout):
                     exit_code = main(

--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -1,0 +1,188 @@
+import datetime as dt
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+from qfit.validation.mapbox_outdoors_comparison_delta import (
+    build_comparison_delta_paths,
+    build_comparison_delta_report,
+    build_run_directory,
+    build_summary_markdown,
+    load_json_object,
+    main,
+    write_report,
+)
+
+
+def _camera_row(camera, *, mean, rms, changed=0.5, status="passed", zoom=14.25):
+    return {
+        "camera": camera,
+        "zoom": zoom,
+        "status": status,
+        "artifact_status": "metrics_available",
+        "metrics": {
+            "changed_pixel_ratio": changed,
+            "normalized_mean_absolute_channel_delta": mean,
+            "normalized_rms_channel_delta": rms,
+        },
+    }
+
+
+class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
+    def test_build_run_directory_and_paths_are_predictable(self):
+        run_dir = build_run_directory(
+            output_root=Path("/tmp/comparison-delta"),
+            now=dt.datetime(2026, 5, 20, 18, 50, tzinfo=dt.timezone.utc),
+        )
+        paths = build_comparison_delta_paths(run_dir)
+
+        self.assertEqual(run_dir, Path("/tmp/comparison-delta/20260520T185000Z"))
+        self.assertEqual(paths.json_path, run_dir / "comparison-delta.json")
+        self.assertEqual(paths.summary_path, run_dir / "summary.md")
+
+    def test_load_json_object_requires_object(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_path = Path(tmpdir) / "report.json"
+            json_path.write_text('{"ok": true}\n', encoding="utf-8")
+            self.assertEqual(load_json_object(json_path), {"ok": True})
+
+            json_path.write_text('["not", "object"]\n', encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_json_object(json_path)
+
+    def test_build_comparison_delta_report_pairs_cameras_and_counts_directions(self):
+        baseline = {
+            "cameras": [
+                _camera_row("chamonix-trails-z14-outdoors", mean=0.04, rms=0.08, changed=0.95),
+                _camera_row("zermatt-trails-z18-outdoors", mean=0.03, rms=0.09, changed=0.99),
+            ]
+        }
+        candidate = {
+            "cameras": [
+                _camera_row("chamonix-trails-z14-outdoors", mean=0.035, rms=0.081, changed=0.94),
+                _camera_row("zermatt-trails-z18-outdoors", mean=0.031, rms=0.088, changed=0.99),
+            ]
+        }
+
+        report = build_comparison_delta_report(
+            baseline,
+            candidate,
+            baseline_label="post-label-cleanups",
+            candidate_label="probe",
+        )
+
+        self.assertEqual(report["baseline_label"], "post-label-cleanups")
+        self.assertEqual(report["candidate_label"], "probe")
+        self.assertEqual(report["camera_count"], 2)
+        self.assertEqual(
+            report["summary"],
+            {
+                "mean_improved": 1,
+                "mean_worsened": 1,
+                "mean_unchanged": 0,
+                "rms_improved": 1,
+                "rms_worsened": 1,
+                "rms_unchanged": 0,
+            },
+        )
+        chamonix = report["cameras"][0]
+        self.assertEqual(chamonix["camera"], "chamonix-trails-z14-outdoors")
+        self.assertAlmostEqual(
+            chamonix["metrics"]["normalized_mean_absolute_channel_delta"]["delta"],
+            -0.005,
+        )
+        self.assertEqual(chamonix["mean_delta_direction"], "improved")
+        self.assertEqual(chamonix["rms_delta_direction"], "worsened")
+
+    def test_build_comparison_delta_report_preserves_missing_camera_rows(self):
+        report = build_comparison_delta_report(
+            {"cameras": [_camera_row("baseline-only", mean=0.1, rms=0.2)]},
+            {"cameras": [_camera_row("candidate-only", mean=0.3, rms=0.4)]},
+        )
+
+        self.assertEqual(
+            [row["camera"] for row in report["cameras"]],
+            ["baseline-only", "candidate-only"],
+        )
+        self.assertEqual(report["cameras"][0]["candidate_status"], "missing")
+        self.assertIsNone(
+            report["cameras"][0]["metrics"]["normalized_mean_absolute_channel_delta"]["delta"]
+        )
+        self.assertEqual(report["cameras"][1]["baseline_status"], "missing")
+
+    def test_build_summary_markdown_renders_delta_table(self):
+        report = build_comparison_delta_report(
+            {"cameras": [_camera_row("camera-a", mean=0.05, rms=0.08, changed=0.9, zoom=18)]},
+            {"cameras": [_camera_row("camera-a", mean=0.04, rms=0.09, changed=0.91, zoom=18)]},
+            baseline_label="baseline",
+            candidate_label="candidate",
+        )
+
+        markdown = build_summary_markdown(report)
+
+        self.assertIn("# Mapbox Outdoors comparison delta", markdown)
+        self.assertIn("Baseline: `baseline`", markdown)
+        self.assertIn("| `camera-a` | 18.00 | 0.050000000 | 0.040000000 | -0.010000000 |", markdown)
+        self.assertIn("| RMS channel delta | 0 | 1 | 0 |", markdown)
+
+    def test_write_report_outputs_json_and_markdown(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = Path(tmpdir) / "run"
+            paths = build_comparison_delta_paths(run_dir)
+            report = build_comparison_delta_report(
+                {"cameras": [_camera_row("camera-a", mean=0.05, rms=0.08)]},
+                {"cameras": [_camera_row("camera-a", mean=0.04, rms=0.07)]},
+            )
+
+            write_report(report, paths)
+
+            written = json.loads(paths.json_path.read_text(encoding="utf-8"))
+            self.assertEqual(written["camera_count"], 1)
+            self.assertIn("camera-a", paths.summary_path.read_text(encoding="utf-8"))
+
+    def test_main_writes_delta_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            baseline = tmp_path / "baseline.json"
+            candidate = tmp_path / "candidate.json"
+            baseline.write_text(
+                json.dumps({"cameras": [_camera_row("camera-a", mean=0.05, rms=0.08)]}),
+                encoding="utf-8",
+            )
+            candidate.write_text(
+                json.dumps({"cameras": [_camera_row("camera-a", mean=0.04, rms=0.07)]}),
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            with patch(
+                "qfit.validation.mapbox_outdoors_comparison_delta._utc_timestamp",
+                return_value="20260520T185100Z",
+            ):
+                with redirect_stdout(stdout):
+                    exit_code = main(
+                        [
+                            str(baseline),
+                            str(candidate),
+                            "--baseline-label",
+                            "baseline",
+                            "--candidate-label",
+                            "candidate",
+                            "--output-root",
+                            str(tmp_path / "delta"),
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Delta report:", stdout.getvalue())
+            self.assertTrue((tmp_path / "delta" / "20260520T185100Z" / "summary.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -122,6 +122,19 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
         self.assertEqual(report["summary"]["mean_unknown"], 2)
         self.assertEqual(report["summary"]["rms_unknown"], 2)
 
+    def test_build_comparison_delta_report_falls_back_to_baseline_zoom(self):
+        baseline_row = _camera_row("camera-a", mean=0.1, rms=0.2, zoom=12.5)
+        candidate_row = _camera_row("camera-a", mean=0.08, rms=0.18)
+        candidate_row["zoom"] = "unknown"
+
+        report = build_comparison_delta_report(
+            {"cameras": [baseline_row]},
+            {"cameras": [candidate_row]},
+        )
+
+        self.assertEqual(report["cameras"][0]["zoom"], 12.5)
+        self.assertIn("| `camera-a` | 12.50 |", build_summary_markdown(report))
+
     def test_build_summary_markdown_renders_delta_table(self):
         report = build_comparison_delta_report(
             {"cameras": [_camera_row("camera-a", mean=0.05, rms=0.08, changed=0.9, zoom=18)]},

--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -75,8 +75,10 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
             candidate,
             baseline_label="post-label-cleanups",
             candidate_label="probe",
+            now=dt.datetime(2026, 5, 20, 18, 51, tzinfo=dt.timezone.utc),
         )
 
+        self.assertEqual(report["generated_at"], "20260520T185100Z")
         self.assertEqual(report["baseline_label"], "post-label-cleanups")
         self.assertEqual(report["candidate_label"], "probe")
         self.assertEqual(report["camera_count"], 2)
@@ -86,9 +88,11 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
                 "mean_improved": 1,
                 "mean_worsened": 1,
                 "mean_unchanged": 0,
+                "mean_unknown": 0,
                 "rms_improved": 1,
                 "rms_worsened": 1,
                 "rms_unchanged": 0,
+                "rms_unknown": 0,
             },
         )
         chamonix = report["cameras"][0]
@@ -115,6 +119,8 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
             report["cameras"][0]["metrics"]["normalized_mean_absolute_channel_delta"]["delta"]
         )
         self.assertEqual(report["cameras"][1]["baseline_status"], "missing")
+        self.assertEqual(report["summary"]["mean_unknown"], 2)
+        self.assertEqual(report["summary"]["rms_unknown"], 2)
 
     def test_build_summary_markdown_renders_delta_table(self):
         report = build_comparison_delta_report(
@@ -129,7 +135,7 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
         self.assertIn("# Mapbox Outdoors comparison delta", markdown)
         self.assertIn("Baseline: `baseline`", markdown)
         self.assertIn("| `camera-a` | 18.00 | 0.050000000 | 0.040000000 | -0.010000000 |", markdown)
-        self.assertIn("| RMS channel delta | 0 | 1 | 0 |", markdown)
+        self.assertIn("| RMS channel delta | 0 | 1 | 0 | 0 |", markdown)
 
     def test_write_report_outputs_json_and_markdown(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -162,13 +168,27 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
 
             stdout = io.StringIO()
 
-            def fake_run_directory(*, output_root=None, now=None):
-                self.assertIsNone(now)
-                return Path(output_root) / "20260520T185100Z"
+            class SequencedDateTime(dt.datetime):
+                calls = 0
+
+                @classmethod
+                def now(cls, tz=None):
+                    cls.calls += 1
+                    seconds = 0 if cls.calls == 1 else 1
+                    timestamp = dt.datetime(
+                        2026,
+                        5,
+                        20,
+                        18,
+                        51,
+                        seconds,
+                        tzinfo=dt.timezone.utc,
+                    )
+                    return timestamp if tz is None else timestamp.astimezone(tz)
 
             with patch(
-                "qfit.validation.mapbox_outdoors_comparison_delta._build_timestamped_run_directory",
-                side_effect=fake_run_directory,
+                "qfit.validation.mapbox_outdoors_comparison_delta.dt.datetime",
+                SequencedDateTime,
             ):
                 with redirect_stdout(stdout):
                     exit_code = main(
@@ -185,8 +205,12 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
                     )
 
             self.assertEqual(exit_code, 0)
+            self.assertEqual(SequencedDateTime.calls, 1)
             self.assertIn("Delta report:", stdout.getvalue())
-            self.assertTrue((tmp_path / "delta" / "20260520T185100Z" / "summary.md").exists())
+            output_dir = tmp_path / "delta" / "20260520T185100Z"
+            self.assertTrue((output_dir / "summary.md").exists())
+            written = json.loads((output_dir / "comparison-delta.json").read_text(encoding="utf-8"))
+            self.assertEqual(written["generated_at"], "20260520T185100Z")
 
 
 if __name__ == "__main__":

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -5,9 +5,19 @@ import datetime as dt
 import json
 import sys
 from collections.abc import Mapping
-from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
+try:
+    from .mapbox_outdoors_path_pedestrian_focus import (
+        build_run_directory as _build_timestamped_run_directory,
+        load_json_object,
+    )
+except ImportError:  # pragma: no cover - supports direct script execution.
+    from mapbox_outdoors_path_pedestrian_focus import (  # type: ignore[no-redef]
+        build_run_directory as _build_timestamped_run_directory,
+        load_json_object,
+    )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-comparison-delta"
@@ -18,16 +28,14 @@ DELTA_METRIC_KEYS = (
 )
 
 
-@dataclass(frozen=True)
-class ComparisonDeltaPaths:
+class ComparisonDeltaPaths(NamedTuple):
     run_dir: Path
     json_path: Path
     summary_path: Path
 
 
-def _utc_timestamp(now: dt.datetime | None = None) -> str:
-    timestamp = now or dt.datetime.now(dt.timezone.utc)
-    return timestamp.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+def _report_timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 def build_run_directory(
@@ -35,8 +43,10 @@ def build_run_directory(
     output_root: Path | None = None,
     now: dt.datetime | None = None,
 ) -> Path:
-    root = DEFAULT_OUTPUT_ROOT if output_root is None else output_root
-    return root / _utc_timestamp(now)
+    return _build_timestamped_run_directory(
+        output_root=output_root if output_root is not None else DEFAULT_OUTPUT_ROOT,
+        now=now,
+    )
 
 
 def build_comparison_delta_paths(run_dir: Path) -> ComparisonDeltaPaths:
@@ -45,14 +55,6 @@ def build_comparison_delta_paths(run_dir: Path) -> ComparisonDeltaPaths:
         json_path=run_dir / "comparison-delta.json",
         summary_path=run_dir / "summary.md",
     )
-
-
-def load_json_object(path: Path) -> dict[str, object]:
-    with path.open("r", encoding="utf-8") as handle:
-        loaded = json.load(handle)
-    if not isinstance(loaded, dict):
-        raise ValueError(f"Expected JSON object in {path}")
-    return loaded
 
 
 def _camera_rows(summary: Mapping[str, object]) -> list[Mapping[str, object]]:
@@ -197,7 +199,7 @@ def build_comparison_delta_report(
         if isinstance(row.get("rms_delta_direction"), str)
     ]
     return {
-        "generated_at": _utc_timestamp(),
+        "generated_at": _report_timestamp(),
         "baseline_label": baseline_label,
         "candidate_label": candidate_label,
         "camera_count": len(rows),

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-comparison-delta"
+DELTA_METRIC_KEYS = (
+    "changed_pixel_ratio",
+    "normalized_mean_absolute_channel_delta",
+    "normalized_rms_channel_delta",
+)
+
+
+@dataclass(frozen=True)
+class ComparisonDeltaPaths:
+    run_dir: Path
+    json_path: Path
+    summary_path: Path
+
+
+def _utc_timestamp(now: dt.datetime | None = None) -> str:
+    timestamp = now or dt.datetime.now(dt.timezone.utc)
+    return timestamp.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def build_run_directory(
+    *,
+    output_root: Path | None = None,
+    now: dt.datetime | None = None,
+) -> Path:
+    root = DEFAULT_OUTPUT_ROOT if output_root is None else output_root
+    return root / _utc_timestamp(now)
+
+
+def build_comparison_delta_paths(run_dir: Path) -> ComparisonDeltaPaths:
+    return ComparisonDeltaPaths(
+        run_dir=run_dir,
+        json_path=run_dir / "comparison-delta.json",
+        summary_path=run_dir / "summary.md",
+    )
+
+
+def load_json_object(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return loaded
+
+
+def _camera_rows(summary: Mapping[str, object]) -> list[Mapping[str, object]]:
+    cameras = summary.get("cameras")
+    if not isinstance(cameras, list):
+        return []
+    return [camera for camera in cameras if isinstance(camera, Mapping)]
+
+
+def _camera_name(row: Mapping[str, object]) -> str | None:
+    camera = row.get("camera")
+    return camera if isinstance(camera, str) and camera else None
+
+
+def _metric_value(row: Mapping[str, object] | None, key: str) -> float | None:
+    if row is None:
+        return None
+    metrics = row.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return None
+    value = metrics.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _row_status(row: Mapping[str, object] | None) -> str:
+    if row is None:
+        return "missing"
+    status = row.get("status")
+    return status if isinstance(status, str) and status else "unknown"
+
+
+def _row_artifact_status(row: Mapping[str, object] | None) -> str:
+    if row is None:
+        return "missing"
+    status = row.get("artifact_status")
+    return status if isinstance(status, str) and status else "unknown"
+
+
+def _row_zoom(row: Mapping[str, object] | None) -> float | None:
+    if row is None:
+        return None
+    zoom = row.get("zoom")
+    if isinstance(zoom, bool) or not isinstance(zoom, (int, float)):
+        return None
+    return float(zoom)
+
+
+def _ordered_camera_names(
+    baseline_rows: list[Mapping[str, object]],
+    candidate_rows: list[Mapping[str, object]],
+) -> list[str]:
+    names: list[str] = []
+    seen = set()
+    for row in (*baseline_rows, *candidate_rows):
+        camera = _camera_name(row)
+        if camera is not None and camera not in seen:
+            names.append(camera)
+            seen.add(camera)
+    return names
+
+
+def _metric_delta(
+    baseline_row: Mapping[str, object] | None,
+    candidate_row: Mapping[str, object] | None,
+    key: str,
+) -> dict[str, float | None]:
+    baseline = _metric_value(baseline_row, key)
+    candidate = _metric_value(candidate_row, key)
+    return {
+        "baseline": baseline,
+        "candidate": candidate,
+        "delta": None if baseline is None or candidate is None else candidate - baseline,
+    }
+
+
+def _delta_direction(value: float | None) -> str:
+    if value is None:
+        return "unknown"
+    if value < 0:
+        return "improved"
+    if value > 0:
+        return "worsened"
+    return "unchanged"
+
+
+def build_comparison_delta_report(
+    baseline_summary: Mapping[str, object],
+    candidate_summary: Mapping[str, object],
+    *,
+    baseline_label: str = "baseline",
+    candidate_label: str = "candidate",
+) -> dict[str, object]:
+    baseline_rows = _camera_rows(baseline_summary)
+    candidate_rows = _camera_rows(candidate_summary)
+    baseline_by_camera = {
+        camera: row for row in baseline_rows if (camera := _camera_name(row)) is not None
+    }
+    candidate_by_camera = {
+        camera: row for row in candidate_rows if (camera := _camera_name(row)) is not None
+    }
+
+    rows = []
+    for camera in _ordered_camera_names(baseline_rows, candidate_rows):
+        baseline_row = baseline_by_camera.get(camera)
+        candidate_row = candidate_by_camera.get(camera)
+        metric_deltas = {
+            key: _metric_delta(baseline_row, candidate_row, key)
+            for key in DELTA_METRIC_KEYS
+        }
+        rows.append(
+            {
+                "camera": camera,
+                "zoom": (
+                    _row_zoom(candidate_row)
+                    if candidate_row is not None
+                    else _row_zoom(baseline_row)
+                ),
+                "baseline_status": _row_status(baseline_row),
+                "candidate_status": _row_status(candidate_row),
+                "baseline_artifact_status": _row_artifact_status(baseline_row),
+                "candidate_artifact_status": _row_artifact_status(candidate_row),
+                "metrics": metric_deltas,
+                "mean_delta_direction": _delta_direction(
+                    metric_deltas["normalized_mean_absolute_channel_delta"]["delta"]
+                ),
+                "rms_delta_direction": _delta_direction(
+                    metric_deltas["normalized_rms_channel_delta"]["delta"]
+                ),
+            }
+        )
+
+    mean_directions = [
+        row["mean_delta_direction"]
+        for row in rows
+        if isinstance(row.get("mean_delta_direction"), str)
+    ]
+    rms_directions = [
+        row["rms_delta_direction"]
+        for row in rows
+        if isinstance(row.get("rms_delta_direction"), str)
+    ]
+    return {
+        "generated_at": _utc_timestamp(),
+        "baseline_label": baseline_label,
+        "candidate_label": candidate_label,
+        "camera_count": len(rows),
+        "summary": {
+            "mean_improved": mean_directions.count("improved"),
+            "mean_worsened": mean_directions.count("worsened"),
+            "mean_unchanged": mean_directions.count("unchanged"),
+            "rms_improved": rms_directions.count("improved"),
+            "rms_worsened": rms_directions.count("worsened"),
+            "rms_unchanged": rms_directions.count("unchanged"),
+        },
+        "cameras": rows,
+    }
+
+
+def _format_float(value: object, *, precision: int = 9) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "-"
+    return f"{float(value):.{precision}f}"
+
+
+def _format_delta(value: object) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "-"
+    return f"{float(value):+.9f}"
+
+
+def _metric_delta_value(row: Mapping[str, object], key: str, field: str) -> object:
+    metrics = row.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return None
+    metric = metrics.get(key)
+    if not isinstance(metric, Mapping):
+        return None
+    return metric.get(field)
+
+
+def build_summary_markdown(report: Mapping[str, object]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    lines = [
+        "# Mapbox Outdoors comparison delta",
+        "",
+        f"Generated: `{report.get('generated_at', '-')}`",
+        "",
+        f"Baseline: `{report.get('baseline_label', 'baseline')}`",
+        f"Candidate: `{report.get('candidate_label', 'candidate')}`",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Improved | Worsened | Unchanged |",
+        "| --- | ---: | ---: | ---: |",
+        (
+            "| Mean absolute channel delta | "
+            f"{summary.get('mean_improved', 0)} | "
+            f"{summary.get('mean_worsened', 0)} | "
+            f"{summary.get('mean_unchanged', 0)} |"
+        ),
+        (
+            "| RMS channel delta | "
+            f"{summary.get('rms_improved', 0)} | "
+            f"{summary.get('rms_worsened', 0)} | "
+            f"{summary.get('rms_unchanged', 0)} |"
+        ),
+        "",
+        "## Cameras",
+        "",
+        (
+            "| Camera | z | Mean baseline | Mean candidate | Mean delta | "
+            "RMS baseline | RMS candidate | RMS delta | Changed ratio delta | Status |"
+        ),
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    cameras = report.get("cameras")
+    rows = cameras if isinstance(cameras, list) else []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        status = f"{row.get('baseline_status', '-')}/{row.get('candidate_status', '-')}"
+        mean_baseline = _metric_delta_value(
+            row,
+            "normalized_mean_absolute_channel_delta",
+            "baseline",
+        )
+        mean_candidate = _metric_delta_value(
+            row,
+            "normalized_mean_absolute_channel_delta",
+            "candidate",
+        )
+        mean_delta = _metric_delta_value(
+            row,
+            "normalized_mean_absolute_channel_delta",
+            "delta",
+        )
+        rms_baseline = _metric_delta_value(
+            row,
+            "normalized_rms_channel_delta",
+            "baseline",
+        )
+        rms_candidate = _metric_delta_value(
+            row,
+            "normalized_rms_channel_delta",
+            "candidate",
+        )
+        rms_delta = _metric_delta_value(row, "normalized_rms_channel_delta", "delta")
+        changed_ratio_delta = _metric_delta_value(row, "changed_pixel_ratio", "delta")
+        lines.append(
+            "| "
+            f"`{row.get('camera', '-')}` | "
+            f"{_format_float(row.get('zoom'), precision=2)} | "
+            f"{_format_float(mean_baseline)} | "
+            f"{_format_float(mean_candidate)} | "
+            f"{_format_delta(mean_delta)} | "
+            f"{_format_float(rms_baseline)} | "
+            f"{_format_float(rms_candidate)} | "
+            f"{_format_delta(rms_delta)} | "
+            f"{_format_delta(changed_ratio_delta)} | "
+            f"{status} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Notes:",
+            (
+                "- Negative mean/RMS deltas indicate the candidate moved closer "
+                "to the Mapbox GL reference."
+            ),
+            (
+                "- This is a manual validation aid; visual contact sheets still "
+                "decide whether a style probe is worth promoting."
+            ),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_report(report: Mapping[str, object], paths: ComparisonDeltaPaths) -> None:
+    paths.run_dir.mkdir(parents=True, exist_ok=True)
+    paths.json_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    paths.summary_path.write_text(build_summary_markdown(report), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare two Mapbox Outdoors all-camera summary.json reports.",
+    )
+    parser.add_argument("baseline_summary", type=Path)
+    parser.add_argument("candidate_summary", type=Path)
+    parser.add_argument("--baseline-label", default="baseline")
+    parser.add_argument("--candidate-label", default="candidate")
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    baseline_summary = load_json_object(args.baseline_summary)
+    candidate_summary = load_json_object(args.candidate_summary)
+    report = build_comparison_delta_report(
+        baseline_summary,
+        candidate_summary,
+        baseline_label=args.baseline_label,
+        candidate_label=args.candidate_label,
+    )
+    paths = build_comparison_delta_paths(build_run_directory(output_root=args.output_root))
+    write_report(report, paths)
+    print(f"Delta JSON: {paths.json_path}")
+    print(f"Delta report: {paths.summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -169,6 +169,7 @@ def build_comparison_delta_report(
     for camera in _ordered_camera_names(baseline_rows, candidate_rows):
         baseline_row = baseline_by_camera.get(camera)
         candidate_row = candidate_by_camera.get(camera)
+        candidate_zoom = _row_zoom(candidate_row)
         metric_deltas = {
             key: _metric_delta(baseline_row, candidate_row, key)
             for key in DELTA_METRIC_KEYS
@@ -177,8 +178,8 @@ def build_comparison_delta_report(
             {
                 "camera": camera,
                 "zoom": (
-                    _row_zoom(candidate_row)
-                    if candidate_row is not None
+                    candidate_zoom
+                    if candidate_zoom is not None
                     else _row_zoom(baseline_row)
                 ),
                 "baseline_status": _row_status(baseline_row),

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -26,6 +26,7 @@ DELTA_METRIC_KEYS = (
     "normalized_mean_absolute_channel_delta",
     "normalized_rms_channel_delta",
 )
+DIRECTION_BUCKETS = ("improved", "worsened", "unchanged", "unknown")
 
 
 class ComparisonDeltaPaths(NamedTuple):
@@ -34,8 +35,9 @@ class ComparisonDeltaPaths(NamedTuple):
     summary_path: Path
 
 
-def _report_timestamp() -> str:
-    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+def _report_timestamp(now: dt.datetime | None = None) -> str:
+    timestamp = now or dt.datetime.now(dt.timezone.utc)
+    return timestamp.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 def build_run_directory(
@@ -142,12 +144,17 @@ def _delta_direction(value: float | None) -> str:
     return "unchanged"
 
 
+def _direction_counts(prefix: str, directions: list[str]) -> dict[str, int]:
+    return {f"{prefix}_{bucket}": directions.count(bucket) for bucket in DIRECTION_BUCKETS}
+
+
 def build_comparison_delta_report(
     baseline_summary: Mapping[str, object],
     candidate_summary: Mapping[str, object],
     *,
     baseline_label: str = "baseline",
     candidate_label: str = "candidate",
+    now: dt.datetime | None = None,
 ) -> dict[str, object]:
     baseline_rows = _camera_rows(baseline_summary)
     candidate_rows = _camera_rows(candidate_summary)
@@ -199,18 +206,12 @@ def build_comparison_delta_report(
         if isinstance(row.get("rms_delta_direction"), str)
     ]
     return {
-        "generated_at": _report_timestamp(),
+        "generated_at": _report_timestamp(now),
         "baseline_label": baseline_label,
         "candidate_label": candidate_label,
         "camera_count": len(rows),
-        "summary": {
-            "mean_improved": mean_directions.count("improved"),
-            "mean_worsened": mean_directions.count("worsened"),
-            "mean_unchanged": mean_directions.count("unchanged"),
-            "rms_improved": rms_directions.count("improved"),
-            "rms_worsened": rms_directions.count("worsened"),
-            "rms_unchanged": rms_directions.count("unchanged"),
-        },
+        "summary": _direction_counts("mean", mean_directions)
+        | _direction_counts("rms", rms_directions),
         "cameras": rows,
     }
 
@@ -249,19 +250,21 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         "",
         "## Summary",
         "",
-        "| Metric | Improved | Worsened | Unchanged |",
-        "| --- | ---: | ---: | ---: |",
+        "| Metric | Improved | Worsened | Unchanged | Unknown |",
+        "| --- | ---: | ---: | ---: | ---: |",
         (
             "| Mean absolute channel delta | "
             f"{summary.get('mean_improved', 0)} | "
             f"{summary.get('mean_worsened', 0)} | "
-            f"{summary.get('mean_unchanged', 0)} |"
+            f"{summary.get('mean_unchanged', 0)} | "
+            f"{summary.get('mean_unknown', 0)} |"
         ),
         (
             "| RMS channel delta | "
             f"{summary.get('rms_improved', 0)} | "
             f"{summary.get('rms_worsened', 0)} | "
-            f"{summary.get('rms_unchanged', 0)} |"
+            f"{summary.get('rms_unchanged', 0)} | "
+            f"{summary.get('rms_unknown', 0)} |"
         ),
         "",
         "## Cameras",
@@ -360,13 +363,17 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     baseline_summary = load_json_object(args.baseline_summary)
     candidate_summary = load_json_object(args.candidate_summary)
+    now = dt.datetime.now(dt.timezone.utc)
     report = build_comparison_delta_report(
         baseline_summary,
         candidate_summary,
         baseline_label=args.baseline_label,
         candidate_label=args.candidate_label,
+        now=now,
     )
-    paths = build_comparison_delta_paths(build_run_directory(output_root=args.output_root))
+    paths = build_comparison_delta_paths(
+        build_run_directory(output_root=args.output_root, now=now)
+    )
     write_report(report, paths)
     print(f"Delta JSON: {paths.json_path}")
     print(f"Delta report: {paths.summary_path}")


### PR DESCRIPTION
## Summary

- add `validation/mapbox_outdoors_comparison_delta.py` to compare two Mapbox Outdoors all-camera `summary.json` files
- emit JSON and Markdown delta reports with per-camera mean/RMS/changed-ratio differences
- add unit coverage for camera pairing, missing rows, Markdown output, and CLI report writing

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison_delta.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- ran the helper against the #949 steps z18 sample probe; it captured one tiny mean improvement, one tiny RMS regression, and six unchanged cameras, so that style probe stays diagnostic

Refs #949
