### PR TITLE
fix: split path high zoom width bands

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -644,10 +644,30 @@ _PATH_TYPE_FILTER_SPLIT_LAYER_IDS = {
     "road-path-bg",
 }
 _PATH_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES = (
+    "road-path-z16-to-z18",
+    "road-path-z18-plus",
     "road-path-z16-plus",
+    "road-path-bg-z16-to-z18",
+    "road-path-bg-z18-plus",
     "road-path-bg-z16-plus",
+    "bridge-path-bg-z16-to-z18",
+    "bridge-path-bg-z18-plus",
     "bridge-path-bg-z16-plus",
 )
+_PATH_MID_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES = (
+    "road-path-z16-to-z18",
+    "road-path-bg-z16-to-z18",
+    "bridge-path-bg-z16-to-z18",
+)
+_PATH_MAX_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES = (
+    "road-path-z18-plus",
+    "road-path-z16-plus",
+    "road-path-bg-z18-plus",
+    "road-path-bg-z16-plus",
+    "bridge-path-bg-z18-plus",
+    "bridge-path-bg-z16-plus",
+)
+_PATH_MID_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 17.0
 _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 18.0
 _PATH_LOW_ZOOM_LINE_WIDTH_LAYER_PREFIXES = ("road-path-below-z16",)
 _PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_LAYER_PREFIXES = (
@@ -692,7 +712,8 @@ _PATH_TRAIL_LINE_WIDTH_LAYER_IDS = {
 }
 _PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("below-z16", None, 16.0, 15.0),
-    ("z16-plus", 16.0, None, 18.0),
+    ("z16-to-z18", 16.0, 18.0, 17.0),
+    ("z18-plus", 18.0, None, 18.0),
 )
 # Shared by trail and cycleway/piste overlays so outdoor route strokes remain
 # legible against contour/landcover-heavy Mapbox Outdoors scenes.
@@ -828,12 +849,20 @@ _PATH_BACKGROUND_LINE_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ),
 )
 _PATH_HIGH_ZOOM_PALE_CASING_LAYER_IDS = {
+    "bridge-path-bg-z16-to-z18-outdoor",
+    "bridge-path-bg-z16-to-z18-remaining",
     "bridge-path-bg-z16-plus-outdoor",
     "bridge-path-bg-z16-plus-remaining",
+    "bridge-path-bg-z18-plus-outdoor",
+    "bridge-path-bg-z18-plus-remaining",
     "bridge-pedestrian-case-z16-to-z18",
     "bridge-pedestrian-case-z18-plus",
+    "road-path-bg-z16-to-z18-outdoor",
+    "road-path-bg-z16-to-z18-remaining",
     "road-path-bg-z16-plus-outdoor",
     "road-path-bg-z16-plus-remaining",
+    "road-path-bg-z18-plus-outdoor",
+    "road-path-bg-z18-plus-remaining",
     "road-pedestrian-case-z16-to-z18",
     "road-pedestrian-case-z18-plus",
 }
@@ -854,6 +883,10 @@ _PATH_TYPE_FILTER_LOW_ZOOM_SIMPLIFIED_MATCH = [
     True,
 ]
 _PATH_TYPE_FILTER_SPLIT_ZOOM = 16.0
+_PATH_TYPE_FILTER_HIGH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("z16-to-z18", _PATH_TYPE_FILTER_SPLIT_ZOOM, 18.0),
+    ("z18-plus", 18.0, None),
+)
 _NATURAL_POINT_LABEL_LAYER_ID = "natural-point-label"
 _POI_LABEL_LAYER_ID = "poi-label"
 _GATE_LABEL_LAYER_ID = "gate-label"
@@ -2019,13 +2052,134 @@ def _zoom_band_label(zoom: float) -> str:
     return str(int(zoom)) if zoom.is_integer() else str(zoom).replace(".", "_")
 
 
