### PR TITLE
[codex] Show path focus coverage

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -135,6 +135,8 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json
 ```
 
+The crop report also includes a path/pedestrian focus coverage section for that focus input. It shows the raw non-auxiliary stroke and dash counts per camera before the cue table filters down to meaningful candidate-backed rows, which helps explain cases where a visually suspicious camera has decoded candidates but no surfaced focus cue.
+
 To inspect only cameras that still have candidate-backed path/pedestrian focus cues, add `--focus-cue-cameras`. This is useful after a global highest-delta crop run is dominated by a different camera and hides lower-scoring stroke-width or dash candidates:
 
 ```bash

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -224,6 +224,8 @@ def _path_pedestrian_focus_report(
                         "decoded_candidate_type_counts": {},
                         "source_sampled_controls": {
                             "line-width": 1.0583333333333333,
+                            "line-width_raw_mm": 1.3229166666666665,
+                            "line-width_capped": True,
                             "line-dasharray": [1, 0.25],
                         },
                         "qgis_controls": [
@@ -756,6 +758,23 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 [str(summary_path)],
             )
             self.assertIs(report["path_pedestrian_focus_comparison_match"], True)
+            self.assertEqual(
+                report["path_pedestrian_focus_coverage"],
+                [
+                    {
+                        "camera": "chamonix-trails-z14-outdoors",
+                        "stroke_rows": 3,
+                        "candidate_backed_stroke_rows": 2,
+                        "candidate_backed_width_delta_rows": 1,
+                        "candidate_backed_zero_delta_rows": 1,
+                        "zero_candidate_stroke_rows": 1,
+                        "source_capped_stroke_rows": 1,
+                        "dash_mismatch_rows": 2,
+                        "candidate_backed_dash_rows": 1,
+                        "zero_candidate_dash_rows": 1,
+                    }
+                ],
+            )
             self.assertEqual(stroke_cues[0]["source_layer_id"], "road-path-trail")
             self.assertEqual(stroke_cues[0]["candidate_types"], ["trail=69", "hiking=5"])
             self.assertEqual(dash_cues[0]["source_layer_id"], "road-steps")
@@ -1171,6 +1190,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 ["debug/comparison/summary.json"],
             )
             self.assertIs(report["path_pedestrian_focus_comparison_match"], False)
+            self.assertNotIn("path_pedestrian_focus_coverage", report)
             self.assertNotIn("path_pedestrian_focus", report["cameras"][0])
 
     def test_generate_visual_crop_report_rejects_focus_filter_with_mismatched_focus_cues(self):
@@ -1768,6 +1788,20 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         for index in range(1, 8)
                     ],
                 ],
