### PR TITLE
test: show source-capped focus cues

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -127,7 +127,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --crops-per-camera 2
 ```
 
-When path/pedestrian styling is under review, pass the matching focus report so each crop row is annotated with the strongest per-camera stroke-width and dash cues:
+When path/pedestrian styling is under review, pass the matching focus report so each crop row is annotated with the strongest per-camera stroke-width, source-capped stroke, and dash cues:
 
 ```bash
 python3 validation/mapbox_outdoors_visual_crops.py \
@@ -135,7 +135,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json
 ```
 
-The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, representative candidate-backed zero-delta, source-capped, and zero-candidate rows, and decoded path/step/pedestrian feature type or structure counts before the cue table filters down to meaningful candidate-backed rows. This helps explain cases where a visually suspicious camera has decoded candidates but no surfaced focus cue.
+The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, representative candidate-backed zero-delta, source-capped, and zero-candidate rows, and decoded path/step/pedestrian feature type or structure counts before the cue table filters down to meaningful candidate-backed rows. This helps explain cases where a visually suspicious camera has decoded candidates but no standard width-delta or dash cue.
 
 To inspect only cameras that still have candidate-backed path/pedestrian focus cues, add `--focus-cue-cameras`. This is useful after a global highest-delta crop run is dominated by a different camera and hides lower-scoring stroke-width or dash candidates:
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -287,6 +287,34 @@ def _path_pedestrian_focus_report(
     }
 
 
+def _candidate_backed_source_capped_stroke_comparison():
+    return {
+        "source_layer_id": "road-pedestrian",
+        "decoded_candidate_count": 191,
+        "decoded_candidate_type_counts": {"pedestrian": 191},
+        "source_sampled_controls": {
+            "line-width": 3.0,
+            "line-width_raw_mm": 3.175,
+            "line-width_capped": True,
+        },
+        "qgis_controls": [
+            {
+                "layer_id": "road-pedestrian-z18-plus",
+                "controls": {"line-width": 3.0},
+            }
+        ],
+        "qgis_control_deltas": [
+            {
+                "layer_id": "road-pedestrian-z18-plus",
+                "deltas": {
+                    "line-width_delta_mm": 0.0,
+                    "line-width_ratio": 1.0,
+                },
+            }
+        ],
+    }
+
+
 def _comparison_delta_report(candidate_summary_json, *, camera_name="chamonix-trails-z14-outdoors"):
     return {
         "input_artifacts": {
@@ -735,6 +763,12 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             comparison_summary, summary_path = _write_visual_triplet(root, image_module)
             focus_path = root / "focus" / "path-pedestrian-focus.json"
             focus_path.parent.mkdir(parents=True)
+            focus_report = _path_pedestrian_focus_report(
+                comparison_summary_jsons=[str(summary_path)]
+            )
+            focus_report["cameras"][0]["source_qgis_stroke_control_comparisons"].append(
+                _candidate_backed_source_capped_stroke_comparison()
+            )
             paths = build_visual_crop_paths(root / "debug" / "run")
 
             report = generate_visual_crop_report(
@@ -742,9 +776,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 comparison_summary_path=summary_path,
                 paths=paths,
                 annotation_inputs=VisualCropAnnotationInputs(
-                    path_pedestrian_focus_report=_path_pedestrian_focus_report(
-                        comparison_summary_jsons=[str(summary_path)]
-                    ),
+                    path_pedestrian_focus_report=focus_report,
                     path_pedestrian_focus_report_path=focus_path,
                 ),
                 crop_size=(4, 4),
@@ -756,6 +788,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
 
             focus_cues = report["cameras"][0]["path_pedestrian_focus"]
             stroke_cues = focus_cues["stroke_width_deltas"]
+            source_capped_cues = focus_cues["source_capped_strokes"]
             dash_cues = focus_cues["dash_mismatches"]
             self.assertEqual(report["path_pedestrian_focus_json"], str(focus_path))
             self.assertEqual(
@@ -768,17 +801,21 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 [
                     {
                         "camera": "chamonix-trails-z14-outdoors",
-                        "stroke_rows": 3,
-                        "candidate_backed_stroke_rows": 2,
+                        "stroke_rows": 4,
+                        "candidate_backed_stroke_rows": 3,
                         "candidate_backed_width_delta_rows": 1,
-                        "candidate_backed_zero_delta_rows": 1,
+                        "candidate_backed_zero_delta_rows": 2,
                         "zero_candidate_stroke_rows": 1,
-                        "source_capped_stroke_rows": 1,
+                        "source_capped_stroke_rows": 2,
                         "dash_mismatch_rows": 2,
                         "candidate_backed_dash_rows": 1,
                         "zero_candidate_dash_rows": 1,
                         "candidate_zero_delta_stroke_samples": [
-                            "road-steps->road-steps delta=0mm ratio=1 candidates=3"
+                            "road-steps->road-steps delta=0mm ratio=1 candidates=3",
+                            (
+                                "road-pedestrian->road-pedestrian-z18-plus delta=0mm "
+                                "ratio=1 candidates=191 source-capped"
+                            ),
                         ],
                         "zero_candidate_stroke_samples": [
                             (
@@ -790,7 +827,11 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                             (
                                 "bridge-path->bridge-path delta=-0.7937mm ratio=0.25 "
                                 "candidates=0 source-capped"
-                            )
+                            ),
+                            (
+                                "road-pedestrian->road-pedestrian-z18-plus delta=0mm "
+                                "ratio=1 candidates=191 source-capped"
+                            ),
                         ],
                         "zero_candidate_dash_samples": [
                             "bridge-path->bridge-path dash=[1,0.25]!=[4,0.3] candidates=0"
@@ -804,6 +845,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             )
             self.assertEqual(stroke_cues[0]["source_layer_id"], "road-path-trail")
             self.assertEqual(stroke_cues[0]["candidate_types"], ["trail=69", "hiking=5"])
+            self.assertEqual(source_capped_cues[0]["source_layer_id"], "road-pedestrian")
+            self.assertEqual(source_capped_cues[0]["candidate_types"], ["pedestrian=191"])
             self.assertEqual(dash_cues[0]["source_layer_id"], "road-steps")
             self.assertEqual(dash_cues[0]["source_dasharray"], [0.3, 0.3])
 
@@ -1910,6 +1953,17 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                                     "line_width_delta_mm": 0.079375,
                                 }
                             ],
+                            "source_capped_strokes": [
+                                {
+                                    "source_layer_id": "road-pedestrian",
+                                    "qgis_layer_id": "road-pedestrian-z18-plus",
+                                    "decoded_candidate_count": 191,
+                                    "candidate_types": ["pedestrian=191"],
+                                    "line_width_delta_mm": 0.0,
+                                    "line_width_ratio": 1.0,
+                                    "source_line_width_capped": True,
+                                }
+                            ],
                             "dash_mismatches": [
                                 {
                                     "source_layer_id": "bridge-path",
@@ -1949,13 +2003,24 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             markdown,
         )
         self.assertIn("## Path/pedestrian focus cues", markdown)
-        self.assertIn("| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |", markdown)
+        self.assertIn(
+            (
+                "| Camera | Crop movement groups | Stroke width cues | "
+                "Source-capped stroke cues | Dash mismatch cues |"
+            ),
+            markdown,
+        )
         self.assertIn("| chamonix-trails-z14-outdoors | lighter + blue higher=2", markdown)
         self.assertIn("camera movement below global top=1", markdown)
         self.assertIn("extra chamonix movement 6=1", markdown)
         self.assertNotIn("extra chamonix movement 7=1", markdown)
         self.assertIn("road-path-trail->road-path-trail-below-z16", markdown)
         self.assertIn("candidates=74 (trail=69, hiking=5)", markdown)
+        self.assertIn(
+            "road-pedestrian->road-pedestrian-z18-plus delta=0mm ratio=1",
+            markdown,
+        )
+        self.assertIn("candidates=191 (pedestrian=191) source-capped", markdown)
         self.assertIn("candidate_types=trail=69", markdown)
         self.assertNotIn("candidates=None", markdown)
         self.assertIn("dash=[1,0.25]!=[4,0.3]", markdown)

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -472,10 +472,19 @@ def _path_pedestrian_focus_cues_by_camera(
         camera_name = str(camera.get("camera") or "")
         if not camera_name:
             continue
+        ranked_stroke_rows = _largest_non_auxiliary_stroke_delta_rows(
+            [camera],
+            limit=10_000,
+        )
         width_delta_rows = [
             row
-            for row in _largest_non_auxiliary_stroke_delta_rows([camera], limit=10_000)
+            for row in ranked_stroke_rows
             if _has_meaningful_width_delta(row) and _has_decoded_candidates(row)
+        ][: max(0, stroke_limit)]
+        source_capped_rows = [
+            row
+            for row in ranked_stroke_rows
+            if row.get("source_line_width_capped") is True and _has_decoded_candidates(row)
         ][: max(0, stroke_limit)]
         width_rows = [
             _focus_cue_from_row(
@@ -491,6 +500,21 @@ def _path_pedestrian_focus_cues_by_camera(
                 ),
             )
             for row in width_delta_rows
+        ]
+        source_capped_stroke_rows = [
+            _focus_cue_from_row(
+                row,
+                (
+                    "source_layer_id",
+                    "qgis_layer_id",
+                    "decoded_candidate_count",
+                    "line_width_delta_mm",
+                    "line_width_abs_delta_mm",
+                    "line_width_ratio",
+                    "source_line_width_capped",
+                ),
+            )
+            for row in source_capped_rows
         ]
         dash_rows = [
             _focus_cue_from_row(
@@ -509,9 +533,10 @@ def _path_pedestrian_focus_cues_by_camera(
             if _has_decoded_candidates(row)
         ]
         dash_rows = dash_rows[: max(0, dash_limit)]
-        if width_rows or dash_rows:
+        if width_rows or source_capped_stroke_rows or dash_rows:
             cues_by_camera[camera_name] = {
                 "stroke_width_deltas": width_rows,
+                "source_capped_strokes": source_capped_stroke_rows,
                 "dash_mismatches": dash_rows,
             }
     return cues_by_camera
@@ -2131,12 +2156,17 @@ def _summary_focus_row(
         "stroke_width_deltas",
         _stroke_focus_cue_summary,
     )
+    source_capped_summaries = _candidate_backed_focus_summaries(
+        focus,
+        "source_capped_strokes",
+        _stroke_focus_cue_summary,
+    )
     dash_summaries = _candidate_backed_focus_summaries(
         focus,
         "dash_mismatches",
         _dash_focus_cue_summary,
     )
-    if not stroke_summaries and not dash_summaries:
+    if not stroke_summaries and not source_capped_summaries and not dash_summaries:
         return None
     camera_name = camera.get("camera")
     return [
@@ -2145,6 +2175,7 @@ def _summary_focus_row(
             _focus_movement_group_labels(movement_group_records, camera_name)
         ),
         stroke_summaries,
+        source_capped_summaries,
         dash_summaries,
     ]
 
@@ -2315,8 +2346,11 @@ def _summary_focus_cue_lines(report: Mapping[str, object]) -> list[str]:
                 "color movement families."
             ),
             "",
-            "| Camera | Crop movement groups | Stroke width cues | Dash mismatch cues |",
-            "| --- | --- | --- | --- |",
+            (
+                "| Camera | Crop movement groups | Stroke width cues | "
+                "Source-capped stroke cues | Dash mismatch cues |"
+            ),
+            "| --- | --- | --- | --- | --- |",
         ]
     )
     lines.extend(_markdown_table_row(row) for row in rows)


### PR DESCRIPTION
## Summary

- Adds candidate-backed source-capped stroke rows to the path/pedestrian focus cue table.
- Keeps zero-candidate source-capped rows in the coverage samples only, so bridge/tunnel artifacts do not become focus cues without decoded backing.
- Updates the comparison harness docs for the new source-capped cue column.

## Evidence

- Regenerated crop report from the existing #1303 artifacts without using Mapbox credentials: `debug/mapbox-outdoors-visual-crops/20260521T183109Z/summary.md`.
- The regenerated focus cue table now surfaces `zermatt-trails-z18-outdoors` source-capped `road-pedestrian` and `road-pedestrian-case` rows next to the crop movement groups, while zero-candidate bridge/tunnel rows remain only in the coverage samples.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short` -> 45 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2397 passed, 180 skipped, 171 subtests passed
- `git diff --check` -> clean

#949
