### PR TITLE
test: show visual crop color metrics

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -156,6 +156,8 @@ python3 validation/mapbox_outdoors_visual_crops.py \
 
 The delta context is shown only when the comparison-delta candidate summary matches the crop report's comparison summary, which keeps stale probe movement from being mixed into a newer visual crop sheet.
 
+Every crop report also includes a crop color metrics section with crop-local mean RGB values for the Mapbox GL and QGIS crops, plus QGIS-minus-Mapbox RGB and luminance deltas. Use these numbers as triage context when broad terrain, landcover, water, or tint differences dominate the hotspot sheet.
+
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
 The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, sample layers, and compact qfit simplification snippets for sampled controls:
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -12,6 +12,8 @@ from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_visual_crops import (
     VisualCropAnnotationInputs,
+    _crop_color_metric,
+    _three_channel_color_values,
     annotate_visual_crop_report_with_comparison_delta,
     build_run_directory,
     build_summary_markdown,
@@ -98,6 +100,20 @@ class _FakeImageStatModule:
             self.sum = [image.brightness_sum()]
             pixel_count = max(1, image.width * image.height)
             self.mean = [self.sum[0] / pixel_count]
+
+
+class _EmptyColorStatModule:
+    class Stat:
+        def __init__(self, _image):
+            self.mean = []
+
+
+class _TwoChannelColorSumStatModule:
+    class Stat:
+        def __init__(self, image):
+            pixel_count = max(1, image.width * image.height)
+            self.mean = []
+            self.sum = [10.0 * pixel_count, 20.0 * pixel_count]
 
 
 def _fake_image_modules():
@@ -427,6 +443,42 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
 
         with self.assertRaises(argparse.ArgumentTypeError):
             parse_crop_size("320-by-240")
+
+    def test_three_channel_color_values_handles_short_stat_outputs(self):
+        self.assertEqual(_three_channel_color_values([]), [0.0, 0.0, 0.0])
+        self.assertEqual(_three_channel_color_values([5]), [5.0, 5.0, 5.0])
+        self.assertEqual(_three_channel_color_values([5, 6]), [5.0, 6.0, 0.0])
+        self.assertEqual(_three_channel_color_values([5, 6, 7, 8]), [5.0, 6.0, 7.0])
+
+    def test_crop_color_metric_handles_empty_stat_outputs(self):
+        image_module = _FakeImageModule()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_path = Path(tmpdir) / "crop.png"
+            _save_rgb_image(image_path, image_module, (5, 5, 5))
+
+            metric = _crop_color_metric(
+                image_path=image_path,
+                image_module=image_module,
+                image_stat_module=_EmptyColorStatModule,
+            )
+
+        self.assertEqual(metric["mean_rgb"], [0.0, 0.0, 0.0])
+        self.assertEqual(metric["luminance"], 0.0)
+
+    def test_crop_color_metric_pads_two_channel_fallback_stats(self):
+        image_module = _FakeImageModule()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_path = Path(tmpdir) / "crop.png"
+            _save_rgb_image(image_path, image_module, (5, 5, 5))
+
+            metric = _crop_color_metric(
+                image_path=image_path,
+                image_module=image_module,
+                image_stat_module=_TwoChannelColorSumStatModule,
+            )
+
+        self.assertEqual(metric["mean_rgb"], [10.0, 20.0, 0.0])
+        self.assertEqual(metric["luminance"], 16.43)
 
     def test_find_hotspot_crop_boxes_prefers_bright_non_overlapping_regions(self):
         image_module, image_stat_module = _fake_image_modules()

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -96,6 +96,8 @@ class _FakeImageStatModule:
     class Stat:
         def __init__(self, image):
             self.sum = [image.brightness_sum()]
+            pixel_count = max(1, image.width * image.height)
+            self.mean = [self.sum[0] / pixel_count]
 
 
 def _fake_image_modules():
@@ -531,6 +533,23 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             outputs = crop["outputs"]
             for path_text in outputs.values():
                 self.assertTrue((Path.cwd() / path_text).exists())
+            self.assertEqual(
+                crop["color_metrics"],
+                {
+                    "browser_reference": {
+                        "mean_rgb": [255.0, 255.0, 255.0],
+                        "luminance": 255.0,
+                    },
+                    "qgis_vector_render": {
+                        "mean_rgb": [128.0, 128.0, 128.0],
+                        "luminance": 128.0,
+                    },
+                    "delta": {
+                        "mean_rgb": [-127.0, -127.0, -127.0],
+                        "luminance": -127.0,
+                    },
+                },
+            )
             self.assertEqual(report["crop_count"], 1)
             self.assertTrue(paths.contact_sheet_path.exists())
             self.assertTrue(paths.json_path.exists())
@@ -548,6 +567,9 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     "status": "passed",
                 },
             )
