### PR TITLE
Record focus comparison run metadata

### DIFF
--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -1832,6 +1832,13 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                 "road_features_json": "debug/roads/road-features.json",
                 "source_style_json": "debug/source/mapbox-outdoors-v12.json",
                 "comparison_summary_jsons": ["debug/comparison/summary.json"],
+                "comparison_summary_runs": [
+                    {
+                        "path": "debug/comparison/summary.json",
+                        "generated_at": "2026-05-20T00:35:04+00:00",
+                        "style_url": "mapbox://styles/mapbox/outdoors-v12",
+                    }
+                ],
                 "qgis_style_cameras": ["chamonix-trails-z14-outdoors"],
                 "qgis_label_style_cameras": ["chamonix-trails-z14-outdoors"],
             },
@@ -1846,6 +1853,13 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn("Road features input: `debug/roads/road-features.json`", markdown)
         self.assertIn("Source style input: `debug/source/mapbox-outdoors-v12.json`", markdown)
         self.assertIn("Comparison summary inputs: `debug/comparison/summary.json`", markdown)
+        self.assertIn("Comparison summary runs:", markdown)
+        self.assertIn(
+            "- `debug/comparison/summary.json` "
+            "(generated_at=2026-05-20T00:35:04+00:00, "
+            "style_url=mapbox://styles/mapbox/outdoors-v12)",
+            markdown,
+        )
         self.assertIn("QGIS style input cameras: `chamonix-trails-z14-outdoors`", markdown)
         self.assertIn("QGIS label style input cameras: `chamonix-trails-z14-outdoors`", markdown)
 
