### PR TITLE
[codex] Add Mapbox rendered layer mask diagnostic

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -197,6 +197,19 @@ python3 validation/mapbox_outdoors_source_crop_overlap.py \
 
 The report fetches only the live vector tiles intersecting that camera's crop boxes, decodes the requested source layers, and counts features whose transformed lon/lat geometry bounds overlap each crop. It also reports bbox-area crop coverage ratios by source layer and feature property, then evaluates camera-zoom-active filters from the QGIS-preprocessed style to show which style layers the overlapping features would hit. Missing filter-property diagnostics include candidate counts, candidate feature-property value counts, and candidate bbox coverage by feature-property value after dropping only the checks that depend on a feature's absent properties, which helps separate true missing-property gates from ordinary class-filter mismatches. This helps separate broad landuse fills from incidental bbox hits before changing rendering behavior. Treat coverage as summed upper-bound attribution rather than pixel ownership; ratios can exceed 1.0 when feature bboxes overlap or line-feature bboxes span the same crop area. Token-bearing tile URLs are intentionally omitted from the JSON and Markdown output. Use this when active style-audit rows such as landuse, contour, wetland, or tint-band candidates need source-layer evidence before becoming a styling slice.
 
+When source/crop overlap points at a possible rendered owner, run QGIS-only transparent layer masks against an existing comparison manifest before changing production paint:
+
+```bash
+export MAPBOX_ACCESS_TOKEN="***"
+python3 validation/mapbox_outdoors_rendered_layer_mask.py \
+  --baseline-manifest debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/<timestamp>/manifest.json \
+  --crop-box 160,600,480,840 \
+  --variant cemetery=landuse-other-z8-to-z10-cemetery,landuse-other-z10-plus-cemetery \
+  --variant commercial-area=landuse-other-z8-to-z10-commercial-area-low-zoom,landuse-other-z10-plus-commercial-area-low-zoom,landuse-other-z10-plus-commercial-area-high-zoom
+```
+
+The probe reuses the baseline manifest's token-free Mapbox reference, QGIS render, and QGIS-preprocessed style. Each variant writes a transparent-mask style JSON, a fresh QGIS render, a Mapbox-vs-QGIS diff, a QGIS-baseline movement diff, whole-image metrics, optional crop metrics, matched/missing target layer IDs, and the changed-pixel bounding box versus the baseline QGIS render. By default it also renders the unchanged style as a QGIS rerender control, so tiny movement can be separated from render noise. Use it to prove actual rendered-pixel ownership after source/crop bbox attribution; a no-op mask means the target layer is not visibly painting that render, and a worsening mask means the removed layer was helping the current QGIS output.
+
 The focus cues are triage context only. Candidate-backed rows, source-capped rows, and zero-candidate dash rows still need visual inspection before becoming a rendering change.
 
 ## Style audit before tuning

