### PR TITLE
fix: keep mid-high path widths unscaled

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -849,16 +849,12 @@ _PATH_BACKGROUND_LINE_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ),
 )
 _PATH_HIGH_ZOOM_PALE_CASING_LAYER_IDS = {
-    "bridge-path-bg-z16-to-z18-outdoor",
-    "bridge-path-bg-z16-to-z18-remaining",
     "bridge-path-bg-z16-plus-outdoor",
     "bridge-path-bg-z16-plus-remaining",
     "bridge-path-bg-z18-plus-outdoor",
     "bridge-path-bg-z18-plus-remaining",
     "bridge-pedestrian-case-z16-to-z18",
     "bridge-pedestrian-case-z18-plus",
-    "road-path-bg-z16-to-z18-outdoor",
-    "road-path-bg-z16-to-z18-remaining",
     "road-path-bg-z16-plus-outdoor",
     "road-path-bg-z16-plus-remaining",
     "road-path-bg-z18-plus-outdoor",
@@ -3077,6 +3073,7 @@ def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: o
         width is not None
         and high_zoom_path_width
         and _path_background_line_color_base_layer_id(layer_id) is not None
+        and target_sample_zoom == _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
     ):
         width *= _PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
     if width is not None and low_zoom_path_background_width:
@@ -3158,7 +3155,10 @@ def _path_trail_line_width_layer_variants(layer: dict[str, object]) -> list[dict
         layer,
         layer_ids=_PATH_TRAIL_LINE_WIDTH_LAYER_IDS,
         zoom_bands=_PATH_TRAIL_LINE_WIDTH_ZOOM_BANDS,
-        line_width_scale=_PATH_TRAIL_LINE_WIDTH_QGIS_SCALE,
+        line_width_scales_by_suffix={
+            "below-z16": _PATH_TRAIL_LINE_WIDTH_QGIS_SCALE,
+            "z18-plus": _PATH_TRAIL_LINE_WIDTH_QGIS_SCALE,
+        },
     )
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5337,9 +5337,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-path-bg-below-z16-outdoor",
                 "road-path-bg-below-z16-remaining",
                 "road-path-bg-z16-to-z18-piste",
-                "road-path-bg-z16-to-z18-outdoor-pale-casing",
                 "road-path-bg-z16-to-z18-outdoor",
-                "road-path-bg-z16-to-z18-remaining-pale-casing",
                 "road-path-bg-z16-to-z18-remaining",
                 "road-path-bg-z18-plus-piste",
                 "road-path-bg-z18-plus-outdoor-pale-casing",
@@ -5350,9 +5348,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "bridge-path-bg-below-z16-outdoor",
                 "bridge-path-bg-below-z16-remaining",
                 "bridge-path-bg-z16-to-z18-piste",
-                "bridge-path-bg-z16-to-z18-outdoor-pale-casing",
                 "bridge-path-bg-z16-to-z18-outdoor",
-                "bridge-path-bg-z16-to-z18-remaining-pale-casing",
                 "bridge-path-bg-z16-to-z18-remaining",
                 "bridge-path-bg-z18-plus-piste",
                 "bridge-path-bg-z18-plus-outdoor-pale-casing",
@@ -5372,27 +5368,28 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 self.assertEqual(by_id[f"{layer_id}-z16-to-z18-{suffix}"]["minzoom"], 16.0)
                 self.assertEqual(by_id[f"{layer_id}-z16-to-z18-{suffix}"]["maxzoom"], 18.0)
                 self.assertEqual(by_id[f"{layer_id}-z18-plus-{suffix}"]["minzoom"], 18.0)