+                "path_pedestrian_focus_coverage": [
+                    {
+                        "camera": "chamonix-trails-z14-outdoors",
+                        "stroke_rows": 3,
+                        "candidate_backed_stroke_rows": 2,
+                        "candidate_backed_width_delta_rows": 1,
+                        "candidate_backed_zero_delta_rows": 1,
+                        "zero_candidate_stroke_rows": 1,
+                        "source_capped_stroke_rows": 1,
+                        "dash_mismatch_rows": 2,
+                        "candidate_backed_dash_rows": 1,
+                        "zero_candidate_dash_rows": 1,
+                    }
+                ],
                 "cameras": [
                     {
                         "camera": "chamonix-trails-z14-outdoors",
@@ -1810,6 +1844,11 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             markdown,
         )
         self.assertIn("Path/pedestrian focus comparison match: `True`", markdown)
+        self.assertIn("## Path/pedestrian focus coverage", markdown)
+        self.assertIn(
+            "| chamonix-trails-z14-outdoors | 3 | 2 | 1 | 1 | 1 | 1 | 2 | 1 | 1 |",
+            markdown,
+        )
         self.assertIn("## Path/pedestrian focus cues", markdown)
         self.assertIn("| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | lighter + blue higher=2", markdown)
@@ -1906,6 +1945,12 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 "crops_per_camera": 1,
                 "camera_count": 1,
                 "crop_count": 0,
+                "path_pedestrian_focus_coverage": [
+                    {
+                        "camera": "chamonix-trails-z14-outdoors",
+                        "stroke_rows": 1,
+                    }
+                ],
                 "cameras": [
                     {
                         "camera": "chamonix-trails-z14-outdoors",
@@ -1926,6 +1971,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         )
 
         self.assertIn("Path/pedestrian focus comparison match: `False`", markdown)
+        self.assertNotIn("## Path/pedestrian focus coverage", markdown)
         self.assertNotIn("## Path/pedestrian focus cues", markdown)
         self.assertNotIn("road-path-trail->road-path-trail-below-z16", markdown)
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -14,6 +14,7 @@ from qfit.validation.mapbox_outdoors_visual_crops import (
     VisualCropAnnotationInputs,
     _computed_crop_color_movement_group_records,
     _crop_color_metric,
+    _path_pedestrian_focus_coverage_rows,
     _three_channel_color_values,
     annotate_visual_crop_report_with_comparison_delta,
     build_run_directory,
@@ -779,6 +780,44 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertEqual(stroke_cues[0]["candidate_types"], ["trail=69", "hiking=5"])
             self.assertEqual(dash_cues[0]["source_layer_id"], "road-steps")
             self.assertEqual(dash_cues[0]["source_dasharray"], [0.3, 0.3])
+
+    def test_path_pedestrian_focus_coverage_counts_all_stroke_rows(self):
+        focus_report = {
+            "cameras": [
+                {
+                    "camera": "large-focus-camera",
+                    "source_qgis_stroke_control_comparisons": [
+                        {
+                            "source_layer_id": "road-path-trail",
+                            "decoded_candidate_count": 1,
+                            "source_sampled_controls": {"line-width": 0.1},
+                            "qgis_controls": [
+                                {
+                                    "layer_id": f"road-path-trail-{index}",
+                                    "controls": {"line-width": 0.2},
+                                }
+                            ],
+                            "qgis_control_deltas": [
+                                {
+                                    "layer_id": f"road-path-trail-{index}",
+                                    "deltas": {
+                                        "line-width_delta_mm": 0.1,
+                                        "line-width_ratio": 2.0,
+                                        "line-dasharray_match": True,
+                                    },
+                                }
+                            ],
+                        }
+                        for index in range(10_001)
+                    ],
+                }
+            ]
+        }
+
+        self.assertEqual(
+            _path_pedestrian_focus_coverage_rows(focus_report)[0]["stroke_rows"],
+            10_001,
+        )
 
     def test_generate_visual_crop_report_attaches_style_audit_area_fill_focus(self):
         image_module, image_stat_module = _fake_image_modules()

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -14,6 +14,7 @@ try:
     from .mapbox_outdoors_path_pedestrian_focus import (
         COMPARISON_VISUAL_METRIC_KEYS,
         REPO_ROOT,
+        _camera_non_auxiliary_stroke_delta_rows,
         _display_input_path,
         _largest_non_auxiliary_stroke_delta_rows,
         _non_auxiliary_dash_mismatch_rows,
@@ -27,6 +28,7 @@ except ImportError:  # pragma: no cover - direct script execution
     from mapbox_outdoors_path_pedestrian_focus import (  # type: ignore[no-redef]
         COMPARISON_VISUAL_METRIC_KEYS,
         REPO_ROOT,
+        _camera_non_auxiliary_stroke_delta_rows,
         _display_input_path,
         _largest_non_auxiliary_stroke_delta_rows,
         _non_auxiliary_dash_mismatch_rows,
@@ -103,6 +105,7 @@ class _FocusAnnotationContext:
     comparison_paths: list[str]
     comparison_match: bool | None
     cues_by_camera: dict[str, dict[str, list[dict[str, object]]]]
+    coverage_rows: list[dict[str, object]]
 
 
 def build_run_directory(
@@ -513,6 +516,57 @@ def _path_pedestrian_focus_cues_by_camera(
     return cues_by_camera
 
 
+def _path_pedestrian_focus_coverage_rows(
+    focus_report: Mapping[str, object] | None,
+) -> list[dict[str, object]]:
+    if not focus_report:
+        return []
+    cameras = focus_report.get("cameras")
+    if not isinstance(cameras, list):
+        return []
+    coverage_rows: list[dict[str, object]] = []
+    for camera in cameras:
+        if not isinstance(camera, Mapping):
+            continue
+        camera_name = str(camera.get("camera") or "")
+        if not camera_name:
+            continue
+        stroke_rows = _camera_non_auxiliary_stroke_delta_rows(camera)
+        dash_rows = _non_auxiliary_dash_mismatch_rows([camera])
+        if not stroke_rows and not dash_rows:
+            continue
+        candidate_stroke_rows = [
+            row for row in stroke_rows if _has_decoded_candidates(row)
+        ]
+        coverage_rows.append(
+            {
+                "camera": camera_name,
+                "stroke_rows": len(stroke_rows),
+                "candidate_backed_stroke_rows": len(candidate_stroke_rows),
+                "candidate_backed_width_delta_rows": sum(
+                    1 for row in candidate_stroke_rows if _has_meaningful_width_delta(row)
+                ),
+                "candidate_backed_zero_delta_rows": sum(
+                    1 for row in candidate_stroke_rows if not _has_meaningful_width_delta(row)
+                ),
+                "zero_candidate_stroke_rows": sum(
+                    1 for row in stroke_rows if not _has_decoded_candidates(row)
+                ),
+                "source_capped_stroke_rows": sum(
+                    1 for row in stroke_rows if row.get("source_line_width_capped") is True
+                ),
+                "dash_mismatch_rows": len(dash_rows),
+                "candidate_backed_dash_rows": sum(
+                    1 for row in dash_rows if _has_decoded_candidates(row)
+                ),
+                "zero_candidate_dash_rows": sum(
+                    1 for row in dash_rows if not _has_decoded_candidates(row)
+                ),
+            }
+        )
+    return coverage_rows
+
+
 def _focus_annotation_context(
     annotations: VisualCropAnnotationInputs,
     *,
@@ -537,10 +591,16 @@ def _focus_annotation_context(
             annotations.path_pedestrian_focus_report
         )
     )
+    coverage_rows = (
+        []
+        if comparison_match is False
+        else _path_pedestrian_focus_coverage_rows(annotations.path_pedestrian_focus_report)
+    )
     return _FocusAnnotationContext(
         comparison_paths=comparison_paths,
         comparison_match=comparison_match,
         cues_by_camera=cues_by_camera,
+        coverage_rows=coverage_rows,
     )
 
 
@@ -1128,6 +1188,8 @@ def _add_visual_crop_annotation_metadata(
         report["path_pedestrian_focus_json"] = _display_input_path(
             annotations.path_pedestrian_focus_report_path
         )
+        if focus_context.coverage_rows:
+            report["path_pedestrian_focus_coverage"] = focus_context.coverage_rows
         if focus_context.comparison_paths:
             report["path_pedestrian_focus_comparison_summary_jsons"] = (
                 focus_context.comparison_paths
@@ -2058,6 +2120,51 @@ def _summary_focus_rows(report: Mapping[str, object]) -> list[list[object]]:
     ]
 
 
+def _summary_focus_coverage_lines(report: Mapping[str, object]) -> list[str]:
+    if report.get("path_pedestrian_focus_comparison_match") is False:
+        return []
+    rows = report.get("path_pedestrian_focus_coverage")
+    coverage_rows = rows if isinstance(rows, list) else []
+    if not coverage_rows:
+        return []
+    lines = [
+        "",
+        "## Path/pedestrian focus coverage",
+        "",
+        (
+            "Shows per-camera non-auxiliary path/pedestrian focus coverage before the "
+            "focus cue table filters down to meaningful candidate-backed rows."
+        ),
+        "",
+        (
+            "| Camera | Stroke rows | Candidate strokes | Candidate width deltas | "
+            "Candidate zero-delta strokes | Zero-candidate strokes | Source-capped strokes | "
+            "Dash mismatches | Candidate dashes | Zero-candidate dashes |"
+        ),
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in coverage_rows:
+        if not isinstance(row, Mapping):
+            continue
+        lines.append(
+            _markdown_table_row(
+                [
+                    row.get("camera"),
+                    row.get("stroke_rows"),
+                    row.get("candidate_backed_stroke_rows"),
+                    row.get("candidate_backed_width_delta_rows"),
+                    row.get("candidate_backed_zero_delta_rows"),
+                    row.get("zero_candidate_stroke_rows"),
+                    row.get("source_capped_stroke_rows"),
+                    row.get("dash_mismatch_rows"),
+                    row.get("candidate_backed_dash_rows"),
+                    row.get("zero_candidate_dash_rows"),
+                ]
+            )
+        )
+    return lines
+
+
 def _summary_focus_cue_lines(report: Mapping[str, object]) -> list[str]:
     if report.get("path_pedestrian_focus_comparison_match") is False:
         return []
@@ -2265,6 +2372,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines.extend(_summary_crop_color_movement_group_lines(report))
     lines.extend(_summary_crop_color_metric_lines(report))
     lines.extend(_style_audit_area_fill_focus_lines(report))
+    lines.extend(_summary_focus_coverage_lines(report))
     lines.extend(_summary_focus_cue_lines(report))
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
## Summary

- Add a path/pedestrian focus coverage section to the visual crop report.
- Show raw non-auxiliary stroke and dash counts per camera before the focus cue table filters to meaningful candidate-backed rows.
- Document the new coverage section and cover matched/mismatched focus-report behavior with tests.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- Regenerated the current #949 visual crop report at `debug/mapbox-outdoors-visual-crops/20260521T170353Z/summary.md`

Refs #949
