### PR TITLE
Show area-fill sample control details

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -652,6 +652,11 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("Terrain/landcover", markdown)
             self.assertIn("landcover=1", markdown)
             self.assertIn("landuse-other-z10-plus-airport", markdown)
+            self.assertIn(
+                "landcover (landcover/fill; controls=filter, paint.fill-color, "
+                "paint.fill-opacity; qfit=paint.fill-color, paint.fill-opacity; qgis=filter)",
+                markdown,
+            )
             self.assertIn("unknown-layer (landcover/fill)", markdown)
             self.assertNotIn("None (", markdown)
 

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1275,6 +1275,12 @@ def _candidate_sample_label(candidate: Mapping[str, object]) -> str:
         details.append(f"{source_layer}/{layer_type}")
     if controls:
         details.append(f"controls={', '.join(controls[:4])}")
+    qfit_simplified = _string_values(candidate.get("qfit_simplified_properties"))
+    if qfit_simplified:
+        details.append(f"qfit={', '.join(qfit_simplified[:4])}")
+    qgis_dependent = _string_values(candidate.get("qgis_dependent_properties"))
+    if qgis_dependent:
+        details.append(f"qgis={', '.join(qgis_dependent[:4])}")
     detail_suffix = f" ({'; '.join(details)})" if details else ""
     return f"{layer}{detail_suffix}"
 


### PR DESCRIPTION
## Summary
- show per-sample qfit-simplified and QGIS-dependent controls in the style-audit area-fill crop-report samples
- keep the existing aggregate source/type/control summaries unchanged
- add regression coverage for the markdown sample labels

This keeps the #949 area-fill crop report useful for choosing between terrain/landcover/contour and airport/landuse follow-up slices without reopening the full style audit.

## Validation
- python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- git diff --check
- regenerated local crop report: debug/mapbox-outdoors-visual-crops/20260521T110634Z/summary.md