+            for suffix in ("outdoor", "remaining"):
+                self.assertNotIn(f"{layer_id}-z16-to-z18-{suffix}-pale-casing", by_id)
+                cased_layer = by_id[f"{layer_id}-z18-plus-{suffix}-pale-casing"]
+                target_layer = by_id[f"{layer_id}-z18-plus-{suffix}"]
+                self.assertEqual(cased_layer["filter"], target_layer["filter"])
+                self.assertEqual(cased_layer["minzoom"], target_layer["minzoom"])
+                self.assertEqual(cased_layer.get("maxzoom"), target_layer.get("maxzoom"))
+                self.assertEqual(
+                    cased_layer["paint"],
+                    {
+                        "line-width": 3.0,
+                        "line-color": "hsl(0, 0%, 98%)",
+                        "line-opacity": 1.0,
+                    },
+                )
+                self.assertEqual(
+                    mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                        f"{layer_id}-z18-plus-{suffix}-pale-casing"
+                    ),
+                    layer_id,
+                )
             for band in ("z16-to-z18", "z18-plus"):
-                for suffix in ("outdoor", "remaining"):
-                    cased_layer = by_id[f"{layer_id}-{band}-{suffix}-pale-casing"]
-                    target_layer = by_id[f"{layer_id}-{band}-{suffix}"]
-                    self.assertEqual(cased_layer["filter"], target_layer["filter"])
-                    self.assertEqual(cased_layer["minzoom"], target_layer["minzoom"])
-                    self.assertEqual(cased_layer.get("maxzoom"), target_layer.get("maxzoom"))
-                    self.assertEqual(
-                        cased_layer["paint"],
-                        {
-                            "line-width": 3.0,
-                            "line-color": "hsl(0, 0%, 98%)",
-                            "line-opacity": 1.0,
-                        },
-                    )
-                    self.assertEqual(
-                        mapbox_config.base_mapbox_style_layer_id_for_qfit(
-                            f"{layer_id}-{band}-{suffix}-pale-casing"
-                        ),
-                        layer_id,
-                    )
                 self.assertNotIn(f"{layer_id}-{band}-piste-pale-casing", by_id)
         self.assertEqual(by_id["road-path-bg-below-z16-piste"]["minzoom"], 12)
         self.assertEqual(by_id["bridge-path-bg-below-z16-piste"]["minzoom"], 14)
@@ -5598,10 +5595,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
         high_width_mm = 7 * mapbox_config._MAPBOX_PIXEL_TO_MM
-        mid_high_background_width_mm = min(
-            mid_high_width_mm * mapbox_config._PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE,
-            mapbox_config._MAX_LINE_WIDTH_MM,
-        )
+        mid_high_background_width_mm = mid_high_width_mm
         high_background_width_mm = min(
             high_width_mm * mapbox_config._PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE,
             mapbox_config._MAX_LINE_WIDTH_MM,
@@ -5773,7 +5767,6 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         mid_high_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
-            * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
         )
         high_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(trail_width, 18.0)
@@ -5884,7 +5877,6 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         mid_high_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(cycleway_piste_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
-            * mapbox_config._PATH_TRAIL_LINE_WIDTH_QGIS_SCALE
         )
         high_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(cycleway_piste_width, 18.0)


### PR DESCRIPTION
## Summary
- keep the `z16-to-z18` path-background variants at their sampled z17 Mapbox width instead of applying the z18 casing boost
- remove the path-background pale-casing helper from the `z16-to-z18` band while keeping the `z18-plus` helper intact
- keep the 1.6 trail/cycleway width boost on `below-z16` and `z18-plus`, but leave `z16-to-z18` at the sampled source width

## Evidence
- Previous focus report `debug/mapbox-outdoors-path-pedestrian-focus/20260521T041458Z/summary.md` still ranked z17 `road-path-bg-z16-to-z18` at +0.61 mm and z17 trail/cycleway overlays at +0.41 mm.
- Fresh all-camera visual matrix: `debug/mapbox-outdoors-comparison-mid-high-scale/all-cameras/20260521T042045Z/summary.md`.
- Fresh path/pedestrian focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T042051Z/summary.md`. The z17 path-background and trail/cycleway rows drop out of the largest non-auxiliary stroke-width delta list; the remaining large deltas are z18-only or existing low-zoom scaling tradeoffs.
- Visual review: inspected the generated contact sheet for the fresh all-camera matrix.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests -q --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `git diff --check`

Refs #949
