### PR TITLE
test: surface capped source stroke widths

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -922,6 +922,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                     },
                     "source_sampled_controls": {
                         "line-width": 3.0,
+                        "line-width_raw_mm": 3.175,
+                        "line-width_capped": True,
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-dasharray": [1, 0.2],
                     },
@@ -952,6 +954,9 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                 }
             ],
         )
+        markdown = build_summary_markdown(report)
+        self.assertIn("line-width_raw_mm=3.175", markdown)
+        self.assertIn("line-width_capped=true", markdown)
 
     def test_build_path_pedestrian_focus_report_pairs_split_road_path_strokes_with_source_layer(self):
         road_report = _road_feature_report()
@@ -1052,6 +1057,29 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                 "line-color": "expression-not-sampled",
             },
         )
+
+    def test_build_path_pedestrian_focus_report_does_not_mark_minimum_width_floor_as_cap(self):
+        source_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-path",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {"line-width": 0.1},
+                }
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            source_style=source_style,
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        [comparison] = camera["source_qgis_stroke_control_comparisons"]
+        self.assertEqual(comparison["source_sampled_controls"], {"line-width": 0.1})
 
     def test_build_path_pedestrian_focus_report_adds_visual_artifacts_to_focused_cameras(self):
         report = build_path_pedestrian_focus_report(

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -16,9 +16,10 @@ if package_parent not in sys.path:
     sys.path.insert(0, package_parent)
 
 from qfit.mapbox_config import (  # noqa: E402
+    _MAPBOX_PIXEL_TO_MM,
+    _MAX_LINE_WIDTH_MM,
     _extract_line_dasharray_literal,
     _extract_zoom_scalar_size_at_zoom,
-    _line_width_mm_at_zoom,
     _literal_line_dasharray,
     base_mapbox_style_layer_id_for_qfit,
 )
@@ -58,6 +59,8 @@ PATH_PEDESTRIAN_DETAIL_PAINT_KEYS = (
 )
 PATH_PEDESTRIAN_STROKE_CONTROL_KEYS = (
     "line-width",
+    "line-width_raw_mm",
+    "line-width_capped",
     "line-color",
     "line-dasharray",
     "line-opacity",
@@ -1038,9 +1041,7 @@ def _source_sampled_stroke_controls(
     if camera_zoom is None:
         return {}
     sampled_controls: dict[str, object] = {}
-    line_width = _line_width_mm_at_zoom(detail.get("line-width"), camera_zoom)
-    if line_width is not None:
-        sampled_controls["line-width"] = line_width
+    sampled_controls.update(_source_line_width_controls(detail.get("line-width"), camera_zoom))
     line_color = detail.get("line-color")
     if isinstance(line_color, str) and line_color:
         sampled_controls["line-color"] = line_color
@@ -1053,6 +1054,19 @@ def _source_sampled_stroke_controls(
     if line_opacity is not None:
         sampled_controls["line-opacity"] = line_opacity
     return sampled_controls
+
+
+def _source_line_width_controls(line_width_expr: object, camera_zoom: float) -> dict[str, object]:
+    line_width_px = _extract_zoom_scalar_size_at_zoom(line_width_expr, camera_zoom)
+    if line_width_px is None:
+        return {}
+    raw_width_mm = line_width_px * _MAPBOX_PIXEL_TO_MM
+    capped_width_mm = max(0.1, min(raw_width_mm, _MAX_LINE_WIDTH_MM))
+    controls: dict[str, object] = {"line-width": capped_width_mm}
+    if raw_width_mm > _MAX_LINE_WIDTH_MM + 1e-12:
+        controls["line-width_raw_mm"] = raw_width_mm
+        controls["line-width_capped"] = True
+    return controls
 
 
 def _numeric_control(value: object) -> float | None:


### PR DESCRIPTION
## Summary

- Add raw/capped source line-width metadata to the path/pedestrian focus report when sampled Mapbox source widths hit qfit's 3 mm QGIS cap.
- Keep the existing capped `line-width` deltas unchanged while making the z18 pedestrian core/case cap relationship explicit before any production styling change.
- Update regression coverage for the sampled controls, Markdown output, and the minimum-width floor edge case flagged by Greptile.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `python3 scripts/package_plugin.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T202841Z/road-features.json --source-style-json debug/mapbox-outdoors-source-style/20260520T042926Z/mapbox-outdoors-v12.json --qgis-style-json zermatt-trails-z18-outdoors=debug/mapbox-outdoors-comparison-steps-z18-width/zermatt-trails-z18-outdoors/20260521T014450Z/qgis-preprocessed-style.json --qgis-label-styles-json zermatt-trails-z18-outdoors=debug/mapbox-outdoors-comparison-steps-z18-width/zermatt-trails-z18-outdoors/20260521T014450Z/qgis-label-styles.json`

## Evidence

- Refreshed report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T020350Z/summary.md`
- The z18 `road-pedestrian` row now shows source `line-width_raw_mm=3.175` capped to `line-width=3.0`.
- The z18 `road-pedestrian-case` row now shows source `line-width_raw_mm=3.8364583333333333` capped to `line-width=3.0`.