### PR TITLE
Annotate Mapbox visual crops with delta movements

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -144,6 +144,18 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --focus-cue-cameras
 ```
 
+When reviewing a before/after styling probe, pass the matching comparison-delta report so each crop row includes the per-camera mean/RMS movement from the candidate run:
+
+```bash
+python3 validation/mapbox_outdoors_visual_crops.py \
+  --comparison-summary-json debug/mapbox-outdoors-comparison/<candidate>/all-cameras/<timestamp>/summary.json \
+  --comparison-delta-json debug/mapbox-outdoors-comparison-delta/<timestamp>/comparison-delta.json \
+  --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json \
+  --focus-cue-cameras
+```
+
+The delta context is shown only when the comparison-delta candidate summary matches the crop report's comparison summary, which keeps stale probe movement from being mixed into a newer visual crop sheet.
+
 The focus cues are triage context only. Candidate-backed rows, source-capped rows, and zero-candidate dash rows still need visual inspection before becoming a rendering change.
 
 ## Style audit before tuning

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_visual_crops import (
+    annotate_visual_crop_report_with_comparison_delta,
     build_run_directory,
     build_summary_markdown,
     build_visual_crop_paths,
@@ -259,6 +260,36 @@ def _path_pedestrian_focus_report(
     }
 
 
+def _comparison_delta_report(candidate_summary_json, *, camera_name="chamonix-trails-z14-outdoors"):
+    return {
+        "input_artifacts": {
+            "candidate": {
+                "summary_json": str(candidate_summary_json),
+            }
+        },
+        "cameras": [
+            {
+                "camera": camera_name,
+                "baseline_status": "passed",
+                "candidate_status": "passed",
+                "mean_delta_direction": "improved",
+                "rms_delta_direction": "worsened",
+                "metrics": {
+                    "changed_pixel_ratio": {
+                        "delta": -0.0000008680555555,
+                    },
+                    "normalized_mean_absolute_channel_delta": {
+                        "delta": -0.00015750385802469,
+                    },
+                    "normalized_rms_channel_delta": {
+                        "delta": 0.00047919108424084,
+                    },
+                },
+            }
+        ],
+    }
+
+
 class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
     def test_build_run_directory_and_paths_are_predictable(self):
         run_dir = build_run_directory(
@@ -489,6 +520,120 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertEqual(stroke_cues[0]["candidate_types"], ["trail=69", "hiking=5"])
             self.assertEqual(dash_cues[0]["source_layer_id"], "road-steps")
             self.assertEqual(dash_cues[0]["source_dasharray"], [0.3, 0.3])
+
+    def test_generate_visual_crop_report_attaches_matching_comparison_delta_context(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            delta_path = root / "delta" / "comparison-delta.json"
+            delta_path.parent.mkdir(parents=True)
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                crop_size=(4, 4),
+                crops_per_camera=1,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+            report = annotate_visual_crop_report_with_comparison_delta(
+                report,
+                comparison_summary_path=summary_path,
+                comparison_delta_report=_comparison_delta_report(summary_path),
+                comparison_delta_report_path=delta_path,
+            )
+            markdown = build_summary_markdown(report)
+
+            self.assertEqual(report["comparison_delta_json"], str(delta_path))
+            self.assertEqual(
+                report["comparison_delta_candidate_summary_json"],
+                str(summary_path),
+            )
+            self.assertIs(report["comparison_delta_candidate_summary_match"], True)
+            self.assertEqual(
+                report["cameras"][0]["comparison_delta"],
+                {
+                    "baseline_status": "passed",
+                    "candidate_status": "passed",
+                    "changed_pixel_ratio_delta": -0.0000008680555555,
+                    "mean_delta": -0.00015750385802469,
+                    "mean_delta_direction": "improved",
+                    "rms_delta": 0.00047919108424084,
+                    "rms_delta_direction": "worsened",
+                },
+            )
+            self.assertIn("Comparison delta input: `", markdown)
+            self.assertIn("Comparison delta candidate match: `True`", markdown)
+            self.assertIn("| Camera | Comparison status | Artifact status | Changed ratio | Mean delta | RMS delta | Mean movement | RMS movement |", markdown)
+            self.assertIn("| chamonix-trails-z14-outdoors | passed | metrics_available | 0.9820 | 0.0352 | 0.0761 | -0.000157504 | +0.000479191 |", markdown)
+
+    def test_generate_visual_crop_report_suppresses_mismatched_comparison_delta_context(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            delta_path = root / "delta" / "comparison-delta.json"
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                crop_size=(4, 4),
+                crops_per_camera=1,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+            report = annotate_visual_crop_report_with_comparison_delta(
+                report,
+                comparison_summary_path=summary_path,
+                comparison_delta_report=_comparison_delta_report(root / "stale" / "summary.json"),
+                comparison_delta_report_path=delta_path,
+            )
+            markdown = build_summary_markdown(report)
+
+            self.assertIs(report["comparison_delta_candidate_summary_match"], False)
+            self.assertNotIn("comparison_delta", report["cameras"][0])
+            self.assertIn("Comparison delta candidate match: `False`", markdown)
+            self.assertNotIn("Mean movement", markdown)
+
+    def test_generate_visual_crop_report_requires_comparison_delta_candidate_summary(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            delta_path = root / "delta" / "comparison-delta.json"
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                crop_size=(4, 4),
+                crops_per_camera=1,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+            delta_report = _comparison_delta_report(summary_path)
+            del delta_report["input_artifacts"]
+            report = annotate_visual_crop_report_with_comparison_delta(
+                report,
+                comparison_summary_path=summary_path,
+                comparison_delta_report=delta_report,
+                comparison_delta_report_path=delta_path,
+            )
+            markdown = build_summary_markdown(report)
+
+            self.assertEqual(report["comparison_delta_json"], str(delta_path))
+            self.assertNotIn("comparison_delta_candidate_summary_match", report)
+            self.assertNotIn("comparison_delta", report["cameras"][0])
+            self.assertNotIn("Mean movement", markdown)
 
     def test_generate_visual_crop_report_can_filter_to_focus_cue_cameras(self):
         image_module, image_stat_module = _fake_image_modules()
@@ -984,6 +1129,12 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            delta_path = root / "delta" / "comparison-delta.json"
+            delta_path.parent.mkdir(parents=True)
+            delta_path.write_text(
+                json.dumps(_comparison_delta_report(summary_path)),
+                encoding="utf-8",
+            )
             output_root = root / "debug"
             stdout = io.StringIO()
 
@@ -1003,6 +1154,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         str(summary_path),
                         "--path-pedestrian-focus-json",
                         str(focus_path),
+                        "--comparison-delta-json",
+                        str(delta_path),
                         "--camera",
                         "chamonix-trails-z14-outdoors",
                         "--crops-per-camera",
@@ -1028,6 +1181,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 report["path_pedestrian_focus_comparison_summary_jsons"],
                 [str(summary_path)],
             )
+            self.assertIs(report["comparison_delta_candidate_summary_match"], True)
+            self.assertIn("comparison_delta", report["cameras"][0])
             self.assertIs(report["path_pedestrian_focus_comparison_match"], True)
             self.assertEqual(report["path_pedestrian_focus_json"], str(focus_path))
             self.assertEqual(

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -382,6 +382,158 @@ def _comparison_context_from_artifacts(artifacts: Mapping[str, object]) -> dict[
     }
 
 
+def _resolve_report_input_path(
+    path_text: str,
+    *,
+    report_path: Path | None,
+) -> Path:
+    path = Path(path_text)
+    if path.is_absolute():
+        return path
+    if report_path is not None:
+        return report_path.parent / path
+    return path
+
+
+def _same_resolved_path(first: Path, second: Path) -> bool:
+    return first.resolve() == second.resolve()
+
+
+def _comparison_delta_candidate_summary_path(
+    comparison_delta_report: Mapping[str, object],
+    *,
+    comparison_delta_report_path: Path | None,
+) -> Path | None:
+    input_artifacts = comparison_delta_report.get("input_artifacts")
+    if not isinstance(input_artifacts, Mapping):
+        return None
+    candidate = input_artifacts.get("candidate")
+    if not isinstance(candidate, Mapping):
+        return None
+    summary_json = candidate.get("summary_json")
+    if not isinstance(summary_json, str) or not summary_json:
+        return None
+    return _resolve_report_input_path(
+        summary_json,
+        report_path=comparison_delta_report_path,
+    )
+
+
+def _comparison_delta_metric(row: Mapping[str, object], metric_key: str) -> float | None:
+    metrics = row.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return None
+    metric = metrics.get(metric_key)
+    if not isinstance(metric, Mapping):
+        return None
+    value = metric.get("delta")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _comparison_delta_camera_context(row: Mapping[str, object]) -> dict[str, object]:
+    context: dict[str, object] = {}
+    for source_key, target_key in (
+        ("changed_pixel_ratio", "changed_pixel_ratio_delta"),
+        ("normalized_mean_absolute_channel_delta", "mean_delta"),
+        ("normalized_rms_channel_delta", "rms_delta"),
+    ):
+        value = _comparison_delta_metric(row, source_key)
+        if value is not None:
+            context[target_key] = value
+    for key in (
+        "baseline_status",
+        "candidate_status",
+        "mean_delta_direction",
+        "rms_delta_direction",
+    ):
+        value = row.get(key)
+        if isinstance(value, str) and value:
+            context[key] = value
+    return context
+
+
+def _comparison_delta_context_by_camera(
+    comparison_delta_report: Mapping[str, object] | None,
+) -> dict[str, dict[str, object]]:
+    if comparison_delta_report is None:
+        return {}
+    cameras = comparison_delta_report.get("cameras")
+    if not isinstance(cameras, list):
+        return {}
+    rows: dict[str, dict[str, object]] = {}
+    for row in cameras:
+        if not isinstance(row, Mapping):
+            continue
+        camera = row.get("camera")
+        if not isinstance(camera, str) or not camera:
+            continue
+        context = _comparison_delta_camera_context(row)
+        if context:
+            rows[camera] = context
+    return rows
+
+
+def _annotated_delta_camera_rows(
+    cameras: object,
+    delta_context_by_camera: Mapping[str, Mapping[str, object]],
+) -> list[object]:
+    if not isinstance(cameras, list):
+        return []
+    annotated_rows: list[object] = []
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            annotated_rows.append(camera)
+            continue
+        camera_row = dict(camera)
+        camera_name = camera_row.get("camera")
+        delta_context = (
+            delta_context_by_camera.get(camera_name)
+            if isinstance(camera_name, str)
+            else None
+        )
+        if delta_context:
+            camera_row["comparison_delta"] = dict(delta_context)
+        annotated_rows.append(camera_row)
+    return annotated_rows
+
+
+def annotate_visual_crop_report_with_comparison_delta(
+    report: Mapping[str, object],
+    *,
+    comparison_summary_path: Path,
+    comparison_delta_report: Mapping[str, object],
+    comparison_delta_report_path: Path,
+) -> dict[str, object]:
+    delta_candidate_summary_path = _comparison_delta_candidate_summary_path(
+        comparison_delta_report,
+        comparison_delta_report_path=comparison_delta_report_path,
+    )
+    delta_candidate_match = (
+        _same_resolved_path(delta_candidate_summary_path, comparison_summary_path)
+        if delta_candidate_summary_path is not None
+        else None
+    )
+    delta_context_by_camera = (
+        _comparison_delta_context_by_camera(comparison_delta_report)
+        if delta_candidate_match is True
+        else {}
+    )
+    annotated_report = dict(report)
+    annotated_report["cameras"] = _annotated_delta_camera_rows(
+        report.get("cameras"),
+        delta_context_by_camera,
+    )
+    annotated_report["comparison_delta_json"] = _display_input_path(comparison_delta_report_path)
+    if delta_candidate_summary_path is not None:
+        annotated_report["comparison_delta_candidate_summary_json"] = _display_input_path(
+            delta_candidate_summary_path,
+        )
+        annotated_report["comparison_delta_candidate_summary_match"] = delta_candidate_match
+    return annotated_report
+
+
 def _hotspot_crop_rows(
     *,
     camera_name: str,
@@ -681,6 +833,16 @@ def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
     comparison_summary_run = _comparison_summary_run_markdown(report.get("comparison_summary_run"))
     if comparison_summary_run:
         lines.append(f"Comparison summary run: {comparison_summary_run}")
+    if report.get("comparison_delta_json"):
+        lines.append(f"Comparison delta input: `{report.get('comparison_delta_json')}`")
+    if report.get("comparison_delta_candidate_summary_json"):
+        lines.append(
+            "Comparison delta candidate summary: "
+            f"`{report.get('comparison_delta_candidate_summary_json')}`"
+        )
+        match = report.get("comparison_delta_candidate_summary_match")
+        if match is not None:
+            lines.append(f"Comparison delta candidate match: `{match}`")
     if report.get("path_pedestrian_focus_json"):
         lines.append(f"Path/pedestrian focus input: `{report.get('path_pedestrian_focus_json')}`")
     focus_comparison_paths = report.get("path_pedestrian_focus_comparison_summary_jsons")
@@ -713,17 +875,39 @@ def _comparison_summary_run_markdown(value: object) -> str:
     return f"`{path_value}`{suffix}"
 
 
-def _summary_table_intro_lines() -> list[str]:
+def _include_comparison_delta_columns(report: Mapping[str, object]) -> bool:
+    return any(
+        isinstance(camera, Mapping) and isinstance(camera.get("comparison_delta"), Mapping)
+        for camera in report.get("cameras", [])
+    )
+
+
+def _summary_table_intro_lines(report: Mapping[str, object]) -> list[str]:
+    headers = [
+        "Camera",
+        "Comparison status",
+        "Artifact status",
+        "Changed ratio",
+        "Mean delta",
+        "RMS delta",
+    ]
+    alignments = ["---", "---", "---", "---:", "---:", "---:"]
+    if _include_comparison_delta_columns(report):
+        headers.extend(["Mean movement", "RMS movement"])
+        alignments.extend(["---:", "---:"])
+    headers.extend(["Crop status", "Crop", "Box", "Score", "Mapbox GL", "QGIS render", "Diff"])
+    alignments.extend(["---", "---:", "---", "---:", "---", "---", "---"])
     return [
         "",
         (
             "Crops are selected from the highest-delta windows in the comparison diff image, "
             "then applied to the matching Mapbox GL, QGIS, and diff artifacts. "
-            "Comparison metric columns come from the same all-camera comparison summary."
+            "Comparison metric columns come from the same all-camera comparison summary; "
+            "movement columns come from the optional comparison-delta report."
         ),
         "",
-        "| Camera | Comparison status | Artifact status | Changed ratio | Mean delta | RMS delta | Crop status | Crop | Box | Score | Mapbox GL | QGIS render | Diff |",
-        "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | --- | ---: | --- | --- | --- |",
+        _markdown_table_row(headers),
+        _markdown_table_row(alignments),
     ]
 
 
@@ -739,17 +923,43 @@ def _comparison_context_cell(camera: Mapping[str, object], key: str) -> object:
     return value
 
 
-def _summary_crop_row(camera: Mapping[str, object], crop: Mapping[str, object]) -> str:
+def _comparison_delta_context(camera: Mapping[str, object]) -> Mapping[str, object]:
+    comparison_delta = camera.get("comparison_delta")
+    return comparison_delta if isinstance(comparison_delta, Mapping) else {}
+
+
+def _comparison_delta_context_cell(camera: Mapping[str, object], key: str) -> object:
+    value = _comparison_delta_context(camera).get(key)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"{float(value):+.9f}"
+    return value
+
+
+def _summary_crop_row(
+    camera: Mapping[str, object],
+    crop: Mapping[str, object],
+    *,
+    include_comparison_delta: bool,
+) -> str:
     outputs = crop.get("outputs")
     output_paths = outputs if isinstance(outputs, Mapping) else {}
-    return _markdown_table_row(
+    cells = [
+        camera.get("camera"),
+        _comparison_context_cell(camera, "status"),
+        _comparison_context_cell(camera, "artifact_status"),
+        _comparison_context_cell(camera, "changed_pixel_ratio"),
+        _comparison_context_cell(camera, "normalized_mean_absolute_channel_delta"),
+        _comparison_context_cell(camera, "normalized_rms_channel_delta"),
+    ]
+    if include_comparison_delta:
+        cells.extend(
+            [
+                _comparison_delta_context_cell(camera, "mean_delta"),
+                _comparison_delta_context_cell(camera, "rms_delta"),
+            ]
+        )
+    cells.extend(
         [
-            camera.get("camera"),
-            _comparison_context_cell(camera, "status"),
-            _comparison_context_cell(camera, "artifact_status"),
-            _comparison_context_cell(camera, "changed_pixel_ratio"),
-            _comparison_context_cell(camera, "normalized_mean_absolute_channel_delta"),
-            _comparison_context_cell(camera, "normalized_rms_channel_delta"),
             camera.get("status"),
             crop.get("index"),
             crop.get("box"),
@@ -759,32 +969,45 @@ def _summary_crop_row(camera: Mapping[str, object], crop: Mapping[str, object]) 
             f"`{output_paths.get('diff')}`",
         ]
     )
+    return _markdown_table_row(cells)
 
 
-def _summary_camera_rows(camera: Mapping[str, object]) -> list[str]:
+def _summary_camera_rows(
+    camera: Mapping[str, object],
+    *,
+    include_comparison_delta: bool,
+) -> list[str]:
     crops = camera.get("crops")
     crop_rows = crops if isinstance(crops, list) else []
     if not crop_rows:
-        return [
-            _markdown_table_row(
+        cells = [
+            camera.get("camera"),
+            _comparison_context_cell(camera, "status"),
+            _comparison_context_cell(camera, "artifact_status"),
+            _comparison_context_cell(camera, "changed_pixel_ratio"),
+            _comparison_context_cell(camera, "normalized_mean_absolute_channel_delta"),
+            _comparison_context_cell(camera, "normalized_rms_channel_delta"),
+        ]
+        if include_comparison_delta:
+            cells.extend(
                 [
-                    camera.get("camera"),
-                    _comparison_context_cell(camera, "status"),
-                    _comparison_context_cell(camera, "artifact_status"),
-                    _comparison_context_cell(camera, "changed_pixel_ratio"),
-                    _comparison_context_cell(camera, "normalized_mean_absolute_channel_delta"),
-                    _comparison_context_cell(camera, "normalized_rms_channel_delta"),
-                    camera.get("status"),
-                    "-",
-                    "-",
-                    "-",
-                    "-",
-                    "-",
-                    "-",
+                    _comparison_delta_context_cell(camera, "mean_delta"),
+                    _comparison_delta_context_cell(camera, "rms_delta"),
                 ]
             )
+        cells.extend([camera.get("status"), "-", "-", "-", "-", "-", "-"])
+        return [
+            _markdown_table_row(cells)
         ]
-    return [_summary_crop_row(camera, crop) for crop in crop_rows if isinstance(crop, Mapping)]
+    return [
+        _summary_crop_row(
+            camera,
+            crop,
+            include_comparison_delta=include_comparison_delta,
+        )
+        for crop in crop_rows
+        if isinstance(crop, Mapping)
+    ]
 
 
 def _candidate_backed_focus_summaries(
@@ -855,11 +1078,17 @@ def _summary_focus_cue_lines(report: Mapping[str, object]) -> list[str]:
 
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines = _summary_header_lines(report)
-    lines.extend(_summary_table_intro_lines())
+    include_comparison_delta = _include_comparison_delta_columns(report)
+    lines.extend(_summary_table_intro_lines(report))
     for camera in report.get("cameras", []):
         if not isinstance(camera, Mapping):
             continue
-        lines.extend(_summary_camera_rows(camera))
+        lines.extend(
+            _summary_camera_rows(
+                camera,
+                include_comparison_delta=include_comparison_delta,
+            )
+        )
     lines.extend(_summary_focus_cue_lines(report))
     return "\n".join(lines) + "\n"
 
@@ -900,6 +1129,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--path-pedestrian-focus-json",
         type=Path,
         help="Optional path-pedestrian-focus.json to annotate visual crops with per-camera stroke cues.",
+    )
+    parser.add_argument(
+        "--comparison-delta-json",
+        type=Path,
+        help="Optional comparison-delta.json to annotate crops with per-camera metric movements.",
     )
     parser.add_argument(
         "--camera",
@@ -961,6 +1195,13 @@ def main(argv: list[str] | None = None) -> int:
             args.path_pedestrian_focus_json,
             label="Path/pedestrian focus JSON",
         )
+    comparison_delta_report = None
+    if args.comparison_delta_json is not None:
+        comparison_delta_report = _load_cli_json_object(
+            parser,
+            args.comparison_delta_json,
+            label="Comparison delta JSON",
+        )
     paths = build_visual_crop_paths(build_run_directory())
     try:
         report = generate_visual_crop_report(
@@ -974,6 +1215,13 @@ def main(argv: list[str] | None = None) -> int:
             crop_size=args.crop_size,
             crops_per_camera=args.crops_per_camera,
         )
+        if comparison_delta_report is not None and args.comparison_delta_json is not None:
+            report = annotate_visual_crop_report_with_comparison_delta(
+                report,
+                comparison_summary_path=args.comparison_summary_json,
+                comparison_delta_report=comparison_delta_report,
+                comparison_delta_report_path=args.comparison_delta_json,
+            )
     except (OSError, RuntimeError, ValueError) as error:
         parser.error(str(error))
     write_report(report, paths)


### PR DESCRIPTION
## Summary

- lets visual crop reports accept a matching `comparison-delta.json` and annotate crop rows with per-camera mean/RMS movement
- suppresses movement annotations when the delta report candidate summary does not match the crop report input, avoiding stale probe context
- documents the new crop/delta workflow for #949 probe review

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- generated `debug/mapbox-outdoors-visual-crops/20260521T100352Z/summary.md` from the post-#1271 comparison summary, focus report, and thresholded comparison-delta report

Refs #949.

