### PR TITLE
Threshold comparison delta movements

### DIFF
--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -140,6 +140,40 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
         self.assertEqual(report["cameras"][0]["zoom"], 12.5)
         self.assertIn("| `camera-a` | 12.50 |", build_summary_markdown(report))
 
+    def test_build_comparison_delta_report_filters_small_metric_movements(self):
+        baseline = {
+            "cameras": [
+                _camera_row("large-move", mean=0.10, rms=0.20),
+                _camera_row("small-move", mean=0.10, rms=0.20),
+            ]
+        }
+        candidate = {
+            "cameras": [
+                _camera_row("large-move", mean=0.08, rms=0.19),
+                _camera_row("small-move", mean=0.09995, rms=0.19996),
+            ]
+        }
+
+        report = build_comparison_delta_report(
+            baseline,
+            candidate,
+            movement_threshold=0.001,
+        )
+        markdown = build_summary_markdown(report)
+
+        self.assertEqual(report["movement_threshold"], 0.001)
+        self.assertEqual(
+            [row["camera"] for row in report["largest_metric_movements"]],
+            ["large-move"],
+        )
+        self.assertIn(
+            "Minimum absolute mean/RMS delta shown: `0.001000000`\n\n"
+            "| Camera | z | Mean delta | RMS delta | Changed ratio delta |",
+            markdown,
+        )
+        self.assertIn("| `large-move` |", markdown)
+        self.assertNotIn("| `small-move` | 14.25 | -0.000050000 |", markdown)
+
     def test_build_summary_markdown_renders_delta_table(self):
         report = build_comparison_delta_report(
             {"cameras": [_camera_row("camera-a", mean=0.05, rms=0.08, changed=0.9, zoom=18)]},
@@ -292,6 +326,8 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
                             "baseline",
                             "--candidate-label",
                             "candidate",
+                            "--movement-threshold",
+                            "0.001",
                             "--output-root",
                             str(tmp_path / "delta"),
                         ]
@@ -304,6 +340,7 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
             self.assertTrue((output_dir / "summary.md").exists())
             written = json.loads((output_dir / "comparison-delta.json").read_text(encoding="utf-8"))
             self.assertEqual(written["generated_at"], "20260520T185100Z")
+            self.assertEqual(written["movement_threshold"], 0.001)
 
 
 if __name__ == "__main__":

--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -1,3 +1,4 @@
+import argparse
 import datetime as dt
 import io
 import json
@@ -10,6 +11,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_comparison_delta import (
+    _non_negative_float,
     build_comparison_delta_paths,
     build_comparison_delta_report,
     build_run_directory,
@@ -173,6 +175,14 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
         )
         self.assertIn("| `large-move` |", markdown)
         self.assertNotIn("| `small-move` | 14.25 | -0.000050000 |", markdown)
