### PR TITLE
test: show area filter signatures

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -162,7 +162,7 @@ It also groups crop movements by luminance direction and dominant RGB channel, i
 The same movement groups are stored in `visual-crops.json` under `crop_color_movement_groups`, including a representative crop for each group, for follow-up scripts that should not parse the Markdown summary.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
-The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, sample layers, and compact qfit simplification snippets for sampled controls:
+The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, filter-operator signatures, sample layers, and compact qfit simplification snippets for sampled controls:
 
 ```bash
 python3 validation/mapbox_outdoors_visual_crops.py \

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -789,6 +789,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             focus = report["style_audit_area_fill_focus"]
             self.assertEqual([row["key"] for row in focus], ["terrain_landcover", "airport_special_landuse"])
             self.assertEqual(focus[0]["candidate_count"], 2)
+            self.assertEqual(
+                focus[0]["filter_signatures"],
+                [{"filter_operator_signature": "all, get, match", "count": 1}],
+            )
             focus[0]["sample_candidates"].append({"source_layer": "landcover", "type": "fill"})
             markdown = build_summary_markdown(report)
             self.assertEqual(
@@ -825,6 +829,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("## Style audit area-fill focus", markdown)
             self.assertIn("Terrain/landcover", markdown)
             self.assertIn("landcover=1", markdown)
+            self.assertIn("all, get, match=1", markdown)
             self.assertIn("landuse-other-z10-plus-airport", markdown)
             self.assertIn(
                 "landcover (landcover/fill; controls=filter, paint.fill-color, "
@@ -881,7 +886,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertEqual(focus[1]["candidate_count"], 0)
             self.assertEqual(focus[1]["sample_candidates"], [])
             markdown = build_summary_markdown(report)
-            self.assertIn("| Airport/special landuse | 0 | - | - | - | - | - |", markdown)
+            self.assertIn("| Airport/special landuse | 0 | - | - | - | - | - | - |", markdown)
 
     def test_generate_visual_crop_report_samples_representative_area_fill_candidates(self):
         image_module, image_stat_module = _fake_image_modules()

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -787,6 +787,20 @@ def _style_audit_sample_candidates(
     return [candidates[index] for index in sorted(selected_indexes)]
 
 
+def _style_audit_filter_signature_rows(
+    candidates: list[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    counts: dict[str, int] = {}
+    for candidate in candidates:
+        signature = candidate.get("filter_operator_signature")
+        if isinstance(signature, str) and signature:
+            counts[signature] = counts.get(signature, 0) + 1
+    return [
+        {"filter_operator_signature": signature, "count": count}
+        for signature, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
 def _style_audit_area_fill_focus(
     style_audit_report: Mapping[str, object] | None,
     *,
@@ -818,6 +832,7 @@ def _style_audit_area_fill_focus(
                 "qgis_dependent_by_property": list(
                     _style_audit_rows(summary, section["qgis_dependent_by_property"])
                 ),
+                "filter_signatures": _style_audit_filter_signature_rows(candidates),
                 "sample_candidates": [
                     _style_audit_candidate_sample(
                         candidate,
@@ -2160,8 +2175,11 @@ def _style_audit_area_fill_focus_lines(report: Mapping[str, object]) -> list[str
             "without reopening the full audit."
         ),
         "",
-        "| Area | Candidates | Source layers | Types | Simplified controls | QGIS-dependent controls | Sample layers |",
-        "| --- | ---: | --- | --- | --- | --- | --- |",
+        (
+            "| Area | Candidates | Source layers | Types | Simplified controls | "
+            "QGIS-dependent controls | Filter signatures | Sample layers |"
+        ),
+        "| --- | ---: | --- | --- | --- | --- | --- | --- |",
     ]
     for row in rows:
         if not isinstance(row, Mapping):
@@ -2180,6 +2198,12 @@ def _style_audit_area_fill_focus_lines(report: Mapping[str, object]) -> list[str
                     ),
                     _joined_summary_labels(
                         _count_summary_labels(row.get("qgis_dependent_by_property"), "property")
+                    ),
+                    _joined_summary_labels(
+                        _count_summary_labels(
+                            row.get("filter_signatures"),
+                            "filter_operator_signature",
+                        )
                     ),
                     _joined_summary_labels(_candidate_sample_labels(row.get("sample_candidates"))),
                 ]


### PR DESCRIPTION
## Summary

- add area-fill filter-operator signature counts to the visual crop style-audit focus table
- keep the crop summary self-contained when deciding whether terrain/landcover or airport fill gaps are tied to remaining filter handling
- document the added filter-signature context in the comparison harness notes

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `python3 validation/mapbox_outdoors_visual_crops.py --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/20260521T120446Z/summary.json --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/20260521T122404Z/path-pedestrian-focus.json --style-audit-json debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/20260521T115924Z/audit.json --crop-size 420x300`

Part of #949.
