### PR TITLE
Cap z18 pedestrian core width

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -686,20 +686,15 @@ _PEDESTRIAN_LINE_WIDTH_LAYER_IDS = {
     "tunnel-pedestrian",
     "tunnel-pedestrian-case",
 }
-_PEDESTRIAN_CASE_LINE_WIDTH_LAYER_IDS = {
-    "bridge-pedestrian-case",
-    "road-pedestrian-case",
-    "tunnel-pedestrian-case",
-}
 _PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX = "z18-plus"
-_PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM = 17.0
+_PEDESTRIAN_MID_HIGH_ZOOM_SAMPLE_ZOOM = 17.0
 _PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, float], ...] = (
     ("below-z16", None, 16.0, 14.0),
-    # The live z18 pedestrian case width exceeds qfit's QGIS max line width.
-    # Keep z16-z18 at the z17 sample, then scale the z18+ pair together until
-    # the case stroke reaches the QGIS cap.
-    ("z16-to-z18", 16.0, 18.0, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM),
-    (_PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX, 18.0, None, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM),
+    # The live z18 pedestrian core and case widths exceed qfit's QGIS max line
+    # width. Keep z16-z18 at the z17 sample, then sample z18+ at z18 so both
+    # strokes converge on the cap.
+    ("z16-to-z18", 16.0, 18.0, _PEDESTRIAN_MID_HIGH_ZOOM_SAMPLE_ZOOM),
+    (_PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX, 18.0, None, 18.0),
 )
 _PATH_TRAIL_LINE_WIDTH_LAYER_IDS = {
     "bridge-path-cycleway-piste",
@@ -3155,48 +3150,12 @@ def _split_path_trail_line_width_layers_for_qgis(layers: object) -> object:
     )
 
 
-def _pedestrian_pair_base_layer_id(layer_id: str) -> str:
-    return layer_id[: -len("-case")] if layer_id.endswith("-case") else layer_id
-
-
-def _pedestrian_high_zoom_cap_scales_by_base_layer_id(layers: list[object]) -> dict[str, float]:
-    scales: dict[str, float] = {}
-    for layer in layers:
-        if not isinstance(layer, dict):
-            continue
-        layer_id = str(layer.get("id") or "")
-        paint = layer.get("paint")
-        if (
-            layer_id not in _PEDESTRIAN_CASE_LINE_WIDTH_LAYER_IDS
-            or layer.get("type") != "line"
-            or not isinstance(paint, dict)
-        ):
-            continue
-        line_width = paint.get("line-width")
-        if not isinstance(line_width, list):
-            continue
-        case_width_mm = _line_width_mm_at_zoom(line_width, _PEDESTRIAN_HIGH_ZOOM_SAMPLE_ZOOM)
-        if case_width_mm is not None and case_width_mm < _MAX_LINE_WIDTH_MM:
-            scales[_pedestrian_pair_base_layer_id(layer_id)] = _MAX_LINE_WIDTH_MM / case_width_mm
-    return scales
-
-
-def _pedestrian_line_width_layer_variants(
-    layer: dict[str, object],
-    *,
-    high_zoom_cap_scales_by_base_layer_id: dict[str, float],
-) -> list[dict[str, object]] | None:
+def _pedestrian_line_width_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
     """Split audited pedestrian widths into static QGIS zoom bands."""
-    layer_id = str(layer.get("id") or "")
-    base_layer_id = _pedestrian_pair_base_layer_id(layer_id)
-    high_zoom_scale = high_zoom_cap_scales_by_base_layer_id.get(base_layer_id, 1.0)
     return _line_width_zoom_band_layer_variants(
         layer,
         layer_ids=_PEDESTRIAN_LINE_WIDTH_LAYER_IDS,
         zoom_bands=_PEDESTRIAN_LINE_WIDTH_ZOOM_BANDS,
-        line_width_scales_by_suffix={
-            _PEDESTRIAN_HIGH_ZOOM_WIDTH_BAND_SUFFIX: high_zoom_scale,
-        },
         clamp_sample_zoom_to_band=False,
     )
 
