### PR TITLE
Clarify source label duplicate diagnostics

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -799,8 +799,20 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             ["path-pedestrian-label: pedestrian"],
         )
         self.assertEqual(
+            camera["duplicate_label_diagnostic"]["visible_source_label_category_matches"],
+            ["path-pedestrian-label: pedestrian"],
+        )
+        self.assertEqual(
             camera["duplicate_label_diagnostic"]["unmatched_duplicate_name_categories"],
             ["path", "step"],
+        )
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["source_excluded_duplicate_name_categories"],
+            ["path", "step"],
+        )
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["qgis_unmatched_source_label_categories"],
+            [],
         )
         self.assertEqual(
             camera["source_qgis_stroke_control_comparisons"],
@@ -854,6 +866,45 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                     ],
                 }
             ],
+        )
+
+    def test_duplicate_label_diagnostic_marks_qgis_missing_source_categories(self):
+        source_style = {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "path-pedestrian-label",
+                    "type": "symbol",
+                    "minzoom": 12,
+                    "filter": ["match", ["get", "class"], ["pedestrian", "path"], True, False],
+                },
+            ],
+        }
+
+        report = build_path_pedestrian_focus_report(
+            _road_feature_report(),
+            source_style=source_style,
+            qgis_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_preprocessed_style()},
+            qgis_label_styles_by_camera={"chamonix-trails-z14-outdoors": _qgis_label_styles()},
+            generated_at=dt.datetime(2026, 5, 20, 1, 35, tzinfo=dt.timezone.utc),
+        )
+
+        [camera] = report["cameras"]
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["visible_source_label_category_matches"],
+            ["path-pedestrian-label: pedestrian, path, step"],
+        )
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["visible_label_source_category_matches"],
+            ["path-pedestrian-label: pedestrian"],
+        )
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["source_excluded_duplicate_name_categories"],
+            [],
+        )
+        self.assertEqual(
+            camera["duplicate_label_diagnostic"]["qgis_unmatched_source_label_categories"],
+            ["path", "step"],
         )
 
     def test_build_path_pedestrian_focus_report_pairs_qgis_variant_strokes_with_source_ids(self):
@@ -1668,7 +1719,10 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             markdown,
         )
         self.assertIn("## Duplicate label diagnostics", markdown)
-        self.assertIn("Visible source-label category matches", markdown)
+        self.assertIn("Visible source-style label category matches", markdown)
+        self.assertIn("Visible QGIS label category matches", markdown)
+        self.assertIn("Source-excluded duplicate categories", markdown)
+        self.assertIn("QGIS-missing source categories", markdown)
         self.assertIn('"pedestrian: Englischer Viertel=5"', markdown)
         self.assertIn('"path: Hofmattweg=3"', markdown)
         self.assertIn('"road-label-z12-to-z15"', markdown)

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -1028,8 +1028,11 @@ def _visible_label_repeat_distances(camera: Mapping[str, object]) -> list[str]:
     return repeat_distances
 
 
-def _visible_label_source_detail_rows(camera: Mapping[str, object]) -> list[Mapping[str, object]]:
-    details = camera.get("qgis_path_pedestrian_visible_label_source_details")
+def _visible_label_source_detail_rows(
+    camera: Mapping[str, object],
+    detail_key: str,
+) -> list[Mapping[str, object]]:
+    details = camera.get(detail_key)
     detail_rows = details if isinstance(details, list) else []
     return [detail for detail in detail_rows if isinstance(detail, Mapping)]
 
