### PR TITLE
[codex] Reduce Mapbox outdoor path background opacity

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -839,6 +839,7 @@ _PATH_BACKGROUND_LINE_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
         "hsl(60, 1%, 64%)",
     ),
 )
+_PATH_BACKGROUND_OUTDOOR_LINE_OPACITY = 0.5
 _PATH_HIGH_ZOOM_PALE_CASING_LAYER_IDS = {
     "bridge-path-bg-z16-to-z18-outdoor",
     "bridge-path-bg-z16-to-z18-remaining",
@@ -2456,6 +2457,8 @@ def _path_background_line_color_layer_variants(layer: dict[str, object]) -> list
         variant_paint = variant["paint"]
         assert isinstance(variant_paint, dict)
         variant_paint["line-color"] = line_color
+        if suffix == "outdoor":
+            variant_paint["line-opacity"] = _PATH_BACKGROUND_OUTDOOR_LINE_OPACITY
         variants.append(variant)
     return variants or None
 

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5481,6 +5481,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             for band in ("below-z16", "z16-to-z18", "z18-plus"):
                 self.assertEqual(by_id[f"{layer_id}-{band}-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
                 self.assertEqual(by_id[f"{layer_id}-{band}-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
+                self.assertEqual(
+                    by_id[f"{layer_id}-{band}-outdoor"]["paint"]["line-opacity"],
+                    mapbox_config._PATH_BACKGROUND_OUTDOOR_LINE_OPACITY,
+                )
                 self.assertEqual(by_id[f"{layer_id}-{band}-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
             for suffix in ("piste", "outdoor", "remaining"):
                 self.assertEqual(by_id[f"{layer_id}-below-z16-{suffix}"]["maxzoom"], 16.0)
@@ -5579,6 +5583,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(result[1]["id"], "road-path-bg")
         self.assertEqual(result[2]["id"], "bridge-path-bg-below-z16-piste")
         self.assertEqual(result[3]["id"], "bridge-path-bg-below-z16-outdoor")
+        self.assertEqual(
+            result[3]["paint"]["line-opacity"],
+            mapbox_config._PATH_BACKGROUND_OUTDOOR_LINE_OPACITY,
+        )
         self.assertEqual(result[4]["id"], "bridge-path-bg-below-z16-remaining")
 
     def test_path_high_zoom_pale_casing_helper_inserts_only_selected_layers(self):

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -5480,12 +5480,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         for layer_id in ("road-path-bg", "bridge-path-bg"):
             for band in ("below-z16", "z16-to-z18", "z18-plus"):
                 self.assertEqual(by_id[f"{layer_id}-{band}-piste"]["paint"]["line-color"], "hsl(215, 80%, 48%)")
+                self.assertNotIn("line-opacity", by_id[f"{layer_id}-{band}-piste"]["paint"])
                 self.assertEqual(by_id[f"{layer_id}-{band}-outdoor"]["paint"]["line-color"], "hsl(35, 80%, 48%)")
                 self.assertEqual(
                     by_id[f"{layer_id}-{band}-outdoor"]["paint"]["line-opacity"],
                     mapbox_config._PATH_BACKGROUND_OUTDOOR_LINE_OPACITY,
                 )
                 self.assertEqual(by_id[f"{layer_id}-{band}-remaining"]["paint"]["line-color"], "hsl(60, 1%, 64%)")
+                self.assertNotIn("line-opacity", by_id[f"{layer_id}-{band}-remaining"]["paint"])
             for suffix in ("piste", "outdoor", "remaining"):
                 self.assertEqual(by_id[f"{layer_id}-below-z16-{suffix}"]["maxzoom"], 16.0)
                 self.assertEqual(by_id[f"{layer_id}-z16-to-z18-{suffix}"]["minzoom"], 16.0)


### PR DESCRIPTION
Refs #949.

## Summary
- set the Mapbox Outdoors outdoor path background split layers to 50% line opacity
- keep piste and remaining path background variants unchanged
- extend Mapbox preprocessing tests for the new outdoor opacity behavior

## Validation
- python3 -m pytest tests/test_mapbox_config.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
- live all-camera comparison: debug/mapbox-outdoors-comparison/all-cameras/20260522T101005Z/summary.md
- comparison delta vs main 20260522T033725Z: debug/mapbox-outdoors-comparison-delta/20260522T101021Z/summary.md

## Evidence
The all-camera delta shows improved mean/RMS on Chamonix z13.75, Zermatt trails z18, and Geneva z14, unchanged Lausanne, and only a very small z17 piste regression. This promotes the targeted path-background opacity probe into the production preprocessing path without changing hue or width.