### PR TITLE
test: rank crop color deltas

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -157,6 +157,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
 The delta context is shown only when the comparison-delta candidate summary matches the crop report's comparison summary, which keeps stale probe movement from being mixed into a newer visual crop sheet.
 
 Every crop report also includes a crop color metrics section with crop-local mean RGB values for the Mapbox GL and QGIS crops, plus QGIS-minus-Mapbox RGB and luminance deltas. Use these numbers as triage context when broad terrain, landcover, water, or tint differences dominate the hotspot sheet.
+The report also ranks the largest crop color deltas first, which keeps the worst tint and terrain outliers visible before scanning the full per-crop metrics table.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
 The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, sample layers, and compact qfit simplification snippets for sampled controls:

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -620,6 +620,11 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 },
             )
             summary = paths.summary_path.read_text(encoding="utf-8")
+            self.assertIn("## Largest crop color deltas", summary)
+            self.assertIn(
+                "| chamonix-trails-z14-outdoors | 1 | -127.0, -127.0, -127.0 | -127.0 | 127.0 |",
+                summary,
+            )
             self.assertIn("## Crop color metrics", summary)
             self.assertIn("| chamonix-trails-z14-outdoors | 1 | 255.0, 255.0, 255.0 | 128.0, 128.0, 128.0 | -127.0, -127.0, -127.0 | -127.0 |", summary)
 
@@ -1314,6 +1319,97 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             markdown,
         )
         self.assertIn("debug/crops/crop-sheet.jpg", markdown)
