### PR TITLE
chore: add candidate context to path stroke deltas

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -959,6 +959,59 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("line-width_raw_mm=3.175", markdown)
         self.assertIn("line-width_capped=true", markdown)
 
+    def test_build_path_pedestrian_focus_report_adds_step_structure_candidate_counts(self):
+        road_report = {
+            "generated": "2026-05-20T01:09:13+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "cameras": [
+                {
+                    "status": "decoded",
+                    "camera": "zermatt-trails-z18-outdoors",
+                    "camera_zoom": 18.0,
+                    "tile_zoom": 18,
+                    "step_line_candidate_count": 3,
+                    "step_line_structure_counts": {"none": 2, "bridge": 1},
+                }
+            ],
+        }
+        source_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-steps",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {"line-width": 2},
+                }
+            ],
+        }
+        qgis_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "road-steps-z18-plus",
+                    "type": "line",
+                    "minzoom": 18,
+                    "paint": {"line-width": 1.0},
+                }
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(
+            road_report,
+            source_style=source_style,
+            qgis_styles_by_camera={"zermatt-trails-z18-outdoors": qgis_style},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        [comparison] = camera["source_qgis_stroke_control_comparisons"]
+        self.assertEqual(comparison["decoded_candidate_count"], 3)
+        self.assertEqual(comparison["decoded_candidate_type_counts"], {"none": 2, "bridge": 1})
+        markdown = build_summary_markdown(report)
+        self.assertIn('types={\\"bridge\\":1,\\"none\\":2}', markdown)
+
     def test_build_path_pedestrian_focus_report_pairs_split_road_path_strokes_with_source_layer(self):
         road_report = _road_feature_report()
         road_report["cameras"][0]["camera_zoom"] = 18.0

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -823,6 +823,13 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-dasharray": [4, 0.3],
                     },
