### PR TITLE
[codex] split commercial area landuse color

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1368,6 +1368,16 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ("pitch", ["match", ["get", "class"], "pitch", True, False], _LANDUSE_PITCH_FILL_COLOR),
     ("school", ["match", ["get", "class"], "school", True, False], _LANDUSE_SCHOOL_FILL_COLOR),
     (
+        "commercial-area-low-zoom",
+        ["match", ["get", "class"], "commercial_area", True, False],
+        _LANDUSE_COMMERCIAL_AREA_FILL_COLOR,
+    ),
+    (
+        "commercial-area-high-zoom",
+        ["match", ["get", "class"], "commercial_area", True, False],
+        _LANDUSE_COMMERCIAL_AREA_HIGH_ZOOM_FILL_COLOR,
+    ),
+    (
         "industrial",
         ["match", ["get", "class"], ["facility", "industrial"], True, False],
         _LANDUSE_INDUSTRIAL_FILL_COLOR,
@@ -1391,6 +1401,7 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
                 "hospital",
                 "pitch",
                 "school",
+                "commercial_area",
                 "facility",
                 "industrial",
             ],
@@ -1404,6 +1415,8 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANT_ZOOM_BOUNDS = {
     # Match the live Outdoors z16 rock-color stop without recoloring lower zooms.
     "rock-low-zoom": (None, 16.0),
     "rock-high-zoom": (16.0, None),
+    "commercial-area-low-zoom": (None, 16.0),
+    "commercial-area-high-zoom": (16.0, None),
 }
 _LANDCOVER_CROP_FILL_COLOR = "hsla(68, 55%, 70%, 0.6)"
 _LANDCOVER_FALLBACK_FILL_COLOR = "hsl(98, 48%, 67%)"

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3557,7 +3557,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS,
             {"landuse-other-z8-to-z10", "landuse-other-z10-plus"},
         )
-        self.assertEqual(len(result["layers"]), 37)
+        self.assertEqual(len(result["layers"]), 40)
         self.assertIn("landuse-other-below-z8", by_id)
         self.assertNotIn("landuse-other-below-z8-park", by_id)
         stable_class_variants = {
@@ -3580,6 +3580,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         rock_mid = by_id["landuse-other-z8-to-z10-rock-low-zoom"]
         rock_high_low = by_id["landuse-other-z10-plus-rock-low-zoom"]
         rock_high = by_id["landuse-other-z10-plus-rock-high-zoom"]
+        commercial_mid = by_id["landuse-other-z8-to-z10-commercial-area-low-zoom"]
+        commercial_high_low = by_id["landuse-other-z10-plus-commercial-area-low-zoom"]
+        commercial_high = by_id["landuse-other-z10-plus-commercial-area-high-zoom"]
         park_special_high = by_id["landuse-other-z10-plus-park-special"]
         park_high = by_id["landuse-other-z10-plus-park"]
         airport_high = by_id["landuse-other-z10-plus-airport"]
@@ -3600,6 +3603,20 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             self.assertEqual(
                 rock_layer["filter"][-1],
                 ["match", ["get", "class"], "rock", True, False],
+            )
+        self.assertEqual(commercial_mid["paint"]["fill-color"], mapbox_config._LANDUSE_COMMERCIAL_AREA_FILL_COLOR)
+        self.assertEqual(
+            commercial_high_low["paint"]["fill-color"],
+            mapbox_config._LANDUSE_COMMERCIAL_AREA_FILL_COLOR,
+        )
+        self.assertEqual(
+            commercial_high["paint"]["fill-color"],
+            mapbox_config._LANDUSE_COMMERCIAL_AREA_HIGH_ZOOM_FILL_COLOR,
+        )
+        for commercial_layer in (commercial_mid, commercial_high_low, commercial_high):
+            self.assertEqual(
+                commercial_layer["filter"][-1],
+                ["match", ["get", "class"], "commercial_area", True, False],
             )
         self.assertEqual(park_special_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_SPECIAL_FILL_COLOR)
         self.assertEqual(park_mid["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
@@ -3625,6 +3642,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(rock_high_low["maxzoom"], 16.0)
         self.assertEqual(rock_high["minzoom"], 16.0)
         self.assertNotIn("maxzoom", rock_high)
+        self.assertEqual(commercial_mid["minzoom"], 8.0)
+        self.assertEqual(commercial_mid["maxzoom"], 10.0)
+        self.assertEqual(commercial_high_low["minzoom"], 10.0)
+        self.assertEqual(commercial_high_low["maxzoom"], 16.0)
+        self.assertEqual(commercial_high["minzoom"], 16.0)
+        self.assertNotIn("maxzoom", commercial_high)
         self.assertEqual(
             park_mid["filter"],
             [
@@ -3669,6 +3692,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     "hospital",
                     "pitch",
                     "school",
+                    "commercial_area",
                     "facility",
                     "industrial",
                 ],
@@ -3772,6 +3796,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "landuse-other-z10-plus-hospital",
                 "landuse-other-z10-plus-pitch",
                 "landuse-other-z10-plus-school",
+                "landuse-other-z10-plus-commercial-area-low-zoom",
+                "landuse-other-z10-plus-commercial-area-high-zoom",
                 "landuse-other-z10-plus-industrial",
                 "landuse-other-z10-plus-remaining",
             ],


### PR DESCRIPTION
## Summary
- split `commercial_area` out of the high-zoom landuse fallback color bucket
- preserve the Mapbox low/high commercial-area color stops as separate QGIS-safe zoom-band layers
- keep the remaining landuse fallback layer from also matching commercial-area features

## Evidence
- The source/crop overlap candidate coverage from #1316 showed the remaining z10+ landuse bucket's only candidate value as `commercial_area`.
- The live style preprocess validation generated `debug/mapbox-commercial-area-style-split/20260522T032907Z/qgis-preprocessed-style.json` and confirmed:
  - `landuse-other-z10-plus-commercial-area-low-zoom` uses `hsl(55, 45%, 85%)` for z10-z16
  - `landuse-other-z10-plus-commercial-area-high-zoom` uses `hsla(55, 45%, 85%, 0.5)` for z16+
  - `landuse-other-z10-plus-remaining` now excludes `commercial_area` in its final class filter

## Validation
- `python3 -m py_compile mapbox_config.py tests/test_mapbox_config.py`
- `git diff --check`
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short` -> 217 passed
- `coverage run -m pytest tests/test_mapbox_config.py -q && coverage report -m mapbox_config.py` -> 93%
- `python3 -m pytest tests/ -x -q --tb=short` -> 2419 passed, 180 skipped, 177 subtests passed

Refs #949
