### PR TITLE
[codex] Show active area-fill candidate details

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -184,7 +184,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
   --style-audit-json debug/mapbox-outdoors-style-audit/mapbox-outdoors-v12/<timestamp>/audit.json
 ```
 
-The camera-focus table uses the comparison summary's camera zoom and Mapbox-style minzoom/maxzoom bands to keep global area-fill audit rows that are outside the cropped camera's inspection scale out of the per-camera sample list. It keeps every active layer ID visible even when the detailed sample-layer cells are capped.
+The camera-focus table uses the comparison summary's camera zoom and Mapbox-style minzoom/maxzoom bands to keep global area-fill audit rows that are outside the cropped camera's inspection scale out of the per-camera sample list. It keeps every active layer ID visible even when the detailed sample-layer cells are capped. A follow-up active-layer detail table then lists every active area-fill candidate with compact controls and qfit simplification snippets, so unsampled layers such as pattern/tint rows can still be inspected from the crop report.
 
 The focus cues are triage context only. Candidate-backed rows, source-capped rows, and zero-candidate dash rows still need visual inspection before becoming a rendering change.
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -12,6 +12,7 @@ from tests import _path  # noqa: F401
 
 from qfit.validation.mapbox_outdoors_visual_crops import (
     VisualCropAnnotationInputs,
+    _candidate_source_type_label,
     _computed_crop_color_movement_group_records,
     _crop_color_metric,
     _path_pedestrian_focus_coverage_rows,
@@ -558,6 +559,18 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             )
         )
 
+    def test_candidate_source_type_label_handles_missing_fields(self):
+        self.assertEqual(
+            _candidate_source_type_label({"source_layer": "landuse_overlay", "type": "fill"}),
+            "landuse_overlay/fill",
+        )
+        self.assertEqual(
+            _candidate_source_type_label({"source_layer": "landuse_overlay"}),
+            "landuse_overlay/-",
+        )
+        self.assertEqual(_candidate_source_type_label({"type": "fill"}), "-/fill")
+        self.assertEqual(_candidate_source_type_label({}), "-")
+
     def test_crop_color_metric_handles_empty_stat_outputs(self):
         image_module = _FakeImageModule()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -908,6 +921,33 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertEqual(report["cameras"][0]["status"], "no_hotspot_crops")
             self.assertEqual(report["cameras"][0]["crops"], [])
 
+    def test_generate_visual_crop_report_skips_area_fill_camera_focus_without_crops(self):
+        image_module, image_stat_module = _fake_image_modules()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparison_summary, summary_path = _write_visual_triplet(root, image_module)
+            paths = build_visual_crop_paths(root / "debug" / "run")
+
+            report = generate_visual_crop_report(
+                comparison_summary,
+                comparison_summary_path=summary_path,
+                paths=paths,
+                annotation_inputs=VisualCropAnnotationInputs(
+                    style_audit_report=_style_audit_report(),
+                    style_audit_report_path=root / "style-audit" / "audit.json",
+                ),
+                crop_size=(4, 4),
+                crops_per_camera=0,
+                trusted_output_root=root / "debug",
+                image_module=image_module,
+                image_stat_module=image_stat_module,
+            )
+
+            self.assertEqual(report["crop_count"], 0)
+            self.assertIn("style_audit_area_fill_focus", report)
+            self.assertNotIn("style_audit_area_fill_camera_focus", report)
+            self.assertNotIn("Style audit area-fill camera focus", build_summary_markdown(report))
+
     def test_generate_visual_crop_report_attaches_path_pedestrian_focus_cues(self):
         image_module, image_stat_module = _fake_image_modules()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1138,6 +1178,10 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                 ["contour"],
             )
             self.assertEqual(
+                camera_focus_areas["terrain_landcover"]["active_candidate_details"][0]["layer"],
+                "contour",
+            )
+            self.assertEqual(
                 camera_focus_areas["terrain_landcover"]["sample_candidates"][0]["layer"],
                 "contour",
             )
@@ -1184,6 +1228,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("Style audit input: `", markdown)
             self.assertIn("## Style audit area-fill focus", markdown)
             self.assertIn("## Style audit area-fill camera focus", markdown)
