### PR TITLE
fix: sample z18 step widths

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -697,7 +697,8 @@ _ROAD_STEPS_LINE_STYLE_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, 
     ("below-z15", None, 15.0, 14.0),
     ("z15-to-z16", 15.0, 16.0, 15.0),
     ("z16-to-z17", 16.0, 17.0, 16.0),
-    ("z17-plus", 17.0, None, 17.0),
+    ("z17-to-z18", 17.0, 18.0, 17.0),
+    ("z18-plus", 18.0, None, 18.0),
 )
 _PATH_BACKGROUND_LINE_COLOR_LAYER_IDS = {
     "bridge-path-bg",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -6048,11 +6048,13 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-steps-below-z15",
                 "road-steps-z15-to-z16",
                 "road-steps-z16-to-z17",
-                "road-steps-z17-plus",
+                "road-steps-z17-to-z18",
+                "road-steps-z18-plus",
                 "road-steps-bg-below-z15",
                 "road-steps-bg-z15-to-z16",
                 "road-steps-bg-z16-to-z17",
-                "road-steps-bg-z17-plus",
+                "road-steps-bg-z17-to-z18",
+                "road-steps-bg-z18-plus",
                 "road-path",
             ],
         )
@@ -6061,27 +6063,38 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(by_id["road-steps-below-z15"]["paint"]["line-dasharray"], [1, 0])
         self.assertEqual(by_id["road-steps-z15-to-z16"]["paint"]["line-dasharray"], [1.75, 1])
         self.assertEqual(by_id["road-steps-z16-to-z17"]["paint"]["line-dasharray"], [1, 0.75])
-        self.assertEqual(by_id["road-steps-z17-plus"]["paint"]["line-dasharray"], [0.3, 0.3])
+        self.assertEqual(by_id["road-steps-z17-to-z18"]["paint"]["line-dasharray"], [0.3, 0.3])
+        self.assertEqual(by_id["road-steps-z18-plus"]["paint"]["line-dasharray"], [0.3, 0.3])
         self.assertAlmostEqual(
-            by_id["road-steps-z17-plus"]["paint"]["line-width"],
+            by_id["road-steps-z17-to-z18"]["paint"]["line-width"],
             (
                 mapbox_config._extract_zoom_scalar_size_at_zoom(steps_width, 17.0)
                 * mapbox_config._MAPBOX_PIXEL_TO_MM
             ),
         )
         self.assertAlmostEqual(
-            by_id["road-steps-bg-z17-plus"]["paint"]["line-width"],
+            by_id["road-steps-bg-z17-to-z18"]["paint"]["line-width"],
             4.6 * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
+        self.assertAlmostEqual(
+            by_id["road-steps-z18-plus"]["paint"]["line-width"],
+            6 * mapbox_config._MAPBOX_PIXEL_TO_MM,
+        )
+        self.assertAlmostEqual(
+            by_id["road-steps-bg-z18-plus"]["paint"]["line-width"],
+            7 * mapbox_config._MAPBOX_PIXEL_TO_MM,
         )
         self.assertEqual(by_id["road-steps-below-z15"]["minzoom"], 14)
         self.assertEqual(by_id["road-steps-below-z15"]["maxzoom"], 15.0)
-        self.assertEqual(by_id["road-steps-z17-plus"]["minzoom"], 17.0)
+        self.assertEqual(by_id["road-steps-z17-to-z18"]["minzoom"], 17.0)
+        self.assertEqual(by_id["road-steps-z17-to-z18"]["maxzoom"], 18.0)
+        self.assertEqual(by_id["road-steps-z18-plus"]["minzoom"], 18.0)
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-steps-z17-plus"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-steps-z18-plus"),
             "road-steps",
         )
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-steps-bg-z17-plus"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-steps-bg-z18-plus"),
             "road-steps-bg",
         )
 


### PR DESCRIPTION
## Summary
- split the high-zoom Mapbox Outdoors steps line-style band into z17-to-z18 and z18-plus variants
- keep the existing z17 sampled widths unchanged while sampling z18+ steps and steps background widths at the actual z18 source zoom
- update the regression test for the new static QGIS steps bands

Refs #949.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests::test_road_steps_line_styles_split_high_zoom_widths_and_dashes -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `python3 scripts/package_plugin.py`
- QGIS-only z18 render: `debug/mapbox-outdoors-comparison-steps-z18-width/zermatt-trails-z18-outdoors/20260521T014132Z/qgis-vector-render.png` (1280x900, nonblank RGB extrema)
- Focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T014351Z/summary.md`

## Evidence
- The refreshed report shows `road-steps-z18-plus` with `line-width_delta_mm=0.0`, `line-width_ratio=1.0`, `line-dasharray_match=true`, and `line-color_match=true`.
- It also shows `road-steps-bg-z18-plus` with `line-width_delta_mm=0.0`, `line-width_ratio=1.0`, `line-color_match=true`, and `line-opacity_delta=0.0`.
- The remaining z18 `road-pedestrian-z16-plus` width gap is intentionally left for a separate slice because it interacts with the 3 mm QGIS cap and casing/core relationship.
