### PR TITLE
Keep empty style audit focus sections

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -655,6 +655,46 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("unknown-layer (landcover/fill)", markdown)
             self.assertNotIn("None (", markdown)
 
+    def test_generate_visual_crop_report_keeps_zero_candidate_style_audit_sections(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            style_audit_report = _style_audit_report()
+            summary = style_audit_report["summary"]
+            summary["airport_special_landuse_candidates"] = []
+            summary["airport_special_landuse_candidates_by_source_layer"] = []
+            summary["airport_special_landuse_candidates_by_type"] = []
+            summary["airport_special_landuse_simplified_by_property"] = []
+            summary["airport_special_landuse_qgis_dependent_by_property"] = []
+            style_audit_path = root / "style-audit" / "audit.json"
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                annotation_inputs=VisualCropAnnotationInputs(
+                    style_audit_report=style_audit_report,
+                    style_audit_report_path=style_audit_path,
+                ),
+                crop_size=(4, 4),
+                crops_per_camera=1,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+
+            focus = report["style_audit_area_fill_focus"]
+            self.assertEqual(
+                [row["key"] for row in focus],
+                ["terrain_landcover", "airport_special_landuse"],
+            )
+            self.assertEqual(focus[1]["candidate_count"], 0)
+            self.assertEqual(focus[1]["sample_candidates"], [])
+            markdown = build_summary_markdown(report)
+            self.assertIn("| Airport/special landuse | 0 | - | - | - | - | - |", markdown)
+
     def test_generate_visual_crop_report_attaches_matching_comparison_delta_context(self):
         image_module, image_stat_module = _fake_image_modules()
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -429,11 +429,14 @@ def _style_audit_summary(style_audit_report: Mapping[str, object] | None) -> Map
     return summary if isinstance(summary, Mapping) else {}
 
 
-def _style_audit_rows(summary: Mapping[str, object], key: object) -> list[Mapping[str, object]]:
-    rows = summary.get(str(key))
+def _style_audit_mapping_rows(rows: object) -> list[Mapping[str, object]]:
     if not isinstance(rows, list):
         return []
     return [row for row in rows if isinstance(row, Mapping)]
+
+
+def _style_audit_rows(summary: Mapping[str, object], key: object) -> list[Mapping[str, object]]:
+    return _style_audit_mapping_rows(summary.get(str(key)))
 
 
 def _style_audit_candidate_sample(
@@ -475,9 +478,10 @@ def _style_audit_area_fill_focus(
         return []
     focus_rows: list[dict[str, object]] = []
     for section in STYLE_AUDIT_AREA_FILL_SECTIONS:
-        candidates = _style_audit_rows(summary, section["candidates"])
-        if not candidates:
+        candidate_rows = summary.get(str(section["candidates"]))
+        if not isinstance(candidate_rows, list):
             continue
+        candidates = _style_audit_mapping_rows(candidate_rows)
         focus_rows.append(
             {
                 "key": section["key"],


### PR DESCRIPTION
## Summary
- keep style-audit area-fill rows when a valid audit section has zero candidates
- continue omitting genuinely missing/non-list section data
- add regression coverage for the zero-candidate airport/special-landuse row and markdown output

Addresses Codex feedback on #1277: https://github.com/ebelo/qfit/pull/1277#discussion_r3280519784

## Tests
- python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short