### PR TITLE
Surface largest Mapbox comparison delta movements

### DIFF
--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -103,6 +103,11 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
         )
         self.assertEqual(chamonix["mean_delta_direction"], "improved")
         self.assertEqual(chamonix["rms_delta_direction"], "worsened")
+        self.assertEqual(
+            [row["camera"] for row in report["largest_metric_movements"]],
+            ["chamonix-trails-z14-outdoors", "zermatt-trails-z18-outdoors"],
+        )
+        self.assertAlmostEqual(report["largest_metric_movements"][0]["mean_delta"], -0.005)
 
     def test_build_comparison_delta_report_preserves_missing_camera_rows(self):
         report = build_comparison_delta_report(
@@ -147,6 +152,8 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
 
         self.assertIn("# Mapbox Outdoors comparison delta", markdown)
         self.assertIn("Baseline: `baseline`", markdown)
+        self.assertIn("## Largest Metric Movements", markdown)
+        self.assertIn("| `camera-a` | 18.00 | -0.010000000 | +0.010000000 | +0.010000000 |", markdown)
         self.assertIn("| `camera-a` | 18.00 | 0.050000000 | 0.040000000 | -0.010000000 |", markdown)
         self.assertIn("| RMS channel delta | 0 | 1 | 0 | 0 |", markdown)
 

--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -153,9 +153,34 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
         self.assertIn("# Mapbox Outdoors comparison delta", markdown)
         self.assertIn("Baseline: `baseline`", markdown)
         self.assertIn("## Largest Metric Movements", markdown)
-        self.assertIn("| `camera-a` | 18.00 | -0.010000000 | +0.010000000 | +0.010000000 |", markdown)
+        self.assertIn(
+            "| `camera-a` | 18.00 | -0.010000000 | +0.010000000 | +0.010000000 | "
+            "improved/worsened |",
+            markdown,
+        )
         self.assertIn("| `camera-a` | 18.00 | 0.050000000 | 0.040000000 | -0.010000000 |", markdown)
         self.assertIn("| RMS channel delta | 0 | 1 | 0 | 0 |", markdown)
+
+    def test_build_summary_markdown_coerces_missing_movement_directions(self):
+        markdown = build_summary_markdown(
+            {
+                "largest_metric_movements": [
+                    {
+                        "camera": "camera-a",
+                        "zoom": 14,
+                        "mean_delta": 0.01,
+                        "rms_delta": -0.02,
+                        "changed_pixel_ratio_delta": None,
+                        "mean_delta_direction": None,
+                        "rms_delta_direction": None,
+                    }
+                ],
+                "summary": {},
+                "cameras": [],
+            }
+        )
+
+        self.assertIn("| `camera-a` | 14.00 | +0.010000000 | -0.020000000 | - | -/- |", markdown)
 
     def test_build_summary_markdown_links_input_artifacts_relative_to_report(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -28,6 +28,7 @@ DELTA_METRIC_KEYS = (
     "normalized_rms_channel_delta",
 )
 DIRECTION_BUCKETS = ("improved", "worsened", "unchanged", "unknown")
+TOP_MOVEMENT_LIMIT = 5
 
 
 class ComparisonDeltaPaths(NamedTuple):
@@ -149,6 +150,53 @@ def _direction_counts(prefix: str, directions: list[str]) -> dict[str, int]:
     return {f"{prefix}_{bucket}": directions.count(bucket) for bucket in DIRECTION_BUCKETS}
 
 
+def _metric_delta_value(row: Mapping[str, object], key: str, field: str) -> object:
+    metrics = row.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return None
+    metric = metrics.get(key)
+    if not isinstance(metric, Mapping):
+        return None
+    return metric.get(field)
+
+
+def _numeric_delta(row: Mapping[str, object], key: str) -> float | None:
+    value = _metric_delta_value(row, key, "delta")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _largest_metric_movement_rows(
+    rows: list[Mapping[str, object]],
+    *,
+    limit: int = TOP_MOVEMENT_LIMIT,
+) -> list[dict[str, object]]:
+    scored_rows: list[tuple[float, str, dict[str, object]]] = []
+    for row in rows:
+        mean_delta = _numeric_delta(row, "normalized_mean_absolute_channel_delta")
+        rms_delta = _numeric_delta(row, "normalized_rms_channel_delta")
+        deltas = [abs(delta) for delta in (mean_delta, rms_delta) if delta is not None]
+        if not deltas:
+            continue
+        score = max(deltas)
+        if score == 0:
+            continue
+        camera = row.get("camera")
+        movement = {
+            "camera": camera if isinstance(camera, str) else "-",
+            "zoom": row.get("zoom"),
+            "mean_delta": mean_delta,
+            "rms_delta": rms_delta,
+            "changed_pixel_ratio_delta": _numeric_delta(row, "changed_pixel_ratio"),
+            "mean_delta_direction": row.get("mean_delta_direction"),
+            "rms_delta_direction": row.get("rms_delta_direction"),
+        }
+        scored_rows.append((score, str(movement["camera"]), movement))
+    scored_rows.sort(key=lambda item: (-item[0], item[1]))
+    return [row for _score, _camera, row in scored_rows[:limit]]
+
+
 def _report_path(path: Path, *, artifact_base_dir: Path | None) -> str:
     if artifact_base_dir is not None:
         try:
@@ -254,6 +302,9 @@ def build_comparison_delta_report(
         | _direction_counts("rms", rms_directions),
         "cameras": rows,
     }
+    largest_metric_movements = _largest_metric_movement_rows(rows)
+    if largest_metric_movements:
+        report["largest_metric_movements"] = largest_metric_movements
     input_artifacts = {
         label: artifacts
         for label, artifacts in {
@@ -285,16 +336,6 @@ def _format_delta(value: object) -> str:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return "-"
     return f"{float(value):+.9f}"
-
-
-def _metric_delta_value(row: Mapping[str, object], key: str, field: str) -> object:
-    metrics = row.get("metrics")
-    if not isinstance(metrics, Mapping):
-        return None
-    metric = metrics.get(key)
-    if not isinstance(metric, Mapping):
-        return None
-    return metric.get(field)
 
 
 def _artifact_path_cell(row: Mapping[str, object], key: str) -> str:
@@ -331,6 +372,40 @@ def _append_input_artifacts_section(lines: list[str], report: Mapping[str, objec
     lines.append("")
 
 
+def _append_largest_metric_movements_section(lines: list[str], report: Mapping[str, object]) -> None:
+    movements = report.get("largest_metric_movements")
+    if not isinstance(movements, list) or not movements:
+        return
+    lines.extend(
+        [
+            "## Largest Metric Movements",
+            "",
+            (
+                "| Camera | z | Mean delta | RMS delta | Changed ratio delta | "
+                "Direction (mean/RMS) |"
+            ),
+            "| --- | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for movement in movements:
+        if not isinstance(movement, Mapping):
+            continue
+        direction = (
+            f"{movement.get('mean_delta_direction', '-')}/"
+            f"{movement.get('rms_delta_direction', '-')}"
+        )
+        lines.append(
+            "| "
+            f"`{movement.get('camera', '-')}` | "
+            f"{_format_float(movement.get('zoom'), precision=2)} | "
+            f"{_format_delta(movement.get('mean_delta'))} | "
+            f"{_format_delta(movement.get('rms_delta'))} | "
+            f"{_format_delta(movement.get('changed_pixel_ratio_delta'))} | "
+            f"{direction} |"
+        )
+    lines.append("")
+
+
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
     lines = [
@@ -343,6 +418,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         "",
     ]
     _append_input_artifacts_section(lines, report)
+    _append_largest_metric_movements_section(lines, report)
     lines.extend(
         [
             "## Summary",

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -391,8 +391,8 @@ def _append_largest_metric_movements_section(lines: list[str], report: Mapping[s
         if not isinstance(movement, Mapping):
             continue
         direction = (
-            f"{movement.get('mean_delta_direction', '-')}/"
-            f"{movement.get('rms_delta_direction', '-')}"
+            f"{movement.get('mean_delta_direction') or '-'}/"
+            f"{movement.get('rms_delta_direction') or '-'}"
         )
         lines.append(
             "| "


### PR DESCRIPTION
## Summary

- adds a Largest Metric Movements section to Mapbox Outdoors comparison-delta reports
- records the top absolute mean/RMS metric shifts in the JSON report so #949 style probes are easier to review
- keeps unchanged cameras in the full camera table while highlighting the cameras that actually moved

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison_delta.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- generated `debug/mapbox-outdoors-comparison-delta-path-bg-source-width/20260521T090345Z/summary.md` from the post-#1271 comparison summaries

Refs #949
