### PR TITLE
Add path/pedestrian label focus diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -16,8 +16,11 @@ from qfit.validation.mapbox_outdoors_path_pedestrian_focus import (
     build_run_directory,
     build_summary_markdown,
     comparison_visual_artifacts_from_summary,
+    load_json_list,
     load_json_object,
     main,
+    qgis_label_style_paths_from_comparison_summary,
+    qgis_path_pedestrian_label_summary,
     qgis_style_paths_from_comparison_summary,
     qgis_path_pedestrian_style_summary,
     write_report,
@@ -109,6 +112,86 @@ def _qgis_preprocessed_style():
     }
 
 
+def _qgis_label_styles():
+    return [
+        {
+            "style_name": "road-label-z12-to-z15",
+            "layer_name": "road",
+            "geometry_type": 1,
+            "filter_expression": '"name" IS NOT NULL',
+            "min_zoom_level": 12,
+            "max_zoom_level": 14,
+            "label_settings": {
+                "field_name": '"name"',
+                "placement": 3,
+                "priority": 4,
+                "repeat_distance": 39.6875,
+                "repeat_distance_unit": 0,
+                "label_per_part": False,
+                "merge_lines": True,
+                "text_size": 2.6458333333333335,
+                "text_color": "#606060",
+                "buffer_enabled": True,
+                "buffer_size": 0.5291666666666667,
+                "buffer_color": "#ffffff",
+            },
+        },
+        {
+            "style_name": "road-label-z15-plus",
+            "layer_name": "road",
+            "geometry_type": 1,
+            "filter_expression": '"name" IS NOT NULL',
+            "min_zoom_level": 15,
+            "max_zoom_level": -1,
+            "label_settings": {
+                "field_name": '"name"',
+                "placement": 3,
+                "priority": 4,
+                "repeat_distance": 105.83333333333333,
+                "repeat_distance_unit": 0,
+                "label_per_part": False,
+                "merge_lines": True,
+                "text_size": 2.6458333333333335,
+                "text_color": "#606060",
+                "buffer_enabled": True,
+                "buffer_size": 0.5291666666666667,
+                "buffer_color": "#ffffff",
+            },
+        },
+        {
+            "style_name": "path-pedestrian-label",
+            "layer_name": "road",
+            "geometry_type": 1,
+            "filter_expression": '"class" = \'pedestrian\'',
+            "min_zoom_level": 12,
+            "max_zoom_level": -1,
+            "label_settings": {
+                "field_name": '"name"',
+                "placement": 3,
+                "priority": 3,
+                "repeat_distance": 105.83333333333333,
+                "repeat_distance_unit": 0,
+                "label_per_part": False,
+                "merge_lines": True,
+                "text_size": 2.38125,
+                "text_color": "#000000",
+                "buffer_enabled": True,
+                "buffer_size": 0.5291666666666667,
+                "buffer_color": "#ffffff",
+            },
+        },
+        {
+            "style_name": "poi-label",
+            "layer_name": "poi_label",
+            "geometry_type": 0,
+            "filter_expression": "",
+            "min_zoom_level": 14,
+            "max_zoom_level": -1,
+            "label_settings": {"field_name": '"name"'},
+        },
+    ]
+
+
 class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
     def test_build_run_directory_and_paths_are_predictable(self):
         run_dir = build_run_directory(
@@ -130,6 +213,16 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             json_path.write_text('["not", "object"]\n', encoding="utf-8")
             with self.assertRaises(ValueError):
                 load_json_object(json_path)
+
+    def test_load_json_list_requires_list(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_path = Path(tmpdir) / "report.json"
+            json_path.write_text('["ok"]\n', encoding="utf-8")
+            self.assertEqual(load_json_list(json_path), ["ok"])
+
+            json_path.write_text('{"not": "a list"}\n', encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_json_list(json_path)
 
     def test_qgis_style_paths_from_comparison_summary_reads_manifest_outputs(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -159,6 +252,35 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             )
 
             self.assertEqual(paths, {"chamonix-trails-z14-outdoors": style_path.resolve()})
+
+    def test_qgis_label_style_paths_from_comparison_summary_reads_manifest_outputs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_root = root / "comparison"
+            run_dir = comparison_root / "camera" / "20260520T003504Z"
+            run_dir.mkdir(parents=True)
+            label_path = run_dir / "qgis-label-styles.json"
+            manifest_path = run_dir / "manifest.json"
+            label_path.write_text(json.dumps(_qgis_label_styles()), encoding="utf-8")
+            manifest_path.write_text(
+                json.dumps({"outputs": {"qgis_label_styles": str(label_path)}}),
+                encoding="utf-8",
+            )
+            comparison_summary = {
+                "cameras": [
+                    {
+                        "camera": "chamonix-trails-z14-outdoors",
+                        "manifest": str(manifest_path),
+                    }
+                ]
+            }
+
+            paths = qgis_label_style_paths_from_comparison_summary(
+                comparison_summary,
+                summary_path=comparison_root / "all-cameras" / "summary.json",
+            )
+
+            self.assertEqual(paths, {"chamonix-trails-z14-outdoors": label_path.resolve()})
 
     def test_qgis_style_paths_from_comparison_summary_rejects_untrusted_manifest_paths(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -388,10 +510,32 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             list(range(1, 11)),
         )
 
+    def test_qgis_path_pedestrian_label_summary_counts_visible_road_and_path_labels(self):
+        summary = qgis_path_pedestrian_label_summary(_qgis_label_styles(), camera_zoom=18.0)
+
+        self.assertEqual(summary["qgis_label_style_status"], "available")
+        self.assertEqual(summary["qgis_path_pedestrian_label_style_count"], 3)
+        self.assertEqual(summary["qgis_path_pedestrian_visible_label_style_count"], 2)
+        self.assertEqual(
+            summary["qgis_path_pedestrian_label_style_names"],
+            ["road-label-z12-to-z15", "road-label-z15-plus", "path-pedestrian-label"],
+        )
+        self.assertEqual(
+            summary["qgis_path_pedestrian_visible_label_style_names"],
+            ["road-label-z15-plus", "path-pedestrian-label"],
+        )
+        details = {
+            detail["style_name"]: detail for detail in summary["qgis_path_pedestrian_visible_label_details"]
+        }
+        self.assertEqual(details["road-label-z15-plus"]["repeat_distance"], 105.83333333333333)
+        self.assertTrue(details["road-label-z15-plus"]["merge_lines"])
+        self.assertEqual(details["path-pedestrian-label"]["text_size"], 2.38125)
+
     def test_build_path_pedestrian_focus_report_cross_links_feature_counts_and_qgis_style(self):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),
             qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            qgis_label_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_label_styles()},
             generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
         )
 
