### PR TITLE
test: compare source and qgis path strokes

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -910,6 +910,52 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             ],
         )
 
+    def test_build_path_pedestrian_focus_report_pairs_split_road_path_strokes_with_source_layer(self):
+        road_report = _road_feature_report()
+        road_report["cameras"][0]["camera_zoom"] = 18.0
+        qgis_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-path-z16-plus",
+                    "type": "line",
+                    "minzoom": 16,
+                    "paint": {
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-width": 1.0583333333333333,
+                        "line-dasharray": [1, 0.3],
+                    },
+                }
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(
+            road_report,
+            source_style=_source_style(),
+            qgis_styles_by_camera={"chamonix-trails-z14-outdoors": qgis_style},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        comparisons = {
+            comparison["source_layer_id"]: comparison
+            for comparison in camera["source_qgis_stroke_control_comparisons"]
+        }
+        self.assertEqual(comparisons["road-path"]["qgis_layer_ids"], ["road-path-z16-plus"])
+        self.assertEqual(
+            comparisons["road-path"]["qgis_controls"],
+            [
+                {
+                    "layer_id": "road-path-z16-plus",
+                    "controls": {
+                        "line-width": 1.0583333333333333,
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-dasharray": [1, 0.3],
+                    },
+                }
+            ],
+        )
+
     def test_build_path_pedestrian_focus_report_adds_visual_artifacts_to_focused_cameras(self):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -802,6 +802,113 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             camera["duplicate_label_diagnostic"]["unmatched_duplicate_name_categories"],
             ["path", "step"],
         )
