### PR TITLE
Focus visual crops on cue cameras

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -135,6 +135,15 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json
 ```
 
+To inspect only cameras that still have candidate-backed path/pedestrian focus cues, add `--focus-cue-cameras`. This is useful after a global highest-delta crop run is dominated by a different camera and hides lower-scoring stroke-width or dash candidates:
+
+```bash
+python3 validation/mapbox_outdoors_visual_crops.py \
+  --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/summary.json \
+  --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json \
+  --focus-cue-cameras
+```
+
 The focus cues are triage context only. Candidate-backed rows, source-capped rows, and zero-candidate dash rows still need visual inspection before becoming a rendering change.
 
 ## Style audit before tuning

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -127,8 +127,8 @@ def _write_visual_triplet(root, image_module, *, camera_name="chamonix-trails-z1
     browser_path = camera_dir / "mapbox-gl-reference.png"
     qgis_path = camera_dir / "qgis-vector-render.png"
     diff_path = camera_dir / "mapbox-gl-vs-qgis-diff.png"
-    camera_dir.mkdir(parents=True)
-    summary_path.parent.mkdir(parents=True)
+    camera_dir.mkdir(parents=True, exist_ok=True)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
     _save_rgb_image(browser_path, image_module, (255, 255, 255))
     _save_rgb_image(qgis_path, image_module, (128, 128, 128))
     diff = image_module.new("RGB", (12, 12), (0, 0, 0))
@@ -490,6 +490,48 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertEqual(dash_cues[0]["source_layer_id"], "road-steps")
             self.assertEqual(dash_cues[0]["source_dasharray"], [0.3, 0.3])
 
+    def test_generate_visual_crop_report_can_filter_to_focus_cue_cameras(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            second_summary, _summary_path = _write_visual_triplet(
+                root,
+                image_module,
+                camera_name="zermatt-trails-z18-outdoors",
+            )
+            comparison_summary["cameras"].append(second_summary["cameras"][0])
+            focus_path = root / "focus" / "path-pedestrian-focus.json"
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                path_pedestrian_focus_report=_path_pedestrian_focus_report(
+                    comparison_summary_jsons=[str(summary_path)]
+                ),
+                path_pedestrian_focus_report_path=focus_path,
+                focus_cue_cameras_only=True,
+                crop_size=(4, 4),
+                crops_per_camera=1,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+
+            self.assertIs(report["focus_cue_cameras_only"], True)
+            self.assertEqual(report["camera_count"], 1)
+            self.assertEqual(
+                [camera["camera"] for camera in report["cameras"]],
+                ["chamonix-trails-z14-outdoors"],
+            )
+            self.assertIn("path_pedestrian_focus", report["cameras"][0])
+            self.assertIn(
+                "Camera filter: `candidate-backed path/pedestrian focus cues`",
+                build_summary_markdown(report),
+            )
+
     def test_generate_visual_crop_report_filters_zero_candidate_focus_cues(self):
         image_module, image_stat_module = _fake_image_modules()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -547,6 +589,31 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             )
             self.assertIs(report["path_pedestrian_focus_comparison_match"], False)
             self.assertNotIn("path_pedestrian_focus", report["cameras"][0])
+
+    def test_generate_visual_crop_report_rejects_focus_filter_with_mismatched_focus_cues(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "Focus cue camera filtering requires .* to match the comparison summary",
+            ):
+                generate_visual_crop_report(
+                    comparison_summary,
+                    comparison_summary_path=summary_path,
+                    paths=paths,
+                    path_pedestrian_focus_report=_path_pedestrian_focus_report(),
+                    path_pedestrian_focus_report_path=root / "focus" / "path-pedestrian-focus.json",
+                    focus_cue_cameras_only=True,
+                    crop_size=(4, 4),
+                    crops_per_camera=1,
+                    trusted_output_root=root / "debug",
+                    image_module=image_module,
+                    image_stat_module=image_stat_module,
+                )
 
     def test_generate_visual_crop_report_matches_focus_comparison_runs(self):
         image_module, image_stat_module = _fake_image_modules()
@@ -978,6 +1045,19 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("--crops-per-camera must be greater than zero", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_main_requires_focus_report_for_focus_cue_camera_filter(self):
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+            main(["--comparison-summary-json", "/missing/summary.json", "--focus-cue-cameras"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn(
+            "--focus-cue-cameras requires --path-pedestrian-focus-json",
+            stderr.getvalue(),
+        )
         self.assertNotIn("Traceback", stderr.getvalue())
 
     def test_main_reports_missing_comparison_summary_without_traceback(self):

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -236,10 +236,19 @@ def _contact_sheet_outputs(outputs: Mapping[str, Path]) -> dict[str, str]:
 def _selected_camera_names(
     visual_artifacts_by_camera: Mapping[str, Mapping[str, object]],
     requested_cameras: Sequence[str] | None,
+    focus_camera_names: set[str] | None = None,
 ) -> list[str]:
     if requested_cameras:
-        return [camera for camera in requested_cameras if camera in visual_artifacts_by_camera]
-    return sorted(visual_artifacts_by_camera)
+        camera_names = [
+            camera
+            for camera in requested_cameras
+            if camera in visual_artifacts_by_camera
+        ]
+    else:
+        camera_names = sorted(visual_artifacts_by_camera)
+    if focus_camera_names is None:
+        return camera_names
+    return [camera for camera in camera_names if camera in focus_camera_names]
 
 
 def _required_visual_artifacts(artifacts: Mapping[str, object]) -> bool:
@@ -460,6 +469,7 @@ def generate_visual_crop_report(
     path_pedestrian_focus_report: Mapping[str, object] | None = None,
     path_pedestrian_focus_report_path: Path | None = None,
     camera_names: Sequence[str] | None = None,
+    focus_cue_cameras_only: bool = False,
     crop_size: tuple[int, int] = DEFAULT_CROP_SIZE,
     crops_per_camera: int = DEFAULT_CROPS_PER_CAMERA,
     generated_at: dt.datetime | None = None,
@@ -483,14 +493,24 @@ def generate_visual_crop_report(
     focus_comparison_match = None
     if focus_comparison_paths:
         focus_comparison_match = _display_input_path(comparison_summary_path) in focus_comparison_paths
+    if focus_cue_cameras_only and focus_comparison_match is False:
+        raise ValueError(
+            "Focus cue camera filtering requires the path/pedestrian focus report "
+            "to match the comparison summary."
+        )
     focus_cues_by_camera = (
         {}
         if focus_comparison_match is False
         else _path_pedestrian_focus_cues_by_camera(path_pedestrian_focus_report)
     )
+    focus_camera_names = set(focus_cues_by_camera) if focus_cue_cameras_only else None
     camera_rows = []
     contact_sheet_entries: list[dict[str, object]] = []
-    for camera_name in _selected_camera_names(visual_artifacts_by_camera, camera_names):
+    for camera_name in _selected_camera_names(
+        visual_artifacts_by_camera,
+        camera_names,
+        focus_camera_names=focus_camera_names,
+    ):
         status, crops, crop_contact_entries = _camera_visual_crop_rows(
             camera_name=camera_name,
             artifacts=visual_artifacts_by_camera[camera_name],
@@ -523,6 +543,7 @@ def generate_visual_crop_report(
         ),
         "crop_size": {"width": crop_size[0], "height": crop_size[1]},
         "crops_per_camera": crops_per_camera,
+        "focus_cue_cameras_only": focus_cue_cameras_only,
         "camera_count": len(camera_rows),
         "crop_count": sum(len(row.get("crops", [])) for row in camera_rows),
         "contact_sheet": _display_input_path(contact_sheet) if contact_sheet is not None else None,
@@ -653,6 +674,8 @@ def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
         f"Focused cameras: `{report.get('camera_count')}`",
         f"Generated crops: `{report.get('crop_count')}`",
     ]
+    if report.get("focus_cue_cameras_only") is True:
+        lines.append("Camera filter: `candidate-backed path/pedestrian focus cues`")
     if report.get("contact_sheet"):
         lines.append(f"Crop contact sheet: `{report.get('contact_sheet')}`")
     comparison_summary_run = _comparison_summary_run_markdown(report.get("comparison_summary_run"))
@@ -885,6 +908,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Camera to crop. May be repeated. Defaults to all cameras with complete visual artifacts.",
     )
     parser.add_argument(
+        "--focus-cue-cameras",
+        action="store_true",
+        help=(
+            "Crop only cameras with candidate-backed path/pedestrian focus cues. "
+            "Use with --path-pedestrian-focus-json when visually inspecting focus gaps."
+        ),
+    )
+    parser.add_argument(
         "--crop-size",
         default=DEFAULT_CROP_SIZE,
         type=parse_crop_size,
@@ -916,6 +947,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.crops_per_camera <= 0:
         parser.error("--crops-per-camera must be greater than zero")
+    if args.focus_cue_cameras and args.path_pedestrian_focus_json is None:
+        parser.error("--focus-cue-cameras requires --path-pedestrian-focus-json")
     comparison_summary = _load_cli_json_object(
         parser,
         args.comparison_summary_json,
@@ -937,6 +970,7 @@ def main(argv: list[str] | None = None) -> int:
             path_pedestrian_focus_report=path_pedestrian_focus_report,
             path_pedestrian_focus_report_path=args.path_pedestrian_focus_json,
             camera_names=args.camera,
+            focus_cue_cameras_only=args.focus_cue_cameras,
             crop_size=args.crop_size,
             crops_per_camera=args.crops_per_camera,
         )


### PR DESCRIPTION
## Summary
- add `--focus-cue-cameras` to visual crop generation so crop reports can target only cameras with candidate-backed path/pedestrian focus cues
- record the camera filter in the report/markdown and require `--path-pedestrian-focus-json` when the filter is used
- document the focused crop workflow for #949 follow-up visual review

## Evidence
- Local focused crop run: `python3 validation/mapbox_outdoors_visual_crops.py --comparison-summary-json debug/mapbox-outdoors-comparison-pedestrian-z18-cap/all-cameras/20260521T072521Z/summary.json --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/20260521T072645Z/path-pedestrian-focus.json --focus-cue-cameras --crops-per-camera 2`
- Output: `debug/mapbox-outdoors-visual-crops/20260521T081758Z/summary.md`
- Result: two focused z14 cameras and four crops, with candidate-backed cue rows for Chamonix and Geneva.

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Closes no issue; continues #949.