+            self.assertIn("## Style audit area-fill active layer details", markdown)
             self.assertIn("Report color movements", markdown)
             self.assertIn(
                 "darker + red lower=1 (rep -127.0, -127.0, -127.0 / -127.0)",
@@ -1202,6 +1247,18 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             self.assertIn("| chamonix-trails-z14-outdoors | 14.25 | 1 |", camera_focus_markdown)
             self.assertIn("contour (contour/line", camera_focus_markdown)
             self.assertNotIn("landcover (landcover/fill", camera_focus_markdown)
+            active_detail_markdown = markdown.split(
+                "## Style audit area-fill active layer details",
+                1,
+            )[1]
+            self.assertIn(
+                "| chamonix-trails-z14-outdoors | 14.25 | Terrain/landcover |",
+                active_detail_markdown,
+            )
+            self.assertIn(
+                "| chamonix-trails-z14-outdoors | 14.25 | Airport/special landuse |",
+                active_detail_markdown,
+            )
             self.assertIn(
                 "landcover (landcover/fill; filter-ops: all, get, match; controls=filter, paint.fill-color, "
                 "paint.fill-opacity; qfit=paint.fill-color, paint.fill-opacity; "
@@ -1387,12 +1444,37 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     "pitch-outline",
                 ],
             )
+            self.assertEqual(
+                [
+                    candidate["layer"]
+                    for candidate in terrain_camera_focus["active_candidate_details"]
+                ],
+                [
+                    "landcover",
+                    "landuse",
+                    "national-park",
+                    "wetland",
+                    "wetland-pattern",
+                    "contour-line",
+                    "national-park_tint-band",
+                    "pitch-outline",
+                    "wetland",
+                ],
+            )
             markdown = build_summary_markdown(report)
             camera_focus_md = markdown.split(
                 "## Style audit area-fill camera focus",
                 1,
             )[1]
