### PR TITLE
Drop high-zoom pedestrian pattern fallback

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1503,6 +1503,9 @@ _WETLAND_PATTERN_FILL_OPACITY_ZOOM_BANDS: tuple[tuple[str, float | None, float |
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID = "road-pedestrian-polygon-pattern"
 _ROAD_PEDESTRIAN_POLYGON_PATTERN = "pedestrian-polygon"
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_FILL_COLOR = "hsl(0, 0%, 96%)"
+# The full-opacity sprite fallback paints as a solid pale fill in QGIS and
+# worsens high-zoom Zermatt parity; keep the fade-in band only.
+_ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_SKIPPED_BANDS = {"z17-plus"}
 _ROAD_PEDESTRIAN_POLYGON_PATTERN_FILL_OPACITY_EXPRESSIONS = {
     _ROAD_PEDESTRIAN_POLYGON_PATTERN_LAYER_ID: ["interpolate", ["linear"], ["zoom"], 16, 0, 17, 1],
 }
@@ -4629,9 +4632,16 @@ def _road_pedestrian_polygon_pattern_fill_opacity_layer_variants(
     if variants is None:
         fallback_layer = _road_pedestrian_polygon_pattern_fallback_layer(layer)
         return [fallback_layer] if fallback_layer is not None else None
+    visible_variants: list[dict[str, object]] = []
+    layer_id = str(layer.get("id") or "")
     for variant in variants:
         _apply_road_pedestrian_polygon_pattern_fallback(variant)
-    return variants
+        variant_id = str(variant.get("id") or "")
+        suffix = variant_id.removeprefix(f"{layer_id}-")
+        if suffix in _ROAD_PEDESTRIAN_POLYGON_PATTERN_QGIS_SKIPPED_BANDS:
+            continue
+        visible_variants.append(variant)
+    return visible_variants
 
 
 def _road_pedestrian_polygon_pattern_fallback_layer(

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -4079,16 +4079,13 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         result = simplify_mapbox_style_expressions(style)
 
-        self.assertEqual(len(result["layers"]), 2)
+        self.assertEqual(len(result["layers"]), 1)
         by_id = {layer["id"]: layer for layer in result["layers"]}
         fade_layer = by_id["road-pedestrian-polygon-pattern-z16-to-z17"]
-        full_layer = by_id["road-pedestrian-polygon-pattern-z17-plus"]
         self.assertEqual(fade_layer["minzoom"], 16)
         self.assertEqual(fade_layer["maxzoom"], 17.0)
-        self.assertEqual(full_layer["minzoom"], 17.0)
-        self.assertNotIn("maxzoom", full_layer)
         self.assertAlmostEqual(fade_layer["paint"]["fill-opacity"], 0.5)
-        self.assertAlmostEqual(full_layer["paint"]["fill-opacity"], 1.0)
+        self.assertNotIn("road-pedestrian-polygon-pattern-z17-plus", by_id)
         for layer in result["layers"]:
             self.assertNotIn("fill-pattern", layer["paint"])
             self.assertEqual(layer["paint"]["fill-color"], "hsl(0, 0%, 96%)")
@@ -4106,6 +4103,15 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertNotIn("fill-pattern", result["layers"][0]["paint"])
         self.assertEqual(result["layers"][0]["paint"]["fill-color"], "hsl(0, 0%, 96%)")
 
+    def test_road_pedestrian_polygon_pattern_skips_z17_only_fallback(self):
+        layer = self._road_pedestrian_polygon_pattern_layer()
+        layer["minzoom"] = 17
+        style = {"layers": [layer]}
+
+        result = simplify_mapbox_style_expressions(style)
+
+        self.assertEqual(result["layers"], [])
+
     def test_road_pedestrian_polygon_pattern_fill_opacity_helpers_keep_passthrough_inputs(self):
         unchanged_layers = "not-a-layer-list"
         mixed_layers = ["not-a-layer", self._road_pedestrian_polygon_pattern_layer()]
@@ -4122,7 +4128,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
 
         self.assertEqual(result[0], "not-a-layer")
         self.assertEqual(result[1]["id"], "road-pedestrian-polygon-pattern-z16-to-z17")
-        self.assertEqual(result[2]["id"], "road-pedestrian-polygon-pattern-z17-plus")
+        self.assertEqual(len(result), 2)
 
     def _rail_track_layer(self, layer_id="road-rail-tracks", line_opacity=None):
         if line_opacity is None:


### PR DESCRIPTION
## Summary
- Drop the full-opacity `road-pedestrian-polygon-pattern` z17+ QGIS solid fallback while keeping the z16-z17 fade band.
- Add regression coverage so z17-only pedestrian polygon pattern inputs are skipped instead of rendered as a pale solid fill.
- References #949.

## Validation
- `python3 -m pytest tests/test_mapbox_config.py -q` -> 217 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2429 passed, 180 skipped, 177 subtests passed
- Rendered-layer mask, all cameras, pattern-only: Switzerland z5, Valais/Geneva z8, Lausanne z10, Geneva z14, and Zermatt piste z17 were unchanged; Chamonix z14 improved mean/RMS by -0.000010425/-0.000014354; Zermatt trails z18 improved by -0.000173529/-0.000123027.
- Production all-camera comparison delta: Zermatt trails z18 improved mean/RMS by -0.000172325/-0.000255906; Geneva z14 moved by +0.000002324/+0.000005696, consistent with tiny render noise from a camera where the isolated layer mask was unchanged; the other five cameras were unchanged.
- Artifacts: `debug/mapbox-outdoors-rendered-layer-mask/comparison-camera/20260522T124057Z/summary.md`, `debug/mapbox-outdoors-comparison/all-cameras/20260522T124334Z/summary.md`, `debug/mapbox-outdoors-comparison-delta/20260522T124340Z/summary.md`.
