### PR TITLE
[codex] Show focus coverage samples

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -135,7 +135,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json
 ```
 
-The crop report also includes a path/pedestrian focus coverage section for that focus input. It shows the raw non-auxiliary stroke and dash counts per camera before the cue table filters down to meaningful candidate-backed rows, which helps explain cases where a visually suspicious camera has decoded candidates but no surfaced focus cue.
+The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, plus representative candidate-backed zero-delta and zero-candidate rows, before the cue table filters down to meaningful candidate-backed rows. This helps explain cases where a visually suspicious camera has decoded candidates but no surfaced focus cue.
 
 To inspect only cameras that still have candidate-backed path/pedestrian focus cues, add `--focus-cue-cameras`. This is useful after a global highest-delta crop run is dominated by a different camera and hides lower-scoring stroke-width or dash candidates:
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -773,6 +773,18 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         "dash_mismatch_rows": 2,
                         "candidate_backed_dash_rows": 1,
                         "zero_candidate_dash_rows": 1,
+                        "candidate_zero_delta_stroke_samples": [
+                            "road-steps->road-steps delta=0mm ratio=1 candidates=3"
+                        ],
+                        "zero_candidate_stroke_samples": [
+                            (
+                                "bridge-path->bridge-path delta=-0.7937mm ratio=0.25 "
+                                "candidates=0 source-capped"
+                            )
+                        ],
+                        "zero_candidate_dash_samples": [
+                            "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0"
+                        ],
                     }
                 ],
             )
@@ -1839,6 +1851,18 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         "dash_mismatch_rows": 2,
                         "candidate_backed_dash_rows": 1,
                         "zero_candidate_dash_rows": 1,
+                        "candidate_zero_delta_stroke_samples": [
+                            "road-steps->road-steps delta=0mm ratio=1 candidates=3"
+                        ],
+                        "zero_candidate_stroke_samples": [
+                            (
+                                "bridge-path->bridge-path delta=-0.7937mm ratio=0.25 "
+                                "candidates=0 source-capped"
+                            )
+                        ],
+                        "zero_candidate_dash_samples": [
+                            "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0"
+                        ],
                     }
                 ],
                 "cameras": [
@@ -1888,6 +1912,9 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             "| chamonix-trails-z14-outdoors | 3 | 2 | 1 | 1 | 1 | 1 | 2 | 1 | 1 |",
             markdown,
         )
+        self.assertIn("## Path/pedestrian focus coverage samples", markdown)
+        self.assertIn("road-steps->road-steps delta=0mm ratio=1 candidates=3", markdown)
+        self.assertIn("bridge-path->bridge-path delta=-0.7937mm ratio=0.25", markdown)
         self.assertIn("## Path/pedestrian focus cues", markdown)
         self.assertIn("| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | lighter + blue higher=2", markdown)

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1927,6 +1927,31 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertNotIn("candidates=None", markdown)
         self.assertIn("dash=[1,0.25]!=[4,0.3]", markdown)
 
+    def test_build_summary_markdown_handles_partial_focus_coverage_sample_rows(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "path_pedestrian_focus_comparison_match": True,
+                "path_pedestrian_focus_coverage": [
+                    {
+                        "camera": "legacy-focus-report-camera",
+                        "zero_candidate_dash_samples": [
+                            "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0"
+                        ],
+                    }
+                ],
+            }
+        )
+
+        self.assertIn("## Path/pedestrian focus coverage samples", markdown)
+        self.assertIn(
+            (
+                "| legacy-focus-report-camera | - | - | "
+                "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0 |"
+            ),
+            markdown,
+        )
+
     def test_build_summary_markdown_omits_zero_candidate_focus_cues(self):
         markdown = build_summary_markdown(
             {

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -47,6 +47,7 @@ DEFAULT_STYLE_AUDIT_SAMPLE_LIMIT = 5
 DEFAULT_STYLE_AUDIT_SIMPLIFICATION_LIMIT = 3
 DEFAULT_CROP_COLOR_DELTA_SUMMARY_LIMIT = 5
 DEFAULT_CROP_COLOR_MOVEMENT_GROUP_LIMIT = 8
+DEFAULT_FOCUS_COVERAGE_SAMPLE_LIMIT = 3
 MAX_STYLE_AUDIT_SIMPLIFICATION_VALUE_LENGTH = 96
 MIN_SCORE_FOR_CROP = 1.0
 MAX_OVERLAP_RATIO = 0.35
@@ -516,6 +517,17 @@ def _path_pedestrian_focus_cues_by_camera(
     return cues_by_camera
 
 
+def _focus_coverage_sample_labels(
+    rows: Sequence[Mapping[str, object]],
+    formatter: Callable[[Mapping[str, object]], str],
+    *,
+    sample_limit: int = DEFAULT_FOCUS_COVERAGE_SAMPLE_LIMIT,
+) -> list[str]:
+    if sample_limit <= 0:
+        return []
+    return [formatter(row) for row in rows[:sample_limit]]
+
+
 def _path_pedestrian_focus_coverage_rows(
     focus_report: Mapping[str, object] | None,
 ) -> list[dict[str, object]]:
@@ -538,6 +550,15 @@ def _path_pedestrian_focus_coverage_rows(
         candidate_stroke_rows = [
             row for row in stroke_rows if _has_decoded_candidates(row)
         ]
+        candidate_zero_delta_rows = [
+            row for row in candidate_stroke_rows if not _has_meaningful_width_delta(row)
+        ]
+        zero_candidate_stroke_rows = [
+            row for row in stroke_rows if not _has_decoded_candidates(row)
+        ]
+        zero_candidate_dash_rows = [
+            row for row in dash_rows if not _has_decoded_candidates(row)
+        ]
         coverage_rows.append(
             {
                 "camera": camera_name,
@@ -546,12 +567,8 @@ def _path_pedestrian_focus_coverage_rows(
                 "candidate_backed_width_delta_rows": sum(
                     1 for row in candidate_stroke_rows if _has_meaningful_width_delta(row)
                 ),
-                "candidate_backed_zero_delta_rows": sum(
-                    1 for row in candidate_stroke_rows if not _has_meaningful_width_delta(row)
-                ),
-                "zero_candidate_stroke_rows": sum(
-                    1 for row in stroke_rows if not _has_decoded_candidates(row)
-                ),
+                "candidate_backed_zero_delta_rows": len(candidate_zero_delta_rows),
+                "zero_candidate_stroke_rows": len(zero_candidate_stroke_rows),
                 "source_capped_stroke_rows": sum(
                     1 for row in stroke_rows if row.get("source_line_width_capped") is True
                 ),
@@ -559,8 +576,18 @@ def _path_pedestrian_focus_coverage_rows(
                 "candidate_backed_dash_rows": sum(
                     1 for row in dash_rows if _has_decoded_candidates(row)
                 ),
-                "zero_candidate_dash_rows": sum(
-                    1 for row in dash_rows if not _has_decoded_candidates(row)
+                "zero_candidate_dash_rows": len(zero_candidate_dash_rows),
+                "candidate_zero_delta_stroke_samples": _focus_coverage_sample_labels(
+                    candidate_zero_delta_rows,
+                    _stroke_focus_cue_summary,
+                ),
+                "zero_candidate_stroke_samples": _focus_coverage_sample_labels(
+                    zero_candidate_stroke_rows,
+                    _stroke_focus_cue_summary,
+                ),
+                "zero_candidate_dash_samples": _focus_coverage_sample_labels(
+                    zero_candidate_dash_rows,
+                    _dash_focus_cue_summary,
                 ),
             }
         )
@@ -2165,6 +2192,48 @@ def _summary_focus_coverage_lines(report: Mapping[str, object]) -> list[str]:
     return lines
 
 
+def _summary_focus_coverage_sample_lines(report: Mapping[str, object]) -> list[str]:
+    if report.get("path_pedestrian_focus_comparison_match") is False:
+        return []
+    rows = report.get("path_pedestrian_focus_coverage")
+    coverage_rows = rows if isinstance(rows, list) else []
+    sample_rows: list[list[object]] = []
+    for row in coverage_rows:
+        if not isinstance(row, Mapping):
+            continue
+        samples = [
+            row.get("candidate_zero_delta_stroke_samples"),
+            row.get("zero_candidate_stroke_samples"),
+            row.get("zero_candidate_dash_samples"),
+        ]
+        if not any(isinstance(sample, list) and sample for sample in samples):
+            continue
+        sample_rows.append(
+            [
+                row.get("camera"),
+                _joined_summary_labels(row.get("candidate_zero_delta_stroke_samples")),
+                _joined_summary_labels(row.get("zero_candidate_stroke_samples")),
+                _joined_summary_labels(row.get("zero_candidate_dash_samples")),
+            ]
+        )
+    if not sample_rows:
+        return []
+    lines = [
+        "",
+        "## Path/pedestrian focus coverage samples",
+        "",
+        (
+            "Shows representative focus rows hidden from the cue table because they are "
+            "candidate-backed zero-delta rows or zero-candidate rows."
+        ),
+        "",
+        "| Camera | Candidate zero-delta strokes | Zero-candidate strokes | Zero-candidate dashes |",
+        "| --- | --- | --- | --- |",
+    ]
+    lines.extend(_markdown_table_row(row) for row in sample_rows)
+    return lines
+
+
 def _summary_focus_cue_lines(report: Mapping[str, object]) -> list[str]:
     if report.get("path_pedestrian_focus_comparison_match") is False:
         return []
@@ -2373,6 +2442,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines.extend(_summary_crop_color_metric_lines(report))
     lines.extend(_style_audit_area_fill_focus_lines(report))
     lines.extend(_summary_focus_coverage_lines(report))
+    lines.extend(_summary_focus_coverage_sample_lines(report))
     lines.extend(_summary_focus_cue_lines(report))
     return "\n".join(lines) + "\n"
 

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -2208,12 +2208,27 @@ def _summary_focus_coverage_sample_lines(report: Mapping[str, object]) -> list[s
         ]
         if not any(isinstance(sample, list) and sample for sample in samples):
             continue
+        candidate_zero_delta_samples = row.get("candidate_zero_delta_stroke_samples")
+        zero_candidate_stroke_samples = row.get("zero_candidate_stroke_samples")
+        zero_candidate_dash_samples = row.get("zero_candidate_dash_samples")
         sample_rows.append(
             [
                 row.get("camera"),
-                _joined_summary_labels(row.get("candidate_zero_delta_stroke_samples")),
-                _joined_summary_labels(row.get("zero_candidate_stroke_samples")),
-                _joined_summary_labels(row.get("zero_candidate_dash_samples")),
+                _joined_summary_labels(
+                    candidate_zero_delta_samples
+                    if isinstance(candidate_zero_delta_samples, list)
+                    else []
+                ),
+                _joined_summary_labels(
+                    zero_candidate_stroke_samples
+                    if isinstance(zero_candidate_stroke_samples, list)
+                    else []
+                ),
+                _joined_summary_labels(
+                    zero_candidate_dash_samples
+                    if isinstance(zero_candidate_dash_samples, list)
+                    else []
+                ),
             ]
         )
     if not sample_rows:


### PR DESCRIPTION
## Summary

- add a path/pedestrian focus coverage samples section to the visual crop report
- show representative candidate-backed zero-delta and zero-candidate stroke/dash rows hidden from the cue table
- document the richer coverage sections and cover the markdown/report output in tests

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- Regenerated the current #949 visual crop report at `debug/mapbox-outdoors-visual-crops/20260521T172503Z/summary.md`

Refs #949