@@ -2022,6 +2036,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             comparison_summary_path.write_text(
                 json.dumps(
                     {
+                        "generated_at": "2026-05-20T00:35:04+00:00",
+                        "style_url": "mapbox://styles/mapbox/outdoors-v12",
                         "contact_sheet": str(contact_sheet_path),
                         "cameras": [
                             {
@@ -2074,6 +2090,16 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             self.assertEqual(
                 report["input_artifacts"]["comparison_summary_jsons"],
                 [str(comparison_summary_path)],
+            )
+            self.assertEqual(
+                report["input_artifacts"]["comparison_summary_runs"],
+                [
+                    {
+                        "path": str(comparison_summary_path),
+                        "generated_at": "2026-05-20T00:35:04+00:00",
+                        "style_url": "mapbox://styles/mapbox/outdoors-v12",
+                    }
+                ],
             )
             self.assertEqual(report["input_artifacts"]["qgis_style_cameras"], ["chamonix-trails-z14-outdoors"])
             self.assertEqual(

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -1740,12 +1740,38 @@ def _input_artifact_markdown_lines(report: Mapping[str, object]) -> list[str]:
     comparison_summary_jsons = _string_list(input_artifacts.get("comparison_summary_jsons"))
     if comparison_summary_jsons:
         lines.append(f"Comparison summary inputs: `{', '.join(comparison_summary_jsons)}`")
+    comparison_summary_runs = _comparison_summary_run_markdown_lines(
+        input_artifacts.get("comparison_summary_runs")
+    )
+    if comparison_summary_runs:
+        lines.append("Comparison summary runs:")
+        lines.extend(comparison_summary_runs)
     qgis_style_cameras = _string_list(input_artifacts.get("qgis_style_cameras"))
     if qgis_style_cameras:
         lines.append(f"QGIS style input cameras: `{', '.join(qgis_style_cameras)}`")
     qgis_label_style_cameras = _string_list(input_artifacts.get("qgis_label_style_cameras"))
     if qgis_label_style_cameras:
         lines.append(f"QGIS label style input cameras: `{', '.join(qgis_label_style_cameras)}`")
+    return lines
+
+
+def _comparison_summary_run_markdown_lines(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    lines: list[str] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        path_value = item.get("path")
+        if not isinstance(path_value, str) or not path_value:
+            continue
+        details = [
+            f"{key}={detail_value}"
+            for key in ("generated_at", "style_url")
+            if isinstance((detail_value := item.get(key)), str) and detail_value
+        ]
+        suffix = f" ({', '.join(details)})" if details else ""
+        lines.append(f"- `{path_value}`{suffix}")
     return lines
 
 
@@ -2787,7 +2813,12 @@ def _load_cli_json_list(parser: argparse.ArgumentParser, path: Path, *, label: s
 def _comparison_inputs_from_cli_summary(
     parser: argparse.ArgumentParser,
     path: Path,
-) -> tuple[dict[str, Path], dict[str, Path], dict[str, dict[str, object]]]:
+) -> tuple[
+    dict[str, Path],
+    dict[str, Path],
+    dict[str, dict[str, object]],
+    dict[str, object],
+]:
     comparison_summary = _load_cli_json_object(parser, path, label="Comparison summary JSON")
     try:
         qgis_style_paths = qgis_style_paths_from_comparison_summary(comparison_summary, summary_path=path)
@@ -2796,7 +2827,12 @@ def _comparison_inputs_from_cli_summary(
             summary_path=path,
         )
         visual_artifacts = comparison_visual_artifacts_from_summary(comparison_summary, summary_path=path)
-        return qgis_style_paths, qgis_label_style_paths, visual_artifacts
+        return (
+            qgis_style_paths,
+            qgis_label_style_paths,
+            visual_artifacts,
+            _comparison_summary_metadata(comparison_summary),
+        )
     except FileNotFoundError as error:
         parser.error(f"Comparison manifest not found: {error.filename}")
     except json.JSONDecodeError as error:
@@ -2804,6 +2840,14 @@ def _comparison_inputs_from_cli_summary(
     except ValueError as error:
         parser.error(str(error))
     raise AssertionError(ARGPARSE_EXIT_SENTINEL)
+
+
+def _comparison_summary_metadata(comparison_summary: Mapping[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key in ("generated_at", "style_url")
+        if isinstance((value := comparison_summary.get(key)), str) and value
+    }
 
 
 def _display_input_path(path: Path) -> str:
@@ -2842,14 +2886,23 @@ def main(argv: list[str] | None = None) -> int:
     qgis_style_paths_by_camera: dict[str, Path] = {}
     qgis_label_style_paths_by_camera: dict[str, Path] = {}
     visual_artifacts_by_camera: dict[str, dict[str, object]] = {}
+    comparison_summary_runs: list[dict[str, object]] = []
     for comparison_summary_path in args.comparison_summary_json:
-        qgis_style_paths, qgis_label_style_paths, visual_artifacts = _comparison_inputs_from_cli_summary(
-            parser,
-            comparison_summary_path,
+        qgis_style_paths, qgis_label_style_paths, visual_artifacts, summary_metadata = (
+            _comparison_inputs_from_cli_summary(
+                parser,
+                comparison_summary_path,
+            )
         )
         qgis_style_paths_by_camera.update(qgis_style_paths)
         qgis_label_style_paths_by_camera.update(qgis_label_style_paths)
         visual_artifacts_by_camera.update(visual_artifacts)
+        comparison_summary_runs.append(
+            {
+                "path": _display_input_path(comparison_summary_path),
+                **summary_metadata,
+            }
+        )
     qgis_style_paths_by_camera.update(dict(args.qgis_style_json))
     qgis_label_style_paths_by_camera.update(dict(args.qgis_label_styles_json))
     qgis_styles_by_camera = {
@@ -2873,7 +2926,10 @@ def main(argv: list[str] | None = None) -> int:
                 if args.source_style_json is not None
                 else None
             ),
-            "comparison_summary_jsons": [_display_input_path(path) for path in args.comparison_summary_json],
+            "comparison_summary_jsons": [
+                _display_input_path(path) for path in args.comparison_summary_json
+            ],
+            "comparison_summary_runs": comparison_summary_runs,
             "qgis_style_cameras": sorted(qgis_style_paths_by_camera),
             "qgis_label_style_cameras": sorted(qgis_label_style_paths_by_camera),
         },


### PR DESCRIPTION
## Summary
- record comparison-summary run metadata alongside path/pedestrian focus report inputs
- render comparison run generated/style metadata in the summary markdown
- keep the existing comparison summary input list while adding structured run provenance for visual/audit evidence

## Evidence
- Regenerated current focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T062357Z/summary.md`
- The report now lists `Comparison summary runs` with `generated_at=20260521T043142Z` for `debug/mapbox-outdoors-comparison-z18-path-bg-source-width/all-cameras/20260521T043142Z/summary.json`.
- Rechecking against that current comparison input removes the stale z18 `road-path-bg` +0.926 mm rows from the top width-delta table; the remaining candidate-backed rows are z14 trail/cycleway/piste deltas at +0.15875 mm.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949.
