### PR TITLE
Show candidate-backed visual crop cues

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -225,6 +225,34 @@ def _path_pedestrian_focus_report(
                             }
                         ],
                     },
+                    {
+                        "source_layer_id": "road-steps",
+                        "decoded_candidate_count": 3,
+                        "decoded_candidate_type_counts": {"steps": 3},
+                        "source_sampled_controls": {
+                            "line-width": 0.5291666666666667,
+                            "line-dasharray": [0.3, 0.3],
+                        },
+                        "qgis_controls": [
+                            {
+                                "layer_id": "road-steps",
+                                "controls": {
+                                    "line-width": 0.5291666666666667,
+                                    "line-dasharray": [1, 0],
+                                },
+                            }
+                        ],
+                        "qgis_control_deltas": [
+                            {
+                                "layer_id": "road-steps",
+                                "deltas": {
+                                    "line-width_delta_mm": 0.0,
+                                    "line-width_ratio": 1.0,
+                                    "line-dasharray_match": False,
+                                },
+                            }
+                        ],
+                    },
                 ],
             }
         ]
@@ -459,7 +487,38 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIs(report["path_pedestrian_focus_comparison_match"], True)
             self.assertEqual(stroke_cues[0]["source_layer_id"], "road-path-trail")
             self.assertEqual(stroke_cues[0]["candidate_types"], ["trail=69", "hiking=5"])
