### PR TITLE
Capture QGIS label thinning diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -1007,6 +1007,55 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             },
         )
 
+    def test_qgis_label_styles_snapshot_keeps_missing_thinning_methods_as_none(self):
+        class FakePartialThinningSettings:
+            def limitNumberOfLabelsEnabled(self):
+                return False
+
+            def maximumNumberLabels(self):
+                return 0
+
+            def minimumFeatureSize(self):
+                return 1.25
+
+        class FakeSettings:
+            def thinningSettings(self):
+                return FakePartialThinningSettings()
+
+        class FakeStyle:
+            def styleName(self):
+                return "path-pedestrian-label"
+
+            def layerName(self):
+                return "road"
+
+            def labelSettings(self):
+                return FakeSettings()
+
+        class FakeLabeling:
+            def styles(self):
+                return [FakeStyle()]
+
+        class FakeLayer:
+            def labeling(self):
+                return FakeLabeling()
+
+        [snapshot] = qgis_label_styles_snapshot(FakeLayer())
+
+        self.assertEqual(
+            snapshot["label_settings"]["thinning_settings"],
+            {
+                "limit_number_of_labels_enabled": False,
+                "maximum_number_labels": 0,
+                "minimum_feature_size": 1.25,
+                "allow_duplicate_removal": None,
+                "minimum_distance_to_duplicate": None,
+                "minimum_distance_to_duplicate_unit": None,
+                "label_margin_distance": None,
+                "label_margin_distance_unit": None,
+            },
+        )
+
     def test_label_value_normalizes_named_sequence_and_opaque_values(self):
         class NamedValue:
             name = "Line"

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -943,6 +943,70 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             },
         }])
 
+    def test_qgis_label_styles_snapshot_captures_label_thinning_settings(self):
+        class FakeThinningSettings:
+            def limitNumberOfLabelsEnabled(self):
+                return False
+
+            def maximumNumberLabels(self):
+                return 0
+
+            def minimumFeatureSize(self):
+                return 1.25
+
+            def allowDuplicateRemoval(self):
+                return True
+
+            def minimumDistanceToDuplicate(self):
+                return 20.0
+
+            def minimumDistanceToDuplicateUnit(self):
+                return "Millimeters"
+
+            def labelMarginDistance(self):
+                return 1.5
+
+            def labelMarginDistanceUnit(self):
+                return "Millimeters"
+
+        class FakeSettings:
+            def thinningSettings(self):
+                return FakeThinningSettings()
+
+        class FakeStyle:
+            def styleName(self):
+                return "path-pedestrian-label"
+
+            def layerName(self):
+                return "road"
+
+            def labelSettings(self):
+                return FakeSettings()
+
+        class FakeLabeling:
+            def styles(self):
+                return [FakeStyle()]
+
+        class FakeLayer:
+            def labeling(self):
+                return FakeLabeling()
+
+        [snapshot] = qgis_label_styles_snapshot(FakeLayer())
+
+        self.assertEqual(
+            snapshot["label_settings"]["thinning_settings"],
+            {
+                "limit_number_of_labels_enabled": False,
+                "maximum_number_labels": 0,
+                "minimum_feature_size": 1.25,
+                "allow_duplicate_removal": True,
+                "minimum_distance_to_duplicate": 20.0,
+                "minimum_distance_to_duplicate_unit": "Millimeters",
+                "label_margin_distance": 1.5,
+                "label_margin_distance_unit": "Millimeters",
+            },
+        )
+
     def test_label_value_normalizes_named_sequence_and_opaque_values(self):
         class NamedValue:
             name = "Line"

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -112,6 +112,19 @@ def _qgis_preprocessed_style():
     }
 
 
