### PR TITLE
test: expose ranked crop diff paths

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -157,7 +157,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
 The delta context is shown only when the comparison-delta candidate summary matches the crop report's comparison summary, which keeps stale probe movement from being mixed into a newer visual crop sheet.
 
 Every crop report also includes a crop color metrics section with crop-local mean RGB values for the Mapbox GL and QGIS crops, plus QGIS-minus-Mapbox RGB/luminance deltas and the dominant color direction. Use these numbers as triage context when broad terrain, landcover, water, or tint differences dominate the hotspot sheet.
-The report also ranks the largest crop color deltas first, which keeps the worst tint and terrain outliers and their dominant movement visible before scanning the full per-crop metrics table.
+The report also ranks the largest crop color deltas first, which keeps the worst tint and terrain outliers, crop boxes, diff crop paths, and dominant movement visible before scanning the full per-crop metrics table.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
 The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, sample layers, and compact qfit simplification snippets for sampled controls:

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -628,7 +628,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             summary = paths.summary_path.read_text(encoding="utf-8")
             self.assertIn("## Largest crop color deltas", summary)
             self.assertIn(
-                "| chamonix-trails-z14-outdoors | 1 | -127.0, -127.0, -127.0 | -127.0 | 127.0 | darker; red -127.0 |",
+                f"| chamonix-trails-z14-outdoors | 1 | [6,6,10,10] | `{outputs['diff']}` | -127.0, -127.0, -127.0 | -127.0 | 127.0 | darker; red -127.0 |",
                 summary,
             )
             self.assertIn("## Crop color metrics", summary)
@@ -1366,8 +1366,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             "## Crop color metrics",
             1,
         )[0]
-        self.assertIn("| camera-6 | 1 | 6.0, 0.0, 0.0 | +1.0 | 6.0 |", ranked_section)
-        self.assertIn("| camera-2 | 1 | 2.0, 0.0, 0.0 | +1.0 | 2.0 |", ranked_section)
+        self.assertIn("| camera-6 | 1 | [0,0,4,4] | - | 6.0, 0.0, 0.0 | +1.0 | 6.0 |", ranked_section)
+        self.assertIn("| camera-2 | 1 | [0,0,4,4] | - | 2.0, 0.0, 0.0 | +1.0 | 2.0 |", ranked_section)
         self.assertLess(ranked_section.index("camera-6"), ranked_section.index("camera-2"))
         self.assertNotIn("camera-1", ranked_section)
         self.assertIn("| camera-1 | 1 | - | - | 1.0, 0.0, 0.0 | +1.0 |", markdown)
@@ -1414,7 +1414,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             "## Crop color metrics",
             1,
         )[0]
-        self.assertIn("| bad-color | 1 | - | +9.0 | - |", ranked_section)
+        self.assertIn("| bad-color | 1 | - | - | - | +9.0 | - |", ranked_section)
         self.assertNotIn("| bad-color | 2 |", ranked_section)
 
     def test_build_summary_markdown_lists_path_pedestrian_focus_cues(self):

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1562,6 +1562,23 @@ def _dominant_color_delta_label(metrics: object) -> str:
     return "; ".join(movement) if movement else "-"
 
 
+def _crop_box_label(crop: Mapping[str, object]) -> object:
+    box = crop.get("box")
+    if not isinstance(box, list):
+        return "-"
+    return box
+
+
+def _crop_output_path_label(crop: Mapping[str, object], key: str) -> str:
+    outputs = crop.get("outputs")
+    if not isinstance(outputs, Mapping):
+        return "-"
+    path = outputs.get(key)
+    if not isinstance(path, str) or not path:
+        return "-"
+    return f"`{path}`"
+
+
 def _summary_crop_mappings(report: Mapping[str, object]) -> list[tuple[Mapping[str, object], Mapping[str, object]]]:
     crop_mappings: list[tuple[Mapping[str, object], Mapping[str, object]]] = []
     cameras = report.get("cameras")
@@ -1600,6 +1617,8 @@ def _summary_crop_color_delta_entry(
         [
             camera.get("camera"),
             crop.get("index"),
+            _crop_box_label(crop),
+            _crop_output_path_label(crop, "diff"),
             _color_metric_label(delta, "mean_rgb"),
             _luminance_metric_label(delta),
             f"{max_abs_rgb:.1f}" if max_abs_rgb is not None else "-",
@@ -1635,8 +1654,8 @@ def _summary_largest_crop_color_delta_lines(report: Mapping[str, object]) -> lis
             "reading every crop row."
         ),
         "",
-        "| Camera | Crop | QGIS-Mapbox RGB | QGIS-Mapbox luminance | Max abs RGB | Dominant movement |",
-        "| --- | ---: | --- | ---: | ---: | --- |",
+        "| Camera | Crop | Box | Diff crop | QGIS-Mapbox RGB | QGIS-Mapbox luminance | Max abs RGB | Dominant movement |",
+        "| --- | ---: | --- | --- | --- | ---: | ---: | --- |",
     ]
     lines.extend(_markdown_table_row(row) for _score, _luminance_score, row in entries)
     return lines


### PR DESCRIPTION
## Summary

- add crop box and diff-crop path columns to the largest crop color deltas table
- keep the full crop metrics table unchanged while making the ranked outliers directly inspectable
- update the comparison harness docs for the ranked locator fields

## Evidence

- Regenerated crop report: `debug/mapbox-outdoors-visual-crops/20260521T141920Z/summary.md`
- The ranked table now points directly at the top outlier diff crops, e.g. Zermatt `[0,450,420,750]`, Geneva `[630,300,1050,600]`, and Lausanne `[420,0,840,300]`.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949
