### PR TITLE
test: store crop movement representatives

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -159,7 +159,7 @@ The delta context is shown only when the comparison-delta candidate summary matc
 Every crop report also includes a crop color metrics section with crop-local mean RGB values for the Mapbox GL and QGIS crops, plus QGIS-minus-Mapbox RGB/luminance deltas and the dominant color direction. Use these numbers as triage context when broad terrain, landcover, water, or tint differences dominate the hotspot sheet.
 The report also ranks the largest crop color deltas first, which keeps the worst tint and terrain outliers, crop boxes, diff crop paths, and dominant movement visible before scanning the full per-crop metrics table.
 It also groups crop movements by luminance direction and dominant RGB channel, so repeated tint families can be reviewed before trying a single global style lever.
-The same movement groups are stored in `visual-crops.json` under `crop_color_movement_groups` for follow-up scripts that should not parse the Markdown summary.
+The same movement groups are stored in `visual-crops.json` under `crop_color_movement_groups`, including a representative crop for each group, for follow-up scripts that should not parse the Markdown summary.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
 The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, sample layers, and compact qfit simplification snippets for sampled controls:

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -12,6 +12,7 @@ from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_visual_crops import (
     VisualCropAnnotationInputs,
+    _computed_crop_color_movement_group_records,
     _crop_color_metric,
     _three_channel_color_values,
     annotate_visual_crop_report_with_comparison_delta,
@@ -621,6 +622,16 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         "max_abs_rgb_delta": 127.0,
                         "max_abs_luminance_delta": 127.0,
                         "cameras": {"chamonix-trails-z14-outdoors": 1},
+                        "representative_crop": {
+                            "camera": "chamonix-trails-z14-outdoors",
+                            "crop": 1,
+                            "score": 127.0,
+                            "box": [6, 6, 10, 10],
+                            "diff": outputs["diff"],
+                            "qgis_minus_mapbox_rgb": [-127.0, -127.0, -127.0],
+                            "max_abs_rgb_delta": 127.0,
+                            "qgis_minus_mapbox_luminance": -127.0,
+                        },
                     }
                 ],
             )
