### PR TITLE
[codex] Align source overlap to-number handling

### DIFF
--- a/tests/test_mapbox_outdoors_source_crop_overlap.py
+++ b/tests/test_mapbox_outdoors_source_crop_overlap.py
@@ -182,25 +182,19 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
             combined["landuse"]["qgis_filter_property_requirements"]["landuse-park-sized"][
                 "candidate_missing_feature_counts"
             ],
-            {"sizerank": 1},
+            {},
         )
         self.assertEqual(
             combined["landuse"]["qgis_filter_property_requirements"]["landuse-park-sized"][
                 "candidate_property_counts"
             ],
-            {"class": {"park": 1}, "type": {"park": 1}},
-        )
-        self.assertAlmostEqual(
-            combined["landuse"]["qgis_filter_property_requirements"]["landuse-park-sized"][
-                "candidate_property_overlap_areas"
-            ]["class"]["park"]["crop_coverage_ratio"],
-            0.128418417649,
+            {},
         )
         self.assertEqual(
             combined["landuse"]["qgis_filter_property_requirements"]["landuse-park-sized"][
                 "matched_feature_count"
             ],
-            0,
+            1,
         )
         self.assertEqual(combined["landuse_overlay"]["overlap_feature_count"], 0)
         self.assertEqual(combined["contour"]["overlap_feature_count"], 2)
@@ -221,7 +215,7 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
         self.assertIn("QGIS style-layer coverage evaluates camera-zoom-active filters", markdown)
         self.assertIn("QGIS filter missing props reports active style-layer filter properties", markdown)
         self.assertIn(
-            "| `landuse` | 2 | 1 | 0.128 | park=1 | park=0.128 | landuse-park=0.128 | landuse-park-sized: sizerank=1/1 candidate=1 candidates [class: park=1; type: park=1] candidate coverage [class: park=0.128; type: park=0.128] (matched=0) | park=1 | - | - |",
+            "| `landuse` | 2 | 1 | 0.128 | park=1 | park=0.128 | landuse-park=0.128, landuse-park-sized=0.128 | landuse-park-sized: sizerank=1/1 candidate=0 (matched=1) | park=1 | - | - |",
             markdown,
         )
         self.assertIn("| `landuse_overlay` | 0 | 0 | 0.000 | - | - | - | - | - | - | - |", markdown)
@@ -334,14 +328,11 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
 
         requirement = record["qgis_filter_property_requirements"]["landuse-park-sized"]
         self.assertEqual(requirement["missing_feature_counts"], {"sizerank": 2})
-        self.assertEqual(requirement["candidate_missing_feature_counts"], {"sizerank": 1})
-        self.assertEqual(requirement["candidate_property_counts"], {"class": {"park": 1}})
-        self.assertAlmostEqual(
-            requirement["candidate_property_overlap_areas"]["class"]["park"]["crop_coverage_ratio"],
-            0.16,
-        )
-        self.assertEqual(requirement["candidate_missing_feature_total"], 1)
-        self.assertEqual(requirement["matched_feature_count"], 1)
+        self.assertEqual(requirement["candidate_missing_feature_counts"], {})
+        self.assertEqual(requirement["candidate_property_counts"], {})
+        self.assertEqual(requirement["candidate_property_overlap_areas"], {})
+        self.assertEqual(requirement["candidate_missing_feature_total"], 0)
+        self.assertEqual(requirement["matched_feature_count"], 2)
         self.assertEqual(
             record["qgis_filter_property_requirements"]["landuse-park-or-sized"][
                 "candidate_missing_feature_counts"
@@ -362,13 +353,13 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
             record["qgis_filter_property_requirements"]["landuse-case-sized-park"][
                 "candidate_missing_feature_counts"
             ],
-            {"sizerank": 1},
+            {},
         )
         self.assertEqual(
             record["qgis_filter_property_requirements"]["landuse-match-sized-park"][
                 "candidate_missing_feature_counts"
             ],
-            {"sizerank": 1},
+            {},
         )
 
     def test_match_input_missing_property_counts_as_candidate_gate(self):
@@ -420,7 +411,7 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
             ["class", "sizerank"],
             [
                 "all",
-                [">=", ["to-number", ["get", "sizerank"]], 0],
+                ["==", ["get", "sizerank"], 1],
                 ["!=", ["get", "class"], "excluded"],
             ],
             bounds={"west": 0.0, "south": 0.0, "east": 9.0, "north": 1.0},
@@ -489,6 +480,10 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
         self.assertTrue(_comparison_membership_contains("park", ["park", "cemetery"]))
         self.assertEqual(_mapbox_expression_value(["get", "class"], properties), "park")
         self.assertEqual(_mapbox_expression_value(["literal", ["park", "cemetery"]], properties), ["park", "cemetery"])
+        self.assertEqual(_mapbox_expression_value(["to-number", ["get", "missing"]], properties), 0.0)
+        self.assertEqual(_mapbox_expression_value(["to-number", False], properties), 0.0)
+        self.assertEqual(_mapbox_expression_value(["to-number", True], properties), 1.0)
+        self.assertEqual(_mapbox_expression_value(["to-number", ["get", "class"], 5], properties), 5.0)
         self.assertTrue(_mapbox_expression_value(["has", "class"], properties))
         self.assertFalse(_mapbox_expression_value(["!has", "class"], properties))
         self.assertTrue(_mapbox_expression_value(["!has", "missing"], properties))
@@ -523,6 +518,17 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
                     ["!=", ["get", "type"], "zoo"],
                 ],
                 properties,
