### PR TITLE
fix: cap contour labels before bbox edge handoff

### DIFF
--- a/tests/test_background_map_service.py
+++ b/tests/test_background_map_service.py
@@ -1344,6 +1344,9 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
             _mock_bms_mod._CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_MIN_ZOOM
         )
         appended_style.setLabelSettings.assert_called_once_with(copied_settings)
+        source_style.setMaxZoomLevel.assert_called_once_with(
+            _mock_bms_mod._CONTOUR_LABEL_MAX_ZOOM_BEFORE_BBOX_EDGE_DIFFERENCE
+        )
         self.assertEqual(copied_settings.fieldName, "concat(\"ele\", ' m')")
         self.assertTrue(copied_settings.isExpression)
         self.assertEqual(copied_settings.placement, _qstub.QgsPalLayerSettings.Curved)
@@ -1355,6 +1358,80 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
         self.assertTrue(copied_settings.geometryGeneratorEnabled)
         self.assertEqual(copied_settings.geometryGeneratorType, _qstub.Qgis.GeometryType.Line)
         labeling.setStyles.assert_called_once_with([source_style, appended_style])
+
+    def test_contour_label_clone_failure_keeps_source_label_uncapped(self):
+        labeling = MagicMock()
+        source_style, source_settings = self._make_style("contour", "contour-label")
+        source_style.maxZoomLevel.return_value = -1
+        source_settings.mergeLines = True
+        source_settings.fieldName = "concat(\"ele\", ' m')"
+        source_settings.isExpression = True
+        labeling.styles.return_value = [source_style]
+        _qstub.QgsPalLayerSettings.reset_mock(return_value=True, side_effect=True)
+        _qstub.QgsPalLayerSettings.side_effect = RuntimeError("copy failed")
+        _qstub.QgsVectorTileBasicLabelingStyle.reset_mock(
+            return_value=True,
+            side_effect=True,
+        )
+
+        self.service._apply_label_priority(labeling)
+
+        source_style.setMaxZoomLevel.assert_not_called()
+        _qstub.QgsVectorTileBasicLabelingStyle.assert_not_called()
+        labeling.setStyles.assert_not_called()
+
+    def test_contour_label_cap_failure_still_appends_bbox_edge_style(self):
+        labeling = MagicMock()
+        source_style, source_settings = self._make_style("contour", "contour-label")
+        source_style.setMaxZoomLevel.side_effect = RuntimeError("cap failed")
+        source_settings.mergeLines = True
+        source_settings.fieldName = "concat(\"ele\", ' m')"
+        source_settings.isExpression = True
+        labeling.styles.return_value = [source_style]
+        copied_settings = SimpleNamespace()
+        appended_style = MagicMock()
+        _qstub.QgsPalLayerSettings.reset_mock(return_value=True, side_effect=True)
+        _qstub.QgsPalLayerSettings.return_value = copied_settings
+        _qstub.QgsVectorTileBasicLabelingStyle.reset_mock(
+            return_value=True,
+            side_effect=True,
+        )
+        _qstub.QgsVectorTileBasicLabelingStyle.return_value = appended_style
+
+        self.service._apply_label_priority(labeling)
+
+        source_style.setMaxZoomLevel.assert_called_once_with(
+            _mock_bms_mod._CONTOUR_LABEL_MAX_ZOOM_BEFORE_BBOX_EDGE_DIFFERENCE
+        )
+        appended_style.setLabelSettings.assert_called_once_with(copied_settings)
+        labeling.setStyles.assert_called_once_with([source_style, appended_style])
+
+    def test_existing_high_zoom_bbox_edge_style_caps_uncapped_source_label(self):
+        labeling = MagicMock()
+        source_style, source_settings = self._make_style("contour", "contour-label")
+        source_style.maxZoomLevel.return_value = -1
+        source_settings.mergeLines = True
+        source_settings.fieldName = "concat(\"ele\", ' m')"
+        source_settings.isExpression = True
+        existing_style, _existing_settings = self._make_style(
+            "contour",
+            _mock_bms_mod._CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_STYLE_NAME,
+        )
+        labeling.styles.return_value = [source_style, existing_style]
+        _qstub.QgsPalLayerSettings.reset_mock(return_value=True, side_effect=True)
+        _qstub.QgsVectorTileBasicLabelingStyle.reset_mock(
+            return_value=True,
+            side_effect=True,
+        )
+
+        self.service._apply_label_priority(labeling)
+
+        source_style.setMaxZoomLevel.assert_called_once_with(
+            _mock_bms_mod._CONTOUR_LABEL_MAX_ZOOM_BEFORE_BBOX_EDGE_DIFFERENCE
+        )
+        _qstub.QgsPalLayerSettings.assert_not_called()
+        _qstub.QgsVectorTileBasicLabelingStyle.assert_not_called()
+        labeling.setStyles.assert_called_once_with([source_style, existing_style])
 
     def test_custom_contour_label_field_does_not_append_high_zoom_bbox_edge_style(self):
         labeling = MagicMock()
@@ -1370,11 +1447,15 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
         _qstub.QgsPalLayerSettings.assert_not_called()
         _qstub.QgsVectorTileBasicLabelingStyle.assert_not_called()