+def _path_type_high_zoom_filter_layer_variants(
+    layer: dict[str, object],
+    *,
+    layer_id: str,
+    filter_value: list[object],
+    clause_index: int,
+    high_zoom_filter: object,
+) -> list[dict[str, object]]:
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    variants: list[dict[str, object]] = []
+    for suffix, band_minzoom, band_maxzoom in _PATH_TYPE_FILTER_HIGH_ZOOM_BANDS:
+        effective_zoom_band = _effective_zoom_band(
+            existing_minzoom,
+            existing_maxzoom,
+            band_minzoom,
+            band_maxzoom,
+        )
+        if effective_zoom_band is None:
+            continue
+        variant = copy.deepcopy(layer)
+        variant["id"] = f"{layer_id}-{suffix}"
+        variant["filter"] = _filter_with_replaced_clause(filter_value, clause_index, high_zoom_filter)
+        _set_zoom_bounds(variant, *effective_zoom_band)
+        variants.append(variant)
+    return variants
+
+
+def _path_type_filter_layer_with_static_clause(
+    layer: dict[str, object],
+    *,
+    filter_value: list[object],
+    clause_index: int,
+    replacement: object,
+) -> dict[str, object]:
+    variant = copy.deepcopy(layer)
+    variant["filter"] = _filter_with_replaced_clause(filter_value, clause_index, replacement)
+    return variant
+
+
+def _path_type_split_filter_layer_variants(
+    layer: dict[str, object],
+    *,
+    layer_id: str,
+    filter_value: list[object],
+    clause_index: int,
+    threshold: float,
+    low_zoom_filter: object,
+    high_zoom_filter: object,
+) -> list[dict[str, object]]:
+    zoom_label = _zoom_band_label(threshold)
+    low_layer = _path_type_filter_layer_with_static_clause(
+        layer,
+        filter_value=filter_value,
+        clause_index=clause_index,
+        replacement=low_zoom_filter,
+    )
+    low_layer["id"] = f"{layer_id}-below-z{zoom_label}"
+    low_layer["maxzoom"] = threshold
+
+    high_zoom_layers = _path_type_high_zoom_filter_layer_variants(
+        layer,
+        layer_id=layer_id,
+        filter_value=filter_value,
+        clause_index=clause_index,
+        high_zoom_filter=high_zoom_filter,
+    )
+    if high_zoom_layers:
+        return [low_layer, *high_zoom_layers]
+
+    high_layer = _path_type_filter_layer_with_static_clause(
+        layer,
+        filter_value=filter_value,
+        clause_index=clause_index,
+        replacement=high_zoom_filter,
+    )
+    high_layer["id"] = f"{layer_id}-z{zoom_label}-plus"
+    high_layer["minzoom"] = threshold
+    return [low_layer, high_layer]
+
+
+def _path_type_filter_layer_variants_for_clause(
+    layer: dict[str, object],
+    *,
+    layer_id: str,
+    filter_value: list[object],
+    clause_index: int,
+    path_type_clause: tuple[float, object, object],
+) -> list[dict[str, object]]:
+    threshold, low_zoom_filter, high_zoom_filter = path_type_clause
+    existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
+    existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
+    if existing_maxzoom is not None and existing_maxzoom <= threshold:
+        return [
+            _path_type_filter_layer_with_static_clause(
+                layer,
+                filter_value=filter_value,
+                clause_index=clause_index,
+                replacement=low_zoom_filter,
+            )
+        ]
+    if existing_minzoom is not None and existing_minzoom >= threshold:
+        return [
+            _path_type_filter_layer_with_static_clause(
+                layer,
+                filter_value=filter_value,
+                clause_index=clause_index,
+                replacement=high_zoom_filter,
+            )
+        ]
+    return _path_type_split_filter_layer_variants(
+        layer,
+        layer_id=layer_id,
+        filter_value=filter_value,
+        clause_index=clause_index,
+        threshold=threshold,
+        low_zoom_filter=low_zoom_filter,
+        high_zoom_filter=high_zoom_filter,
+    )
+
+
 def _path_type_filter_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited path filters at their Mapbox zoom threshold for QGIS.
 
     QGIS cannot parse the Mapbox ``step(['zoom'], ...)`` filter clause used by
     the Outdoors path layers.  A single representative snapshot either hides
     sidewalks/crossings at high zoom or renders them too early at mid zoom, so
