### PR TITLE
Use source path casing width at z14

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -3037,9 +3037,10 @@ def _should_sample_path_low_zoom_background_line_width(layer_id: object, prop: s
 
 
 def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: object, maxzoom: object) -> float | None:
-    if _should_sample_path_low_zoom_line_width(layer_id, prop, maxzoom):
-        target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
-    elif _should_sample_path_low_zoom_background_line_width(layer_id, prop):
+    if (
+        _should_sample_path_low_zoom_line_width(layer_id, prop, maxzoom)
+        or _should_sample_path_low_zoom_background_line_width(layer_id, prop)
+    ):
         target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
     elif _should_sample_path_high_zoom_line_width(layer_id, prop, minzoom):
         target_sample_zoom = (

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -675,9 +675,6 @@ _PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_LAYER_PREFIXES = (
     "bridge-path-bg-below-z16",
 )
 _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM = 14.0
-# The z14 Geneva/Chamonix comparisons benefit from a small casing-only boost,
-# but larger low-zoom path casings overshoot the Mapbox GL reference.
-_PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE = 1.15
 _PEDESTRIAN_LINE_WIDTH_LAYER_IDS = {
     "bridge-pedestrian",
     "bridge-pedestrian-case",
@@ -3040,12 +3037,10 @@ def _should_sample_path_low_zoom_background_line_width(layer_id: object, prop: s
 
 
 def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: object, maxzoom: object) -> float | None:
-    low_zoom_path_background_width = False
     if _should_sample_path_low_zoom_line_width(layer_id, prop, maxzoom):
         target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
     elif _should_sample_path_low_zoom_background_line_width(layer_id, prop):
         target_sample_zoom = _PATH_LOW_ZOOM_LINE_WIDTH_SAMPLE_ZOOM
-        low_zoom_path_background_width = True
     elif _should_sample_path_high_zoom_line_width(layer_id, prop, minzoom):
         target_sample_zoom = (
             _path_high_zoom_line_width_sample_zoom(layer_id)
@@ -3056,10 +3051,7 @@ def _path_split_line_width(expr: object, layer_id: object, prop: str, minzoom: o
     target_zoom = _zoom_in_layer_range(target_sample_zoom, minzoom, maxzoom)
     if target_zoom is None:
         return None
-    width = _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
-    if width is not None and low_zoom_path_background_width:
-        width *= _PATH_LOW_ZOOM_BACKGROUND_LINE_WIDTH_QGIS_SCALE
-    return width
+    return _extract_zoom_scalar_size_at_zoom(expr, target_zoom)
 
 
 def _line_width_mm_at_zoom(expr: object, target_zoom: float) -> float | None:

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5565,7 +5565,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._extract_zoom_scalar_size_at_zoom(line_width, 14.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM
         )
-        path_background_low_width_mm = path_core_low_width_mm * 1.15
+        path_background_low_width_mm = path_core_low_width_mm
         mid_high_width_mm = (
             mapbox_config._extract_zoom_scalar_size_at_zoom(line_width, 17.0)
             * mapbox_config._MAPBOX_PIXEL_TO_MM


### PR DESCRIPTION
## Summary

- removes the extra qfit-only 1.15 multiplier from z14 road/bridge path background casings
- keeps the low-zoom path casing sample tied directly to the Mapbox source line-width expression
- updates the path split-width unit test to assert the source sampled casing width

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live comparison with local Mapbox token:
  - `chamonix-trails-z14-outdoors`: mean 0.03523346722948439 -> 0.0350759633714597; RMS 0.07608105570020197 -> 0.07560186461596113
  - `geneva-airport-motorway-z14-outdoors`: mean 0.061117134168482204 -> 0.0609815711238199; RMS 0.10740925038383613 -> 0.10706254706723764

## Artifacts

- `debug/mapbox-outdoors-comparison-low-zoom-path-bg-source-width/chamonix-trails-z14-outdoors/20260521T083803Z/`
- `debug/mapbox-outdoors-comparison-low-zoom-path-bg-source-width/geneva-airport-motorway-z14-outdoors/20260521T083820Z/`

Refs #949