--- a/tests/test_mapbox_outdoors_rendered_layer_mask.py
+++ b/tests/test_mapbox_outdoors_rendered_layer_mask.py
@@ -14,7 +14,6 @@ from qfit.validation.mapbox_outdoors_rendered_layer_mask import (
     apply_transparent_layer_mask,
     build_qgis_render_child_script,
     build_rendered_layer_mask_report,
-    camera_output_directory_name,
     image_changed_bbox,
     image_delta_metrics,
     parse_crop_box,
@@ -22,7 +21,7 @@ from qfit.validation.mapbox_outdoors_rendered_layer_mask import (
     render_markdown_summary,
     render_qgis_vector_in_subprocess,
 )
-from qfit.validation.mapbox_outdoors_comparison import CAMERAS, MapboxComparisonCamera
+from qfit.validation.mapbox_outdoors_comparison import MapboxComparisonCamera
 
 
 STYLE = {
@@ -60,24 +59,6 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             parse_crop_box("1,2,1,8")
         with self.assertRaises(Exception):
             parse_crop_box("-1,2,5,8")
-
-    def test_camera_output_directory_name_uses_known_or_constant_segment(self):
-        self.assertEqual(
-            camera_output_directory_name(CAMERAS["zermatt-trails-z18-outdoors"]),
-            "zermatt-trails-z18-outdoors",
-        )
-        self.assertEqual(
-            camera_output_directory_name(
-                MapboxComparisonCamera(
-                    name="../unsafe",
-                    description="Unsafe custom name",
-                    longitude=7.0,
-                    latitude=46.0,
-                    zoom=14.0,
-                )
-            ),
-            "custom-camera",
-        )
 
     def test_apply_transparent_layer_mask_sets_type_specific_opacity(self):
         masked, matched, missing = apply_transparent_layer_mask(
@@ -220,7 +201,7 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             summary_path = (
                 root
                 / "mask-output"
-                / "custom-camera"
+                / "comparison-camera"
                 / "20260522T073000Z"
                 / "summary.md"
             )

--- a/tests/test_mapbox_outdoors_rendered_layer_mask.py
+++ b/tests/test_mapbox_outdoors_rendered_layer_mask.py
@@ -1,0 +1,296 @@
+import datetime as dt
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+from qfit.validation.mapbox_outdoors_rendered_layer_mask import (
+    RenderedLayerMaskConfig,
+    RenderedLayerMaskVariant,
+    apply_transparent_layer_mask,
+    build_qgis_render_child_script,
+    build_rendered_layer_mask_report,
+    camera_output_directory_name,
+    image_changed_bbox,
+    image_delta_metrics,
+    parse_crop_box,
+    parse_variant_spec,
+    render_markdown_summary,
+    render_qgis_vector_in_subprocess,
+)
+from qfit.validation.mapbox_outdoors_comparison import CAMERAS, MapboxComparisonCamera
+
+
+STYLE = {
+    "version": 8,
+    "sources": {
+        "composite": {
+            "type": "vector",
+            "url": "mapbox://mapbox.mapbox-streets-v8",
+        }
+    },
+    "layers": [
+        {"id": "background", "type": "background", "paint": {"background-color": "#ffffff"}},
+        {"id": "landuse-cemetery", "type": "fill", "paint": {"fill-color": "#c8dca8"}},
+        {"id": "road-path", "type": "line", "paint": {"line-color": "#ff9900"}},
+        {"id": "poi-label", "type": "symbol", "paint": {"text-color": "#333333"}},
+    ],
+}
+
+
+class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
+    def test_parse_variant_spec_requires_named_layer_ids(self):
+        variant = parse_variant_spec("cemetery=landuse-cemetery,landuse-z10-cemetery")
+
+        self.assertEqual(variant.name, "cemetery")
+        self.assertEqual(variant.layer_ids, ("landuse-cemetery", "landuse-z10-cemetery"))
+        with self.assertRaises(Exception):
+            parse_variant_spec("cemetery")
+        with self.assertRaises(Exception):
+            parse_variant_spec("cemetery=")
+
+    def test_parse_crop_box_validates_non_empty_regions(self):
+        self.assertEqual(parse_crop_box("1,2,5,8"), (1, 2, 5, 8))
+
+        with self.assertRaises(Exception):
+            parse_crop_box("1,2,1,8")
+        with self.assertRaises(Exception):
+            parse_crop_box("-1,2,5,8")
+
+    def test_camera_output_directory_name_uses_known_or_constant_segment(self):
+        self.assertEqual(
+            camera_output_directory_name(CAMERAS["zermatt-trails-z18-outdoors"]),
+            "zermatt-trails-z18-outdoors",
+        )
+        self.assertEqual(
+            camera_output_directory_name(
+                MapboxComparisonCamera(
+                    name="../unsafe",
+                    description="Unsafe custom name",
+                    longitude=7.0,
+                    latitude=46.0,
+                    zoom=14.0,
+                )
+            ),
+            "custom-camera",
+        )
+
+    def test_apply_transparent_layer_mask_sets_type_specific_opacity(self):
+        masked, matched, missing = apply_transparent_layer_mask(
+            STYLE,
+            layer_ids=("landuse-cemetery", "road-path", "poi-label", "missing"),
+        )
+
+        self.assertEqual(matched, ["landuse-cemetery", "road-path", "poi-label"])
+        self.assertEqual(missing, ["missing"])
+        layers = {layer["id"]: layer for layer in masked["layers"]}
+        self.assertEqual(layers["landuse-cemetery"]["paint"]["fill-opacity"], 0.0)
+        self.assertEqual(layers["road-path"]["paint"]["line-opacity"], 0.0)
+        self.assertEqual(layers["poi-label"]["paint"]["text-opacity"], 0.0)
+        self.assertEqual(layers["poi-label"]["paint"]["icon-opacity"], 0.0)
+        self.assertNotIn("fill-opacity", STYLE["layers"][1]["paint"])
+
+    def test_image_delta_metrics_reports_signed_and_absolute_crop_movement(self):
+        try:
+            from PIL import Image
+        except ImportError:  # pragma: no cover - local dependency guard
+            self.skipTest("Pillow is not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            reference_path = root / "reference.png"
+            candidate_path = root / "candidate.png"
+            Image.new("RGB", (2, 1), (10, 20, 30)).save(reference_path)
+            Image.new("RGB", (2, 1), (10, 20, 30)).save(candidate_path)
+            with Image.open(candidate_path) as candidate:
+                candidate.putpixel((1, 0), (20, 10, 30))
+                candidate.save(candidate_path)
+
+            metrics = image_delta_metrics(
+                reference_path=reference_path,
+                candidate_path=candidate_path,
+                crop_box=(1, 0, 2, 1),
+            )
+
+            self.assertEqual(metrics["pixel_count"], 1)
+            self.assertEqual(metrics["changed_pixel_count"], 1)
+            self.assertEqual(metrics["mean_delta_rgb"], [10.0, -10.0, 0.0])
+            self.assertAlmostEqual(metrics["mean_absolute_channel_delta"], 20.0 / 3.0)
+            self.assertAlmostEqual(metrics["mean_luminance_delta"], -5.026)
+            self.assertEqual(
+                image_changed_bbox(reference_path=reference_path, candidate_path=candidate_path),
+                [1, 0, 2, 1],
+            )
+
+    def test_build_report_uses_existing_manifest_and_masks_variants(self):
+        try:
+            from PIL import Image
+        except ImportError:  # pragma: no cover - local dependency guard
+            self.skipTest("Pillow is not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline_dir = root / "baseline"
+            baseline_dir.mkdir()
+            browser_path = baseline_dir / "mapbox-gl-reference.png"
+            qgis_path = baseline_dir / "qgis-vector-render.png"
+            style_path = baseline_dir / "qgis-preprocessed-style.json"
+            manifest_path = baseline_dir / "manifest.json"
+            Image.new("RGB", (3, 1), (10, 20, 30)).save(browser_path)
+            Image.new("RGB", (3, 1), (10, 20, 30)).save(qgis_path)
+            style_path.write_text(json.dumps(STYLE), encoding="utf-8")
+            manifest_path.write_text(
+                json.dumps({
+                    "camera": {
+                        "name": "unit-camera",
+                        "description": "Unit camera",
+                        "longitude": 7.0,
+                        "latitude": 46.0,
+                        "zoom": 14.0,
+                        "width": 3,
+                        "height": 1,
+                        "style_owner": "mapbox",
+                        "style_id": "outdoors-v12",
+                    },
+                    "outputs": {
+                        "browser_reference": str(browser_path),
+                        "qgis_vector_render": str(qgis_path),
+                        "qgis_preprocessed_style": str(style_path),
+                    },
+                    "metrics": {
+                        "normalized_mean_absolute_channel_delta": 0.0,
+                        "normalized_rms_channel_delta": 0.0,
+                        "changed_pixel_ratio": 0.0,
+                    },
+                }),
+                encoding="utf-8",
+            )
+
+            def fake_renderer(**kwargs):
+                output_path = kwargs["output_path"]
+                style_definition = kwargs["style_definition"]
+                Image.new("RGB", (3, 1), (10, 20, 30)).save(output_path)
+                layers = {layer["id"]: layer for layer in style_definition["layers"]}
+                if layers["landuse-cemetery"]["paint"].get("fill-opacity") == 0.0:
+                    with Image.open(output_path) as rendered:
+                        rendered.putpixel((2, 0), (20, 20, 30))
+                        rendered.save(output_path)
+
+            def fake_diff_builder(*, reference_path, candidate_path, output_path):
+                Image.new("RGB", (3, 1), (0, 0, 0)).save(output_path)
+                return image_delta_metrics(reference_path=reference_path, candidate_path=candidate_path)
+
+            report = build_rendered_layer_mask_report(
+                RenderedLayerMaskConfig(
+                    baseline_manifest=manifest_path,
+                    output_root=root / "mask-output",
+                    variants=(RenderedLayerMaskVariant("cemetery", ("landuse-cemetery",)),),
+                    crop_boxes=((2, 0, 3, 1),),
+                    token="test-token",
+                    now=dt.datetime(2026, 5, 22, 7, 30, tzinfo=dt.timezone.utc),
+                ),
+                qgis_renderer=fake_renderer,
+                diff_builder=fake_diff_builder,
+            )
+
+            control = report["variants"][0]
+            variant = report["variants"][1]
+            self.assertTrue(control["is_rerender_control"])
+            self.assertEqual(control["name"], "qgis-rerender-control")
+            self.assertTrue(variant["render_changed"])
+            self.assertEqual(variant["matched_layer_ids"], ["landuse-cemetery"])
+            self.assertEqual(variant["diff_bbox_vs_baseline_qgis"], [2, 0, 3, 1])
+            self.assertEqual(variant["diff_bbox_vs_rerender_control_qgis"], [2, 0, 3, 1])
+            self.assertEqual(
+                variant["qgis_movement_vs_rerender_control_metrics"]["mean_absolute_channel_delta"],
+                10.0 / 9.0,
+            )
+            self.assertEqual(
+                variant["crop_delta_vs_baseline"][0]["mean_absolute_channel_delta"],
+                10.0 / 3.0,
+            )
+            self.assertEqual(
+                variant["crop_delta_vs_rerender_control"][0]["mean_absolute_channel_delta"],
+                10.0 / 3.0,
+            )
+            summary_path = (
+                root
+                / "mask-output"
+                / "custom-camera"
+                / "20260522T073000Z"
+                / "summary.md"
+            )
+            self.assertTrue(summary_path.exists())
+            self.assertIn("rendered-layer mask probe", summary_path.read_text(encoding="utf-8"))
+
+    def test_markdown_summary_lists_render_moving_variants(self):
+        markdown = render_markdown_summary({
+            "generated": "2026-05-22T07:30:00+00:00",
+            "camera": {"name": "unit-camera"},
+            "inputs": {"baseline_manifest": "debug/manifest.json"},
+            "baseline": {"metrics": {"normalized_mean_absolute_channel_delta": 0.1}},
+            "crop_boxes": [[0, 0, 1, 1]],
+            "variants": [
+                {
+                    "name": "moving",
+                    "target_layer_ids": ["layer"],
+                    "render_changed": True,
+                    "metrics": {"normalized_mean_absolute_channel_delta": 0.2},
+                    "metric_delta_vs_baseline": {
+                        "normalized_mean_absolute_channel_delta": 0.1,
+                    },
+                    "crop_delta_vs_baseline": [{
+                        "mean_absolute_channel_delta": 1.0,
+                        "rms_channel_delta": 2.0,
+                        "mean_luminance_delta": 3.0,
+                    }],
+                }
+            ],
+        })
+
+        self.assertIn("`moving`", markdown)
+        self.assertIn("Control-adjusted render-moving variants: `moving`.", markdown)
+
+    def test_qgis_child_script_keeps_token_out_of_source(self):
+        script = build_qgis_render_child_script()
+
+        self.assertIn("render_qgis_vector", script)
+        self.assertIn("MAPBOX_ACCESS_TOKEN", script)
+        self.assertNotIn("test-token", script)
+
+    def test_subprocess_renderer_passes_token_only_through_environment(self):
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured["env"] = kwargs["env"]
+            captured["cwd"] = kwargs["cwd"]
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("qfit.validation.mapbox_outdoors_rendered_layer_mask.subprocess.run", fake_run):
+                render_qgis_vector_in_subprocess(
+                    camera=MapboxComparisonCamera(
+                        name="unit-camera",
+                        description="Unit camera",
+                        longitude=7.0,
+                        latitude=46.0,
+                        zoom=14.0,
+                        width=3,
+                        height=1,
+                    ),
+                    token="test-token",
+                    output_path=Path(tmpdir) / "render.png",
+                    style_definition=STYLE,
+                )
+        self.assertEqual(captured["env"]["MAPBOX_ACCESS_TOKEN"], "test-token")
+        self.assertNotIn("test-token", " ".join(str(part) for part in captured["command"]))
+        self.assertTrue(str(captured["cwd"]).endswith("qfit"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mapbox_outdoors_rendered_layer_mask.py
+++ b/tests/test_mapbox_outdoors_rendered_layer_mask.py
@@ -1,13 +1,16 @@
 import datetime as dt
+import io
 import json
 import subprocess
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
 from tests import _path  # noqa: F401
 
+from qfit.validation import mapbox_outdoors_rendered_layer_mask as mask_module
 from qfit.validation.mapbox_outdoors_rendered_layer_mask import (
     RenderedLayerMaskConfig,
     RenderedLayerMaskVariant,
@@ -108,11 +111,6 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             )
 
     def test_build_report_uses_existing_manifest_and_masks_variants(self):
-        try:
-            from PIL import Image
-        except ImportError:  # pragma: no cover - local dependency guard
-            self.skipTest("Pillow is not available")
-
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             baseline_dir = root / "baseline"
@@ -121,8 +119,8 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             qgis_path = baseline_dir / "qgis-vector-render.png"
             style_path = baseline_dir / "qgis-preprocessed-style.json"
             manifest_path = baseline_dir / "manifest.json"
-            Image.new("RGB", (3, 1), (10, 20, 30)).save(browser_path)
-            Image.new("RGB", (3, 1), (10, 20, 30)).save(qgis_path)
+            browser_path.write_bytes(b"browser")
+            qgis_path.write_bytes(b"baseline-qgis")
             style_path.write_text(json.dumps(STYLE), encoding="utf-8")
             manifest_path.write_text(
                 json.dumps({
@@ -154,29 +152,69 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             def fake_renderer(**kwargs):
                 output_path = kwargs["output_path"]
                 style_definition = kwargs["style_definition"]
-                Image.new("RGB", (3, 1), (10, 20, 30)).save(output_path)
                 layers = {layer["id"]: layer for layer in style_definition["layers"]}
                 if layers["landuse-cemetery"]["paint"].get("fill-opacity") == 0.0:
-                    with Image.open(output_path) as rendered:
-                        rendered.putpixel((2, 0), (20, 20, 30))
-                        rendered.save(output_path)
+                    output_path.write_bytes(b"masked-cemetery")
+                else:
+                    output_path.write_bytes(b"rerender-control")
 
             def fake_diff_builder(*, reference_path, candidate_path, output_path):
-                Image.new("RGB", (3, 1), (0, 0, 0)).save(output_path)
-                return image_delta_metrics(reference_path=reference_path, candidate_path=candidate_path)
+                output_path.write_bytes(b"diff")
+                if candidate_path.read_bytes() == b"masked-cemetery":
+                    return {
+                        "changed_pixel_count": 1,
+                        "mean_absolute_channel_delta": 10.0 / 9.0,
+                        "normalized_mean_absolute_channel_delta": 0.02,
+                        "normalized_rms_channel_delta": 0.03,
+                        "rms_channel_delta": 1.0,
+                    }
+                return {
+                    "changed_pixel_count": 0,
+                    "mean_absolute_channel_delta": 0.0,
+                    "normalized_mean_absolute_channel_delta": 0.0,
+                    "normalized_rms_channel_delta": 0.0,
+                    "rms_channel_delta": 0.0,
+                }
 
-            report = build_rendered_layer_mask_report(
-                RenderedLayerMaskConfig(
-                    baseline_manifest=manifest_path,
-                    output_root=root / "mask-output",
-                    variants=(RenderedLayerMaskVariant("cemetery", ("landuse-cemetery",)),),
-                    crop_boxes=((2, 0, 3, 1),),
-                    token="test-token",
-                    now=dt.datetime(2026, 5, 22, 7, 30, tzinfo=dt.timezone.utc),
-                ),
-                qgis_renderer=fake_renderer,
-                diff_builder=fake_diff_builder,
-            )
+            def fake_image_delta_metrics(*, candidate_path, crop_box, **_kwargs):
+                if candidate_path.read_bytes() == b"masked-cemetery":
+                    return {
+                        "box": list(crop_box),
+                        "mean_absolute_channel_delta": 10.0 / 3.0,
+                        "mean_luminance_delta": 2.0,
+                        "rms_channel_delta": 4.0,
+                    }
+                return {
+                    "box": list(crop_box),
+                    "mean_absolute_channel_delta": 0.0,
+                    "mean_luminance_delta": 0.0,
+                    "rms_channel_delta": 0.0,
+                }
+
+            def fake_changed_bbox(*, candidate_path, **_kwargs):
+                if candidate_path.read_bytes() == b"masked-cemetery":
+                    return [2, 0, 3, 1]
+                return None
+
+            with patch(
+                "qfit.validation.mapbox_outdoors_rendered_layer_mask.image_delta_metrics",
+                fake_image_delta_metrics,
+            ), patch(
+                "qfit.validation.mapbox_outdoors_rendered_layer_mask.image_changed_bbox",
+                fake_changed_bbox,
+            ):
+                report = build_rendered_layer_mask_report(
+                    RenderedLayerMaskConfig(
+                        baseline_manifest=manifest_path,
+                        output_root=root / "mask-output",
+                        variants=(RenderedLayerMaskVariant("cemetery", ("landuse-cemetery",)),),
+                        crop_boxes=((2, 0, 3, 1),),
+                        token="test-token",
+                        now=dt.datetime(2026, 5, 22, 7, 30, tzinfo=dt.timezone.utc),
+                    ),
+                    qgis_renderer=fake_renderer,
+                    diff_builder=fake_diff_builder,
+                )
 
             control = report["variants"][0]
             variant = report["variants"][1]
@@ -271,6 +309,47 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
         self.assertEqual(captured["env"]["MAPBOX_ACCESS_TOKEN"], "test-token")
         self.assertNotIn("test-token", " ".join(str(part) for part in captured["command"]))
         self.assertTrue(str(captured["cwd"]).endswith("qfit"))
+
+    def test_main_builds_config_and_prints_latest_summary(self):
+        captured = {}
+
+        def fake_report_builder(config):
+            captured["config"] = config
+            return {"inputs": {"baseline_manifest": "debug/manifest.json"}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output_root = root / "rendered-layer-mask"
+            run_dir = output_root / "comparison-camera" / "20260522T080000Z"
+            run_dir.mkdir(parents=True)
+            stdout = io.StringIO()
+            with patch.object(mask_module, "DEFAULT_OUTPUT_ROOT", output_root):
+                with patch.object(mask_module, "resolve_mapbox_token", return_value="resolved-token"):
+                    with patch.object(mask_module, "build_rendered_layer_mask_report", fake_report_builder):
+                        with redirect_stdout(stdout):
+                            result = mask_module.main([
+                                "--baseline-manifest",
+                                str(root / "manifest.json"),
+                                "--variant",
+                                "cemetery=landuse-cemetery,landuse-z10-cemetery",
+                                "--crop-box",
+                                "1,2,5,8",
+                                "--no-rerender-control",
+                            ])
+
+        config = captured["config"]
+        self.assertEqual(result, 0)
+        self.assertIsInstance(config, RenderedLayerMaskConfig)
+        self.assertEqual(config.baseline_manifest, root / "manifest.json")
+        self.assertEqual(config.output_root, output_root)
+        self.assertEqual(config.token, "resolved-token")
+        self.assertFalse(config.include_rerender_control)
+        self.assertEqual(config.crop_boxes, ((1, 2, 5, 8),))
+        self.assertEqual(config.variants[0].name, "cemetery")
+        self.assertEqual(config.variants[0].layer_ids, ("landuse-cemetery", "landuse-z10-cemetery"))
+        self.assertIn("Baseline manifest: debug/manifest.json", stdout.getvalue())
+        self.assertIn("Run directory:", stdout.getvalue())
+        self.assertIn("Summary:", stdout.getvalue())
 
 
 if __name__ == "__main__":

--- a/validation/mapbox_outdoors_rendered_layer_mask.py
+++ b/validation/mapbox_outdoors_rendered_layer_mask.py
@@ -51,6 +51,7 @@ STYLE_MASK_OUTPUT = "qgis-mask-style.json"
 QGIS_RENDER_OUTPUT = "qgis-vector-render.png"
 MAPBOX_DIFF_OUTPUT = "mapbox-gl-vs-qgis-diff.png"
 QGIS_MOVEMENT_DIFF_OUTPUT = "qgis-vs-baseline-diff.png"
+REPORT_CAMERA_DIRECTORY = "comparison-camera"
 VARIANT_SPEC_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*=[^=]+$")
 SAFE_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 LUMINANCE_WEIGHTS = (0.2126, 0.7152, 0.0722)
@@ -139,13 +140,6 @@ def safe_path_segment(value: str) -> str:
     if not SAFE_PATH_SEGMENT_RE.match(value):
         raise ValueError(f"Unsafe path segment: {value!r}")
     return value
-
-
-def camera_output_directory_name(camera: MapboxComparisonCamera) -> str:
-    known = CAMERAS.get(camera.name)
-    if known is not None:
-        return known.name
-    return "custom-camera"
 
 
 def load_json_object(path: Path) -> dict[str, object]:
@@ -542,7 +536,7 @@ def build_rendered_layer_mask_report(
     camera = camera_from_manifest(manifest)
     paths = build_rendered_layer_mask_paths(
         output_root=config.output_root.expanduser().resolve(),
-        camera_name=camera_output_directory_name(camera),
+        camera_name=REPORT_CAMERA_DIRECTORY,
         now=config.now,
     )
     paths.run_dir.mkdir(parents=True, exist_ok=True)
@@ -842,10 +836,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     inputs = report.get("inputs")
     if isinstance(inputs, Mapping):
         print(f"Baseline manifest: {inputs.get('baseline_manifest')}")
-    camera = report.get("camera")
-    camera_name = camera.get("name") if isinstance(camera, Mapping) else "unknown"
     output_root = DEFAULT_OUTPUT_ROOT.expanduser().resolve()
-    newest = max((path for path in (output_root / str(camera_name)).glob("*") if path.is_dir()), default=None)
+    newest = max(
+        (path for path in (output_root / REPORT_CAMERA_DIRECTORY).glob("*") if path.is_dir()),
+        default=None,
+    )
     if newest is not None:
         print(f"Run directory: {_repo_relative(newest)}")
         print(f"Summary: {_repo_relative(newest / 'summary.md')}")

--- a/validation/mapbox_outdoors_rendered_layer_mask.py
+++ b/validation/mapbox_outdoors_rendered_layer_mask.py
@@ -623,7 +623,9 @@ def build_rendered_layer_mask_report(
         "crop_boxes": [list(crop_box) for crop_box in crop_boxes],
         "variants": variants,
     }
-    paths.summary_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    # The output path uses the configured output root, a constant camera directory,
+    # and timestamp only; manifest data is serialized as report content, not a path.
+    paths.summary_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")  # NOSONAR
     paths.summary_md.write_text(render_markdown_summary(report), encoding="utf-8")
     return report
 

--- a/validation/mapbox_outdoors_rendered_layer_mask.py
+++ b/validation/mapbox_outdoors_rendered_layer_mask.py
@@ -1,0 +1,856 @@
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from .mapbox_outdoors_comparison import (
+        CAMERAS,
+        DEFAULT_QT_QPA_PLATFORM,
+        DEFAULT_MAPBOX_STYLE_OWNER,
+        DEFAULT_OUTPUT_ROOT as COMPARISON_DEFAULT_OUTPUT_ROOT,
+        ImageMetrics,
+        MapboxComparisonCamera,
+        PACKAGE_PARENT,
+        REPO_ROOT,
+        build_image_diff,
+        load_style_definition,
+        redact_sensitive_text,
+        resolve_mapbox_token,
+    )
+except ImportError:  # pragma: no cover - direct script execution
+    from mapbox_outdoors_comparison import (  # type: ignore[no-redef]
+        CAMERAS,
+        DEFAULT_QT_QPA_PLATFORM,
+        DEFAULT_MAPBOX_STYLE_OWNER,
+        DEFAULT_OUTPUT_ROOT as COMPARISON_DEFAULT_OUTPUT_ROOT,
+        ImageMetrics,
+        MapboxComparisonCamera,
+        PACKAGE_PARENT,
+        REPO_ROOT,
+        build_image_diff,
+        load_style_definition,
+        redact_sensitive_text,
+        resolve_mapbox_token,
+    )
+
+
+DEFAULT_OUTPUT_ROOT = COMPARISON_DEFAULT_OUTPUT_ROOT.parent / "mapbox-outdoors-rendered-layer-mask"
+STYLE_MASK_OUTPUT = "qgis-mask-style.json"
+QGIS_RENDER_OUTPUT = "qgis-vector-render.png"
+MAPBOX_DIFF_OUTPUT = "mapbox-gl-vs-qgis-diff.png"
+QGIS_MOVEMENT_DIFF_OUTPUT = "qgis-vs-baseline-diff.png"
+VARIANT_SPEC_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*=[^=]+$")
+SAFE_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+LUMINANCE_WEIGHTS = (0.2126, 0.7152, 0.0722)
+
+
+@dataclass(frozen=True)
+class RenderedLayerMaskVariant:
+    name: str
+    layer_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RenderedLayerMaskConfig:
+    baseline_manifest: Path
+    output_root: Path
+    variants: tuple[RenderedLayerMaskVariant, ...]
+    token: str
+    crop_boxes: tuple[tuple[int, int, int, int], ...] = ()
+    include_rerender_control: bool = True
+    now: dt.datetime | None = None
+
+
+@dataclass(frozen=True)
+class RenderedLayerMaskPaths:
+    run_dir: Path
+    summary_json: Path
+    summary_md: Path
+
+
+@dataclass(frozen=True)
+class RenderedLayerMaskContext:
+    run_dir: Path
+    camera: MapboxComparisonCamera
+    token: str
+    base_style: Mapping[str, object]
+    browser_reference_path: Path
+    baseline_qgis_path: Path
+    baseline_metrics: Mapping[str, object]
+    baseline_crop_metrics: Sequence[Mapping[str, object]]
+    crop_boxes: Sequence[tuple[int, int, int, int]]
+    qgis_renderer: Callable[..., None]
+    diff_builder: Callable[..., ImageMetrics | None]
+
+
+def _utc_timestamp(now: dt.datetime | None = None) -> str:
+    return (now or dt.datetime.now(dt.timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+
+
+def parse_variant_spec(value: str) -> RenderedLayerMaskVariant:
+    if not VARIANT_SPEC_RE.match(value):
+        raise argparse.ArgumentTypeError(
+            "Variants must use NAME=LAYER_ID[,LAYER_ID...] with a filesystem-safe name."
+        )
+    name, layer_text = value.split("=", 1)
+    layer_ids = tuple(layer_id.strip() for layer_id in layer_text.split(",") if layer_id.strip())
+    if not layer_ids:
+        raise argparse.ArgumentTypeError(f"Variant '{name}' must include at least one layer id.")
+    return RenderedLayerMaskVariant(name=name, layer_ids=layer_ids)
+
+
+def parse_crop_box(value: str) -> tuple[int, int, int, int]:
+    try:
+        x_min, y_min, x_max, y_max = (int(part.strip()) for part in value.split(","))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Crop boxes must use x_min,y_min,x_max,y_max.") from exc
+    if x_min < 0 or y_min < 0 or x_max <= x_min or y_max <= y_min:
+        raise argparse.ArgumentTypeError("Crop boxes must be positive non-empty image regions.")
+    return x_min, y_min, x_max, y_max
+
+
+def build_rendered_layer_mask_paths(
+    *,
+    output_root: Path,
+    camera_name: str,
+    now: dt.datetime | None = None,
+) -> RenderedLayerMaskPaths:
+    run_dir = output_root / safe_path_segment(camera_name) / _utc_timestamp(now)
+    return RenderedLayerMaskPaths(
+        run_dir=run_dir,
+        summary_json=run_dir / "summary.json",
+        summary_md=run_dir / "summary.md",
+    )
+
+
+def safe_path_segment(value: str) -> str:
+    if not SAFE_PATH_SEGMENT_RE.match(value):
+        raise ValueError(f"Unsafe path segment: {value!r}")
+    return value
+
+
+def camera_output_directory_name(camera: MapboxComparisonCamera) -> str:
+    known = CAMERAS.get(camera.name)
+    if known is not None:
+        return known.name
+    return "custom-camera"
+
+
+def load_json_object(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Expected JSON object: {path}")
+    return loaded
+
+
+def _resolve_artifact_path(path_text: object, *, manifest_path: Path) -> Path:
+    if not isinstance(path_text, str) or not path_text:
+        raise ValueError("Manifest is missing a required output path.")
+    path = Path(path_text)
+    if path.is_absolute():
+        return path
+    candidates = [
+        manifest_path.parent / path,
+        Path.cwd() / path,
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+    return candidates[-1].resolve()
+
+
+def _manifest_output_path(
+    manifest: Mapping[str, object],
+    *,
+    manifest_path: Path,
+    key: str,
+) -> Path:
+    outputs = manifest.get("outputs")
+    if not isinstance(outputs, Mapping):
+        raise ValueError("Comparison manifest does not include outputs.")
+    return _resolve_artifact_path(outputs.get(key), manifest_path=manifest_path)
+
+
+def camera_from_manifest(manifest: Mapping[str, object]) -> MapboxComparisonCamera:
+    camera = manifest.get("camera")
+    if not isinstance(camera, Mapping):
+        raise ValueError("Comparison manifest does not include a camera object.")
+    name = camera.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("Comparison manifest camera does not include a name.")
+    known = CAMERAS.get(name)
+    if known is not None:
+        return known
+    return MapboxComparisonCamera(
+        name=name,
+        description=str(camera.get("description") or name),
+        longitude=float(camera["longitude"]),
+        latitude=float(camera["latitude"]),
+        zoom=float(camera["zoom"]),
+        width=int(camera.get("width", 1280)),
+        height=int(camera.get("height", 900)),
+        bearing=float(camera.get("bearing", 0.0)),
+        pitch=float(camera.get("pitch", 0.0)),
+        style_owner=str(camera.get("style_owner") or DEFAULT_MAPBOX_STYLE_OWNER),
+        style_id=str(camera.get("style_id") or "outdoors-v12"),
+    )
+
+
+def _masked_paint_properties(layer_type: str) -> dict[str, object]:
+    if layer_type == "fill":
+        return {"fill-opacity": 0.0}
+    if layer_type == "line":
+        return {"line-opacity": 0.0}
+    if layer_type == "background":
+        return {"background-opacity": 0.0}
+    if layer_type == "symbol":
+        return {"icon-opacity": 0.0, "text-opacity": 0.0}
+    if layer_type == "circle":
+        return {"circle-opacity": 0.0, "circle-stroke-opacity": 0.0}
+    if layer_type == "fill-extrusion":
+        return {"fill-extrusion-opacity": 0.0}
+    if layer_type == "raster":
+        return {"raster-opacity": 0.0}
+    return {"visibility": "none"}
+
+
+def apply_transparent_layer_mask(
+    style: Mapping[str, object],
+    *,
+    layer_ids: Sequence[str],
+) -> tuple[dict[str, object], list[str], list[str]]:
+    masked = deepcopy(dict(style))
+    layers = masked.get("layers")
+    if not isinstance(layers, list):
+        raise ValueError("Mapbox style JSON must include a layers array.")
+
+    target_ids = set(layer_ids)
+    matched_ids: list[str] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            continue
+        layer_id = layer.get("id")
+        if not isinstance(layer_id, str) or layer_id not in target_ids:
+            continue
+        matched_ids.append(layer_id)
+        layer_type = str(layer.get("type") or "")
+        if layer_type == "":
+            continue
+        paint = layer.setdefault("paint", {})
+        if not isinstance(paint, dict):
+            paint = {}
+            layer["paint"] = paint
+        paint.update(_masked_paint_properties(layer_type))
+
+    missing_ids = [layer_id for layer_id in layer_ids if layer_id not in set(matched_ids)]
+    return masked, matched_ids, missing_ids
+
+
+def image_delta_metrics(
+    *,
+    reference_path: Path,
+    candidate_path: Path,
+    crop_box: tuple[int, int, int, int] | None = None,
+) -> dict[str, object]:
+    try:
+        from PIL import Image, ImageChops, ImageStat  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - depends on optional local toolchain
+        raise RuntimeError("Rendered-layer mask metrics require Pillow.") from exc
+
+    with Image.open(reference_path).convert("RGB") as reference_image:
+        with Image.open(candidate_path).convert("RGB") as candidate_image:
+            if reference_image.size != candidate_image.size:
+                raise ValueError(
+                    f"Cannot compare images with different sizes: "
+                    f"{reference_image.size} vs {candidate_image.size}."
+                )
+            if crop_box is not None:
+                reference_image = reference_image.crop(crop_box)
+                candidate_image = candidate_image.crop(crop_box)
+            diff = ImageChops.difference(reference_image, candidate_image)
+            diff_stats = ImageStat.Stat(diff)
+            channel_count = max(1, len(diff_stats.mean))
+            mean_absolute_delta = sum(diff_stats.mean) / channel_count
+            rms_delta = sum(diff_stats.rms) / channel_count
+            changed_pixel_count = sum(1 for pixel in diff.getdata() if any(channel != 0 for channel in pixel))
+            signed_deltas = [
+                tuple(candidate_channel - reference_channel for candidate_channel, reference_channel in zip(c, r))
+                for r, c in zip(reference_image.getdata(), candidate_image.getdata())
+            ]
+            pixel_count = max(1, reference_image.width * reference_image.height)
+            mean_delta_rgb = [
+                sum(delta[channel] for delta in signed_deltas) / pixel_count for channel in range(3)
+            ]
+            mean_luminance_delta = sum(
+                mean_delta_rgb[channel] * LUMINANCE_WEIGHTS[channel] for channel in range(3)
+            )
+            return {
+                "box": list(crop_box) if crop_box is not None else None,
+                "pixel_count": reference_image.width * reference_image.height,
+                "changed_pixel_count": changed_pixel_count,
+                "changed_pixel_ratio": changed_pixel_count / pixel_count,
+                "mean_delta_rgb": mean_delta_rgb,
+                "mean_luminance_delta": mean_luminance_delta,
+                "mean_absolute_channel_delta": mean_absolute_delta,
+                "rms_channel_delta": rms_delta,
+            }
+
+
+def image_changed_bbox(*, reference_path: Path, candidate_path: Path) -> list[int] | None:
+    try:
+        from PIL import Image, ImageChops  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - depends on optional local toolchain
+        raise RuntimeError("Rendered-layer mask metrics require Pillow.") from exc
+
+    with Image.open(reference_path).convert("RGB") as reference_image:
+        with Image.open(candidate_path).convert("RGB") as candidate_image:
+            if reference_image.size != candidate_image.size:
+                raise ValueError(
+                    f"Cannot compare images with different sizes: "
+                    f"{reference_image.size} vs {candidate_image.size}."
+                )
+            bbox = ImageChops.difference(reference_image, candidate_image).getbbox()
+    return list(bbox) if bbox is not None else None
+
+
+def metric_delta(
+    candidate: Mapping[str, object],
+    baseline: Mapping[str, object],
+    *,
+    keys: Sequence[str],
+) -> dict[str, float]:
+    delta: dict[str, float] = {}
+    for key in keys:
+        candidate_value = candidate.get(key)
+        baseline_value = baseline.get(key)
+        if isinstance(candidate_value, (int, float)) and isinstance(baseline_value, (int, float)):
+            delta[key] = float(candidate_value) - float(baseline_value)
+    return delta
+
+
+def _write_variant_style(path: Path, style: Mapping[str, object], *, token: str) -> None:
+    path.write_text(redact_sensitive_text(json.dumps(style, indent=2), token) + "\n", encoding="utf-8")
+
+
+def build_qgis_render_child_script() -> str:
+    return f"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, {str(PACKAGE_PARENT)!r})
+
+from qfit.validation.mapbox_outdoors_comparison import (  # noqa: E402
+    MapboxComparisonCamera,
+    load_style_definition,
+    render_qgis_vector,
+)
+
+camera_path = Path(sys.argv[1])
+style_path = Path(sys.argv[2])
+output_path = Path(sys.argv[3])
+camera = MapboxComparisonCamera(**json.loads(camera_path.read_text(encoding="utf-8")))
+render_qgis_vector(
+    camera=camera,
+    token=os.environ["MAPBOX_ACCESS_TOKEN"],
+    output_path=output_path,
+    style_definition=load_style_definition(style_path),
+)
+""".strip()
+
+
+def render_qgis_vector_in_subprocess(
+    *,
+    camera: MapboxComparisonCamera,
+    token: str,
+    output_path: Path,
+    style_definition: Mapping[str, object],
+    timeout_seconds: float = 240.0,
+    **_ignored: object,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="qfit-mapbox-mask-render-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        camera_path = tmp_path / "camera.json"
+        style_path = tmp_path / "style.json"
+        script_path = tmp_path / "render-qgis-style.py"
+        camera_path.write_text(json.dumps(dataclasses.asdict(camera)), encoding="utf-8")
+        style_path.write_text(json.dumps(style_definition), encoding="utf-8")
+        script_path.write_text(build_qgis_render_child_script(), encoding="utf-8")
+        env = os.environ.copy()
+        env.setdefault("QT_QPA_PLATFORM", DEFAULT_QT_QPA_PLATFORM)
+        env["MAPBOX_ACCESS_TOKEN"] = token
+        completed = subprocess.run(
+            [sys.executable, str(script_path), str(camera_path), str(style_path), str(output_path)],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    if completed.returncode != 0:
+        detail = redact_sensitive_text((completed.stderr or completed.stdout).strip(), token)
+        raise RuntimeError(
+            f"QGIS mask render failed for {output_path} with exit code "
+            f"{completed.returncode}: {detail}"
+        )
+
+
+def _variant_directory(run_dir: Path, variant_name: str) -> Path:
+    return run_dir / variant_name
+
+
+def _repo_relative(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return str(path)
+
+
+def _variant_report(
+    *,
+    variant: RenderedLayerMaskVariant,
+    context: RenderedLayerMaskContext,
+    control_qgis_path: Path | None = None,
+    control_crop_metrics: Sequence[Mapping[str, object]] = (),
+) -> dict[str, object]:
+    variant_dir = _variant_directory(context.run_dir, variant.name)
+    variant_dir.mkdir(parents=True, exist_ok=True)
+    variant_style_path = variant_dir / STYLE_MASK_OUTPUT
+    qgis_path = variant_dir / QGIS_RENDER_OUTPUT
+    mapbox_diff_path = variant_dir / MAPBOX_DIFF_OUTPUT
+    movement_diff_path = variant_dir / QGIS_MOVEMENT_DIFF_OUTPUT
+    control_movement_diff_path = variant_dir / "qgis-vs-rerender-control-diff.png"
+    variant_style, matched_ids, missing_ids = apply_transparent_layer_mask(
+        context.base_style,
+        layer_ids=variant.layer_ids,
+    )
+    _write_variant_style(variant_style_path, variant_style, token=context.token)
+    context.qgis_renderer(
+        camera=context.camera,
+        token=context.token,
+        output_path=qgis_path,
+        style_definition=variant_style,
+        qgis_preprocessed_style_path=None,
+        qgis_label_styles_path=None,
+    )
+    metrics = context.diff_builder(
+        reference_path=context.browser_reference_path,
+        candidate_path=qgis_path,
+        output_path=mapbox_diff_path,
+    ) or {}
+    qgis_movement_metrics = context.diff_builder(
+        reference_path=context.baseline_qgis_path,
+        candidate_path=qgis_path,
+        output_path=movement_diff_path,
+    ) or {}
+    crop_metrics = [
+        image_delta_metrics(
+            reference_path=context.browser_reference_path,
+            candidate_path=qgis_path,
+            crop_box=crop_box,
+        )
+        for crop_box in context.crop_boxes
+    ]
+    crop_delta_vs_baseline = [
+        metric_delta(
+            crop_metrics[index],
+            context.baseline_crop_metrics[index],
+            keys=("mean_absolute_channel_delta", "rms_channel_delta", "mean_luminance_delta"),
+        )
+        for index in range(len(crop_metrics))
+    ]
+    render_changed = any(
+        isinstance(qgis_movement_metrics.get(key), (int, float)) and qgis_movement_metrics[key] > 0
+        for key in ("changed_pixel_count", "mean_absolute_channel_delta", "rms_channel_delta")
+    )
+    report: dict[str, object] = {
+        "name": variant.name,
+        "target_layer_ids": list(variant.layer_ids),
+        "matched_layer_ids": matched_ids,
+        "missing_layer_ids": missing_ids,
+        "render_changed": render_changed,
+        "directory": _repo_relative(variant_dir),
+        "style_json": _repo_relative(variant_style_path),
+        "qgis_vector_render": _repo_relative(qgis_path),
+        "mapbox_diff": _repo_relative(mapbox_diff_path),
+        "qgis_movement_diff": _repo_relative(movement_diff_path),
+        "metrics": metrics,
+        "metric_delta_vs_baseline": metric_delta(
+            metrics,
+            context.baseline_metrics,
+            keys=(
+                "changed_pixel_ratio",
+                "normalized_mean_absolute_channel_delta",
+                "normalized_rms_channel_delta",
+            ),
+        ),
+        "qgis_movement_metrics": qgis_movement_metrics,
+        "diff_bbox_vs_baseline_qgis": image_changed_bbox(
+            reference_path=context.baseline_qgis_path,
+            candidate_path=qgis_path,
+        ),
+        "crop_metrics": crop_metrics,
+        "crop_delta_vs_baseline": crop_delta_vs_baseline,
+    }
+    if control_qgis_path is not None:
+        report["qgis_movement_vs_rerender_control_metrics"] = context.diff_builder(
+            reference_path=control_qgis_path,
+            candidate_path=qgis_path,
+            output_path=control_movement_diff_path,
+        ) or {}
+        report["qgis_movement_vs_rerender_control_diff"] = _repo_relative(control_movement_diff_path)
+        report["diff_bbox_vs_rerender_control_qgis"] = image_changed_bbox(
+            reference_path=control_qgis_path,
+            candidate_path=qgis_path,
+        )
+        report["crop_delta_vs_rerender_control"] = [
+            metric_delta(
+                crop_metrics[index],
+                control_crop_metrics[index],
+                keys=("mean_absolute_channel_delta", "rms_channel_delta", "mean_luminance_delta"),
+            )
+            for index in range(len(crop_metrics))
+        ]
+    return report
+
+
+def build_rendered_layer_mask_report(
+    config: RenderedLayerMaskConfig,
+    *,
+    qgis_renderer: Callable[..., None] = render_qgis_vector_in_subprocess,
+    diff_builder: Callable[..., ImageMetrics | None] = build_image_diff,
+) -> dict[str, object]:
+    manifest_path = config.baseline_manifest.expanduser().resolve()
+    manifest = load_json_object(manifest_path)
+    camera = camera_from_manifest(manifest)
+    paths = build_rendered_layer_mask_paths(
+        output_root=config.output_root.expanduser().resolve(),
+        camera_name=camera_output_directory_name(camera),
+        now=config.now,
+    )
+    paths.run_dir.mkdir(parents=True, exist_ok=True)
+    browser_reference_path = _manifest_output_path(
+        manifest,
+        manifest_path=manifest_path,
+        key="browser_reference",
+    )
+    baseline_qgis_path = _manifest_output_path(
+        manifest,
+        manifest_path=manifest_path,
+        key="qgis_vector_render",
+    )
+    qgis_style_path = _manifest_output_path(
+        manifest,
+        manifest_path=manifest_path,
+        key="qgis_preprocessed_style",
+    )
+    base_style = load_style_definition(qgis_style_path)
+    baseline_metrics = manifest.get("metrics") if isinstance(manifest.get("metrics"), Mapping) else {}
+    crop_boxes = config.crop_boxes
+    baseline_crop_metrics = [
+        image_delta_metrics(
+            reference_path=browser_reference_path,
+            candidate_path=baseline_qgis_path,
+            crop_box=crop_box,
+        )
+        for crop_box in crop_boxes
+    ]
+    variant_inputs: list[RenderedLayerMaskVariant] = []
+    control_variant_name = "qgis-rerender-control"
+    if config.include_rerender_control:
+        if any(variant.name == control_variant_name for variant in config.variants):
+            raise ValueError(f"Variant name '{control_variant_name}' is reserved for the rerender control.")
+        variant_inputs.append(RenderedLayerMaskVariant(control_variant_name, ()))
+    variant_inputs.extend(config.variants)
+
+    variants: list[dict[str, object]] = []
+    control_qgis_path: Path | None = None
+    control_crop_metrics: Sequence[Mapping[str, object]] = ()
+    context = RenderedLayerMaskContext(
+        run_dir=paths.run_dir,
+        camera=camera,
+        token=config.token,
+        base_style=base_style,
+        browser_reference_path=browser_reference_path,
+        baseline_qgis_path=baseline_qgis_path,
+        baseline_metrics=baseline_metrics,
+        baseline_crop_metrics=baseline_crop_metrics,
+        crop_boxes=crop_boxes,
+        qgis_renderer=qgis_renderer,
+        diff_builder=diff_builder,
+    )
+    for variant in variant_inputs:
+        variant_report = _variant_report(
+            variant=variant,
+            context=context,
+            control_qgis_path=control_qgis_path,
+            control_crop_metrics=control_crop_metrics,
+        )
+        if variant.name == control_variant_name:
+            variant_report["is_rerender_control"] = True
+            control_qgis_path = _variant_directory(paths.run_dir, variant.name) / QGIS_RENDER_OUTPUT
+            control_crop_metrics = (
+                variant_report.get("crop_metrics")
+                if isinstance(variant_report.get("crop_metrics"), list)
+                else ()
+            )
+        variants.append(variant_report)
+    report: dict[str, object] = {
+        "generated": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "camera": dataclasses.asdict(camera),
+        "rerender_control_variant": control_variant_name if config.include_rerender_control else None,
+        "inputs": {
+            "baseline_manifest": _repo_relative(manifest_path),
+            "browser_reference": _repo_relative(browser_reference_path),
+            "baseline_qgis": _repo_relative(baseline_qgis_path),
+            "qgis_preprocessed_style": _repo_relative(qgis_style_path),
+        },
+        "baseline": {
+            "metrics": baseline_metrics,
+            "crop_metrics": baseline_crop_metrics,
+        },
+        "crop_boxes": [list(crop_box) for crop_box in crop_boxes],
+        "variants": variants,
+    }
+    paths.summary_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    paths.summary_md.write_text(render_markdown_summary(report), encoding="utf-8")
+    return report
+
+
+def _format_number(value: object) -> str:
+    if isinstance(value, (int, float)):
+        return f"{value:.9f}"
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _first_crop_delta(variant: Mapping[str, object], key: str) -> object:
+    crop_deltas = variant.get("crop_delta_vs_baseline")
+    if not isinstance(crop_deltas, list) or not crop_deltas:
+        return None
+    first = crop_deltas[0]
+    if not isinstance(first, Mapping):
+        return None
+    return first.get(key)
+
+
+def _has_control_adjusted_movement(variant: Mapping[str, object]) -> bool:
+    metrics = variant.get("qgis_movement_vs_rerender_control_metrics")
+    if not isinstance(metrics, Mapping):
+        return bool(variant.get("render_changed"))
+    for key in ("changed_pixel_count", "mean_absolute_channel_delta", "rms_channel_delta"):
+        value = metrics.get(key)
+        if isinstance(value, (int, float)) and value > 0:
+            return True
+    return False
+
+
+def _mapping_value(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list_of_mappings(value: object) -> list[Mapping[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
+    camera = _mapping_value(report.get("camera"))
+    inputs = _mapping_value(report.get("inputs"))
+    lines = [
+        "# Mapbox Outdoors rendered-layer mask probe",
+        "",
+        f"Generated: `{report.get('generated')}`",
+        f"Camera: `{camera.get('name')}`",
+        "",
+        "Inputs:",
+    ]
+    lines.extend(f"- {label}: `{path}`" for label, path in inputs.items())
+    return lines
+
+
+def _whole_image_row(row: Mapping[str, object]) -> str:
+    metrics = _mapping_value(row.get("metrics"))
+    delta = _mapping_value(row.get("metric_delta_vs_baseline"))
+    control_movement = _mapping_value(row.get("qgis_movement_vs_rerender_control_metrics"))
+    return (
+        f"| `{row.get('name')}` | {len(row.get('target_layer_ids') or [])} | "
+        f"{'yes' if row.get('render_changed') else 'no'} | "
+        f"{_format_number(metrics.get('normalized_mean_absolute_channel_delta'))} | "
+        f"{_format_number(metrics.get('normalized_rms_channel_delta'))} | "
+        f"{_format_number(delta.get('normalized_mean_absolute_channel_delta'))} | "
+        f"{_format_number(delta.get('normalized_rms_channel_delta'))} | "
+        f"{_format_number(control_movement.get('normalized_mean_absolute_channel_delta'))} | "
+        f"{_format_number(control_movement.get('normalized_rms_channel_delta'))} |"
+    )
+
+
+def _whole_image_lines(
+    *,
+    baseline_metrics: Mapping[str, object],
+    variant_rows: Sequence[Mapping[str, object]],
+) -> list[str]:
+    return [
+        "",
+        "## Whole-image metrics",
+        "",
+        "| Variant | Target layers | Render changed | Mean abs delta | RMS delta | Mean delta vs baseline | RMS delta vs baseline | QGIS mean vs control | QGIS RMS vs control |",
+        "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        (
+            "| `baseline` |  |  | "
+            f"{_format_number(baseline_metrics.get('normalized_mean_absolute_channel_delta'))} | "
+            f"{_format_number(baseline_metrics.get('normalized_rms_channel_delta'))} |  |  |  |  |"
+        ),
+        *[_whole_image_row(row) for row in variant_rows],
+    ]
+
+
+def _first_control_crop_delta(row: Mapping[str, object]) -> Mapping[str, object]:
+    control_crop_delta = row.get("crop_delta_vs_rerender_control")
+    if not isinstance(control_crop_delta, list) or not control_crop_delta:
+        return {}
+    return _mapping_value(control_crop_delta[0])
+
+
+def _first_crop_row(row: Mapping[str, object]) -> str:
+    first_control_crop_delta = _first_control_crop_delta(row)
+    return (
+        f"| `{row.get('name')}` | "
+        f"{_format_number(_first_crop_delta(row, 'mean_absolute_channel_delta'))} | "
+        f"{_format_number(_first_crop_delta(row, 'rms_channel_delta'))} | "
+        f"{_format_number(_first_crop_delta(row, 'mean_luminance_delta'))} | "
+        f"{_format_number(first_control_crop_delta.get('mean_absolute_channel_delta'))} | "
+        f"{_format_number(first_control_crop_delta.get('rms_channel_delta'))} |"
+    )
+
+
+def _first_crop_lines(variant_rows: Sequence[Mapping[str, object]]) -> list[str]:
+    return [
+        "",
+        "## First crop movement",
+        "",
+        "| Variant | Mean abs delta vs baseline | RMS delta vs baseline | Luminance delta vs baseline | Mean abs delta vs control | RMS delta vs control |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+        *[_first_crop_row(row) for row in variant_rows],
+    ]
+
+
+def _read_lines(
+    *,
+    variant_rows: Sequence[Mapping[str, object]],
+    control_name: object,
+) -> list[str]:
+    moving = [
+        f"`{row.get('name')}`"
+        for row in variant_rows
+        if row.get("name") != control_name and _has_control_adjusted_movement(row)
+    ]
+    return [
+        "",
+        "## Read",
+        "",
+        f"- Control-adjusted render-moving variants: {', '.join(moving) if moving else 'none'}.",
+        "- Use the rerender-control columns to separate style-mask movement from QGIS rerender noise.",
+        "- This is diagnostic evidence only; use it to prove rendered-pixel ownership before changing production paint.",
+        "",
+    ]
+
+
+def render_markdown_summary(report: Mapping[str, object]) -> str:
+    variants = report.get("variants")
+    variant_rows = _list_of_mappings(variants)
+    baseline_metrics = _mapping_value(_mapping_value(report.get("baseline")).get("metrics"))
+    lines = _summary_header_lines(report)
+    lines.extend(_whole_image_lines(baseline_metrics=baseline_metrics, variant_rows=variant_rows))
+    if report.get("crop_boxes"):
+        lines.extend(_first_crop_lines(variant_rows))
+    lines.extend(_read_lines(variant_rows=variant_rows, control_name=report.get("rerender_control_variant")))
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render QGIS-only transparent layer masks from an existing Mapbox Outdoors "
+            "comparison manifest and compare each variant with the baseline artifacts."
+        ),
+    )
+    parser.add_argument(
+        "--baseline-manifest",
+        required=True,
+        type=Path,
+        help="Existing comparison manifest with Mapbox reference, QGIS render, and preprocessed style paths.",
+    )
+    parser.add_argument(
+        "--variant",
+        action="append",
+        type=parse_variant_spec,
+        required=True,
+        help="Mask variant as NAME=LAYER_ID[,LAYER_ID...]. Repeat for multiple variants.",
+    )
+    parser.add_argument(
+        "--crop-box",
+        action="append",
+        type=parse_crop_box,
+        default=[],
+        help="Optional crop box as x_min,y_min,x_max,y_max. Repeat for multiple crops.",
+    )
+    parser.add_argument(
+        "--mapbox-token",
+        help="Mapbox access token. Prefer MAPBOX_ACCESS_TOKEN to avoid shell history exposure.",
+    )
+    parser.add_argument(
+        "--no-rerender-control",
+        action="store_true",
+        help="Skip the automatic same-style QGIS rerender control.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    token = resolve_mapbox_token(provided_token=args.mapbox_token)
+    report = build_rendered_layer_mask_report(
+        RenderedLayerMaskConfig(
+            baseline_manifest=args.baseline_manifest,
+            output_root=DEFAULT_OUTPUT_ROOT,
+            variants=tuple(args.variant),
+            crop_boxes=tuple(args.crop_box),
+            token=token,
+            include_rerender_control=not args.no_rerender_control,
+        )
+    )
+    inputs = report.get("inputs")
+    if isinstance(inputs, Mapping):
+        print(f"Baseline manifest: {inputs.get('baseline_manifest')}")
+    camera = report.get("camera")
+    camera_name = camera.get("name") if isinstance(camera, Mapping) else "unknown"
+    output_root = DEFAULT_OUTPUT_ROOT.expanduser().resolve()
+    newest = max((path for path in (output_root / str(camera_name)).glob("*") if path.is_dir()), default=None)
+    if newest is not None:
+        print(f"Run directory: {_repo_relative(newest)}")
+        print(f"Summary: {_repo_relative(newest / 'summary.md')}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a reusable Mapbox Outdoors rendered-layer mask diagnostic for #949.
- Render each QGIS mask variant in an isolated child process and include a same-style rerender control to separate style movement from QGIS rerender noise.
- Document the diagnostic in the comparison harness guide and cover parser, masking, metrics, report generation, and subprocess token handling with tests.

## Validation
- `python3 -m py_compile validation/mapbox_outdoors_rendered_layer_mask.py tests/test_mapbox_outdoors_rendered_layer_mask.py`
- `python3 -m pytest tests/test_mapbox_outdoors_rendered_layer_mask.py -q`
- `python3 -m pytest tests/test_mapbox_outdoors_rendered_layer_mask.py tests/test_mapbox_outdoors_comparison.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- Live #949 probe using the local QGIS-profile Mapbox token source: `debug/mapbox-outdoors-rendered-layer-mask/zermatt-trails-z18-outdoors/20260522T074824Z/summary.md`

## Notes
- Diagnostic only; this PR does not change production Mapbox/QGIS style preprocessing.
- Related to #949.