+        self.assertIn("| `small-move` | 14.25 | 0.100000000 |", markdown)
+
+    def test_non_negative_float_rejects_invalid_thresholds(self):
+        self.assertEqual(_non_negative_float("0.001"), 0.001)
+        for value in ("-0.1", "nan", "inf", "-inf"):
+            with self.subTest(value=value):
+                with self.assertRaises(argparse.ArgumentTypeError):
+                    _non_negative_float(value)
 
     def test_build_summary_markdown_renders_delta_table(self):
         report = build_comparison_delta_report(

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -29,6 +29,7 @@ DELTA_METRIC_KEYS = (
 )
 DIRECTION_BUCKETS = ("improved", "worsened", "unchanged", "unknown")
 TOP_MOVEMENT_LIMIT = 5
+DEFAULT_MOVEMENT_THRESHOLD = 0.0
 
 
 class ComparisonDeltaPaths(NamedTuple):
@@ -171,6 +172,7 @@ def _largest_metric_movement_rows(
     rows: list[Mapping[str, object]],
     *,
     limit: int = TOP_MOVEMENT_LIMIT,
+    minimum_abs_delta: float = DEFAULT_MOVEMENT_THRESHOLD,
 ) -> list[dict[str, object]]:
     scored_rows: list[tuple[float, str, dict[str, object]]] = []
     for row in rows:
@@ -180,7 +182,7 @@ def _largest_metric_movement_rows(
         if not deltas:
             continue
         score = max(deltas)
-        if score == 0:
+        if score == 0 or score < minimum_abs_delta:
             continue
         camera = row.get("camera")
         movement = {
@@ -241,6 +243,7 @@ def build_comparison_delta_report(
     baseline_summary_path: Path | None = None,
     candidate_summary_path: Path | None = None,
     artifact_base_dir: Path | None = None,
+    movement_threshold: float = DEFAULT_MOVEMENT_THRESHOLD,
     now: dt.datetime | None = None,
 ) -> dict[str, object]:
     baseline_rows = _camera_rows(baseline_summary)
@@ -298,11 +301,15 @@ def build_comparison_delta_report(
         "baseline_label": baseline_label,
         "candidate_label": candidate_label,
         "camera_count": len(rows),
+        "movement_threshold": movement_threshold,
         "summary": _direction_counts("mean", mean_directions)
         | _direction_counts("rms", rms_directions),
         "cameras": rows,
     }
-    largest_metric_movements = _largest_metric_movement_rows(rows)
+    largest_metric_movements = _largest_metric_movement_rows(
+        rows,
+        minimum_abs_delta=movement_threshold,
+    )
     if largest_metric_movements:
         report["largest_metric_movements"] = largest_metric_movements
     input_artifacts = {
@@ -380,6 +387,18 @@ def _append_largest_metric_movements_section(lines: list[str], report: Mapping[s
         [
             "## Largest Metric Movements",
             "",
+        ]
+    )
+    threshold = report.get("movement_threshold")
+    if isinstance(threshold, (int, float)) and not isinstance(threshold, bool) and threshold > 0:
+        lines.extend(
+            [
+                f"Minimum absolute mean/RMS delta shown: `{threshold:.9f}`",
+                "",
+            ]
+        )
+    lines.extend(
+        [
             (
                 "| Camera | z | Mean delta | RMS delta | Changed ratio delta | "
                 "Direction (mean/RMS) |"
@@ -529,8 +548,27 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("candidate_summary", type=Path)
     parser.add_argument("--baseline-label", default="baseline")
     parser.add_argument("--candidate-label", default="candidate")
+    parser.add_argument(
+        "--movement-threshold",
+        type=_non_negative_float,
+        default=DEFAULT_MOVEMENT_THRESHOLD,
+        help=(
+            "Minimum absolute mean/RMS metric delta required for a camera to appear "
+            "in the Largest Metric Movements section."
+        ),
+    )
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
     return parser
+
+
+def _non_negative_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Expected a numeric threshold") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("Threshold must be non-negative")
+    return parsed
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -549,6 +587,7 @@ def main(argv: list[str] | None = None) -> int:
         baseline_summary_path=args.baseline_summary,
         candidate_summary_path=args.candidate_summary,
         artifact_base_dir=paths.run_dir,
+        movement_threshold=args.movement_threshold,
         now=now,
     )
     write_report(report, paths)

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -183,7 +183,7 @@ def _largest_metric_movement_rows(
         if not deltas:
             continue
         score = max(deltas)
-        if score == 0 or score < minimum_abs_delta:
+        if score <= minimum_abs_delta:
             continue
         camera = row.get("camera")
         movement = {

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import math
 import os
 import sys
 from collections.abc import Mapping
@@ -566,8 +567,8 @@ def _non_negative_float(value: str) -> float:
         parsed = float(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError("Expected a numeric threshold") from exc
-    if parsed < 0:
-        raise argparse.ArgumentTypeError("Threshold must be non-negative")
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("Threshold must be a finite non-negative number")
     return parsed
 
 


### PR DESCRIPTION
## Summary

- adds `--movement-threshold` to Mapbox Outdoors comparison-delta reports
- filters the Largest Metric Movements section by minimum absolute mean/RMS delta while keeping the full camera table unchanged
- records the selected threshold in JSON and Markdown so probe reports are auditable

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison_delta.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- Generated thresholded report: `debug/mapbox-outdoors-comparison-delta-threshold-probe/20260521T092400Z/summary.md`

Refs #949.
