### PR TITLE
test: load path focus source style from audit

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -307,6 +307,17 @@ debug/mapbox-outdoors-road-features/all-cameras/<UTC timestamp>/
 
 Use the aggregate table to compare candidate road/path feature counts across the z5-z18 camera matrix before selecting a rendering slice. Per-camera status and error columns keep the batch useful when one camera fails before tile-level diagnostics can be collected.
 
+To connect decoded road/path features with the source Mapbox style, QGIS-preprocessed style, and visual artifacts, build a path/pedestrian focus report from the road diagnostic, the matching comparison summary, and the latest style audit:
+
+```bash
+python3 validation/mapbox_outdoors_path_pedestrian_focus.py \
+  --road-features-json debug/mapbox-outdoors-road-features/all-cameras/<timestamp>/road-features.json \
+  --style-audit-json debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/<timestamp>/audit.json \
+  --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/summary.json
+```
+
+Passing `--style-audit-json` uses the audit's source Mapbox layer records, which keeps source-vs-QGIS stroke and dash cues available without maintaining a separate downloaded style snapshot.
+
 ## PR notes
 
 For rendering-sensitive Mapbox vector-style changes, include a concise validation note such as:

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -1831,6 +1831,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
             input_artifacts={
                 "road_features_json": "debug/roads/road-features.json",
                 "source_style_json": "debug/source/mapbox-outdoors-v12.json",
+                "style_audit_json": "debug/style-audit/audit.json",
                 "comparison_summary_jsons": ["debug/comparison/summary.json"],
                 "comparison_summary_runs": [
                     {
@@ -1852,6 +1853,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         )
         self.assertIn("Road features input: `debug/roads/road-features.json`", markdown)
         self.assertIn("Source style input: `debug/source/mapbox-outdoors-v12.json`", markdown)
+        self.assertIn("Style audit source input: `debug/style-audit/audit.json`", markdown)
         self.assertIn("Comparison summary inputs: `debug/comparison/summary.json`", markdown)
         self.assertIn("Comparison summary runs:", markdown)
         self.assertIn(
@@ -1975,6 +1977,105 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                 ["chamonix-trails-z14-outdoors"],
             )
             self.assertEqual(report["qgis_label_style_camera_count"], 1)
+
+    def test_main_loads_source_style_from_style_audit_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            road_features_path = root / "road-features.json"
+            style_audit_path = root / "style-audit.json"
+            style_path = root / "qgis-preprocessed-style.json"
+            output_root = root / "out"
+            road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
+            style_audit_path.write_text(
+                json.dumps({"layers": _source_style()["layers"]}),
+                encoding="utf-8",
+            )
+            style_path.write_text(json.dumps(_qgis_preprocessed_style()), encoding="utf-8")
+
+            stdout = io.StringIO()
+            with patch(
+                "qfit.validation.mapbox_outdoors_path_pedestrian_focus.DEFAULT_OUTPUT_ROOT",
+                output_root,
+            ), redirect_stdout(stdout):
+                result = main(
+                    [
+                        "--road-features-json",
+                        str(road_features_path),
+                        "--style-audit-json",
+                        str(style_audit_path),
+                        "--qgis-style-json",
+                        f"chamonix-trails-z14-outdoors={style_path}",
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            report_path = Path(stdout.getvalue().strip()).parent / "path-pedestrian-focus.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["source_style_camera_count"], 1)
+            self.assertEqual(report["source_style_input_count"], 1)
+            self.assertEqual(
+                report["input_artifacts"]["style_audit_json"],
+                str(style_audit_path.resolve()),
+            )
+            self.assertIsNone(report["input_artifacts"]["source_style_json"])
+            [camera] = report["cameras"]
+            self.assertEqual(
+                camera["source_path_pedestrian_visible_layer_ids"],
+                ["road-path"],
+            )
+
+    def test_main_rejects_style_audit_with_missing_layers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            road_features_path = root / "road-features.json"
+            style_audit_path = root / "style-audit.json"
+            road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
+            style_audit_path.write_text(json.dumps({"summary": {}}), encoding="utf-8")
+            stderr = io.StringIO()
+
+            with redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+                main(
+                    [
+                        "--road-features-json",
+                        str(road_features_path),
+                        "--style-audit-json",
+                        str(style_audit_path),
+                    ]
+                )
+
+            self.assertEqual(raised.exception.code, 2)
+            self.assertIn("Style audit JSON does not contain source layer records", stderr.getvalue())
+            self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_main_rejects_source_style_and_style_audit_together(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            road_features_path = root / "road-features.json"
+            source_style_path = root / "source-style.json"
+            style_audit_path = root / "style-audit.json"
+            road_features_path.write_text(json.dumps(_road_feature_report()), encoding="utf-8")
+            source_style_path.write_text(json.dumps(_source_style()), encoding="utf-8")
+            style_audit_path.write_text(
+                json.dumps({"layers": _source_style()["layers"]}),
+                encoding="utf-8",
+            )
+            stderr = io.StringIO()
+
+            with redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+                main(
+                    [
+                        "--road-features-json",
+                        str(road_features_path),
+                        "--source-style-json",
+                        str(source_style_path),
+                        "--style-audit-json",
+                        str(style_audit_path),
+                    ]
+                )
+
+            self.assertEqual(raised.exception.code, 2)
+            self.assertIn("Use either --source-style-json or --style-audit-json", stderr.getvalue())
+            self.assertNotIn("Traceback", stderr.getvalue())
 
     def test_main_records_resolved_external_relative_input_path(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -1737,6 +1737,9 @@ def _input_artifact_markdown_lines(report: Mapping[str, object]) -> list[str]:
     source_style_json = input_artifacts.get("source_style_json")
     if isinstance(source_style_json, str) and source_style_json:
         lines.append(f"Source style input: `{source_style_json}`")
+    style_audit_json = input_artifacts.get("style_audit_json")
+    if isinstance(style_audit_json, str) and style_audit_json:
+        lines.append(f"Style audit source input: `{style_audit_json}`")
     comparison_summary_jsons = _string_list(input_artifacts.get("comparison_summary_jsons"))
     if comparison_summary_jsons:
         lines.append(f"Comparison summary inputs: `{', '.join(comparison_summary_jsons)}`")
@@ -2758,6 +2761,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Source Mapbox style JSON used to capture browser reference artifacts.",
     )
     parser.add_argument(
+        "--style-audit-json",
+        type=Path,
+        help=(
+            "Style-audit JSON whose audited source Mapbox layer records should be used "
+            "for source-vs-QGIS path/pedestrian stroke comparisons."
+        ),
+    )
+    parser.add_argument(
         "--qgis-style-json",
         action="append",
         default=[],
@@ -2808,6 +2819,17 @@ def _load_cli_json_list(parser: argparse.ArgumentParser, path: Path, *, label: s
     except ValueError as error:
         parser.error(str(error))
     raise AssertionError(ARGPARSE_EXIT_SENTINEL)
+
+
+def _load_source_style_from_audit(
+    parser: argparse.ArgumentParser,
+    path: Path,
+) -> dict[str, object]:
+    audit_report = _load_cli_json_object(parser, path, label="Style audit JSON")
+    layers = audit_report.get("layers")
+    if not isinstance(layers, list):
+        parser.error(f"Style audit JSON does not contain source layer records: {path}")
+    return {"version": 8, "layers": layers}
 
 
 def _comparison_inputs_from_cli_summary(
@@ -2878,11 +2900,14 @@ def main(argv: list[str] | None = None) -> int:
         args.road_features_json,
         label="Road features JSON",
     )
-    source_style = (
-        _load_cli_json_object(parser, args.source_style_json, label="Source style JSON")
-        if args.source_style_json is not None
-        else None
-    )
+    if args.source_style_json is not None and args.style_audit_json is not None:
+        parser.error("Use either --source-style-json or --style-audit-json, not both.")
+    if args.source_style_json is not None:
+        source_style = _load_cli_json_object(parser, args.source_style_json, label="Source style JSON")
+    elif args.style_audit_json is not None:
+        source_style = _load_source_style_from_audit(parser, args.style_audit_json)
+    else:
+        source_style = None
     qgis_style_paths_by_camera: dict[str, Path] = {}
     qgis_label_style_paths_by_camera: dict[str, Path] = {}
     visual_artifacts_by_camera: dict[str, dict[str, object]] = {}
@@ -2924,6 +2949,11 @@ def main(argv: list[str] | None = None) -> int:
             "source_style_json": (
                 _display_input_path(args.source_style_json)
                 if args.source_style_json is not None
+                else None
+            ),
+            "style_audit_json": (
+                _display_input_path(args.style_audit_json)
+                if args.style_audit_json is not None
                 else None
             ),
             "comparison_summary_jsons": [


### PR DESCRIPTION
## Summary
- let `mapbox_outdoors_path_pedestrian_focus.py` use source Mapbox layer records from an existing style-audit JSON
- record the style-audit source input in the focus report metadata/markdown
- document the #949 path/pedestrian focus workflow using road features + style audit + comparison summary

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

## #949 evidence
- Rebuilt the path/pedestrian focus report with the post-#1282 road features, style audit, and comparison summary: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T122404Z/summary.md`.
- Rebuilt focus-cue-only visual crops from that report: `debug/mapbox-outdoors-visual-crops/20260521T122410Z/summary.md`.
- The corrected focus report matches source style for 4/4 focused cameras and the crop report now surfaces 4 candidate-backed crops across 2 cameras instead of 0 crops.

Fixes part of #949.
