### PR TITLE
test: surface path layout focus cues

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -139,7 +139,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
 
 Manual boxes are recorded in `visual-crops.json`, echoed in the Markdown report header, and marked as `manual` in the crop table's selection column.
 
-When path/pedestrian styling is under review, pass the matching focus report so each crop row is annotated with the strongest per-camera stroke-width, source-capped stroke, and dash cues:
+When path/pedestrian styling is under review, pass the matching focus report so each crop row is annotated with the strongest per-camera stroke-width, source-capped stroke, pedestrian core/case cap, and dash cues:
 
 ```bash
 python3 validation/mapbox_outdoors_visual_crops.py \
@@ -147,7 +147,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --path-pedestrian-focus-json debug/mapbox-outdoors-path-pedestrian-focus/<timestamp>/path-pedestrian-focus.json
 ```
 
-The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, representative candidate-backed zero-delta, source-capped, and zero-candidate rows, and decoded path/step/pedestrian feature type or structure counts before the cue table filters down to meaningful candidate-backed rows. Source-capped labels include the capped source width and raw source width when both values are available. This helps explain cases where a visually suspicious camera has decoded candidates but no standard width-delta or dash cue.
+The crop report also includes path/pedestrian focus coverage sections for that focus input. They show the raw non-auxiliary stroke and dash counts per camera, representative candidate-backed zero-delta, source-capped, and zero-candidate rows, and decoded path/step/pedestrian feature type or structure counts before the cue table filters down to meaningful candidate-backed rows. Source-capped labels include the capped source width and raw source width when both values are available. Pedestrian core/case cap cues show the source core/case widths, QGIS core/case widths, pale casing width, and ratio-preserving core-width diagnostic when the focus input contains those relationships. This helps explain cases where a visually suspicious camera has decoded candidates but no standard width-delta or dash cue.
 
 To inspect only cameras that still have candidate-backed path/pedestrian focus cues, add `--focus-cue-cameras`. This is useful after a global highest-delta crop run is dominated by a different camera and hides lower-scoring stroke-width or dash candidates:
 
