### PR TITLE
fix: preserve pedestrian cap width ratio

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -3032,7 +3032,7 @@ def _pedestrian_high_zoom_cap_scales_by_base_layer_id(layers: list[object]) -> d
         if not isinstance(line_width, list):
             continue
         case_width_mm = _line_width_mm_at_zoom(line_width, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM)
-        if case_width_mm is not None and 0 < case_width_mm < _MAX_LINE_WIDTH_MM:
+        if case_width_mm is not None and case_width_mm < _MAX_LINE_WIDTH_MM:
             scales[_pedestrian_pair_base_layer_id(layer_id)] = _MAX_LINE_WIDTH_MM / case_width_mm
     return scales
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -667,12 +667,19 @@ _PEDESTRIAN_LINE_WIDTH_LAYER_IDS = {
     "tunnel-pedestrian",
     "tunnel-pedestrian-case",
 }
+_PEDESTRIAN_CASE_LINE_WIDTH_LAYER_IDS = {
+    "bridge-pedestrian-case",
+    "road-pedestrian-case",
+    "tunnel-pedestrian-case",
+}
+_PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX = "z16-plus"
+_PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM = 17.0
 _PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("below-z16", None, 16.0, 14.0),
     # The live z18 pedestrian case width exceeds qfit's QGIS max line width.
