### PR TITLE
test: surface active area-fill layer ids

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -176,7 +176,7 @@ It also groups crop movements by luminance direction and dominant RGB channel, i
 The same movement groups are stored in `visual-crops.json` under `crop_color_movement_groups`, including a representative crop for each group, for follow-up scripts that should not parse the Markdown summary.
 
 When reviewing broad landcover, terrain, airport, or other area-fill differences, pass the latest style audit.
-The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, crop-local color movement cues, camera-zoom-filtered active area-fill candidates, filter-operator signatures, sample-layer filter signatures, and compact qfit simplification snippets for sampled controls:
+The crop report includes the global terrain/landcover and airport/special-landuse candidate counts, crop-local color movement cues, camera-zoom-filtered active area-fill candidate counts and layer IDs, filter-operator signatures, sample-layer filter signatures, and compact qfit simplification snippets for sampled controls:
 
 ```bash
 python3 validation/mapbox_outdoors_visual_crops.py \
@@ -184,7 +184,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --style-audit-json debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/<timestamp>/audit.json
 ```
 
-The camera-focus table uses the comparison summary's camera zoom and Mapbox-style minzoom/maxzoom bands to keep global area-fill audit rows that are outside the cropped camera's inspection scale out of the per-camera sample list.
+The camera-focus table uses the comparison summary's camera zoom and Mapbox-style minzoom/maxzoom bands to keep global area-fill audit rows that are outside the cropped camera's inspection scale out of the per-camera sample list. It keeps every active layer ID visible even when the detailed sample-layer cells are capped.
 
 The focus cues are triage context only. Candidate-backed rows, source-capped rows, and zero-candidate dash rows still need visual inspection before becoming a rendering change.
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1134,12 +1134,20 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 1,
             )
             self.assertEqual(
+                camera_focus_areas["terrain_landcover"]["active_layers"],
+                ["contour"],
+            )
+            self.assertEqual(
                 camera_focus_areas["terrain_landcover"]["sample_candidates"][0]["layer"],
                 "contour",
             )
             self.assertEqual(
                 camera_focus_areas["airport_special_landuse"]["active_candidate_count"],
                 1,
+            )
+            self.assertEqual(
+                camera_focus_areas["airport_special_landuse"]["active_layers"],
+                ["landuse-other-z10-plus-airport"],
             )
             focus[0]["sample_candidates"].append({"source_layer": "landcover", "type": "fill"})
             markdown = build_summary_markdown(report)
@@ -1190,6 +1198,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 1,
             )[1]
             self.assertIn("| Camera | Zoom | Crops |", camera_focus_markdown)
+            self.assertIn("Active layers", camera_focus_markdown)
             self.assertIn("| chamonix-trails-z14-outdoors | 14.25 | 1 |", camera_focus_markdown)
             self.assertIn("contour (contour/line", camera_focus_markdown)
             self.assertNotIn("landcover (landcover/fill", camera_focus_markdown)
@@ -1333,6 +1342,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     "type": "line",
                 },
                 {"layer": "pitch-outline", "source_layer": "landuse", "type": "line"},
+                {"layer": "wetland", "source_layer": "landuse_overlay", "type": "fill"},
             ]
             paths = build_visual_crop_paths(root / "debug" / "run")
 
@@ -1362,12 +1372,33 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     "national-park_tint-band",
                 ],
             )
-            self.assertNotIn("wetland (", build_summary_markdown(report))
-            self.assertIn("wetland-pattern", build_summary_markdown(report))
-            self.assertIn("contour-line", build_summary_markdown(report))
+            terrain_camera_focus = report["style_audit_area_fill_camera_focus"][0]["areas"][0]
+            self.assertEqual(terrain_camera_focus["active_candidate_count"], 9)
+            self.assertEqual(
+                terrain_camera_focus["active_layers"],
+                [
+                    "landcover",
+                    "landuse",
+                    "national-park",
+                    "wetland",
+                    "wetland-pattern",
+                    "contour-line",
+                    "national-park_tint-band",
+                    "pitch-outline",
+                ],
+            )
+            markdown = build_summary_markdown(report)
+            camera_focus_md = markdown.split(
+                "## Style audit area-fill camera focus",
+                1,
+            )[1]
+            self.assertNotIn("wetland (", markdown)
+            self.assertIn("wetland-pattern", markdown)
+            self.assertIn("wetland-pattern, contour-line", camera_focus_md)
+            self.assertIn("contour-line", markdown)
             self.assertIn(
                 "qgis-warnings=Could not retrieve sprite 'wetland'",
-                build_summary_markdown(report),
+                markdown,
             )
 
     def test_generate_visual_crop_report_attaches_matching_comparison_delta_context(self):

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1131,6 +1131,19 @@ def _style_audit_count_rows(
     ]
 
 
+def _style_audit_candidate_layer_ids(
+    candidates: Sequence[Mapping[str, object]],
+) -> list[str]:
+    seen: set[str] = set()
+    layer_ids: list[str] = []
+    for candidate in candidates:
+        layer_id = candidate.get("layer")
+        if isinstance(layer_id, str) and layer_id and layer_id not in seen:
+            seen.add(layer_id)
+            layer_ids.append(layer_id)
+    return layer_ids
+
+
 def _style_audit_filter_signature_rows(
     candidates: list[Mapping[str, object]],
 ) -> list[dict[str, object]]:
@@ -1350,6 +1363,7 @@ def _style_audit_area_fill_camera_area_row(
         "key": section["key"],
         "label": section["label"],
         "active_candidate_count": len(active_candidates),
+        "active_layers": _style_audit_candidate_layer_ids(active_candidates),
         "by_source_layer": _style_audit_count_rows(
             active_candidates,
             "source_layer",
@@ -3152,10 +3166,10 @@ def _style_audit_area_fill_camera_focus_lines(report: Mapping[str, object]) -> l
         "",
         (
             "| Camera | Zoom | Crops | Crop movement groups | Area | Active candidates | "
-            "Source layers | Types | Simplified controls | QGIS-dependent controls | "
+            "Active layers | Source layers | Types | Simplified controls | QGIS-dependent controls | "
             "Sample active layers |"
         ),
-        "| --- | ---: | ---: | --- | --- | ---: | --- | --- | --- | --- | --- |",
+        "| --- | ---: | ---: | --- | --- | ---: | --- | --- | --- | --- | --- | --- |",
     ]
     for camera_focus in rows:
         if not isinstance(camera_focus, Mapping):
@@ -3181,6 +3195,7 @@ def _style_audit_area_fill_camera_focus_lines(report: Mapping[str, object]) -> l
                         ),
                         area.get("label"),
                         area.get("active_candidate_count"),
+                        _joined_summary_labels(_string_values(area.get("active_layers"))),
                         _joined_summary_labels(
                             _count_summary_labels(area.get("by_source_layer"), "source_layer")
                         ),


### PR DESCRIPTION
## Summary
- add all zoom-active area-fill layer IDs to the visual crop camera-focus JSON and Markdown table
- keep capped sample-layer details unchanged while making hidden active layers visible for #949 tint attribution
- document the active layer ID cue in the Mapbox Outdoors comparison harness notes

## Evidence
- regenerated Zermatt manual crop report: `debug/mapbox-outdoors-visual-crops/20260521T201622Z/summary.md`
- the z18 terrain/landcover focus now lists all 7 active layers: `landuse`, `national-park`, `wetland`, `wetland-pattern`, `contour-line`, `national-park_tint-band`, `pitch-outline`

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Part of #949.