### PR TITLE
fix: guard focus cue candidate summaries

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -498,6 +498,12 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                                     "candidate_types": ["trail=69", "hiking=5"],
                                     "line_width_delta_mm": 0.15875,
                                     "line_width_ratio": 1.6,
+                                },
+                                {
+                                    "source_layer_id": "road-path-bg",
+                                    "qgis_layer_id": "road-path-bg-below-z16-outdoor",
+                                    "candidate_types": ["trail=69"],
+                                    "line_width_delta_mm": 0.079375,
                                 }
                             ],
                             "dash_mismatches": [
@@ -519,6 +525,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertIn("## Path/pedestrian focus cues", markdown)
         self.assertIn("road-path-trail->road-path-trail-below-z16", markdown)
         self.assertIn("candidates=74 (trail=69, hiking=5)", markdown)
+        self.assertIn("candidate_types=trail=69", markdown)
+        self.assertNotIn("candidates=None", markdown)
         self.assertIn("dash=[1,0.25]!=[4,0.3]", markdown)
 
     def test_build_summary_markdown_lists_empty_camera_status(self):

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -485,7 +485,10 @@ def _candidate_focus_summary(cue: Mapping[str, object]) -> str | None:
     candidate_count = cue.get("decoded_candidate_count")
     candidate_types = cue.get("candidate_types")
     if isinstance(candidate_types, list) and candidate_types:
-        return f"candidates={candidate_count} ({', '.join(str(value) for value in candidate_types[:3])})"
+        type_summary = ", ".join(str(value) for value in candidate_types[:3])
+        if candidate_count is not None:
+            return f"candidates={candidate_count} ({type_summary})"
+        return f"candidate_types={type_summary}"
     if candidate_count is not None:
         return f"candidates={candidate_count}"
     return None


### PR DESCRIPTION
## Summary
- guard visual-crop focus cue summaries when candidate type labels exist without a decoded candidate count
- add a regression assertion that Markdown does not render `candidates=None`

## Context
Greptile flagged this defensive display edge case on #1260 after the PR had already merged. This follow-up applies the requested guard directly and keeps the validation-tool output clean for atypical focus rows.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 scripts/package_plugin.py`
- `git diff --check`
