### PR TITLE
fix: split pedestrian cap band at z18

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -672,14 +672,15 @@ _PEDESTRIAN_CASE_LINE_WIDTH_LAYER_IDS = {
     "road-pedestrian-case",
     "tunnel-pedestrian-case",
 }
-_PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX = "z16-plus"
+_PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX = "z18-plus"
 _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM = 17.0
 _PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("below-z16", None, 16.0, 14.0),
     # The live z18 pedestrian case width exceeds qfit's QGIS max line width.
-    # Sampling z17 provides a stable case/core ratio; high-zoom pedestrian pairs
-    # scale together until the case stroke reaches the QGIS cap.
-    (_PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX, 16.0, None, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM),
+    # Keep z16-z18 at the z17 sample, then scale the z18+ pair together until
+    # the case stroke reaches the QGIS cap.
+    ("z16-to-z18", 16.0, 18.0, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM),
+    (_PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX, 18.0, None, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM),
 )
 _PATH_TRAIL_LINE_WIDTH_LAYER_IDS = {
     "bridge-path-cycleway-piste",
@@ -829,10 +830,12 @@ _PATH_BACKGROUND_LINE_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
 _PATH_HIGH_ZOOM_PALE_CASING_LAYER_IDS = {
     "bridge-path-bg-z16-plus-outdoor",
     "bridge-path-bg-z16-plus-remaining",
-    "bridge-pedestrian-case-z16-plus",
+    "bridge-pedestrian-case-z16-to-z18",
+    "bridge-pedestrian-case-z18-plus",
     "road-path-bg-z16-plus-outdoor",
     "road-path-bg-z16-plus-remaining",
-    "road-pedestrian-case-z16-plus",
+    "road-pedestrian-case-z16-to-z18",
+    "road-pedestrian-case-z18-plus",
 }
 _PATH_HIGH_ZOOM_PALE_CASING_SUFFIX = "pale-casing"
 _PATH_HIGH_ZOOM_PALE_CASING_COLOR = "hsl(0, 0%, 98%)"
@@ -2943,6 +2946,7 @@ def _line_width_zoom_band_layer_variants(
     zoom_bands: tuple[tuple[str, float | None, float | None, float], ...],
     line_width_scale: float = 1.0,
     line_width_scales_by_suffix: dict[str, float] | None = None,
+    clamp_sample_zoom_to_band: bool = True,
 ) -> list[dict[str, object]] | None:
     layer_id = str(layer.get("id") or "")
     paint = layer.get("paint")
@@ -2968,7 +2972,12 @@ def _line_width_zoom_band_layer_variants(
         )
         if effective_zoom_band is None:
             continue
-        sampled_zoom = _zoom_in_layer_range(target_zoom, *effective_zoom_band)
+        sample_zoom_range = (
+            effective_zoom_band
+            if clamp_sample_zoom_to_band
+            else (existing_minzoom, existing_maxzoom)
+        )
+        sampled_zoom = _zoom_in_layer_range(target_zoom, *sample_zoom_range)
         if sampled_zoom is None:
             continue
         line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
@@ -3053,6 +3062,7 @@ def _pedestrian_line_width_layer_variants(
         line_width_scales_by_suffix={
             _PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX: high_zoom_scale,
         },
+        clamp_sample_zoom_to_band=False,
     )
 
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -2962,6 +2962,7 @@ def _line_width_zoom_band_layer_variants(
 
     existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
     existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    suffix_scales = line_width_scales_by_suffix or {}
     variants: list[dict[str, object]] = []
     for suffix, band_minzoom, band_maxzoom, target_zoom in zoom_bands:
         effective_zoom_band = _effective_zoom_band(
@@ -2983,11 +2984,7 @@ def _line_width_zoom_band_layer_variants(
         line_width_mm = _line_width_mm_at_zoom(line_width, sampled_zoom)
         if line_width_mm is None:
             continue
-        band_scale = (
-            line_width_scales_by_suffix.get(suffix, 1.0)
-            if line_width_scales_by_suffix is not None
-            else 1.0
-        )
+        band_scale = suffix_scales.get(suffix, 1.0)
         line_width_mm = max(
             0.1,
             min(line_width_mm * line_width_scale * band_scale, _MAX_LINE_WIDTH_MM),

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5445,9 +5445,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
     def test_path_high_zoom_pale_casing_helper_inserts_only_selected_layers(self):
         unchanged_layers = "not-a-layer-list"
         selected_layer = {
-            "id": "road-pedestrian-case-z16-plus",
+            "id": "road-pedestrian-case-z18-plus",
             "type": "line",
-            "minzoom": 16,
+            "minzoom": 18,
             "filter": ["==", ["get", "class"], "pedestrian"],
             "paint": {"line-width": 2.4, "line-color": "hsl(60, 10%, 70%)"},
         }
@@ -5465,7 +5465,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result[0], "not-a-layer")
         self.assertEqual(result[1]["id"], "road-path-bg-z16-plus-piste")
-        self.assertEqual(result[2]["id"], "road-pedestrian-case-z16-plus-pale-casing")
+        self.assertEqual(result[2]["id"], "road-pedestrian-case-z18-plus-pale-casing")
         self.assertEqual(result[2]["filter"], selected_layer["filter"])
         self.assertEqual(
             result[2]["paint"],
@@ -5475,9 +5475,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "line-opacity": 1.0,
             },
         )
-        self.assertEqual(result[3]["id"], "road-pedestrian-case-z16-plus")
+        self.assertEqual(result[3]["id"], "road-pedestrian-case-z18-plus")
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-case-z16-plus-pale-casing"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-case-z18-plus-pale-casing"),
             "road-pedestrian-case",
         )
         self.assertEqual(
@@ -5488,7 +5488,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertEqual(
             mapbox_config._path_high_zoom_pale_casing_base_layer_id(
-                "road-pedestrian-case-z16-plus-pale-casing"
+                "road-pedestrian-case-z18-plus-pale-casing"
             ),
             "road-pedestrian-case",
         )
@@ -5906,12 +5906,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             [layer["id"] for layer in result["layers"]],
             [
                 "road-pedestrian-below-z16",
-                "road-pedestrian-z16-plus",
+                "road-pedestrian-z16-to-z18",
+                "road-pedestrian-z18-plus",
                 "road-pedestrian-case-below-z16",
-                "road-pedestrian-case-z16-plus-pale-casing",
-                "road-pedestrian-case-z16-plus",
+                "road-pedestrian-case-z16-to-z18-pale-casing",
+                "road-pedestrian-case-z16-to-z18",
+                "road-pedestrian-case-z18-plus-pale-casing",
+                "road-pedestrian-case-z18-plus",
                 "bridge-pedestrian-below-z16",
-                "bridge-pedestrian-z16-plus",
+                "bridge-pedestrian-z16-to-z18",
+                "bridge-pedestrian-z18-plus",
                 "road-minor",
             ],
         )
@@ -5932,6 +5936,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._extract_zoom_scalar_size_at_zoom(case_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
+        case_mid_mm = min(case_high_unscaled_mm, mapbox_config._MAX_LINE_WIDTH_MM)
         high_zoom_cap_scale = mapbox_config._MAX_LINE_WIDTH_MM / case_high_unscaled_mm
         pedestrian_high_mm = pedestrian_high_unscaled_mm * high_zoom_cap_scale
         case_high_mm = mapbox_config._MAX_LINE_WIDTH_MM
@@ -5941,19 +5946,31 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             pedestrian_low_mm,
         )
         self.assertAlmostEqual(
-            by_id["road-pedestrian-z16-plus"]["paint"]["line-width"],
+            by_id["road-pedestrian-z16-to-z18"]["paint"]["line-width"],
+            pedestrian_high_unpaired_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["road-pedestrian-z18-plus"]["paint"]["line-width"],
             pedestrian_high_mm,
         )
         self.assertAlmostEqual(
-            by_id["road-pedestrian-case-z16-plus"]["paint"]["line-width"],
+            by_id["road-pedestrian-case-z16-to-z18"]["paint"]["line-width"],
+            case_mid_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["road-pedestrian-case-z18-plus"]["paint"]["line-width"],
             case_high_mm,
         )
         self.assertAlmostEqual(
-            by_id["bridge-pedestrian-z16-plus"]["paint"]["line-width"],
+            by_id["bridge-pedestrian-z16-to-z18"]["paint"]["line-width"],
+            pedestrian_high_unpaired_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-pedestrian-z18-plus"]["paint"]["line-width"],
             pedestrian_high_unpaired_mm,
         )
         self.assertEqual(
-            by_id["road-pedestrian-case-z16-plus-pale-casing"]["paint"],
+            by_id["road-pedestrian-case-z16-to-z18-pale-casing"]["paint"],
             {
                 "line-width": 3.0,
                 "line-color": "hsl(0, 0%, 98%)",
@@ -5961,8 +5978,20 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             },
         )
         self.assertEqual(
-            by_id["road-pedestrian-case-z16-plus-pale-casing"].get("filter"),
-            by_id["road-pedestrian-case-z16-plus"].get("filter"),
+            by_id["road-pedestrian-case-z18-plus-pale-casing"]["paint"],
+            {
+                "line-width": 3.0,
+                "line-color": "hsl(0, 0%, 98%)",
+                "line-opacity": 1.0,
+            },
+        )
+        self.assertEqual(
+            by_id["road-pedestrian-case-z16-to-z18-pale-casing"].get("filter"),
+            by_id["road-pedestrian-case-z16-to-z18"].get("filter"),
+        )
+        self.assertEqual(
+            by_id["road-pedestrian-case-z18-plus-pale-casing"].get("filter"),
+            by_id["road-pedestrian-case-z18-plus"].get("filter"),
         )
         self.assertGreater(case_high_mm, pedestrian_high_mm)
         self.assertAlmostEqual(
@@ -5970,19 +5999,29 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             case_high_unscaled_mm / pedestrian_high_unscaled_mm,
         )
         self.assertEqual(by_id["road-pedestrian-below-z16"]["maxzoom"], 16.0)
-        self.assertEqual(by_id["road-pedestrian-z16-plus"]["minzoom"], 16.0)
+        self.assertEqual(by_id["road-pedestrian-z16-to-z18"]["minzoom"], 16.0)
+        self.assertEqual(by_id["road-pedestrian-z16-to-z18"]["maxzoom"], 18.0)
+        self.assertEqual(by_id["road-pedestrian-z18-plus"]["minzoom"], 18.0)
         self.assertEqual(by_id["road-pedestrian-case-below-z16"]["minzoom"], 14)
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-z16-plus"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-z16-to-z18"),
             "road-pedestrian",
         )
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-case-z16-plus"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-z18-plus"),
+            "road-pedestrian",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-case-z16-to-z18"),
+            "road-pedestrian-case",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-pedestrian-case-z18-plus"),
             "road-pedestrian-case",
         )
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit(
-                "road-pedestrian-case-z16-plus-pale-casing"
+                "road-pedestrian-case-z18-plus-pale-casing"
             ),
             "road-pedestrian-case",
         )

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -883,19 +883,13 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             "version": 8,
             "layers": [
                 {
-                    "id": "road-pedestrian-z16-plus",
+                    "id": "road-pedestrian-z18-plus",
                     "type": "line",
-                    "minzoom": 16,
+                    "minzoom": 18,
                     "paint": {
                         "line-color": "#f6f2e8",
-                        "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
-                        "line-dasharray": [
-                            "step",
-                            ["zoom"],
-                            ["literal", [1, 0]],
-                            16,
-                            ["literal", [1, 0.2]],
-                        ],
+                        "line-width": 2.328099173553719,
+                        "line-dasharray": [1, 0.2],
                         "line-opacity": 0.65,
                     },
                 }
@@ -927,28 +921,27 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-dasharray": [1, 0.2],
                     },