-    # Sampling z17 restores high-zoom prominence while preserving the case/core
-    # width relationship instead of clamping both strokes to the same value.
-    ("z16-plus", 16.0, None, 17.0),
+    # Sampling z17 provides a stable case/core ratio; high-zoom pedestrian pairs
+    # scale together until the case stroke reaches the QGIS cap.
+    (_PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX, 16.0, None, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM),
 )
 _PATH_TRAIL_LINE_WIDTH_LAYER_IDS = {
     "bridge-path-cycleway-piste",
@@ -2935,6 +2942,7 @@ def _line_width_zoom_band_layer_variants(
     layer_ids: set[str],
     zoom_bands: tuple[tuple[str, float | None, float | None, float], ...],
     line_width_scale: float = 1.0,
+    line_width_scales_by_suffix: dict[str, float] | None = None,
 ) -> list[dict[str, object]] | None:
     layer_id = str(layer.get("id") or "")
     paint = layer.get("paint")
@@ -2966,7 +2974,15 @@ def _line_width_zoom_band_layer_variants(
         line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
         if line_width_mm is None:
             continue
-        line_width_mm = max(0.1, min(line_width_mm * line_width_scale, _MAX_LINE_WIDTH_MM))
+        band_scale = (
+            line_width_scales_by_suffix.get(suffix, 1.0)
+            if line_width_scales_by_suffix is not None
+            else 1.0
+        )
+        line_width_mm = max(
+            0.1,
+            min(line_width_mm * line_width_scale * band_scale, _MAX_LINE_WIDTH_MM),
+        )
 
         variant = copy.deepcopy(layer)
         variant["id"] = f"{layer_id}-{suffix}"
@@ -2995,12 +3011,48 @@ def _split_path_trail_line_width_layers_for_qgis(layers: object) -> object:
     )
 
 
-def _pedestrian_line_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+def _pedestrian_pair_base_layer_id(layer_id: str) -> str:
+    return layer_id[: -len("-case")] if layer_id.endswith("-case") else layer_id
+
+
+def _pedestrian_high_zoom_cap_scales_by_base_layer_id(layers: list[object]) -> dict[str, float]:
+    scales: dict[str, float] = {}
+    for layer in layers:
+        if not isinstance(layer, dict):
+            continue
+        layer_id = str(layer.get("id") or "")
+        paint = layer.get("paint")
+        if (
+            layer_id not in _PEDESTRIAN_CASE_LINE_WIDTH_LAYER_IDS
+            or layer.get("type") != "line"
+            or not isinstance(paint, dict)
+        ):
+            continue
+        line_width = paint.get("line-width")
+        if not isinstance(line_width, list):
+            continue
+        case_width_mm = _line_width_mm_at_zoom(line_width, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM)
+        if case_width_mm is not None and 0 < case_width_mm < _MAX_LINE_WIDTH_MM:
+            scales[_pedestrian_pair_base_layer_id(layer_id)] = _MAX_LINE_WIDTH_MM / case_width_mm
+    return scales
+
+
+def _pedestrian_line_width_layer_variants(
+    layer: dict[str, object],
+    *,
+    high_zoom_cap_scales_by_base_layer_id: dict[str, float],
+) -> list[dict[str, object]] | None:
     """Split audited pedestrian widths into static QGIS zoom bands."""
+    layer_id = str(layer.get("id") or "")
+    base_layer_id = _pedestrian_pair_base_layer_id(layer_id)
+    high_zoom_scale = high_zoom_cap_scales_by_base_layer_id.get(base_layer_id, 1.0)
     return _line_width_zoom_band_layer_variants(
         layer,
         layer_ids=_PEDESTRIAN_LINE_WIDTH_LAYER_IDS,
         zoom_bands=_PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS,
+        line_width_scales_by_suffix={
+            _PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX: high_zoom_scale,
+        },
     )
 
 
@@ -3018,9 +3070,15 @@ def _split_line_width_zoom_band_layers_for_qgis(layers: object, *, variants_for_
 
 
 def _split_pedestrian_line_width_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    high_zoom_cap_scales_by_base_layer_id = _pedestrian_high_zoom_cap_scales_by_base_layer_id(layers)
     return _split_line_width_zoom_band_layers_for_qgis(
         layers,
-        variants_for_layer=_pedestrian_line_width_layer_variants,
+        variants_for_layer=lambda layer: _pedestrian_line_width_layer_variants(
+            layer,
+            high_zoom_cap_scales_by_base_layer_id=high_zoom_cap_scales_by_base_layer_id,
+        ),
     )
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5920,14 +5920,17 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._extract_zoom_scalar_size_at_zoom(pedestrian_width, 14.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
-        pedestrian_high_mm = (
+        pedestrian_high_unscaled_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(pedestrian_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
-        case_high_mm = (
+        case_high_unscaled_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(case_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
+        high_zoom_cap_scale = mapbox_config._MAX_LINE_WIDTH_MM / case_high_unscaled_mm
+        pedestrian_high_mm = pedestrian_high_unscaled_mm * high_zoom_cap_scale
+        case_high_mm = mapbox_config._MAX_LINE_WIDTH_MM
 
         self.assertAlmostEqual(
             by_id["road-pedestrian-below-z16"]["paint"]["line-width"],
@@ -5940,6 +5943,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(
             by_id["road-pedestrian-case-z16-plus"]["paint"]["line-width"],
             case_high_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-pedestrian-z16-plus"]["paint"]["line-width"],
+            pedestrian_high_unscaled_mm,
         )
         self.assertEqual(
             by_id["road-pedestrian-case-z16-plus-pale-casing"]["paint"],
@@ -5954,6 +5961,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             by_id["road-pedestrian-case-z16-plus"].get("filter"),
         )
         self.assertGreater(case_high_mm, pedestrian_high_mm)
+        self.assertAlmostEqual(
+            case_high_mm / pedestrian_high_mm,
+            case_high_unscaled_mm / pedestrian_high_unscaled_mm,
+        )
         self.assertEqual(by_id["road-pedestrian-below-z16"]["maxzoom"], 16.0)
         self.assertEqual(by_id["road-pedestrian-z16-plus"]["minzoom"], 16.0)
         self.assertEqual(by_id["road-pedestrian-case-below-z16"]["minzoom"], 14)

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5924,6 +5924,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._extract_zoom_scalar_size_at_zoom(pedestrian_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
+        pedestrian_high_unpaired_mm = min(
+            pedestrian_high_unscaled_mm,
+            mapbox_config._MAX_LINE_WIDTH_MM,
+        )
         case_high_unscaled_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(case_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
@@ -5946,7 +5950,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertAlmostEqual(
             by_id["bridge-pedestrian-z16-plus"]["paint"]["line-width"],
-            pedestrian_high_unscaled_mm,
+            pedestrian_high_unpaired_mm,
         )
         self.assertEqual(
             by_id["road-pedestrian-case-z16-plus-pale-casing"]["paint"],


### PR DESCRIPTION
## Summary

- Scale high-zoom pedestrian core/case widths together when the sampled case can be raised to qfit's 3 mm QGIS cap.
- Keep the current z17-derived pedestrian case/core ratio instead of blindly sampling both z18 widths and collapsing core/case separation to 1:1.
- Extend the Mapbox style simplification regression test to cover the capped case width, ratio-preserving core width, and unpaired bridge pedestrian passthrough.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests::test_pedestrian_line_width_splits_high_zoom_widths -q --tb=short`
- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- `python3 scripts/package_plugin.py`
- `python3 validation/mapbox_outdoors_comparison.py zermatt-trails-z18-outdoors --style-json debug/mapbox-outdoors-source-style/20260520T042926Z/mapbox-outdoors-v12.json --output-root debug/mapbox-outdoors-comparison-pedestrian-ratio-cap --skip-browser --skip-diff`
- `python3 validation/mapbox_outdoors_path_pedestrian_focus.py --road-features-json debug/mapbox-outdoors-road-features/all-cameras/20260520T202841Z/road-features.json --source-style-json debug/mapbox-outdoors-source-style/20260520T042926Z/mapbox-outdoors-v12.json --qgis-style-json zermatt-trails-z18-outdoors=debug/mapbox-outdoors-comparison-pedestrian-ratio-cap/zermatt-trails-z18-outdoors/20260521T023538Z/qgis-preprocessed-style.json --qgis-label-styles-json zermatt-trails-z18-outdoors=debug/mapbox-outdoors-comparison-pedestrian-ratio-cap/zermatt-trails-z18-outdoors/20260521T023538Z/qgis-label-styles.json`

## Rendering proof

- Data: live/offline Mapbox Outdoors z18 Zermatt trail camera using the local QGIS-profile token source only inside the command environment.
- Artifact checked: `debug/mapbox-outdoors-comparison-pedestrian-ratio-cap/zermatt-trails-z18-outdoors/20260521T023538Z/qgis-vector-render.png`.
- Path checked: headless QGIS vector render, no browser refresh for this narrow QGIS-only production candidate.
- Result: render is nonblank at 1280x900; pixel delta vs current QGIS baseline is `changed_pixel_ratio=0.019582`, normalized mean `0.000613`, RMS `0.006090`; visual review found no obvious regression and preserved core/case separation better than the blind z18 probe.

## Evidence

- Refreshed focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T023548Z/summary.md`
- z18 `road-pedestrian-case-z16-plus` now reaches `3.0` mm while `road-pedestrian-z16-plus` becomes `2.328099173553719` mm.
- The report preserves the current QGIS `qgis_case_to_core_ratio=1.288604898828541` and avoids the blind z18 probe's `1.0` case/core collapse.
