### PR TITLE
test: group crop color movements

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -158,6 +158,7 @@ The delta context is shown only when the comparison-delta candidate summary matc
 
 Every crop report also includes a crop color metrics section with crop-local mean RGB values for the Mapbox GL and QGIS crops, plus QGIS-minus-Mapbox RGB/luminance deltas and the dominant color direction. Use these numbers as triage context when broad terrain, landcover, water, or tint differences dominate the hotspot sheet.
 The report also ranks the largest crop color deltas first, which keeps the worst tint and terrain outliers, crop boxes, diff crop paths, and dominant movement visible before scanning the full per-crop metrics table.
+It also groups crop movements by luminance direction and dominant RGB channel, so repeated tint families can be reviewed before trying a single global style lever.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
 The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, sample layers, and compact qfit simplification snippets for sampled controls:

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -632,6 +632,11 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 summary,
             )
             self.assertIn("## Crop color metrics", summary)
+            self.assertIn("## Crop color movement groups", summary)
+            self.assertIn(
+                "| darker + red lower | 1 | 127.0 | 127.0 | chamonix-trails-z14-outdoors=1 |",
+                summary,
+            )
             self.assertIn("| chamonix-trails-z14-outdoors | 1 | 255.0, 255.0, 255.0 | 128.0, 128.0, 128.0 | -127.0, -127.0, -127.0 | -127.0 | darker; red -127.0 |", summary)
 
     def test_generate_visual_crop_report_marks_missing_required_artifacts(self):
@@ -1371,6 +1376,115 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertLess(ranked_section.index("camera-6"), ranked_section.index("camera-2"))
         self.assertNotIn("camera-1", ranked_section)
         self.assertIn("| camera-1 | 1 | - | - | 1.0, 0.0, 0.0 | +1.0 |", markdown)
