### PR TITLE
[codex] Mute airport landuse at mid zoom

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1159,6 +1159,7 @@ _LANDUSE_AGRICULTURE_FILL_COLOR = "hsla(98, 50%, 74%, 0.6)"
 _LANDUSE_PARK_SPECIAL_FILL_COLOR = "hsl(98, 38%, 68%)"
 _LANDUSE_PARK_FILL_COLOR = "hsl(98, 55%, 70%)"
 _LANDUSE_AIRPORT_FILL_COLOR = "hsl(230, 40%, 82%)"
+_LANDUSE_AIRPORT_MUTED_FILL_COLOR = "hsl(230, 36%, 76%)"
 _LANDUSE_CEMETERY_FILL_COLOR = "hsl(98, 45%, 75%)"
 _LANDUSE_GLACIER_FILL_COLOR = "hsl(205, 45%, 95%)"
 _LANDUSE_HOSPITAL_FILL_COLOR = "hsl(20, 45%, 82%)"
@@ -1335,6 +1336,11 @@ _LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY = 0.66
 # aeroway polygons in the Geneva z14 comparison. Keep this override narrow.
 _LANDUSE_CLASS_FILL_OPACITY_OVERRIDES = {
     (f"{_LANDUSE_LAYER_ID}-other-z10-plus", "airport"): _LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,
+    (
+        f"{_LANDUSE_LAYER_ID}-other-z10-plus",
+        "airport-muted-z14-to-z15",
+    ): _LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,
+    (f"{_LANDUSE_LAYER_ID}-other-z10-plus", "airport-z15-plus"): _LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,
 }
 _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ("wood", ["match", ["get", "class"], "wood", True, False], _LANDUSE_WOOD_FILL_COLOR),
@@ -1364,6 +1370,16 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
         _LANDUSE_PARK_FILL_COLOR,
     ),
     ("airport", ["match", ["get", "class"], "airport", True, False], _LANDUSE_AIRPORT_FILL_COLOR),
+    (
+        "airport-muted-z14-to-z15",
+        ["match", ["get", "class"], "airport", True, False],
+        _LANDUSE_AIRPORT_MUTED_FILL_COLOR,
+    ),
+    (
+        "airport-z15-plus",
+        ["match", ["get", "class"], "airport", True, False],
+        _LANDUSE_AIRPORT_FILL_COLOR,
+    ),
     ("cemetery", ["match", ["get", "class"], "cemetery", True, False], _LANDUSE_CEMETERY_FILL_COLOR),
     ("hospital", ["match", ["get", "class"], "hospital", True, False], _LANDUSE_HOSPITAL_FILL_COLOR),
     ("pitch", ["match", ["get", "class"], "pitch", True, False], _LANDUSE_PITCH_FILL_COLOR),
@@ -1416,6 +1432,9 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANT_ZOOM_BOUNDS = {
     # Match the live Outdoors z16 rock-color stop without recoloring lower zooms.
     "rock-low-zoom": (None, 16.0),
     "rock-high-zoom": (16.0, None),
+    "airport": (None, 14.0),
+    "airport-muted-z14-to-z15": (14.0, 15.0),
+    "airport-z15-plus": (15.0, None),
     "commercial-area-low-zoom": (None, 16.0),
     "commercial-area-high-zoom": (16.0, None),
 }

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3557,7 +3557,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS,
             {"landuse-other-z8-to-z10", "landuse-other-z10-plus"},
         )
-        self.assertEqual(len(result["layers"]), 40)
+        self.assertEqual(len(result["layers"]), 42)
         self.assertIn("landuse-other-below-z8", by_id)
         self.assertNotIn("landuse-other-below-z8-park", by_id)
         stable_class_variants = {
@@ -3585,7 +3585,9 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         commercial_high = by_id["landuse-other-z10-plus-commercial-area-high-zoom"]
         park_special_high = by_id["landuse-other-z10-plus-park-special"]
         park_high = by_id["landuse-other-z10-plus-park"]
-        airport_high = by_id["landuse-other-z10-plus-airport"]
+        airport_high_low = by_id["landuse-other-z10-plus-airport"]
+        airport_high_muted = by_id["landuse-other-z10-plus-airport-muted-z14-to-z15"]
+        airport_high = by_id["landuse-other-z10-plus-airport-z15-plus"]
         remaining_high = by_id["landuse-other-z10-plus-remaining"]
         for band in ("z8-to-z10", "z10-plus"):
             for class_name, (fill_color, class_filter) in stable_class_variants.items():
@@ -3596,6 +3598,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     ["match", ["get", "class"], class_filter, True, False],
                 )
         self.assertNotIn("landuse-other-z8-to-z10-rock-high-zoom", by_id)
