### PR TITLE
[codex] cover commercial area split symmetry

### DIFF
--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3596,6 +3596,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     ["match", ["get", "class"], class_filter, True, False],
                 )
         self.assertNotIn("landuse-other-z8-to-z10-rock-high-zoom", by_id)
+        self.assertNotIn("landuse-other-z8-to-z10-commercial-area-high-zoom", by_id)
         self.assertEqual(rock_mid["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_FILL_COLOR)
         self.assertEqual(rock_high_low["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_FILL_COLOR)
         self.assertEqual(rock_high["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR)
@@ -3700,6 +3701,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 True,
             ],
         )
+        self.assertEqual(remaining_high["filter"][-1], remaining_mid["filter"][-1])
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-airport"),
             "landuse",


### PR DESCRIPTION
## Summary
- add regression assertions for the commercial-area landuse split from #1318
- verify the high-zoom commercial-area layer does not leak into the z8-z10 band
- verify the z10+ fallback exclusion filter stays symmetric with the z8-z10 fallback filter

## Validation
- `git diff --check`
- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short` -> 217 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2419 passed, 180 skipped, 177 subtests passed

Refs #949