### PR TITLE
test: add sampled source stroke controls

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -818,6 +818,11 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                             ["literal", [1, 0.3]],
                         ],
                     },
+                    "source_sampled_controls": {
+                        "line-width": 0.5622395833333333,
+                        "line-color": "hsl(0, 0%, 95%)",
+                        "line-dasharray": [4, 0.3],
+                    },
                     "qgis_layer_ids": ["road-path"],
                     "qgis_controls": [
                         {
@@ -895,6 +900,10 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
                     },
+                    "source_sampled_controls": {
+                        "line-width": 3.0,
+                        "line-color": "hsl(0, 0%, 95%)",
+                    },
                     "qgis_layer_ids": ["road-pedestrian-z16-plus"],
                     "qgis_controls": [
                         {
@@ -943,6 +952,14 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         }
         self.assertEqual(comparisons["road-path"]["qgis_layer_ids"], ["road-path-z16-plus"])
         self.assertEqual(
+            comparisons["road-path"]["source_sampled_controls"],
+            {
+                "line-width": 1.0583333333333333,
+                "line-color": "hsl(0, 0%, 95%)",
+                "line-dasharray": [1, 0.3],
+            },
+        )
+        self.assertEqual(
             comparisons["road-path"]["qgis_controls"],
             [
                 {
@@ -954,6 +971,38 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                     },
                 }
             ],
+        )
+
+    def test_build_path_pedestrian_focus_report_marks_unsampled_source_color_expressions(self):
+        source_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-path",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {
+                        "line-color": ["match", ["get", "type"], "piste", "#2365d1", "#f2f2f2"],
+                        "line-width": 2,
+                    },
+                }
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            source_style=source_style,
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        [comparison] = camera["source_qgis_stroke_control_comparisons"]
+        self.assertEqual(
+            comparison["source_sampled_controls"],
+            {
+                "line-width": 0.5291666666666667,
+                "line-color": "expression-not-sampled",
+            },
         )
 
     def test_build_path_pedestrian_focus_report_adds_visual_artifacts_to_focused_cameras(self):
@@ -1081,7 +1130,11 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("| road-path | line | z>=12 |", markdown)
         self.assertIn('"line-width=[\\"interpolate\\",[\\"linear\\"],[\\"zoom\\"],12,1,18,4]"', markdown)
         self.assertIn("## Source vs QGIS stroke controls", markdown)
+        self.assertIn("Source sampled controls evaluate zoom expressions at the camera zoom", markdown)
+        self.assertIn("expression colors are marked as expression-not-sampled", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | road-path |", markdown)
+        self.assertIn('"line-width=0.5622395833333333"', markdown)
+        self.assertIn('"line-dasharray=[4,0.3]"', markdown)
         self.assertIn('["road-path"]', markdown)
         self.assertIn('road-path: line-width=1.5', markdown)
         self.assertIn('line-dasharray=[1,1]', markdown)
@@ -1194,7 +1247,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             "Rows with empty QGIS columns identify source strokes with no visible QGIS counterpart.",
             markdown,
         )
-        self.assertIn("| unmatched-source-stroke | road-path | [\"line-width=1.0\"] | [] | [] |", markdown)
+        self.assertIn("| unmatched-source-stroke | road-path | [\"line-width=1.0\"] | [] | [] | [] |", markdown)
 
     def test_build_summary_markdown_handles_no_focus_rows(self):
         markdown = build_summary_markdown({"generated": "now", "cameras": []})

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -15,6 +15,13 @@ package_parent = str(PACKAGE_PARENT)
 if package_parent not in sys.path:
     sys.path.insert(0, package_parent)
 
