### PR TITLE
Show representative camera in crop movement groups

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1617,6 +1617,49 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             markdown,
         )
 
+    def test_build_summary_markdown_keeps_representative_camera_visible(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "comparison_summary_json": "debug/comparison/summary.json",
+                "crop_size": {"width": 4, "height": 4},
+                "crops_per_camera": 1,
+                "camera_count": 4,
+                "crop_count": 8,
+                "crop_color_movement_groups": [
+                    {
+                        "movement": "lighter + red higher",
+                        "crop_count": 8,
+                        "max_abs_rgb_delta": 11.8,
+                        "max_abs_luminance_delta": 9.0,
+                        "cameras": {
+                            "zermatt-piste-z17-outdoors": 3,
+                            "geneva-airport-motorway-z14-outdoors": 2,
+                            "valais-geneva-outdoors": 2,
+                            "switzerland-alps-z5-outdoors": 1,
+                        },
+                        "representative_crop": {
+                            "camera": "switzerland-alps-z5-outdoors",
+                            "crop": 1,
+                            "box": [210, 600, 630, 900],
+                            "diff": "debug/switzerland-diff.png",
+                        },
+                    }
+                ],
+                "cameras": [],
+            }
+        )
+
+        self.assertIn(
+            (
+                "| lighter + red higher | 8 | 11.8 | 9.0 | "
+                "zermatt-piste-z17-outdoors=3, geneva-airport-motorway-z14-outdoors=2, "
+                "valais-geneva-outdoors=2, switzerland-alps-z5-outdoors=1 (representative) | "
+                "switzerland-alps-z5-outdoors crop 1 [210,600,630,900] `debug/switzerland-diff.png` |"
+            ),
+            markdown,
+        )
+
     def test_build_summary_markdown_handles_malformed_color_delta_values(self):
         markdown = build_summary_markdown(
             {

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1808,6 +1808,24 @@ def _movement_group_representative_label(record: Mapping[str, object]) -> str:
     return " ".join(parts)
 
 
+def _movement_group_camera_labels(record: Mapping[str, object]) -> list[str]:
+    cameras = record.get("cameras")
+    labels = _top_count_labels(cameras)
+    representative = record.get("representative_crop")
+    if not isinstance(representative, Mapping) or not isinstance(cameras, Mapping):
+        return labels
+    representative_camera = representative.get("camera")
+    if not isinstance(representative_camera, str) or not representative_camera:
+        return labels
+    representative_count = cameras.get(representative_camera)
+    if not isinstance(representative_count, int) or isinstance(representative_count, bool):
+        return labels
+    prefix = f"{representative_camera}="
+    if any(label.startswith(prefix) for label in labels):
+        return labels
+    return [*labels, f"{representative_camera}={representative_count} (representative)"]
+
+
 def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> list[list[object]]:
     return [
         [
@@ -1815,7 +1833,7 @@ def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> lis
             record.get("crop_count"),
             f"{_crop_color_movement_group_record_float(record, 'max_abs_rgb_delta'):.1f}",
             f"{_crop_color_movement_group_record_float(record, 'max_abs_luminance_delta'):.1f}",
-            _joined_summary_labels(_top_count_labels(record.get("cameras"))),
+            _joined_summary_labels(_movement_group_camera_labels(record)),
             _movement_group_representative_label(record),
         ]
         for record in _crop_color_movement_group_records(report)[:DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT]


### PR DESCRIPTION
Refs #949.

## Summary
- keep a movement group representative camera visible in the Markdown Cameras cell when top-count truncation would otherwise hide it
- mark that extra camera as `(representative)` so the column explains why it appears beyond the top camera counts
- add a regression test based on the latest #949 crop movement report shape

## Evidence
- Latest #1292-era report had `lighter + red higher` represented by `switzerland-alps-z5-outdoors`, while the Cameras cell omitted that camera due top-count truncation.
- Regenerated report after this change: `debug/mapbox-outdoors-visual-crops/20260521T152816Z/summary.md`.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check HEAD~1..HEAD`