+        style.setMaxZoomLevel.assert_not_called()
         labeling.setStyles.assert_not_called()
 
     def test_existing_high_zoom_bbox_edge_style_is_not_duplicated(self):
         labeling = MagicMock()
         source_style, source_settings = self._make_style("contour", "contour-label")
+        source_style.maxZoomLevel.return_value = (
+            _mock_bms_mod._CONTOUR_LABEL_MAX_ZOOM_BEFORE_BBOX_EDGE_DIFFERENCE
+        )
         source_settings.mergeLines = True
         source_settings.fieldName = "concat(\"ele\", ' m')"
         source_settings.isExpression = True
@@ -1390,6 +1471,7 @@ class ApplyLabelPriorityMockTests(unittest.TestCase):
 
         _qstub.QgsPalLayerSettings.assert_not_called()
         _qstub.QgsVectorTileBasicLabelingStyle.assert_not_called()
+        source_style.setMaxZoomLevel.assert_not_called()
         labeling.setStyles.assert_not_called()
 
     def test_custom_contour_label_field_is_left_unchanged(self):

--- a/visualization/infrastructure/background_map_service.py
+++ b/visualization/infrastructure/background_map_service.py
@@ -85,6 +85,9 @@ _CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_EXPRESSION = (
 )
 _CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_FILTER = '("index" = 5 OR "index" = 10)'
 _CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_MIN_ZOOM = 17
+_CONTOUR_LABEL_MAX_ZOOM_BEFORE_BBOX_EDGE_DIFFERENCE = (
+    _CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_MIN_ZOOM - 1
+)
 
 
 def _label_style_mapbox_layer_id(style) -> str:
@@ -394,20 +397,24 @@ def _append_high_zoom_contour_bbox_edge_label_style(
     qgs_vector_tile_labeling_style,
     qgis,
 ) -> bool:
-    if any(
+    has_bbox_edge_style = any(
         _label_style_name(style) == _CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_STYLE_NAME
         for style in styles
-    ):
-        return False
+    )
 
+    source_style = None
     source_settings = None
     for style in styles:
         if _label_style_mapbox_layer_id(style) != _CONTOUR_LABEL_LAYER_ID:
             continue
+        source_style = style
         source_settings = style.labelSettings()
         break
     if source_settings is None or not _is_contour_elevation_label(source_settings):
         return False
+
+    if has_bbox_edge_style:
+        return _cap_source_contour_label_before_bbox_edge(source_style)
 
     try:
         settings = qgs_pal_layer_settings(source_settings)
@@ -432,7 +439,28 @@ def _append_high_zoom_contour_bbox_edge_label_style(
     style.setFilterExpression(_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_FILTER)
     style.setMinZoomLevel(_CONTOUR_LABEL_BBOX_EDGE_DIFFERENCE_MIN_ZOOM)
     style.setLabelSettings(settings)
+    _cap_source_contour_label_before_bbox_edge(source_style)
     styles.append(style)
+    return True
+
+
+def _cap_source_contour_label_before_bbox_edge(style) -> bool:
+    if style is None:
+        return False
+    target_max_zoom = _CONTOUR_LABEL_MAX_ZOOM_BEFORE_BBOX_EDGE_DIFFERENCE
+    try:
+        current_max_zoom = style.maxZoomLevel()
+    except (AttributeError, RuntimeError, TypeError):
+        current_max_zoom = None
+    if isinstance(current_max_zoom, int) and 0 <= current_max_zoom <= target_max_zoom:
+        return False
+    set_max_zoom_level = getattr(style, "setMaxZoomLevel", None)
+    if not callable(set_max_zoom_level):
+        return False
+    try:
+        set_max_zoom_level(target_max_zoom)
+    except (RuntimeError, TypeError):
+        return False
     return True
 
 


### PR DESCRIPTION
## Summary

- Caps the original QGIS `contour-label` labeling style at zoom 16 when the z17+ bbox-edge contour label style is present.
- Keeps the z17+ bbox-edge contour label style as the high-zoom replacement instead of drawing both contour label strategies at once.
- Adds regression coverage for appending the replacement style, existing replacement styles, and already-capped source styles.

## Why

This is a small #949 rendering-parity slice from the visual crop investigation. The z17 Zermatt contour crop showed contour label drift and clutter around high-zoom terrain labels. We already add a bbox-edge contour label style at z17+, but the source contour label style could remain uncapped, so QGIS could keep both label strategies active at high zoom.

## Validation

- `python3 -m pytest tests/test_background_map_service.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live Mapbox/QGIS comparison, `zermatt-piste-z17-outdoors`: `debug/mapbox-outdoors-comparison-contour-label-cap/zermatt-piste-z17-outdoors/20260520T212857Z/`
- Live Mapbox/QGIS comparison, `chamonix-trails-z14-outdoors`: `debug/mapbox-outdoors-comparison-contour-label-cap/chamonix-trails-z14-outdoors/20260520T212910Z/`

The live label-style snapshots show `contour-label` with `max_zoom_level=16` and `contour-label-bbox-edge-difference-z17-plus` with `min_zoom_level=17` in both validation runs.

Part of #949.