+
+    def test_build_summary_markdown_groups_crop_color_movements(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "comparison_summary_json": "debug/comparison/summary.json",
+                "crop_size": {"width": 4, "height": 4},
+                "crops_per_camera": 2,
+                "camera_count": 3,
+                "crop_count": 4,
+                "cameras": [
+                    {
+                        "camera": "geneva",
+                        "status": "cropped",
+                        "crops": [
+                            {
+                                "index": 1,
+                                "color_metrics": {
+                                    "delta": {
+                                        "mean_rgb": [4.0, 0.0, 12.0],
+                                        "luminance": 6.0,
+                                        "luminance_direction": "lighter",
+                                        "dominant_rgb_delta": {
+                                            "channel": "blue",
+                                            "delta": 12.0,
+                                            "direction": "higher",
+                                        },
+                                    }
+                                },
+                            },
+                            {
+                                "index": 2,
+                                "color_metrics": {
+                                    "delta": {
+                                        "mean_rgb": [1.0, 0.0, 5.0],
+                                        "luminance": 2.0,
+                                        "luminance_direction": "lighter",
+                                        "dominant_rgb_delta": {
+                                            "channel": "blue",
+                                            "delta": 5.0,
+                                            "direction": "higher",
+                                        },
+                                    }
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "camera": "zermatt",
+                        "status": "cropped",
+                        "crops": [
+                            {
+                                "index": 1,
+                                "color_metrics": {
+                                    "delta": {
+                                        "mean_rgb": [2.0, 0.0, 16.0],
+                                        "luminance": 8.0,
+                                        "luminance_direction": "lighter",
+                                        "dominant_rgb_delta": {
+                                            "channel": "blue",
+                                            "delta": 16.0,
+                                            "direction": "higher",
+                                        },
+                                    }
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "camera": "lausanne",
+                        "status": "cropped",
+                        "crops": [
+                            {
+                                "index": 1,
+                                "color_metrics": {
+                                    "delta": {
+                                        "mean_rgb": [-18.0, -1.0, -16.0],
+                                        "luminance": -6.0,
+                                        "luminance_direction": "darker",
+                                        "dominant_rgb_delta": {
+                                            "channel": "red",
+                                            "delta": -18.0,
+                                            "direction": "lower",
+                                        },
+                                    }
+                                },
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+
+        movement_section = markdown.split("## Crop color movement groups", 1)[1].split(
+            "## Crop color metrics",
+            1,
+        )[0]
+        self.assertIn(
+            "| lighter + blue higher | 3 | 16.0 | 8.0 | geneva=2, zermatt=1 |",
+            movement_section,
+        )
+        self.assertIn(
+            "| darker + red lower | 1 | 18.0 | 6.0 | lausanne=1 |",
+            movement_section,
+        )
+        self.assertLess(
+            movement_section.index("lighter + blue higher"),
+            movement_section.index("darker + red lower"),
+        )
 
     def test_build_summary_markdown_handles_malformed_color_delta_values(self):
         markdown = build_summary_markdown(

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -5,7 +5,7 @@ import datetime as dt
 import json
 import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +44,7 @@ DEFAULT_FOCUS_STROKE_CUE_LIMIT = 3
 DEFAULT_STYLE_AUDIT_SAMPLE_LIMIT = 5
 DEFAULT_STYLE_AUDIT_SIMPLIFICATION_LIMIT = 3
 DEFAULT_CROP_COLOR_DELTA_SUMMARY_LIMIT = 5
+DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT = 8
 MAX_STYLE_AUDIT_SIMPLIFICATION_VALUE_LENGTH = 96
 MIN_SCORE_FOR_CROP = 1.0
 MAX_OVERLAP_RATIO = 0.35
@@ -1639,6 +1640,105 @@ def _summary_crop_color_delta_entries(
     return entries
 
 
+def _crop_color_movement_group_key(delta: object) -> tuple[str, str, str] | None:
+    if not isinstance(delta, Mapping):
+        return None
+    luminance_direction = delta.get("luminance_direction")
+    dominant_rgb_delta = delta.get("dominant_rgb_delta")
+    if not isinstance(luminance_direction, str) or not luminance_direction:
+        return None
+    if not isinstance(dominant_rgb_delta, Mapping):
+        return None
+    channel = dominant_rgb_delta.get("channel")
+    rgb_direction = dominant_rgb_delta.get("direction")
+    if not isinstance(channel, str) or not channel:
+        return None
+    if not isinstance(rgb_direction, str) or not rgb_direction:
+        return None
+    return luminance_direction, channel, rgb_direction
+
+
+def _crop_color_movement_group_label(key: tuple[str, str, str]) -> str:
+    luminance_direction, channel, rgb_direction = key
+    return f"{luminance_direction} + {channel} {rgb_direction}"
+
+
+def _increment_count(counts: dict[str, int], key: object) -> None:
+    if isinstance(key, str) and key:
+        counts[key] = counts.get(key, 0) + 1
+
+
+@dataclass
+class _CropColorMovementGroup:
+    count: int = 0
+    max_abs_rgb: float = 0.0
+    max_abs_luminance: float = 0.0
+    cameras: dict[str, int] = field(default_factory=dict)
+
+    def add(self, delta: Mapping[str, object], camera_name: object) -> None:
+        self.count += 1
+        dominant_rgb_delta = delta.get("dominant_rgb_delta")
+        rgb_delta = (
+            _metric_float(dominant_rgb_delta, "delta")
+            if isinstance(dominant_rgb_delta, Mapping)
+            else None
+        )
+        luminance = _metric_float(delta, "luminance")
+        if rgb_delta is not None:
+            self.max_abs_rgb = max(self.max_abs_rgb, abs(rgb_delta))
+        if luminance is not None:
+            self.max_abs_luminance = max(self.max_abs_luminance, abs(luminance))
+        _increment_count(self.cameras, camera_name)
+
+
+def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> list[list[object]]:
+    groups: dict[tuple[str, str, str], _CropColorMovementGroup] = {}
+    for camera, crop in _summary_crop_mappings(report):
+        metrics = crop.get("color_metrics")
+        if not isinstance(metrics, Mapping):
+            continue
+        delta = metrics.get("delta")
+        group_key = _crop_color_movement_group_key(delta)
+        if group_key is None or not isinstance(delta, Mapping):
+            continue
+        groups.setdefault(group_key, _CropColorMovementGroup()).add(delta, camera.get("camera"))
+    sorted_groups = sorted(
+        groups.items(),
+        key=lambda item: (-item[1].count, -item[1].max_abs_rgb, item[0]),
+    )
+    return [
+        [
+            _crop_color_movement_group_label(group_key),
+            group.count,
+            f"{group.max_abs_rgb:.1f}",
+            f"{group.max_abs_luminance:.1f}",
+            _joined_summary_labels(_top_count_labels(group.cameras)),
+        ]
+        for group_key, group in sorted_groups[:DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT]
+    ]
+
+
+def _summary_crop_color_movement_group_lines(report: Mapping[str, object]) -> list[str]:
+    rows = _summary_crop_color_movement_group_rows(report)
+    if not rows:
+        return []
+    lines = [
+        "",
+        "## Crop color movement groups",
+        "",
+        (
+            "Groups crop-local QGIS-minus-Mapbox color movements by luminance direction "
+            "and dominant RGB channel, so repeated tint families are visible before "
+            "tuning a single style rule."
+        ),
+        "",
+        "| Movement | Crops | Max abs RGB | Max abs luminance | Cameras |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
+
+
 def _summary_largest_crop_color_delta_lines(report: Mapping[str, object]) -> list[str]:
     entries = _summary_crop_color_delta_entries(report)[:DEFAULT_CROP_COLOR_DELTA_SUMMARY_LIMIT]
     if not entries:
@@ -1948,6 +2048,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
             )
         )
     lines.extend(_summary_largest_crop_color_delta_lines(report))
+    lines.extend(_summary_crop_color_movement_group_lines(report))
     lines.extend(_summary_crop_color_metric_lines(report))
     lines.extend(_style_audit_area_fill_focus_lines(report))
     lines.extend(_summary_focus_cue_lines(report))


### PR DESCRIPTION
## Summary
- add a visual crop summary section that groups QGIS-minus-Mapbox color movement by luminance direction and dominant RGB channel
- show per-group crop counts, max RGB/luminance movement, and the cameras contributing to each tint family
- document the movement-group triage cue in the Mapbox Outdoors comparison harness notes

## Evidence
- Refs #949
- Fresh local report: `debug/mapbox-outdoors-visual-crops/20260521T143704Z/summary.md`
- Latest report groups repeated crop movement families, including `lighter + red higher` across 8 crops, `darker + red lower` across 4 crops, and `lighter + blue higher` across 3 crops.
- This is a validation-aid slice only; it does not change QGIS rendering behavior.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short` -> 40 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2392 passed, 180 skipped, 171 subtests passed
- `git diff --check` -> clean
