### PR TITLE
Show crop movement representatives in summary

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -158,7 +158,7 @@ The delta context is shown only when the comparison-delta candidate summary matc
 
 Every crop report also includes a crop color metrics section with crop-local mean RGB values for the Mapbox GL and QGIS crops, plus QGIS-minus-Mapbox RGB/luminance deltas and the dominant color direction. Use these numbers as triage context when broad terrain, landcover, water, or tint differences dominate the hotspot sheet.
 The report also ranks the largest crop color deltas first, which keeps the worst tint and terrain outliers, crop boxes, diff crop paths, and dominant movement visible before scanning the full per-crop metrics table.
-It also groups crop movements by luminance direction and dominant RGB channel, so repeated tint families can be reviewed before trying a single global style lever.
+It also groups crop movements by luminance direction and dominant RGB channel, including a representative crop for each group, so repeated tint families can be reviewed before trying a single global style lever.
 The same movement groups are stored in `visual-crops.json` under `crop_color_movement_groups`, including a representative crop for each group, for follow-up scripts that should not parse the Markdown summary.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -664,7 +664,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("## Crop color metrics", summary)
             self.assertIn("## Crop color movement groups", summary)
             self.assertIn(
-                "| darker + red lower | 1 | 127.0 | 127.0 | chamonix-trails-z14-outdoors=1 |",
+                f"| darker + red lower | 1 | 127.0 | 127.0 | chamonix-trails-z14-outdoors=1 | chamonix-trails-z14-outdoors crop 1 [6,6,10,10] `{outputs['diff']}` |",
                 summary,
             )
             self.assertIn("| chamonix-trails-z14-outdoors | 1 | 255.0, 255.0, 255.0 | 128.0, 128.0, 128.0 | -127.0, -127.0, -127.0 | -127.0 | darker; red -127.0 |", summary)
@@ -1504,11 +1504,11 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             1,
         )[0]
         self.assertIn(
-            "| lighter + blue higher | 3 | 16.0 | 8.0 | geneva=2, zermatt=1 |",
+            "| lighter + blue higher | 3 | 16.0 | 8.0 | geneva=2, zermatt=1 | zermatt crop 1 |",
             movement_section,
         )
         self.assertIn(
-            "| darker + red lower | 1 | 18.0 | 6.0 | lausanne=1 |",
+            "| darker + red lower | 1 | 18.0 | 6.0 | lausanne=1 | lausanne crop 1 |",
             movement_section,
         )
         self.assertLess(
@@ -1582,6 +1582,39 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 "max_abs_rgb_delta": 16.0,
                 "qgis_minus_mapbox_luminance": 8.0,
             },
+        )
+
+    def test_build_summary_markdown_shows_stored_movement_group_representative(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "comparison_summary_json": "debug/comparison/summary.json",
+                "crop_size": {"width": 4, "height": 4},
+                "crops_per_camera": 1,
+                "camera_count": 1,
+                "crop_count": 1,
+                "crop_color_movement_groups": [
+                    {
+                        "movement": "lighter + blue higher",
+                        "crop_count": 2,
+                        "max_abs_rgb_delta": 16.0,
+                        "max_abs_luminance_delta": 8.0,
+                        "cameras": {"zermatt": 2},
+                        "representative_crop": {
+                            "camera": "zermatt",
+                            "crop": 2,
+                            "box": [4, 4, 8, 8],
+                            "diff": "debug/zermatt-diff.png",
+                        },
+                    }
+                ],
+                "cameras": [],
+            }
+        )
+
+        self.assertIn(
+            "| lighter + blue higher | 2 | 16.0 | 8.0 | zermatt=2 | zermatt crop 2 [4,4,8,8] `debug/zermatt-diff.png` |",
+            markdown,
         )
 
     def test_build_summary_markdown_handles_malformed_color_delta_values(self):

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1791,6 +1791,23 @@ def _crop_color_movement_group_record_float(record: Mapping[str, object], key: s
     return 0.0
 
 
+def _movement_group_representative_label(record: Mapping[str, object]) -> str:
+    representative = record.get("representative_crop")
+    if not isinstance(representative, Mapping):
+        return "-"
+    parts = [str(representative.get("camera") or "-")]
+    crop_index = representative.get("crop")
+    if crop_index is not None:
+        parts.append(f"crop {crop_index}")
+    box = representative.get("box")
+    if isinstance(box, list):
+        parts.append(json.dumps(box, ensure_ascii=True, separators=(",", ":")))
+    diff_path = representative.get("diff")
+    if isinstance(diff_path, str) and diff_path:
+        parts.append(f"`{diff_path}`")
+    return " ".join(parts)
+
+
 def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> list[list[object]]:
     return [
         [
@@ -1799,6 +1816,7 @@ def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> lis
             f"{_crop_color_movement_group_record_float(record, 'max_abs_rgb_delta'):.1f}",
             f"{_crop_color_movement_group_record_float(record, 'max_abs_luminance_delta'):.1f}",
             _joined_summary_labels(_top_count_labels(record.get("cameras"))),
+            _movement_group_representative_label(record),
         ]
         for record in _crop_color_movement_group_records(report)[:DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT]
     ]
@@ -1818,8 +1836,8 @@ def _summary_crop_color_movement_group_lines(report: Mapping[str, object]) -> li
             "tuning a single style rule."
         ),
         "",
-        "| Movement | Crops | Max abs RGB | Max abs luminance | Cameras |",
-        "| --- | ---: | ---: | ---: | --- |",
+        "| Movement | Crops | Max abs RGB | Max abs luminance | Cameras | Representative crop |",
+        "| --- | ---: | ---: | ---: | --- | --- |",
     ]
     lines.extend(_markdown_table_row(row) for row in rows)
     return lines


### PR DESCRIPTION
## Summary
- show each crop color movement group's representative crop directly in the Markdown movement-group table
- include the representative camera, crop index, crop box, and diff crop path beside the grouped tint family
- document that the report summary now surfaces a representative crop for each group

## Evidence
- Refs #949
- Fresh local report: `debug/mapbox-outdoors-visual-crops/20260521T151749Z/summary.md`
- The movement-group table now points `lighter + red higher` to `switzerland-alps-z5-outdoors` crop 1, `darker + red lower` to `lausanne-lavaux-z10-outdoors` crop 1, and `lighter + blue higher` to `zermatt-trails-z18-outdoors` crop 2.
- This is a validation-aid slice only; it does not change QGIS rendering behavior.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short` -> 42 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2394 passed, 180 skipped, 171 subtests passed
- `git diff --check` -> clean