-            self.assertNotIn("wetland (", markdown)
+            active_detail_md = markdown.split(
+                "## Style audit area-fill active layer details",
+                1,
+            )[1]
+            self.assertIn(
+                "| chamonix-trails-z14-outdoors | 14.25 | Terrain/landcover | "
+                "wetland | landuse_overlay/fill |",
+                active_detail_md,
+            )
             self.assertIn("wetland-pattern", markdown)
             self.assertIn("wetland-pattern, contour-line", camera_focus_md)
             self.assertIn("contour-line", markdown)

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -1364,6 +1364,14 @@ def _style_audit_area_fill_camera_area_row(
         "label": section["label"],
         "active_candidate_count": len(active_candidates),
         "active_layers": _style_audit_candidate_layer_ids(active_candidates),
+        "active_candidate_details": [
+            _style_audit_candidate_sample(
+                candidate,
+                qgis_converter_warnings_by_layer=qgis_converter_warnings_by_layer,
+                style_audit_layers_by_id=style_audit_layers_by_id,
+            )
+            for candidate in active_candidates
+        ],
         "by_source_layer": _style_audit_count_rows(
             active_candidates,
             "source_layer",
@@ -1400,10 +1408,12 @@ def _style_audit_area_fill_camera_row(
     sample_limit: int,
 ) -> dict[str, object] | None:
     camera_name = str(camera.get("camera") or "")
+    crops = camera.get("crops")
+    if not isinstance(crops, list) or not crops:
+        return None
     camera_zoom = _numeric_zoom_bound(camera.get("camera_zoom"))
     if not camera_name or camera_zoom is None:
         return None
-    crops = camera.get("crops")
     area_rows = [
         area_row
         for section in STYLE_AUDIT_AREA_FILL_SECTIONS
@@ -3216,6 +3226,104 @@ def _style_audit_area_fill_camera_focus_lines(report: Mapping[str, object]) -> l
     return lines
 
 
+def _candidate_source_type_label(candidate: Mapping[str, object]) -> str:
+    source_layer = candidate.get("source_layer")
+    layer_type = candidate.get("type")
+    if source_layer is None and layer_type is None:
+        return "-"
+    return f"{source_layer or '-'}/{layer_type or '-'}"
+
+
+def _style_audit_area_fill_candidate_detail_header_lines() -> list[str]:
+    return [
+        "",
+        "## Style audit area-fill active layer details",
+        "",
+        (
+            "Lists every camera-zoom-active area-fill candidate with compact style-audit "
+            "controls, so active layers hidden behind the camera-focus sample cap remain "
+            "visible during crop attribution."
+        ),
+        "",
+        (
+            "| Camera | Zoom | Area | Layer | Source/type | Zoom band | Controls | "
+            "Simplified controls | QGIS-dependent controls | Qfit simplifications |"
+        ),
+        "| --- | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+
+
+def _style_audit_area_fill_candidate_detail_row(
+    *,
+    camera_focus: Mapping[str, object],
+    area: Mapping[str, object],
+    candidate: Mapping[str, object],
+) -> str:
+    return _markdown_table_row(
+        [
+            camera_focus.get("camera"),
+            _format_focus_number(camera_focus.get("camera_zoom")),
+            area.get("label"),
+            candidate.get("layer"),
+            _candidate_source_type_label(candidate),
+            candidate.get("zoom_band"),
+            _joined_summary_labels(_string_values(candidate.get("control_properties"))),
+            _joined_summary_labels(_string_values(candidate.get("qfit_simplified_properties"))),
+            _joined_summary_labels(_string_values(candidate.get("qgis_dependent_properties"))),
+            _joined_summary_labels(_candidate_qfit_simplification_labels(candidate)),
+        ]
+    )
+
+
+def _style_audit_area_fill_candidate_detail_area_lines(
+    *,
+    camera_focus: Mapping[str, object],
+    area: Mapping[str, object],
+) -> list[str]:
+    candidates = area.get("active_candidate_details")
+    if not isinstance(candidates, list):
+        return []
+    return [
+        _style_audit_area_fill_candidate_detail_row(
+            camera_focus=camera_focus,
+            area=area,
+            candidate=candidate,
+        )
+        for candidate in candidates
+        if isinstance(candidate, Mapping)
+    ]
+
+
+def _style_audit_area_fill_candidate_detail_camera_lines(
+    camera_focus: Mapping[str, object],
+) -> list[str]:
+    area_rows = camera_focus.get("areas")
+    if not isinstance(area_rows, list):
+        return []
+    lines: list[str] = []
+    for area in area_rows:
+        if isinstance(area, Mapping):
+            lines.extend(
+                _style_audit_area_fill_candidate_detail_area_lines(
+                    camera_focus=camera_focus,
+                    area=area,
+                )
+            )
+    return lines
+
+
+def _style_audit_area_fill_candidate_detail_lines(report: Mapping[str, object]) -> list[str]:
+    focus = report.get("style_audit_area_fill_camera_focus")
+    rows = focus if isinstance(focus, list) else []
+    if not rows:
+        return []
+    lines = _style_audit_area_fill_candidate_detail_header_lines()
+    for camera_focus in rows:
+        if isinstance(camera_focus, Mapping):
+            lines.extend(_style_audit_area_fill_candidate_detail_camera_lines(camera_focus))
+    return lines
+
+
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines = _summary_header_lines(report)
     include_comparison_delta = _include_comparison_delta_columns(report)
@@ -3234,6 +3342,7 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines.extend(_summary_crop_color_metric_lines(report))
     lines.extend(_style_audit_area_fill_focus_lines(report))
     lines.extend(_style_audit_area_fill_camera_focus_lines(report))
+    lines.extend(_style_audit_area_fill_candidate_detail_lines(report))
     lines.extend(_summary_focus_coverage_lines(report))
     lines.extend(_summary_focus_coverage_sample_lines(report))
     lines.extend(_summary_focus_decoded_feature_lines(report))


### PR DESCRIPTION
## Summary

- Keep area-fill camera-focus rows limited to cameras that actually produced visual crops.
- Add an area-fill active-layer detail table so every zoom-active candidate shows compact controls and qfit simplification snippets, including layers hidden by the sample cap.
- Document the new active-layer detail table in the Mapbox Outdoors comparison harness notes.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

## Evidence

- Regenerated Zermatt manual crop report without Mapbox credentials: `debug/mapbox-outdoors-visual-crops/20260521T203421Z/summary.md`
- The report now keeps the Zermatt z18 active detail table focused on cropped cameras and surfaces `wetland`, `wetland-pattern`, `landuse`, `national-park`, `national-park_tint-band`, `contour-line`, and `pitch-outline` controls for the lighter/blue crop family.

Refs #949