-    preserve the Mapbox behavior by emitting two static zoom-band layers.
+    preserve the Mapbox behavior by emitting static zoom-band layers.
     """
     layer_id = str(layer.get("id") or "")
     if layer_id not in _PATH_TYPE_FILTER_SPLIT_LAYER_IDS or layer.get("type") != "line":
@@ -2038,30 +2192,13 @@ def _path_type_filter_layer_variants(layer: dict[str, object]) -> list[dict[str,
         path_type_clause = _path_type_zoom_step_filter_clause(clause)
         if path_type_clause is None:
             continue
-
-        threshold, low_zoom_filter, high_zoom_filter = path_type_clause
-        existing_minzoom = _numeric_zoom_bound(layer.get("minzoom"))
-        existing_maxzoom = _numeric_zoom_bound(layer.get("maxzoom"))
-        if existing_maxzoom is not None and existing_maxzoom <= threshold:
-            low_layer = copy.deepcopy(layer)
-            low_layer["filter"] = _filter_with_replaced_clause(filter_value, clause_index, low_zoom_filter)
-            return [low_layer]
-        if existing_minzoom is not None and existing_minzoom >= threshold:
-            high_layer = copy.deepcopy(layer)
-            high_layer["filter"] = _filter_with_replaced_clause(filter_value, clause_index, high_zoom_filter)
-            return [high_layer]
-
-        zoom_label = _zoom_band_label(threshold)
-        low_layer = copy.deepcopy(layer)
-        low_layer["id"] = f"{layer_id}-below-z{zoom_label}"
-        low_layer["filter"] = _filter_with_replaced_clause(filter_value, clause_index, low_zoom_filter)
-        low_layer["maxzoom"] = threshold
-
-        high_layer = copy.deepcopy(layer)
-        high_layer["id"] = f"{layer_id}-z{zoom_label}-plus"
-        high_layer["filter"] = _filter_with_replaced_clause(filter_value, clause_index, high_zoom_filter)
-        high_layer["minzoom"] = threshold
-        return [low_layer, high_layer]
+        return _path_type_filter_layer_variants_for_clause(
+            layer,
+            layer_id=layer_id,
+            filter_value=filter_value,
+            clause_index=clause_index,
+            path_type_clause=path_type_clause,
+        )
     return None
 
 
@@ -2871,14 +3008,26 @@ def _should_sample_path_high_zoom_line_width(layer_id: object, prop: str, minzoo
     )
 
 
-def _path_dasharray_sample_zoom(layer_id: object, minzoom: object, maxzoom: object) -> float | None:
+def _path_high_zoom_line_width_sample_zoom(layer_id: object) -> float | None:
     normalized = str(layer_id or "")
-    if not any(
+    if any(
         normalized == prefix or normalized.startswith(f"{prefix}-")
-        for prefix in _PATH_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES
+        for prefix in _PATH_MID_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES
     ):
+        return _PATH_MID_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+    if any(
+        normalized == prefix or normalized.startswith(f"{prefix}-")
+        for prefix in _PATH_MAX_HIGH_ZOOM_LINE_WIDTH_LAYER_PREFIXES
+    ):
+        return _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+    return None
+
+
+def _path_dasharray_sample_zoom(layer_id: object, minzoom: object, maxzoom: object) -> float | None:
+    sample_zoom = _path_high_zoom_line_width_sample_zoom(layer_id)
+    if sample_zoom is None:
         return _representative_zoom_in_layer_range(minzoom, maxzoom)
-    return _zoom_in_layer_range(_PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM, minzoom, maxzoom)
+    return _zoom_in_layer_range(sample_zoom, minzoom, maxzoom)
 
 
 def _should_sample_path_low_zoom_line_width(layer_id: object, prop: str, maxzoom: object) -> bool:
@@ -2913,7 +3062,10 @@ def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: o
         target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
         low_zoom_path_background_width = True
     elif _should_sample_path_high_zoom_line_width(layer_id, prop, minzoom):
-        target_sample_zoom = _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+        target_sample_zoom = (
+            _path_high_zoom_line_width_sample_zoom(layer_id)
+            or _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
+        )
         high_zoom_path_width = True
     else:
         return None

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -2091,7 +2091,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
         self.assertEqual(by_id["road-path-below-z16"]["paint"]["line-dasharray"], [4, 0.3])
-        self.assertEqual(by_id["road-path-z16-plus"]["paint"]["line-dasharray"], [1, 0.25])
+        self.assertEqual(by_id["road-path-z16-to-z18"]["paint"]["line-dasharray"], [1, 0.25])
+        self.assertEqual(by_id["road-path-z18-plus"]["paint"]["line-dasharray"], [1, 0.25])
 
     def test_ferry_line_widths_keep_lake_routes_visible(self):
         ferry_width = ["interpolate", ["exponential", 1.5], ["zoom"], 14, 0.5, 20, 1]
@@ -5245,11 +5246,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             [layer["id"] for layer in result["layers"]],
             [
                 "road-path-bg-below-z16",
-                "road-path-bg-z16-plus",
+                "road-path-bg-z16-to-z18",
+                "road-path-bg-z18-plus",
                 "road-path-below-z16",
-                "road-path-z16-plus",
+                "road-path-z16-to-z18",
+                "road-path-z18-plus",
                 "bridge-path-bg-below-z16",
-                "bridge-path-bg-z16-plus",
+                "bridge-path-bg-z16-to-z18",
+                "bridge-path-bg-z18-plus",
                 "road-minor",
             ],
         )
@@ -5272,12 +5276,21 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result["layers"][0]["maxzoom"], 16.0)
         self.assertEqual(result["layers"][1]["filter"], expected_high_filter)
         self.assertEqual(result["layers"][1]["minzoom"], 16.0)
-        self.assertEqual(result["layers"][2]["filter"], expected_low_filter)
-        self.assertEqual(result["layers"][3]["filter"], expected_high_filter)
-        self.assertEqual(result["layers"][4]["minzoom"], 14)
-        self.assertEqual(result["layers"][4]["maxzoom"], 16.0)
-        self.assertEqual(result["layers"][5]["minzoom"], 16.0)
-        self.assertEqual(result["layers"][6]["filter"], expected_low_filter)
+        self.assertEqual(result["layers"][1]["maxzoom"], 18.0)
+        self.assertEqual(result["layers"][2]["filter"], expected_high_filter)
+        self.assertEqual(result["layers"][2]["minzoom"], 18.0)
+        self.assertEqual(result["layers"][3]["filter"], expected_low_filter)
+        self.assertEqual(result["layers"][4]["filter"], expected_high_filter)
+        self.assertEqual(result["layers"][4]["minzoom"], 16.0)
+        self.assertEqual(result["layers"][4]["maxzoom"], 18.0)
+        self.assertEqual(result["layers"][5]["filter"], expected_high_filter)
+        self.assertEqual(result["layers"][5]["minzoom"], 18.0)
+        self.assertEqual(result["layers"][6]["minzoom"], 14)
+        self.assertEqual(result["layers"][6]["maxzoom"], 16.0)
+        self.assertEqual(result["layers"][7]["minzoom"], 16.0)
+        self.assertEqual(result["layers"][7]["maxzoom"], 18.0)
+        self.assertEqual(result["layers"][8]["minzoom"], 18.0)
+        self.assertEqual(result["layers"][9]["filter"], expected_low_filter)
         self.assertEqual(path_filter, original_path_filter)
         for layer in style["layers"]:
             self.assertEqual(layer["filter"], original_path_filter)
@@ -5323,51 +5336,64 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-path-bg-below-z16-piste",
                 "road-path-bg-below-z16-outdoor",
                 "road-path-bg-below-z16-remaining",
-                "road-path-bg-z16-plus-piste",
-                "road-path-bg-z16-plus-outdoor-pale-casing",
-                "road-path-bg-z16-plus-outdoor",
-                "road-path-bg-z16-plus-remaining-pale-casing",
-                "road-path-bg-z16-plus-remaining",
+                "road-path-bg-z16-to-z18-piste",
+                "road-path-bg-z16-to-z18-outdoor-pale-casing",
+                "road-path-bg-z16-to-z18-outdoor",
+                "road-path-bg-z16-to-z18-remaining-pale-casing",
+                "road-path-bg-z16-to-z18-remaining",
+                "road-path-bg-z18-plus-piste",
+                "road-path-bg-z18-plus-outdoor-pale-casing",
+                "road-path-bg-z18-plus-outdoor",
+                "road-path-bg-z18-plus-remaining-pale-casing",
+                "road-path-bg-z18-plus-remaining",
                 "bridge-path-bg-below-z16-piste",
                 "bridge-path-bg-below-z16-outdoor",
                 "bridge-path-bg-below-z16-remaining",
-                "bridge-path-bg-z16-plus-piste",
-                "bridge-path-bg-z16-plus-outdoor-pale-casing",
-                "bridge-path-bg-z16-plus-outdoor",
-                "bridge-path-bg-z16-plus-remaining-pale-casing",
-                "bridge-path-bg-z16-plus-remaining",
+                "bridge-path-bg-z16-to-z18-piste",
+                "bridge-path-bg-z16-to-z18-outdoor-pale-casing",
+                "bridge-path-bg-z16-to-z18-outdoor",
+                "bridge-path-bg-z16-to-z18-remaining-pale-casing",
+                "bridge-path-bg-z16-to-z18-remaining",
+                "bridge-path-bg-z18-plus-piste",
+                "bridge-path-bg-z18-plus-outdoor-pale-casing",
+                "bridge-path-bg-z18-plus-outdoor",
+                "bridge-path-bg-z18-plus-remaining-pale-casing",
+                "bridge-path-bg-z18-plus-remaining",
             ],
         )
         by_id = {layer["id"]: layer for layer in result["layers"]}
         for layer_id in ("road-path-bg", "bridge-path-bg"):
-            for band in ("below-z16", "z16-plus"):
+            for band in ("below-z16", "z16-to-z18", "z18-plus"):
                 self.assertEqual(by_id[f"{layer_id}-{band}-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
                 self.assertEqual(by_id[f"{layer_id}-{band}-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
                 self.assertEqual(by_id[f"{layer_id}-{band}-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
             for suffix in ("piste", "outdoor", "remaining"):
                 self.assertEqual(by_id[f"{layer_id}-below-z16-{suffix}"]["maxzoom"], 16.0)
-                self.assertEqual(by_id[f"{layer_id}-z16-plus-{suffix}"]["minzoom"], 16.0)
-            for suffix in ("outdoor", "remaining"):
-                cased_layer = by_id[f"{layer_id}-z16-plus-{suffix}-pale-casing"]
-                target_layer = by_id[f"{layer_id}-z16-plus-{suffix}"]
-                self.assertEqual(cased_layer["filter"], target_layer["filter"])
-                self.assertEqual(cased_layer["minzoom"], 16.0)
-                self.assertNotIn("maxzoom", cased_layer)
-                self.assertEqual(
-                    cased_layer["paint"],
-                    {
-                        "line-width": 3.0,
-                        "line-color": "hsl(0, 0%, 98%)",
-                        "line-opacity": 1.0,
-                    },
-                )
-                self.assertEqual(
-                    mapbox_config.base_mapbox_style_layer_id_for_qfit(
-                        f"{layer_id}-z16-plus-{suffix}-pale-casing"
-                    ),
-                    layer_id,
-                )
-            self.assertNotIn(f"{layer_id}-z16-plus-piste-pale-casing", by_id)
+                self.assertEqual(by_id[f"{layer_id}-z16-to-z18-{suffix}"]["minzoom"], 16.0)
+                self.assertEqual(by_id[f"{layer_id}-z16-to-z18-{suffix}"]["maxzoom"], 18.0)
+                self.assertEqual(by_id[f"{layer_id}-z18-plus-{suffix}"]["minzoom"], 18.0)
+            for band in ("z16-to-z18", "z18-plus"):
+                for suffix in ("outdoor", "remaining"):
+                    cased_layer = by_id[f"{layer_id}-{band}-{suffix}-pale-casing"]
+                    target_layer = by_id[f"{layer_id}-{band}-{suffix}"]
+                    self.assertEqual(cased_layer["filter"], target_layer["filter"])
+                    self.assertEqual(cased_layer["minzoom"], target_layer["minzoom"])
+                    self.assertEqual(cased_layer.get("maxzoom"), target_layer.get("maxzoom"))
+                    self.assertEqual(
+                        cased_layer["paint"],
+                        {
+                            "line-width": 3.0,
+                            "line-color": "hsl(0, 0%, 98%)",
+                            "line-opacity": 1.0,
+                        },
+                    )
+                    self.assertEqual(
+                        mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                            f"{layer_id}-{band}-{suffix}-pale-casing"
+                        ),
+                        layer_id,
+                    )
+                self.assertNotIn(f"{layer_id}-{band}-piste-pale-casing", by_id)
         self.assertEqual(by_id["road-path-bg-below-z16-piste"]["minzoom"], 12)
         self.assertEqual(by_id["bridge-path-bg-below-z16-piste"]["minzoom"], 14)
         expected_below_z16_outdoor_filter = [
@@ -5402,7 +5428,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             by_id["road-path-bg-below-z16-outdoor"]["filter"],
             expected_below_z16_outdoor_filter,
         )
-        self.assertEqual(by_id["road-path-bg-z16-plus-outdoor"]["filter"], expected_z16_plus_outdoor_filter)
+        self.assertEqual(by_id["road-path-bg-z16-to-z18-outdoor"]["filter"], expected_z16_plus_outdoor_filter)
+        self.assertEqual(by_id["road-path-bg-z18-plus-outdoor"]["filter"], expected_z16_plus_outdoor_filter)
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-bg-below-z16-outdoor"),
             "road-path-bg",
@@ -5412,7 +5439,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             expected_below_z16_outdoor_filter,
         )
         self.assertEqual(
-            by_id["bridge-path-bg-z16-plus-outdoor"]["filter"],
+            by_id["bridge-path-bg-z16-to-z18-outdoor"]["filter"],
+            expected_z16_plus_outdoor_filter,
+        )
+        self.assertEqual(
+            by_id["bridge-path-bg-z18-plus-outdoor"]["filter"],
             expected_z16_plus_outdoor_filter,
         )
         self.assertEqual(
@@ -5562,14 +5593,23 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
         path_background_low_width_mm = path_core_low_width_mm * 1.15
+        mid_high_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(line_width, 17.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+        )
         high_width_mm = 7 * mapbox_config._MAPBOX_PIXEL_TO_MM
+        mid_high_background_width_mm = min(
+            mid_high_width_mm * mapbox_config._PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE,
+            mapbox_config._MAX_LINE_WIDTH_MM,
+        )
         high_background_width_mm = min(
             high_width_mm * mapbox_config._PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE,
             mapbox_config._MAX_LINE_WIDTH_MM,
         )
         self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path"]["paint"]["line-width"], path_core_low_width_mm)
-        self.assertAlmostEqual(by_id["road-path-z16-plus"]["paint"]["line-width"], high_width_mm)
+        self.assertAlmostEqual(by_id["road-path-z16-to-z18"]["paint"]["line-width"], mid_high_width_mm)
+        self.assertAlmostEqual(by_id["road-path-z18-plus"]["paint"]["line-width"], high_width_mm)
         self.assertAlmostEqual(
             by_id["road-path-bg-below-z16-outdoor"]["paint"]["line-width"],
             path_background_low_width_mm,
@@ -5579,11 +5619,19 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             path_background_low_width_mm,
         )
         self.assertAlmostEqual(
-            by_id["road-path-bg-z16-plus-outdoor"]["paint"]["line-width"],
+            by_id["road-path-bg-z16-to-z18-outdoor"]["paint"]["line-width"],
+            mid_high_background_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["road-path-bg-z18-plus-outdoor"]["paint"]["line-width"],
             high_background_width_mm,
         )
         self.assertAlmostEqual(
-            by_id["bridge-path-bg-z16-plus-outdoor"]["paint"]["line-width"],
+            by_id["bridge-path-bg-z16-to-z18-outdoor"]["paint"]["line-width"],
+            mid_high_background_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-path-bg-z18-plus-outdoor"]["paint"]["line-width"],
             high_background_width_mm,
         )
         self.assertAlmostEqual(by_id["road-minor"]["paint"]["line-width"], low_width_mm)
@@ -5618,9 +5666,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         by_id = {layer["id"]: layer for layer in result["layers"]}
         self.assertAlmostEqual(
-            by_id["road-path-z16-plus"]["paint"]["line-width"],
+            by_id["road-path-z16-to-z18"]["paint"]["line-width"],
             4 * mapbox_config._MAPBOX_PIXEL_TO_MM,
         )
+        self.assertNotIn("road-path-z18-plus", by_id)
 
     def test_filter_simplification_replaces_path_filter_without_split_outside_threshold(self):
         path_filter = [
@@ -5704,17 +5753,25 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             [layer["id"] for layer in result["layers"]],
             [
                 "road-path-trail-below-z16",
-                "road-path-trail-z16-plus",
+                "road-path-trail-z16-to-z18",
+                "road-path-trail-z18-plus",
                 "bridge-path-trail-below-z16",
-                "bridge-path-trail-z16-plus",
+                "bridge-path-trail-z16-to-z18",
+                "bridge-path-trail-z18-plus",
                 "tunnel-path-trail-below-z16",
-                "tunnel-path-trail-z16-plus",
+                "tunnel-path-trail-z16-to-z18",
+                "tunnel-path-trail-z18-plus",
                 "road-minor",
             ],
         )
         by_id = {layer["id"]: layer for layer in result["layers"]}
         low_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 15.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+            * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
+        )
+        mid_high_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
             * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
         )
@@ -5729,26 +5786,40 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             low_width_mm,
         )
         self.assertAlmostEqual(
-            by_id["road-path-trail-z16-plus"]["paint"]["line-width"],
+            by_id["road-path-trail-z16-to-z18"]["paint"]["line-width"],
+            mid_high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["road-path-trail-z18-plus"]["paint"]["line-width"],
             high_width_mm,
         )
         self.assertAlmostEqual(
-            by_id["bridge-path-trail-z16-plus"]["paint"]["line-width"],
+            by_id["bridge-path-trail-z16-to-z18"]["paint"]["line-width"],
+            mid_high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-path-trail-z18-plus"]["paint"]["line-width"],
             high_width_mm,
         )
         self.assertAlmostEqual(
-            by_id["tunnel-path-trail-z16-plus"]["paint"]["line-width"],
+            by_id["tunnel-path-trail-z16-to-z18"]["paint"]["line-width"],
+            mid_high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["tunnel-path-trail-z18-plus"]["paint"]["line-width"],
             high_width_mm,
         )
         self.assertEqual(by_id["road-path-trail-below-z16"]["maxzoom"], 16.0)
-        self.assertEqual(by_id["road-path-trail-z16-plus"]["minzoom"], 16.0)
+        self.assertEqual(by_id["road-path-trail-z16-to-z18"]["minzoom"], 16.0)
+        self.assertEqual(by_id["road-path-trail-z16-to-z18"]["maxzoom"], 18.0)
+        self.assertEqual(by_id["road-path-trail-z18-plus"]["minzoom"], 18.0)
         self.assertEqual(by_id["bridge-path-trail-below-z16"]["minzoom"], 14)
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-trail-z16-plus"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-trail-z16-to-z18"),
             "road-path-trail",
         )
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("tunnel-path-trail-z16-plus"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("tunnel-path-trail-z18-plus"),
             "tunnel-path-trail",
         )
         self.assertAlmostEqual(
@@ -5794,16 +5865,24 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             [layer["id"] for layer in result["layers"]],
             [
                 "road-path-cycleway-piste-below-z16",
-                "road-path-cycleway-piste-z16-plus",
+                "road-path-cycleway-piste-z16-to-z18",
+                "road-path-cycleway-piste-z18-plus",
                 "bridge-path-cycleway-piste-below-z16",
-                "bridge-path-cycleway-piste-z16-plus",
+                "bridge-path-cycleway-piste-z16-to-z18",
+                "bridge-path-cycleway-piste-z18-plus",
                 "tunnel-path-cycleway-piste-below-z16",
-                "tunnel-path-cycleway-piste-z16-plus",
+                "tunnel-path-cycleway-piste-z16-to-z18",
+                "tunnel-path-cycleway-piste-z18-plus",
             ],
         )
         by_id = {layer["id"]: layer for layer in result["layers"]}
         low_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(cycleway_piste_width, 15.0)
+            * mapbox_config._MAPBOX_PIXEL_TO_MM
+            * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
+        )
+        mid_high_width_mm = (
+            mapbox_config._extract_zoom_scalar_size_at_zoom(cycleway_piste_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
             * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
         )
@@ -5818,7 +5897,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             low_width_mm,
         )
         self.assertAlmostEqual(
-            by_id["road-path-cycleway-piste-z16-plus"]["paint"]["line-width"],
+            by_id["road-path-cycleway-piste-z16-to-z18"]["paint"]["line-width"],
+            mid_high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["road-path-cycleway-piste-z18-plus"]["paint"]["line-width"],
             high_width_mm,
         )
         self.assertAlmostEqual(
@@ -5826,7 +5909,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             low_width_mm,
         )
         self.assertAlmostEqual(
-            by_id["bridge-path-cycleway-piste-z16-plus"]["paint"]["line-width"],
+            by_id["bridge-path-cycleway-piste-z16-to-z18"]["paint"]["line-width"],
+            mid_high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["bridge-path-cycleway-piste-z18-plus"]["paint"]["line-width"],
             high_width_mm,
         )
         self.assertAlmostEqual(
@@ -5834,15 +5921,21 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             low_width_mm,
         )
         self.assertAlmostEqual(
-            by_id["tunnel-path-cycleway-piste-z16-plus"]["paint"]["line-width"],
+            by_id["tunnel-path-cycleway-piste-z16-to-z18"]["paint"]["line-width"],
+            mid_high_width_mm,
+        )
+        self.assertAlmostEqual(
+            by_id["tunnel-path-cycleway-piste-z18-plus"]["paint"]["line-width"],
             high_width_mm,
         )
         self.assertEqual(by_id["road-path-cycleway-piste-below-z16"]["paint"]["line-dasharray"], [10, 0])
         self.assertEqual(by_id["road-path-cycleway-piste-below-z16"]["maxzoom"], 16.0)
-        self.assertEqual(by_id["road-path-cycleway-piste-z16-plus"]["minzoom"], 16.0)
+        self.assertEqual(by_id["road-path-cycleway-piste-z16-to-z18"]["minzoom"], 16.0)
+        self.assertEqual(by_id["road-path-cycleway-piste-z16-to-z18"]["maxzoom"], 18.0)
+        self.assertEqual(by_id["road-path-cycleway-piste-z18-plus"]["minzoom"], 18.0)
         self.assertEqual(by_id["bridge-path-cycleway-piste-below-z16"]["minzoom"], 14)
         self.assertEqual(
-            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-cycleway-piste-z16-plus"),
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("road-path-cycleway-piste-z18-plus"),
             "road-path-cycleway-piste",
         )
 

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -80,6 +80,8 @@ PATH_PEDESTRIAN_SOURCE_SPLIT_BASE_LAYER_IDS = frozenset(
 )
 PATH_PEDESTRIAN_SOURCE_SPLIT_SUFFIXES = (
     "-below-z16",
+    "-z16-to-z18",
+    "-z18-plus",
     "-z16-plus",
 )
 PATH_PEDESTRIAN_CORE_CASE_LAYER_PAIRS = (


### PR DESCRIPTION
## Summary
- split Mapbox Outdoors `road-path`/`road-path-bg` high-zoom QGIS variants into `z16-to-z18` and `z18-plus` bands
- split path trail and cycleway/piste overlay widths across the same high-zoom bands
- keep high-zoom pale casing helpers on both path background bands and update the path/pedestrian focus report suffix mapping

## Evidence
- Previous focus report `debug/mapbox-outdoors-path-pedestrian-focus/20260521T033536Z/summary.md` ranked the largest non-auxiliary width deltas at z17: `road-path-bg-z16-plus` was +1.55 mm, and trail/cycleway overlays were +1.01 mm.
- Fresh QGIS-only all-camera matrix: `debug/mapbox-outdoors-comparison-path-z18-width-bands/all-cameras/20260521T035633Z/summary.md`.
- Fresh path/pedestrian focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T035638Z/summary.md`. The z17 path background delta is now +0.61 mm, trail/cycleway deltas are +0.41 mm, and z18 remains on the existing z18 samples.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `git diff --check`

Refs #949
