### PR TITLE
Record visual crop comparison metadata

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -136,6 +136,8 @@ def _write_visual_triplet(root, image_module, *, camera_name="chamonix-trails-z1
     diff.save(diff_path)
     diff.close()
     comparison_summary = {
+        "generated_at": "2026-05-20T20:00:00+00:00",
+        "style_url": "mapbox://styles/mapbox/outdoors-v12",
         "cameras": [
             {
                 "camera": camera_name,
@@ -445,6 +447,11 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             {
                 "generated": "2026-05-20T20:00:00+00:00",
                 "comparison_summary_json": "debug/comparison/summary.json",
+                "comparison_summary_run": {
+                    "path": "debug/comparison/summary.json",
+                    "generated_at": "2026-05-20T20:00:00+00:00",
+                    "style_url": "mapbox://styles/mapbox/outdoors-v12",
+                },
                 "crop_size": {"width": 4, "height": 4},
                 "crops_per_camera": 1,
                 "camera_count": 1,
@@ -472,6 +479,12 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         )
 
         self.assertIn("# Mapbox Outdoors visual crop report", markdown)
+        self.assertIn(
+            "Comparison summary run: `debug/comparison/summary.json` "
+            "(generated_at=2026-05-20T20:00:00+00:00, "
+            "style_url=mapbox://styles/mapbox/outdoors-v12)",
+            markdown,
+        )
         self.assertIn("zermatt-trails-z18-outdoors", markdown)
         self.assertIn("debug/crops/crop-sheet.jpg", markdown)
 
@@ -586,6 +599,14 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             report_path = Path(stdout.getvalue().strip()).parent / "visual-crops.json"
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertEqual(report["crop_count"], 1)
+            self.assertEqual(
+                report["comparison_summary_run"],
+                {
+                    "path": str(summary_path),
+                    "generated_at": "2026-05-20T20:00:00+00:00",
+                    "style_url": "mapbox://styles/mapbox/outdoors-v12",
+                },
+            )
             self.assertEqual(report["path_pedestrian_focus_json"], str(focus_path))
             self.assertIn("path_pedestrian_focus", report["cameras"][0])
             self.assertTrue((report_path.parent / "crop-sheet.jpg").exists())

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -463,6 +463,10 @@ def generate_visual_crop_report(
     report = {
         "generated": generated.astimezone(dt.timezone.utc).isoformat(),
         "comparison_summary_json": _display_input_path(comparison_summary_path),
+        "comparison_summary_run": _comparison_summary_run_metadata(
+            comparison_summary,
+            comparison_summary_path,
+        ),
         "crop_size": {"width": crop_size[0], "height": crop_size[1]},
         "crops_per_camera": crops_per_camera,
         "camera_count": len(camera_rows),
@@ -473,6 +477,18 @@ def generate_visual_crop_report(
     if path_pedestrian_focus_report_path is not None:
         report["path_pedestrian_focus_json"] = _display_input_path(path_pedestrian_focus_report_path)
     return report
+
+
+def _comparison_summary_run_metadata(
+    comparison_summary: Mapping[str, object],
+    comparison_summary_path: Path,
+) -> dict[str, object]:
+    run_metadata: dict[str, object] = {"path": _display_input_path(comparison_summary_path)}
+    for key in ("generated_at", "style_url"):
+        value = comparison_summary.get(key)
+        if isinstance(value, str) and value:
+            run_metadata[key] = value
+    return run_metadata
 
 
 def _format_focus_number(value: object) -> str:
@@ -559,9 +575,27 @@ def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
     ]
     if report.get("contact_sheet"):
         lines.append(f"Crop contact sheet: `{report.get('contact_sheet')}`")
+    comparison_summary_run = _comparison_summary_run_markdown(report.get("comparison_summary_run"))
+    if comparison_summary_run:
+        lines.append(f"Comparison summary run: {comparison_summary_run}")
     if report.get("path_pedestrian_focus_json"):
         lines.append(f"Path/pedestrian focus input: `{report.get('path_pedestrian_focus_json')}`")
     return lines
+
+
+def _comparison_summary_run_markdown(value: object) -> str:
+    if not isinstance(value, Mapping):
+        return ""
+    path_value = value.get("path")
+    if not isinstance(path_value, str) or not path_value:
+        return ""
+    details = [
+        f"{key}={detail_value}"
+        for key in ("generated_at", "style_url")
+        if isinstance((detail_value := value.get(key)), str) and detail_value
+    ]
+    suffix = f" ({', '.join(details)})" if details else ""
+    return f"`{path_value}`{suffix}"
 
 
 def _summary_table_intro_lines() -> list[str]:


### PR DESCRIPTION
## Summary
- record comparison-summary run metadata in visual crop reports
- render the comparison run path and generated/style metadata in visual crop summary markdown
- keep the existing comparison summary input path while adding structured provenance for crop/audit evidence

## Evidence
- Regenerated visual crop report: `debug/mapbox-outdoors-visual-crops/20260521T063405Z/summary.md`
- The report now lists `Comparison summary run` with `generated_at=20260521T043142Z` for `debug/mapbox-outdoors-comparison-z18-path-bg-source-width/all-cameras/20260521T043142Z/summary.json`.
- The crop report is paired with `debug/mapbox-outdoors-path-pedestrian-focus/20260521T062357Z/path-pedestrian-focus.json`, so current z14 path/trail/cycleway cues and zero-candidate z18 bridge/tunnel cues can be reviewed against known comparison provenance.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949.