@@ -336,7 +336,7 @@ python3 validation/mapbox_outdoors_path_pedestrian_focus.py \
   --comparison-summary-json debug/mapbox-outdoors-comparison/all-cameras/<timestamp>/summary.json
 ```
 
-Passing `--style-audit-json` uses the audit's source Mapbox layer records, which keeps source-vs-QGIS stroke and dash cues available without maintaining a separate downloaded style snapshot.
+Passing `--style-audit-json` uses the audit's source Mapbox layer records, which keeps source-vs-QGIS stroke, line cap/join layout, and dash cues available without maintaining a separate downloaded style snapshot.
 
 ## PR notes
 

--- a/tests/test_mapbox_outdoors_path_pedestrian_focus.py
+++ b/tests/test_mapbox_outdoors_path_pedestrian_focus.py
@@ -934,6 +934,10 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
                         "line-dasharray": ["literal", [1, 0.2]],
                     },
+                    "layout": {
+                        "line-cap": ["step", ["zoom"], "butt", 17, "round"],
+                        "line-join": "round",
+                    },
                 }
             ],
         }
@@ -950,6 +954,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-dasharray": [1, 0.2],
                         "line-opacity": 0.65,
                     },
+                    "layout": {"line-cap": "butt", "line-join": "round"},
                 }
             ],
         }
@@ -971,6 +976,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-width": ["interpolate", ["linear"], ["zoom"], 14, 0.5, 18, 12],
                         "line-dasharray": ["literal", [1, 0.2]],
+                        "line-cap": ["step", ["zoom"], "butt", 17, "round"],
+                        "line-join": "round",
                     },
                     "source_sampled_controls": {
                         "line-width": 3.0,
@@ -978,6 +985,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                         "line-width_capped": True,
                         "line-color": "hsl(0, 0%, 95%)",
                         "line-dasharray": [1, 0.2],
+                        "line-cap": "round",
+                        "line-join": "round",
                     },
                     "decoded_candidate_count": 1,
                     "qgis_layer_ids": ["road-pedestrian-z18-plus"],
@@ -988,6 +997,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                                 "line-width": 2.328099173553719,
                                 "line-color": "#f6f2e8",
                                 "line-dasharray": [1, 0.2],
+                                "line-cap": "butt",
+                                "line-join": "round",
                                 "line-opacity": 0.65,
                             },
                         }
@@ -999,6 +1010,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
                                 "line-width_delta_mm": -0.6719008264462811,
                                 "line-width_ratio": 0.7760330578512397,
                                 "line-dasharray_match": True,
+                                "line-cap_match": False,
+                                "line-join_match": True,
                                 "line-color_match": False,
                             },
                         }
@@ -1009,6 +1022,8 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         markdown = build_summary_markdown(report)
         self.assertIn("line-width_raw_mm=3.175", markdown)
         self.assertIn("line-width_capped=true", markdown)
+        self.assertIn('line-cap=\\"round\\"', markdown)
+        self.assertIn("line-cap_match=false", markdown)
 
     def test_build_path_pedestrian_focus_report_adds_step_structure_candidate_counts(self):
         road_report = {
@@ -1690,7 +1705,7 @@ class MapboxOutdoorsPathPedestrianFocusTests(unittest.TestCase):
         self.assertIn('"line-width=[\\"interpolate\\",[\\"linear\\"],[\\"zoom\\"],12,1,18,4]"', markdown)
         self.assertIn("## Source vs QGIS stroke controls", markdown)
         self.assertIn("Source sampled controls evaluate zoom expressions at the camera zoom", markdown)
-        self.assertIn("expression colors are marked as expression-not-sampled", markdown)
+        self.assertIn("unsampled layout expressions are marked as expression-not-sampled", markdown)
         self.assertIn("QGIS deltas compare visible QGIS controls against source sampled controls", markdown)
         self.assertIn("| chamonix-trails-z14-outdoors | road-path |", markdown)
         self.assertIn('"line-width=0.5622395833333333"', markdown)

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -283,8 +283,33 @@ def _path_pedestrian_focus_report(
                         ],
                     },
                 ],
+                "pedestrian_core_case_cap_relationships": [
+                    _pedestrian_core_case_cap_relationship()
+                ],
             }
         ]
+    }
+
+
+def _pedestrian_core_case_cap_relationship():
+    return {
+        "source_core_layer_id": "road-pedestrian",
+        "source_case_layer_id": "road-pedestrian-case",
+        "cap_limit_mm": 3.0,
+        "source_core_width_mm": 3.0,
+        "source_core_raw_width_mm": 3.175,
+        "source_case_width_mm": 3.0,
+        "source_case_raw_width_mm": 3.8364583333333333,
+        "source_both_widths_capped": True,
+        "source_case_to_core_ratio": 1.0,
+        "qgis_core_layer_id": "road-pedestrian-z18-plus",
+        "qgis_core_width_mm": 1.92,
+        "qgis_case_layer_id": "road-pedestrian-case-z18-plus",
+        "qgis_case_width_mm": 2.4,
+        "qgis_case_to_core_ratio": 1.25,
+        "qgis_pale_casing_layer_id": "road-pedestrian-case-z18-plus-pale-casing",
+        "qgis_pale_casing_width_mm": 3.0,
+        "qgis_ratio_preserving_core_width_mm_at_cap": 2.4,
     }
 
 
@@ -888,6 +913,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             focus_cues = report["cameras"][0]["path_pedestrian_focus"]
             stroke_cues = focus_cues["stroke_width_deltas"]
             source_capped_cues = focus_cues["source_capped_strokes"]
+            core_case_cues = focus_cues["pedestrian_core_case_caps"]
             dash_cues = focus_cues["dash_mismatches"]
             self.assertEqual(report["path_pedestrian_focus_json"], str(focus_path))
             self.assertEqual(
@@ -948,8 +974,56 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertEqual(source_capped_cues[0]["candidate_types"], ["pedestrian=191"])
             self.assertEqual(source_capped_cues[0]["source_line_width_mm"], 3.0)
             self.assertEqual(source_capped_cues[0]["source_line_width_raw_mm"], 3.175)
+            self.assertEqual(core_case_cues[0]["source_core_layer_id"], "road-pedestrian")
+            self.assertEqual(core_case_cues[0]["source_case_layer_id"], "road-pedestrian-case")
+            self.assertEqual(core_case_cues[0]["qgis_pale_casing_width_mm"], 3.0)
+            self.assertEqual(
+                core_case_cues[0]["qgis_ratio_preserving_core_width_mm_at_cap"],
+                2.4,
+            )
             self.assertEqual(dash_cues[0]["source_layer_id"], "road-steps")
             self.assertEqual(dash_cues[0]["source_dasharray"], [0.3, 0.3])
+
+    def test_generate_visual_crop_report_keeps_core_case_only_focus_cues(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            focus_path = root / "focus" / "path-pedestrian-focus.json"
+            focus_report = _path_pedestrian_focus_report(
+                comparison_summary_jsons=[str(summary_path)]
+            )
+            focus_report["cameras"][0]["source_qgis_stroke_control_comparisons"] = []
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                annotation_inputs=VisualCropAnnotationInputs(
+                    path_pedestrian_focus_report=focus_report,
+                    path_pedestrian_focus_report_path=focus_path,
+                ),
+                focus_cue_cameras_only=True,
+                crops_per_camera=0,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+
+            self.assertEqual(report["camera_count"], 1)
+            focus_cues = report["cameras"][0]["path_pedestrian_focus"]
+            self.assertEqual(focus_cues["stroke_width_deltas"], [])
+            self.assertEqual(focus_cues["source_capped_strokes"], [])
+            self.assertEqual(focus_cues["dash_mismatches"], [])
+            self.assertEqual(
+                focus_cues["pedestrian_core_case_caps"][0]["source_core_layer_id"],
+                "road-pedestrian",
+            )
+            markdown = build_summary_markdown(report)
+            self.assertIn("## Path/pedestrian focus cues", markdown)
+            self.assertIn("Core/case cap cues", markdown)
+            self.assertIn("source-both-capped", markdown)
 
     def test_path_pedestrian_focus_coverage_counts_all_stroke_rows(self):
         focus_report = {
@@ -1351,6 +1425,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             comparisons[0]["decoded_candidate_type_counts"] = {}
             comparisons[2]["decoded_candidate_count"] = 0
             comparisons[2]["decoded_candidate_type_counts"] = {}
+            focus_report["cameras"][0]["pedestrian_core_case_cap_relationships"] = []
             paths = build_visual_crop_paths(root / "debug" / "run")
 
             report = generate_visual_crop_report(
@@ -2067,6 +2142,9 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                                     "source_line_width_capped": True,
                                 }
                             ],
+                            "pedestrian_core_case_caps": [
+                                _pedestrian_core_case_cap_relationship()
+                            ],
                             "dash_mismatches": [
                                 {
                                     "source_layer_id": "bridge-path",
@@ -2109,7 +2187,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertIn(
             (
                 "| Camera | Crop movement groups | Stroke width cues | "
-                "Source-capped stroke cues | Dash mismatch cues |"
+                "Source-capped stroke cues | Core/case cap cues | Dash mismatch cues |"
             ),
             markdown,
         )
@@ -2129,6 +2207,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         )
         self.assertIn("candidate_types=trail=69", markdown)
         self.assertNotIn("candidates=None", markdown)
+        self.assertIn("source-both-capped", markdown)
+        self.assertIn("qgis_ratio=1.25", markdown)
+        self.assertIn("ratio_preserving_core_at_cap=2.4mm", markdown)
+        self.assertIn("pale_casing=road-pedestrian-case-z18-plus-pale-casing", markdown)
         self.assertIn("dash=[1,0.25]!=[4,0.3]", markdown)
 
     def test_build_summary_markdown_handles_partial_focus_coverage_sample_rows(self):

--- a/validation/mapbox_outdoors_path_pedestrian_focus.py
+++ b/validation/mapbox_outdoors_path_pedestrian_focus.py
@@ -21,6 +21,7 @@ from qfit.mapbox_config import (  # noqa: E402
     _extract_line_dasharray_literal,
     _extract_zoom_scalar_size_at_zoom,
     _literal_line_dasharray,
+    _step_zoom_value,
     base_mapbox_style_layer_id_for_qfit,
 )
 
@@ -63,21 +64,33 @@ PATH_PEDESTRIAN_DETAIL_PAINT_KEYS = (
     "fill-color",
     "fill-opacity",
 )
+PATH_PEDESTRIAN_DETAIL_LAYOUT_KEYS = (
+    "line-cap",
+    "line-join",
+)
 PATH_PEDESTRIAN_STROKE_CONTROL_KEYS = (
     "line-width",
     "line-width_raw_mm",
     "line-width_capped",
     "line-color",
     "line-dasharray",
+    "line-cap",
+    "line-join",
     "line-opacity",
 )
 PATH_PEDESTRIAN_STROKE_DELTA_KEYS = (
     "line-width_delta_mm",
     "line-width_ratio",
     "line-dasharray_match",
+    "line-cap_match",
+    "line-join_match",
     "line-color_match",
     "line-opacity_delta",
 )
+PATH_PEDESTRIAN_LINE_LAYOUT_CHOICES = {
+    "line-cap": frozenset({"butt", "round", "square"}),
+    "line-join": frozenset({"bevel", "round", "miter"}),
+}
 PATH_PEDESTRIAN_SOURCE_LAYER_PREFIXES = ("road", "bridge", "tunnel")
 PATH_PEDESTRIAN_SOURCE_STRUCTURES_BY_PREFIX = {
     "bridge": "bridge",
@@ -704,6 +717,11 @@ def _style_control_count(layers: Iterable[Mapping[str, object]], property_name: 
     return sum(1 for layer in layers if property_name in _layer_paint(layer))
 
 
+def _layer_layout(layer: Mapping[str, object]) -> Mapping[str, object]:
+    layout = layer.get("layout")
+    return layout if isinstance(layout, Mapping) else {}
+
+
 def _layer_detail(layer: Mapping[str, object]) -> dict[str, object]:
     detail = {
         "id": str(layer.get("id") or ""),
@@ -717,6 +735,10 @@ def _layer_detail(layer: Mapping[str, object]) -> dict[str, object]:
     for key in PATH_PEDESTRIAN_DETAIL_PAINT_KEYS:
         if key in paint:
             detail[key] = paint[key]
+    layout = _layer_layout(layer)
+    for key in PATH_PEDESTRIAN_DETAIL_LAYOUT_KEYS:
+        if key in layout:
+            detail[key] = layout[key]
     return detail
 
 
@@ -1266,7 +1288,34 @@ def _source_sampled_stroke_controls(
     line_opacity = _extract_zoom_scalar_size_at_zoom(detail.get("line-opacity"), camera_zoom)
     if line_opacity is not None:
         sampled_controls["line-opacity"] = line_opacity
+    for key, choices in PATH_PEDESTRIAN_LINE_LAYOUT_CHOICES.items():
+        if key not in detail:
+            continue
+        line_layout = _sample_line_layout_control(
+            detail.get(key),
+            camera_zoom,
+            choices=choices,
+        )
+        if line_layout is not None:
+            sampled_controls[key] = line_layout
     return sampled_controls
+
+
+def _sample_line_layout_control(
+    value: object,
+    camera_zoom: float,
+    *,
+    choices: frozenset[str],
+) -> str | None:
+    if isinstance(value, str) and value in choices:
+        return value
+    if isinstance(value, list):
+        if len(value) >= 3 and value[0] == "step" and value[1] == ["zoom"]:
+            stepped_value = _step_zoom_value(value, target_zoom=camera_zoom)
+            if isinstance(stepped_value, str) and stepped_value in choices:
+                return stepped_value
+        return UNSAMPLED_EXPRESSION_CONTROL
+    return None
 
 
 def _source_line_width_controls(line_width_expr: object, camera_zoom: float) -> dict[str, object]:
@@ -1303,6 +1352,17 @@ def _stroke_control_deltas(
     qgis_dasharray = _literal_line_dasharray(qgis_controls.get("line-dasharray"))
     if source_dasharray is not None and qgis_dasharray is not None:
         deltas["line-dasharray_match"] = qgis_dasharray == source_dasharray
+    for key in PATH_PEDESTRIAN_DETAIL_LAYOUT_KEYS:
+        source_layout = source_sampled_controls.get(key)
+        qgis_layout = qgis_controls.get(key)
+        if (
+            isinstance(source_layout, str)
+            and source_layout
+            and source_layout != UNSAMPLED_EXPRESSION_CONTROL
+            and isinstance(qgis_layout, str)
+            and qgis_layout
+        ):
+            deltas[f"{key}_match"] = qgis_layout == source_layout
     source_color = source_sampled_controls.get("line-color")
     qgis_color = qgis_controls.get("line-color")
     if (
@@ -1793,7 +1853,7 @@ def _detail_zoom_band(detail: Mapping[str, object]) -> str:
 def _detail_paint_controls(detail: Mapping[str, object]) -> list[str]:
     return [
         f"{key}={_compact_json(detail.get(key))}"
-        for key in PATH_PEDESTRIAN_DETAIL_PAINT_KEYS
+        for key in (*PATH_PEDESTRIAN_DETAIL_PAINT_KEYS, *PATH_PEDESTRIAN_DETAIL_LAYOUT_KEYS)
         if key in detail
     ]
 
@@ -1819,7 +1879,7 @@ def _visible_style_detail_markdown_lines(
             [
                 f"### {camera.get('camera')}",
                 "",
-                "| Layer | Type | Zoom band | Paint controls | Filter |",
+                "| Layer | Type | Zoom band | Paint/layout controls | Filter |",
                 MARKDOWN_SEPARATOR_5_COLUMNS,
             ]
         )
@@ -1948,9 +2008,10 @@ def _source_qgis_stroke_control_markdown_lines(cameras: Iterable[object]) -> lis
             (
                 "Source sampled controls evaluate zoom expressions at the camera zoom; "
                 "line-width is shown in QGIS millimetres and dash arrays are the selected "
-                "Mapbox line-width-relative pattern. Literal line colors are carried through; "
-                "expression colors are marked as expression-not-sampled and remain available "
-                "in the raw source controls."
+                "Mapbox line-width-relative pattern. Literal line colors and sampled line "
+                "cap/join layout choices are carried through; expression colors and "
+                "unsampled layout expressions are marked as expression-not-sampled and remain "
+                "available in the raw source controls."
             ),
             (
                 "QGIS deltas compare visible QGIS controls against source sampled controls "

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -42,6 +42,7 @@ DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-visual-crops"
 DEFAULT_CROP_SIZE = (320, 240)
 DEFAULT_CROPS_PER_CAMERA = 3
 DEFAULT_FOCUS_DASH_CUE_LIMIT = 2
+DEFAULT_FOCUS_CORE_CASE_CUE_LIMIT = 3
 DEFAULT_FOCUS_STROKE_CUE_LIMIT = 3
 DEFAULT_STYLE_AUDIT_SAMPLE_LIMIT = 5
 DEFAULT_STYLE_AUDIT_SIMPLIFICATION_LIMIT = 3
@@ -82,6 +83,26 @@ STYLE_AUDIT_AREA_FILL_SECTIONS = (
         "simplified_by_property": "airport_special_landuse_simplified_by_property",
         "qgis_dependent_by_property": "airport_special_landuse_qgis_dependent_by_property",
     },
+)
+FOCUS_STROKE_CUE_KEYS = (
+    "source_layer_id",
+    "qgis_layer_id",
+    "decoded_candidate_count",
+    "line_width_delta_mm",
+    "line_width_abs_delta_mm",
+    "line_width_ratio",
+    "source_line_width_mm",
+    "source_line_width_raw_mm",
+    "source_line_width_capped",
+)
+FOCUS_DASH_CUE_KEYS = (
+    "source_layer_id",
+    "qgis_layer_id",
+    "decoded_candidate_count",
+    "source_dasharray",
+    "qgis_dasharray",
+    "line_width_delta_mm",
+    "line_width_ratio",
 )
 
 
@@ -553,6 +574,152 @@ def _has_decoded_candidates(row: Mapping[str, object]) -> bool:
     return isinstance(candidate_types, list) and bool(candidate_types)
 
 
+def _pedestrian_core_case_cap_cues(
+    camera: Mapping[str, object],
+    *,
+    limit: int = DEFAULT_FOCUS_CORE_CASE_CUE_LIMIT,
+) -> list[dict[str, object]]:
+    relationships = camera.get("pedestrian_core_case_cap_relationships")
+    relationship_rows = relationships if isinstance(relationships, list) else []
+    cues: list[dict[str, object]] = []
+    cue_keys = (
+        "source_core_layer_id",
+        "source_case_layer_id",
+        "source_core_width_mm",
+        "source_core_raw_width_mm",
+        "source_case_width_mm",
+        "source_case_raw_width_mm",
+        "source_both_widths_capped",
+        "source_case_to_core_ratio",
+        "qgis_core_layer_id",
+        "qgis_core_width_mm",
+        "qgis_case_layer_id",
+        "qgis_case_width_mm",
+        "qgis_case_to_core_ratio",
+        "qgis_pale_casing_layer_id",
+        "qgis_pale_casing_width_mm",
+        "qgis_ratio_preserving_core_width_mm_at_cap",
+        "cap_limit_mm",
+    )
+    for relationship in relationship_rows:
+        if not isinstance(relationship, Mapping):
+            continue
+        if (
+            relationship.get("source_both_widths_capped") is not True
+            and not relationship.get("qgis_pale_casing_layer_id")
+        ):
+            continue
+        cue = {
+            key: relationship.get(key)
+            for key in cue_keys
+            if _non_empty_focus_value(relationship.get(key))
+        }
+        if cue:
+            cues.append(cue)
+        if len(cues) >= max(0, limit):
+            break
+    return cues
+
+
+def _limited_focus_cues(
+    rows: Iterable[Mapping[str, object]],
+    *,
+    row_filter: Callable[[Mapping[str, object]], bool],
+    cue_keys: Sequence[str],
+    limit: int,
+) -> list[dict[str, object]]:
+    cue_limit = max(0, limit)
+    if cue_limit == 0:
+        return []
+    cues: list[dict[str, object]] = []
+    for row in rows:
+        if not row_filter(row):
+            continue
+        cues.append(_focus_cue_from_row(row, cue_keys))
+        if len(cues) >= cue_limit:
+            break
+    return cues
+
+
+def _is_width_focus_row(row: Mapping[str, object]) -> bool:
+    return _has_meaningful_width_delta(row) and _has_decoded_candidates(row)
+
+
+def _is_source_capped_focus_row(row: Mapping[str, object]) -> bool:
+    return row.get("source_line_width_capped") is True and _has_decoded_candidates(row)
+
+
+def _limited_width_focus_rows(
+    ranked_stroke_rows: Sequence[Mapping[str, object]],
+    *,
+    stroke_limit: int,
+) -> list[dict[str, object]]:
+    return _limited_focus_cues(
+        ranked_stroke_rows,
+        row_filter=_is_width_focus_row,
+        cue_keys=FOCUS_STROKE_CUE_KEYS,
+        limit=stroke_limit,
+    )
+
+
+def _limited_source_capped_focus_rows(
+    ranked_stroke_rows: Sequence[Mapping[str, object]],
+    *,
+    stroke_limit: int,
+) -> list[dict[str, object]]:
+    return _limited_focus_cues(
+        ranked_stroke_rows,
+        row_filter=_is_source_capped_focus_row,
+        cue_keys=FOCUS_STROKE_CUE_KEYS,
+        limit=stroke_limit,
+    )
+
+
+def _limited_dash_focus_rows(
+    camera: Mapping[str, object],
+    *,
+    dash_limit: int,
+) -> list[dict[str, object]]:
+    return _limited_focus_cues(
+        _non_auxiliary_dash_mismatch_rows([camera]),
+        row_filter=_has_decoded_candidates,
+        cue_keys=FOCUS_DASH_CUE_KEYS,
+        limit=dash_limit,
+    )
+
+
+def _path_pedestrian_focus_cues_for_camera(
+    camera: Mapping[str, object],
+    *,
+    stroke_limit: int,
+    dash_limit: int,
+) -> dict[str, list[dict[str, object]]] | None:
+    ranked_stroke_rows = _largest_non_auxiliary_stroke_delta_rows(
+        [camera],
+        limit=10_000,
+    )
+    width_rows = _limited_width_focus_rows(
+        ranked_stroke_rows,
+        stroke_limit=stroke_limit,
+    )
+    source_capped_stroke_rows = _limited_source_capped_focus_rows(
+        ranked_stroke_rows,
+        stroke_limit=stroke_limit,
+    )
+    dash_rows = _limited_dash_focus_rows(camera, dash_limit=dash_limit)
+    core_case_cap_rows = _pedestrian_core_case_cap_cues(camera)
+    if not (width_rows or source_capped_stroke_rows or core_case_cap_rows or dash_rows):
+        return None
+    cues = {
+        "stroke_width_deltas": width_rows,
+        "source_capped_strokes": source_capped_stroke_rows,
+        "dash_mismatches": dash_rows,
+    }
+    if core_case_cap_rows:
+        cues["pedestrian_core_case_caps"] = core_case_cap_rows
+    return cues
+
+
 def _path_pedestrian_focus_cues_by_camera(
     focus_report: Mapping[str, object] | None,
     *,
@@ -571,77 +738,13 @@ def _path_pedestrian_focus_cues_by_camera(
         camera_name = str(camera.get("camera") or "")
         if not camera_name:
             continue
-        ranked_stroke_rows = _largest_non_auxiliary_stroke_delta_rows(
-            [camera],
-            limit=10_000,
+        cues = _path_pedestrian_focus_cues_for_camera(
+            camera,
+            stroke_limit=stroke_limit,
+            dash_limit=dash_limit,
         )
-        width_delta_rows = [
-            row
-            for row in ranked_stroke_rows
-            if _has_meaningful_width_delta(row) and _has_decoded_candidates(row)
-        ][: max(0, stroke_limit)]
-        source_capped_rows = [
-            row
-            for row in ranked_stroke_rows
-            if row.get("source_line_width_capped") is True and _has_decoded_candidates(row)
-        ][: max(0, stroke_limit)]
-        width_rows = [
-            _focus_cue_from_row(
-                row,
-                (
-                    "source_layer_id",
-                    "qgis_layer_id",
-                    "decoded_candidate_count",
-                    "line_width_delta_mm",
-                    "line_width_abs_delta_mm",
-                    "line_width_ratio",
-                    "source_line_width_mm",
-                    "source_line_width_raw_mm",
-                    "source_line_width_capped",
-                ),
-            )
-            for row in width_delta_rows
-        ]
-        source_capped_stroke_rows = [
-            _focus_cue_from_row(
-                row,
-                (
-                    "source_layer_id",
-                    "qgis_layer_id",
-                    "decoded_candidate_count",
-                    "line_width_delta_mm",
-                    "line_width_abs_delta_mm",
-                    "line_width_ratio",
-                    "source_line_width_mm",
-                    "source_line_width_raw_mm",
-                    "source_line_width_capped",
-                ),
-            )
-            for row in source_capped_rows
-        ]
-        dash_rows = [
-            _focus_cue_from_row(
-                row,
-                (
-                    "source_layer_id",
-                    "qgis_layer_id",
-                    "decoded_candidate_count",
-                    "source_dasharray",
-                    "qgis_dasharray",
-                    "line_width_delta_mm",
-                    "line_width_ratio",
-                ),
-            )
-            for row in _non_auxiliary_dash_mismatch_rows([camera])
-            if _has_decoded_candidates(row)
-        ]
-        dash_rows = dash_rows[: max(0, dash_limit)]
-        if width_rows or source_capped_stroke_rows or dash_rows:
-            cues_by_camera[camera_name] = {
-                "stroke_width_deltas": width_rows,
-                "source_capped_strokes": source_capped_stroke_rows,
-                "dash_mismatches": dash_rows,
-            }
+        if cues is not None:
+            cues_by_camera[camera_name] = cues
     return cues_by_camera
 
 
@@ -1559,6 +1662,42 @@ def _dash_focus_cue_summary(cue: Mapping[str, object]) -> str:
     return " ".join(parts)
 
 
+def _append_mm_focus_part(parts: list[str], label: str, value: object) -> None:
+    if value is not None:
+        parts.append(f"{label}={_format_focus_number(value)}mm")
+
+
+def _append_ratio_focus_part(parts: list[str], label: str, value: object) -> None:
+    if value is not None:
+        parts.append(f"{label}={_format_focus_number(value)}")
+
+
+def _core_case_focus_cue_summary(cue: Mapping[str, object]) -> str:
+    source_pair = f"{cue.get('source_core_layer_id')}/{cue.get('source_case_layer_id')}"
+    qgis_pair = f"{cue.get('qgis_core_layer_id')}/{cue.get('qgis_case_layer_id')}"
+    parts = [f"{source_pair}->{qgis_pair}"]
+    if cue.get("source_both_widths_capped") is True:
+        parts.append("source-both-capped")
+    _append_mm_focus_part(parts, "source_core", cue.get("source_core_width_mm"))
+    _append_mm_focus_part(parts, "raw_core", cue.get("source_core_raw_width_mm"))
+    _append_mm_focus_part(parts, "source_case", cue.get("source_case_width_mm"))
+    _append_mm_focus_part(parts, "raw_case", cue.get("source_case_raw_width_mm"))
+    _append_ratio_focus_part(parts, "source_ratio", cue.get("source_case_to_core_ratio"))
+    _append_mm_focus_part(parts, "qgis_core", cue.get("qgis_core_width_mm"))
+    _append_mm_focus_part(parts, "qgis_case", cue.get("qgis_case_width_mm"))
+    _append_ratio_focus_part(parts, "qgis_ratio", cue.get("qgis_case_to_core_ratio"))
+    if cue.get("qgis_pale_casing_layer_id"):
+        parts.append(f"pale_casing={cue.get('qgis_pale_casing_layer_id')}")
+        _append_mm_focus_part(parts, "pale_width", cue.get("qgis_pale_casing_width_mm"))
+    _append_mm_focus_part(
+        parts,
+        "ratio_preserving_core_at_cap",
+        cue.get("qgis_ratio_preserving_core_width_mm_at_cap"),
+    )
+    _append_mm_focus_part(parts, "cap_limit", cue.get("cap_limit_mm"))
+    return " ".join(parts)
+
+
 def _compact_focus_value(value: object) -> str:
     if isinstance(value, list):
         return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
@@ -2324,7 +2463,19 @@ def _summary_focus_row(
         "dash_mismatches",
         _dash_focus_cue_summary,
     )
-    if not stroke_summaries and not source_capped_summaries and not dash_summaries:
+    core_case_cues = focus.get("pedestrian_core_case_caps")
+    core_case_cue_rows = core_case_cues if isinstance(core_case_cues, list) else []
+    core_case_summaries = [
+        _core_case_focus_cue_summary(cue)
+        for cue in core_case_cue_rows
+        if isinstance(cue, Mapping)
+    ]
+    if (
+        not stroke_summaries
+        and not source_capped_summaries
+        and not core_case_summaries
+        and not dash_summaries
+    ):
         return None
     camera_name = camera.get("camera")
     return [
@@ -2334,6 +2485,7 @@ def _summary_focus_row(
         ),
         stroke_summaries,
         source_capped_summaries,
+        core_case_summaries,
         dash_summaries,
     ]
 
@@ -2506,9 +2658,9 @@ def _summary_focus_cue_lines(report: Mapping[str, object]) -> list[str]:
             "",
             (
                 "| Camera | Crop movement groups | Stroke width cues | "
-                "Source-capped stroke cues | Dash mismatch cues |"
+                "Source-capped stroke cues | Core/case cap cues | Dash mismatch cues |"
             ),
-            "| --- | --- | --- | --- | --- |",
+            "| --- | --- | --- | --- | --- | --- |",
         ]
     )
     lines.extend(_markdown_table_row(row) for row in rows)


### PR DESCRIPTION
## Summary
- include path/pedestrian `line-cap` and `line-join` layout controls in the source-vs-QGIS focus report, including sampled zoom-step source controls and match deltas
- surface pedestrian core/case cap relationships in the visual crop focus cue table so manual crops show capped source widths, QGIS core/case widths, pale casing width, and the ratio-preserving core-width diagnostic
- document the new focus cues for #949 validation workflows

## Evidence
- Official Mapbox style spec treats `line-cap`/`line-join` as line layout properties and `line-dasharray` lengths as line-width-relative, so cap/join needs to be visible beside dash/width before tuning path rendering.
- QGIS exposes line cap/join and custom dash controls on simple line symbol layers, so the report can audit whether qfit's QGIS-preprocessed layers retained the same layout semantics.
- Regenerated path focus report without Mapbox credentials: `debug/mapbox-outdoors-path-pedestrian-focus/20260521T191947Z/summary.md`
- Regenerated Zermatt manual crop report without Mapbox credentials: `debug/mapbox-outdoors-visual-crops/20260521T191742Z/summary.md`

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_path_pedestrian_focus.py tests/test_mapbox_outdoors_visual_crops.py -q --tb=short` -> 97 passed, 6 subtests passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2401 passed, 180 skipped, 177 subtests passed
- `git diff --check` -> clean

Refs #949
