### PR TITLE
[codex] Show focus cue movement groups

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1740,6 +1740,16 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 "crops_per_camera": 1,
                 "camera_count": 1,
                 "crop_count": 0,
+                "crop_color_movement_groups": [
+                    {
+                        "movement": "lighter + blue higher",
+                        "cameras": {"chamonix-trails-z14-outdoors": 2},
+                    },
+                    {
+                        "movement": "darker + red lower",
+                        "cameras": {"lausanne-lavaux-z10-outdoors": 1},
+                    },
+                ],
                 "cameras": [
                     {
                         "camera": "chamonix-trails-z14-outdoors",
@@ -1783,6 +1793,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         )
         self.assertIn("Path/pedestrian focus comparison match: `True`", markdown)
         self.assertIn("## Path/pedestrian focus cues", markdown)
+        self.assertIn("| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |", markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | lighter + blue higher=2 |", markdown)
         self.assertIn("road-path-trail->road-path-trail-below-z16", markdown)
         self.assertIn("candidates=74 (trail=69, hiking=5)", markdown)
         self.assertIn("candidate_types=trail=69", markdown)

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1749,6 +1749,17 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         "movement": "darker + red lower",
                         "cameras": {"lausanne-lavaux-z10-outdoors": 1},
                     },
+                    *[
+                        {
+                            "movement": f"unrelated movement {index}",
+                            "cameras": {"other-camera": 1},
+                        }
+                        for index in range(3, 9)
+                    ],
+                    {
+                        "movement": "hidden ninth movement",
+                        "cameras": {"chamonix-trails-z14-outdoors": 1},
+                    },
                 ],
                 "cameras": [
                     {
@@ -1795,6 +1806,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertIn("## Path/pedestrian focus cues", markdown)
         self.assertIn("| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | lighter + blue higher=2 |", markdown)
+        self.assertNotIn("hidden ninth movement=1", markdown)
         self.assertIn("road-path-trail->road-path-trail-below-z16", markdown)
         self.assertIn("candidates=74 (trail=69, hiking=5)", markdown)
         self.assertIn("candidate_types=trail=69", markdown)

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1997,7 +1997,28 @@ def _candidate_backed_focus_summaries(
     ]
 
 
-def _summary_focus_row(camera: object) -> list[object] | None:
+def _focus_movement_group_labels(
+    report: Mapping[str, object],
+    camera_name: object,
+) -> list[str]:
+    if not isinstance(camera_name, str) or not camera_name:
+        return []
+    labels: list[str] = []
+    for record in _crop_color_movement_group_records(report):
+        movement = record.get("movement")
+        cameras = record.get("cameras")
+        if not isinstance(movement, str) or not isinstance(cameras, Mapping):
+            continue
+        count = cameras.get(camera_name)
+        if isinstance(count, int) and not isinstance(count, bool):
+            labels.append(f"{movement}={count}")
+    return labels
+
+
+def _summary_focus_row(
+    report: Mapping[str, object],
+    camera: object,
+) -> list[object] | None:
     if not isinstance(camera, Mapping):
         return None
     focus = camera.get("path_pedestrian_focus")
@@ -2015,14 +2036,20 @@ def _summary_focus_row(camera: object) -> list[object] | None:
     )
     if not stroke_summaries and not dash_summaries:
         return None
-    return [camera.get("camera"), stroke_summaries, dash_summaries]
+    camera_name = camera.get("camera")
+    return [
+        camera_name,
+        _joined_summary_labels(_focus_movement_group_labels(report, camera_name)),
+        stroke_summaries,
+        dash_summaries,
+    ]
 
 
 def _summary_focus_rows(report: Mapping[str, object]) -> list[list[object]]:
     return [
         row
         for camera in report.get("cameras", [])
-        if (row := _summary_focus_row(camera)) is not None
+        if (row := _summary_focus_row(report, camera)) is not None
     ]
 
 
@@ -2038,11 +2065,12 @@ def _summary_focus_cue_lines(report: Mapping[str, object]) -> list[str]:
             (
                 "Shows the strongest per-camera path/pedestrian stroke cues from the focus report "
                 "next to visual hotspots, so crop review can distinguish candidate-backed style gaps "
-                "from capped-width or zero-candidate artifacts."
+                "from capped-width or zero-candidate artifacts and relate those cues to crop-local "
+                "color movement families."
             ),
             "",
-            "| Camera | Stroke width cues | Dash mismatch cues |",
-            "| --- | --- | --- |",
+            "| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |",
+            "| --- | --- | --- | --- |",
         ]
     )
     lines.extend(_markdown_table_row(row) for row in rows)

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -2004,7 +2004,9 @@ def _focus_movement_group_labels(
     if not isinstance(camera_name, str) or not camera_name:
         return []
     labels: list[str] = []
-    for record in _crop_color_movement_group_records(report):
+    for record in _crop_color_movement_group_records(report)[
+        :DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT
+    ]:
         movement = record.get("movement")
         cameras = record.get("cameras")
         if not isinstance(movement, str) or not isinstance(cameras, Mapping):


### PR DESCRIPTION
## Summary

- Add crop movement group context to the visual crop report path/pedestrian focus table.
- Keep the new column report-only so the latest #949 path/stroke evidence can be tied back to the crop-local color movement families without changing rendering behavior.
- Cover the Markdown output with a regression test.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949