-                    "qgis_layer_ids": ["road-pedestrian-z16-plus"],
+                    "qgis_layer_ids": ["road-pedestrian-z18-plus"],
                     "qgis_controls": [
                         {
-                            "layer_id": "road-pedestrian-z16-plus",
+                            "layer_id": "road-pedestrian-z18-plus",
                             "controls": {
+                                "line-width": 2.328099173553719,
                                 "line-color": "#f6f2e8",
-                                "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
-                                "line-dasharray": [
-                                    "step",
-                                    ["zoom"],
-                                    ["literal", [1, 0]],
-                                    16,
-                                    ["literal", [1, 0.2]],
-                                ],
+                                "line-dasharray": [1, 0.2],
                                 "line-opacity": 0.65,
                             },
                         }
                     ],
                     "qgis_control_deltas": [
                         {
-                            "layer_id": "road-pedestrian-z16-plus",
-                            "deltas": {"line-color_match": False},
+                            "layer_id": "road-pedestrian-z18-plus",
+                            "deltas": {
+                                "line-width_delta_mm": -0.6719008264462811,
+                                "line-width_ratio": 0.7760330578512397,
+                                "line-dasharray_match": True,
+                                "line-color_match": False,
+                            },
                         }
                     ],
                 }
@@ -1117,21 +1110,21 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             "version": 8,
             "layers": [
                 {
-                    "id": "road-pedestrian-case-z16-plus-pale-casing",
+                    "id": "road-pedestrian-case-z18-plus-pale-casing",
                     "type": "line",
-                    "minzoom": 16,
+                    "minzoom": 18,
                     "paint": {"line-width": 3.0},
                 },
                 {
-                    "id": "road-pedestrian-case-z16-plus",
+                    "id": "road-pedestrian-case-z18-plus",
                     "type": "line",
-                    "minzoom": 16,
+                    "minzoom": 18,
                     "paint": {"line-width": 2.4},
                 },
                 {
-                    "id": "road-pedestrian-z16-plus",
+                    "id": "road-pedestrian-z18-plus",
                     "type": "line",
-                    "minzoom": 16,
+                    "minzoom": 18,
                     "paint": {"line-width": 1.92},
                 },
             ],
