### PR TITLE
chore: annotate visual crops with path focus cues

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -116,6 +116,27 @@ Use the browser image as the Mapbox GL reference. Inspect the QGIS image for hig
 
 Use the brightness-enhanced diff image and metrics as navigation aids, not as pass/fail gates. Label placement and antialiasing differences will create expected diff noise.
 
+## Visual hotspot crops
+
+After a full comparison run, crop the highest-delta windows when the contact sheet is too broad to choose the next tuning slice:
+
+```bash
+python3 validation/mapbox_outdoors_visual_crops.py \
+  --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/summary.json \
+  --crop-size 420x300 \
+  --crops-per-camera 2
+```
+
+When path/pedestrian styling is under review, pass the matching focus report so each crop row is annotated with the strongest per-camera stroke-width and dash cues:
+
+```bash
+python3 validation/mapbox_outdoors_visual_crops.py \
+  --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/summary.json \
+  --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json
+```
+
+The focus cues are triage context only. Candidate-backed rows, source-capped rows, and zero-candidate dash rows still need visual inspection before becoming a rendering change.
+
 ## Style audit before tuning
 
 Before choosing another rendering-tuning slice, generate a style audit so the work is tied to the actual Mapbox Outdoors layer rules and qfit's current QGIS preprocessing choices.

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -150,6 +150,68 @@ def _write_visual_triplet(root, image_module, *, camera_name="chamonix-trails-z1
     return comparison_summary, summary_path
 
 
+def _path_pedestrian_focus_report(camera_name="chamonix-trails-z14-outdoors"):
+    return {
+        "cameras": [
+            {
+                "camera": camera_name,
+                "source_qgis_stroke_control_comparisons": [
+                    {
+                        "source_layer_id": "road-path-trail",
+                        "decoded_candidate_count": 74,
+                        "decoded_candidate_type_counts": {"trail": 69, "hiking": 5},
+                        "source_sampled_controls": {"line-width": 0.26458333333333334},
+                        "qgis_controls": [
+                            {
+                                "layer_id": "road-path-trail-below-z16",
+                                "controls": {"line-width": 0.42333333333333334},
+                            }
+                        ],
+                        "qgis_control_deltas": [
+                            {
+                                "layer_id": "road-path-trail-below-z16",
+                                "deltas": {
+                                    "line-width_delta_mm": 0.15875,
+                                    "line-width_ratio": 1.6,
+                                    "line-dasharray_match": True,
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "source_layer_id": "bridge-path",
+                        "decoded_candidate_count": 0,
+                        "decoded_candidate_type_counts": {},
+                        "source_sampled_controls": {
+                            "line-width": 1.0583333333333333,
+                            "line-dasharray": [1, 0.25],
+                        },
+                        "qgis_controls": [
+                            {
+                                "layer_id": "bridge-path",
+                                "controls": {
+                                    "line-width": 0.26458333333333334,
+                                    "line-dasharray": [4, 0.3],
+                                },
+                            }
+                        ],
+                        "qgis_control_deltas": [
+                            {
+                                "layer_id": "bridge-path",
+                                "deltas": {
+                                    "line-width_delta_mm": -0.79375,
+                                    "line-width_ratio": 0.25,
+                                    "line-dasharray_match": False,
+                                },
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+
 class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
     def test_build_run_directory_and_paths_are_predictable(self):
         run_dir = build_run_directory(
@@ -324,6 +386,36 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertEqual(report["cameras"][0]["status"], "no_hotspot_crops")
             self.assertEqual(report["cameras"][0]["crops"], [])
 
+    def test_generate_visual_crop_report_attaches_path_pedestrian_focus_cues(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            focus_path = root / "focus" / "path-pedestrian-focus.json"
+            focus_path.parent.mkdir(parents=True)
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                path_pedestrian_focus_report=_path_pedestrian_focus_report(),
+                path_pedestrian_focus_report_path=focus_path,
+                crop_size=(4, 4),
+                crops_per_camera=1,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+
+            focus_cues = report["cameras"][0]["path_pedestrian_focus"]
+            stroke_cues = focus_cues["stroke_width_deltas"]
+            dash_cues = focus_cues["dash_mismatches"]
+            self.assertEqual(report["path_pedestrian_focus_json"], str(focus_path))
+            self.assertEqual(stroke_cues[0]["source_layer_id"], "road-path-trail")
+            self.assertEqual(stroke_cues[0]["candidate_types"], ["trail=69", "hiking=5"])
+            self.assertEqual(dash_cues[0]["source_dasharray"], [1, 0.25])
+
     def test_generate_visual_crop_report_rejects_output_outside_trusted_root(self):
         image_module, image_stat_module = _fake_image_modules()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -383,6 +475,52 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertIn("zermatt-trails-z18-outdoors", markdown)
         self.assertIn("debug/crops/crop-sheet.jpg", markdown)
 
+    def test_build_summary_markdown_lists_path_pedestrian_focus_cues(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "comparison_summary_json": "debug/comparison/summary.json",
+                "path_pedestrian_focus_json": "debug/focus/path-pedestrian-focus.json",
+                "crop_size": {"width": 4, "height": 4},
+                "crops_per_camera": 1,
+                "camera_count": 1,
+                "crop_count": 0,
+                "cameras": [
+                    {
+                        "camera": "chamonix-trails-z14-outdoors",
+                        "status": "no_hotspot_crops",
+                        "path_pedestrian_focus": {
+                            "stroke_width_deltas": [
+                                {
+                                    "source_layer_id": "road-path-trail",
+                                    "qgis_layer_id": "road-path-trail-below-z16",
+                                    "decoded_candidate_count": 74,
+                                    "candidate_types": ["trail=69", "hiking=5"],
+                                    "line_width_delta_mm": 0.15875,
+                                    "line_width_ratio": 1.6,
+                                }
+                            ],
+                            "dash_mismatches": [
+                                {
+                                    "source_layer_id": "bridge-path",
+                                    "qgis_layer_id": "bridge-path",
+                                    "decoded_candidate_count": 0,
+                                    "source_dasharray": [1, 0.25],
+                                    "qgis_dasharray": [4, 0.3],
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+
+        self.assertIn("Path/pedestrian focus input: `debug/focus/path-pedestrian-focus.json`", markdown)
+        self.assertIn("## Path/pedestrian focus cues", markdown)
+        self.assertIn("road-path-trail->road-path-trail-below-z16", markdown)
+        self.assertIn("candidates=74 (trail=69, hiking=5)", markdown)
+        self.assertIn("dash=[1,0.25]!=[4,0.3]", markdown)
+
     def test_build_summary_markdown_lists_empty_camera_status(self):
         markdown = build_summary_markdown(
             {
@@ -405,6 +543,9 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             root = Path(tmpdir)
             comparison_summary, summary_path = _write_visual_triplet(root, image_module)
             summary_path.write_text(json.dumps(comparison_summary), encoding="utf-8")
+            focus_path = root / "focus" / "path-pedestrian-focus.json"
+            focus_path.parent.mkdir(parents=True)
+            focus_path.write_text(json.dumps(_path_pedestrian_focus_report()), encoding="utf-8")
             output_root = root / "debug"
             stdout = io.StringIO()
 
@@ -422,6 +563,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     [
                         "--comparison-summary-json",
                         str(summary_path),
+                        "--path-pedestrian-focus-json",
+                        str(focus_path),
                         "--camera",
                         "chamonix-trails-z14-outdoors",
                         "--crops-per-camera",
@@ -435,6 +578,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             report_path = Path(stdout.getvalue().strip()).parent / "visual-crops.json"
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertEqual(report["crop_count"], 1)
+            self.assertEqual(report["path_pedestrian_focus_json"], str(focus_path))
+            self.assertIn("path_pedestrian_focus", report["cameras"][0])
             self.assertTrue((report_path.parent / "crop-sheet.jpg").exists())
 
     def test_main_reports_bad_crop_count_without_traceback(self):

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -14,6 +14,9 @@ try:
     from .mapbox_outdoors_path_pedestrian_focus import (
         REPO_ROOT,
         _display_input_path,
+        _largest_non_auxiliary_stroke_delta_rows,
+        _non_auxiliary_dash_mismatch_rows,
+        _top_count_labels,
         build_run_directory as _build_focus_run_directory,
         comparison_visual_artifacts_from_summary,
         load_json_object,
@@ -23,6 +26,9 @@ except ImportError:  # pragma: no cover - direct script execution
     from mapbox_outdoors_path_pedestrian_focus import (  # type: ignore[no-redef]
         REPO_ROOT,
         _display_input_path,
+        _largest_non_auxiliary_stroke_delta_rows,
+        _non_auxiliary_dash_mismatch_rows,
+        _top_count_labels,
         build_run_directory as _build_focus_run_directory,
         comparison_visual_artifacts_from_summary,
         load_json_object,
@@ -31,6 +37,8 @@ except ImportError:  # pragma: no cover - direct script execution
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-visual-crops"
 DEFAULT_CROP_SIZE = (320, 240)
 DEFAULT_CROPS_PER_CAMERA = 3
+DEFAULT_FOCUS_DASH_CUE_LIMIT = 2
+DEFAULT_FOCUS_STROKE_CUE_LIMIT = 3
 MIN_SCORE_FOR_CROP = 1.0
 MAX_OVERLAP_RATIO = 0.35
 CROP_IMAGE_COLUMNS = (
@@ -231,11 +239,183 @@ def _required_visual_artifacts(artifacts: Mapping[str, object]) -> bool:
     return all(isinstance(artifacts.get(key), Path) for key, _label in CROP_IMAGE_COLUMNS)
 
 
+def _non_empty_focus_value(value: object) -> bool:
+    return value is not None and value != "" and value != []
+
+
+def _focus_cue_from_row(row: Mapping[str, object], keys: Sequence[str]) -> dict[str, object]:
+    cue = {key: row.get(key) for key in keys if _non_empty_focus_value(row.get(key))}
+    candidate_types = _top_count_labels(row.get("decoded_candidate_type_counts"))
+    if candidate_types:
+        cue["candidate_types"] = candidate_types
+    return cue
+
+
+def _has_meaningful_width_delta(row: Mapping[str, object]) -> bool:
+    value = row.get("line_width_abs_delta_mm")
+    return isinstance(value, (int, float)) and abs(float(value)) > 1e-12
+
+
+def _path_pedestrian_focus_cues_by_camera(
+    focus_report: Mapping[str, object] | None,
+    *,
+    stroke_limit: int = DEFAULT_FOCUS_STROKE_CUE_LIMIT,
+    dash_limit: int = DEFAULT_FOCUS_DASH_CUE_LIMIT,
+) -> dict[str, dict[str, list[dict[str, object]]]]:
+    if not focus_report:
+        return {}
+    cameras = focus_report.get("cameras")
+    if not isinstance(cameras, list):
+        return {}
+    cues_by_camera: dict[str, dict[str, list[dict[str, object]]]] = {}
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        camera_name = str(camera.get("camera") or "")
+        if not camera_name:
+            continue
+        width_delta_rows = [
+            row
+            for row in _largest_non_auxiliary_stroke_delta_rows([camera], limit=10_000)
+            if _has_meaningful_width_delta(row)
+        ][: max(0, stroke_limit)]
+        width_rows = [
+            _focus_cue_from_row(
+                row,
+                (
+                    "source_layer_id",
+                    "qgis_layer_id",
+                    "decoded_candidate_count",
+                    "line_width_delta_mm",
+                    "line_width_abs_delta_mm",
+                    "line_width_ratio",
+                    "source_line_width_capped",
+                ),
+            )
+            for row in width_delta_rows
+        ]
+        dash_rows = [
+            _focus_cue_from_row(
+                row,
+                (
+                    "source_layer_id",
+                    "qgis_layer_id",
+                    "decoded_candidate_count",
+                    "source_dasharray",
+                    "qgis_dasharray",
+                    "line_width_delta_mm",
+                    "line_width_ratio",
+                ),
+            )
+            for row in _non_auxiliary_dash_mismatch_rows([camera])[: max(0, dash_limit)]
+        ]
+        if width_rows or dash_rows:
+            cues_by_camera[camera_name] = {
+                "stroke_width_deltas": width_rows,
+                "dash_mismatches": dash_rows,
+            }
+    return cues_by_camera
+
+
+def _camera_row_with_focus(
+    *,
+    camera_name: str,
+    status: str,
+    crops: list[dict[str, object]],
+    focus_cues: Mapping[str, object] | None,
+) -> dict[str, object]:
+    camera_row: dict[str, object] = {"camera": camera_name, "status": status, "crops": crops}
+    if focus_cues:
+        camera_row["path_pedestrian_focus"] = dict(focus_cues)
+    return camera_row
+
+
+def _hotspot_crop_rows(
+    *,
+    camera_name: str,
+    artifacts: Mapping[str, object],
+    diff_path: Path,
+    paths: VisualCropPaths,
+    crop_size: tuple[int, int],
+    crops_per_camera: int,
+    image_module: Any,
+    image_stat_module: Any,
+) -> tuple[str, list[dict[str, object]], list[dict[str, object]]]:
+    crops: list[dict[str, object]] = []
+    contact_sheet_entries: list[dict[str, object]] = []
+    for crop_index, crop in enumerate(
+        find_hotspot_crop_boxes(
+            diff_path,
+            crop_size=crop_size,
+            crop_count=crops_per_camera,
+            image_module=image_module,
+            image_stat_module=image_stat_module,
+        ),
+        start=1,
+    ):
+        box = crop["box"]
+        if not isinstance(box, tuple):
+            continue
+        outputs = _write_crop_triplet(
+            camera_name=camera_name,
+            crop_index=crop_index,
+            artifacts=artifacts,
+            box=box,
+            run_dir=paths.run_dir,
+            image_module=image_module,
+        )
+        crops.append(
+            {
+                "index": crop_index,
+                "box": list(box),
+                "score": crop["score"],
+                "outputs": _display_crop_outputs(outputs),
+            }
+        )
+        contact_sheet_entries.append(
+            {
+                "camera": f"{camera_name} crop {crop_index}",
+                "outputs": _contact_sheet_outputs(outputs),
+            }
+        )
+    status = "cropped" if crops else "no_hotspot_crops"
+    return status, crops, contact_sheet_entries
+
+
+def _camera_visual_crop_rows(
+    *,
+    camera_name: str,
+    artifacts: Mapping[str, object],
+    paths: VisualCropPaths,
+    crop_size: tuple[int, int],
+    crops_per_camera: int,
+    image_module: Any,
+    image_stat_module: Any,
+) -> tuple[str, list[dict[str, object]], list[dict[str, object]]]:
+    if not _required_visual_artifacts(artifacts):
+        return "missing_required_artifacts", [], []
+    diff_path = artifacts["diff"]
+    if not isinstance(diff_path, Path):
+        return "missing_diff", [], []
+    return _hotspot_crop_rows(
+        camera_name=camera_name,
+        artifacts=artifacts,
+        diff_path=diff_path,
+        paths=paths,
+        crop_size=crop_size,
+        crops_per_camera=crops_per_camera,
+        image_module=image_module,
+        image_stat_module=image_stat_module,
+    )
+
+
 def generate_visual_crop_report(
     comparison_summary: Mapping[str, object],
     *,
     comparison_summary_path: Path,
     paths: VisualCropPaths,
+    path_pedestrian_focus_report: Mapping[str, object] | None = None,
+    path_pedestrian_focus_report_path: Path | None = None,
     camera_names: Sequence[str] | None = None,
     crop_size: tuple[int, int] = DEFAULT_CROP_SIZE,
     crops_per_camera: int = DEFAULT_CROPS_PER_CAMERA,
@@ -256,57 +436,31 @@ def generate_visual_crop_report(
         comparison_summary,
         summary_path=comparison_summary_path,
     )
+    focus_cues_by_camera = _path_pedestrian_focus_cues_by_camera(path_pedestrian_focus_report)
     camera_rows = []
     contact_sheet_entries: list[dict[str, object]] = []
     for camera_name in _selected_camera_names(visual_artifacts_by_camera, camera_names):
-        artifacts = visual_artifacts_by_camera[camera_name]
-        if not _required_visual_artifacts(artifacts):
-            camera_rows.append({"camera": camera_name, "status": "missing_required_artifacts", "crops": []})
-            continue
-        diff_path = artifacts["diff"]
-        if not isinstance(diff_path, Path):
-            camera_rows.append({"camera": camera_name, "status": "missing_diff", "crops": []})
-            continue
-        crops = []
-        for crop_index, crop in enumerate(
-            find_hotspot_crop_boxes(
-                diff_path,
-                crop_size=crop_size,
-                crop_count=crops_per_camera,
-                image_module=image_module,
-                image_stat_module=image_stat_module,
-            ),
-            start=1,
-        ):
-            box = crop["box"]
-            if not isinstance(box, tuple):
-                continue
-            outputs = _write_crop_triplet(
+        status, crops, crop_contact_entries = _camera_visual_crop_rows(
+            camera_name=camera_name,
+            artifacts=visual_artifacts_by_camera[camera_name],
+            paths=paths,
+            crop_size=crop_size,
+            crops_per_camera=crops_per_camera,
+            image_module=image_module,
+            image_stat_module=image_stat_module,
+        )
+        camera_rows.append(
+            _camera_row_with_focus(
                 camera_name=camera_name,
-                crop_index=crop_index,
-                artifacts=artifacts,
-                box=box,
-                run_dir=paths.run_dir,
-                image_module=image_module,
+                status=status,
+                crops=crops,
+                focus_cues=focus_cues_by_camera.get(camera_name),
             )
-            crop_row = {
-                "index": crop_index,
-                "box": list(box),
-                "score": crop["score"],
-                "outputs": _display_crop_outputs(outputs),
-            }
-            crops.append(crop_row)
-            contact_sheet_entries.append(
-                {
-                    "camera": f"{camera_name} crop {crop_index}",
-                    "outputs": _contact_sheet_outputs(outputs),
-                }
-            )
-        status = "cropped" if crops else "no_hotspot_crops"
-        camera_rows.append({"camera": camera_name, "status": status, "crops": crops})
+        )
+        contact_sheet_entries.extend(crop_contact_entries)
     contact_sheet = build_all_cameras_contact_sheet(entries=contact_sheet_entries, output_path=paths.contact_sheet_path)
     generated = generated_at or dt.datetime.now(dt.timezone.utc)
-    return {
+    report = {
         "generated": generated.astimezone(dt.timezone.utc).isoformat(),
         "comparison_summary_json": _display_input_path(comparison_summary_path),
         "crop_size": {"width": crop_size[0], "height": crop_size[1]},
@@ -316,6 +470,56 @@ def generate_visual_crop_report(
         "contact_sheet": _display_input_path(contact_sheet) if contact_sheet is not None else None,
         "cameras": camera_rows,
     }
+    if path_pedestrian_focus_report_path is not None:
+        report["path_pedestrian_focus_json"] = _display_input_path(path_pedestrian_focus_report_path)
+    return report
+
+
+def _format_focus_number(value: object) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.4g}"
+    return str(value)
+
+
+def _candidate_focus_summary(cue: Mapping[str, object]) -> str | None:
+    candidate_count = cue.get("decoded_candidate_count")
+    candidate_types = cue.get("candidate_types")
+    if isinstance(candidate_types, list) and candidate_types:
+        return f"candidates={candidate_count} ({', '.join(str(value) for value in candidate_types[:3])})"
+    if candidate_count is not None:
+        return f"candidates={candidate_count}"
+    return None
+
+
+def _stroke_focus_cue_summary(cue: Mapping[str, object]) -> str:
+    parts = [f"{cue.get('source_layer_id')}->{cue.get('qgis_layer_id')}"]
+    if cue.get("line_width_delta_mm") is not None:
+        parts.append(f"delta={_format_focus_number(cue.get('line_width_delta_mm'))}mm")
+    if cue.get("line_width_ratio") is not None:
+        parts.append(f"ratio={_format_focus_number(cue.get('line_width_ratio'))}")
+    candidate_summary = _candidate_focus_summary(cue)
+    if candidate_summary is not None:
+        parts.append(candidate_summary)
+    if cue.get("source_line_width_capped") is True:
+        parts.append("source-capped")
+    return " ".join(parts)
+
+
+def _dash_focus_cue_summary(cue: Mapping[str, object]) -> str:
+    parts = [
+        f"{cue.get('source_layer_id')}->{cue.get('qgis_layer_id')}",
+        f"dash={_compact_focus_value(cue.get('source_dasharray'))}!={_compact_focus_value(cue.get('qgis_dasharray'))}",
+    ]
+    candidate_summary = _candidate_focus_summary(cue)
+    if candidate_summary is not None:
+        parts.append(candidate_summary)
+    return " ".join(parts)
+
+
+def _compact_focus_value(value: object) -> str:
+    if isinstance(value, list):
+        return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+    return str(value)
 
 
 def _markdown_cell(value: object) -> str:
@@ -352,6 +556,8 @@ def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
     ]
     if report.get("contact_sheet"):
         lines.append(f"Crop contact sheet: `{report.get('contact_sheet')}`")
+    if report.get("path_pedestrian_focus_json"):
+        lines.append(f"Path/pedestrian focus input: `{report.get('path_pedestrian_focus_json')}`")
     return lines
 
 
@@ -392,6 +598,52 @@ def _summary_camera_rows(camera: Mapping[str, object]) -> list[str]:
     return [_summary_crop_row(camera, crop) for crop in crop_rows if isinstance(crop, Mapping)]
 
 
+def _summary_focus_cue_lines(report: Mapping[str, object]) -> list[str]:
+    rows: list[list[object]] = []
+    for camera in report.get("cameras", []):
+        if not isinstance(camera, Mapping):
+            continue
+        focus = camera.get("path_pedestrian_focus")
+        if not isinstance(focus, Mapping):
+            continue
+        stroke_cues = focus.get("stroke_width_deltas")
+        dash_cues = focus.get("dash_mismatches")
+        stroke_rows = stroke_cues if isinstance(stroke_cues, list) else []
+        dash_rows = dash_cues if isinstance(dash_cues, list) else []
+        rows.append(
+            [
+                camera.get("camera"),
+                [
+                    _stroke_focus_cue_summary(cue)
+                    for cue in stroke_rows
+                    if isinstance(cue, Mapping)
+                ],
+                [
+                    _dash_focus_cue_summary(cue)
+                    for cue in dash_rows
+                    if isinstance(cue, Mapping)
+                ],
+            ]
+        )
+    if not rows:
+        return []
+    lines = ["", "## Path/pedestrian focus cues", ""]
+    lines.extend(
+        [
+            (
+                "Shows the strongest per-camera path/pedestrian stroke cues from the focus report "
+                "next to visual hotspots, so crop review can distinguish candidate-backed style gaps "
+                "from capped-width or zero-candidate artifacts."
+            ),
+            "",
+            "| Camera | Stroke width cues | Dash mismatch cues |",
+            "| --- | --- | --- |",
+        ]
+    )
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
+
+
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines = _summary_header_lines(report)
     lines.extend(_summary_table_intro_lines())
@@ -399,6 +651,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         if not isinstance(camera, Mapping):
             continue
         lines.extend(_summary_camera_rows(camera))
+    lines.extend(_summary_focus_cue_lines(report))
     return "\n".join(lines) + "\n"
 
 
@@ -433,6 +686,11 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         type=Path,
         help="All-camera comparison summary.json.",
+    )
+    parser.add_argument(
+        "--path-pedestrian-focus-json",
+        type=Path,
+        help="Optional path-pedestrian-focus.json to annotate visual crops with per-camera stroke cues.",
     )
     parser.add_argument(
         "--camera",
@@ -477,12 +735,21 @@ def main(argv: list[str] | None = None) -> int:
         args.comparison_summary_json,
         label="Comparison summary JSON",
     )
+    path_pedestrian_focus_report = None
+    if args.path_pedestrian_focus_json is not None:
+        path_pedestrian_focus_report = _load_cli_json_object(
+            parser,
+            args.path_pedestrian_focus_json,
+            label="Path/pedestrian focus JSON",
+        )
     paths = build_visual_crop_paths(build_run_directory())
     try:
         report = generate_visual_crop_report(
             comparison_summary,
             comparison_summary_path=args.comparison_summary_json,
             paths=paths,
+            path_pedestrian_focus_report=path_pedestrian_focus_report,
+            path_pedestrian_focus_report_path=args.path_pedestrian_focus_json,
             camera_names=args.camera,
             crop_size=args.crop_size,
             crops_per_camera=args.crops_per_camera,


### PR DESCRIPTION
## Summary
- add an optional `--path-pedestrian-focus-json` input to the visual crop report
- annotate cropped cameras with strongest per-camera path/pedestrian stroke-width and dash cues, including candidate counts/types and source-capped markers
- document the focus-cue workflow and cover generation, Markdown output, and CLI loading in tests

## Evidence
- Generated a focused crop report with the latest #949 comparison and focus artifacts: `debug/mapbox-outdoors-visual-crops/20260521T053139Z/summary.md`
- The refreshed report keeps Chamonix z14 candidate-backed path/trail width cues visible next to hotspot crops, while z17/z18 rows identify source-capped or zero-candidate cues before any styling change.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `git diff --check`
