### PR TITLE
Track comparison metrics in visual crop reports

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -141,6 +141,14 @@ def _write_visual_triplet(root, image_module, *, camera_name="chamonix-trails-z1
         "cameras": [
             {
                 "camera": camera_name,
+                "status": "passed",
+                "artifact_status": "metrics_available",
+                "metrics": {
+                    "changed_pixel_ratio": 0.9820199652777778,
+                    "normalized_mean_absolute_channel_delta": 0.03523346722948439,
+                    "normalized_rms_channel_delta": 0.07608105570020197,
+                    "ssim_status": "unavailable",
+                },
                 "outputs": {
                     "browser_reference": str(browser_path),
                     "qgis_vector_render": str(qgis_path),
@@ -311,6 +319,14 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 "cameras": [
                     {
                         "camera": "chamonix-trails-z14-outdoors",
+                        "status": "passed",
+                        "artifact_status": "metrics_available",
+                        "metrics": {
+                            "changed_pixel_ratio": 0.9820199652777778,
+                            "normalized_mean_absolute_channel_delta": 0.03523346722948439,
+                            "normalized_rms_channel_delta": 0.07608105570020197,
+                            "ssim_status": "unavailable",
+                        },
                         "outputs": {
                             "browser_reference": str(browser_path),
                             "qgis_vector_render": str(qgis_path),
@@ -348,6 +364,17 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertTrue(paths.summary_path.exists())
             loaded = json.loads(paths.json_path.read_text(encoding="utf-8"))
             self.assertEqual(loaded["camera_count"], 1)
+            self.assertEqual(
+                loaded["cameras"][0]["comparison"],
+                {
+                    "artifact_status": "metrics_available",
+                    "changed_pixel_ratio": 0.9820199652777778,
+                    "normalized_mean_absolute_channel_delta": 0.03523346722948439,
+                    "normalized_rms_channel_delta": 0.07608105570020197,
+                    "ssim_status": "unavailable",
+                    "status": "passed",
+                },
+            )
 
     def test_generate_visual_crop_report_marks_missing_required_artifacts(self):
         image_module, image_stat_module = _fake_image_modules()
@@ -558,6 +585,13 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     {
                         "camera": "zermatt-trails-z18-outdoors",
                         "status": "cropped",
+                        "comparison": {
+                            "status": "passed",
+                            "artifact_status": "metrics_available",
+                            "changed_pixel_ratio": 0.9820199652777778,
+                            "normalized_mean_absolute_channel_delta": 0.03523346722948439,
+                            "normalized_rms_channel_delta": 0.07608105570020197,
+                        },
                         "crops": [
                             {
                                 "index": 1,
@@ -583,6 +617,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             markdown,
         )
         self.assertIn("zermatt-trails-z18-outdoors", markdown)
+        self.assertIn(
+            "| zermatt-trails-z18-outdoors | passed | metrics_available | 0.9820 | 0.0352 | 0.0761 | cropped | 1 |",
+            markdown,
+        )
         self.assertIn("debug/crops/crop-sheet.jpg", markdown)
 
     def test_build_summary_markdown_lists_path_pedestrian_focus_cues(self):
@@ -686,7 +724,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         )
 
         self.assertIn("Crop size: `-`", markdown)
-        self.assertIn("| zermatt-piste-z17-outdoors | - | missing_diff | - | - | - | - |", markdown)
+        self.assertIn(
+            "| zermatt-piste-z17-outdoors | - | - | - | - | - | missing_diff | - | - | - | - | - | - |",
+            markdown,
+        )
 
     def test_main_writes_visual_crop_report_from_json_input(self):
         image_module, image_stat_module = _fake_image_modules()
@@ -750,6 +791,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             )
             self.assertIs(report["path_pedestrian_focus_comparison_match"], True)
             self.assertEqual(report["path_pedestrian_focus_json"], str(focus_path))
+            self.assertEqual(
+                report["cameras"][0]["comparison"]["changed_pixel_ratio"],
+                0.9820199652777778,
+            )
             self.assertIn("path_pedestrian_focus", report["cameras"][0])
             self.assertTrue((report_path.parent / "crop-sheet.jpg").exists())
 

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -12,6 +12,7 @@ from typing import Any
 try:
     from .mapbox_outdoors_comparison import build_all_cameras_contact_sheet
     from .mapbox_outdoors_path_pedestrian_focus import (
+        COMPARISON_VISUAL_METRIC_KEYS,
         REPO_ROOT,
         _display_input_path,
         _largest_non_auxiliary_stroke_delta_rows,
@@ -24,6 +25,7 @@ try:
 except ImportError:  # pragma: no cover - direct script execution
     from mapbox_outdoors_comparison import build_all_cameras_contact_sheet  # type: ignore[no-redef]
     from mapbox_outdoors_path_pedestrian_focus import (  # type: ignore[no-redef]
+        COMPARISON_VISUAL_METRIC_KEYS,
         REPO_ROOT,
         _display_input_path,
         _largest_non_auxiliary_stroke_delta_rows,
@@ -45,6 +47,11 @@ CROP_IMAGE_COLUMNS = (
     ("browser_reference", "Mapbox GL"),
     ("qgis_vector_render", "QGIS"),
     ("diff", "Diff"),
+)
+COMPARISON_CONTEXT_KEYS = (
+    "status",
+    "artifact_status",
+    *COMPARISON_VISUAL_METRIC_KEYS,
 )
 
 
@@ -322,12 +329,26 @@ def _camera_row_with_focus(
     camera_name: str,
     status: str,
     crops: list[dict[str, object]],
+    comparison_context: Mapping[str, object] | None,
     focus_cues: Mapping[str, object] | None,
 ) -> dict[str, object]:
     camera_row: dict[str, object] = {"camera": camera_name, "status": status, "crops": crops}
+    if comparison_context:
+        camera_row["comparison"] = dict(comparison_context)
     if focus_cues:
         camera_row["path_pedestrian_focus"] = dict(focus_cues)
     return camera_row
+
+
+def _comparison_context_from_artifacts(artifacts: Mapping[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key in COMPARISON_CONTEXT_KEYS
+        if (
+            isinstance((value := artifacts.get(key)), (str, int, float))
+            and not isinstance(value, bool)
+        )
+    }
 
 
 def _hotspot_crop_rows(
@@ -454,6 +475,9 @@ def generate_visual_crop_report(
                 camera_name=camera_name,
                 status=status,
                 crops=crops,
+                comparison_context=_comparison_context_from_artifacts(
+                    visual_artifacts_by_camera[camera_name]
+                ),
                 focus_cues=focus_cues_by_camera.get(camera_name),
             )
         )
@@ -644,12 +668,25 @@ def _summary_table_intro_lines() -> list[str]:
         "",
         (
             "Crops are selected from the highest-delta windows in the comparison diff image, "
-            "then applied to the matching Mapbox GL, QGIS, and diff artifacts."
+            "then applied to the matching Mapbox GL, QGIS, and diff artifacts. "
+            "Comparison metric columns come from the same all-camera comparison summary."
         ),
         "",
-        "| Camera | Crop | Box | Score | Mapbox GL | QGIS render | Diff |",
-        "| --- | ---: | --- | ---: | --- | --- | --- |",
+        "| Camera | Comparison status | Artifact status | Changed ratio | Mean delta | RMS delta | Crop status | Crop | Box | Score | Mapbox GL | QGIS render | Diff |",
+        "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | --- | ---: | --- | --- | --- |",
     ]
+
+
+def _comparison_context(camera: Mapping[str, object]) -> Mapping[str, object]:
+    comparison = camera.get("comparison")
+    return comparison if isinstance(comparison, Mapping) else {}
+
+
+def _comparison_context_cell(camera: Mapping[str, object], key: str) -> object:
+    value = _comparison_context(camera).get(key)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"{float(value):.4f}"
+    return value
 
 
 def _summary_crop_row(camera: Mapping[str, object], crop: Mapping[str, object]) -> str:
@@ -658,6 +695,12 @@ def _summary_crop_row(camera: Mapping[str, object], crop: Mapping[str, object]) 
     return _markdown_table_row(
         [
             camera.get("camera"),
+            _comparison_context_cell(camera, "status"),
+            _comparison_context_cell(camera, "artifact_status"),
+            _comparison_context_cell(camera, "changed_pixel_ratio"),
+            _comparison_context_cell(camera, "normalized_mean_absolute_channel_delta"),
+            _comparison_context_cell(camera, "normalized_rms_channel_delta"),
+            camera.get("status"),
             crop.get("index"),
             crop.get("box"),
             f"{float(crop.get('score', 0.0)):.0f}",
@@ -672,7 +715,25 @@ def _summary_camera_rows(camera: Mapping[str, object]) -> list[str]:
     crops = camera.get("crops")
     crop_rows = crops if isinstance(crops, list) else []
     if not crop_rows:
-        return [_markdown_table_row([camera.get("camera"), "-", camera.get("status"), "-", "-", "-", "-"])]
+        return [
+            _markdown_table_row(
+                [
+                    camera.get("camera"),
+                    _comparison_context_cell(camera, "status"),
+                    _comparison_context_cell(camera, "artifact_status"),
+                    _comparison_context_cell(camera, "changed_pixel_ratio"),
+                    _comparison_context_cell(camera, "normalized_mean_absolute_channel_delta"),
+                    _comparison_context_cell(camera, "normalized_rms_channel_delta"),
+                    camera.get("status"),
+                    "-",
+                    "-",
+                    "-",
+                    "-",
+                    "-",
+                    "-",
+                ]
+            )
+        ]
     return [_summary_crop_row(camera, crop) for crop in crop_rows if isinstance(crop, Mapping)]
 
 


### PR DESCRIPTION
## Summary
- carry comparison status, artifact status, and visual delta metrics into each visual crop camera row
- render those comparison metrics beside crop hotspots in the visual crop summary table
- cover the JSON and markdown output so stale or metricless crop rows remain readable

## Evidence
- Regenerated visual crop report: `debug/mapbox-outdoors-visual-crops/20260521T070538Z/summary.md`
- The report now shows per-camera comparison metrics from `debug/mapbox-outdoors-comparison-z18-path-bg-source-width/all-cameras/20260521T043142Z/summary.json`, e.g. `chamonix-trails-z14-outdoors | passed | metrics_available | 0.9820 | 0.0352 | 0.0761`.
- The same report still shows `Path/pedestrian focus comparison match: True` for the paired focus report `debug/mapbox-outdoors-path-pedestrian-focus/20260521T062357Z/path-pedestrian-focus.json`.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949.