+            summary = paths.summary_path.read_text(encoding="utf-8")
+            self.assertIn("## Crop color metrics", summary)
+            self.assertIn("| chamonix-trails-z14-outdoors | 1 | 255.0, 255.0, 255.0 | 128.0, 128.0, 128.0 | -127.0, -127.0, -127.0 | -127.0 |", summary)
 
     def test_generate_visual_crop_report_marks_missing_required_artifacts(self):
         image_module, image_stat_module = _fake_image_modules()

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -51,6 +51,7 @@ CROP_IMAGE_COLUMNS = (
     ("qgis_vector_render", "QGIS"),
     ("diff", "Diff"),
 )
+CROP_COLOR_METRIC_KEYS = ("browser_reference", "qgis_vector_render")
 COMPARISON_CONTEXT_KEYS = (
     "status",
     "artifact_status",
@@ -265,6 +266,77 @@ def _write_crop_triplet(
 
 def _display_crop_outputs(outputs: Mapping[str, Path]) -> dict[str, str]:
     return {key: _display_input_path(path) for key, path in outputs.items()}
+
+
+def _crop_color_metric(
+    *,
+    image_path: Path,
+    image_module: Any,
+    image_stat_module: Any,
+) -> dict[str, object]:
+    with image_module.open(image_path) as image:
+        rgb_image = image.convert("RGB")
+        try:
+            stat = image_stat_module.Stat(rgb_image)
+            mean_values = list(getattr(stat, "mean", []))
+            if not mean_values:
+                pixel_count = max(1, rgb_image.width * rgb_image.height)
+                mean_values = [value / pixel_count for value in stat.sum]
+            if len(mean_values) == 1:
+                mean_values = [mean_values[0], mean_values[0], mean_values[0]]
+            mean_rgb = [round(float(value), 3) for value in mean_values[:3]]
+            luminance = round(
+                (0.2126 * mean_rgb[0]) + (0.7152 * mean_rgb[1]) + (0.0722 * mean_rgb[2]),
+                3,
+            )
+            return {"mean_rgb": mean_rgb, "luminance": luminance}
+        finally:
+            if rgb_image is not image:
+                rgb_image.close()
+
+
+def _crop_color_delta(
+    browser: Mapping[str, object],
+    qgis: Mapping[str, object],
+) -> dict[str, object] | None:
+    browser_rgb = browser.get("mean_rgb")
+    qgis_rgb = qgis.get("mean_rgb")
+    if not isinstance(browser_rgb, list) or not isinstance(qgis_rgb, list):
+        return None
+    return {
+        "mean_rgb": [
+            round(float(qgis_value) - float(browser_value), 3)
+            for browser_value, qgis_value in zip(browser_rgb[:3], qgis_rgb[:3])
+        ],
+        "luminance": round(
+            float(qgis.get("luminance", 0.0)) - float(browser.get("luminance", 0.0)),
+            3,
+        ),
+    }
+
+
+def _crop_color_metrics(
+    *,
+    outputs: Mapping[str, Path],
+    image_module: Any,
+    image_stat_module: Any,
+) -> dict[str, object]:
+    metrics = {
+        key: _crop_color_metric(
+            image_path=outputs[key],
+            image_module=image_module,
+            image_stat_module=image_stat_module,
+        )
+        for key in CROP_COLOR_METRIC_KEYS
+        if key in outputs
+    }
+    browser = metrics.get("browser_reference")
+    qgis = metrics.get("qgis_vector_render")
+    if isinstance(browser, Mapping) and isinstance(qgis, Mapping):
+        delta = _crop_color_delta(browser, qgis)
+        if delta is not None:
+            metrics["delta"] = delta
+    return metrics
 
 
 def _contact_sheet_outputs(outputs: Mapping[str, Path]) -> dict[str, str]:
@@ -927,12 +999,18 @@ def _hotspot_crop_rows(
             run_dir=paths.run_dir,
             image_module=image_module,
         )
+        color_metrics = _crop_color_metrics(
+            outputs=outputs,
+            image_module=image_module,
+            image_stat_module=image_stat_module,
+        )
         crops.append(
             {
                 "index": crop_index,
                 "box": list(box),
                 "score": crop["score"],
                 "outputs": _display_crop_outputs(outputs),
+                "color_metrics": color_metrics,
             }
         )
         contact_sheet_entries.append(
@@ -1384,6 +1462,76 @@ def _summary_camera_rows(
     ]
 
 
+def _color_metric_label(metrics: object, key: str) -> str:
+    if not isinstance(metrics, Mapping):
+        return "-"
+    values = metrics.get(key)
+    if not isinstance(values, list):
+        return "-"
+    return ", ".join(f"{float(value):.1f}" for value in values[:3])
+
+
+def _luminance_metric_label(metrics: object) -> str:
+    if not isinstance(metrics, Mapping):
+        return "-"
+    value = metrics.get("luminance")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "-"
+    return f"{float(value):+.1f}"
+
+
+def _summary_crop_color_metric_rows(report: Mapping[str, object]) -> list[list[object]]:
+    rows: list[list[object]] = []
+    cameras = report.get("cameras")
+    if not isinstance(cameras, list):
+        return rows
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        crops = camera.get("crops")
+        if not isinstance(crops, list):
+            continue
+        for crop in crops:
+            if not isinstance(crop, Mapping):
+                continue
+            metrics = crop.get("color_metrics")
+            if not isinstance(metrics, Mapping):
+                continue
+            delta = metrics.get("delta")
+            rows.append(
+                [
+                    camera.get("camera"),
+                    crop.get("index"),
+                    _color_metric_label(metrics.get("browser_reference"), "mean_rgb"),
+                    _color_metric_label(metrics.get("qgis_vector_render"), "mean_rgb"),
+                    _color_metric_label(delta, "mean_rgb"),
+                    _luminance_metric_label(delta),
+                ]
+            )
+    return rows
+
+
+def _summary_crop_color_metric_lines(report: Mapping[str, object]) -> list[str]:
+    rows = _summary_crop_color_metric_rows(report)
+    if not rows:
+        return []
+    lines = [
+        "",
+        "## Crop color metrics",
+        "",
+        (
+            "Shows crop-local mean RGB values for the Mapbox GL and QGIS crops, plus "
+            "QGIS minus Mapbox deltas. Use this as triage context for broad terrain, "
+            "landcover, water, and tint differences."
+        ),
+        "",
+        "| Camera | Crop | Mapbox mean RGB | QGIS mean RGB | QGIS-Mapbox RGB | QGIS-Mapbox luminance |",
+        "| --- | ---: | --- | --- | --- | ---: |",
+    ]
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
+
+
 def _candidate_backed_focus_summaries(
     focus: Mapping[str, object],
     cue_key: str,
@@ -1617,6 +1765,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
                 include_comparison_delta=include_comparison_delta,
             )
         )
+    lines.extend(_summary_crop_color_metric_lines(report))
     lines.extend(_style_audit_area_fill_focus_lines(report))
     lines.extend(_summary_focus_cue_lines(report))
     return "\n".join(lines) + "\n"

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -281,9 +281,8 @@ def _crop_color_metric(
             mean_values = list(getattr(stat, "mean", []))
             if not mean_values:
                 pixel_count = max(1, rgb_image.width * rgb_image.height)
-                mean_values = [value / pixel_count for value in stat.sum]
-            if len(mean_values) == 1:
-                mean_values = [mean_values[0], mean_values[0], mean_values[0]]
+                mean_values = [value / pixel_count for value in getattr(stat, "sum", [])]
+            mean_values = _three_channel_color_values(mean_values)
             mean_rgb = [round(float(value), 3) for value in mean_values[:3]]
             luminance = round(
                 (0.2126 * mean_rgb[0]) + (0.7152 * mean_rgb[1]) + (0.0722 * mean_rgb[2]),
@@ -293,6 +292,21 @@ def _crop_color_metric(
         finally:
             if rgb_image is not image:
                 rgb_image.close()
+
+
+def _three_channel_color_values(values: Sequence[object]) -> list[float]:
+    numeric_values = [
+        float(value)
+        for value in values
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    ]
+    if not numeric_values:
+        return [0.0, 0.0, 0.0]
+    if len(numeric_values) == 1:
+        return [numeric_values[0], numeric_values[0], numeric_values[0]]
+    if len(numeric_values) == 2:
+        return [numeric_values[0], numeric_values[1], 0.0]
+    return numeric_values[:3]
 
 
 def _crop_color_delta(


### PR DESCRIPTION
## Summary

- Add crop-local color metrics to Mapbox Outdoors visual crop reports: Mapbox GL mean RGB, QGIS mean RGB, QGIS-minus-Mapbox RGB, and luminance delta.
- Include the color metrics in both JSON and Markdown reports so terrain/landcover/water tint probes can be triaged from the crop sheet without another ad hoc script.
- Document the new section in the comparison harness notes.

## Evidence

- Generated a Chamonix terrain crop report with the new metrics:
  `debug/mapbox-outdoors-visual-crops/20260521T131954Z/summary.md`
- The report shows the current Chamonix crops have small but measurable crop-local color shifts, for example crop 1 QGIS-minus-Mapbox RGB `-0.8, +3.2, +2.7` and luminance `+2.3`.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949
