### PR TITLE
test: link path focus visual artifacts

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -15,6 +15,7 @@ from qfit.validation.mapbox_outdoors_path_pedestrian_focus import (
     build_path_pedestrian_focus_report,
     build_run_directory,
     build_summary_markdown,
+    comparison_visual_artifacts_from_summary,
     load_json_object,
     main,
     qgis_style_paths_from_comparison_summary,
@@ -229,6 +230,49 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                     trusted_root=root,
                 )
 
+    def test_comparison_visual_artifacts_from_summary_reads_metrics_and_output_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            comparison_root = Path(tmpdir) / "comparison"
+            summary_path = comparison_root / "all-cameras" / "20260520T003504Z" / "summary.json"
+            browser_path = comparison_root / "chamonix-trails-z14-outdoors" / "run" / "mapbox-gl-reference.png"
+            qgis_path = comparison_root / "chamonix-trails-z14-outdoors" / "run" / "qgis-vector-render.png"
+            diff_path = comparison_root / "chamonix-trails-z14-outdoors" / "run" / "mapbox-gl-vs-qgis-diff.png"
+            contact_sheet_path = summary_path.parent / "contact-sheet.jpg"
+            comparison_summary = {
+                "contact_sheet": "contact-sheet.jpg",
+                "cameras": [
+                    {
+                        "camera": "chamonix-trails-z14-outdoors",
+                        "status": "passed",
+                        "artifact_status": "metrics_available",
+                        "metrics": {
+                            "changed_pixel_ratio": 0.982,
+                            "normalized_mean_absolute_channel_delta": 0.0352,
+                            "normalized_rms_channel_delta": 0.0761,
+                            "ssim_status": "unavailable",
+                        },
+                        "outputs": {
+                            "browser_reference": str(browser_path),
+                            "qgis_vector_render": str(qgis_path),
+                            "diff": str(diff_path),
+                        },
+                    }
+                ],
+            }
+
+            artifacts = comparison_visual_artifacts_from_summary(
+                comparison_summary,
+                summary_path=summary_path,
+            )
+
+            camera_artifacts = artifacts["chamonix-trails-z14-outdoors"]
+            self.assertEqual(camera_artifacts["browser_reference"], browser_path.resolve())
+            self.assertEqual(camera_artifacts["qgis_vector_render"], qgis_path.resolve())
+            self.assertEqual(camera_artifacts["diff"], diff_path.resolve())
+            self.assertEqual(camera_artifacts["contact_sheet"], contact_sheet_path.resolve())
+            self.assertEqual(camera_artifacts["changed_pixel_ratio"], 0.982)
+            self.assertEqual(camera_artifacts["ssim_status"], "unavailable")
+
     def test_qgis_path_pedestrian_style_summary_counts_current_style_controls(self):
         summary = qgis_path_pedestrian_style_summary(_qgis_preprocessed_style(), camera_zoom=14.25)
 
@@ -369,6 +413,31 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(camera["qgis_path_pedestrian_layer_count"], 4)
         self.assertEqual(camera["qgis_path_pedestrian_visible_layer_count"], 3)
 
+    def test_build_path_pedestrian_focus_report_adds_visual_artifacts_to_focused_cameras(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            visual_artifacts_by_camera={
+                "chamonix-trails-z14-outdoors": {
+                    "changed_pixel_ratio": 0.982,
+                    "browser_reference": Path("debug/comparison/chamonix/mapbox-gl-reference.png"),
+                },
+                "switzerland-alps-z5-outdoors": {
+                    "changed_pixel_ratio": 0.943,
+                    "browser_reference": Path("debug/comparison/switzerland/mapbox-gl-reference.png"),
+                },
+            },
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        self.assertEqual(camera["camera"], "chamonix-trails-z14-outdoors")
+        self.assertEqual(camera["visual_artifacts"]["changed_pixel_ratio"], 0.982)
+        self.assertEqual(
+            camera["visual_artifacts"]["browser_reference"],
+            "debug/comparison/chamonix/mapbox-gl-reference.png",
+        )
+
     def test_build_path_pedestrian_focus_report_marks_missing_qgis_style(self):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),
