### PR TITLE
Add path label duplicate diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -742,6 +742,29 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("`debug/comparison/chamonix/mapbox-gl-vs-qgis-diff.png`", markdown)
         self.assertIn("`debug/comparison/all-cameras/contact-sheet.jpg`", markdown)
 
+    def test_build_summary_markdown_omits_duplicate_label_rows_without_duplicate_names(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "now",
+                "cameras": [
+                    {
+                        "camera": "merge-line-only",
+                        "duplicate_label_diagnostic": {
+                            "has_duplicate_feature_names": False,
+                            "duplicate_name_categories": [],
+                            "visible_merge_line_label_styles": ["road-label-z15-plus"],
+                            "visible_label_repeat_distances": [
+                                "road-label-z15-plus=105.83333333333333"
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+
+        self.assertIn("| merge-line-only |", markdown)
+        self.assertNotIn("## Duplicate label diagnostics", markdown)
+
     def test_build_summary_markdown_handles_no_focus_rows(self):
         markdown = build_summary_markdown({"generated": "now", "cameras": []})
 

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -560,6 +560,25 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(camera["qgis_path_pedestrian_visible_layer_count"], 3)
         self.assertEqual(camera["qgis_path_pedestrian_label_style_count"], 3)
         self.assertEqual(camera["qgis_path_pedestrian_visible_label_style_count"], 2)
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["duplicate_name_categories"],
+            [
+                {"category": "pedestrian", "top_duplicates": ["Englischer Viertel=5"]},
+                {"category": "path", "top_duplicates": ["Hofmattweg=3"]},
+                {"category": "step", "top_duplicates": ["Kirchsteig=2"]},
+            ],
+        )
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["visible_merge_line_label_styles"],
+            ["road-label-z12-to-z15", "path-pedestrian-label"],
+        )
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["visible_label_repeat_distances"],
+            [
+                "road-label-z12-to-z15=39.6875",
+                "path-pedestrian-label=105.83333333333333",
+            ],
+        )
 
     def test_build_path_pedestrian_focus_report_adds_visual_artifacts_to_focused_cameras(self):
         report = build_path_pedestrian_focus_report(
@@ -683,6 +702,11 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("| road-label-z12-to-z15 | road | 12<=z<=14 |", markdown)
         self.assertIn('"repeat_distance=105.83333333333333"', markdown)
         self.assertIn("| path-pedestrian-label | road | z>=12 |", markdown)
+        self.assertIn("## Duplicate label diagnostics", markdown)
+        self.assertIn('"pedestrian: Englischer Viertel=5"', markdown)
+        self.assertIn('"path: Hofmattweg=3"', markdown)
+        self.assertIn('"road-label-z12-to-z15"', markdown)
+        self.assertIn('"path-pedestrian-label=105.83333333333333"', markdown)
         self.assertIn("## Visual comparison artifacts", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | passed | metrics_available | 0.982 | 0.0352 | 0.0761 |", markdown)
         self.assertIn("`debug/comparison/chamonix/mapbox-gl-reference.png`", markdown)

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -47,6 +47,11 @@ PATH_PEDESTRIAN_DETAIL_PAINT_KEYS = (
 )
 TOP_COUNT_LIMIT = 3
 SAMPLE_LAYER_LIMIT = 8
+DUPLICATE_LABEL_CATEGORY_KEYS = (
+    ("pedestrian", "top_pedestrian_line_duplicate_names"),
+    ("path", "top_path_line_duplicate_names"),
+    ("step", "top_step_line_duplicate_names"),
+)
 COMPARISON_VISUAL_OUTPUT_KEYS = ("browser_reference", "qgis_vector_render", "diff")
 COMPARISON_VISUAL_METRIC_KEYS = (
     "changed_pixel_ratio",
@@ -626,6 +631,60 @@ def _missing_qgis_label_summary() -> dict[str, object]:
     }
 
 
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if item is not None]
+
+
+def _duplicate_label_categories(camera: Mapping[str, object]) -> list[dict[str, object]]:
+    categories: list[dict[str, object]] = []
+    for category, key in DUPLICATE_LABEL_CATEGORY_KEYS:
+        duplicates = _string_list(camera.get(key))
+        if duplicates:
+            categories.append({"category": category, "top_duplicates": duplicates})
+    return categories
+
+
+def _visible_label_detail_rows(camera: Mapping[str, object]) -> list[Mapping[str, object]]:
+    details = camera.get("qgis_path_pedestrian_visible_label_details")
+    detail_rows = details if isinstance(details, list) else []
+    return [detail for detail in detail_rows if isinstance(detail, Mapping)]
+
+
+def _visible_merge_line_label_styles(camera: Mapping[str, object]) -> list[str]:
+    style_names: list[str] = []
+    for detail in _visible_label_detail_rows(camera):
+        style_name = str(detail.get("style_name") or "")
+        if style_name and detail.get("merge_lines") is True:
+            style_names.append(style_name)
+    return style_names
+
+
+def _visible_label_repeat_distances(camera: Mapping[str, object]) -> list[str]:
+    repeat_distances: list[str] = []
+    for detail in _visible_label_detail_rows(camera):
+        style_name = str(detail.get("style_name") or "")
+        repeat_distance = detail.get("repeat_distance")
+        if (
+            style_name
+            and isinstance(repeat_distance, (int, float))
+            and not isinstance(repeat_distance, bool)
+        ):
+            repeat_distances.append(f"{style_name}={_compact_json(repeat_distance)}")
+    return repeat_distances
+
+
+def _duplicate_label_diagnostic(camera: Mapping[str, object]) -> dict[str, object]:
+    duplicate_categories = _duplicate_label_categories(camera)
+    return {
+        "has_duplicate_feature_names": bool(duplicate_categories),
+        "duplicate_name_categories": duplicate_categories,
+        "visible_merge_line_label_styles": _visible_merge_line_label_styles(camera),
+        "visible_label_repeat_distances": _visible_label_repeat_distances(camera),
+    }
+
+
 def _camera_focus_row(
     camera_report: Mapping[str, object],
     *,
@@ -663,6 +722,7 @@ def _camera_focus_row(
         if qgis_label_styles is not None
         else _missing_qgis_label_summary()
     )
+    row["duplicate_label_diagnostic"] = _duplicate_label_diagnostic(row)
     return row
 
 
@@ -781,12 +841,6 @@ def _qgis_stroke_samples(camera: Mapping[str, object]) -> list[str]:
     if isinstance(dash_samples, list):
         samples.extend(str(sample) for sample in dash_samples[:2])
     return samples
-
-
-def _string_list(value: object) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [str(item) for item in value if item is not None]
 
 
 def _input_artifact_markdown_lines(report: Mapping[str, object]) -> list[str]:
@@ -974,6 +1028,52 @@ def _visual_artifact_markdown_lines(cameras: Iterable[object]) -> list[str]:
     return lines
 
 
+def _duplicate_category_summaries(diagnostic: Mapping[str, object]) -> list[str]:
+    categories = diagnostic.get("duplicate_name_categories")
+    category_rows = categories if isinstance(categories, list) else []
+    summaries: list[str] = []
+    for category_row in category_rows:
+        if not isinstance(category_row, Mapping):
+            continue
+        category = str(category_row.get("category") or "")
+        duplicates = _string_list(category_row.get("top_duplicates"))
+        if category and duplicates:
+            summaries.append(f"{category}: {', '.join(duplicates)}")
+    return summaries
+
+
+def _duplicate_label_diagnostic_markdown_lines(cameras: Iterable[object]) -> list[str]:
+    rows: list[list[object]] = []
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        diagnostic = camera.get("duplicate_label_diagnostic")
+        if not isinstance(diagnostic, Mapping):
+            continue
+        duplicate_summaries = _duplicate_category_summaries(diagnostic)
+        merge_line_styles = _string_list(diagnostic.get("visible_merge_line_label_styles"))
+        repeat_distances = _string_list(diagnostic.get("visible_label_repeat_distances"))
+        if not duplicate_summaries and not merge_line_styles and not repeat_distances:
+            continue
+        rows.append([camera.get("camera"), duplicate_summaries, merge_line_styles, repeat_distances])
+    if not rows:
+        return []
+    lines = ["", "## Duplicate label diagnostics", ""]
+    lines.extend(
+        [
+            (
+                "Connects duplicate source feature names with the visible QGIS "
+                "line-label merge/repeat controls active at each camera zoom."
+            ),
+            "",
+            "| Camera | Duplicate feature names | Visible merge-line label styles | Visible label repeat distances |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
+
+
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     cameras = report.get("cameras")
     rows = cameras if isinstance(cameras, list) else []
@@ -1066,6 +1166,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
             )
         )
     lines.extend(_visual_artifact_markdown_lines(rows))
+    lines.extend(_duplicate_label_diagnostic_markdown_lines(rows))
     lines.extend(_visible_detail_markdown_lines(rows))
     lines.extend(_visible_label_detail_markdown_lines(rows))
     return "\n".join(lines) + "\n"

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -1051,10 +1051,10 @@ def _duplicate_label_diagnostic_markdown_lines(cameras: Iterable[object]) -> lis
         if not isinstance(diagnostic, Mapping):
             continue
         duplicate_summaries = _duplicate_category_summaries(diagnostic)
+        if not duplicate_summaries:
+            continue
         merge_line_styles = _string_list(diagnostic.get("visible_merge_line_label_styles"))
         repeat_distances = _string_list(diagnostic.get("visible_label_repeat_distances"))
-        if not duplicate_summaries and not merge_line_styles and not repeat_distances:
-            continue
         rows.append([camera.get("camera"), duplicate_summaries, merge_line_styles, repeat_distances])
     if not rows:
         return []


### PR DESCRIPTION
## Summary

- Add a duplicate-label diagnostic payload to the Mapbox Outdoors path/pedestrian focus report.
- Render a dedicated Markdown section that connects duplicate source feature names with visible QGIS merge-line label styles and repeat distances.
- Keep the Markdown diagnostics table focused on cameras that actually have duplicate source names, addressing Greptile's row-filter feedback.
- Regenerated the post-contour-cap focus report to confirm the z18 hotspot now surfaces the active label controls next to duplicate pedestrian/path/step names.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T202841Z/road-features.json --comparison-summary-json debug/mapbox-outdoors-comparison-post-contour-cap/all-cameras/20260520T214751Z/summary.json`

Generated report: `debug/mapbox-outdoors-path-pedestrian-focus/20260520T223223Z/summary.md`
