### PR TITLE
[codex] Show focus decoded feature coverage

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -135,7 +135,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json
 ```
 
-The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, plus representative candidate-backed zero-delta and zero-candidate rows, before the cue table filters down to meaningful candidate-backed rows. This helps explain cases where a visually suspicious camera has decoded candidates but no surfaced focus cue.
+The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, representative candidate-backed zero-delta and zero-candidate rows, and decoded path/step/pedestrian feature type or structure counts before the cue table filters down to meaningful candidate-backed rows. This helps explain cases where a visually suspicious camera has decoded candidates but no surfaced focus cue.
 
 To inspect only cameras that still have candidate-backed path/pedestrian focus cues, add `--focus-cue-cameras`. This is useful after a global highest-delta crop run is dominated by a different camera and hides lower-scoring stroke-width or dash candidates:
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -196,6 +196,10 @@ def _path_pedestrian_focus_report(
         "cameras": [
             {
                 "camera": camera_name,
+                "pedestrian_line_structure_counts": {"none": 115},
+                "path_line_type_counts": {"trail": 69, "footway": 56, "piste": 48},
+                "path_line_structure_counts": {"none": 236},
+                "step_line_structure_counts": {"bridge": 1, "none": 16},
                 "source_qgis_stroke_control_comparisons": [
                     {
                         "source_layer_id": "road-path-trail",
@@ -785,6 +789,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         "zero_candidate_dash_samples": [
                             "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0"
                         ],
+                        "path_line_types": ["trail=69", "footway=56", "piste=48"],
+                        "path_line_structures": ["none=236"],
+                        "step_line_structures": ["none=16", "bridge=1"],
+                        "pedestrian_line_structures": ["none=115"],
                     }
                 ],
             )
@@ -1863,6 +1871,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                         "zero_candidate_dash_samples": [
                             "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0"
                         ],
+                        "path_line_types": ["trail=69", "footway=56", "piste=48"],
+                        "path_line_structures": ["none=236"],
+                        "step_line_structures": ["none=16", "bridge=1"],
+                        "pedestrian_line_structures": ["none=115"],
                     }
                 ],
                 "cameras": [
@@ -1915,6 +1927,14 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertIn("## Path/pedestrian focus coverage samples", markdown)
         self.assertIn("road-steps->road-steps delta=0mm ratio=1 candidates=3", markdown)
         self.assertIn("bridge-path->bridge-path delta=-0.7937mm ratio=0.25", markdown)
+        self.assertIn("## Path/pedestrian decoded feature coverage", markdown)
+        self.assertIn(
+            (
+                "| chamonix-trails-z14-outdoors | trail=69, footway=56, piste=48 | "
+                "none=236 | none=16, bridge=1 | none=115 |"
+            ),
+            markdown,
+        )
         self.assertIn("## Path/pedestrian focus cues", markdown)
         self.assertIn("| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | lighter + blue higher=2", markdown)

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1964,6 +1964,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         )
 
         self.assertIn("## Path/pedestrian focus coverage samples", markdown)
+        self.assertNotIn("## Path/pedestrian decoded feature coverage", markdown)
         self.assertIn(
             (
                 "| legacy-focus-report-camera | - | - | "

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -589,6 +589,12 @@ def _path_pedestrian_focus_coverage_rows(
                     zero_candidate_dash_rows,
                     _dash_focus_cue_summary,
                 ),
+                "path_line_types": _top_count_labels(camera.get("path_line_type_counts")),
+                "path_line_structures": _top_count_labels(camera.get("path_line_structure_counts")),
+                "step_line_structures": _top_count_labels(camera.get("step_line_structure_counts")),
+                "pedestrian_line_structures": _top_count_labels(
+                    camera.get("pedestrian_line_structure_counts")
+                ),
             }
         )
     return coverage_rows
@@ -2192,6 +2198,10 @@ def _summary_focus_coverage_lines(report: Mapping[str, object]) -> list[str]:
     return lines
 
 
+def _joined_summary_label_values(value: object) -> str:
+    return _joined_summary_labels(value if isinstance(value, list) else [])
+
+
 def _summary_focus_coverage_sample_lines(report: Mapping[str, object]) -> list[str]:
     if report.get("path_pedestrian_focus_comparison_match") is False:
         return []
@@ -2208,27 +2218,12 @@ def _summary_focus_coverage_sample_lines(report: Mapping[str, object]) -> list[s
         ]
         if not any(isinstance(sample, list) and sample for sample in samples):
             continue
-        candidate_zero_delta_samples = row.get("candidate_zero_delta_stroke_samples")
-        zero_candidate_stroke_samples = row.get("zero_candidate_stroke_samples")
-        zero_candidate_dash_samples = row.get("zero_candidate_dash_samples")
         sample_rows.append(
             [
                 row.get("camera"),
-                _joined_summary_labels(
-                    candidate_zero_delta_samples
-                    if isinstance(candidate_zero_delta_samples, list)
-                    else []
-                ),
-                _joined_summary_labels(
-                    zero_candidate_stroke_samples
-                    if isinstance(zero_candidate_stroke_samples, list)
-                    else []
-                ),
-                _joined_summary_labels(
-                    zero_candidate_dash_samples
-                    if isinstance(zero_candidate_dash_samples, list)
-                    else []
-                ),
+                _joined_summary_label_values(row.get("candidate_zero_delta_stroke_samples")),
+                _joined_summary_label_values(row.get("zero_candidate_stroke_samples")),
+                _joined_summary_label_values(row.get("zero_candidate_dash_samples")),
             ]
         )
     if not sample_rows:
@@ -2246,6 +2241,51 @@ def _summary_focus_coverage_sample_lines(report: Mapping[str, object]) -> list[s
         "| --- | --- | --- | --- |",
     ]
     lines.extend(_markdown_table_row(row) for row in sample_rows)
+    return lines
+
+
+def _summary_focus_decoded_feature_lines(report: Mapping[str, object]) -> list[str]:
+    if report.get("path_pedestrian_focus_comparison_match") is False:
+        return []
+    rows = report.get("path_pedestrian_focus_coverage")
+    coverage_rows = rows if isinstance(rows, list) else []
+    feature_rows: list[list[object]] = []
+    for row in coverage_rows:
+        if not isinstance(row, Mapping):
+            continue
+        labels = [
+            row.get("path_line_types"),
+            row.get("path_line_structures"),
+            row.get("step_line_structures"),
+            row.get("pedestrian_line_structures"),
+        ]
+        if not any(isinstance(label, list) and label for label in labels):
+            continue
+        feature_rows.append(
+            [
+                row.get("camera"),
+                _joined_summary_label_values(row.get("path_line_types")),
+                _joined_summary_label_values(row.get("path_line_structures")),
+                _joined_summary_label_values(row.get("step_line_structures")),
+                _joined_summary_label_values(row.get("pedestrian_line_structures")),
+            ]
+        )
+    if not feature_rows:
+        return []
+    lines = [
+        "",
+        "## Path/pedestrian decoded feature coverage",
+        "",
+        (
+            "Shows decoded road-feature type and structure counts behind the focus rows, "
+            "so bridge/tunnel zero-candidate samples can be separated from cameras that "
+            "only decode surface path or step features."
+        ),
+        "",
+        "| Camera | Path types | Path structures | Step structures | Pedestrian structures |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    lines.extend(_markdown_table_row(row) for row in feature_rows)
     return lines
 
 
@@ -2458,6 +2498,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines.extend(_style_audit_area_fill_focus_lines(report))
     lines.extend(_summary_focus_coverage_lines(report))
     lines.extend(_summary_focus_coverage_sample_lines(report))
+    lines.extend(_summary_focus_decoded_feature_lines(report))
     lines.extend(_summary_focus_cue_lines(report))
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
## Summary
- add decoded path/pedestrian feature coverage to the visual crop report
- surface path type counts plus path/step/pedestrian structure counts beside the focus coverage samples
- document and test the new attribution section

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- regenerated `debug/mapbox-outdoors-visual-crops/20260521T174433Z/summary.md`

## Issue
- Continues #949