@@ -1503,6 +1514,73 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertLess(
             movement_section.index("lighter + blue higher"),
             movement_section.index("darker + red lower"),
+        )
+
+    def test_computed_crop_color_movement_groups_keep_representative_crop(self):
+        records = _computed_crop_color_movement_group_records(
+            {
+                "cameras": [
+                    {
+                        "camera": "geneva",
+                        "crops": [
+                            {
+                                "index": 1,
+                                "box": [0, 0, 4, 4],
+                                "outputs": {"diff": "debug/geneva-diff.png"},
+                                "color_metrics": {
+                                    "delta": {
+                                        "mean_rgb": [4.0, 0.0, 12.0],
+                                        "luminance": 6.0,
+                                        "luminance_direction": "lighter",
+                                        "dominant_rgb_delta": {
+                                            "channel": "blue",
+                                            "delta": 12.0,
+                                            "direction": "higher",
+                                        },
+                                    }
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "camera": "zermatt",
+                        "crops": [
+                            {
+                                "index": 2,
+                                "box": [4, 4, 8, 8],
+                                "outputs": {"diff": "debug/zermatt-diff.png"},
+                                "color_metrics": {
+                                    "delta": {
+                                        "mean_rgb": [2.0, 0.0, 16.0],
+                                        "luminance": 8.0,
+                                        "luminance_direction": "lighter",
+                                        "dominant_rgb_delta": {
+                                            "channel": "blue",
+                                            "delta": 16.0,
+                                            "direction": "higher",
+                                        },
+                                    }
+                                },
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(
+            records[0]["representative_crop"],
+            {
+                "camera": "zermatt",
+                "crop": 2,
+                "score": 16.0,
+                "box": [4, 4, 8, 8],
+                "diff": "debug/zermatt-diff.png",
+                "qgis_minus_mapbox_rgb": [2.0, 0.0, 16.0],
+                "max_abs_rgb_delta": 16.0,
+                "qgis_minus_mapbox_luminance": 8.0,
+            },
         )
 
     def test_build_summary_markdown_handles_malformed_color_delta_values(self):

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1517,56 +1517,57 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         )
 
     def test_computed_crop_color_movement_groups_keep_representative_crop(self):
-        records = _computed_crop_color_movement_group_records(
-            {
-                "cameras": [
-                    {
-                        "camera": "geneva",
-                        "crops": [
-                            {
-                                "index": 1,
-                                "box": [0, 0, 4, 4],
-                                "outputs": {"diff": "debug/geneva-diff.png"},
-                                "color_metrics": {
-                                    "delta": {
-                                        "mean_rgb": [4.0, 0.0, 12.0],
-                                        "luminance": 6.0,
-                                        "luminance_direction": "lighter",
-                                        "dominant_rgb_delta": {
-                                            "channel": "blue",
-                                            "delta": 12.0,
-                                            "direction": "higher",
-                                        },
-                                    }
-                                },
-                            }
-                        ],
-                    },
-                    {
-                        "camera": "zermatt",
-                        "crops": [
-                            {
-                                "index": 2,
-                                "box": [4, 4, 8, 8],
-                                "outputs": {"diff": "debug/zermatt-diff.png"},
-                                "color_metrics": {
-                                    "delta": {
-                                        "mean_rgb": [2.0, 0.0, 16.0],
-                                        "luminance": 8.0,
-                                        "luminance_direction": "lighter",
-                                        "dominant_rgb_delta": {
-                                            "channel": "blue",
-                                            "delta": 16.0,
-                                            "direction": "higher",
-                                        },
-                                    }
-                                },
-                            }
-                        ],
-                    },
-                ],
-            }
-        )
+        report = {
+            "cameras": [
+                {
+                    "camera": "geneva",
+                    "crops": [
+                        {
+                            "index": 1,
+                            "box": [0, 0, 4, 4],
+                            "outputs": {"diff": "debug/geneva-diff.png"},
+                            "color_metrics": {
+                                "delta": {
+                                    "mean_rgb": [4.0, 0.0, 12.0],
+                                    "luminance": 6.0,
+                                    "luminance_direction": "lighter",
+                                    "dominant_rgb_delta": {
+                                        "channel": "blue",
+                                        "delta": 12.0,
+                                        "direction": "higher",
+                                    },
+                                }
+                            },
+                        }
+                    ],
+                },
+                {
+                    "camera": "zermatt",
+                    "crops": [
+                        {
+                            "index": 2,
+                            "box": [4, 4, 8, 8],
+                            "outputs": {"diff": "debug/zermatt-diff.png"},
+                            "color_metrics": {
+                                "delta": {
+                                    "mean_rgb": [2.0, 0.0, 16.0],
+                                    "luminance": 8.0,
+                                    "luminance_direction": "lighter",
+                                    "dominant_rgb_delta": {
+                                        "channel": "blue",
+                                        "delta": 16.0,
+                                        "direction": "higher",
+                                    },
+                                }
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+
+        records = _computed_crop_color_movement_group_records(report)
+        report["cameras"][1]["crops"][0]["box"][0] = 99
 
         self.assertEqual(len(records), 1)
         self.assertEqual(

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1692,7 +1692,7 @@ def _crop_color_movement_representative_record(
     }
     box = crop.get("box")
     if isinstance(box, list):
-        record["box"] = box
+        record["box"] = list(box)
     diff_path = _crop_output_path_value(crop, "diff")
     if diff_path is not None:
         record["diff"] = diff_path

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1574,13 +1574,20 @@ def _crop_box_label(crop: Mapping[str, object]) -> object:
 
 
 def _crop_output_path_label(crop: Mapping[str, object], key: str) -> str:
-    outputs = crop.get("outputs")
-    if not isinstance(outputs, Mapping):
-        return "-"
-    path = outputs.get(key)
-    if not isinstance(path, str) or not path:
+    path = _crop_output_path_value(crop, key)
+    if path is None:
         return "-"
     return f"`{path}`"
+
+
+def _crop_output_path_value(crop: Mapping[str, object], key: str) -> str | None:
+    outputs = crop.get("outputs")
+    if not isinstance(outputs, Mapping):
+        return None
+    path = outputs.get(key)
+    if not isinstance(path, str) or not path:
+        return None
+    return path
 
 
 def _summary_crop_mappings(report: Mapping[str, object]) -> list[tuple[Mapping[str, object], Mapping[str, object]]]:
@@ -1671,14 +1678,44 @@ def _increment_count(counts: dict[str, int], key: object) -> None:
         counts[key] = counts.get(key, 0) + 1
 
 
+def _crop_color_movement_representative_record(
+    *,
+    camera_name: object,
+    crop: Mapping[str, object],
+    delta: Mapping[str, object],
+    score: float,
+) -> dict[str, object]:
+    record: dict[str, object] = {
+        "camera": camera_name,
+        "crop": crop.get("index"),
+        "score": score,
+    }
+    box = crop.get("box")
+    if isinstance(box, list):
+        record["box"] = box
+    diff_path = _crop_output_path_value(crop, "diff")
+    if diff_path is not None:
+        record["diff"] = diff_path
+    rgb_values = _color_metric_values(delta, "mean_rgb")
+    if rgb_values:
+        record["qgis_minus_mapbox_rgb"] = rgb_values
+        record["max_abs_rgb_delta"] = max(abs(value) for value in rgb_values)
+    luminance = _metric_float(delta, "luminance")
+    if luminance is not None:
+        record["qgis_minus_mapbox_luminance"] = luminance
+    return record
+
+
 @dataclass
 class _CropColorMovementGroup:
     count: int = 0
     max_abs_rgb: float = 0.0
     max_abs_luminance: float = 0.0
     cameras: dict[str, int] = field(default_factory=dict)
+    representative_crop: dict[str, object] | None = None
+    representative_score: float = 0.0
 
-    def add(self, delta: Mapping[str, object], camera_name: object) -> None:
+    def add(self, delta: Mapping[str, object], camera_name: object, crop: Mapping[str, object]) -> None:
         self.count += 1
         dominant_rgb_delta = delta.get("dominant_rgb_delta")
         rgb_delta = (
@@ -1692,10 +1729,22 @@ class _CropColorMovementGroup:
         if luminance is not None:
             self.max_abs_luminance = max(self.max_abs_luminance, abs(luminance))
         _increment_count(self.cameras, camera_name)
+        score = max(
+            abs(rgb_delta) if rgb_delta is not None else 0.0,
+            abs(luminance) if luminance is not None else 0.0,
+        )
+        if self.representative_crop is None or score > self.representative_score:
+            self.representative_score = score
+            self.representative_crop = _crop_color_movement_representative_record(
+                camera_name=camera_name,
+                crop=crop,
+                delta=delta,
+                score=score,
+            )
 
     def to_record(self, key: tuple[str, str, str]) -> dict[str, object]:
         luminance_direction, channel, rgb_direction = key
-        return {
+        record: dict[str, object] = {
             "movement": _crop_color_movement_group_label(key),
             "luminance_direction": luminance_direction,
             "dominant_rgb_channel": channel,
@@ -1705,6 +1754,9 @@ class _CropColorMovementGroup:
             "max_abs_luminance_delta": self.max_abs_luminance,
             "cameras": dict(sorted(self.cameras.items())),
         }
+        if self.representative_crop is not None:
+            record["representative_crop"] = self.representative_crop
+        return record
 
 
 def _computed_crop_color_movement_group_records(report: Mapping[str, object]) -> list[dict[str, object]]:
@@ -1717,7 +1769,7 @@ def _computed_crop_color_movement_group_records(report: Mapping[str, object]) ->
         group_key = _crop_color_movement_group_key(delta)
         if group_key is None or not isinstance(delta, Mapping):
             continue
-        groups.setdefault(group_key, _CropColorMovementGroup()).add(delta, camera.get("camera"))
+        groups.setdefault(group_key, _CropColorMovementGroup()).add(delta, camera.get("camera"), crop)
     sorted_groups = sorted(
         groups.items(),
         key=lambda item: (-item[1].count, -item[1].max_abs_rgb, item[0]),


### PR DESCRIPTION
## Summary
- persist a representative crop for each `crop_color_movement_groups` JSON record
- include the representative crop camera/index, box, diff path, RGB/luminance deltas, and score
- document that movement groups include a representative crop for follow-up scripts

## Evidence
- Refs #949
- Fresh local report: `debug/mapbox-outdoors-visual-crops/20260521T150100Z/summary.md`
- Fresh JSON artifact: `debug/mapbox-outdoors-visual-crops/20260521T150100Z/visual-crops.json`
- Representative examples from the fresh JSON: `lighter + red higher` points to `switzerland-alps-z5-outdoors` crop 1, `darker + red lower` points to `lausanne-lavaux-z10-outdoors` crop 1, and `lighter + blue higher` points to `zermatt-trails-z18-outdoors` crop 2.
- This is a validation-aid slice only; it does not change QGIS rendering behavior.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short` -> 41 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2393 passed, 180 skipped, 171 subtests passed
- `git diff --check` -> clean
