### PR TITLE
test: expose crop style simplification samples

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -156,7 +156,8 @@ python3 validation/mapbox_outdoors_visual_crops.py \
 
 The delta context is shown only when the comparison-delta candidate summary matches the crop report's comparison summary, which keeps stale probe movement from being mixed into a newer visual crop sheet.
 
-When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit so the crop report includes the global terrain/landcover and airport/special-landuse candidate counts and sample layers:
+When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
+The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, sample layers, and compact qfit simplification snippets for sampled controls:
 
 ```bash
 python3 validation/mapbox_outdoors_visual_crops.py \

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -295,6 +295,26 @@ def _style_audit_report():
     return {
         "layers": [
             {
+                "id": "landcover",
+                "qfit_simplifies": [
+                    {
+                        "property": "paint.fill-color",
+                        "from": (
+                            '["match",["get","class"],"wood",'
+                            '"hsla(103,50%,60%,0.8)","hsl(98,48%,67%)"]'
+                        ),
+                        "to": '"hsl(98,48%,67%)"',
+                    },
+                    {
+                        "property": "paint.fill-opacity",
+                        "from": (
+                            '["interpolate",["exponential",1.5],["zoom"],8,0.8,12,0]'
+                        ),
+                        "to": "0.8",
+                    },
+                ],
+            },
+            {
                 "id": "contour",
                 "qgis_converter_warnings": {
                     "by_message": [{"count": 1, "message": "Example contour warning"}],
@@ -651,6 +671,23 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     "zoom_band": "z0-z12",
                     "filter_operator_signature": "all, get, match",
                     "control_properties": ["filter", "paint.fill-color", "paint.fill-opacity"],
+                    "qfit_simplifications": [
+                        {
+                            "property": "paint.fill-color",
+                            "from": (
+                                '["match",["get","class"],"wood",'
+                                '"hsla(103,50%,60%,0.8)","hsl(98,48%,67%)"]'
+                            ),
+                            "to": '"hsl(98,48%,67%)"',
+                        },
+                        {
+                            "property": "paint.fill-opacity",
+                            "from": (
+                                '["interpolate",["exponential",1.5],["zoom"],8,0.8,12,0]'
+                            ),
+                            "to": "0.8",
+                        },
+                    ],
                     "qfit_simplified_properties": ["paint.fill-color", "paint.fill-opacity"],
                     "qgis_dependent_properties": ["filter"],
                 },
@@ -662,7 +699,13 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("landuse-other-z10-plus-airport", markdown)
             self.assertIn(
                 "landcover (landcover/fill; controls=filter, paint.fill-color, "
-                "paint.fill-opacity; qfit=paint.fill-color, paint.fill-opacity; qgis=filter)",
+                "paint.fill-opacity; qfit=paint.fill-color, paint.fill-opacity; "
+                "simplifies=paint.fill-color",
+                markdown,
+            )
+            self.assertIn(
+                'simplifies=paint.fill-color: ["match",["get","class"],"wood",'
+                '"hsla(103,50%,60%,0.8)","hsl(98,48%,67%)"] -> "hsl(98,48%,67%)"',
                 markdown,
             )
             self.assertIn("unknown-layer (landcover/fill)", markdown)

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -312,6 +312,11 @@ def _style_audit_report():
                         ),
                         "to": "0.8",
                     },
+                    {
+                        "property": "layout.visibility",
+                        "from": '"visible"',
+                        "to": '"none"',
+                    },
                 ],
             },
             {
@@ -708,6 +713,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 '"hsla(103,50%,60%,0.8)","hsl(98,48%,67%)"] -> "hsl(98,48%,67%)"',
                 markdown,
             )
+            self.assertIn(r" \| paint.fill-opacity:", markdown)
+            self.assertNotIn("layout.visibility", markdown)
             self.assertIn("unknown-layer (landcover/fill)", markdown)
             self.assertIn("qgis-warnings=Example contour warning", markdown)
             self.assertNotIn("None (", markdown)

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -444,34 +444,34 @@ def _style_audit_rows(summary: Mapping[str, object], key: object) -> list[Mappin
 def _style_audit_qgis_converter_warnings_by_layer(
     style_audit_report: Mapping[str, object],
 ) -> dict[str, Mapping[str, object]]:
-    layers = style_audit_report.get("layers")
-    if not isinstance(layers, list):
-        return {}
     warnings_by_layer: dict[str, Mapping[str, object]] = {}
-    for layer in layers:
-        if not isinstance(layer, Mapping):
-            continue
-        layer_id = str(layer.get("id") or "")
+    for layer_id, layer in _style_audit_layer_items(style_audit_report):
         qgis_converter_warnings = layer.get("qgis_converter_warnings")
-        if layer_id and isinstance(qgis_converter_warnings, Mapping):
+        if isinstance(qgis_converter_warnings, Mapping):
             warnings_by_layer[layer_id] = qgis_converter_warnings
     return warnings_by_layer
 
 
-def _style_audit_layers_by_id(
+def _style_audit_layer_items(
     style_audit_report: Mapping[str, object],
-) -> dict[str, Mapping[str, object]]:
+) -> list[tuple[str, Mapping[str, object]]]:
     layers = style_audit_report.get("layers")
     if not isinstance(layers, list):
-        return {}
-    layers_by_id: dict[str, Mapping[str, object]] = {}
+        return []
+    layer_items: list[tuple[str, Mapping[str, object]]] = []
     for layer in layers:
         if not isinstance(layer, Mapping):
             continue
         layer_id = str(layer.get("id") or "")
         if layer_id:
-            layers_by_id[layer_id] = layer
-    return layers_by_id
+            layer_items.append((layer_id, layer))
+    return layer_items
+
+
+def _style_audit_layers_by_id(
+    style_audit_report: Mapping[str, object],
+) -> dict[str, Mapping[str, object]]:
+    return dict(_style_audit_layer_items(style_audit_report))
 
 
 def _compact_style_audit_value(value: object) -> str:
@@ -498,14 +498,10 @@ def _style_audit_ordered_simplification_rows(
     relevant_properties: set[str],
 ) -> list[Mapping[str, object]]:
     if not relevant_properties:
-        return simplifications
-    relevant_rows = [
+        return []
+    return [
         row for row in simplifications if row.get("property") in relevant_properties
     ]
-    other_rows = [
-        row for row in simplifications if row.get("property") not in relevant_properties
-    ]
-    return [*relevant_rows, *other_rows]
 
 
 def _style_audit_simplification_row_sample(row: Mapping[str, object]) -> dict[str, str] | None:
@@ -1494,7 +1490,7 @@ def _candidate_sample_label(candidate: Mapping[str, object]) -> str:
         details.append(f"qfit={', '.join(qfit_simplified[:4])}")
     qfit_simplifications = _candidate_qfit_simplification_labels(candidate)
     if qfit_simplifications:
-        details.append(f"simplifies={'; '.join(qfit_simplifications[:2])}")
+        details.append(f"simplifies={' | '.join(qfit_simplifications[:2])}")
     qgis_dependent = _string_values(candidate.get("qgis_dependent_properties"))
     if qgis_dependent:
         details.append(f"qgis={', '.join(qgis_dependent[:4])}")

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -481,6 +481,45 @@ def _compact_style_audit_value(value: object) -> str:
     return f"{text[: MAX_STYLE_AUDIT_SIMPLIFICATION_VALUE_LENGTH - 3]}..."
 
 
+def _style_audit_simplification_rows(
+    candidate: Mapping[str, object],
+    *,
+    style_audit_layer: Mapping[str, object] | None = None,
+) -> list[Mapping[str, object]]:
+    simplifications = _style_audit_mapping_rows(candidate.get("qfit_simplifies"))
+    if simplifications or style_audit_layer is None:
+        return simplifications
+    return _style_audit_mapping_rows(style_audit_layer.get("qfit_simplifies"))
+
+
+def _style_audit_ordered_simplification_rows(
+    simplifications: list[Mapping[str, object]],
+    *,
+    relevant_properties: set[str],
+) -> list[Mapping[str, object]]:
+    if not relevant_properties:
+        return simplifications
+    relevant_rows = [
+        row for row in simplifications if row.get("property") in relevant_properties
+    ]
+    other_rows = [
+        row for row in simplifications if row.get("property") not in relevant_properties
+    ]
+    return [*relevant_rows, *other_rows]
+
+
+def _style_audit_simplification_row_sample(row: Mapping[str, object]) -> dict[str, str] | None:
+    property_name = str(row.get("property") or "")
+    if not property_name:
+        return None
+    sample = {"property": property_name}
+    for value_key in ("from", "to"):
+        value = row.get(value_key)
+        if _non_empty_focus_value(value):
+            sample[value_key] = _compact_style_audit_value(value)
+    return sample
+
+
 def _style_audit_qfit_simplification_sample(
     candidate: Mapping[str, object],
     *,
@@ -489,47 +528,28 @@ def _style_audit_qfit_simplification_sample(
 ) -> list[dict[str, str]]:
     if sample_limit <= 0:
         return []
-    simplifications = _style_audit_mapping_rows(candidate.get("qfit_simplifies"))
-    if not simplifications and style_audit_layer is not None:
-        simplifications = _style_audit_mapping_rows(style_audit_layer.get("qfit_simplifies"))
-    if not simplifications:
-        return []
-
+    simplifications = _style_audit_simplification_rows(
+        candidate,
+        style_audit_layer=style_audit_layer,
+    )
     relevant_properties = set(_string_values(candidate.get("qfit_simplified_control_properties")))
     selected: list[dict[str, str]] = []
     selected_properties: set[str] = set()
-
-    def add_simplification(row: Mapping[str, object]) -> None:
-        if len(selected) >= sample_limit:
-            return
-        property_name = str(row.get("property") or "")
-        if not property_name or property_name in selected_properties:
-            return
-        selected_properties.add(property_name)
-        sample = {"property": property_name}
-        for value_key in ("from", "to"):
-            value = row.get(value_key)
-            if _non_empty_focus_value(value):
-                sample[value_key] = _compact_style_audit_value(value)
+    for simplification in _style_audit_ordered_simplification_rows(
+        simplifications,
+        relevant_properties=relevant_properties,
+    ):
+        sample = _style_audit_simplification_row_sample(simplification)
+        if sample is None or sample["property"] in selected_properties:
+            continue
+        selected_properties.add(sample["property"])
         selected.append(sample)
-
-    if relevant_properties:
-        for simplification in simplifications:
-            if simplification.get("property") in relevant_properties:
-                add_simplification(simplification)
-
-    for simplification in simplifications:
-        add_simplification(simplification)
-
+        if len(selected) >= sample_limit:
+            break
     return selected
 
 
-def _style_audit_candidate_sample(
-    candidate: Mapping[str, object],
-    *,
-    qgis_converter_warnings_by_layer: Mapping[str, Mapping[str, object]] | None = None,
-    style_audit_layers_by_id: Mapping[str, Mapping[str, object]] | None = None,
-) -> dict[str, object]:
+def _style_audit_candidate_base_sample(candidate: Mapping[str, object]) -> dict[str, object]:
     sample: dict[str, object] = {}
     for key in (
         "layer",
@@ -541,20 +561,49 @@ def _style_audit_candidate_sample(
         value = candidate.get(key)
         if _non_empty_focus_value(value):
             sample[key] = value
+    return sample
+
+
+def _style_audit_candidate_control_properties(candidate: Mapping[str, object]) -> object:
     control_properties = candidate.get("terrain_landcover_palette_control_properties")
-    if not _non_empty_focus_value(control_properties):
-        control_properties = candidate.get("airport_special_landuse_control_properties")
+    if _non_empty_focus_value(control_properties):
+        return control_properties
+    return candidate.get("airport_special_landuse_control_properties")
+
+
+def _style_audit_candidate_layer(
+    candidate: Mapping[str, object],
+    style_audit_layers_by_id: Mapping[str, Mapping[str, object]] | None,
+) -> Mapping[str, object] | None:
+    layer_id = str(candidate.get("layer") or "")
+    if style_audit_layers_by_id is None or not layer_id:
+        return None
+    return style_audit_layers_by_id.get(layer_id)
+
+
+def _style_audit_candidate_qgis_warnings(
+    candidate: Mapping[str, object],
+    qgis_converter_warnings_by_layer: Mapping[str, Mapping[str, object]] | None,
+) -> object:
+    qgis_converter_warnings = candidate.get("qgis_converter_warnings")
+    if isinstance(qgis_converter_warnings, Mapping) or not qgis_converter_warnings_by_layer:
+        return qgis_converter_warnings
+    return qgis_converter_warnings_by_layer.get(str(candidate.get("layer") or ""))
+
+
+def _style_audit_candidate_sample(
+    candidate: Mapping[str, object],
+    *,
+    qgis_converter_warnings_by_layer: Mapping[str, Mapping[str, object]] | None = None,
+    style_audit_layers_by_id: Mapping[str, Mapping[str, object]] | None = None,
+) -> dict[str, object]:
+    sample = _style_audit_candidate_base_sample(candidate)
+    control_properties = _style_audit_candidate_control_properties(candidate)
     if _non_empty_focus_value(control_properties):
         sample["control_properties"] = control_properties
-    layer_id = str(candidate.get("layer") or "")
-    style_audit_layer = (
-        style_audit_layers_by_id.get(layer_id)
-        if style_audit_layers_by_id is not None and layer_id
-        else None
-    )
     qfit_simplifications = _style_audit_qfit_simplification_sample(
         candidate,
-        style_audit_layer=style_audit_layer,
+        style_audit_layer=_style_audit_candidate_layer(candidate, style_audit_layers_by_id),
     )
     if qfit_simplifications:
         sample["qfit_simplifications"] = qfit_simplifications
@@ -565,11 +614,10 @@ def _style_audit_candidate_sample(
         value = candidate.get(source_key)
         if _non_empty_focus_value(value):
             sample[target_key] = value
-    qgis_converter_warnings = candidate.get("qgis_converter_warnings")
-    if not isinstance(qgis_converter_warnings, Mapping) and qgis_converter_warnings_by_layer:
-        qgis_converter_warnings = qgis_converter_warnings_by_layer.get(
-            str(candidate.get("layer") or "")
-        )
+    qgis_converter_warnings = _style_audit_candidate_qgis_warnings(
+        candidate,
+        qgis_converter_warnings_by_layer,
+    )
     if isinstance(qgis_converter_warnings, Mapping):
         sample["qgis_converter_warnings"] = qgis_converter_warnings
     return sample

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -42,6 +42,8 @@ DEFAULT_CROPS_PER_CAMERA = 3
 DEFAULT_FOCUS_DASH_CUE_LIMIT = 2
 DEFAULT_FOCUS_STROKE_CUE_LIMIT = 3
 DEFAULT_STYLE_AUDIT_SAMPLE_LIMIT = 5
+DEFAULT_STYLE_AUDIT_SIMPLIFICATION_LIMIT = 3
+MAX_STYLE_AUDIT_SIMPLIFICATION_VALUE_LENGTH = 96
 MIN_SCORE_FOR_CROP = 1.0
 MAX_OVERLAP_RATIO = 0.35
 CROP_IMAGE_COLUMNS = (
@@ -456,10 +458,77 @@ def _style_audit_qgis_converter_warnings_by_layer(
     return warnings_by_layer
 
 
+def _style_audit_layers_by_id(
+    style_audit_report: Mapping[str, object],
+) -> dict[str, Mapping[str, object]]:
+    layers = style_audit_report.get("layers")
+    if not isinstance(layers, list):
+        return {}
+    layers_by_id: dict[str, Mapping[str, object]] = {}
+    for layer in layers:
+        if not isinstance(layer, Mapping):
+            continue
+        layer_id = str(layer.get("id") or "")
+        if layer_id:
+            layers_by_id[layer_id] = layer
+    return layers_by_id
+
+
+def _compact_style_audit_value(value: object) -> str:
+    text = str(value)
+    if len(text) <= MAX_STYLE_AUDIT_SIMPLIFICATION_VALUE_LENGTH:
+        return text
+    return f"{text[: MAX_STYLE_AUDIT_SIMPLIFICATION_VALUE_LENGTH - 3]}..."
+
+
+def _style_audit_qfit_simplification_sample(
+    candidate: Mapping[str, object],
+    *,
+    style_audit_layer: Mapping[str, object] | None = None,
+    sample_limit: int = DEFAULT_STYLE_AUDIT_SIMPLIFICATION_LIMIT,
+) -> list[dict[str, str]]:
+    if sample_limit <= 0:
+        return []
+    simplifications = _style_audit_mapping_rows(candidate.get("qfit_simplifies"))
+    if not simplifications and style_audit_layer is not None:
+        simplifications = _style_audit_mapping_rows(style_audit_layer.get("qfit_simplifies"))
+    if not simplifications:
+        return []
+
+    relevant_properties = set(_string_values(candidate.get("qfit_simplified_control_properties")))
+    selected: list[dict[str, str]] = []
+    selected_properties: set[str] = set()
+
+    def add_simplification(row: Mapping[str, object]) -> None:
+        if len(selected) >= sample_limit:
+            return
+        property_name = str(row.get("property") or "")
+        if not property_name or property_name in selected_properties:
+            return
+        selected_properties.add(property_name)
+        sample = {"property": property_name}
+        for value_key in ("from", "to"):
+            value = row.get(value_key)
+            if _non_empty_focus_value(value):
+                sample[value_key] = _compact_style_audit_value(value)
+        selected.append(sample)
+
+    if relevant_properties:
+        for simplification in simplifications:
+            if simplification.get("property") in relevant_properties:
+                add_simplification(simplification)
+
+    for simplification in simplifications:
+        add_simplification(simplification)
+
+    return selected
+
+
 def _style_audit_candidate_sample(
     candidate: Mapping[str, object],
     *,
     qgis_converter_warnings_by_layer: Mapping[str, Mapping[str, object]] | None = None,
+    style_audit_layers_by_id: Mapping[str, Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     sample: dict[str, object] = {}
     for key in (
@@ -477,6 +546,18 @@ def _style_audit_candidate_sample(
         control_properties = candidate.get("airport_special_landuse_control_properties")
     if _non_empty_focus_value(control_properties):
         sample["control_properties"] = control_properties
+    layer_id = str(candidate.get("layer") or "")
+    style_audit_layer = (
+        style_audit_layers_by_id.get(layer_id)
+        if style_audit_layers_by_id is not None and layer_id
+        else None
+    )
+    qfit_simplifications = _style_audit_qfit_simplification_sample(
+        candidate,
+        style_audit_layer=style_audit_layer,
+    )
+    if qfit_simplifications:
+        sample["qfit_simplifications"] = qfit_simplifications
     for source_key, target_key in (
         ("qfit_simplified_control_properties", "qfit_simplified_properties"),
         ("qgis_dependent_control_properties", "qgis_dependent_properties"),
@@ -553,6 +634,7 @@ def _style_audit_area_fill_focus(
     qgis_converter_warnings_by_layer = _style_audit_qgis_converter_warnings_by_layer(
         style_audit_report
     )
+    style_audit_layers_by_id = _style_audit_layers_by_id(style_audit_report)
     focus_rows: list[dict[str, object]] = []
     for section in STYLE_AUDIT_AREA_FILL_SECTIONS:
         candidate_rows = summary.get(str(section["candidates"]))
@@ -576,6 +658,7 @@ def _style_audit_area_fill_focus(
                     _style_audit_candidate_sample(
                         candidate,
                         qgis_converter_warnings_by_layer=qgis_converter_warnings_by_layer,
+                        style_audit_layers_by_id=style_audit_layers_by_id,
                     )
                     for candidate in _style_audit_sample_candidates(
                         candidates,
@@ -1361,6 +1444,9 @@ def _candidate_sample_label(candidate: Mapping[str, object]) -> str:
     qfit_simplified = _string_values(candidate.get("qfit_simplified_properties"))
     if qfit_simplified:
         details.append(f"qfit={', '.join(qfit_simplified[:4])}")
+    qfit_simplifications = _candidate_qfit_simplification_labels(candidate)
+    if qfit_simplifications:
+        details.append(f"simplifies={'; '.join(qfit_simplifications[:2])}")
     qgis_dependent = _string_values(candidate.get("qgis_dependent_properties"))
     if qgis_dependent:
         details.append(f"qgis={', '.join(qgis_dependent[:4])}")
@@ -1369,6 +1455,26 @@ def _candidate_sample_label(candidate: Mapping[str, object]) -> str:
         details.append(f"qgis-warnings={', '.join(qgis_warnings[:2])}")
     detail_suffix = f" ({'; '.join(details)})" if details else ""
     return f"{layer}{detail_suffix}"
+
+
+def _candidate_qfit_simplification_labels(candidate: Mapping[str, object]) -> list[str]:
+    simplifications = candidate.get("qfit_simplifications")
+    if not isinstance(simplifications, list):
+        return []
+    labels = []
+    for row in simplifications:
+        if not isinstance(row, Mapping):
+            continue
+        property_name = row.get("property")
+        if property_name in (None, ""):
+            continue
+        if row.get("from") not in (None, "") and row.get("to") not in (None, ""):
+            labels.append(f"{property_name}: {row.get('from')} -> {row.get('to')}")
+        elif row.get("to") not in (None, ""):
+            labels.append(f"{property_name}: -> {row.get('to')}")
+        else:
+            labels.append(str(property_name))
+    return labels
 
 
 def _candidate_qgis_converter_warning_labels(


### PR DESCRIPTION
## Summary
- include compact qfit simplification snippets in visual crop style-audit sample labels
- reuse full layer audit records so terrain/landcover samples show the source-to-QGIS values behind sampled controls
- document the enriched `--style-audit-json` crop-report context

## #949 evidence
- Generated a Chamonix-only terrain crop report with the new annotations: `debug/mapbox-outdoors-visual-crops/20260521T125112Z/summary.md`
- The report now surfaces examples such as `hillshade` collapsing `paint.fill-color` to `hsla(66, 38%, 17%, 0.08)` and `landcover`/`landuse` opacity/color simplifications beside the crop sheet.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Closes no issue; continues #949.
