### PR TITLE
Persist crop color movement groups to JSON

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -159,6 +159,7 @@ The delta context is shown only when the comparison-delta candidate summary matc
 Every crop report also includes a crop color metrics section with crop-local mean RGB values for the Mapbox GL and QGIS crops, plus QGIS-minus-Mapbox RGB/luminance deltas and the dominant color direction. Use these numbers as triage context when broad terrain, landcover, water, or tint differences dominate the hotspot sheet.
 The report also ranks the largest crop color deltas first, which keeps the worst tint and terrain outliers, crop boxes, diff crop paths, and dominant movement visible before scanning the full per-crop metrics table.
 It also groups crop movements by luminance direction and dominant RGB channel, so repeated tint families can be reviewed before trying a single global style lever.
+The same movement groups are stored in `visual-crops.json` under `crop_color_movement_groups` for follow-up scripts that should not parse the Markdown summary.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
 The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, sample layers, and compact qfit simplification snippets for sampled controls:

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -609,11 +609,30 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 },
             )
             self.assertEqual(report["crop_count"], 1)
+            self.assertEqual(
+                report["crop_color_movement_groups"],
+                [
+                    {
+                        "movement": "darker + red lower",
+                        "luminance_direction": "darker",
+                        "dominant_rgb_channel": "red",
+                        "dominant_rgb_direction": "lower",
+                        "crop_count": 1,
+                        "max_abs_rgb_delta": 127.0,
+                        "max_abs_luminance_delta": 127.0,
+                        "cameras": {"chamonix-trails-z14-outdoors": 1},
+                    }
+                ],
+            )
             self.assertTrue(paths.contact_sheet_path.exists())
             self.assertTrue(paths.json_path.exists())
             self.assertTrue(paths.summary_path.exists())
             loaded = json.loads(paths.json_path.read_text(encoding="utf-8"))
             self.assertEqual(loaded["camera_count"], 1)
+            self.assertEqual(
+                loaded["crop_color_movement_groups"],
+                report["crop_color_movement_groups"],
+            )
             self.assertEqual(
                 loaded["cameras"][0]["comparison"],
                 {

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1201,6 +1201,9 @@ def generate_visual_crop_report(
         "contact_sheet": _display_input_path(contact_sheet) if contact_sheet is not None else None,
         "cameras": camera_rows,
     }
+    crop_color_movement_groups = _crop_color_movement_group_records(report)
+    if crop_color_movement_groups:
+        report["crop_color_movement_groups"] = crop_color_movement_groups
     _add_visual_crop_annotation_metadata(
         report,
         annotations=annotations,
@@ -1690,8 +1693,21 @@ class _CropColorMovementGroup:
             self.max_abs_luminance = max(self.max_abs_luminance, abs(luminance))
         _increment_count(self.cameras, camera_name)
 
+    def to_record(self, key: tuple[str, str, str]) -> dict[str, object]:
+        luminance_direction, channel, rgb_direction = key
+        return {
+            "movement": _crop_color_movement_group_label(key),
+            "luminance_direction": luminance_direction,
+            "dominant_rgb_channel": channel,
+            "dominant_rgb_direction": rgb_direction,
+            "crop_count": self.count,
+            "max_abs_rgb_delta": self.max_abs_rgb,
+            "max_abs_luminance_delta": self.max_abs_luminance,
+            "cameras": dict(sorted(self.cameras.items())),
+        }
 
-def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> list[list[object]]:
+
+def _computed_crop_color_movement_group_records(report: Mapping[str, object]) -> list[dict[str, object]]:
     groups: dict[tuple[str, str, str], _CropColorMovementGroup] = {}
     for camera, crop in _summary_crop_mappings(report):
         metrics = crop.get("color_metrics")
@@ -1706,15 +1722,33 @@ def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> lis
         groups.items(),
         key=lambda item: (-item[1].count, -item[1].max_abs_rgb, item[0]),
     )
+    return [group.to_record(group_key) for group_key, group in sorted_groups]
+
+
+def _crop_color_movement_group_records(report: Mapping[str, object]) -> list[Mapping[str, object]]:
+    records = report.get("crop_color_movement_groups")
+    if isinstance(records, list):
+        return [record for record in records if isinstance(record, Mapping)]
+    return _computed_crop_color_movement_group_records(report)
+
+
+def _crop_color_movement_group_record_float(record: Mapping[str, object], key: str) -> float:
+    value = record.get(key)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return 0.0
+
+
+def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> list[list[object]]:
     return [
         [
-            _crop_color_movement_group_label(group_key),
-            group.count,
-            f"{group.max_abs_rgb:.1f}",
-            f"{group.max_abs_luminance:.1f}",
-            _joined_summary_labels(_top_count_labels(group.cameras)),
+            record.get("movement"),
+            record.get("crop_count"),
+            f"{_crop_color_movement_group_record_float(record, 'max_abs_rgb_delta'):.1f}",
+            f"{_crop_color_movement_group_record_float(record, 'max_abs_luminance_delta'):.1f}",
+            _joined_summary_labels(_top_count_labels(record.get("cameras"))),
         ]
-        for group_key, group in sorted_groups[:DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT]
+        for record in _crop_color_movement_group_records(report)[:DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT]
     ]
 
 


### PR DESCRIPTION
## Summary
- store visual crop color movement groups in `visual-crops.json` under `crop_color_movement_groups`
- keep the Markdown movement-group table backed by the stored JSON records when present
- document the machine-readable movement-group field for follow-up analysis scripts

## Evidence
- Refs #949
- Fresh local report: `debug/mapbox-outdoors-visual-crops/20260521T144944Z/summary.md`
- Fresh JSON artifact: `debug/mapbox-outdoors-visual-crops/20260521T144944Z/visual-crops.json`
- The JSON now records the same repeated crop movement families surfaced in the summary, including `lighter + red higher`, `darker + red lower`, and `lighter + blue higher`.
- This is a validation-aid slice only; it does not change QGIS rendering behavior.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short` -> 40 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2392 passed, 180 skipped, 171 subtests passed
- `git diff --check` -> clean