@@ -1161,11 +1154,11 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                     "source_both_widths_capped": True,
                     "source_case_over_core_mm": 0.0,
                     "source_case_to_core_ratio": 1.0,
-                    "qgis_core_layer_id": "road-pedestrian-z16-plus",
+                    "qgis_core_layer_id": "road-pedestrian-z18-plus",
                     "qgis_core_width_mm": 1.92,
-                    "qgis_case_layer_id": "road-pedestrian-case-z16-plus",
+                    "qgis_case_layer_id": "road-pedestrian-case-z18-plus",
                     "qgis_case_width_mm": 2.4,
-                    "qgis_pale_casing_layer_id": "road-pedestrian-case-z16-plus-pale-casing",
+                    "qgis_pale_casing_layer_id": "road-pedestrian-case-z18-plus-pale-casing",
                     "qgis_pale_casing_width_mm": 3.0,
                     "qgis_case_over_core_mm": 0.48,
                     "qgis_case_to_core_ratio": 1.25,


### PR DESCRIPTION
## Summary

- Split high-zoom pedestrian line-width variants into `z16-to-z18` and `z18-plus` bands.
- Keep z16-z18 pedestrian core/case widths at the raw z17 Mapbox sample, so the z17 control deltas return to 0.0.
- Keep the #1251 ratio-preserving cap strategy only for z18+, where the source core/case widths both hit qfit's 3 mm QGIS cap.
- Update pale-casing/base-layer handling and focus-report tests for the new pedestrian variant IDs.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests::test_pedestrian_line_width_splits_high_zoom_widths -q --tb=short`
- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests -q --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py::MapboxOutdoorsPathPedestrianFocusTests::test_build_path_pedestrian_focus_report_pairs_qgis_variant_strokes_with_source_ids -q --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py::MapboxOutdoorsPathPedestrianFocusTests::test_build_path_pedestrian_focus_report_summarizes_pedestrian_cap_relationship -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short` -> 2350 passed, 180 skipped, 167 subtests passed
- `python3 scripts/package_plugin.py` -> built `dist/qfit-0.50.zip`
- `git diff --check`

## Evidence

- Live post-#1251 baseline comparison: `debug/mapbox-outdoors-comparison-post-pedestrian-ratio-cap-live/all-cameras/20260521T025254Z/summary.md`
- Candidate QGIS-only render matrix: `debug/mapbox-outdoors-comparison-pedestrian-z18-band/all-cameras/20260521T025722Z/summary.md`
- Candidate focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T025729Z/summary.md`
- z17 `road-pedestrian-z16-to-z18`: source/QGIS `line-width_delta_mm=0.0`, `line-width_ratio=1.0`, `line-dasharray_match=true`, `line-color_match=true`.
- z17 `road-pedestrian-case-z16-to-z18`: source/QGIS `line-width_delta_mm=0.0`, `line-width_ratio=1.0`, `line-color_match=true`.
- z18 remains the #1251 cap/ratio behavior: `road-pedestrian-case-z18-plus=3.0` mm and `road-pedestrian-z18-plus=2.328099173553719` mm, preserving `qgis_case_to_core_ratio=1.288604898828541`.
- z17 and z18 candidate QGIS renders were pixel-identical to the post-#1251 baseline in the current camera matrix; the z17 camera has no pedestrian line features, so this is a style-control correction with no sampled visual regression.

Refs #949
