### PR TITLE
test: show area sample filter signatures

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -162,7 +162,7 @@ It also groups crop movements by luminance direction and dominant RGB channel, i
 The same movement groups are stored in `visual-crops.json` under `crop_color_movement_groups`, including a representative crop for each group, for follow-up scripts that should not parse the Markdown summary.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
-The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, filter-operator signatures, sample layers, and compact qfit simplification snippets for sampled controls:
+The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, filter-operator signatures, sample-layer filter signatures, and compact qfit simplification snippets for sampled controls:
 
 ```bash
 python3 validation/mapbox_outdoors_visual_crops.py \

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -832,7 +832,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("all, get, match=1", markdown)
             self.assertIn("landuse-other-z10-plus-airport", markdown)
             self.assertIn(
-                "landcover (landcover/fill; controls=filter, paint.fill-color, "
+                "landcover (landcover/fill; filter-ops: all, get, match; controls=filter, paint.fill-color, "
                 "paint.fill-opacity; qfit=paint.fill-color, paint.fill-opacity; "
                 "simplifies=paint.fill-color",
                 markdown,

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -2082,6 +2082,9 @@ def _candidate_sample_label(candidate: Mapping[str, object]) -> str:
     details = []
     if source_layer is not None or layer_type is not None:
         details.append(f"{source_layer}/{layer_type}")
+    filter_signature = candidate.get("filter_operator_signature")
+    if isinstance(filter_signature, str) and filter_signature:
+        details.append(f"filter-ops: {filter_signature}")
     if controls:
         details.append(f"controls={', '.join(controls[:4])}")
     qfit_simplified = _string_values(candidate.get("qfit_simplified_properties"))


### PR DESCRIPTION
Refs #949.

## Summary
- show each sampled area-fill candidate layer's filter-operator signature in the visual crop Markdown summary
- use `filter-ops:` labels so operator signatures beginning with `==` remain readable
- document that the area-fill focus includes sample-layer filter signatures

## Evidence
- Regenerated report after this change: `debug/mapbox-outdoors-visual-crops/20260521T161546Z/summary.md`.
- The area-fill sample labels now show examples such as `filter-ops: ==, all, get, match`, `filter-ops: all, get, match`, and `filter-ops: <=, >=, all, get, match, to-number`.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short` -> 43 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2395 passed, 180 skipped, 171 subtests passed
- `git diff --check`