+            )
+        )
+        self.assertTrue(
+            _mapbox_filter_matches(
+                [
+                    "all",
+                    [">=", ["to-number", ["get", "sizerank"]], 0],
+                    ["<=", ["to-number", ["get", "sizerank"]], 14],
+                    ["match", ["get", "class"], "commercial_area", True, False],
+                ],
+                {"class": "commercial_area"},
             )
         )
         self.assertFalse(

--- a/validation/mapbox_outdoors_source_crop_overlap.py
+++ b/validation/mapbox_outdoors_source_crop_overlap.py
@@ -662,6 +662,22 @@ def _numeric_value(value: object) -> float | None:
     return None
 
 
+def _mapbox_to_number_value(value: object) -> float | None:
+    if value is None or value is False:
+        return 0.0
+    if value is True:
+        return 1.0
+    return _numeric_value(value)
+
+
+def _mapbox_to_number_expression_value(operands: Sequence[object], properties: Mapping[str, object]) -> float | None:
+    for operand in operands:
+        converted = _mapbox_to_number_value(_mapbox_expression_value(operand, properties))
+        if converted is not None:
+            return converted
+    return None
+
+
 def _comparison_membership_contains(left: object, right: object) -> bool:
     if isinstance(right, str):
         return isinstance(left, str) and left in right
@@ -710,7 +726,7 @@ def _mapbox_simple_expression_value(
     if operator == "get" and operands:
         return properties.get(str(operands[0]))
     if operator == "to-number" and operands:
-        return _numeric_value(_mapbox_expression_value(operands[0], properties))
+        return _mapbox_to_number_expression_value(operands, properties)
     if operator == "literal" and operands:
         return operands[0]
     if operator == "has" and operands:
@@ -1791,8 +1807,9 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         (
             "QGIS filter missing props reports active style-layer filter properties that are absent from "
             "overlapping source features as missing/overlap feature counts. Candidate counts only include "
-            "features that still match the layer's other available filter predicates after missing-property "
-            "checks are removed, with candidate bbox coverage ratios attributed by feature-property value."
+            "features that do not already match the full filter but still match the layer's other available "
+            "filter predicates after missing-property checks are removed, with candidate bbox coverage ratios "
+            "attributed by feature-property value."
         ),
         "",
         "## Combined overlap by source layer",


### PR DESCRIPTION
## Summary
- Align source/crop overlap expression evaluation with Mapbox `to-number` fallback semantics for null, false, true, and fallback operands.
- Update missing-filter candidate reporting expectations so missing `sizerank` is not treated as a blocker when the full Mapbox filter already matches.
- Refresh the Zermatt z18 source-overlap evidence after the fix: `debug/mapbox-outdoors-source-crop-overlap/zermatt-trails-z18-outdoors/20260522T040916Z/summary.md`.

Official spec reference: https://docs.mapbox.com/style-spec/reference/expressions/#to-number

## Validation
- `python3 -m py_compile validation/mapbox_outdoors_source_crop_overlap.py tests/test_mapbox_outdoors_source_crop_overlap.py`
- `git diff --check`
- `python3 -m pytest tests/test_mapbox_outdoors_source_crop_overlap.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`

## Issue
- Part of #949.