+        self.assertEqual(
+            camera["source_qgis_stroke_control_comparisons"],
+            [
+                {
+                    "source_layer_id": "road-path",
+                    "source_controls": {
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 12, 1, 18, 4],
+                        "line-dasharray": [
+                            "step",
+                            ["zoom"],
+                            ["literal", [4, 0.3]],
+                            15,
+                            ["literal", [1, 0.3]],
+                        ],
+                    },
+                    "qgis_layer_ids": ["road-path"],
+                    "qgis_controls": [
+                        {
+                            "layer_id": "road-path",
+                            "controls": {
+                                "line-color": "#d8c6a3",
+                                "line-width": 1.5,
+                                "line-dasharray": [1, 1],
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+
+    def test_build_path_pedestrian_focus_report_pairs_qgis_variant_strokes_with_source_ids(self):
+        road_report = {
+            "generated": "2026-05-20T01:09:13+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "cameras": [
+                {
+                    "status": "decoded",
+                    "camera": "zermatt-trails-z18-outdoors",
+                    "camera_zoom": 18.0,
+                    "tile_zoom": 18,
+                    "pedestrian_line_candidate_count": 1,
+                }
+            ],
+        }
+        source_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-pedestrian",
+                    "type": "line",
+                    "minzoom": 16,
+                    "paint": {
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
+                    },
+                }
+            ],
+        }
+        qgis_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-pedestrian-z16-plus",
+                    "type": "line",
+                    "minzoom": 16,
+                    "paint": {
+                        "line-color": "#f6f2e8",
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
+                        "line-opacity": 0.65,
+                    },
+                }
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(
+            road_report,
+            source_style=source_style,
+            qgis_styles_by_camera={"zermatt-trails-z18-outdoors": qgis_style},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        self.assertEqual(
+            camera["source_qgis_stroke_control_comparisons"],
+            [
+                {
+                    "source_layer_id": "road-pedestrian",
+                    "source_controls": {
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
+                    },
+                    "qgis_layer_ids": ["road-pedestrian-z16-plus"],
+                    "qgis_controls": [
+                        {
+                            "layer_id": "road-pedestrian-z16-plus",
+                            "controls": {
+                                "line-color": "#f6f2e8",
+                                "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
+                                "line-opacity": 0.65,
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
 
     def test_build_path_pedestrian_focus_report_adds_visual_artifacts_to_focused_cameras(self):
         report = build_path_pedestrian_focus_report(
@@ -849,6 +956,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertEqual(camera["qgis_path_pedestrian_visible_layer_details"], [])
         self.assertEqual(camera["qgis_path_pedestrian_label_details"], [])
         self.assertEqual(camera["qgis_path_pedestrian_visible_label_details"], [])
+        self.assertEqual(camera["source_qgis_stroke_control_comparisons"], [])
         self.assertIn("Source style cameras: 0/0 matched", build_summary_markdown(report))
 
     def test_build_path_pedestrian_focus_report_ignores_boolean_counts(self):
@@ -926,6 +1034,11 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("## Visible source Mapbox layer details", markdown)
         self.assertIn("| road-path | line | z>=12 |", markdown)
         self.assertIn('"line-width=[\\"interpolate\\",[\\"linear\\"],[\\"zoom\\"],12,1,18,4]"', markdown)
+        self.assertIn("## Source vs QGIS stroke controls", markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | road-path |", markdown)
+        self.assertIn('["road-path"]', markdown)
+        self.assertIn('road-path: line-width=1.5', markdown)
+        self.assertIn('line-dasharray=[1,1]', markdown)
         self.assertIn("## Visible QGIS layer details", markdown)
         self.assertIn("### chamonix-trails-z14-outdoors", markdown)
         self.assertIn("| road-path | line | 12<=z<16 |", markdown)

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -1170,6 +1170,32 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("| merge-line-only |", markdown)
         self.assertNotIn("## Duplicate label diagnostics", markdown)
 
+    def test_build_summary_markdown_marks_unmatched_source_stroke_rows(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "now",
+                "cameras": [
+                    {
+                        "camera": "unmatched-source-stroke",
+                        "source_qgis_stroke_control_comparisons": [
+                            {
+                                "source_layer_id": "road-path",
+                                "source_controls": {"line-width": 1.0},
+                                "qgis_layer_ids": [],
+                                "qgis_controls": [],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        self.assertIn(
+            "Rows with empty QGIS columns identify source strokes with no visible QGIS counterpart.",
+            markdown,
+        )
+        self.assertIn("| unmatched-source-stroke | road-path | [\"line-width=1.0\"] | [] | [] |", markdown)
+
     def test_build_summary_markdown_handles_no_focus_rows(self):
         markdown = build_summary_markdown({"generated": "now", "cameras": []})
 

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -4,6 +4,7 @@ import argparse
 import datetime as dt
 import json
 import sys
+from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,6 +47,12 @@ PATH_PEDESTRIAN_DETAIL_PAINT_KEYS = (
     "line-opacity",
     "fill-color",
     "fill-opacity",
+)
+PATH_PEDESTRIAN_STROKE_CONTROL_KEYS = (
+    "line-width",
+    "line-color",
+    "line-dasharray",
+    "line-opacity",
 )
 TOP_COUNT_LIMIT = 3
 SAMPLE_LAYER_LIMIT = 8
@@ -965,6 +972,66 @@ def _duplicate_label_diagnostic(camera: Mapping[str, object]) -> dict[str, objec
     }
 
 
+def _qfit_base_style_layer_id(layer_id: object) -> str:
+    from qfit.mapbox_config import base_mapbox_style_layer_id_for_qfit  # noqa: PLC0415
+
+    return base_mapbox_style_layer_id_for_qfit(layer_id)
+
+
+def _visible_line_details(camera: Mapping[str, object], detail_key: str) -> list[Mapping[str, object]]:
+    details = camera.get(detail_key)
+    detail_rows = details if isinstance(details, list) else []
+    return [
+        detail
+        for detail in detail_rows
+        if isinstance(detail, Mapping) and detail.get("type") == "line"
+    ]
+
+
+def _stroke_controls(detail: Mapping[str, object]) -> dict[str, object]:
+    return {
+        key: detail[key]
+        for key in PATH_PEDESTRIAN_STROKE_CONTROL_KEYS
+        if key in detail
+    }
+
+
+def _qgis_stroke_details_by_source_id(
+    qgis_details: Iterable[Mapping[str, object]],
+) -> dict[str, list[Mapping[str, object]]]:
+    details_by_source_id: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    for detail in qgis_details:
+        layer_id = str(detail.get("id") or "")
+        source_id = _qfit_base_style_layer_id(layer_id)
+        details_by_source_id[source_id].append(detail)
+    return details_by_source_id
+
+
+def _source_qgis_stroke_control_comparisons(camera: Mapping[str, object]) -> list[dict[str, object]]:
+    source_details = _visible_line_details(camera, "source_path_pedestrian_visible_layer_details")
+    qgis_details = _visible_line_details(camera, "qgis_path_pedestrian_visible_layer_details")
+    qgis_details_by_source_id = _qgis_stroke_details_by_source_id(qgis_details)
+    comparisons = []
+    for source_detail in source_details:
+        source_id = str(source_detail.get("id") or "")
+        matched_details = qgis_details_by_source_id.get(source_id, [])
+        comparisons.append(
+            {
+                "source_layer_id": source_id,
+                "source_controls": _stroke_controls(source_detail),
+                "qgis_layer_ids": [str(detail.get("id") or "") for detail in matched_details],
+                "qgis_controls": [
+                    {
+                        "layer_id": str(detail.get("id") or ""),
+                        "controls": _stroke_controls(detail),
+                    }
+                    for detail in matched_details
+                ],
+            }
+        )
+    return comparisons
+
+
 def _camera_focus_row(
     camera_report: Mapping[str, object],
     *,
@@ -1009,6 +1076,7 @@ def _camera_focus_row(
         else _missing_qgis_label_summary()
     )
     row["duplicate_label_diagnostic"] = _duplicate_label_diagnostic(row)
+    row["source_qgis_stroke_control_comparisons"] = _source_qgis_stroke_control_comparisons(row)
     return row
 
 
@@ -1258,6 +1326,67 @@ def _visible_detail_markdown_lines(cameras: Iterable[object]) -> list[str]:
         detail_key="qgis_path_pedestrian_visible_layer_details",
         title="## Visible QGIS layer details",
     )
+
+
+def _qgis_stroke_control_summaries(comparison: Mapping[str, object]) -> list[str]:
+    controls = comparison.get("qgis_controls")
+    control_rows = controls if isinstance(controls, list) else []
+    summaries = []
+    for control_row in control_rows:
+        if not isinstance(control_row, Mapping):
+            continue
+        layer_id = str(control_row.get("layer_id") or "")
+        layer_controls = control_row.get("controls")
+        if layer_id and isinstance(layer_controls, Mapping):
+            summaries.append(f"{layer_id}: {', '.join(_stroke_control_summaries(layer_controls))}")
+    return summaries
+
+
+def _stroke_control_summaries(controls: object) -> list[str]:
+    if not isinstance(controls, Mapping):
+        return []
+    return [
+        f"{key}={_compact_json(controls.get(key))}"
+        for key in PATH_PEDESTRIAN_STROKE_CONTROL_KEYS
+        if key in controls
+    ]
+
+
+def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> list[str]:
+    rows: list[list[object]] = []
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        comparisons = camera.get("source_qgis_stroke_control_comparisons")
+        comparison_rows = comparisons if isinstance(comparisons, list) else []
+        for comparison in comparison_rows:
+            if not isinstance(comparison, Mapping) or not comparison.get("source_layer_id"):
+                continue
+            rows.append(
+                [
+                    camera.get("camera"),
+                    comparison.get("source_layer_id"),
+                    _stroke_control_summaries(comparison.get("source_controls")),
+                    comparison.get("qgis_layer_ids"),
+                    _qgis_stroke_control_summaries(comparison),
+                ]
+            )
+    if not rows:
+        return []
+    lines = ["", "## Source vs QGIS stroke controls", ""]
+    lines.extend(
+        [
+            (
+                "Pairs visible source Mapbox path/pedestrian line layers with visible QGIS "
+                "variants by original style-layer id."
+            ),
+            "",
+            "| Camera | Source layer | Source controls | QGIS layer ids | QGIS controls |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
 
 
 def _label_detail_zoom_band(detail: Mapping[str, object]) -> str:
@@ -1562,6 +1691,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         )
     lines.extend(_visual_artifact_markdown_lines(rows))
     lines.extend(_duplicate_label_diagnostic_markdown_lines(rows))
+    lines.extend(_source_qgis_stroke_control_markdown_lines(rows))
     lines.extend(_visible_source_detail_markdown_lines(rows))
     lines.extend(_visible_detail_markdown_lines(rows))
     lines.extend(_visible_label_thinning_markdown_lines(rows))

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -1399,6 +1399,7 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
                 "Pairs visible source Mapbox path/pedestrian line layers with visible QGIS "
                 "variants by original style-layer id."
             ),
+            "Rows with empty QGIS columns identify source strokes with no visible QGIS counterpart.",
             "",
             "| Camera | Source layer | Source controls | QGIS layer ids | QGIS controls |",
             MARKDOWN_SEPARATOR_5_COLUMNS,

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -54,6 +54,15 @@ PATH_PEDESTRIAN_STROKE_CONTROL_KEYS = (
     "line-dasharray",
     "line-opacity",
 )
+PATH_PEDESTRIAN_SOURCE_SPLIT_BASE_LAYER_IDS = frozenset(
+    {
+        "road-path",
+    }
+)
+PATH_PEDESTRIAN_SOURCE_SPLIT_SUFFIXES = (
+    "-below-z16",
+    "-z16-plus",
+)
 TOP_COUNT_LIMIT = 3
 SAMPLE_LAYER_LIMIT = 8
 DUPLICATE_LABEL_CATEGORY_KEYS = (
@@ -88,6 +97,7 @@ COMPARISON_VISUAL_METRIC_KEYS = (
     "normalized_rms_channel_delta",
     "ssim_status",
 )
+MARKDOWN_SEPARATOR_5_COLUMNS = "| --- | --- | --- | --- | --- |"
 ARGPARSE_EXIT_SENTINEL = "argparse error should exit"
 
 
@@ -975,7 +985,16 @@ def _duplicate_label_diagnostic(camera: Mapping[str, object]) -> dict[str, objec
 def _qfit_base_style_layer_id(layer_id: object) -> str:
     from qfit.mapbox_config import base_mapbox_style_layer_id_for_qfit  # noqa: PLC0415
 
-    return base_mapbox_style_layer_id_for_qfit(layer_id)
+    normalized = str(layer_id or "")
+    base_layer_id = base_mapbox_style_layer_id_for_qfit(layer_id)
+    if base_layer_id != normalized:
+        return base_layer_id
+    for split_suffix in PATH_PEDESTRIAN_SOURCE_SPLIT_SUFFIXES:
+        if normalized.endswith(split_suffix):
+            split_base_layer_id = normalized[: -len(split_suffix)]
+            if split_base_layer_id in PATH_PEDESTRIAN_SOURCE_SPLIT_BASE_LAYER_IDS:
+                return split_base_layer_id
+    return base_layer_id
 
 
 def _visible_line_details(camera: Mapping[str, object], detail_key: str) -> list[Mapping[str, object]]:
@@ -1293,7 +1312,7 @@ def _visible_style_detail_markdown_lines(
                 f"### {camera.get('camera')}",
                 "",
                 "| Layer | Type | Zoom band | Paint controls | Filter |",
-                "| --- | --- | --- | --- | --- |",
+                MARKDOWN_SEPARATOR_5_COLUMNS,
             ]
         )
         for detail in mapping_rows:
@@ -1382,7 +1401,7 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
             ),
             "",
             "| Camera | Source layer | Source controls | QGIS layer ids | QGIS controls |",
-            "| --- | --- | --- | --- | --- |",
+            MARKDOWN_SEPARATOR_5_COLUMNS,
         ]
     )
     lines.extend(_markdown_table_row(row) for row in rows)
@@ -1438,7 +1457,7 @@ def _visible_label_detail_markdown_lines(cameras: Iterable[object]) -> list[str]
                 f"### {camera.get('camera')}",
                 "",
                 "| Style | Layer | Zoom band | Controls | Filter |",
-                "| --- | --- | --- | --- | --- |",
+                MARKDOWN_SEPARATOR_5_COLUMNS,
             ]
         )
         for detail in mapping_rows:


### PR DESCRIPTION
## Summary
- add source-vs-QGIS visible stroke-control comparisons to the path/pedestrian focus report
- match QGIS-generated layer variants back to their original Mapbox style-layer ids before comparing stroke controls
- include markdown output and tests for exact, split variant, and unmatched stroke-control rows

Refs #949.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T202841Z/road-features.json --source-style-json debug/mapbox-outdoors-source-style/20260520T042926Z/mapbox-outdoors-v12.json --comparison-summary-json debug/mapbox-outdoors-comparison-post-label-split-live/all-cameras/20260520T234632Z/summary.json` -> `debug/mapbox-outdoors-path-pedestrian-focus/20260521T003814Z/summary.md`