### PR TITLE
fix: tune low-zoom path casing scale

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -654,9 +654,9 @@ _PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_LAYER_PREFIXES = (
     "bridge-path-bg-below-z16",
 )
 _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 14.0
-# The z14 Chamonix comparison showed Outdoors path casings reading too faintly
-# in QGIS after px-to-mm conversion; keep this as a modest casing-only boost.
-_PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.25
+# The z14 Geneva/Chamonix comparisons benefit from a small casing-only boost,
+# but larger low-zoom path casings overshoot the Mapbox GL reference.
+_PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.15
 _PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.5
 _PEDESTRIAN_LINE_WIDTH_LAYER_IDS = {
     "bridge-pedestrian",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5479,15 +5479,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
         low_width_mm = 1 * mapbox_config._MAPBOX_PIXEL_TO_MM
-        path_background_low_width_mm = (
-            mapbox_config._extract_zoom_scalar_size_at_zoom(line_width, 14.0)
-            * mapbox_config._MAPBOX_PIXEL_TO_MM
-            * mapbox_config._PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
-        )
         path_core_low_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(line_width, 14.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
+        path_background_low_width_mm = path_core_low_width_mm * 1.15
         high_width_mm = 7 * mapbox_config._MAPBOX_PIXEL_TO_MM
         high_background_width_mm = min(
             high_width_mm * mapbox_config._PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE,
@@ -5496,7 +5492,6 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path-z16-plus"]["paint"]["line-width"], high_width_mm)
-        self.assertAlmostEqual(path_background_low_width_mm, path_core_low_width_mm * 1.15)
         self.assertAlmostEqual(
             by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"],
             path_background_low_width_mm,

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5496,6 +5496,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path-z16-plus"]["paint"]["line-width"], high_width_mm)
+        self.assertAlmostEqual(path_background_low_width_mm, path_core_low_width_mm * 1.15)
         self.assertAlmostEqual(
             by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"],
             path_background_low_width_mm,


### PR DESCRIPTION
## Summary
- tune the low-zoom Mapbox Outdoors path background/casing scale from `1.25` to `1.15`
- keep the existing small casing boost while reducing the overshoot seen in the z14 Geneva/Chamonix comparisons
- lock the expected scale relationship in `tests/test_mapbox_config.py`

## Visual comparison
- Baseline: `debug/mapbox-outdoors-comparison-path-pedestrian-label-spacing-all/all-cameras/20260520T181842Z/summary.json`
- Candidate: `debug/mapbox-outdoors-comparison-path-bg-lowzoom-115-all/all-cameras/20260520T191405Z/summary.md`
- Delta report: `debug/mapbox-outdoors-comparison-delta/20260520T191415Z/summary.md`
- Result: z14 Geneva and Chamonix improved on mean/RMS deltas; z5, z8, z10, and z17 were unchanged; z18 had a tiny RMS/mean metric regression even though this low-zoom casing layer is not active there, so I treated that as residual render/comparison noise rather than a visible high-zoom styling tradeoff.

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