+
+    def test_build_summary_markdown_ranks_largest_crop_color_deltas(self):
+        cameras = []
+        for index in range(1, 7):
+            cameras.append(
+                {
+                    "camera": f"camera-{index}",
+                    "status": "cropped",
+                    "crops": [
+                        {
+                            "index": 1,
+                            "box": [0, 0, 4, 4],
+                            "score": 255,
+                            "outputs": {},
+                            "color_metrics": {
+                                "delta": {
+                                    "mean_rgb": [index, 0.0, 0.0],
+                                    "luminance": 1.0,
+                                }
+                            },
+                        }
+                    ],
+                }
+            )
+
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "comparison_summary_json": "debug/comparison/summary.json",
+                "crop_size": {"width": 4, "height": 4},
+                "crops_per_camera": 1,
+                "camera_count": len(cameras),
+                "crop_count": len(cameras),
+                "cameras": cameras,
+            }
+        )
+
+        ranked_section = markdown.split("## Largest crop color deltas", 1)[1].split(
+            "## Crop color metrics",
+            1,
+        )[0]
+        self.assertIn("| camera-6 | 1 | 6.0, 0.0, 0.0 | +1.0 | 6.0 |", ranked_section)
+        self.assertIn("| camera-2 | 1 | 2.0, 0.0, 0.0 | +1.0 | 2.0 |", ranked_section)
+        self.assertLess(ranked_section.index("camera-6"), ranked_section.index("camera-2"))
+        self.assertNotIn("camera-1", ranked_section)
+        self.assertIn("| camera-1 | 1 | - | - | 1.0, 0.0, 0.0 | +1.0 |", markdown)
+
+    def test_build_summary_markdown_handles_malformed_color_delta_values(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "comparison_summary_json": "debug/comparison/summary.json",
+                "crop_size": {"width": 4, "height": 4},
+                "crops_per_camera": 1,
+                "camera_count": 1,
+                "crop_count": 2,
+                "cameras": [
+                    {
+                        "camera": "bad-color",
+                        "status": "cropped",
+                        "crops": [
+                            {
+                                "index": 1,
+                                "color_metrics": {
+                                    "delta": {
+                                        "mean_rgb": ["bad", 2, 3],
+                                        "luminance": 9,
+                                    },
+                                },
+                            },
+                            {
+                                "index": 2,
+                                "color_metrics": {
+                                    "delta": {
+                                        "mean_rgb": ["bad"],
+                                        "luminance": "bad",
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        ranked_section = markdown.split("## Largest crop color deltas", 1)[1].split(
+            "## Crop color metrics",
+            1,
+        )[0]
+        self.assertIn("| bad-color | 1 | - | +9.0 | - |", ranked_section)
+        self.assertNotIn("| bad-color | 2 |", ranked_section)
 
     def test_build_summary_markdown_lists_path_pedestrian_focus_cues(self):
         markdown = build_summary_markdown(

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -43,6 +43,7 @@ DEFAULT_FOCUS_DASH_CUE_LIMIT = 2
 DEFAULT_FOCUS_STROKE_CUE_LIMIT = 3
 DEFAULT_STYLE_AUDIT_SAMPLE_LIMIT = 5
 DEFAULT_STYLE_AUDIT_SIMPLIFICATION_LIMIT = 3
+DEFAULT_CROP_COLOR_DELTA_SUMMARY_LIMIT = 5
 MAX_STYLE_AUDIT_SIMPLIFICATION_VALUE_LENGTH = 96
 MIN_SCORE_FOR_CROP = 1.0
 MAX_OVERLAP_RATIO = 0.35
@@ -1476,22 +1477,107 @@ def _summary_camera_rows(
     ]
 
 
-def _color_metric_label(metrics: object, key: str) -> str:
+def _metric_float(metrics: object, key: str) -> float | None:
     if not isinstance(metrics, Mapping):
-        return "-"
+        return None
+    value = metrics.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _color_metric_values(metrics: object, key: str) -> list[float]:
+    if not isinstance(metrics, Mapping):
+        return []
     values = metrics.get(key)
     if not isinstance(values, list):
+        return []
+    numeric_values: list[float] = []
+    for value in values[:3]:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return []
+        numeric_values.append(float(value))
+    return numeric_values if len(numeric_values) == 3 else []
+
+
+def _color_metric_label(metrics: object, key: str) -> str:
+    values = _color_metric_values(metrics, key)
+    if not values:
         return "-"
-    return ", ".join(f"{float(value):.1f}" for value in values[:3])
+    return ", ".join(f"{value:.1f}" for value in values)
 
 
 def _luminance_metric_label(metrics: object) -> str:
-    if not isinstance(metrics, Mapping):
+    value = _metric_float(metrics, "luminance")
+    if value is None:
         return "-"
-    value = metrics.get("luminance")
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return "-"
-    return f"{float(value):+.1f}"
+    return f"{value:+.1f}"
+
+
+def _summary_crop_color_delta_entries(
+    report: Mapping[str, object],
+) -> list[tuple[float, float, list[object]]]:
+    entries: list[tuple[float, float, list[object]]] = []
+    cameras = report.get("cameras")
+    if not isinstance(cameras, list):
+        return entries
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        crops = camera.get("crops")
+        if not isinstance(crops, list):
+            continue
+        for crop in crops:
+            if not isinstance(crop, Mapping):
+                continue
+            metrics = crop.get("color_metrics")
+            if not isinstance(metrics, Mapping):
+                continue
+            delta = metrics.get("delta")
+            rgb_values = _color_metric_values(delta, "mean_rgb")
+            luminance = _metric_float(delta, "luminance")
+            if not rgb_values and luminance is None:
+                continue
+            max_abs_rgb = max(abs(value) for value in rgb_values) if rgb_values else None
+            luminance_score = abs(luminance) if luminance is not None else 0.0
+            rgb_score = max_abs_rgb if max_abs_rgb is not None else 0.0
+            score = max(rgb_score, luminance_score)
+            entries.append(
+                (
+                    score,
+                    luminance_score,
+                    [
+                        camera.get("camera"),
+                        crop.get("index"),
+                        _color_metric_label(delta, "mean_rgb"),
+                        _luminance_metric_label(delta),
+                        f"{max_abs_rgb:.1f}" if max_abs_rgb is not None else "-",
+                    ],
+                )
+            )
+    entries.sort(key=lambda entry: (entry[0], entry[1]), reverse=True)
+    return entries
+
+
+def _summary_largest_crop_color_delta_lines(report: Mapping[str, object]) -> list[str]:
+    entries = _summary_crop_color_delta_entries(report)[:DEFAULT_CROP_COLOR_DELTA_SUMMARY_LIMIT]
+    if not entries:
+        return []
+    lines = [
+        "",
+        "## Largest crop color deltas",
+        "",
+        (
+            "Ranks crop-local QGIS-minus-Mapbox color deltas by the largest absolute "
+            "RGB or luminance difference, so the worst terrain, landcover, water, "
+            "or tint outliers are visible before reading every crop row."
+        ),
+        "",
+        "| Camera | Crop | QGIS-Mapbox RGB | QGIS-Mapbox luminance | Max abs RGB |",
+        "| --- | ---: | --- | ---: | ---: |",
+    ]
+    lines.extend(_markdown_table_row(row) for _score, _luminance_score, row in entries)
+    return lines
 
 
 def _summary_crop_color_metric_rows(report: Mapping[str, object]) -> list[list[object]]:
@@ -1779,6 +1865,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
                 include_comparison_delta=include_comparison_delta,
             )
         )
+    lines.extend(_summary_largest_crop_color_delta_lines(report))
     lines.extend(_summary_crop_color_metric_lines(report))
     lines.extend(_style_audit_area_fill_focus_lines(report))
     lines.extend(_summary_focus_cue_lines(report))

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1514,13 +1514,11 @@ def _luminance_metric_label(metrics: object) -> str:
     return f"{value:+.1f}"
 
 
-def _summary_crop_color_delta_entries(
-    report: Mapping[str, object],
-) -> list[tuple[float, float, list[object]]]:
-    entries: list[tuple[float, float, list[object]]] = []
+def _summary_crop_mappings(report: Mapping[str, object]) -> list[tuple[Mapping[str, object], Mapping[str, object]]]:
+    crop_mappings: list[tuple[Mapping[str, object], Mapping[str, object]]] = []
     cameras = report.get("cameras")
     if not isinstance(cameras, list):
-        return entries
+        return crop_mappings
     for camera in cameras:
         if not isinstance(camera, Mapping):
             continue
@@ -1528,33 +1526,47 @@ def _summary_crop_color_delta_entries(
         if not isinstance(crops, list):
             continue
         for crop in crops:
-            if not isinstance(crop, Mapping):
-                continue
-            metrics = crop.get("color_metrics")
-            if not isinstance(metrics, Mapping):
-                continue
-            delta = metrics.get("delta")
-            rgb_values = _color_metric_values(delta, "mean_rgb")
-            luminance = _metric_float(delta, "luminance")
-            if not rgb_values and luminance is None:
-                continue
-            max_abs_rgb = max(abs(value) for value in rgb_values) if rgb_values else None
-            luminance_score = abs(luminance) if luminance is not None else 0.0
-            rgb_score = max_abs_rgb if max_abs_rgb is not None else 0.0
-            score = max(rgb_score, luminance_score)
-            entries.append(
-                (
-                    score,
-                    luminance_score,
-                    [
-                        camera.get("camera"),
-                        crop.get("index"),
-                        _color_metric_label(delta, "mean_rgb"),
-                        _luminance_metric_label(delta),
-                        f"{max_abs_rgb:.1f}" if max_abs_rgb is not None else "-",
-                    ],
-                )
-            )
+            if isinstance(crop, Mapping):
+                crop_mappings.append((camera, crop))
+    return crop_mappings
+
+
+def _summary_crop_color_delta_entry(
+    camera: Mapping[str, object],
+    crop: Mapping[str, object],
+) -> tuple[float, float, list[object]] | None:
+    metrics = crop.get("color_metrics")
+    if not isinstance(metrics, Mapping):
+        return None
+    delta = metrics.get("delta")
+    rgb_values = _color_metric_values(delta, "mean_rgb")
+    luminance = _metric_float(delta, "luminance")
+    if not rgb_values and luminance is None:
+        return None
+    max_abs_rgb = max(abs(value) for value in rgb_values) if rgb_values else None
+    luminance_score = abs(luminance) if luminance is not None else 0.0
+    rgb_score = max_abs_rgb if max_abs_rgb is not None else 0.0
+    return (
+        max(rgb_score, luminance_score),
+        luminance_score,
+        [
+            camera.get("camera"),
+            crop.get("index"),
+            _color_metric_label(delta, "mean_rgb"),
+            _luminance_metric_label(delta),
+            f"{max_abs_rgb:.1f}" if max_abs_rgb is not None else "-",
+        ],
+    )
+
+
+def _summary_crop_color_delta_entries(
+    report: Mapping[str, object],
+) -> list[tuple[float, float, list[object]]]:
+    entries = [
+        entry
+        for camera, crop in _summary_crop_mappings(report)
+        if (entry := _summary_crop_color_delta_entry(camera, crop)) is not None
+    ]
     entries.sort(key=lambda entry: (entry[0], entry[1]), reverse=True)
     return entries
 


### PR DESCRIPTION
## Summary
- add a ranked "Largest crop color deltas" section before the full crop color metrics table
- harden color metric Markdown labels for malformed delta values
- document the ranked section in the Mapbox Outdoors comparison harness

## Evidence
- Generated token-free crop report: `debug/mapbox-outdoors-visual-crops/20260521T134002Z/summary.md`
- Largest deltas surfaced there: geneva-airport-motorway-z14-outdoors max RGB 17.2 / luminance +8.8; lausanne-lavaux-z10-outdoors max RGB 16.6 / luminance -5.0; zermatt-trails-z18-outdoors max RGB 16.0 / luminance +5.9

## Tests
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949