@@ -3215,15 +3174,9 @@ def _split_line_width_zoom_band_layers_for_qgis(layers: object, *, variants_for_
 
 
 def _split_pedestrian_line_width_layers_for_qgis(layers: object) -> object:
-    if not isinstance(layers, list):
-        return layers
-    high_zoom_cap_scales_by_base_layer_id = _pedestrian_high_zoom_cap_scales_by_base_layer_id(layers)
     return _split_line_width_zoom_band_layers_for_qgis(
         layers,
-        variants_for_layer=lambda layer: _pedestrian_line_width_layer_variants(
-            layer,
-            high_zoom_cap_scales_by_base_layer_id=high_zoom_cap_scales_by_base_layer_id,
-        ),
+        variants_for_layer=_pedestrian_line_width_layer_variants,
     )
 
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5995,8 +5995,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
         case_mid_mm = min(case_high_unscaled_mm, mapbox_config._MAX_LINE_WIDTH_MM)
-        high_zoom_cap_scale = mapbox_config._MAX_LINE_WIDTH_MM / case_high_unscaled_mm
-        pedestrian_high_mm = pedestrian_high_unscaled_mm * high_zoom_cap_scale
+        pedestrian_high_mm = mapbox_config._MAX_LINE_WIDTH_MM
         case_high_mm = mapbox_config._MAX_LINE_WIDTH_MM
 
         self.assertAlmostEqual(
@@ -6025,7 +6024,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         )
         self.assertAlmostEqual(
             by_id["bridge-pedestrian-z18-plus"]["paint"]["line-width"],
-            pedestrian_high_unpaired_mm,
+            mapbox_config._MAX_LINE_WIDTH_MM,
         )
         self.assertEqual(
             by_id["road-pedestrian-case-z16-to-z18-pale-casing"]["paint"],
@@ -6051,10 +6050,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             by_id["road-pedestrian-case-z18-plus-pale-casing"].get("filter"),
             by_id["road-pedestrian-case-z18-plus"].get("filter"),
         )
-        self.assertGreater(case_high_mm, pedestrian_high_mm)
         self.assertAlmostEqual(
-            case_high_mm / pedestrian_high_mm,
-            case_high_unscaled_mm / pedestrian_high_unscaled_mm,
+            by_id["road-pedestrian-z18-plus"]["paint"]["line-width"],
+            by_id["road-pedestrian-case-z18-plus"]["paint"]["line-width"],
         )
         self.assertEqual(by_id["road-pedestrian-below-z16"]["maxzoom"], 16.0)
         self.assertEqual(by_id["road-pedestrian-z16-to-z18"]["minzoom"], 16.0)


### PR DESCRIPTION
## Summary
- sample z18+ pedestrian line-width bands at z18 so source-capped pedestrian core strokes reach qfit's QGIS line-width cap
- keep the z16-z18 pedestrian band at the existing z17 sample
- update the style simplification regression test for equal z18+ pedestrian core/case cap behavior

## Evidence
- Candidate all-camera comparison: `debug/mapbox-outdoors-comparison-pedestrian-z18-cap/all-cameras/20260521T072521Z/summary.md`
- Delta report versus the current baseline `debug/mapbox-outdoors-comparison-z18-path-bg-source-width/all-cameras/20260521T043142Z/summary.json`: `debug/mapbox-outdoors-comparison-delta-pedestrian-z18-cap/20260521T072530Z/summary.md`
- Impacted z18 camera mean delta improved from `0.030070842` to `0.029902242`; changed ratio improved by `-0.001076389`. RMS moved by `+0.000025117`, so this is a small targeted improvement rather than a broad visual fix.
- Candidate focus report: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T072645Z/summary.md`; `road-pedestrian-z18-plus` now matches the capped source width with `line-width_delta_mm=0.0` for 191 decoded pedestrian candidates.
- Candidate visual crop report: `debug/mapbox-outdoors-visual-crops/20260521T072610Z/summary.md`

## Tests
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949.
