### PR TITLE
test: add pedestrian cap relationship report

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -1081,6 +1081,103 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         [comparison] = camera["source_qgis_stroke_control_comparisons"]
         self.assertEqual(comparison["source_sampled_controls"], {"line-width": 0.1})
 
+    def test_build_path_pedestrian_focus_report_summarizes_pedestrian_cap_relationship(self):
+        road_report = {
+            "generated": "2026-05-20T01:09:13+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "cameras": [
+                {
+                    "status": "decoded",
+                    "camera": "zermatt-trails-z18-outdoors",
+                    "camera_zoom": 18.0,
+                    "tile_zoom": 18,
+                    "pedestrian_line_candidate_count": 1,
+                }
+            ],
+        }
+        source_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-pedestrian",
+                    "type": "line",
+                    "minzoom": 12,
+                    "paint": {"line-width": 12},
+                },
+                {
+                    "id": "road-pedestrian-case",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {"line-width": 14.5},
+                },
+            ],
+        }
+        qgis_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-pedestrian-case-z16-plus-pale-casing",
+                    "type": "line",
+                    "minzoom": 16,
+                    "paint": {"line-width": 3.0},
+                },
+                {
+                    "id": "road-pedestrian-case-z16-plus",
+                    "type": "line",
+                    "minzoom": 16,
+                    "paint": {"line-width": 2.4},
+                },
+                {
+                    "id": "road-pedestrian-z16-plus",
+                    "type": "line",
+                    "minzoom": 16,
+                    "paint": {"line-width": 1.92},
+                },
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(
+            road_report,
+            source_style=source_style,
+            qgis_styles_by_camera={"zermatt-trails-z18-outdoors": qgis_style},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        self.assertEqual(
+            camera["pedestrian_core_case_cap_relationships"],
+            [
+                {
+                    "source_core_layer_id": "road-pedestrian",
+                    "source_case_layer_id": "road-pedestrian-case",
+                    "cap_limit_mm": 3.0,
+                    "source_core_width_mm": 3.0,
+                    "source_core_raw_width_mm": 3.175,
+                    "source_core_capped": True,
+                    "source_case_width_mm": 3.0,
+                    "source_case_raw_width_mm": 3.8364583333333333,
+                    "source_case_capped": True,
+                    "source_both_widths_capped": True,
+                    "source_case_over_core_mm": 0.0,
+                    "source_case_to_core_ratio": 1.0,
+                    "qgis_core_layer_id": "road-pedestrian-z16-plus",
+                    "qgis_core_width_mm": 1.92,
+                    "qgis_case_layer_id": "road-pedestrian-case-z16-plus",
+                    "qgis_case_width_mm": 2.4,
+                    "qgis_pale_casing_layer_id": "road-pedestrian-case-z16-plus-pale-casing",
+                    "qgis_pale_casing_width_mm": 3.0,
+                    "qgis_case_over_core_mm": 0.48,
+                    "qgis_case_to_core_ratio": 1.25,
+                    "qgis_ratio_preserving_core_width_mm_at_cap": 2.4,
+                }
+            ],
+        )
+        markdown = build_summary_markdown(report)
+        self.assertIn("## Pedestrian core/case cap relationships", markdown)
+        self.assertIn("source_both_widths_capped=true", markdown)
+        self.assertIn("qgis_ratio_preserving_core_width_mm_at_cap=2.4", markdown)
+
     def test_build_path_pedestrian_focus_report_adds_visual_artifacts_to_focused_cameras(self):
         report = build_path_pedestrian_focus_report(
             _road_feature_report(),

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -81,6 +81,34 @@ PATH_PEDESTRIAN_SOURCE_SPLIT_SUFFIXES = (
     "-below-z16",
     "-z16-plus",
 )
+PATH_PEDESTRIAN_CORE_CASE_LAYER_PAIRS = (
+    ("road-pedestrian", "road-pedestrian-case"),
+    ("bridge-pedestrian", "bridge-pedestrian-case"),
+    ("tunnel-pedestrian", "tunnel-pedestrian-case"),
+)
+PATH_PEDESTRIAN_PALE_CASING_SUFFIX = "-pale-casing"
+PATH_PEDESTRIAN_CORE_CASE_SOURCE_KEYS = (
+    "source_both_widths_capped",
+    "source_case_to_core_ratio",
+    "source_case_over_core_mm",
+    "source_core_width_mm",
+    "source_case_width_mm",
+    "source_core_raw_width_mm",
+    "source_case_raw_width_mm",
+    "source_core_capped",
+    "source_case_capped",
+)
+PATH_PEDESTRIAN_CORE_CASE_QGIS_KEYS = (
+    "qgis_case_to_core_ratio",
+    "qgis_case_over_core_mm",
+    "qgis_ratio_preserving_core_width_mm_at_cap",
+    "qgis_core_width_mm",
+    "qgis_case_width_mm",
+    "qgis_pale_casing_width_mm",
+    "qgis_core_layer_id",
+    "qgis_case_layer_id",
+    "qgis_pale_casing_layer_id",
+)
 TOP_COUNT_LIMIT = 3
 SAMPLE_LAYER_LIMIT = 8
 DUPLICATE_LABEL_CATEGORY_KEYS = (
@@ -1156,6 +1184,145 @@ def _source_qgis_stroke_control_comparisons(camera: Mapping[str, object]) -> lis
     return comparisons
 
 
+def _comparison_by_source_id(
+    comparisons: Iterable[Mapping[str, object]],
+) -> dict[str, Mapping[str, object]]:
+    return {
+        str(comparison.get("source_layer_id") or ""): comparison
+        for comparison in comparisons
+        if comparison.get("source_layer_id")
+    }
+
+
+def _source_line_width_summary(
+    comparison: Mapping[str, object],
+    *,
+    prefix: str,
+) -> dict[str, object]:
+    controls = comparison.get("source_sampled_controls")
+    if not isinstance(controls, Mapping):
+        return {}
+    width = _numeric_control(controls.get("line-width"))
+    if width is None:
+        return {}
+    summary: dict[str, object] = {f"source_{prefix}_width_mm": width}
+    raw_width = _numeric_control(controls.get("line-width_raw_mm"))
+    if raw_width is not None:
+        summary[f"source_{prefix}_raw_width_mm"] = raw_width
+    summary[f"source_{prefix}_capped"] = controls.get("line-width_capped") is True
+    return summary
+
+
+def _qgis_line_width_summary(
+    comparison: Mapping[str, object],
+    *,
+    prefix: str,
+    include_layer_suffix: str | None = None,
+    exclude_layer_suffix: str | None = None,
+) -> dict[str, object]:
+    qgis_controls = comparison.get("qgis_controls")
+    control_rows = qgis_controls if isinstance(qgis_controls, list) else []
+    for control_row in control_rows:
+        if not isinstance(control_row, Mapping):
+            continue
+        layer_id = str(control_row.get("layer_id") or "")
+        if include_layer_suffix is not None and not layer_id.endswith(include_layer_suffix):
+            continue
+        if exclude_layer_suffix is not None and layer_id.endswith(exclude_layer_suffix):
+            continue
+        controls = control_row.get("controls")
+        if not isinstance(controls, Mapping):
+            continue
+        width = _numeric_control(controls.get("line-width"))
+        if width is None:
+            continue
+        return {f"qgis_{prefix}_layer_id": layer_id, f"qgis_{prefix}_width_mm": width}
+    return {}
+
+
+def _width_relationship(numerator: object, denominator: object) -> float | None:
+    numerator_value = _numeric_control(numerator)
+    denominator_value = _numeric_control(denominator)
+    if numerator_value is None or denominator_value is None or denominator_value == 0:
+        return None
+    return numerator_value / denominator_value
+
+
+def _add_source_core_case_relationship_fields(relationship: dict[str, object]) -> None:
+    core_width = _numeric_control(relationship.get("source_core_width_mm"))
+    case_width = _numeric_control(relationship.get("source_case_width_mm"))
+    if core_width is not None and case_width is not None:
+        relationship["source_both_widths_capped"] = (
+            relationship.get("source_core_capped") is True
+            and relationship.get("source_case_capped") is True
+        )
+        relationship["source_case_over_core_mm"] = case_width - core_width
+        source_ratio = _width_relationship(case_width, core_width)
+        if source_ratio is not None:
+            relationship["source_case_to_core_ratio"] = source_ratio
+
+
+def _add_qgis_core_case_relationship_fields(relationship: dict[str, object]) -> None:
+    core_width = _numeric_control(relationship.get("qgis_core_width_mm"))
+    case_width = _numeric_control(relationship.get("qgis_case_width_mm"))
+    if core_width is None or case_width is None:
+        return
+    relationship["qgis_case_over_core_mm"] = case_width - core_width
+    qgis_ratio = _width_relationship(case_width, core_width)
+    if qgis_ratio is not None:
+        relationship["qgis_case_to_core_ratio"] = qgis_ratio
+    if relationship.get("source_both_widths_capped") is True and qgis_ratio:
+        relationship["qgis_ratio_preserving_core_width_mm_at_cap"] = _MAX_LINE_WIDTH_MM / qgis_ratio
+
+
+def _pedestrian_core_case_cap_relationships(
+    camera: Mapping[str, object],
+) -> list[dict[str, object]]:
+    comparisons = camera.get("source_qgis_stroke_control_comparisons")
+    comparison_rows = comparisons if isinstance(comparisons, list) else []
+    comparisons_by_source_id = _comparison_by_source_id(
+        comparison for comparison in comparison_rows if isinstance(comparison, Mapping)
+    )
+    relationships: list[dict[str, object]] = []
+    for core_layer_id, case_layer_id in PATH_PEDESTRIAN_CORE_CASE_LAYER_PAIRS:
+        core_comparison = comparisons_by_source_id.get(core_layer_id)
+        case_comparison = comparisons_by_source_id.get(case_layer_id)
+        if core_comparison is None or case_comparison is None:
+            continue
+        relationship: dict[str, object] = {
+            "source_core_layer_id": core_layer_id,
+            "source_case_layer_id": case_layer_id,
+            "cap_limit_mm": _MAX_LINE_WIDTH_MM,
+        }
+        relationship.update(_source_line_width_summary(core_comparison, prefix="core"))
+        relationship.update(_source_line_width_summary(case_comparison, prefix="case"))
+        relationship.update(
+            _qgis_line_width_summary(
+                core_comparison,
+                prefix="core",
+                exclude_layer_suffix=PATH_PEDESTRIAN_PALE_CASING_SUFFIX,
+            )
+        )
+        relationship.update(
+            _qgis_line_width_summary(
+                case_comparison,
+                prefix="case",
+                exclude_layer_suffix=PATH_PEDESTRIAN_PALE_CASING_SUFFIX,
+            )
+        )
+        relationship.update(
+            _qgis_line_width_summary(
+                case_comparison,
+                prefix="pale_casing",
+                include_layer_suffix=PATH_PEDESTRIAN_PALE_CASING_SUFFIX,
+            )
+        )
+        _add_source_core_case_relationship_fields(relationship)
+        _add_qgis_core_case_relationship_fields(relationship)
+        relationships.append(relationship)
+    return relationships
+
+
 def _camera_focus_row(
     camera_report: Mapping[str, object],
     *,
@@ -1201,6 +1368,7 @@ def _camera_focus_row(
     )
     row["duplicate_label_diagnostic"] = _duplicate_label_diagnostic(row)
     row["source_qgis_stroke_control_comparisons"] = _source_qgis_stroke_control_comparisons(row)
+    row["pedestrian_core_case_cap_relationships"] = _pedestrian_core_case_cap_relationships(row)
     return row
 
 
@@ -1553,6 +1721,68 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
     return lines
 
 
+def _core_case_relationship_summary(
+    relationship: Mapping[str, object],
+    keys: Iterable[str],
+) -> list[str]:
+    return [
+        f"{key}={_compact_json(relationship.get(key))}"
+        for key in keys
+        if key in relationship
+    ]
+
+
+def _pedestrian_core_case_cap_markdown_lines(cameras: Iterable[object]) -> list[str]:
+    rows: list[list[object]] = []
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        relationships = camera.get("pedestrian_core_case_cap_relationships")
+        relationship_rows = relationships if isinstance(relationships, list) else []
+        for relationship in relationship_rows:
+            if not isinstance(relationship, Mapping):
+                continue
+            rows.append(
+                [
+                    camera.get("camera"),
+                    (
+                        f"{relationship.get('source_core_layer_id')}/"
+                        f"{relationship.get('source_case_layer_id')}"
+                    ),
+                    _core_case_relationship_summary(
+                        relationship,
+                        PATH_PEDESTRIAN_CORE_CASE_SOURCE_KEYS,
+                    ),
+                    _core_case_relationship_summary(
+                        relationship,
+                        PATH_PEDESTRIAN_CORE_CASE_QGIS_KEYS,
+                    ),
+                    f"cap_limit_mm={_compact_json(relationship.get('cap_limit_mm'))}",
+                ]
+            )
+    if not rows:
+        return []
+    lines = ["", "## Pedestrian core/case cap relationships", ""]
+    lines.extend(
+        [
+            (
+                "Compares pedestrian core and casing widths when source Mapbox widths "
+                "approach or exceed qfit's QGIS line-width cap."
+            ),
+            (
+                "The QGIS ratio-preserving core width is diagnostic only; it shows the "
+                "core width that would preserve the current QGIS case/core ratio if the "
+                "case stroke hit the cap."
+            ),
+            "",
+            "| Camera | Source pair | Source relationship | QGIS relationship | Cap |",
+            MARKDOWN_SEPARATOR_5_COLUMNS,
+        ]
+    )
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
+
+
 def _label_detail_zoom_band(detail: Mapping[str, object]) -> str:
     minzoom = detail.get("min_zoom_level")
     maxzoom = detail.get("max_zoom_level")
@@ -1856,6 +2086,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines.extend(_visual_artifact_markdown_lines(rows))
     lines.extend(_duplicate_label_diagnostic_markdown_lines(rows))
     lines.extend(_source_qgis_stroke_control_markdown_lines(rows))
+    lines.extend(_pedestrian_core_case_cap_markdown_lines(rows))
     lines.extend(_visible_source_detail_markdown_lines(rows))
     lines.extend(_visible_detail_markdown_lines(rows))
     lines.extend(_visible_label_thinning_markdown_lines(rows))


### PR DESCRIPTION
## Summary

- Add a diagnostic pedestrian core/case cap relationship section to the Mapbox Outdoors path/pedestrian focus report.
- Surface source core/case width ratios, current QGIS core/case ratios, pale casing width, and the ratio-preserving core width implied by the 3 mm cap.
- Cover the new JSON/Markdown output with a focused regression test.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `python3 scripts/package_plugin.py`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T202841Z/road-features.json --source-style-json debug/mapbox-outdoors-source-style/20260520T042926Z/mapbox-outdoors-v12.json --qgis-style-json zermatt-trails-z18-outdoors=debug/mapbox-outdoors-comparison-steps-z18-width/zermatt-trails-z18-outdoors/20260521T014450Z/qgis-preprocessed-style.json --qgis-label-styles-json zermatt-trails-z18-outdoors=debug/mapbox-outdoors-comparison-steps-z18-width/zermatt-trails-z18-outdoors/20260521T014450Z/qgis-label-styles.json`

## Evidence

- Refreshed report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T021522Z/summary.md`
- z18 source pedestrian core/case both cap at 3 mm, while current QGIS keeps a 1.288604898828541 case/core ratio.
- Preserving that current QGIS ratio with a 3 mm case cap implies a 2.328099173553719 mm pedestrian core width before any production style change.