+def _qgis_thinning_settings():
+    return {
+        "limit_number_of_labels_enabled": False,
+        "maximum_number_labels": 0,
+        "minimum_feature_size": 1.25,
+        "allow_duplicate_removal": True,
+        "minimum_distance_to_duplicate": 20,
+        "minimum_distance_to_duplicate_unit": "Millimeters",
+        "label_margin_distance": 1.5,
+        "label_margin_distance_unit": "Millimeters",
+    }
+
+
 def _qgis_label_styles():
     return [
         {
@@ -134,11 +147,7 @@ def _qgis_label_styles():
                 "buffer_enabled": True,
                 "buffer_size": 0.5291666666666667,
                 "buffer_color": "#ffffff",
-                "thinning_settings": {
-                    "allow_duplicate_removal": True,
-                    "minimum_distance_to_duplicate": 20,
-                    "minimum_distance_to_duplicate_unit": "Millimeters",
-                },
+                "thinning_settings": _qgis_thinning_settings(),
             },
         },
         {
@@ -183,11 +192,7 @@ def _qgis_label_styles():
                 "buffer_enabled": True,
                 "buffer_size": 0.5291666666666667,
                 "buffer_color": "#ffffff",
-                "thinning_settings": {
-                    "allow_duplicate_removal": True,
-                    "minimum_distance_to_duplicate": 20,
-                    "minimum_distance_to_duplicate_unit": "Millimeters",
-                },
+                "thinning_settings": _qgis_thinning_settings(),
             },
         },
         {
@@ -542,11 +547,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(details["path-pedestrian-label"]["text_size"], 2.38125)
         self.assertEqual(
             details["path-pedestrian-label"]["thinning_settings"],
-            {
-                "allow_duplicate_removal": True,
-                "minimum_distance_to_duplicate": 20,
-                "minimum_distance_to_duplicate_unit": "Millimeters",
-            },
+            _qgis_thinning_settings(),
         )
 
     def test_build_path_pedestrian_focus_report_cross_links_feature_counts_and_qgis_style(self):
@@ -721,7 +722,13 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn('"repeat_distance=105.83333333333333"', markdown)
         self.assertIn("| path-pedestrian-label | road | z>=12 |", markdown)
         self.assertIn("## Visible QGIS label thinning details", markdown)
-        self.assertIn("| chamonix-trails-z14-outdoors | path-pedestrian-label | True | 20 | Millimeters |", markdown)
+        self.assertIn(
+            (
+                "| chamonix-trails-z14-outdoors | path-pedestrian-label | True | 20 | "
+                "Millimeters | 1.5 | Millimeters | False | 0 | 1.25 |"
+            ),
+            markdown,
+        )
         self.assertIn("## Duplicate label diagnostics", markdown)
         self.assertIn('"pedestrian: Englischer Viertel=5"', markdown)
         self.assertIn('"path: Hofmattweg=3"', markdown)

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -134,6 +134,11 @@ def _qgis_label_styles():
                 "buffer_enabled": True,
                 "buffer_size": 0.5291666666666667,
                 "buffer_color": "#ffffff",
+                "thinning_settings": {
+                    "allow_duplicate_removal": True,
+                    "minimum_distance_to_duplicate": 20,
+                    "minimum_distance_to_duplicate_unit": "Millimeters",
+                },
             },
         },
         {
@@ -178,6 +183,11 @@ def _qgis_label_styles():
                 "buffer_enabled": True,
                 "buffer_size": 0.5291666666666667,
                 "buffer_color": "#ffffff",
+                "thinning_settings": {
+                    "allow_duplicate_removal": True,
+                    "minimum_distance_to_duplicate": 20,
+                    "minimum_distance_to_duplicate_unit": "Millimeters",
+                },
             },
         },
         {
@@ -530,6 +540,14 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(details["road-label-z15-plus"]["repeat_distance"], 105.83333333333333)
         self.assertTrue(details["road-label-z15-plus"]["merge_lines"])
         self.assertEqual(details["path-pedestrian-label"]["text_size"], 2.38125)
+        self.assertEqual(
+            details["path-pedestrian-label"]["thinning_settings"],
+            {
+                "allow_duplicate_removal": True,
+                "minimum_distance_to_duplicate": 20,
+                "minimum_distance_to_duplicate_unit": "Millimeters",
+            },
+        )
 
     def test_build_path_pedestrian_focus_report_cross_links_feature_counts_and_qgis_style(self):
         report = build_path_pedestrian_focus_report(
@@ -702,6 +720,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("| road-label-z12-to-z15 | road | 12<=z<=14 |", markdown)
         self.assertIn('"repeat_distance=105.83333333333333"', markdown)
         self.assertIn("| path-pedestrian-label | road | z>=12 |", markdown)
+        self.assertIn("## Visible QGIS label thinning details", markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | path-pedestrian-label | True | 20 | Millimeters |", markdown)
         self.assertIn("## Duplicate label diagnostics", markdown)
         self.assertIn('"pedestrian: Englischer Viertel=5"', markdown)
         self.assertIn('"path: Hofmattweg=3"', markdown)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -25,6 +25,16 @@ DEFAULT_MAPBOX_STYLE_URL = f"mapbox://styles/{DEFAULT_MAPBOX_STYLE_OWNER}/{DEFAU
 DEFAULT_QT_QPA_PLATFORM = "offscreen"
 WEB_MERCATOR_HALF_WORLD = 20037508.342789244
 WEB_MERCATOR_TILE_SIZE = 512
+QGIS_LABEL_THINNING_SETTING_METHODS = (
+    ("limit_number_of_labels_enabled", "limitNumberOfLabelsEnabled"),
+    ("maximum_number_labels", "maximumNumberLabels"),
+    ("minimum_feature_size", "minimumFeatureSize"),
+    ("allow_duplicate_removal", "allowDuplicateRemoval"),
+    ("minimum_distance_to_duplicate", "minimumDistanceToDuplicate"),
+    ("minimum_distance_to_duplicate_unit", "minimumDistanceToDuplicateUnit"),
+    ("label_margin_distance", "labelMarginDistance"),
+    ("label_margin_distance_unit", "labelMarginDistanceUnit"),
+)
 ImageMetrics: TypeAlias = dict[str, object]
 MATRIX_SUMMARY_METRIC_KEYS = (
     "changed_pixel_ratio",
@@ -643,6 +653,18 @@ def _qgis_label_format_snapshot(settings: object | None) -> dict[str, object]:
     }
 
 
+def _qgis_label_thinning_snapshot(settings: object | None) -> dict[str, object]:
+    thinning_settings = _method_value(settings, "thinningSettings") if settings is not None else None
+    if thinning_settings is None:
+        return {}
+    return {
+        "thinning_settings": {
+            key: _label_value(_method_value(thinning_settings, method_name))
+            for key, method_name in QGIS_LABEL_THINNING_SETTING_METHODS
+        },
+    }
+
+
 def qgis_label_styles_snapshot(layer: object) -> list[dict[str, object]]:
     """Return a token-free diagnostic snapshot of QGIS vector-tile label rules."""
 
@@ -671,6 +693,7 @@ def qgis_label_styles_snapshot(layer: object) -> list[dict[str, object]]:
                 "geometry_generator_enabled": _label_setting_value(settings, "geometryGeneratorEnabled"),
                 "geometry_generator_type": _label_setting_value(settings, "geometryGeneratorType"),
                 **_qgis_label_format_snapshot(settings),
+                **_qgis_label_thinning_snapshot(settings),
             },
         })
     return snapshots

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -587,6 +587,7 @@ def _label_detail(label_style: Mapping[str, object]) -> dict[str, object]:
         "buffer_enabled",
         "buffer_size",
         "buffer_color",
