### PR TITLE
Sample representative area-fill candidates

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -700,6 +700,63 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             markdown = build_summary_markdown(report)
             self.assertIn("| Airport/special landuse | 0 | - | - | - | - | - |", markdown)
 
+    def test_generate_visual_crop_report_samples_representative_area_fill_candidates(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            style_audit_report = _style_audit_report()
+            style_audit_report["summary"]["terrain_landcover_palette_candidates"] = [
+                {"layer": "landcover", "source_layer": "landcover", "type": "fill"},
+                {"layer": "landuse", "source_layer": "landuse", "type": "fill"},
+                {"layer": "national-park", "source_layer": "landuse_overlay", "type": "fill"},
+                {"layer": "wetland", "source_layer": "landuse_overlay", "type": "fill"},
+                {
+                    "layer": "wetland-pattern",
+                    "source_layer": "landuse_overlay",
+                    "type": "fill",
+                    "qgis_dependent_control_properties": ["filter", "paint.fill-pattern"],
+                },
+                {"layer": "contour-line", "source_layer": "contour", "type": "line"},
+                {
+                    "layer": "national-park_tint-band",
+                    "source_layer": "landuse_overlay",
+                    "type": "line",
+                },
+                {"layer": "pitch-outline", "source_layer": "landuse", "type": "line"},
+            ]
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                annotation_inputs=VisualCropAnnotationInputs(
+                    style_audit_report=style_audit_report,
+                    style_audit_report_path=root / "style-audit" / "audit.json",
+                ),
+                crop_size=(4, 4),
+                crops_per_camera=1,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+
+            terrain_samples = report["style_audit_area_fill_focus"][0]["sample_candidates"]
+            self.assertEqual(
+                [sample["layer"] for sample in terrain_samples],
+                [
+                    "landcover",
+                    "landuse",
+                    "wetland-pattern",
+                    "contour-line",
+                    "national-park_tint-band",
+                ],
+            )
+            self.assertNotIn("wetland (", build_summary_markdown(report))
+            self.assertIn("wetland-pattern", build_summary_markdown(report))
+            self.assertIn("contour-line", build_summary_markdown(report))
+
     def test_generate_visual_crop_report_attaches_matching_comparison_delta_context(self):
         image_module, image_stat_module = _fake_image_modules()
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -468,6 +468,54 @@ def _style_audit_candidate_sample(
     return sample
 
 
+def _style_audit_candidate_has_non_filter_qgis_dependency(candidate: Mapping[str, object]) -> bool:
+    return any(
+        property_name != "filter"
+        for property_name in _string_values(candidate.get("qgis_dependent_control_properties"))
+    )
+
+
+def _style_audit_candidate_source_type(candidate: Mapping[str, object]) -> tuple[str, str]:
+    return (
+        str(candidate.get("source_layer") or ""),
+        str(candidate.get("type") or ""),
+    )
+
+
+def _style_audit_sample_candidates(
+    candidates: list[Mapping[str, object]],
+    *,
+    sample_limit: int,
+) -> list[Mapping[str, object]]:
+    if sample_limit <= 0:
+        return []
+
+    selected_indexes: set[int] = set()
+    covered_source_types: set[tuple[str, str]] = set()
+
+    def add_candidate(index: int, candidate: Mapping[str, object]) -> None:
+        if len(selected_indexes) >= sample_limit:
+            return
+        if index in selected_indexes:
+            return
+        selected_indexes.add(index)
+        covered_source_types.add(_style_audit_candidate_source_type(candidate))
+
+    for index, candidate in enumerate(candidates):
+        if _style_audit_candidate_has_non_filter_qgis_dependency(candidate):
+            add_candidate(index, candidate)
+
+    for index, candidate in enumerate(candidates):
+        source_type = _style_audit_candidate_source_type(candidate)
+        if source_type not in covered_source_types:
+            add_candidate(index, candidate)
+
+    for index, candidate in enumerate(candidates):
+        add_candidate(index, candidate)
+
+    return [candidates[index] for index in sorted(selected_indexes)]
+
+
 def _style_audit_area_fill_focus(
     style_audit_report: Mapping[str, object] | None,
     *,
@@ -497,7 +545,10 @@ def _style_audit_area_fill_focus(
                 ),
                 "sample_candidates": [
                     _style_audit_candidate_sample(candidate)
-                    for candidate in candidates[: max(0, sample_limit)]
+                    for candidate in _style_audit_sample_candidates(
+                        candidates,
+                        sample_limit=sample_limit,
+                    )
                 ],
             }
         )


### PR DESCRIPTION
## Summary
- sample style-audit area-fill candidates by unresolved QGIS controls and distinct source/type pairs instead of only taking the first rows
- preserve style order in the final sample labels once representative candidates are selected
- add regression coverage so terrain/landcover samples include contour and wetland-pattern cues that were previously hidden by the sample limit

This keeps #949 visual crop reports focused on the area-fill candidates that matter for the next terrain/landcover/contour versus airport/landuse decision.

## Validation
- python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- git diff --check
- regenerated local crop report: debug/mapbox-outdoors-visual-crops/20260521T112037Z/summary.md