@@ -1037,11 +1040,13 @@ def _visible_label_source_detail_rows(camera: Mapping[str, object]) -> list[Mapp
 def _visible_label_source_category_matches(
     camera: Mapping[str, object],
     duplicate_categories: Iterable[str],
+    *,
+    detail_key: str,
 ) -> tuple[list[str], set[str]]:
     duplicate_category_set = set(duplicate_categories)
     matches: list[str] = []
     matched_categories: set[str] = set()
-    for detail in _visible_label_source_detail_rows(camera):
+    for detail in _visible_label_source_detail_rows(camera, detail_key):
         layer_id = str(detail.get("id") or "")
         categories = [
             category
@@ -1057,18 +1062,35 @@ def _visible_label_source_category_matches(
 def _duplicate_label_diagnostic(camera: Mapping[str, object]) -> dict[str, object]:
     duplicate_categories = _duplicate_label_categories(camera)
     category_names = [str(row.get("category") or "") for row in duplicate_categories]
-    label_source_matches, matched_categories = _visible_label_source_category_matches(
+    source_label_source_matches, source_matched_categories = _visible_label_source_category_matches(
         camera,
         category_names,
+        detail_key="source_path_pedestrian_visible_label_source_details",
+    )
+    qgis_label_source_matches, qgis_matched_categories = _visible_label_source_category_matches(
+        camera,
+        category_names,
+        detail_key="qgis_path_pedestrian_visible_label_source_details",
     )
     return {
         "has_duplicate_feature_names": bool(duplicate_categories),
         "duplicate_name_categories": duplicate_categories,
         "visible_merge_line_label_styles": _visible_merge_line_label_styles(camera),
         "visible_label_repeat_distances": _visible_label_repeat_distances(camera),
-        "visible_label_source_category_matches": label_source_matches,
+        "visible_label_source_category_matches": qgis_label_source_matches,
+        "visible_source_label_category_matches": source_label_source_matches,
         "unmatched_duplicate_name_categories": [
-            category for category in category_names if category and category not in matched_categories
+            category for category in category_names if category and category not in qgis_matched_categories
+        ],
+        "source_excluded_duplicate_name_categories": [
+            category
+            for category in category_names
+            if category and category not in source_matched_categories
+        ],
+        "qgis_unmatched_source_label_categories": [
+            category
+            for category in category_names
+            if category and category in source_matched_categories and category not in qgis_matched_categories
         ],
     }
 
@@ -2506,16 +2528,28 @@ def _duplicate_label_diagnostic_markdown_lines(cameras: Iterable[object]) -> lis
             continue
         merge_line_styles = _string_list(diagnostic.get("visible_merge_line_label_styles"))
         repeat_distances = _string_list(diagnostic.get("visible_label_repeat_distances"))
-        label_source_matches = _string_list(diagnostic.get("visible_label_source_category_matches"))
+        qgis_label_source_matches = _string_list(diagnostic.get("visible_label_source_category_matches"))
+        source_label_source_matches = _string_list(
+            diagnostic.get("visible_source_label_category_matches")
+        )
         unmatched_categories = _string_list(diagnostic.get("unmatched_duplicate_name_categories"))
+        source_excluded_categories = _string_list(
+            diagnostic.get("source_excluded_duplicate_name_categories")
+        )
+        qgis_unmatched_source_categories = _string_list(
+            diagnostic.get("qgis_unmatched_source_label_categories")
+        )
         rows.append(
             [
                 camera.get("camera"),
                 duplicate_summaries,
                 merge_line_styles,
                 repeat_distances,
-                label_source_matches,
+                source_label_source_matches,
+                qgis_label_source_matches,
                 unmatched_categories,
+                source_excluded_categories,
+                qgis_unmatched_source_categories,
             ]
         )
     if not rows:
@@ -2525,12 +2559,12 @@ def _duplicate_label_diagnostic_markdown_lines(cameras: Iterable[object]) -> lis
         [
             (
                 "Connects duplicate source feature names with the visible QGIS "
-                "line-label merge/repeat controls and source-label category matches "
-                "active at each camera zoom."
+                "line-label merge/repeat controls, source-style label filters, "
+                "and QGIS label-source filters active at each camera zoom."
             ),
             "",
-            "| Camera | Duplicate feature names | Visible merge-line label styles | Visible label repeat distances | Visible source-label category matches | Unmatched duplicate categories |",
-            "| --- | --- | --- | --- | --- | --- |",
+            "| Camera | Duplicate feature names | Visible merge-line label styles | Visible label repeat distances | Visible source-style label category matches | Visible QGIS label category matches | Unmatched duplicate categories | Source-excluded duplicate categories | QGIS-missing source categories |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
     lines.extend(_markdown_table_row(row) for row in rows)


### PR DESCRIPTION
## Summary
- compare duplicate label categories against both source-style and QGIS label-source filters
- split source-excluded duplicate categories from QGIS-missing source categories in the path/pedestrian focus report
- keep the existing QGIS unmatched category field for compatibility

## Evidence
- Fresh live road-feature input: `debug/mapbox-outdoors-road-features/all-cameras/20260521T055452Z/road-features.json`
- Regenerated focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T060140Z/summary.md`
- Chamonix/Geneva z14 path duplicate names are now classified as source-excluded, while z18 source/QGIS path/pedestrian/step label categories remain matched.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`

Fixes part of #949.
