### PR TITLE
Approximate wetland pattern fill for QGIS

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1458,6 +1458,11 @@ _WETLAND_PATTERN_QGIS_FILL_COLOR = "hsl(194, 38%, 74%)"
 _WETLAND_PATTERN_FILL_OPACITY_EXPRESSIONS = {
     _WETLAND_PATTERN_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 10, 0, 10.5, 1],
 }
+_WETLAND_PATTERN_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("below-z10", None, 10.0),
+    ("z10-to-z10_5", 10.0, 10.5),
+    ("z10_5-plus", 10.5, None),
+)
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID = "road-pedestrian-polygon-pattern"
 _ROAD_PEDESTRIAN_POLYGON_PATTERN = "pedestrian-polygon"
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_FILL_COLOR = "hsl(0, 0%, 96%)"
@@ -4531,13 +4536,14 @@ def _wetland_pattern_fill_opacity_layer_variants(layer: dict[str, object]) -> li
         layer_type="fill",
         paint_property="fill-opacity",
         expressions_by_layer_id=_WETLAND_PATTERN_FILL_OPACITY_EXPRESSIONS,
-        zoom_bands=_WETLAND_FILL_OPACITY_ZOOM_BANDS,
+        zoom_bands=_WETLAND_PATTERN_FILL_OPACITY_ZOOM_BANDS,
     )
     if variants is None:
         fallback_layer = _wetland_pattern_fallback_layer(layer)
         return [fallback_layer] if fallback_layer is not None else None
     for variant in variants:
-        _apply_wetland_pattern_fallback(variant)
+        if not _apply_wetland_pattern_fallback(variant):
+            return None
     return variants
 
 

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1452,6 +1452,12 @@ _WETLAND_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float | None], 
     ("z10-to-z10_5", 10.0, 10.5),
     ("z10_5-plus", 10.5, None),
 )
+_WETLAND_PATTERN_LAYER_ID = "wetland-pattern"
+_WETLAND_PATTERN = "wetland"
+_WETLAND_PATTERN_QGIS_FILL_COLOR = "hsl(194, 38%, 74%)"
+_WETLAND_PATTERN_FILL_OPACITY_EXPRESSIONS = {
+    _WETLAND_PATTERN_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 10, 0, 10.5, 1],
+}
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID = "road-pedestrian-polygon-pattern"
 _ROAD_PEDESTRIAN_POLYGON_PATTERN = "pedestrian-polygon"
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_FILL_COLOR = "hsl(0, 0%, 96%)"
@@ -4518,6 +4524,52 @@ def _split_wetland_fill_opacity_layers_for_qgis(layers: object) -> object:
     return expanded_layers
 
 
+def _wetland_pattern_fill_opacity_layer_variants(layer: dict[str, object]) -> list[dict[str, object]] | None:
+    """Split the audited wetland pattern opacity fade into static QGIS zoom bands."""
+    variants = _zoom_expression_opacity_layer_variants(
+        layer,
+        layer_type="fill",
+        paint_property="fill-opacity",
+        expressions_by_layer_id=_WETLAND_PATTERN_FILL_OPACITY_EXPRESSIONS,
+        zoom_bands=_WETLAND_FILL_OPACITY_ZOOM_BANDS,
+    )
+    if variants is None:
+        fallback_layer = _wetland_pattern_fallback_layer(layer)
+        return [fallback_layer] if fallback_layer is not None else None
+    for variant in variants:
+        _apply_wetland_pattern_fallback(variant)
+    return variants
+
+
+def _wetland_pattern_fallback_layer(layer: dict[str, object]) -> dict[str, object] | None:
+    if layer.get("id") != _WETLAND_PATTERN_LAYER_ID or layer.get("type") != "fill":
+        return None
+    fallback_layer = copy.deepcopy(layer)
+    return fallback_layer if _apply_wetland_pattern_fallback(fallback_layer) else None
+
+
+def _apply_wetland_pattern_fallback(layer: dict[str, object]) -> bool:
+    paint = layer.get("paint")
+    if not isinstance(paint, dict) or paint.get("fill-pattern") != _WETLAND_PATTERN:
+        return False
+    paint.pop("fill-pattern", None)
+    paint.setdefault("fill-color", _WETLAND_PATTERN_QGIS_FILL_COLOR)
+    return True
+
+
+def _split_wetland_pattern_fill_opacity_layers_for_qgis(layers: object) -> object:
+    if not isinstance(layers, list):
+        return layers
+    expanded_layers: list[object] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            expanded_layers.append(layer)
+            continue
+        variants = _wetland_pattern_fill_opacity_layer_variants(layer)
+        expanded_layers.extend(variants if variants is not None else [layer])
+    return expanded_layers
+
+
 def _road_pedestrian_polygon_pattern_fill_opacity_layer_variants(
     layer: dict[str, object],
 ) -> list[dict[str, object]] | None:
@@ -6471,6 +6523,7 @@ def simplify_mapbox_style_expressions(style_definition: dict[str, object]) -> di
     style["layers"] = _split_landuse_class_fill_color_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_national_park_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_wetland_fill_opacity_layers_for_qgis(style.get("layers"))
+    style["layers"] = _split_wetland_pattern_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_road_pedestrian_polygon_pattern_fill_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_rail_track_line_opacity_layers_for_qgis(style.get("layers"))
     style["layers"] = _split_gate_fence_hedge_line_opacity_layers_for_qgis(style.get("layers"))

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3967,6 +3967,17 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertNotIn("fill-pattern", layer["paint"])
         self.assertEqual(layer["paint"]["fill-color"], "hsl(194, 38%, 74%)")
 
