### PR TITLE
test: add stroke control deltas

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -834,6 +834,17 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                             },
                         }
                     ],
+                    "qgis_control_deltas": [
+                        {
+                            "layer_id": "road-path",
+                            "deltas": {
+                                "line-width_delta_mm": 0.9377604166666667,
+                                "line-width_ratio": 2.667901806391848,
+                                "line-dasharray_match": False,
+                                "line-color_match": False,
+                            },
+                        }
+                    ],
                 }
             ],
         )
@@ -863,6 +874,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                     "paint": {
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
+                        "line-dasharray": ["literal", [1, 0.2]],
                     },
                 }
             ],
@@ -877,6 +889,13 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                     "paint": {
                         "line-color": "#f6f2e8",
                         "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
+                        "line-dasharray": [
+                            "step",
+                            ["zoom"],
+                            ["literal", [1, 0]],
+                            16,
+                            ["literal", [1, 0.2]],
+                        ],
                         "line-opacity": 0.65,
                     },
                 }
@@ -899,10 +918,12 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                     "source_controls": {
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
+                        "line-dasharray": ["literal", [1, 0.2]],
                     },
                     "source_sampled_controls": {
                         "line-width": 3.0,
                         "line-color": "hsl(0, 0%, 95%)",
+                        "line-dasharray": [1, 0.2],
                     },
                     "qgis_layer_ids": ["road-pedestrian-z16-plus"],
                     "qgis_controls": [
@@ -911,8 +932,21 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                             "controls": {
                                 "line-color": "#f6f2e8",
                                 "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
+                                "line-dasharray": [
+                                    "step",
+                                    ["zoom"],
+                                    ["literal", [1, 0]],
+                                    16,
+                                    ["literal", [1, 0.2]],
+                                ],
                                 "line-opacity": 0.65,
                             },
+                        }
+                    ],
+                    "qgis_control_deltas": [
+                        {
+                            "layer_id": "road-pedestrian-z16-plus",
+                            "deltas": {"line-color_match": False},
                         }
                     ],
                 }
@@ -968,6 +1002,20 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-width": 1.0583333333333333,
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-dasharray": [1, 0.3],
+                    },
+                }
+            ],
+        )
+        self.assertEqual(
+            comparisons["road-path"]["qgis_control_deltas"],
+            [
+                {
+                    "layer_id": "road-path-z16-plus",
+                    "deltas": {
+                        "line-width_delta_mm": 0.0,
+                        "line-width_ratio": 1.0,
+                        "line-dasharray_match": True,
+                        "line-color_match": True,
                     },
                 }
             ],
@@ -1132,12 +1180,15 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("## Source vs QGIS stroke controls", markdown)
         self.assertIn("Source sampled controls evaluate zoom expressions at the camera zoom", markdown)
         self.assertIn("expression colors are marked as expression-not-sampled", markdown)
+        self.assertIn("QGIS deltas compare visible QGIS controls against source sampled controls", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | road-path |", markdown)
         self.assertIn('"line-width=0.5622395833333333"', markdown)
         self.assertIn('"line-dasharray=[4,0.3]"', markdown)
         self.assertIn('["road-path"]', markdown)
         self.assertIn('road-path: line-width=1.5', markdown)
         self.assertIn('line-dasharray=[1,1]', markdown)
+        self.assertIn("road-path: line-width_delta_mm=0.9377604166666667", markdown)
+        self.assertIn("line-dasharray_match=false", markdown)
         self.assertIn("## Visible QGIS layer details", markdown)
         self.assertIn("### chamonix-trails-z14-outdoors", markdown)
         self.assertIn("| road-path | line | 12<=z<16 |", markdown)
@@ -1236,6 +1287,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                                 "source_controls": {"line-width": 1.0},
                                 "qgis_layer_ids": [],
                                 "qgis_controls": [],
+                                "qgis_control_deltas": [],
                             }
                         ],
                     }
@@ -1247,7 +1299,10 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             "Rows with empty QGIS columns identify source strokes with no visible QGIS counterpart.",
             markdown,
         )
