### PR TITLE
docs: document z17 Mapbox comparison camera

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -39,6 +39,7 @@ Recommended z5-z18 inspection matrix:
 | `lausanne-lavaux-z10-outdoors` | z9-z11 | Primary qfit activity-area target: road/trail hierarchy, labels, feature density, color/width balance. |
 | `geneva-airport-motorway-z14-outdoors` | z14 | Motorway/urban detail around Geneva airport: road-exit shields, junction labels, urban POIs, dense road hierarchy. |
 | `chamonix-trails-z14-outdoors` | z13-z14 | Local outdoor detail: paths/trails, minor roads, POIs, label emphasis. |
+| `zermatt-piste-z17-outdoors` | z17 | Ski-piste stress target: colored path casings, cycleway/piste overlays, contour density, and high-zoom outdoor route legibility. |
 | `zermatt-trails-z18-outdoors` | z18 | Street/trail-level stress test: casing, widths, local labels, POIs, high-detail symbols. |
 
 ## Required local tools


### PR DESCRIPTION
## Summary

- Add `zermatt-piste-z17-outdoors` to the documented z5-z18 Mapbox Outdoors comparison matrix.
- Keep the harness docs aligned with `--list-cameras` and the existing contour/piste probe commands.

## Verification

- `python3 validation/mapbox_outdoors_comparison.py --list-cameras`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