+    def test_wetland_pattern_fill_opacity_is_not_split_when_pattern_changes(self):
+        layer = self._wetland_pattern_layer()
+        layer["paint"]["fill-pattern"] = "other-pattern"
+        style = {"layers": [layer]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        self.assertEqual(result["layers"][0]["id"], "wetland-pattern")
+        self.assertEqual(result["layers"][0]["paint"]["fill-pattern"], "other-pattern")
+
     def test_wetland_pattern_helpers_keep_passthrough_inputs(self):
         unchanged_layers = "not-a-layer-list"
         mixed_layers = ["not-a-layer", self._wetland_pattern_layer()]

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3911,6 +3911,77 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[2]["id"], "wetland-z10-to-z10_5")
         self.assertEqual(result[3]["id"], "wetland-z10_5-plus")
 
+    def _wetland_pattern_layer(self, fill_opacity=None):
+        if fill_opacity is None:
+            fill_opacity = ["interpolate", ["linear"], ["zoom"], 10, 0, 10.5, 1]
+        return {
+            "id": "wetland-pattern",
+            "type": "fill",
+            "minzoom": 5,
+            "source-layer": "landuse_overlay",
+            "filter": ["match", ["get", "class"], ["wetland", "wetland_noveg"], True, False],
+            "paint": {
+                "fill-color": "hsl(194, 38%, 74%)",
+                "fill-opacity": fill_opacity,
+                "fill-pattern": "wetland",
+            },
+        }
+
+    def test_wetland_pattern_fill_opacity_splits_to_static_zoom_bands(self):
+        style = {"layers": [self._wetland_pattern_layer()]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 3)
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        low_layer = by_id["wetland-pattern-below-z10"]
+        mid_layer = by_id["wetland-pattern-z10-to-z10_5"]
+        high_layer = by_id["wetland-pattern-z10_5-plus"]
+        self.assertEqual(low_layer["minzoom"], 5)
+        self.assertEqual(low_layer["maxzoom"], 10.0)
+        self.assertEqual(mid_layer["minzoom"], 10.0)
+        self.assertEqual(mid_layer["maxzoom"], 10.5)
+        self.assertEqual(high_layer["minzoom"], 10.5)
+        self.assertNotIn("maxzoom", high_layer)
+        self.assertAlmostEqual(low_layer["paint"]["fill-opacity"], 0.0)
+        self.assertAlmostEqual(mid_layer["paint"]["fill-opacity"], 0.5)
+        self.assertAlmostEqual(high_layer["paint"]["fill-opacity"], 1.0)
+        for layer in result["layers"]:
+            self.assertNotIn("fill-pattern", layer["paint"])
+            self.assertEqual(layer["paint"]["fill-color"], "hsl(194, 38%, 74%)")
+            self.assertEqual(
+                layer["filter"],
+                ["match", ["get", "class"], ["wetland", "wetland_noveg"], True, False],
+            )
+
+    def test_wetland_pattern_fallback_removes_pattern_when_opacity_shape_changes(self):
+        fill_opacity = ["get", "opacity"]
+        style = {"layers": [self._wetland_pattern_layer(fill_opacity=fill_opacity)]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(len(result["layers"]), 1)
+        layer = result["layers"][0]
+        self.assertEqual(layer["id"], "wetland-pattern")
+        self.assertEqual(layer["paint"]["fill-opacity"], fill_opacity)
+        self.assertNotIn("fill-pattern", layer["paint"])
+        self.assertEqual(layer["paint"]["fill-color"], "hsl(194, 38%, 74%)")
+
+    def test_wetland_pattern_helpers_keep_passthrough_inputs(self):
+        unchanged_layers = "not-a-layer-list"
+        mixed_layers = ["not-a-layer", self._wetland_pattern_layer()]
+
+        self.assertIs(
+            mapbox_config._split_wetland_pattern_fill_opacity_layers_for_qgis(unchanged_layers),
+            unchanged_layers,
+        )
+        result = mapbox_config._split_wetland_pattern_fill_opacity_layers_for_qgis(mixed_layers)
+
+        self.assertEqual(result[0], "not-a-layer")
+        self.assertEqual(result[1]["id"], "wetland-pattern-below-z10")
+        self.assertEqual(result[2]["id"], "wetland-pattern-z10-to-z10_5")
+        self.assertEqual(result[3]["id"], "wetland-pattern-z10_5-plus")
+
     def _road_pedestrian_polygon_pattern_layer(self, fill_opacity=None):
         if fill_opacity is None:
             fill_opacity = ["interpolate", ["linear"], ["zoom"], 16, 0, 17, 1]


### PR DESCRIPTION
## Summary

- Split the Mapbox Outdoors `wetland-pattern` fill opacity expression into QGIS-safe static zoom bands.
- Replace the unsupported wetland sprite pattern with the audited fill color fallback while preserving the original wetland filter.
- Add regression coverage for the split, fallback, and passthrough helper behavior.

Refs #949.

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live style audit: `debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260521T115924Z/audit.json` shows no `wetland-pattern` QGIS converter warnings after preprocessing.
- Live comparison: `debug/mapbox-outdoors-comparison-wetland-pattern-fallback/lausanne-lavaux-z10-outdoors/20260521T115924Z/manifest.json`
