### PR TITLE
[codex] Show source-capped focus samples

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -135,7 +135,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json
 ```
 
-The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, representative candidate-backed zero-delta and zero-candidate rows, and decoded path/step/pedestrian feature type or structure counts before the cue table filters down to meaningful candidate-backed rows. This helps explain cases where a visually suspicious camera has decoded candidates but no surfaced focus cue.
+The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, representative candidate-backed zero-delta, source-capped, and zero-candidate rows, and decoded path/step/pedestrian feature type or structure counts before the cue table filters down to meaningful candidate-backed rows. This helps explain cases where a visually suspicious camera has decoded candidates but no surfaced focus cue.
 
 To inspect only cameras that still have candidate-backed path/pedestrian focus cues, add `--focus-cue-cameras`. This is useful after a global highest-delta crop run is dominated by a different camera and hides lower-scoring stroke-width or dash candidates:
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -786,6 +786,12 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                                 "candidates=0 source-capped"
                             )
                         ],
+                        "source_capped_stroke_samples": [
+                            (
+                                "bridge-path->bridge-path delta=-0.7937mm ratio=0.25 "
+                                "candidates=0 source-capped"
+                            )
+                        ],
                         "zero_candidate_dash_samples": [
                             "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0"
                         ],
@@ -1868,6 +1874,12 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                                 "candidates=0 source-capped"
                             )
                         ],
+                        "source_capped_stroke_samples": [
+                            (
+                                "bridge-path->bridge-path delta=-0.7937mm ratio=0.25 "
+                                "candidates=0 source-capped"
+                            )
+                        ],
                         "zero_candidate_dash_samples": [
                             "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0"
                         ],
@@ -1925,6 +1937,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             markdown,
         )
         self.assertIn("## Path/pedestrian focus coverage samples", markdown)
+        self.assertIn("Source-capped strokes", markdown)
         self.assertIn("road-steps->road-steps delta=0mm ratio=1 candidates=3", markdown)
         self.assertIn("bridge-path->bridge-path delta=-0.7937mm ratio=0.25", markdown)
         self.assertIn("## Path/pedestrian decoded feature coverage", markdown)
@@ -1967,7 +1980,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertNotIn("## Path/pedestrian decoded feature coverage", markdown)
         self.assertIn(
             (
-                "| legacy-focus-report-camera | - | - | "
+                "| legacy-focus-report-camera | - | - | - | "
                 "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0 |"
             ),
             markdown,

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -556,6 +556,9 @@ def _path_pedestrian_focus_coverage_rows(
         zero_candidate_stroke_rows = [
             row for row in stroke_rows if not _has_decoded_candidates(row)
         ]
+        source_capped_stroke_rows = [
+            row for row in stroke_rows if row.get("source_line_width_capped") is True
+        ]
         zero_candidate_dash_rows = [
             row for row in dash_rows if not _has_decoded_candidates(row)
         ]
@@ -569,9 +572,7 @@ def _path_pedestrian_focus_coverage_rows(
                 ),
                 "candidate_backed_zero_delta_rows": len(candidate_zero_delta_rows),
                 "zero_candidate_stroke_rows": len(zero_candidate_stroke_rows),
-                "source_capped_stroke_rows": sum(
-                    1 for row in stroke_rows if row.get("source_line_width_capped") is True
-                ),
+                "source_capped_stroke_rows": len(source_capped_stroke_rows),
                 "dash_mismatch_rows": len(dash_rows),
                 "candidate_backed_dash_rows": sum(
                     1 for row in dash_rows if _has_decoded_candidates(row)
@@ -583,6 +584,10 @@ def _path_pedestrian_focus_coverage_rows(
                 ),
                 "zero_candidate_stroke_samples": _focus_coverage_sample_labels(
                     zero_candidate_stroke_rows,
+                    _stroke_focus_cue_summary,
+                ),
+                "source_capped_stroke_samples": _focus_coverage_sample_labels(
+                    source_capped_stroke_rows,
                     _stroke_focus_cue_summary,
                 ),
                 "zero_candidate_dash_samples": _focus_coverage_sample_labels(
@@ -2213,6 +2218,7 @@ def _summary_focus_coverage_sample_lines(report: Mapping[str, object]) -> list[s
             continue
         samples = [
             row.get("candidate_zero_delta_stroke_samples"),
+            row.get("source_capped_stroke_samples"),
             row.get("zero_candidate_stroke_samples"),
             row.get("zero_candidate_dash_samples"),
         ]
@@ -2222,6 +2228,7 @@ def _summary_focus_coverage_sample_lines(report: Mapping[str, object]) -> list[s
             [
                 row.get("camera"),
                 _joined_summary_label_values(row.get("candidate_zero_delta_stroke_samples")),
+                _joined_summary_label_values(row.get("source_capped_stroke_samples")),
                 _joined_summary_label_values(row.get("zero_candidate_stroke_samples")),
                 _joined_summary_label_values(row.get("zero_candidate_dash_samples")),
             ]
@@ -2234,11 +2241,14 @@ def _summary_focus_coverage_sample_lines(report: Mapping[str, object]) -> list[s
         "",
         (
             "Shows representative focus rows hidden from the cue table because they are "
-            "candidate-backed zero-delta rows or zero-candidate rows."
+            "candidate-backed zero-delta rows, source-capped rows, or zero-candidate rows."
         ),
         "",
-        "| Camera | Candidate zero-delta strokes | Zero-candidate strokes | Zero-candidate dashes |",
-        "| --- | --- | --- | --- |",
+        (
+            "| Camera | Candidate zero-delta strokes | Source-capped strokes | "
+            "Zero-candidate strokes | Zero-candidate dashes |"
+        ),
+        "| --- | --- | --- | --- | --- |",
     ]
     lines.extend(_markdown_table_row(row) for row in sample_rows)
     return lines


### PR DESCRIPTION
## Summary
- add source-capped stroke samples to the path/pedestrian focus coverage samples table
- reuse the existing source-capped count list so high-zoom capped rows are inspectable from the crop report
- update tests and comparison-harness docs for the wider samples table

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- regenerated `debug/mapbox-outdoors-visual-crops/20260521T175554Z/summary.md`

## Issue
- Continues #949
