### PR TITLE
test: show movement representative deltas

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -158,7 +158,7 @@ The delta context is shown only when the comparison-delta candidate summary matc
 
 Every crop report also includes a crop color metrics section with crop-local mean RGB values for the Mapbox GL and QGIS crops, plus QGIS-minus-Mapbox RGB/luminance deltas and the dominant color direction. Use these numbers as triage context when broad terrain, landcover, water, or tint differences dominate the hotspot sheet.
 The report also ranks the largest crop color deltas first, which keeps the worst tint and terrain outliers, crop boxes, diff crop paths, and dominant movement visible before scanning the full per-crop metrics table.
-It also groups crop movements by luminance direction and dominant RGB channel, including a representative crop for each group, so repeated tint families can be reviewed before trying a single global style lever.
+It also groups crop movements by luminance direction and dominant RGB channel, including a representative crop and its QGIS-minus-Mapbox RGB/luminance deltas for each group, so repeated tint families can be reviewed before trying a single global style lever.
 The same movement groups are stored in `visual-crops.json` under `crop_color_movement_groups`, including a representative crop for each group, for follow-up scripts that should not parse the Markdown summary.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -664,7 +664,11 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("## Crop color metrics", summary)
             self.assertIn("## Crop color movement groups", summary)
             self.assertIn(
-                f"| darker + red lower | 1 | 127.0 | 127.0 | chamonix-trails-z14-outdoors=1 | chamonix-trails-z14-outdoors crop 1 [6,6,10,10] `{outputs['diff']}` |",
+                (
+                    f"| darker + red lower | 1 | 127.0 | 127.0 | chamonix-trails-z14-outdoors=1 | "
+                    f"chamonix-trails-z14-outdoors crop 1 [6,6,10,10] `{outputs['diff']}` | "
+                    "-127.0, -127.0, -127.0 | -127.0 |"
+                ),
                 summary,
             )
             self.assertIn("| chamonix-trails-z14-outdoors | 1 | 255.0, 255.0, 255.0 | 128.0, 128.0, 128.0 | -127.0, -127.0, -127.0 | -127.0 | darker; red -127.0 |", summary)
@@ -1504,11 +1508,17 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             1,
         )[0]
         self.assertIn(
-            "| lighter + blue higher | 3 | 16.0 | 8.0 | geneva=2, zermatt=1 | zermatt crop 1 |",
+            (
+                "| lighter + blue higher | 3 | 16.0 | 8.0 | geneva=2, zermatt=1 | "
+                "zermatt crop 1 | 2.0, 0.0, 16.0 | +8.0 |"
+            ),
             movement_section,
         )
         self.assertIn(
-            "| darker + red lower | 1 | 18.0 | 6.0 | lausanne=1 | lausanne crop 1 |",
+            (
+                "| darker + red lower | 1 | 18.0 | 6.0 | lausanne=1 | lausanne crop 1 | "
+                "-18.0, -1.0, -16.0 | -6.0 |"
+            ),
             movement_section,
         )
         self.assertLess(
@@ -1613,7 +1623,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         )
 
         self.assertIn(
-            "| lighter + blue higher | 2 | 16.0 | 8.0 | zermatt=2 | zermatt crop 2 [4,4,8,8] `debug/zermatt-diff.png` |",
+            (
+                "| lighter + blue higher | 2 | 16.0 | 8.0 | zermatt=2 | "
+                "zermatt crop 2 [4,4,8,8] `debug/zermatt-diff.png` | - | - |"
+            ),
             markdown,
         )
 
@@ -1643,6 +1656,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                             "crop": 1,
                             "box": [210, 600, 630, 900],
                             "diff": "debug/switzerland-diff.png",
+                            "qgis_minus_mapbox_rgb": [11.8, 8.9, 1.9],
+                            "qgis_minus_mapbox_luminance": 9.0,
                         },
                     }
                 ],
@@ -1655,7 +1670,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 "| lighter + red higher | 8 | 11.8 | 9.0 | "
                 "zermatt-piste-z17-outdoors=3, geneva-airport-motorway-z14-outdoors=2, "
                 "valais-geneva-outdoors=2, switzerland-alps-z5-outdoors=1 (representative) | "
-                "switzerland-alps-z5-outdoors crop 1 [210,600,630,900] `debug/switzerland-diff.png` |"
+                "switzerland-alps-z5-outdoors crop 1 [210,600,630,900] `debug/switzerland-diff.png` | "
+                "11.8, 8.9, 1.9 | +9.0 |"
             ),
             markdown,
         )

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1808,6 +1808,33 @@ def _movement_group_representative_label(record: Mapping[str, object]) -> str:
     return " ".join(parts)
 
 
+def _movement_group_representative_rgb_label(record: Mapping[str, object]) -> str:
+    representative = record.get("representative_crop")
+    if not isinstance(representative, Mapping):
+        return "-"
+    values = representative.get("qgis_minus_mapbox_rgb")
+    if not isinstance(values, list):
+        return "-"
+    numeric_values: list[float] = []
+    for value in values[:3]:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return "-"
+        numeric_values.append(float(value))
+    if len(numeric_values) != 3:
+        return "-"
+    return ", ".join(f"{value:.1f}" for value in numeric_values)
+
+
+def _movement_group_representative_luminance_label(record: Mapping[str, object]) -> str:
+    representative = record.get("representative_crop")
+    if not isinstance(representative, Mapping):
+        return "-"
+    value = representative.get("qgis_minus_mapbox_luminance")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "-"
+    return f"{float(value):+.1f}"
+
+
 def _movement_group_camera_labels(record: Mapping[str, object]) -> list[str]:
     cameras = record.get("cameras")
     labels = _top_count_labels(cameras)
@@ -1835,6 +1862,8 @@ def _summary_crop_color_movement_group_rows(report: Mapping[str, object]) -> lis
             f"{_crop_color_movement_group_record_float(record, 'max_abs_luminance_delta'):.1f}",
             _joined_summary_labels(_movement_group_camera_labels(record)),
             _movement_group_representative_label(record),
+            _movement_group_representative_rgb_label(record),
+            _movement_group_representative_luminance_label(record),
         ]
         for record in _crop_color_movement_group_records(report)[:DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT]
     ]
@@ -1854,8 +1883,11 @@ def _summary_crop_color_movement_group_lines(report: Mapping[str, object]) -> li
             "tuning a single style rule."
         ),
         "",
-        "| Movement | Crops | Max abs RGB | Max abs luminance | Cameras | Representative crop |",
-        "| --- | ---: | ---: | ---: | --- | --- |",
+        (
+            "| Movement | Crops | Max abs RGB | Max abs luminance | Cameras | "
+            "Representative crop | Representative RGB | Representative luminance |"
+        ),
+        "| --- | ---: | ---: | ---: | --- | --- | ---: | ---: |",
     ]
     lines.extend(_markdown_table_row(row) for row in rows)
     return lines


### PR DESCRIPTION
## Summary

- show representative QGIS-minus-Mapbox RGB and luminance deltas in the crop movement group table
- keep stored movement groups backward-compatible by rendering missing representative deltas as `-`
- document the representative delta columns in the Mapbox Outdoors comparison harness notes

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 validation/mapbox_outdoors_visual_crops.py --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/20260521T120446Z/summary.json --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/20260521T122404Z/path-pedestrian-focus.json --style-audit-json debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260521T115924Z/audit.json --crop-size 420x300`

Part of #949.