-        self.assertIn("| unmatched-source-stroke | road-path | [\"line-width=1.0\"] | [] | [] | [] |", markdown)
+        self.assertIn(
+            "| unmatched-source-stroke | road-path | [\"line-width=1.0\"] | [] | [] | [] | [] |",
+            markdown,
+        )
 
     def test_build_summary_markdown_handles_no_focus_rows(self):
         markdown = build_summary_markdown({"generated": "now", "cameras": []})

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -19,6 +19,7 @@ from qfit.mapbox_config import (  # noqa: E402
     _extract_line_dasharray_literal,
     _extract_zoom_scalar_size_at_zoom,
     _line_width_mm_at_zoom,
+    _literal_line_dasharray,
     base_mapbox_style_layer_id_for_qfit,
 )
 
@@ -60,6 +61,13 @@ PATH_PEDESTRIAN_STROKE_CONTROL_KEYS = (
     "line-color",
     "line-dasharray",
     "line-opacity",
+)
+PATH_PEDESTRIAN_STROKE_DELTA_KEYS = (
+    "line-width_delta_mm",
+    "line-width_ratio",
+    "line-dasharray_match",
+    "line-color_match",
+    "line-opacity_delta",
 )
 PATH_PEDESTRIAN_SOURCE_SPLIT_BASE_LAYER_IDS = frozenset(
     {
@@ -106,6 +114,7 @@ COMPARISON_VISUAL_METRIC_KEYS = (
 )
 MARKDOWN_SEPARATOR_5_COLUMNS = "| --- | --- | --- | --- | --- |"
 MARKDOWN_SEPARATOR_6_COLUMNS = "| --- | --- | --- | --- | --- | --- |"
+MARKDOWN_SEPARATOR_7_COLUMNS = "| --- | --- | --- | --- | --- | --- | --- |"
 UNSAMPLED_EXPRESSION_CONTROL = "expression-not-sampled"
 ARGPARSE_EXIT_SENTINEL = "argparse error should exit"
 
@@ -1046,6 +1055,44 @@ def _source_sampled_stroke_controls(
     return sampled_controls
 
 
+def _numeric_control(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _stroke_control_deltas(
+    source_sampled_controls: Mapping[str, object],
+    qgis_controls: Mapping[str, object],
+) -> dict[str, object]:
+    deltas: dict[str, object] = {}
+    source_width = _numeric_control(source_sampled_controls.get("line-width"))
+    qgis_width = _numeric_control(qgis_controls.get("line-width"))
+    if source_width is not None and qgis_width is not None:
+        deltas["line-width_delta_mm"] = qgis_width - source_width
+        if source_width:
+            deltas["line-width_ratio"] = qgis_width / source_width
+    source_dasharray = _literal_line_dasharray(source_sampled_controls.get("line-dasharray"))
+    qgis_dasharray = _literal_line_dasharray(qgis_controls.get("line-dasharray"))
+    if source_dasharray is not None and qgis_dasharray is not None:
+        deltas["line-dasharray_match"] = qgis_dasharray == source_dasharray
+    source_color = source_sampled_controls.get("line-color")
+    qgis_color = qgis_controls.get("line-color")
+    if (
+        isinstance(source_color, str)
+        and source_color
+        and source_color != UNSAMPLED_EXPRESSION_CONTROL
+        and isinstance(qgis_color, str)
+        and qgis_color
+    ):
+        deltas["line-color_match"] = qgis_color == source_color
+    source_opacity = _numeric_control(source_sampled_controls.get("line-opacity"))
+    qgis_opacity = _numeric_control(qgis_controls.get("line-opacity"))
+    if source_opacity is not None and qgis_opacity is not None:
+        deltas["line-opacity_delta"] = qgis_opacity - source_opacity
+    return deltas
+
+
 def _qgis_stroke_details_by_source_id(
     qgis_details: Iterable[Mapping[str, object]],
 ) -> dict[str, list[Mapping[str, object]]]:
@@ -1066,16 +1113,27 @@ def _source_qgis_stroke_control_comparisons(camera: Mapping[str, object]) -> lis
     for source_detail in source_details:
         source_id = str(source_detail.get("id") or "")
         matched_details = qgis_details_by_source_id.get(source_id, [])
+        source_sampled_controls = _source_sampled_stroke_controls(source_detail, camera_zoom)
         comparisons.append(
             {
                 "source_layer_id": source_id,
                 "source_controls": _stroke_controls(source_detail),
-                "source_sampled_controls": _source_sampled_stroke_controls(source_detail, camera_zoom),
+                "source_sampled_controls": source_sampled_controls,
                 "qgis_layer_ids": [str(detail.get("id") or "") for detail in matched_details],
                 "qgis_controls": [
                     {
                         "layer_id": str(detail.get("id") or ""),
                         "controls": _stroke_controls(detail),
+                    }
+                    for detail in matched_details
+                ],
+                "qgis_control_deltas": [
+                    {
+                        "layer_id": str(detail.get("id") or ""),
+                        "deltas": _stroke_control_deltas(
+                            source_sampled_controls,
+                            _stroke_controls(detail),
+                        ),
                     }
                     for detail in matched_details
                 ],
@@ -1394,6 +1452,31 @@ def _qgis_stroke_control_summaries(comparison: Mapping[str, object]) -> list[str
     return summaries
 
 
+def _qgis_stroke_delta_summaries(comparison: Mapping[str, object]) -> list[str]:
+    delta_rows = comparison.get("qgis_control_deltas")
+    rows = delta_rows if isinstance(delta_rows, list) else []
+    summaries = []
+    for delta_row in rows:
+        if not isinstance(delta_row, Mapping):
+            continue
+        layer_id = str(delta_row.get("layer_id") or "")
+        deltas = delta_row.get("deltas")
+        delta_summary = _stroke_delta_summaries(deltas)
+        if layer_id and delta_summary:
+            summaries.append(f"{layer_id}: {', '.join(delta_summary)}")
+    return summaries
+
+
+def _stroke_delta_summaries(deltas: object) -> list[str]:
+    if not isinstance(deltas, Mapping):
+        return []
+    return [
+        f"{key}={_compact_json(deltas.get(key))}"
+        for key in PATH_PEDESTRIAN_STROKE_DELTA_KEYS
+        if key in deltas
+    ]
+
+
 def _stroke_control_summaries(controls: object) -> list[str]:
     if not isinstance(controls, Mapping):
         return []
@@ -1422,6 +1505,7 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
                     _stroke_control_summaries(comparison.get("source_sampled_controls")),
                     comparison.get("qgis_layer_ids"),
                     _qgis_stroke_control_summaries(comparison),
+                    _qgis_stroke_delta_summaries(comparison),
                 ]
             )
     if not rows:
@@ -1440,10 +1524,15 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
                 "expression colors are marked as expression-not-sampled and remain available "
                 "in the raw source controls."
             ),
+            (
+                "QGIS deltas compare visible QGIS controls against source sampled controls "
+                "where both sides are directly comparable; line-width deltas are QGIS minus "
+                "source in millimetres."
+            ),
             "Rows with empty QGIS columns identify source strokes with no visible QGIS counterpart.",
             "",
-            "| Camera | Source layer | Source controls | Source sampled controls | QGIS layer ids | QGIS controls |",
-            MARKDOWN_SEPARATOR_6_COLUMNS,
+            "| Camera | Source layer | Source controls | Source sampled controls | QGIS layer ids | QGIS controls | QGIS deltas |",
+            MARKDOWN_SEPARATOR_7_COLUMNS,
         ]
     )
     lines.extend(_markdown_table_row(row) for row in rows)


### PR DESCRIPTION
## Summary
- add structured QGIS-vs-source stroke deltas to the Mapbox Outdoors path/pedestrian focus report
- report width deltas/ratios, dasharray match flags, color match flags, and opacity deltas where the source sampled controls and visible QGIS controls are directly comparable
- update the focus-report tests and Markdown assertions for the new diagnostic column

Refs #949.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `python3 scripts/package_plugin.py`
- Diagnostic report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T012447Z/summary.md`

## Evidence
- The refreshed report now shows `road-path-z16-plus` with `line-width_delta_mm=0.0`, `line-width_ratio=1.0`, and `line-dasharray_match=true` after #1246.
- It also ranks remaining z18 stroke gaps explicitly, including `road-pedestrian-z16-plus` at `line-width_delta_mm=-1.0888942307692306` and `road-steps-z17-plus` at `line-width_delta_mm=-0.6984999999999998`, so follow-up rendering changes can be scoped from measured deltas rather than row-by-row inspection.