+        "thinning_settings",
     ):
         if key in settings:
             detail[key] = settings[key]
@@ -943,6 +944,7 @@ def _label_controls(detail: Mapping[str, object]) -> list[str]:
             "repeat_distance",
             "label_per_part",
             "merge_lines",
+            "thinning_settings",
             "text_size",
             "text_color",
             "buffer_size",
@@ -985,6 +987,42 @@ def _visible_label_detail_markdown_lines(cameras: Iterable[object]) -> list[str]
             )
         lines.append("")
     return lines if detail_row_count else []
+
+
+def _visible_label_thinning_markdown_lines(cameras: Iterable[object]) -> list[str]:
+    rows: list[list[object]] = []
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        for detail in _visible_label_detail_rows(camera):
+            thinning_settings = detail.get("thinning_settings")
+            if not isinstance(thinning_settings, Mapping):
+                continue
+            rows.append(
+                [
+                    camera.get("camera"),
+                    detail.get("style_name"),
+                    thinning_settings.get("allow_duplicate_removal"),
+                    thinning_settings.get("minimum_distance_to_duplicate"),
+                    thinning_settings.get("minimum_distance_to_duplicate_unit"),
+                    thinning_settings.get("label_margin_distance"),
+                    thinning_settings.get("label_margin_distance_unit"),
+                    thinning_settings.get("limit_number_of_labels_enabled"),
+                    thinning_settings.get("maximum_number_labels"),
+                    thinning_settings.get("minimum_feature_size"),
+                ]
+            )
+    if not rows:
+        return []
+    lines = ["", "## Visible QGIS label thinning details", ""]
+    lines.extend(
+        [
+            "| Camera | Style | Duplicate removal | Duplicate distance | Duplicate distance unit | Label margin | Label margin unit | Limit labels | Max labels | Min feature size |",
+            "| --- | --- | --- | ---: | --- | ---: | --- | --- | ---: | ---: |",
+        ]
+    )
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
 
 
 def _artifact_path_cell(value: object) -> object:
@@ -1168,6 +1206,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines.extend(_visual_artifact_markdown_lines(rows))
     lines.extend(_duplicate_label_diagnostic_markdown_lines(rows))
     lines.extend(_visible_detail_markdown_lines(rows))
+    lines.extend(_visible_label_thinning_markdown_lines(rows))
     lines.extend(_visible_label_detail_markdown_lines(rows))
     return "\n".join(lines) + "\n"
 

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -944,7 +944,6 @@ def _label_controls(detail: Mapping[str, object]) -> list[str]:
             "repeat_distance",
             "label_per_part",
             "merge_lines",
-            "thinning_settings",
             "text_size",
             "text_color",
             "buffer_size",


### PR DESCRIPTION
## Summary

- Capture QGIS label `thinningSettings()` values in the Mapbox Outdoors comparison `qgis-label-styles.json` snapshot when the runtime exposes them.
- Surface visible label thinning settings in the path/pedestrian focus Markdown report so duplicate-label follow-up can compare runtime controls against visible road/path label styles.
- Keep this diagnostic-only: no rendering behavior changes and no assumptions about QGIS 3.44 duplicate-removal support on qfit's QGIS 3.28+ baseline.

## Evidence

Local QGIS runtime probe during this slice:

- QGIS version: `3.34.4-Prizren`
- `limitNumberOfLabelsEnabled`, `maximumNumberLabels`, and `minimumFeatureSize`: available
- `allowDuplicateRemoval`, `minimumDistanceToDuplicate`, duplicate-distance units, and label-margin methods: not available in this runtime

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