-            self.assertEqual(dash_cues[0]["source_dasharray"], [1, 0.25])
+            self.assertEqual(dash_cues[0]["source_layer_id"], "road-steps")
+            self.assertEqual(dash_cues[0]["source_dasharray"], [0.3, 0.3])
+
+    def test_generate_visual_crop_report_filters_zero_candidate_focus_cues(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            focus_path = root / "focus" / "path-pedestrian-focus.json"
+            focus_report = _path_pedestrian_focus_report(comparison_summary_jsons=[str(summary_path)])
+            comparisons = focus_report["cameras"][0]["source_qgis_stroke_control_comparisons"]
+            comparisons[0]["decoded_candidate_count"] = 0
+            comparisons[0]["decoded_candidate_type_counts"] = {}
+            comparisons[2]["decoded_candidate_count"] = 0
+            comparisons[2]["decoded_candidate_type_counts"] = {}
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                path_pedestrian_focus_report=focus_report,
+                path_pedestrian_focus_report_path=focus_path,
+                crop_size=(4, 4),
+                crops_per_camera=1,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+
+            self.assertIs(report["path_pedestrian_focus_comparison_match"], True)
+            self.assertNotIn("path_pedestrian_focus", report["cameras"][0])
 
     def test_generate_visual_crop_report_suppresses_mismatched_focus_cues(self):
         image_module, image_stat_module = _fake_image_modules()
@@ -692,7 +751,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                                 {
                                     "source_layer_id": "bridge-path",
                                     "qgis_layer_id": "bridge-path",
-                                    "decoded_candidate_count": 0,
+                                    "decoded_candidate_count": 2,
                                     "source_dasharray": [1, 0.25],
                                     "qgis_dasharray": [4, 0.3],
                                 }
@@ -715,6 +774,52 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertIn("candidate_types=trail=69", markdown)
         self.assertNotIn("candidates=None", markdown)
         self.assertIn("dash=[1,0.25]!=[4,0.3]", markdown)
+
+    def test_build_summary_markdown_omits_zero_candidate_focus_cues(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "comparison_summary_json": "debug/comparison/summary.json",
+                "path_pedestrian_focus_json": "debug/focus/path-pedestrian-focus.json",
+                "path_pedestrian_focus_comparison_summary_jsons": [
+                    "debug/comparison/summary.json",
+                ],
+                "path_pedestrian_focus_comparison_match": True,
+                "crop_size": {"width": 4, "height": 4},
+                "crops_per_camera": 1,
+                "camera_count": 1,
+                "crop_count": 0,
+                "cameras": [
+                    {
+                        "camera": "zermatt-trails-z18-outdoors",
+                        "status": "cropped",
+                        "path_pedestrian_focus": {
+                            "stroke_width_deltas": [
+                                {
+                                    "source_layer_id": "bridge-steps",
+                                    "qgis_layer_id": "bridge-steps",
+                                    "decoded_candidate_count": 0,
+                                    "line_width_delta_mm": -1.3229166666666665,
+                                }
+                            ],
+                            "dash_mismatches": [
+                                {
+                                    "source_layer_id": "bridge-path",
+                                    "qgis_layer_id": "bridge-path",
+                                    "decoded_candidate_count": 0,
+                                    "source_dasharray": [1, 0.25],
+                                    "qgis_dasharray": [4, 0.3],
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+
+        self.assertIn("Path/pedestrian focus comparison match: `True`", markdown)
+        self.assertNotIn("## Path/pedestrian focus cues", markdown)
+        self.assertNotIn("bridge-steps->bridge-steps", markdown)
 
     def test_build_summary_markdown_omits_missing_focus_comparison_match(self):
         markdown = build_summary_markdown(

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -4,7 +4,7 @@ import argparse
 import datetime as dt
 import json
 import re
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -263,6 +263,26 @@ def _has_meaningful_width_delta(row: Mapping[str, object]) -> bool:
     return isinstance(value, (int, float)) and abs(float(value)) > 1e-12
 
 
+def _decoded_candidate_count(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return 0
+
+
+def _has_decoded_candidates(row: Mapping[str, object]) -> bool:
+    if _decoded_candidate_count(row.get("decoded_candidate_count")) > 0:
+        return True
+    candidate_type_counts = row.get("decoded_candidate_type_counts")
+    if isinstance(candidate_type_counts, Mapping) and candidate_type_counts:
+        return True
+    candidate_types = row.get("candidate_types")
+    return isinstance(candidate_types, list) and bool(candidate_types)
+
+
 def _path_pedestrian_focus_cues_by_camera(
     focus_report: Mapping[str, object] | None,
     *,
@@ -284,7 +304,7 @@ def _path_pedestrian_focus_cues_by_camera(
         width_delta_rows = [
             row
             for row in _largest_non_auxiliary_stroke_delta_rows([camera], limit=10_000)
-            if _has_meaningful_width_delta(row)
+            if _has_meaningful_width_delta(row) and _has_decoded_candidates(row)
         ][: max(0, stroke_limit)]
         width_rows = [
             _focus_cue_from_row(
@@ -314,8 +334,10 @@ def _path_pedestrian_focus_cues_by_camera(
                     "line_width_ratio",
                 ),
             )
-            for row in _non_auxiliary_dash_mismatch_rows([camera])[: max(0, dash_limit)]
+            for row in _non_auxiliary_dash_mismatch_rows([camera])
+            if _has_decoded_candidates(row)
         ]
+        dash_rows = dash_rows[: max(0, dash_limit)]
         if width_rows or dash_rows:
             cues_by_camera[camera_name] = {
                 "stroke_width_deltas": width_rows,
@@ -742,35 +764,53 @@ def _summary_camera_rows(camera: Mapping[str, object]) -> list[str]:
     return [_summary_crop_row(camera, crop) for crop in crop_rows if isinstance(crop, Mapping)]
 
 
+def _candidate_backed_focus_summaries(
+    focus: Mapping[str, object],
+    cue_key: str,
+    formatter: Callable[[Mapping[str, object]], str],
+) -> list[str]:
+    cues = focus.get(cue_key)
+    cue_rows = cues if isinstance(cues, list) else []
+    return [
+        formatter(cue)
+        for cue in cue_rows
+        if isinstance(cue, Mapping) and _has_decoded_candidates(cue)
+    ]
+
+
+def _summary_focus_row(camera: object) -> list[object] | None:
+    if not isinstance(camera, Mapping):
+        return None
+    focus = camera.get("path_pedestrian_focus")
+    if not isinstance(focus, Mapping):
+        return None
+    stroke_summaries = _candidate_backed_focus_summaries(
+        focus,
+        "stroke_width_deltas",
+        _stroke_focus_cue_summary,
+    )
+    dash_summaries = _candidate_backed_focus_summaries(
+        focus,
+        "dash_mismatches",
+        _dash_focus_cue_summary,
+    )
+    if not stroke_summaries and not dash_summaries:
+        return None
+    return [camera.get("camera"), stroke_summaries, dash_summaries]
+
+
+def _summary_focus_rows(report: Mapping[str, object]) -> list[list[object]]:
+    return [
+        row
+        for camera in report.get("cameras", [])
+        if (row := _summary_focus_row(camera)) is not None
+    ]
+
+
 def _summary_focus_cue_lines(report: Mapping[str, object]) -> list[str]:
     if report.get("path_pedestrian_focus_comparison_match") is False:
         return []
-    rows: list[list[object]] = []
-    for camera in report.get("cameras", []):
-        if not isinstance(camera, Mapping):
-            continue
-        focus = camera.get("path_pedestrian_focus")
-        if not isinstance(focus, Mapping):
-            continue
-        stroke_cues = focus.get("stroke_width_deltas")
-        dash_cues = focus.get("dash_mismatches")
-        stroke_rows = stroke_cues if isinstance(stroke_cues, list) else []
-        dash_rows = dash_cues if isinstance(dash_cues, list) else []
-        rows.append(
-            [
-                camera.get("camera"),
-                [
-                    _stroke_focus_cue_summary(cue)
-                    for cue in stroke_rows
-                    if isinstance(cue, Mapping)
-                ],
-                [
-                    _dash_focus_cue_summary(cue)
-                    for cue in dash_rows
-                    if isinstance(cue, Mapping)
-                ],
-            ]
-        )
+    rows = _summary_focus_rows(report)
     if not rows:
         return []
     lines = ["", "## Path/pedestrian focus cues", ""]


### PR DESCRIPTION
## Summary
- filter visual-crop path/pedestrian focus cue rows to decoded candidate-backed cues
- keep zero-candidate bridge/tunnel artifacts out of newly generated crop cue tables and legacy markdown re-renders
- preserve matching focus cue behavior when decoded candidate counts or candidate type summaries are present

## Evidence
- Candidate visual crop report: `debug/mapbox-outdoors-visual-crops/20260521T075925Z/summary.md`; it keeps `Path/pedestrian focus comparison match: True` for the current z18 comparison/focus pair and omits the zero-candidate bridge/tunnel cue table.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949.