@@ -399,6 +543,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(report["camera_count"], 1)
         self.assertEqual(report["qgis_style_camera_count"], 1)
         self.assertEqual(report["qgis_style_input_count"], 1)
+        self.assertEqual(report["qgis_label_style_camera_count"], 1)
+        self.assertEqual(report["qgis_label_style_input_count"], 1)
         [camera] = report["cameras"]
         self.assertEqual(camera["camera"], "chamonix-trails-z14-outdoors")
         self.assertEqual(camera["pedestrian_path_polygon_count"], 10)
@@ -412,6 +558,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(camera["top_step_line_duplicate_names"], ["Kirchsteig=2"])
         self.assertEqual(camera["qgis_path_pedestrian_layer_count"], 4)
         self.assertEqual(camera["qgis_path_pedestrian_visible_layer_count"], 3)
+        self.assertEqual(camera["qgis_path_pedestrian_label_style_count"], 3)
+        self.assertEqual(camera["qgis_path_pedestrian_visible_label_style_count"], 2)
 
     def test_build_path_pedestrian_focus_report_adds_visual_artifacts_to_focused_cameras(self):
         report = build_path_pedestrian_focus_report(
@@ -446,11 +594,14 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
 
         [camera] = report["cameras"]
         self.assertEqual(camera["qgis_style_status"], "missing")
+        self.assertEqual(camera["qgis_label_style_status"], "missing")
         self.assertEqual(camera["qgis_path_pedestrian_layer_count"], 0)
         self.assertEqual(camera["qgis_path_pedestrian_visible_layer_count"], 0)
         self.assertEqual(camera["qgis_path_pedestrian_visible_filter_layer_count"], 0)
         self.assertEqual(camera["qgis_path_pedestrian_layer_details"], [])
         self.assertEqual(camera["qgis_path_pedestrian_visible_layer_details"], [])
+        self.assertEqual(camera["qgis_path_pedestrian_label_details"], [])
+        self.assertEqual(camera["qgis_path_pedestrian_visible_label_details"], [])
 
     def test_build_path_pedestrian_focus_report_ignores_boolean_counts(self):
         road_report = {
@@ -475,6 +626,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),
             qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            qgis_label_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_label_styles()},
             visual_artifacts_by_camera={
                 "chamonix-trails-z14-outdoors": {
                     "status": "passed",
@@ -496,8 +648,10 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("# Mapbox Outdoors path/pedestrian focus", markdown)
         self.assertIn("Focused cameras: 1", markdown)
         self.assertIn("QGIS preprocessed style cameras: 1/1 matched", markdown)
+        self.assertIn("QGIS label style cameras: 1/1 matched", markdown)
         self.assertIn("Top pedestrian types", markdown)
         self.assertIn("Duplicate pedestrian labels", markdown)
+        self.assertIn("QGIS labels", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | 14.25 | 14 |", markdown)
         self.assertIn('"path_lines=236"', markdown)
         self.assertIn('"pedestrian=115"', markdown)
@@ -508,6 +662,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn('"status=available"', markdown)
         self.assertIn('"total=4"', markdown)
         self.assertIn('"visible=3"', markdown)
+        self.assertIn('"total=3"', markdown)
+        self.assertIn('"visible=2"', markdown)
         self.assertIn('"line_colors=3"', markdown)
         self.assertIn('"visible_filters=2"', markdown)
         self.assertIn('"visible_widths=1"', markdown)
@@ -523,6 +679,10 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn('"line-width=1.5"', markdown)
         self.assertIn('"line-dasharray=[1,1]"', markdown)
         self.assertIn("| road-pedestrian-polygon | fill | z>=14 |", markdown)
+        self.assertIn("## Visible QGIS label details", markdown)
+        self.assertIn("| road-label-z12-to-z15 | road | 12<=z<=14 |", markdown)
+        self.assertIn('"repeat_distance=105.83333333333333"', markdown)
+        self.assertIn("| path-pedestrian-label | road | z>=12 |", markdown)
         self.assertIn("## Visual comparison artifacts", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | passed | metrics_available | 0.982 | 0.0352 | 0.0761 |", markdown)
         self.assertIn("`debug/comparison/chamonix/mapbox-gl-reference.png`", markdown)
@@ -572,6 +732,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                 "road_features_json": "debug/roads/road-features.json",
                 "comparison_summary_jsons": ["debug/comparison/summary.json"],
                 "qgis_style_cameras": ["chamonix-trails-z14-outdoors"],
+                "qgis_label_style_cameras": ["chamonix-trails-z14-outdoors"],
             },
         )
 
@@ -584,6 +745,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("Road features input: `debug/roads/road-features.json`", markdown)
         self.assertIn("Comparison summary inputs: `debug/comparison/summary.json`", markdown)
         self.assertIn("QGIS style input cameras: `chamonix-trails-z14-outdoors`", markdown)
+        self.assertIn("QGIS label style input cameras: `chamonix-trails-z14-outdoors`", markdown)
 
     def test_build_report_serializes_path_input_artifacts(self):
         report = build_path_pedestrian_focus_report(
@@ -650,9 +812,11 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             road_features_path = Path(tmpdir) / "road-features.json"
             style_path = Path(tmpdir) / "qgis-preprocessed-style.json"
+            label_path = Path(tmpdir) / "qgis-label-styles.json"
             output_root = Path(tmpdir) / "out"
             road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
             style_path.write_text(json.dumps(_qgis_preprocessed_style()), encoding="utf-8")
+            label_path.write_text(json.dumps(_qgis_label_styles()), encoding="utf-8")
 
             stdout = io.StringIO()
             with patch(
@@ -665,6 +829,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         str(road_features_path),
                         "--qgis-style-json",
                         f"chamonix-trails-z14-outdoors={style_path}",
+                        "--qgis-label-styles-json",
+                        f"chamonix-trails-z14-outdoors={label_path}",
                     ]
                 )
 
@@ -679,6 +845,11 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                 report["input_artifacts"]["qgis_style_cameras"],
                 ["chamonix-trails-z14-outdoors"],
             )
+            self.assertEqual(
+                report["input_artifacts"]["qgis_label_style_cameras"],
+                ["chamonix-trails-z14-outdoors"],
+            )
+            self.assertEqual(report["qgis_label_style_camera_count"], 1)
 
     def test_main_records_resolved_external_relative_input_path(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -714,6 +885,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             run_dir = root / "comparison" / "chamonix-trails-z14-outdoors" / "20260520T003504Z"
             run_dir.mkdir(parents=True)
             style_path = run_dir / "qgis-preprocessed-style.json"
+            label_path = run_dir / "qgis-label-styles.json"
             manifest_path = run_dir / "manifest.json"
             browser_path = run_dir / "mapbox-gl-reference.png"
             qgis_path = run_dir / "qgis-vector-render.png"
@@ -723,8 +895,16 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             contact_sheet_path = comparison_summary_path.parent / "contact-sheet.jpg"
             road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
             style_path.write_text(json.dumps(_qgis_preprocessed_style()), encoding="utf-8")
+            label_path.write_text(json.dumps(_qgis_label_styles()), encoding="utf-8")
             manifest_path.write_text(
-                json.dumps({"outputs": {"qgis_preprocessed_style": str(style_path)}}),
+                json.dumps(
+                    {
+                        "outputs": {
+                            "qgis_preprocessed_style": str(style_path),
+                            "qgis_label_styles": str(label_path),
+                        }
+                    }
+                ),
                 encoding="utf-8",
             )
             comparison_summary_path.write_text(
@@ -777,12 +957,19 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertEqual(report["qgis_style_camera_count"], 1)
             self.assertEqual(report["qgis_style_input_count"], 1)
+            self.assertEqual(report["qgis_label_style_camera_count"], 1)
+            self.assertEqual(report["qgis_label_style_input_count"], 1)
             self.assertEqual(
                 report["input_artifacts"]["comparison_summary_jsons"],
                 [str(comparison_summary_path)],
             )
             self.assertEqual(report["input_artifacts"]["qgis_style_cameras"], ["chamonix-trails-z14-outdoors"])
+            self.assertEqual(
+                report["input_artifacts"]["qgis_label_style_cameras"],
+                ["chamonix-trails-z14-outdoors"],
+            )
             [camera] = report["cameras"]
+            self.assertEqual(camera["qgis_path_pedestrian_visible_label_style_count"], 2)
             self.assertEqual(camera["visual_artifacts"]["browser_reference"], str(browser_path.resolve()))
             self.assertEqual(camera["visual_artifacts"]["qgis_vector_render"], str(qgis_path.resolve()))
             self.assertEqual(camera["visual_artifacts"]["diff"], str(diff_path.resolve()))

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -30,6 +30,13 @@ PATH_PEDESTRIAN_LAYER_ID_MARKERS = (
     "road-steps",
 )
 PATH_PEDESTRIAN_STYLE_TYPES = {"fill", "line"}
+PATH_PEDESTRIAN_LABEL_STYLE_IDS = {
+    "path-pedestrian-label",
+    "road-label",
+    "road-label-below-z12",
+    "road-label-z12-to-z15",
+    "road-label-z15-plus",
+}
 PATH_PEDESTRIAN_DETAIL_PAINT_KEYS = (
     "line-width",
     "line-color",
@@ -47,6 +54,7 @@ COMPARISON_VISUAL_METRIC_KEYS = (
     "normalized_rms_channel_delta",
     "ssim_status",
 )
+ARGPARSE_EXIT_SENTINEL = "argparse error should exit"
 
 
 @dataclass(frozen=True)
@@ -86,6 +94,14 @@ def load_json_object(path: Path) -> dict[str, object]:
     return loaded
 
 
+def load_json_list(path: Path) -> list[object]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, list):
+        raise ValueError(f"Expected JSON list in {path}")
+    return loaded
+
+
 def _resolve_trusted_debug_path(raw_path: str, *, base_dir: Path, trusted_root: Path) -> Path:
     path = Path(raw_path)
     candidate = path if path.is_absolute() else base_dir / path
@@ -104,9 +120,10 @@ def _trusted_root_for_comparison_summary(summary_path: Path) -> Path:
     return DEFAULT_COMPARISON_OUTPUT_ROOT
 
 
-def qgis_style_paths_from_comparison_summary(
+def _qgis_output_paths_from_comparison_summary(
     comparison_summary: Mapping[str, object],
     *,
+    output_key: str,
     summary_path: Path | None = None,
     trusted_root: Path | None = None,
 ) -> dict[str, Path]:
@@ -136,7 +153,7 @@ def qgis_style_paths_from_comparison_summary(
         outputs = manifest.get("outputs")
         if not isinstance(outputs, Mapping):
             continue
-        style_value = outputs.get("qgis_preprocessed_style")
+        style_value = outputs.get(output_key)
         if not isinstance(style_value, str):
             continue
         paths[camera_name] = _resolve_trusted_debug_path(
@@ -145,6 +162,34 @@ def qgis_style_paths_from_comparison_summary(
             trusted_root=root,
         )
     return paths
+
+
+def qgis_style_paths_from_comparison_summary(
+    comparison_summary: Mapping[str, object],
+    *,
+    summary_path: Path | None = None,
+    trusted_root: Path | None = None,
+) -> dict[str, Path]:
+    return _qgis_output_paths_from_comparison_summary(
+        comparison_summary,
+        output_key="qgis_preprocessed_style",
+        summary_path=summary_path,
+        trusted_root=trusted_root,
+    )
+
+
+def qgis_label_style_paths_from_comparison_summary(
+    comparison_summary: Mapping[str, object],
+    *,
+    summary_path: Path | None = None,
+    trusted_root: Path | None = None,
+) -> dict[str, Path]:
+    return _qgis_output_paths_from_comparison_summary(
+        comparison_summary,
+        output_key="qgis_label_styles",
+        summary_path=summary_path,
+        trusted_root=trusted_root,
+    )
 
 
 def _comparison_debug_root(summary_path: Path | None, trusted_root: Path | None) -> Path:
@@ -472,10 +517,120 @@ def _missing_qgis_style_summary() -> dict[str, object]:
     }
 
 
+def _label_style_rows(label_styles: Iterable[object]) -> list[dict[str, object]]:
+    return [style for style in label_styles if isinstance(style, dict)]
+
+
+def _is_path_pedestrian_label_style(label_style: Mapping[str, object]) -> bool:
+    style_name = label_style.get("style_name")
+    return isinstance(style_name, str) and style_name in PATH_PEDESTRIAN_LABEL_STYLE_IDS
+
+
+def _label_zoom_level(camera_zoom: float | None) -> int | None:
+    if camera_zoom is None:
+        return None
+    return int(camera_zoom)
+
+
+def _label_zoom_bound(value: object, *, max_bound: bool = False) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        if max_bound and value < 0:
+            return None
+        return float(value)
+    return None
+
+
+def _label_is_visible_at_zoom(label_style: Mapping[str, object], camera_zoom: float | None) -> bool:
+    zoom_level = _label_zoom_level(camera_zoom)
+    if zoom_level is None:
+        return True
+    minzoom = _label_zoom_bound(label_style.get("min_zoom_level"))
+    maxzoom = _label_zoom_bound(label_style.get("max_zoom_level"), max_bound=True)
+    if minzoom is not None and zoom_level < minzoom:
+        return False
+    return not (maxzoom is not None and zoom_level > maxzoom)
+
+
+def _label_settings(label_style: Mapping[str, object]) -> Mapping[str, object]:
+    settings = label_style.get("label_settings")
+    return settings if isinstance(settings, Mapping) else {}
+
+
+def _label_detail(label_style: Mapping[str, object]) -> dict[str, object]:
+    detail = {
+        "style_name": str(label_style.get("style_name") or ""),
+        "layer_name": label_style.get("layer_name"),
+        "geometry_type": label_style.get("geometry_type"),
+    }
+    for key in ("min_zoom_level", "max_zoom_level", "filter_expression"):
+        value = label_style.get(key)
+        if value not in (None, ""):
+            detail[key] = value
+    settings = _label_settings(label_style)
+    for key in (
+        "field_name",
+        "placement",
+        "priority",
+        "repeat_distance",
+        "repeat_distance_unit",
+        "label_per_part",
+        "merge_lines",
+        "text_size",
+        "text_color",
+        "buffer_enabled",
+        "buffer_size",
+        "buffer_color",
+    ):
+        if key in settings:
+            detail[key] = settings[key]
+    return detail
+
+
+def qgis_path_pedestrian_label_summary(
+    label_styles: Iterable[object],
+    *,
+    camera_zoom: float | None = None,
+) -> dict[str, object]:
+    label_rows = [
+        label_style
+        for label_style in _label_style_rows(label_styles)
+        if _is_path_pedestrian_label_style(label_style)
+    ]
+    visible_rows = [row for row in label_rows if _label_is_visible_at_zoom(row, camera_zoom)]
+    return {
+        "qgis_label_style_status": "available",
+        "qgis_path_pedestrian_label_style_count": len(label_rows),
+        "qgis_path_pedestrian_visible_label_style_count": len(visible_rows),
+        "qgis_path_pedestrian_label_style_names": [
+            str(row.get("style_name") or "") for row in label_rows
+        ],
+        "qgis_path_pedestrian_visible_label_style_names": [
+            str(row.get("style_name") or "") for row in visible_rows
+        ],
+        "qgis_path_pedestrian_label_details": [_label_detail(row) for row in label_rows],
+        "qgis_path_pedestrian_visible_label_details": [_label_detail(row) for row in visible_rows],
+    }
+
+
+def _missing_qgis_label_summary() -> dict[str, object]:
+    return {
+        "qgis_label_style_status": "missing",
+        "qgis_path_pedestrian_label_style_count": 0,
+        "qgis_path_pedestrian_visible_label_style_count": 0,
+        "qgis_path_pedestrian_label_style_names": [],
+        "qgis_path_pedestrian_visible_label_style_names": [],
+        "qgis_path_pedestrian_label_details": [],
+        "qgis_path_pedestrian_visible_label_details": [],
+    }
+
+
 def _camera_focus_row(
     camera_report: Mapping[str, object],
     *,
     qgis_style: Mapping[str, object] | None,
+    qgis_label_styles: Iterable[object] | None,
 ) -> dict[str, object]:
     row = {
         "camera": camera_report.get("camera"),
@@ -503,6 +658,11 @@ def _camera_focus_row(
         if qgis_style is not None
         else _missing_qgis_style_summary()
     )
+    row.update(
+        qgis_path_pedestrian_label_summary(qgis_label_styles, camera_zoom=camera_zoom)
+        if qgis_label_styles is not None
+        else _missing_qgis_label_summary()
+    )
     return row
 
 
@@ -526,11 +686,13 @@ def build_path_pedestrian_focus_report(
     road_feature_report: Mapping[str, object],
     *,
     qgis_styles_by_camera: Mapping[str, Mapping[str, object]] | None = None,
+    qgis_label_styles_by_camera: Mapping[str, Iterable[object]] | None = None,
     visual_artifacts_by_camera: Mapping[str, Mapping[str, object]] | None = None,
     generated_at: dt.datetime | None = None,
     input_artifacts: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     qgis_styles = qgis_styles_by_camera or {}
+    qgis_label_styles = qgis_label_styles_by_camera or {}
     visual_artifacts = visual_artifacts_by_camera or {}
     camera_reports = road_feature_report.get("cameras")
     source_rows = camera_reports if isinstance(camera_reports, list) else []
@@ -544,12 +706,16 @@ def build_path_pedestrian_focus_report(
         row = _camera_focus_row(
             camera_report,
             qgis_style=qgis_styles.get(camera_name),
+            qgis_label_styles=qgis_label_styles.get(camera_name),
         )
         if camera_name in visual_artifacts:
             row["visual_artifacts"] = _json_safe_artifact_value(visual_artifacts[camera_name])
         rows.append(row)
     generated = generated_at or dt.datetime.now(dt.timezone.utc)
     qgis_matched_camera_count = sum(1 for row in rows if row.get("qgis_style_status") == "available")
+    qgis_label_matched_camera_count = sum(
+        1 for row in rows if row.get("qgis_label_style_status") == "available"
+    )
     report = {
         "generated": generated.astimezone(dt.timezone.utc).isoformat(),
         "road_feature_generated": road_feature_report.get("generated"),
@@ -558,6 +724,8 @@ def build_path_pedestrian_focus_report(
         "camera_count": len(rows),
         "qgis_style_camera_count": qgis_matched_camera_count,
         "qgis_style_input_count": len(qgis_styles),
+        "qgis_label_style_camera_count": qgis_label_matched_camera_count,
+        "qgis_label_style_input_count": len(qgis_label_styles),
         "cameras": rows,
     }
     if input_artifacts is not None:
@@ -635,6 +803,9 @@ def _input_artifact_markdown_lines(report: Mapping[str, object]) -> list[str]:
     qgis_style_cameras = _string_list(input_artifacts.get("qgis_style_cameras"))
     if qgis_style_cameras:
         lines.append(f"QGIS style input cameras: `{', '.join(qgis_style_cameras)}`")
+    qgis_label_style_cameras = _string_list(input_artifacts.get("qgis_label_style_cameras"))
+    if qgis_label_style_cameras:
+        lines.append(f"QGIS label style input cameras: `{', '.join(qgis_label_style_cameras)}`")
     return lines
 
 
@@ -687,6 +858,74 @@ def _visible_detail_markdown_lines(cameras: Iterable[object]) -> list[str]:
                         _detail_zoom_band(detail),
                         _detail_paint_controls(detail),
                         detail.get("filter"),
+                    ]
+                )
+            )
+        lines.append("")
+    return lines if detail_row_count else []
+
+
+def _label_detail_zoom_band(detail: Mapping[str, object]) -> str:
+    minzoom = detail.get("min_zoom_level")
+    maxzoom = detail.get("max_zoom_level")
+    if isinstance(maxzoom, (int, float)) and not isinstance(maxzoom, bool) and maxzoom < 0:
+        maxzoom = None
+    if minzoom is None and maxzoom is None:
+        return "all"
+    if minzoom is None:
+        return f"z<={maxzoom}"
+    if maxzoom is None:
+        return f"z>={minzoom}"
+    return f"{minzoom}<=z<={maxzoom}"
+
+
+def _label_controls(detail: Mapping[str, object]) -> list[str]:
+    return [
+        f"{key}={_compact_json(detail.get(key))}"
+        for key in (
+            "field_name",
+            "placement",
+            "priority",
+            "repeat_distance",
+            "label_per_part",
+            "merge_lines",
+            "text_size",
+            "text_color",
+            "buffer_size",
+        )
+        if key in detail
+    ]
+
+
+def _visible_label_detail_markdown_lines(cameras: Iterable[object]) -> list[str]:
+    lines = ["", "## Visible QGIS label details", ""]
+    detail_row_count = 0
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        details = camera.get("qgis_path_pedestrian_visible_label_details")
+        detail_rows = details if isinstance(details, list) else []
+        mapping_rows = [detail for detail in detail_rows if isinstance(detail, Mapping)]
+        if not mapping_rows:
+            continue
+        detail_row_count += len(mapping_rows)
+        lines.extend(
+            [
+                f"### {camera.get('camera')}",
+                "",
+                "| Style | Layer | Zoom band | Controls | Filter |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for detail in mapping_rows:
+            lines.append(
+                _markdown_table_row(
+                    [
+                        detail.get("style_name"),
+                        detail.get("layer_name"),
+                        _label_detail_zoom_band(detail),
+                        _label_controls(detail),
+                        detail.get("filter_expression"),
                     ]
                 )
             )
@@ -749,6 +988,10 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
             "QGIS preprocessed style cameras: "
             f"{report.get('qgis_style_camera_count')}/{report.get('qgis_style_input_count', 0)} matched"
         ),
+        (
+            "QGIS label style cameras: "
+            f"{report.get('qgis_label_style_camera_count')}/{report.get('qgis_label_style_input_count', 0)} matched"
+        ),
         "",
     ]
     input_lines = _input_artifact_markdown_lines(report)
@@ -773,8 +1016,8 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         return "\n".join(lines) + "\n"
     lines.extend(
         [
-            "| Camera | Camera zoom | Tile zoom | Feature counts | Top pedestrian types | Top path types | Duplicate pedestrian labels | Duplicate path labels | Duplicate step labels | Top path signatures | Top step signatures | QGIS layers | QGIS controls | Sample visible QGIS strokes | Sample visible QGIS colors | Sample visible QGIS layer ids |",
-            "| --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+            "| Camera | Camera zoom | Tile zoom | Feature counts | Top pedestrian types | Top path types | Duplicate pedestrian labels | Duplicate path labels | Duplicate step labels | Top path signatures | Top step signatures | QGIS layers | QGIS labels | QGIS controls | Sample visible QGIS strokes | Sample visible QGIS colors | Sample visible QGIS layer ids | Visible QGIS label styles |",
+            "| --- | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
     for camera in rows:
@@ -793,6 +1036,11 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
             f"line={camera.get('qgis_path_pedestrian_line_layer_count', 0)}",
             f"fill={camera.get('qgis_path_pedestrian_fill_layer_count', 0)}",
         ]
+        qgis_labels = [
+            f"status={camera.get('qgis_label_style_status')}",
+            f"total={camera.get('qgis_path_pedestrian_label_style_count', 0)}",
+            f"visible={camera.get('qgis_path_pedestrian_visible_label_style_count', 0)}",
+        ]
         lines.append(
             _markdown_table_row(
                 [
@@ -808,15 +1056,18 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
                     camera.get("top_path_signatures"),
                     camera.get("top_step_signatures"),
                     qgis_layers,
+                    qgis_labels,
                     _qgis_control_summary(camera),
                     _qgis_stroke_samples(camera),
                     _qgis_color_samples(camera),
                     camera.get("qgis_path_pedestrian_visible_layer_ids"),
+                    camera.get("qgis_path_pedestrian_visible_label_style_names"),
                 ]
             )
         )
     lines.extend(_visual_artifact_markdown_lines(rows))
     lines.extend(_visible_detail_markdown_lines(rows))
+    lines.extend(_visible_label_detail_markdown_lines(rows))
     return "\n".join(lines) + "\n"
 
 
@@ -873,6 +1124,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Camera-specific qgis-preprocessed-style.json. May be repeated.",
     )
     parser.add_argument(
+        "--qgis-label-styles-json",
+        action="append",
+        default=[],
+        type=_parse_qgis_style_json,
+        metavar="CAMERA=PATH",
+        help="Camera-specific qgis-label-styles.json. May be repeated.",
+    )
+    parser.add_argument(
         "--comparison-summary-json",
         action="append",
         default=[],
@@ -894,25 +1153,41 @@ def _load_cli_json_object(parser: argparse.ArgumentParser, path: Path, *, label:
         parser.error(f"{label} is not valid JSON: {path}: {error.msg}")
     except ValueError as error:
         parser.error(str(error))
-    raise AssertionError("argparse error should exit")
+    raise AssertionError(ARGPARSE_EXIT_SENTINEL)
+
+
+def _load_cli_json_list(parser: argparse.ArgumentParser, path: Path, *, label: str) -> list[object]:
+    try:
+        return load_json_list(path)
+    except FileNotFoundError:
+        parser.error(f"{label} not found: {path}")
+    except json.JSONDecodeError as error:
+        parser.error(f"{label} is not valid JSON: {path}: {error.msg}")
+    except ValueError as error:
+        parser.error(str(error))
+    raise AssertionError(ARGPARSE_EXIT_SENTINEL)
 
 
 def _comparison_inputs_from_cli_summary(
     parser: argparse.ArgumentParser,
     path: Path,
-) -> tuple[dict[str, Path], dict[str, dict[str, object]]]:
+) -> tuple[dict[str, Path], dict[str, Path], dict[str, dict[str, object]]]:
     comparison_summary = _load_cli_json_object(parser, path, label="Comparison summary JSON")
     try:
         qgis_style_paths = qgis_style_paths_from_comparison_summary(comparison_summary, summary_path=path)
+        qgis_label_style_paths = qgis_label_style_paths_from_comparison_summary(
+            comparison_summary,
+            summary_path=path,
+        )
         visual_artifacts = comparison_visual_artifacts_from_summary(comparison_summary, summary_path=path)
-        return qgis_style_paths, visual_artifacts
+        return qgis_style_paths, qgis_label_style_paths, visual_artifacts
     except FileNotFoundError as error:
         parser.error(f"Comparison manifest not found: {error.filename}")
     except json.JSONDecodeError as error:
         parser.error(f"Comparison manifest is not valid JSON: {error.msg}")
     except ValueError as error:
         parser.error(str(error))
-    raise AssertionError("argparse error should exit")
+    raise AssertionError(ARGPARSE_EXIT_SENTINEL)
 
 
 def _display_input_path(path: Path) -> str:
@@ -944,27 +1219,36 @@ def main(argv: list[str] | None = None) -> int:
         label="Road features JSON",
     )
     qgis_style_paths_by_camera: dict[str, Path] = {}
+    qgis_label_style_paths_by_camera: dict[str, Path] = {}
     visual_artifacts_by_camera: dict[str, dict[str, object]] = {}
     for comparison_summary_path in args.comparison_summary_json:
-        qgis_style_paths, visual_artifacts = _comparison_inputs_from_cli_summary(
+        qgis_style_paths, qgis_label_style_paths, visual_artifacts = _comparison_inputs_from_cli_summary(
             parser,
             comparison_summary_path,
         )
         qgis_style_paths_by_camera.update(qgis_style_paths)
+        qgis_label_style_paths_by_camera.update(qgis_label_style_paths)
         visual_artifacts_by_camera.update(visual_artifacts)
     qgis_style_paths_by_camera.update(dict(args.qgis_style_json))
+    qgis_label_style_paths_by_camera.update(dict(args.qgis_label_styles_json))
     qgis_styles_by_camera = {
         camera: _load_cli_json_object(parser, path, label=f"QGIS style JSON for {camera}")
         for camera, path in qgis_style_paths_by_camera.items()
     }
+    qgis_label_styles_by_camera = {
+        camera: _load_cli_json_list(parser, path, label=f"QGIS label styles JSON for {camera}")
+        for camera, path in qgis_label_style_paths_by_camera.items()
+    }
     report = build_path_pedestrian_focus_report(
         road_feature_report,
         qgis_styles_by_camera=qgis_styles_by_camera,
+        qgis_label_styles_by_camera=qgis_label_styles_by_camera,
         visual_artifacts_by_camera=_display_visual_artifacts_by_camera(visual_artifacts_by_camera),
         input_artifacts={
             "road_features_json": _display_input_path(args.road_features_json),
             "comparison_summary_jsons": [_display_input_path(path) for path in args.comparison_summary_json],
             "qgis_style_cameras": sorted(qgis_style_paths_by_camera),
+            "qgis_label_style_cameras": sorted(qgis_label_style_paths_by_camera),
         },
     )
     paths = build_path_pedestrian_focus_paths(build_run_directory())


### PR DESCRIPTION
## Summary
- extend the path/pedestrian focus report to read `qgis-label-styles.json` from comparison manifests
- add visible road/path label settings to the focus JSON and Markdown output
- include CLI support for camera-specific `qgis-label-styles.json` inputs

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`

## #949 evidence
Generated a refreshed path/pedestrian focus report against the post-#1237 all-camera comparison:

- `debug/mapbox-outdoors-path-pedestrian-focus/20260520T220456Z/summary.md`
- road features input: `debug/mapbox-outdoors-road-features/all-cameras/20260520T202841Z/road-features.json`
- comparison input: `debug/mapbox-outdoors-comparison-post-contour-cap/all-cameras/20260520T214751Z/summary.json`

The report now links the z18 duplicate road/path feature counts with the visible converted QGIS label rules (`road-label-z15-plus` and `path-pedestrian-label`), including repeat distance and merge-lines settings.

Closes no issue; contributes a small diagnostic slice for #949.