+                    "decoded_candidate_count": 236,
+                    "decoded_candidate_type_counts": {
+                        "trail": 69,
+                        "footway": 56,
+                        "piste": 48,
+                        "path": 4,
+                    },
                     "qgis_layer_ids": ["road-path"],
                     "qgis_controls": [
                         {
@@ -921,6 +928,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-dasharray": [1, 0.2],
                     },
+                    "decoded_candidate_count": 1,
                     "qgis_layer_ids": ["road-pedestrian-z18-plus"],
                     "qgis_controls": [
                         {
@@ -1146,6 +1154,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             comparisons["road-pedestrian-case"]["qgis_auxiliary_layer_ids"],
             ["road-pedestrian-case-z18-plus-pale-casing"],
         )
+        self.assertEqual(comparisons["road-pedestrian"]["decoded_candidate_count"], 1)
         self.assertEqual(
             camera["pedestrian_core_case_cap_relationships"],
             [
@@ -1183,6 +1192,10 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         )[1].split("## QGIS auxiliary stroke layers", 1)[0]
         self.assertIn("road-pedestrian-z18-plus", largest_delta_section)
         self.assertIn("road-pedestrian-case-z18-plus", largest_delta_section)
+        self.assertIn(
+            "| zermatt-trails-z18-outdoors | road-pedestrian | road-pedestrian-z18-plus | 1 |",
+            largest_delta_section,
+        )
         self.assertNotIn("road-pedestrian-case-z18-plus-pale-casing", largest_delta_section)
         self.assertIn("## QGIS auxiliary stroke layers", markdown)
         self.assertIn("road-pedestrian-case-z18-plus-pale-casing", markdown)
@@ -1437,7 +1450,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             markdown,
         )
         self.assertIn(
-            "| unmatched-source-stroke | road-path | [\"line-width=1.0\"] | [] | [] | [] | [] |",
+            "| unmatched-source-stroke | road-path | [] | [\"line-width=1.0\"] | [] | [] | [] | [] |",
             markdown,
         )
 

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -1012,6 +1012,129 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         markdown = build_summary_markdown(report)
         self.assertIn('types={\\"bridge\\":1,\\"none\\":2}', markdown)
 
+    def test_build_path_pedestrian_focus_report_adds_bridge_tunnel_candidate_counts(self):
+        road_report = {
+            "generated": "2026-05-20T01:09:13+00:00",
+            "style_owner": "mapbox",
+            "style_id": "outdoors-v12",
+            "cameras": [
+                {
+                    "status": "decoded",
+                    "camera": "zermatt-trails-z18-outdoors",
+                    "camera_zoom": 18.0,
+                    "tile_zoom": 18,
+                    "pedestrian_line_candidate_count": 4,
+                    "pedestrian_line_structure_counts": {"none": 1, "bridge": 1, "tunnel": 2},
+                    "path_line_candidate_count": 5,
+                    "path_line_structure_counts": {"none": 2, "bridge": 2, "tunnel": 1},
+                    "step_line_candidate_count": 3,
+                    "step_line_structure_counts": {"none": 1, "bridge": 1, "tunnel": 1},
+                }
+            ],
+        }
+        source_style = {
+            "version": 8,
+            "layers": [
+                {"id": "bridge-path-trail", "type": "line", "minzoom": 14, "paint": {"line-width": 2}},
+                {
+                    "id": "tunnel-path-cycleway-piste",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {"line-width": 2},
+                },
+                {"id": "bridge-pedestrian", "type": "line", "minzoom": 14, "paint": {"line-width": 2}},
+                {"id": "tunnel-steps", "type": "line", "minzoom": 14, "paint": {"line-width": 2}},
+            ],
+        }
+        qgis_style = {
+            "version": 8,
+            "layers": [
+                {"id": "bridge-path-trail", "type": "line", "minzoom": 14, "paint": {"line-width": 1}},
+                {
+                    "id": "tunnel-path-cycleway-piste",
+                    "type": "line",
+                    "minzoom": 14,
+                    "paint": {"line-width": 1},
+                },
+                {"id": "bridge-pedestrian", "type": "line", "minzoom": 14, "paint": {"line-width": 1}},
+                {"id": "tunnel-steps", "type": "line", "minzoom": 14, "paint": {"line-width": 1}},
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(
+            road_report,
+            source_style=source_style,
+            qgis_styles_by_camera={"zermatt-trails-z18-outdoors": qgis_style},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        self.assertEqual(
+            camera["source_path_pedestrian_visible_layer_ids"],
+            ["bridge-path-trail", "tunnel-path-cycleway-piste", "bridge-pedestrian", "tunnel-steps"],
+        )
+        comparisons = {
+            comparison["source_layer_id"]: comparison
+            for comparison in camera["source_qgis_stroke_control_comparisons"]
+        }
+        self.assertEqual(comparisons["bridge-path-trail"]["decoded_candidate_count"], 2)
+        self.assertEqual(comparisons["bridge-path-trail"]["decoded_candidate_type_counts"], {"bridge": 2})
+        self.assertEqual(comparisons["tunnel-path-cycleway-piste"]["decoded_candidate_count"], 1)
+        self.assertEqual(
+            comparisons["tunnel-path-cycleway-piste"]["decoded_candidate_type_counts"],
+            {"tunnel": 1},
+        )
+        self.assertEqual(comparisons["bridge-pedestrian"]["decoded_candidate_count"], 1)
+        self.assertEqual(comparisons["bridge-pedestrian"]["decoded_candidate_type_counts"], {"bridge": 1})
+        self.assertEqual(comparisons["tunnel-steps"]["decoded_candidate_count"], 1)
+        self.assertEqual(comparisons["tunnel-steps"]["decoded_candidate_type_counts"], {"tunnel": 1})
+        markdown = build_summary_markdown(report)
+        self.assertIn("| zermatt-trails-z18-outdoors | bridge-path-trail |", markdown)
+        self.assertIn('types={\\"bridge\\":2}', markdown)
+
+    def test_summary_markdown_prioritizes_candidate_backed_stroke_deltas(self):
+        report = {
+            "generated": "2026-05-20T01:35:00+00:00",
+            "cameras": [
+                {
+                    "camera": "zermatt-trails-z18-outdoors",
+                    "source_qgis_stroke_control_comparisons": [
+                        {
+                            "source_layer_id": "zero-candidate-source",
+                            "decoded_candidate_count": 0,
+                            "qgis_control_deltas": [
+                                {
+                                    "layer_id": "zero-candidate-qgis",
+                                    "deltas": {"line-width_delta_mm": 10.0},
+                                }
+                            ],
+                        },
+                        {
+                            "source_layer_id": "candidate-backed-source",
+                            "decoded_candidate_count": 1,
+                            "qgis_control_deltas": [
+                                {
+                                    "layer_id": "candidate-backed-qgis",
+                                    "deltas": {"line-width_delta_mm": 1.0},
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ],
+        }
+
+        markdown = build_summary_markdown(report)
+        largest_delta_section = markdown.split(
+            "## Largest non-auxiliary stroke width deltas",
+            1,
+        )[1].split("##", 1)[0]
+
+        self.assertLess(
+            largest_delta_section.index("candidate-backed-source"),
+            largest_delta_section.index("zero-candidate-source"),
+        )
+
     def test_build_path_pedestrian_focus_report_pairs_split_road_path_strokes_with_source_layer(self):
         road_report = _road_feature_report()
         road_report["cameras"][0]["camera_zoom"] = 18.0

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -72,6 +72,8 @@ PATH_PEDESTRIAN_STROKE_DELTA_KEYS = (
     "line-color_match",
     "line-opacity_delta",
 )
+PATH_PEDESTRIAN_TRAIL_TYPES = frozenset({"hiking", "mountain_bike", "trail"})
+PATH_PEDESTRIAN_CYCLEWAY_PISTE_TYPES = frozenset({"cycleway", "piste"})
 PATH_PEDESTRIAN_LARGEST_STROKE_DELTA_LIMIT = 12
 PATH_PEDESTRIAN_SOURCE_SPLIT_BASE_LAYER_IDS = frozenset(
     {
@@ -152,6 +154,7 @@ COMPARISON_VISUAL_METRIC_KEYS = (
 MARKDOWN_SEPARATOR_5_COLUMNS = "| --- | --- | --- | --- | --- |"
 MARKDOWN_SEPARATOR_6_COLUMNS = "| --- | --- | --- | --- | --- | --- |"
 MARKDOWN_SEPARATOR_7_COLUMNS = "| --- | --- | --- | --- | --- | --- | --- |"
+MARKDOWN_SEPARATOR_8_COLUMNS = "| --- | --- | --- | --- | --- | --- | --- | --- |"
 UNSAMPLED_EXPRESSION_CONTROL = "expression-not-sampled"
 ARGPARSE_EXIT_SENTINEL = "argparse error should exit"
 
@@ -1068,6 +1071,76 @@ def _stroke_controls(detail: Mapping[str, object]) -> dict[str, object]:
     }
 
 
+def _candidate_count_value(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return int(value)
+
+
+def _candidate_count_map(value: object) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(key): count
+        for key, raw_count in value.items()
+        if (count := _candidate_count_value(raw_count)) > 0
+    }
+
+
+def _filtered_candidate_counts(value: object, allowed_types: frozenset[str]) -> dict[str, int]:
+    return {
+        path_type: count
+        for path_type, count in _candidate_count_map(value).items()
+        if path_type in allowed_types
+    }
+
+
+def _candidate_count_summary(
+    counts: Mapping[str, int],
+    *,
+    total_count: int | None = None,
+) -> dict[str, object]:
+    summary: dict[str, object] = {
+        "decoded_candidate_count": sum(counts.values()) if total_count is None else total_count
+    }
+    if counts:
+        summary["decoded_candidate_type_counts"] = dict(counts)
+    return summary
+
+
+def _source_layer_decoded_candidate_summary(
+    camera: Mapping[str, object],
+    source_layer_id: str,
+) -> dict[str, object]:
+    if source_layer_id in {"road-pedestrian", "road-pedestrian-case"}:
+        return _candidate_count_summary(
+            _candidate_count_map(camera.get("pedestrian_line_type_counts")),
+            total_count=_candidate_count_value(camera.get("pedestrian_line_count")),
+        )
+    if source_layer_id in {"road-steps", "road-steps-bg"}:
+        return {"decoded_candidate_count": _candidate_count_value(camera.get("step_line_count"))}
+    if source_layer_id == "road-path-trail":
+        return _candidate_count_summary(
+            _filtered_candidate_counts(
+                camera.get("path_line_type_counts"),
+                PATH_PEDESTRIAN_TRAIL_TYPES,
+            )
+        )
+    if source_layer_id == "road-path-cycleway-piste":
+        return _candidate_count_summary(
+            _filtered_candidate_counts(
+                camera.get("path_line_type_counts"),
+                PATH_PEDESTRIAN_CYCLEWAY_PISTE_TYPES,
+            )
+        )
+    if source_layer_id in {"road-path", "road-path-bg"}:
+        return _candidate_count_summary(
+            _candidate_count_map(camera.get("path_line_type_counts")),
+            total_count=_candidate_count_value(camera.get("path_line_count")),
+        )
+    return {}
+
+
 def _source_sampled_stroke_controls(
     detail: Mapping[str, object],
     camera_zoom: float | None,
@@ -1179,6 +1252,7 @@ def _source_qgis_stroke_control_comparisons(camera: Mapping[str, object]) -> lis
             "source_layer_id": source_id,
             "source_controls": _stroke_controls(source_detail),
             "source_sampled_controls": source_sampled_controls,
+            **_source_layer_decoded_candidate_summary(camera, source_id),
             "qgis_layer_ids": [str(detail.get("id") or "") for detail in matched_details],
             "qgis_controls": [
                 {
@@ -1360,6 +1434,9 @@ def _camera_focus_row(
         "pedestrian_line_count": camera_report.get("pedestrian_line_candidate_count", 0),
         "path_line_count": camera_report.get("path_line_candidate_count", 0),
         "step_line_count": camera_report.get("step_line_candidate_count", 0),
+        "pedestrian_line_type_counts": _candidate_count_map(camera_report.get("pedestrian_line_type_counts")),
+        "path_line_type_counts": _candidate_count_map(camera_report.get("path_line_type_counts")),
+        "step_line_structure_counts": _candidate_count_map(camera_report.get("step_line_structure_counts")),
         "top_pedestrian_line_types": _top_count_labels(camera_report.get("pedestrian_line_type_counts")),
         "top_path_line_types": _top_count_labels(camera_report.get("path_line_type_counts")),
         "top_step_structures": _top_count_labels(camera_report.get("step_line_structure_counts")),
@@ -1670,6 +1747,16 @@ def _qgis_stroke_delta_summaries(comparison: Mapping[str, object]) -> list[str]:
     return summaries
 
 
+def _decoded_candidate_summaries(comparison: Mapping[str, object]) -> list[str]:
+    summaries = []
+    if "decoded_candidate_count" in comparison:
+        summaries.append(f"count={_compact_json(comparison.get('decoded_candidate_count'))}")
+    type_counts = comparison.get("decoded_candidate_type_counts")
+    if isinstance(type_counts, Mapping) and type_counts:
+        summaries.append(f"types={_compact_json(type_counts)}")
+    return summaries
+
+
 def _stroke_delta_summaries(deltas: object) -> list[str]:
     if not isinstance(deltas, Mapping):
         return []
@@ -1704,6 +1791,7 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
                 [
                     camera.get("camera"),
                     comparison.get("source_layer_id"),
+                    _decoded_candidate_summaries(comparison),
                     _stroke_control_summaries(comparison.get("source_controls")),
                     _stroke_control_summaries(comparison.get("source_sampled_controls")),
                     comparison.get("qgis_layer_ids"),
@@ -1732,10 +1820,15 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
                 "where both sides are directly comparable; line-width deltas are QGIS minus "
                 "source in millimetres."
             ),
+            (
+                "Decoded candidate counts estimate how many currently decoded road features "
+                "match each source stroke family, so visible control deltas without matching "
+                "features can be treated as lower-confidence styling signals."
+            ),
             "Rows with empty QGIS columns identify source strokes with no visible QGIS counterpart.",
             "",
-            "| Camera | Source layer | Source controls | Source sampled controls | QGIS layer ids | QGIS controls | QGIS deltas |",
-            MARKDOWN_SEPARATOR_7_COLUMNS,
+            "| Camera | Source layer | Decoded candidates | Source controls | Source sampled controls | QGIS layer ids | QGIS controls | QGIS deltas |",
+            MARKDOWN_SEPARATOR_8_COLUMNS,
         ]
     )
     lines.extend(_markdown_table_row(row) for row in rows)
@@ -1814,7 +1907,7 @@ def _non_auxiliary_stroke_delta_row(
     width_delta = _numeric_control(deltas.get("line-width_delta_mm"))
     if width_delta is None:
         return None
-    return {
+    row = {
         "camera": camera.get("camera"),
         "source_layer_id": comparison.get("source_layer_id"),
         "qgis_layer_id": layer_id,
@@ -1822,6 +1915,11 @@ def _non_auxiliary_stroke_delta_row(
         "line_width_abs_delta_mm": abs(width_delta),
         "line_width_ratio": _numeric_control(deltas.get("line-width_ratio")),
     }
+    if "decoded_candidate_count" in comparison:
+        row["decoded_candidate_count"] = comparison.get("decoded_candidate_count")
+    if "decoded_candidate_type_counts" in comparison:
+        row["decoded_candidate_type_counts"] = comparison.get("decoded_candidate_type_counts")
+    return row
 
 
 def _camera_source_qgis_stroke_comparisons(camera: object) -> list[Mapping[str, object]]:
@@ -1895,8 +1993,8 @@ def _largest_non_auxiliary_stroke_delta_markdown_lines(cameras: Iterable[object]
                 "QGIS is narrower. Use this as a priority signal, not an automatic styling change."
             ),
             "",
-            "| Camera | Source layer | QGIS layer | Delta mm | Abs delta mm | Ratio |",
-            MARKDOWN_SEPARATOR_6_COLUMNS,
+            "| Camera | Source layer | QGIS layer | Decoded candidates | Candidate types | Delta mm | Abs delta mm | Ratio |",
+            MARKDOWN_SEPARATOR_8_COLUMNS,
         ]
     )
     lines.extend(
@@ -1905,6 +2003,8 @@ def _largest_non_auxiliary_stroke_delta_markdown_lines(cameras: Iterable[object]
                 row.get("camera"),
                 row.get("source_layer_id"),
                 row.get("qgis_layer_id"),
+                row.get("decoded_candidate_count"),
+                _top_count_labels(row.get("decoded_candidate_type_counts")),
                 row.get("line_width_delta_mm"),
                 row.get("line_width_abs_delta_mm"),
                 row.get("line_width_ratio"),

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -1118,7 +1118,10 @@ def _source_layer_decoded_candidate_summary(
             total_count=_candidate_count_value(camera.get("pedestrian_line_count")),
         )
     if source_layer_id in {"road-steps", "road-steps-bg"}:
-        return {"decoded_candidate_count": _candidate_count_value(camera.get("step_line_count"))}
+        return _candidate_count_summary(
+            _candidate_count_map(camera.get("step_line_structure_counts")),
+            total_count=_candidate_count_value(camera.get("step_line_count")),
+        )
     if source_layer_id == "road-path-trail":
         return _candidate_count_summary(
             _filtered_candidate_counts(

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -35,9 +35,15 @@ DEFAULT_ROAD_FEATURES_PATH = (
     / "road-features.json"
 )
 PATH_PEDESTRIAN_LAYER_ID_MARKERS = (
+    "bridge-path",
+    "bridge-pedestrian",
+    "bridge-steps",
     "road-path",
     "road-pedestrian",
     "road-steps",
+    "tunnel-path",
+    "tunnel-pedestrian",
+    "tunnel-steps",
 )
 PATH_PEDESTRIAN_STYLE_TYPES = {"fill", "line"}
 PATH_PEDESTRIAN_LABEL_STYLE_IDS = {
@@ -71,6 +77,32 @@ PATH_PEDESTRIAN_STROKE_DELTA_KEYS = (
     "line-dasharray_match",
     "line-color_match",
     "line-opacity_delta",
+)
+PATH_PEDESTRIAN_SOURCE_LAYER_PREFIXES = ("road", "bridge", "tunnel")
+PATH_PEDESTRIAN_SOURCE_STRUCTURES_BY_PREFIX = {
+    "bridge": "bridge",
+    "tunnel": "tunnel",
+}
+PATH_PEDESTRIAN_PATH_SOURCE_LAYER_IDS = frozenset(
+    f"{prefix}-{suffix}"
+    for prefix in PATH_PEDESTRIAN_SOURCE_LAYER_PREFIXES
+    for suffix in ("path", "path-bg")
+)
+PATH_PEDESTRIAN_PATH_TRAIL_SOURCE_LAYER_IDS = frozenset(
+    f"{prefix}-path-trail" for prefix in PATH_PEDESTRIAN_SOURCE_LAYER_PREFIXES
+)
+PATH_PEDESTRIAN_PATH_CYCLEWAY_PISTE_SOURCE_LAYER_IDS = frozenset(
+    f"{prefix}-path-cycleway-piste" for prefix in PATH_PEDESTRIAN_SOURCE_LAYER_PREFIXES
+)
+PATH_PEDESTRIAN_PEDESTRIAN_SOURCE_LAYER_IDS = frozenset(
+    f"{prefix}-{suffix}"
+    for prefix in PATH_PEDESTRIAN_SOURCE_LAYER_PREFIXES
+    for suffix in ("pedestrian", "pedestrian-case")
+)
+PATH_PEDESTRIAN_STEP_SOURCE_LAYER_IDS = frozenset(
+    f"{prefix}-{suffix}"
+    for prefix in PATH_PEDESTRIAN_SOURCE_LAYER_PREFIXES
+    for suffix in ("steps", "steps-bg")
 )
 PATH_PEDESTRIAN_TRAIL_TYPES = frozenset({"hiking", "mountain_bike", "trail"})
 PATH_PEDESTRIAN_CYCLEWAY_PISTE_TYPES = frozenset({"cycleway", "piste"})
@@ -1089,9 +1121,9 @@ def _candidate_count_map(value: object) -> dict[str, int]:
 
 def _filtered_candidate_counts(value: object, allowed_types: frozenset[str]) -> dict[str, int]:
     return {
-        path_type: count
-        for path_type, count in _candidate_count_map(value).items()
-        if path_type in allowed_types
+        candidate_type: count
+        for candidate_type, count in _candidate_count_map(value).items()
+        if candidate_type in allowed_types
     }
 
 
@@ -1108,35 +1140,83 @@ def _candidate_count_summary(
     return summary
 
 
+def _source_layer_structure(source_layer_id: str) -> str | None:
+    prefix, _separator, _suffix = source_layer_id.partition("-")
+    return PATH_PEDESTRIAN_SOURCE_STRUCTURES_BY_PREFIX.get(prefix)
+
+
+def _structure_candidate_count_summary(
+    camera: Mapping[str, object],
+    source_layer_id: str,
+    structure_count_key: str,
+) -> dict[str, object] | None:
+    structure = _source_layer_structure(source_layer_id)
+    if structure is None:
+        return None
+    return _candidate_count_summary(
+        _filtered_candidate_counts(camera.get(structure_count_key), frozenset({structure}))
+    )
+
+
 def _source_layer_decoded_candidate_summary(
     camera: Mapping[str, object],
     source_layer_id: str,
 ) -> dict[str, object]:
-    if source_layer_id in {"road-pedestrian", "road-pedestrian-case"}:
+    if source_layer_id in PATH_PEDESTRIAN_PEDESTRIAN_SOURCE_LAYER_IDS:
+        if (summary := _structure_candidate_count_summary(
+            camera,
+            source_layer_id,
+            "pedestrian_line_structure_counts",
+        )) is not None:
+            return summary
         return _candidate_count_summary(
             _candidate_count_map(camera.get("pedestrian_line_type_counts")),
             total_count=_candidate_count_value(camera.get("pedestrian_line_count")),
         )
-    if source_layer_id in {"road-steps", "road-steps-bg"}:
+    if source_layer_id in PATH_PEDESTRIAN_STEP_SOURCE_LAYER_IDS:
+        if (summary := _structure_candidate_count_summary(
+            camera,
+            source_layer_id,
+            "step_line_structure_counts",
+        )) is not None:
+            return summary
         return _candidate_count_summary(
             _candidate_count_map(camera.get("step_line_structure_counts")),
             total_count=_candidate_count_value(camera.get("step_line_count")),
         )
-    if source_layer_id == "road-path-trail":
+    if source_layer_id in PATH_PEDESTRIAN_PATH_TRAIL_SOURCE_LAYER_IDS:
+        if (summary := _structure_candidate_count_summary(
+            camera,
+            source_layer_id,
+            "path_line_structure_counts",
+        )) is not None:
+            return summary
         return _candidate_count_summary(
             _filtered_candidate_counts(
                 camera.get("path_line_type_counts"),
                 PATH_PEDESTRIAN_TRAIL_TYPES,
             )
         )
-    if source_layer_id == "road-path-cycleway-piste":
+    if source_layer_id in PATH_PEDESTRIAN_PATH_CYCLEWAY_PISTE_SOURCE_LAYER_IDS:
+        if (summary := _structure_candidate_count_summary(
+            camera,
+            source_layer_id,
+            "path_line_structure_counts",
+        )) is not None:
+            return summary
         return _candidate_count_summary(
             _filtered_candidate_counts(
                 camera.get("path_line_type_counts"),
                 PATH_PEDESTRIAN_CYCLEWAY_PISTE_TYPES,
             )
         )
-    if source_layer_id in {"road-path", "road-path-bg"}:
+    if source_layer_id in PATH_PEDESTRIAN_PATH_SOURCE_LAYER_IDS:
+        if (summary := _structure_candidate_count_summary(
+            camera,
+            source_layer_id,
+            "path_line_structure_counts",
+        )) is not None:
+            return summary
         return _candidate_count_summary(
             _candidate_count_map(camera.get("path_line_type_counts")),
             total_count=_candidate_count_value(camera.get("path_line_count")),
@@ -1438,7 +1518,9 @@ def _camera_focus_row(
         "path_line_count": camera_report.get("path_line_candidate_count", 0),
         "step_line_count": camera_report.get("step_line_candidate_count", 0),
         "pedestrian_line_type_counts": _candidate_count_map(camera_report.get("pedestrian_line_type_counts")),
+        "pedestrian_line_structure_counts": _candidate_count_map(camera_report.get("pedestrian_line_structure_counts")),
         "path_line_type_counts": _candidate_count_map(camera_report.get("path_line_type_counts")),
+        "path_line_structure_counts": _candidate_count_map(camera_report.get("path_line_structure_counts")),
         "step_line_structure_counts": _candidate_count_map(camera_report.get("step_line_structure_counts")),
         "top_pedestrian_line_types": _top_count_labels(camera_report.get("pedestrian_line_type_counts")),
         "top_path_line_types": _top_count_labels(camera_report.get("path_line_type_counts")),
@@ -1959,8 +2041,14 @@ def _stroke_delta_sort_text(value: object) -> str:
     return str(value) if value else ""
 
 
-def _stroke_delta_sort_key(row: Mapping[str, object]) -> tuple[float, str, str, str]:
+def _stroke_delta_decoded_candidate_count(row: Mapping[str, object]) -> int:
+    return _candidate_count_value(row.get("decoded_candidate_count"))
+
+
+def _stroke_delta_sort_key(row: Mapping[str, object]) -> tuple[int, float, str, str, str]:
+    decoded_candidate_count = _stroke_delta_decoded_candidate_count(row)
     return (
+        0 if decoded_candidate_count > 0 else 1,
         -float(row["line_width_abs_delta_mm"]),
         _stroke_delta_sort_text(row.get("camera")),
         _stroke_delta_sort_text(row.get("source_layer_id")),
@@ -1992,8 +2080,9 @@ def _largest_non_auxiliary_stroke_delta_markdown_lines(cameras: Iterable[object]
                 "excluding qfit-only auxiliary helper strokes such as pale casing underlays."
             ),
             (
-                "Positive deltas mean QGIS is wider than the sampled source stroke; negative deltas mean "
-                "QGIS is narrower. Use this as a priority signal, not an automatic styling change."
+                "Rows with decoded candidates sort ahead of zero-candidate rows; within each group, "
+                "positive deltas mean QGIS is wider than the sampled source stroke and negative deltas "
+                "mean QGIS is narrower. Use this as a priority signal, not an automatic styling change."
             ),
             "",
             "| Camera | Source layer | QGIS layer | Decoded candidates | Candidate types | Delta mm | Abs delta mm | Ratio |",


### PR DESCRIPTION
## Summary

- Adds decoded candidate counts to the Mapbox Outdoors path/pedestrian stroke-control comparison report.
- Carries candidate context into the largest non-auxiliary stroke-width delta table, including type or structure breakdowns where available.
- Includes bridge/tunnel path, pedestrian, and step source variants in the focus report, with structure-filtered candidate counts.
- Sorts the largest-delta ranking so rows backed by decoded candidates appear ahead of zero-candidate rows.

## Evidence

- Rebuilt the offline path/pedestrian focus report from the latest committed comparison artifacts:
  - `debug/mapbox-outdoors-path-pedestrian-focus/20260521T045927Z/summary.md`
- The refreshed largest-delta table prioritizes candidate-backed rows first; zero-candidate bridge/tunnel and z18 path deltas remain visible in the detailed source-vs-QGIS stroke table as lower-confidence signals.

## Review feedback addressed

- Greptile: step structure breakdowns are now carried into decoded candidate summaries.
- Codex: bridge/tunnel path, pedestrian, and step layers now receive structure-filtered candidate summaries instead of blank candidate context.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_road_features.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `git diff --check`

Issue: #949