### PR TITLE
fix: sample high zoom path dasharray

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2860,6 +2860,16 @@ def _should_sample_path_high_zoom_line_width(layer_id: object, prop: str, minzoo
     )
 
 
+def _path_dasharray_sample_zoom(layer_id: object, minzoom: object, maxzoom: object) -> float | None:
+    normalized = str(layer_id or "")
+    if not any(
+        normalized == prefix or normalized.startswith(f"{prefix}-")
+        for prefix in _PATH_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES
+    ):
+        return _representative_zoom_in_layer_range(minzoom, maxzoom)
+    return _zoom_in_layer_range(_PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM, minzoom, maxzoom)
+
+
 def _should_sample_path_low_zoom_line_width(layer_id: object, prop: str, maxzoom: object) -> bool:
     if prop != "line-width":
         return False
@@ -6512,7 +6522,8 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
                     if blur_width_mm is not None:
                         props[prop] = blur_width_mm
                 elif prop == "line-dasharray":
-                    dasharray_target_zoom = _representative_zoom_in_layer_range(
+                    dasharray_target_zoom = _path_dasharray_sample_zoom(
+                        layer_id,
                         layer.get("minzoom"),
                         layer.get("maxzoom"),
                     )

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2051,7 +2051,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][3]["paint"]["line-dasharray"], [5, 2])
         self.assertIsInstance(style["layers"][0]["paint"]["line-dasharray"][2], list)
 
-    def test_split_high_zoom_path_layers_use_layer_zoom_for_dasharray(self):
+    def test_split_high_zoom_path_layers_use_high_zoom_dasharray(self):
         path_filter = [
             "all",
             ["==", ["get", "class"], "path"],
@@ -2091,7 +2091,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
         self.assertEqual(by_id["road-path-below-z16"]["paint"]["line-dasharray"], [4, 0.3])
-        self.assertEqual(by_id["road-path-z16-plus"]["paint"]["line-dasharray"], [1, 0.3])
+        self.assertEqual(by_id["road-path-z16-plus"]["paint"]["line-dasharray"], [1, 0.25])
 
     def test_ferry_line_widths_keep_lake_routes_visible(self):
         ferry_width = ["interpolate", ["exponential", 1.5], ["zoom"], 14, 0.5, 20, 1]


### PR DESCRIPTION
## Summary
- sample high-zoom `road-path-z16-plus` dash arrays at the same z18 representative zoom used for high-zoom path widths
- align the QGIS high-zoom road-path dash pattern with the source Mapbox z17/z18 `[1,0.25]` pattern exposed by the focus report
- update the Mapbox style simplification regression test for the high-zoom path split

Refs #949.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests::test_split_high_zoom_path_layers_use_high_zoom_dasharray -q --tb=short`
- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `python3 scripts/package_plugin.py`
- QGIS-only z18 render: `debug/mapbox-outdoors-comparison-path-dasharray/zermatt-trails-z18-outdoors/20260521T011151Z/qgis-vector-render.png` (1280x900, nonblank RGB extrema)
- Focus report from that render: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T011217Z/summary.md`

## Evidence
- The refreshed focus report now shows `zermatt-trails-z18-outdoors` `road-path` source sampled `line-dasharray=[1,0.25]` and QGIS `road-path-z16-plus` `line-dasharray=[1,0.25]` in the same row.
