### PR TITLE
fix: keep z18 path backgrounds at source width

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -678,7 +678,6 @@ _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 14.0
 # The z14 Geneva/Chamonix comparisons benefit from a small casing-only boost,
 # but larger low-zoom path casings overshoot the Mapbox GL reference.
 _PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.15
-_PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.5
 _PEDESTRIAN_LINE_WIDTH_LAYER_IDS = {
     "bridge-pedestrian",
     "bridge-pedestrian-case",
@@ -851,14 +850,10 @@ _PATH_BACKGROUND_LINE_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
 _PATH_HIGH_ZOOM_PALE_CASING_LAYER_IDS = {
     "bridge-path-bg-z16-plus-outdoor",
     "bridge-path-bg-z16-plus-remaining",
-    "bridge-path-bg-z18-plus-outdoor",
-    "bridge-path-bg-z18-plus-remaining",
     "bridge-pedestrian-case-z16-to-z18",
     "bridge-pedestrian-case-z18-plus",
     "road-path-bg-z16-plus-outdoor",
     "road-path-bg-z16-plus-remaining",
-    "road-path-bg-z18-plus-outdoor",
-    "road-path-bg-z18-plus-remaining",
     "road-pedestrian-case-z16-to-z18",
     "road-pedestrian-case-z18-plus",
 }
@@ -3050,7 +3045,6 @@ def _should_sample_path_low_zoom_background_line_width(layer_id: object, prop: s
 
 
 def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: object, maxzoom: object) -> float | None:
-    high_zoom_path_width = False
     low_zoom_path_background_width = False
     if _should_sample_path_low_zoom_line_width(layer_id, prop, maxzoom):
         target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
@@ -3062,20 +3056,12 @@ def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: o
             _path_high_zoom_line_width_sample_zoom(layer_id)
             or _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
         )
-        high_zoom_path_width = True
     else:
         return None
     target_zoom = _zoom_in_layer_range(target_sample_zoom, minzoom, maxzoom)
     if target_zoom is None:
         return None
     width = _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
-    if (
-        width is not None
-        and high_zoom_path_width
-        and _path_background_line_color_base_layer_id(layer_id) is not None
-        and target_sample_zoom == _PATH_HIGH_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
-    ):
-        width *= _PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
     if width is not None and low_zoom_path_background_width:
         width *= _PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
     return width

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5340,9 +5340,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "road-path-bg-z16-to-z18-outdoor",
                 "road-path-bg-z16-to-z18-remaining",
                 "road-path-bg-z18-plus-piste",
-                "road-path-bg-z18-plus-outdoor-pale-casing",
                 "road-path-bg-z18-plus-outdoor",
-                "road-path-bg-z18-plus-remaining-pale-casing",
                 "road-path-bg-z18-plus-remaining",
                 "bridge-path-bg-below-z16-piste",
                 "bridge-path-bg-below-z16-outdoor",
@@ -5351,9 +5349,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "bridge-path-bg-z16-to-z18-outdoor",
                 "bridge-path-bg-z16-to-z18-remaining",
                 "bridge-path-bg-z18-plus-piste",
-                "bridge-path-bg-z18-plus-outdoor-pale-casing",
                 "bridge-path-bg-z18-plus-outdoor",
-                "bridge-path-bg-z18-plus-remaining-pale-casing",
                 "bridge-path-bg-z18-plus-remaining",
             ],
         )
@@ -5368,29 +5364,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 self.assertEqual(by_id[f"{layer_id}-z16-to-z18-{suffix}"]["minzoom"], 16.0)
                 self.assertEqual(by_id[f"{layer_id}-z16-to-z18-{suffix}"]["maxzoom"], 18.0)
                 self.assertEqual(by_id[f"{layer_id}-z18-plus-{suffix}"]["minzoom"], 18.0)
-            for suffix in ("outdoor", "remaining"):
-                self.assertNotIn(f"{layer_id}-z16-to-z18-{suffix}-pale-casing", by_id)
-                cased_layer = by_id[f"{layer_id}-z18-plus-{suffix}-pale-casing"]
-                target_layer = by_id[f"{layer_id}-z18-plus-{suffix}"]
-                self.assertEqual(cased_layer["filter"], target_layer["filter"])
-                self.assertEqual(cased_layer["minzoom"], target_layer["minzoom"])
-                self.assertEqual(cased_layer.get("maxzoom"), target_layer.get("maxzoom"))
-                self.assertEqual(
-                    cased_layer["paint"],
-                    {
-                        "line-width": 3.0,
-                        "line-color": "hsl(0, 0%, 98%)",
-                        "line-opacity": 1.0,
-                    },
-                )
-                self.assertEqual(
-                    mapbox_config.base_mapbox_style_layer_id_for_qfit(
-                        f"{layer_id}-z18-plus-{suffix}-pale-casing"
-                    ),
-                    layer_id,
-                )
             for band in ("z16-to-z18", "z18-plus"):
-                self.assertNotIn(f"{layer_id}-{band}-piste-pale-casing", by_id)
+                for suffix in ("piste", "outdoor", "remaining"):
+                    self.assertNotIn(f"{layer_id}-{band}-{suffix}-pale-casing", by_id)
         self.assertEqual(by_id["road-path-bg-below-z16-piste"]["minzoom"], 12)
         self.assertEqual(by_id["bridge-path-bg-below-z16-piste"]["minzoom"], 14)
         expected_below_z16_outdoor_filter = [
@@ -5596,10 +5572,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         high_width_mm = 7 * mapbox_config._MAPBOX_PIXEL_TO_MM
         mid_high_background_width_mm = mid_high_width_mm
-        high_background_width_mm = min(
-            high_width_mm * mapbox_config._PATH_HIGH_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE,
-            mapbox_config._MAX_LINE_WIDTH_MM,
-        )
+        high_background_width_mm = high_width_mm
         self.assertAlmostEqual(by_id["road-path-below-z16"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path"]["paint"]["line-width"], path_core_low_width_mm)
         self.assertAlmostEqual(by_id["road-path-z16-to-z18"]["paint"]["line-width"], mid_high_width_mm)


### PR DESCRIPTION
## Summary
- keep high-zoom path-background line widths at their sampled Mapbox source width instead of applying the former z18 boost
- stop generating path-background pale-casing helper layers for the current `z18-plus` variants
- keep the existing pedestrian pale-casing helpers and trail/cycleway scaling unchanged

## Evidence
- Previous focus report `debug/mapbox-outdoors-path-pedestrian-focus/20260521T042051Z/summary.md` ranked z18 `road-path-bg-z18-plus` variants as the largest remaining non-auxiliary width deltas at +0.93 mm / 1.5x.
- Fresh all-camera visual matrix: `debug/mapbox-outdoors-comparison-z18-path-bg-source-width/all-cameras/20260521T043142Z/summary.md`.
- Fresh path/pedestrian focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T043151Z/summary.md`. The z18 path-background rows drop out of the largest non-auxiliary stroke-width delta list.
- Visual review: inspected the generated all-camera contact sheet; z18 path backgrounds remain visible while the z18 RMS delta improves from about 0.0882 to 0.0866 versus the previous matrix.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py::SimplifyMapboxStyleTests -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `git diff --check`

Refs #949
