### PR TITLE
[codex] Filter focus movement labels before cap

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1757,9 +1757,16 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         for index in range(3, 9)
                     ],
                     {
-                        "movement": "hidden ninth movement",
+                        "movement": "camera movement below global top",
                         "cameras": {"chamonix-trails-z14-outdoors": 1},
                     },
+                    *[
+                        {
+                            "movement": f"extra chamonix movement {index}",
+                            "cameras": {"chamonix-trails-z14-outdoors": 1},
+                        }
+                        for index in range(1, 8)
+                    ],
                 ],
                 "cameras": [
                     {
@@ -1805,8 +1812,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertIn("Path/pedestrian focus comparison match: `True`", markdown)
         self.assertIn("## Path/pedestrian focus cues", markdown)
         self.assertIn("| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |", markdown)
-        self.assertIn("| chamonix-trails-z14-outdoors | lighter + blue higher=2 |", markdown)
-        self.assertNotIn("hidden ninth movement=1", markdown)
+        self.assertIn("| chamonix-trails-z14-outdoors | lighter + blue higher=2", markdown)
+        self.assertIn("camera movement below global top=1", markdown)
+        self.assertIn("extra chamonix movement 6=1", markdown)
+        self.assertNotIn("extra chamonix movement 7=1", markdown)
         self.assertIn("road-path-trail->road-path-trail-below-z16", markdown)
         self.assertIn("candidates=74 (trail=69, hiking=5)", markdown)
         self.assertIn("candidate_types=trail=69", markdown)

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1998,15 +1998,13 @@ def _candidate_backed_focus_summaries(
 
 
 def _focus_movement_group_labels(
-    report: Mapping[str, object],
+    movement_group_records: Sequence[Mapping[str, object]],
     camera_name: object,
 ) -> list[str]:
     if not isinstance(camera_name, str) or not camera_name:
         return []
     labels: list[str] = []
-    for record in _crop_color_movement_group_records(report)[
-        :DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT
-    ]:
+    for record in movement_group_records:
         movement = record.get("movement")
         cameras = record.get("cameras")
         if not isinstance(movement, str) or not isinstance(cameras, Mapping):
@@ -2014,11 +2012,13 @@ def _focus_movement_group_labels(
         count = cameras.get(camera_name)
         if isinstance(count, int) and not isinstance(count, bool):
             labels.append(f"{movement}={count}")
+            if len(labels) >= DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT:
+                break
     return labels
 
 
 def _summary_focus_row(
-    report: Mapping[str, object],
+    movement_group_records: Sequence[Mapping[str, object]],
     camera: object,
 ) -> list[object] | None:
     if not isinstance(camera, Mapping):
@@ -2041,17 +2041,20 @@ def _summary_focus_row(
     camera_name = camera.get("camera")
     return [
         camera_name,
-        _joined_summary_labels(_focus_movement_group_labels(report, camera_name)),
+        _joined_summary_labels(
+            _focus_movement_group_labels(movement_group_records, camera_name)
+        ),
         stroke_summaries,
         dash_summaries,
     ]
 
 
 def _summary_focus_rows(report: Mapping[str, object]) -> list[list[object]]:
+    movement_group_records = _crop_color_movement_group_records(report)
     return [
         row
         for camera in report.get("cameras", [])
-        if (row := _summary_focus_row(report, camera)) is not None
+        if (row := _summary_focus_row(movement_group_records, camera)) is not None
     ]
 
 


### PR DESCRIPTION
## Summary
- address late Codex feedback from #1297 by filtering focus movement labels per camera before applying the display cap
- reuse precomputed movement group records while building focus rows to avoid repeated report scans
- update the summary markdown test to cover below-global-top camera labels and the camera-specific cap

## Tests
- python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short

Refs #949