+from qfit.mapbox_config import (  # noqa: E402
+    _extract_line_dasharray_literal,
+    _extract_zoom_scalar_size_at_zoom,
+    _line_width_mm_at_zoom,
+    base_mapbox_style_layer_id_for_qfit,
+)
+
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-path-pedestrian-focus"
 DEFAULT_COMPARISON_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-comparison"
 DEFAULT_ROAD_FEATURES_PATH = (
@@ -98,6 +105,8 @@ COMPARISON_VISUAL_METRIC_KEYS = (
     "ssim_status",
 )
 MARKDOWN_SEPARATOR_5_COLUMNS = "| --- | --- | --- | --- | --- |"
+MARKDOWN_SEPARATOR_6_COLUMNS = "| --- | --- | --- | --- | --- | --- |"
+UNSAMPLED_EXPRESSION_CONTROL = "expression-not-sampled"
 ARGPARSE_EXIT_SENTINEL = "argparse error should exit"
 
 
@@ -983,8 +992,6 @@ def _duplicate_label_diagnostic(camera: Mapping[str, object]) -> dict[str, objec
 
 
 def _qfit_base_style_layer_id(layer_id: object) -> str:
-    from qfit.mapbox_config import base_mapbox_style_layer_id_for_qfit  # noqa: PLC0415
-
     normalized = str(layer_id or "")
     base_layer_id = base_mapbox_style_layer_id_for_qfit(layer_id)
     if base_layer_id != normalized:
@@ -1015,6 +1022,30 @@ def _stroke_controls(detail: Mapping[str, object]) -> dict[str, object]:
     }
 
 
+def _source_sampled_stroke_controls(
+    detail: Mapping[str, object],
+    camera_zoom: float | None,
+) -> dict[str, object]:
+    if camera_zoom is None:
+        return {}
+    sampled_controls: dict[str, object] = {}
+    line_width = _line_width_mm_at_zoom(detail.get("line-width"), camera_zoom)
+    if line_width is not None:
+        sampled_controls["line-width"] = line_width
+    line_color = detail.get("line-color")
+    if isinstance(line_color, str) and line_color:
+        sampled_controls["line-color"] = line_color
+    elif isinstance(line_color, list):
+        sampled_controls["line-color"] = UNSAMPLED_EXPRESSION_CONTROL
+    line_dasharray = _extract_line_dasharray_literal(detail.get("line-dasharray"), target_zoom=camera_zoom)
+    if line_dasharray is not None:
+        sampled_controls["line-dasharray"] = line_dasharray
+    line_opacity = _extract_zoom_scalar_size_at_zoom(detail.get("line-opacity"), camera_zoom)
+    if line_opacity is not None:
+        sampled_controls["line-opacity"] = line_opacity
+    return sampled_controls
+
+
 def _qgis_stroke_details_by_source_id(
     qgis_details: Iterable[Mapping[str, object]],
 ) -> dict[str, list[Mapping[str, object]]]:
@@ -1030,6 +1061,7 @@ def _source_qgis_stroke_control_comparisons(camera: Mapping[str, object]) -> lis
     source_details = _visible_line_details(camera, "source_path_pedestrian_visible_layer_details")
     qgis_details = _visible_line_details(camera, "qgis_path_pedestrian_visible_layer_details")
     qgis_details_by_source_id = _qgis_stroke_details_by_source_id(qgis_details)
+    camera_zoom = _numeric_zoom(camera.get("camera_zoom"))
     comparisons = []
     for source_detail in source_details:
         source_id = str(source_detail.get("id") or "")
@@ -1038,6 +1070,7 @@ def _source_qgis_stroke_control_comparisons(camera: Mapping[str, object]) -> lis
             {
                 "source_layer_id": source_id,
                 "source_controls": _stroke_controls(source_detail),
+                "source_sampled_controls": _source_sampled_stroke_controls(source_detail, camera_zoom),
                 "qgis_layer_ids": [str(detail.get("id") or "") for detail in matched_details],
                 "qgis_controls": [
                     {
@@ -1386,6 +1419,7 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
                     camera.get("camera"),
                     comparison.get("source_layer_id"),
                     _stroke_control_summaries(comparison.get("source_controls")),
+                    _stroke_control_summaries(comparison.get("source_sampled_controls")),
                     comparison.get("qgis_layer_ids"),
                     _qgis_stroke_control_summaries(comparison),
                 ]
@@ -1399,10 +1433,17 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
                 "Pairs visible source Mapbox path/pedestrian line layers with visible QGIS "
                 "variants by original style-layer id."
             ),
+            (
+                "Source sampled controls evaluate zoom expressions at the camera zoom; "
+                "line-width is shown in QGIS millimetres and dash arrays are the selected "
+                "Mapbox line-width-relative pattern. Literal line colors are carried through; "
+                "expression colors are marked as expression-not-sampled and remain available "
+                "in the raw source controls."
+            ),
             "Rows with empty QGIS columns identify source strokes with no visible QGIS counterpart.",
             "",
-            "| Camera | Source layer | Source controls | QGIS layer ids | QGIS controls |",
-            MARKDOWN_SEPARATOR_5_COLUMNS,
+            "| Camera | Source layer | Source controls | Source sampled controls | QGIS layer ids | QGIS controls |",
+            MARKDOWN_SEPARATOR_6_COLUMNS,
         ]
     )
     lines.extend(_markdown_table_row(row) for row in rows)


### PR DESCRIPTION
## Summary
- add camera-zoom sampled source stroke controls to the path/pedestrian focus report
- show source sampled controls beside raw source expressions and visible QGIS controls in the stroke comparison table
- mark expression line-colors as not sampled instead of omitting them silently

Refs #949.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T202841Z/road-features.json --source-style-json debug/mapbox-outdoors-source-style/20260520T042926Z/mapbox-outdoors-v12.json --comparison-summary-json debug/mapbox-outdoors-comparison-post-label-split-live/all-cameras/20260520T234632Z/summary.json` -> `debug/mapbox-outdoors-path-pedestrian-focus/20260521T010301Z/summary.md`