+        self.assertNotIn("landuse-other-z8-to-z10-airport-muted-z14-to-z15", by_id)
+        self.assertNotIn("landuse-other-z8-to-z10-airport-z15-plus", by_id)
         self.assertNotIn("landuse-other-z8-to-z10-commercial-area-high-zoom", by_id)
         self.assertEqual(rock_mid["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_FILL_COLOR)
         self.assertEqual(rock_high_low["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_FILL_COLOR)
@@ -3625,9 +3629,22 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(remaining_mid["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
         self.assertEqual(park_special_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_SPECIAL_FILL_COLOR)
         self.assertEqual(park_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
+        self.assertEqual(airport_high_low["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
+        self.assertEqual(
+            airport_high_muted["paint"]["fill-color"],
+            mapbox_config._LANDUSE_AIRPORT_MUTED_FILL_COLOR,
+        )
         self.assertEqual(airport_high["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
         self.assertEqual(remaining_high["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
         self.assertAlmostEqual(airport_mid["paint"]["fill-opacity"], 0.6)
+        self.assertAlmostEqual(
+            airport_high_low["paint"]["fill-opacity"],
+            mapbox_config._LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,
+        )
+        self.assertAlmostEqual(
+            airport_high_muted["paint"]["fill-opacity"],
+            mapbox_config._LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,
+        )
         self.assertAlmostEqual(
             airport_high["paint"]["fill-opacity"],
             mapbox_config._LANDUSE_AIRPORT_HIGH_ZOOM_FILL_OPACITY,
@@ -3635,7 +3652,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(remaining_high["paint"]["fill-opacity"], 1.0)
         self.assertEqual(park_mid["minzoom"], 8.0)
         self.assertEqual(park_mid["maxzoom"], 10.0)
-        self.assertEqual(airport_high["minzoom"], 10.0)
+        self.assertEqual(airport_high_low["minzoom"], 10.0)
+        self.assertEqual(airport_high_low["maxzoom"], 14.0)
+        self.assertEqual(airport_high_muted["minzoom"], 14.0)
+        self.assertEqual(airport_high_muted["maxzoom"], 15.0)
+        self.assertEqual(airport_high["minzoom"], 15.0)
         self.assertNotIn("maxzoom", airport_high)
         self.assertEqual(rock_mid["minzoom"], 8.0)
         self.assertEqual(rock_mid["maxzoom"], 10.0)
@@ -3674,6 +3695,11 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             airport_mid["filter"][-1],
             ["match", ["get", "class"], "airport", True, False],
         )
+        for airport_layer in (airport_high_low, airport_high_muted, airport_high):
+            self.assertEqual(
+                airport_layer["filter"][-1],
+                ["match", ["get", "class"], "airport", True, False],
+            )
         self.assertEqual(
             remaining_mid["filter"][-1],
             [
@@ -3704,6 +3730,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(remaining_high["filter"][-1], remaining_mid["filter"][-1])
         self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-airport"),
+            "landuse",
+        )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit(
+                "landuse-other-z10-plus-airport-muted-z14-to-z15",
+            ),
             "landuse",
         )
         self.assertEqual(
@@ -3794,6 +3826,8 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "landuse-other-z10-plus-park-special",
                 "landuse-other-z10-plus-park",
                 "landuse-other-z10-plus-airport",
+                "landuse-other-z10-plus-airport-muted-z14-to-z15",
+                "landuse-other-z10-plus-airport-z15-plus",
                 "landuse-other-z10-plus-cemetery",
                 "landuse-other-z10-plus-hospital",
                 "landuse-other-z10-plus-pitch",

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3739,6 +3739,10 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             "landuse",
         )
         self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-airport-z15-plus"),
+            "landuse",
+        )
+        self.assertEqual(
             mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-rock-high-zoom"),
             "landuse",
         )

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -1502,6 +1502,16 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
 
         self.assertEqual(audit["summary"]["airport_special_landuse_candidates"], [])
 
+    def test_airport_special_landuse_omits_qfit_split_layer_with_non_class_airport_segment(self):
+        self.assertFalse(
+            mapbox_outdoors_style_audit._is_qfit_split_airport_special_landuse_variant(
+                {
+                    "id": "landuse-other-z10-plus-no-airport-overlay",
+                    "qfit_split_variant": True,
+                },
+            )
+        )
+
     def test_build_style_audit_reports_icon_sprite_candidates(self):
         audit = build_style_audit(
             {

--- a/tests/test_mapbox_outdoors_style_audit.py
+++ b/tests/test_mapbox_outdoors_style_audit.py
@@ -1413,7 +1413,12 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
         candidates = audit["summary"]["airport_special_landuse_candidates"]
         self.assertEqual(
             [candidate["layer"] for candidate in candidates],
-            ["landuse-other-z10-plus-airport", "landuse-other-z8-to-z10-airport"],
+            [
+                "landuse-other-z10-plus-airport",
+                "landuse-other-z10-plus-airport-muted-z14-to-z15",
+                "landuse-other-z10-plus-airport-z15-plus",
+                "landuse-other-z8-to-z10-airport",
+            ],
         )
         for candidate in candidates:
             self.assertEqual(candidate["source_layer"], "landuse")
@@ -1434,7 +1439,15 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
             1,
         )[0]
         self.assertIn("| `landuse-other-z8-to-z10-airport` | `fill` | `landuse` | z8–z10 |", airport_section)
-        self.assertIn("| `landuse-other-z10-plus-airport` | `fill` | `landuse` | z≥10 |", airport_section)
+        self.assertIn("| `landuse-other-z10-plus-airport` | `fill` | `landuse` | z10–z14 |", airport_section)
+        self.assertIn(
+            "| `landuse-other-z10-plus-airport-muted-z14-to-z15` | `fill` | `landuse` | z14–z15 |",
+            airport_section,
+        )
+        self.assertIn(
+            "| `landuse-other-z10-plus-airport-z15-plus` | `fill` | `landuse` | z≥15 |",
+            airport_section,
+        )
         self.assertNotIn("| `landuse` | `fill` |", airport_section)
 
     def test_airport_special_landuse_prefers_qfit_split_variants_for_split_positive_landuse(self):
@@ -1459,7 +1472,12 @@ class MapboxOutdoorsStyleAuditTests(unittest.TestCase):
 
         self.assertEqual(
             [candidate["layer"] for candidate in audit["summary"]["airport_special_landuse_candidates"]],
-            ["landuse-other-z10-plus-airport", "landuse-other-z8-to-z10-airport"],
+            [
+                "landuse-other-z10-plus-airport",
+                "landuse-other-z10-plus-airport-muted-z14-to-z15",
+                "landuse-other-z10-plus-airport-z15-plus",
+                "landuse-other-z8-to-z10-airport",
+            ],
         )
 
     def test_airport_special_landuse_omits_qfit_split_variants_when_filter_excludes_airport(self):

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -1497,7 +1497,8 @@ def _is_qfit_split_airport_special_landuse_variant(layer: dict[str, object]) -> 
     if layer.get(_QFIT_SPLIT_VARIANT_KEY) is not True:
         return False
     layer_id = str(layer.get("id") or "").replace("_", "-").lower()
-    return any(layer_id.endswith(f"-{marker}") for marker in _AIRPORT_SPECIAL_LANDUSE_MARKERS)
+    layer_segments = set(layer_id.split("-"))
+    return any(marker in layer_segments for marker in _AIRPORT_SPECIAL_LANDUSE_MARKERS)
 
 
 def _is_airport_special_landuse_candidate_layer(layer: dict[str, object]) -> bool:

--- a/validation/mapbox_outdoors_style_audit.py
+++ b/validation/mapbox_outdoors_style_audit.py
@@ -273,6 +273,7 @@ _AIRPORT_SPECIAL_LANDUSE_MARKERS = (
     "taxiway",
     "apron",
 )
+_AIRPORT_SPECIAL_LANDUSE_QFIT_SPLIT_MARKER_SUFFIXES = frozenset({"muted"})
 _AIRPORT_SPECIAL_LANDUSE_FILTER_PROPERTIES = frozenset({"class", "kind", "maki", "subclass", "type"})
 _AIRPORT_SPECIAL_LANDUSE_EXCLUSION_FILTER_PROPERTIES = frozenset({"class", "kind"})
 _AIRPORT_SPECIAL_LANDUSE_CONTROL_PROPERTIES = tuple(
@@ -1497,8 +1498,19 @@ def _is_qfit_split_airport_special_landuse_variant(layer: dict[str, object]) -> 
     if layer.get(_QFIT_SPLIT_VARIANT_KEY) is not True:
         return False
     layer_id = str(layer.get("id") or "").replace("_", "-").lower()
-    layer_segments = set(layer_id.split("-"))
-    return any(marker in layer_segments for marker in _AIRPORT_SPECIAL_LANDUSE_MARKERS)
+    layer_segments = layer_id.split("-")
+    for index, segment in enumerate(layer_segments):
+        if segment not in _AIRPORT_SPECIAL_LANDUSE_MARKERS:
+            continue
+        if index == len(layer_segments) - 1:
+            return True
+        next_segment = layer_segments[index + 1]
+        if (
+            next_segment in _AIRPORT_SPECIAL_LANDUSE_QFIT_SPLIT_MARKER_SUFFIXES
+            or re.match(r"^z\d+(?:-\d+)?$", next_segment) is not None
+        ):
+            return True
+    return False
 
 
 def _is_airport_special_landuse_candidate_layer(layer: dict[str, object]) -> bool:


### PR DESCRIPTION
## Summary

- split the high-zoom airport landuse variant into z10-z14, z14-z15, and z15+ bands
- use the evidence-backed muted airport fill only for the z14-z15 band
- keep airport/special-landuse audit detection aligned with the new qfit split layer IDs

## Validation

- `python3 -m pytest tests/ -x -q --tb=short`
- Live Mapbox/QGIS all-camera comparison: `debug/mapbox-outdoors-comparison/all-cameras/20260522T121205Z/summary.md`
- Delta against post-path-bg-opacity main: `debug/mapbox-outdoors-comparison-delta/20260522T121217Z/summary.md`

## #949 evidence

The production candidate improved only the Geneva airport z14 camera and left the other comparison cameras unchanged:

- Geneva mean/RMS: `-0.001267933` / `-0.000637900`
- Summary counts: mean improved `1`, worsened `0`, unchanged `6`; RMS improved `1`, worsened `0`, unchanged `6`