@@ -406,6 +475,19 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),
             qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            visual_artifacts_by_camera={
+                "chamonix-trails-z14-outdoors": {
+                    "status": "passed",
+                    "artifact_status": "metrics_available",
+                    "changed_pixel_ratio": 0.982,
+                    "normalized_mean_absolute_channel_delta": 0.0352,
+                    "normalized_rms_channel_delta": 0.0761,
+                    "browser_reference": "debug/comparison/chamonix/mapbox-gl-reference.png",
+                    "qgis_vector_render": "debug/comparison/chamonix/qgis-vector-render.png",
+                    "diff": "debug/comparison/chamonix/mapbox-gl-vs-qgis-diff.png",
+                    "contact_sheet": "debug/comparison/all-cameras/contact-sheet.jpg",
+                },
+            },
             generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
         )
 
@@ -441,6 +523,40 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn('"line-width=1.5"', markdown)
         self.assertIn('"line-dasharray=[1,1]"', markdown)
         self.assertIn("| road-pedestrian-polygon | fill | z>=14 |", markdown)
+        self.assertIn("## Visual comparison artifacts", markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | passed | metrics_available | 0.982 | 0.0352 | 0.0761 |", markdown)
+        self.assertIn("`debug/comparison/chamonix/mapbox-gl-reference.png`", markdown)
+        self.assertIn("`debug/comparison/chamonix/qgis-vector-render.png`", markdown)
+        self.assertIn("`debug/comparison/chamonix/mapbox-gl-vs-qgis-diff.png`", markdown)
+        self.assertIn("`debug/comparison/all-cameras/contact-sheet.jpg`", markdown)
+
+    def test_build_summary_markdown_includes_visual_artifacts(self):
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            visual_artifacts_by_camera={
+                "chamonix-trails-z14-outdoors": {
+                    "status": "passed",
+                    "artifact_status": "metrics_available",
+                    "changed_pixel_ratio": 0.982,
+                    "normalized_mean_absolute_channel_delta": 0.0352,
+                    "normalized_rms_channel_delta": 0.0761,
+                    "browser_reference": "debug/comparison/chamonix/mapbox-gl-reference.png",
+                    "qgis_vector_render": "debug/comparison/chamonix/qgis-vector-render.png",
+                    "diff": "debug/comparison/chamonix/mapbox-gl-vs-qgis-diff.png",
+                    "contact_sheet": "debug/comparison/all-cameras/contact-sheet.jpg",
+                }
+            },
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        markdown = build_summary_markdown(report)
+
+        self.assertIn("## Visual comparison artifacts", markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | passed | metrics_available | 0.982 |", markdown)
+        self.assertIn("`debug/comparison/chamonix/mapbox-gl-reference.png`", markdown)
+        self.assertIn("`debug/comparison/chamonix/qgis-vector-render.png`", markdown)
+        self.assertIn("`debug/comparison/chamonix/mapbox-gl-vs-qgis-diff.png`", markdown)
+        self.assertIn("`debug/comparison/all-cameras/contact-sheet.jpg`", markdown)
 
     def test_build_summary_markdown_handles_no_focus_rows(self):
         markdown = build_summary_markdown({"generated": "now", "cameras": []})
@@ -599,8 +715,12 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             run_dir.mkdir(parents=True)
             style_path = run_dir / "qgis-preprocessed-style.json"
             manifest_path = run_dir / "manifest.json"
+            browser_path = run_dir / "mapbox-gl-reference.png"
+            qgis_path = run_dir / "qgis-vector-render.png"
+            diff_path = run_dir / "mapbox-gl-vs-qgis-diff.png"
             comparison_summary_path = root / "comparison" / "all-cameras" / "summary.json"
             comparison_summary_path.parent.mkdir(parents=True)
+            contact_sheet_path = comparison_summary_path.parent / "contact-sheet.jpg"
             road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
             style_path.write_text(json.dumps(_qgis_preprocessed_style()), encoding="utf-8")
             manifest_path.write_text(
@@ -610,10 +730,23 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             comparison_summary_path.write_text(
                 json.dumps(
                     {
+                        "contact_sheet": str(contact_sheet_path),
                         "cameras": [
                             {
                                 "camera": "chamonix-trails-z14-outdoors",
+                                "status": "passed",
+                                "artifact_status": "metrics_available",
                                 "manifest": str(manifest_path),
+                                "metrics": {
+                                    "changed_pixel_ratio": 0.982,
+                                    "normalized_mean_absolute_channel_delta": 0.0352,
+                                    "normalized_rms_channel_delta": 0.0761,
+                                },
+                                "outputs": {
+                                    "browser_reference": str(browser_path),
+                                    "qgis_vector_render": str(qgis_path),
+                                    "diff": str(diff_path),
+                                },
                             }
                         ]
                     }
@@ -646,6 +779,12 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                 [str(comparison_summary_path)],
             )
             self.assertEqual(report["input_artifacts"]["qgis_style_cameras"], ["chamonix-trails-z14-outdoors"])
+            [camera] = report["cameras"]
+            self.assertEqual(camera["visual_artifacts"]["browser_reference"], str(browser_path.resolve()))
+            self.assertEqual(camera["visual_artifacts"]["qgis_vector_render"], str(qgis_path.resolve()))
+            self.assertEqual(camera["visual_artifacts"]["diff"], str(diff_path.resolve()))
+            self.assertEqual(camera["visual_artifacts"]["contact_sheet"], str(contact_sheet_path.resolve()))
+            self.assertEqual(camera["visual_artifacts"]["normalized_rms_channel_delta"], 0.0761)
 
     def test_main_reports_missing_input_without_traceback(self):
         stderr = io.StringIO()

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -759,7 +759,10 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             with patch(
                 "qfit.validation.mapbox_outdoors_path_pedestrian_focus.DEFAULT_OUTPUT_ROOT",
                 output_root,
-            ), redirect_stdout(stdout):
+            ), patch(
+                "qfit.validation.mapbox_outdoors_path_pedestrian_focus.load_json_object",
+                wraps=load_json_object,
+            ) as loaded_json, redirect_stdout(stdout):
                 result = main(
                     [
                         "--road-features-json",
@@ -785,6 +788,45 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             self.assertEqual(camera["visual_artifacts"]["diff"], str(diff_path.resolve()))
             self.assertEqual(camera["visual_artifacts"]["contact_sheet"], str(contact_sheet_path.resolve()))
             self.assertEqual(camera["visual_artifacts"]["normalized_rms_channel_delta"], 0.0761)
+            loaded_paths = [call.args[0] for call in loaded_json.call_args_list]
+            self.assertEqual(loaded_paths.count(comparison_summary_path), 1)
+
+    def test_main_reports_untrusted_visual_artifact_without_traceback(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            road_features_path = root / "road-features.json"
+            comparison_summary_path = root / "comparison" / "all-cameras" / "summary.json"
+            comparison_summary_path.parent.mkdir(parents=True)
+            road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
+            comparison_summary_path.write_text(
+                json.dumps(
+                    {
+                        "cameras": [
+                            {
+                                "camera": "chamonix-trails-z14-outdoors",
+                                "outputs": {"browser_reference": "/tmp/outside.png"},
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stderr = io.StringIO()
+
+            with redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+                main(
+                    [
+                        "--road-features-json",
+                        str(road_features_path),
+                        "--comparison-summary-json",
+                        str(comparison_summary_path),
+                    ]
+                )
+
+            self.assertEqual(raised.exception.code, 2)
+            self.assertIn("Comparison artifact path must stay under", stderr.getvalue())
+            self.assertIn("/tmp/outside.png", stderr.getvalue())
+            self.assertNotIn("Traceback", stderr.getvalue())
 
     def test_main_reports_missing_input_without_traceback(self):
         stderr = io.StringIO()

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -897,13 +897,15 @@ def _load_cli_json_object(parser: argparse.ArgumentParser, path: Path, *, label:
     raise AssertionError("argparse error should exit")
 
 
-def _qgis_style_paths_from_cli_comparison_summary(
+def _comparison_inputs_from_cli_summary(
     parser: argparse.ArgumentParser,
     path: Path,
-) -> dict[str, Path]:
+) -> tuple[dict[str, Path], dict[str, dict[str, object]]]:
     comparison_summary = _load_cli_json_object(parser, path, label="Comparison summary JSON")
     try:
-        return qgis_style_paths_from_comparison_summary(comparison_summary, summary_path=path)
+        qgis_style_paths = qgis_style_paths_from_comparison_summary(comparison_summary, summary_path=path)
+        visual_artifacts = comparison_visual_artifacts_from_summary(comparison_summary, summary_path=path)
+        return qgis_style_paths, visual_artifacts
     except FileNotFoundError as error:
         parser.error(f"Comparison manifest not found: {error.filename}")
     except json.JSONDecodeError as error:
@@ -944,20 +946,12 @@ def main(argv: list[str] | None = None) -> int:
     qgis_style_paths_by_camera: dict[str, Path] = {}
     visual_artifacts_by_camera: dict[str, dict[str, object]] = {}
     for comparison_summary_path in args.comparison_summary_json:
-        qgis_style_paths_by_camera.update(
-            _qgis_style_paths_from_cli_comparison_summary(parser, comparison_summary_path)
-        )
-        comparison_summary = _load_cli_json_object(
+        qgis_style_paths, visual_artifacts = _comparison_inputs_from_cli_summary(
             parser,
             comparison_summary_path,
-            label="Comparison summary JSON",
         )
-        visual_artifacts_by_camera.update(
-            comparison_visual_artifacts_from_summary(
-                comparison_summary,
-                summary_path=comparison_summary_path,
-            )
-        )
+        qgis_style_paths_by_camera.update(qgis_style_paths)
+        visual_artifacts_by_camera.update(visual_artifacts)
     qgis_style_paths_by_camera.update(dict(args.qgis_style_json))
     qgis_styles_by_camera = {
         camera: _load_cli_json_object(parser, path, label=f"QGIS style JSON for {camera}")

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -40,6 +40,13 @@ PATH_PEDESTRIAN_DETAIL_PAINT_KEYS = (
 )
 TOP_COUNT_LIMIT = 3
 SAMPLE_LAYER_LIMIT = 8
+COMPARISON_VISUAL_OUTPUT_KEYS = ("browser_reference", "qgis_vector_render", "diff")
+COMPARISON_VISUAL_METRIC_KEYS = (
+    "changed_pixel_ratio",
+    "normalized_mean_absolute_channel_delta",
+    "normalized_rms_channel_delta",
+    "ssim_status",
+)
 
 
 @dataclass(frozen=True)
@@ -82,7 +89,8 @@ def load_json_object(path: Path) -> dict[str, object]:
 def _resolve_trusted_debug_path(raw_path: str, *, base_dir: Path, trusted_root: Path) -> Path:
     path = Path(raw_path)
     candidate = path if path.is_absolute() else base_dir / path
-    resolved = candidate.resolve()
+    # Safe: the resolved candidate is rejected unless it stays beneath the trusted debug root.
+    resolved = candidate.resolve()  # NOSONAR
     if not resolved.is_relative_to(trusted_root.resolve()):
         raise ValueError(f"Comparison artifact path must stay under {trusted_root}: {resolved}")
     return resolved
@@ -137,6 +145,106 @@ def qgis_style_paths_from_comparison_summary(
             trusted_root=root,
         )
     return paths
+
+
+def _comparison_debug_root(summary_path: Path | None, trusted_root: Path | None) -> Path:
+    if trusted_root is not None:
+        return trusted_root
+    if summary_path is not None:
+        return _trusted_root_for_comparison_summary(summary_path)
+    return DEFAULT_COMPARISON_OUTPUT_ROOT
+
+
+def _comparison_summary_base_dir(summary_path: Path | None) -> Path:
+    return Path.cwd() if summary_path is None else summary_path.parent
+
+
+def _comparison_camera_rows(comparison_summary: Mapping[str, object]) -> list[object]:
+    cameras = comparison_summary.get("cameras")
+    return cameras if isinstance(cameras, list) else []
+
+
+def _comparison_contact_sheet_path(
+    comparison_summary: Mapping[str, object],
+    *,
+    base_dir: Path,
+    trusted_root: Path,
+) -> Path | None:
+    contact_sheet_value = comparison_summary.get("contact_sheet")
+    if not isinstance(contact_sheet_value, str) or not contact_sheet_value:
+        return None
+    return _resolve_trusted_debug_path(
+        contact_sheet_value,
+        base_dir=base_dir,
+        trusted_root=trusted_root,
+    )
+
+
+def _camera_status_artifacts(camera_report: Mapping[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key in ("status", "artifact_status")
+        if isinstance((value := camera_report.get(key)), str)
+    }
+
+
+def _camera_metric_artifacts(camera_report: Mapping[str, object]) -> dict[str, object]:
+    metrics = camera_report.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return {}
+    return {
+        key: value
+        for key in COMPARISON_VISUAL_METRIC_KEYS
+        if isinstance((value := metrics.get(key)), (str, int, float)) and not isinstance(value, bool)
+    }
+
+
+def _camera_output_artifacts(
+    camera_report: Mapping[str, object],
+    *,
+    base_dir: Path,
+    trusted_root: Path,
+) -> dict[str, object]:
+    outputs = camera_report.get("outputs")
+    if not isinstance(outputs, Mapping):
+        return {}
+    return {
+        key: _resolve_trusted_debug_path(value, base_dir=base_dir, trusted_root=trusted_root)
+        for key in COMPARISON_VISUAL_OUTPUT_KEYS
+        if isinstance((value := outputs.get(key)), str) and value
+    }
+
+
+def comparison_visual_artifacts_from_summary(
+    comparison_summary: Mapping[str, object],
+    *,
+    summary_path: Path | None = None,
+    trusted_root: Path | None = None,
+) -> dict[str, dict[str, object]]:
+    root = _comparison_debug_root(summary_path, trusted_root)
+    base_dir = _comparison_summary_base_dir(summary_path)
+    contact_sheet_path = _comparison_contact_sheet_path(
+        comparison_summary,
+        base_dir=base_dir,
+        trusted_root=root,
+    )
+    artifacts: dict[str, dict[str, object]] = {}
+    for camera_report in _comparison_camera_rows(comparison_summary):
+        if not isinstance(camera_report, Mapping):
+            continue
+        camera_name = camera_report.get("camera")
+        if not isinstance(camera_name, str):
+            continue
+        camera_artifacts = _camera_status_artifacts(camera_report)
+        camera_artifacts.update(_camera_metric_artifacts(camera_report))
+        camera_artifacts.update(
+            _camera_output_artifacts(camera_report, base_dir=base_dir, trusted_root=root)
+        )
+        if contact_sheet_path is not None:
+            camera_artifacts["contact_sheet"] = contact_sheet_path
+        if camera_artifacts:
+            artifacts[camera_name] = camera_artifacts
+    return artifacts
 
 
 def _compact_json(value: object, *, max_length: int = 110) -> str:
@@ -418,10 +526,12 @@ def build_path_pedestrian_focus_report(
     road_feature_report: Mapping[str, object],
     *,
     qgis_styles_by_camera: Mapping[str, Mapping[str, object]] | None = None,
+    visual_artifacts_by_camera: Mapping[str, Mapping[str, object]] | None = None,
     generated_at: dt.datetime | None = None,
     input_artifacts: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     qgis_styles = qgis_styles_by_camera or {}
+    visual_artifacts = visual_artifacts_by_camera or {}
     camera_reports = road_feature_report.get("cameras")
     source_rows = camera_reports if isinstance(camera_reports, list) else []
     rows = []
@@ -431,12 +541,13 @@ def build_path_pedestrian_focus_report(
         if camera_report.get("status") != "decoded" or not _has_path_pedestrian_focus(camera_report):
             continue
         camera_name = str(camera_report.get("camera") or "")
-        rows.append(
-            _camera_focus_row(
-                camera_report,
-                qgis_style=qgis_styles.get(camera_name),
-            )
+        row = _camera_focus_row(
+            camera_report,
+            qgis_style=qgis_styles.get(camera_name),
         )
+        if camera_name in visual_artifacts:
+            row["visual_artifacts"] = _json_safe_artifact_value(visual_artifacts[camera_name])
+        rows.append(row)
     generated = generated_at or dt.datetime.now(dt.timezone.utc)
     qgis_matched_camera_count = sum(1 for row in rows if row.get("qgis_style_status") == "available")
     report = {
@@ -583,6 +694,47 @@ def _visible_detail_markdown_lines(cameras: Iterable[object]) -> list[str]:
     return lines if detail_row_count else []
 
 
+def _artifact_path_cell(value: object) -> object:
+    if isinstance(value, str) and value:
+        return f"`{value}`"
+    return value
+
+
+def _visual_artifact_markdown_lines(cameras: Iterable[object]) -> list[str]:
+    rows: list[list[object]] = []
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        artifacts = camera.get("visual_artifacts")
+        if not isinstance(artifacts, Mapping):
+            continue
+        rows.append(
+            [
+                camera.get("camera"),
+                artifacts.get("status"),
+                artifacts.get("artifact_status"),
+                artifacts.get("changed_pixel_ratio"),
+                artifacts.get("normalized_mean_absolute_channel_delta"),
+                artifacts.get("normalized_rms_channel_delta"),
+                _artifact_path_cell(artifacts.get("browser_reference")),
+                _artifact_path_cell(artifacts.get("qgis_vector_render")),
+                _artifact_path_cell(artifacts.get("diff")),
+                _artifact_path_cell(artifacts.get("contact_sheet")),
+            ]
+        )
+    if not rows:
+        return []
+    lines = ["", "## Visual comparison artifacts", ""]
+    lines.extend(
+        [
+            "| Camera | Status | Artifact status | Changed ratio | Mean delta | RMS delta | Mapbox GL | QGIS render | Diff | Contact sheet |",
+            "| --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
+
+
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     cameras = report.get("cameras")
     rows = cameras if isinstance(cameras, list) else []
@@ -663,6 +815,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
                 ]
             )
         )
+    lines.extend(_visual_artifact_markdown_lines(rows))
     lines.extend(_visible_detail_markdown_lines(rows))
     return "\n".join(lines) + "\n"
 
@@ -768,6 +921,18 @@ def _display_input_path(path: Path) -> str:
         return str(resolved)
 
 
+def _display_visual_artifacts_by_camera(
+    visual_artifacts_by_camera: Mapping[str, Mapping[str, object]],
+) -> dict[str, dict[str, object]]:
+    displayed: dict[str, dict[str, object]] = {}
+    for camera, artifacts in visual_artifacts_by_camera.items():
+        displayed[camera] = {
+            str(key): _display_input_path(value) if isinstance(value, Path) else value
+            for key, value in artifacts.items()
+        }
+    return displayed
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -777,9 +942,21 @@ def main(argv: list[str] | None = None) -> int:
         label="Road features JSON",
     )
     qgis_style_paths_by_camera: dict[str, Path] = {}
+    visual_artifacts_by_camera: dict[str, dict[str, object]] = {}
     for comparison_summary_path in args.comparison_summary_json:
         qgis_style_paths_by_camera.update(
             _qgis_style_paths_from_cli_comparison_summary(parser, comparison_summary_path)
+        )
+        comparison_summary = _load_cli_json_object(
+            parser,
+            comparison_summary_path,
+            label="Comparison summary JSON",
+        )
+        visual_artifacts_by_camera.update(
+            comparison_visual_artifacts_from_summary(
+                comparison_summary,
+                summary_path=comparison_summary_path,
+            )
         )
     qgis_style_paths_by_camera.update(dict(args.qgis_style_json))
     qgis_styles_by_camera = {
@@ -789,6 +966,7 @@ def main(argv: list[str] | None = None) -> int:
     report = build_path_pedestrian_focus_report(
         road_feature_report,
         qgis_styles_by_camera=qgis_styles_by_camera,
+        visual_artifacts_by_camera=_display_visual_artifacts_by_camera(visual_artifacts_by_camera),
         input_artifacts={
             "road_features_json": _display_input_path(args.road_features_json),
             "comparison_summary_jsons": [_display_input_path(path) for path in args.comparison_summary_json],


### PR DESCRIPTION
## Summary

- Add visual comparison artifact extraction to the Mapbox path/pedestrian focus report.
- Include per-focused-camera Mapbox GL, QGIS render, diff, contact-sheet, and metric links when a comparison summary is provided.
- Keep artifact paths constrained to the trusted comparison debug root and render portable repo-relative paths in generated reports.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T202841Z/road-features.json --comparison-summary-json debug/mapbox-outdoors-comparison-current-relative-paths/all-cameras/20260520T194151Z/summary.json`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Generated local report: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T204156Z/summary.md`

Refs #949
