### PR TITLE
test: add Mapbox style adjustment probe

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -210,6 +210,38 @@ python3 validation/mapbox_outdoors_rendered_layer_mask.py \
 
 The probe reuses the baseline manifest's token-free Mapbox reference, QGIS render, and QGIS-preprocessed style. Each variant writes a transparent-mask style JSON, a fresh QGIS render, a Mapbox-vs-QGIS diff, a QGIS-baseline movement diff, whole-image metrics, optional crop metrics, matched/missing target layer IDs, and the changed-pixel bounding box versus the baseline QGIS render. By default it also renders the unchanged style as a QGIS rerender control, so tiny movement can be separated from render noise. Use it to prove actual rendered-pixel ownership after source/crop bbox attribution; a no-op mask means the target layer is not visibly painting that render, and a worsening mask means the removed layer was helping the current QGIS output.
 
+When removal masks prove ownership but not a safe fix, run a style-adjustment probe against the same manifest before changing production preprocessing. The probe reads a JSON plan of named variants and per-layer paint, layout, zoom, or filter overrides, then renders each variant with the same baseline camera and token source:
+
+```json
+{
+  "variants": [
+    {
+      "name": "contour-strong",
+      "adjustments": [
+        {
+          "layer_id": "contour-line-index-minor-z16-plus",
+          "paint": {
+            "line-opacity": 0.68,
+            "line-width": 0.38
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+```bash
+export MAPBOX_ACCESS_TOKEN="***"
+python3 validation/mapbox_outdoors_style_adjustment_probe.py \
+  --baseline-manifest debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/<timestamp>/manifest.json \
+  --variant-json /tmp/zermatt-style-adjustments.json \
+  --crop-box 210,600,630,900 \
+  --crop-box 0,450,420,750
+```
+
+Outputs are written under `debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/<timestamp>/`. Each variant records the adjusted style JSON, fresh QGIS render, Mapbox-vs-QGIS diff, QGIS-baseline movement diff, whole-image metric deltas against both the baseline and rerender control, crop metric deltas, matched/missing adjusted layer IDs, and changed-pixel bounding boxes. Treat this as diagnostic-only evidence; promote a variant only after all-camera validation shows a real improvement without unacceptable regressions.
+
 The focus cues are triage context only. Candidate-backed rows, source-capped rows, and zero-candidate dash rows still need visual inspection before becoming a rendering change.
 
 ## Style audit before tuning

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -229,7 +229,9 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
 
             control = report["variants"][0]
             variant = report["variants"][1]
+            self.assertEqual(report["generated"], "2026-05-24T14:30:00+00:00")
             self.assertTrue(control["is_rerender_control"])
+            self.assertFalse(variant["is_rerender_control"])
             self.assertEqual(variant["matched_layer_ids"], ["contour-minor"])
             self.assertEqual(variant["diff_bbox_vs_baseline_qgis"], [1, 0, 2, 1])
             self.assertAlmostEqual(

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -1,0 +1,350 @@
+import datetime as dt
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+
+from qfit.validation import mapbox_outdoors_style_adjustment_probe as probe_module
+from qfit.validation.mapbox_outdoors_style_adjustment_probe import (
+    StyleAdjustment,
+    StyleAdjustmentProbeConfig,
+    apply_style_adjustments,
+    build_style_adjustment_probe_report,
+    load_style_adjustment_variants,
+    render_markdown_summary,
+)
+
+
+STYLE = {
+    "version": 8,
+    "sources": {
+        "composite": {
+            "type": "vector",
+            "url": "mapbox://mapbox.mapbox-streets-v8",
+        }
+    },
+    "layers": [
+        {"id": "background", "type": "background", "paint": {"background-color": "#ffffff"}},
+        {"id": "contour-minor", "type": "line", "paint": {"line-color": "#555555"}},
+        {"id": "road-label", "type": "symbol", "layout": {"text-size": 10}},
+    ],
+}
+
+
+class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
+    def test_load_style_adjustment_variants_reads_structured_plan(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variants.json"
+            path.write_text(
+                json.dumps({
+                    "variants": [
+                        {
+                            "name": "contour-strong",
+                            "adjustments": [
+                                {
+                                    "layer_id": "contour-minor",
+                                    "paint": {"line-opacity": 0.68},
+                                    "layout": {"line-cap": "round"},
+                                    "minzoom": 16,
+                                }
+                            ],
+                        }
+                    ]
+                }),
+                encoding="utf-8",
+            )
+
+            variants = load_style_adjustment_variants(path)
+
+        self.assertEqual(len(variants), 1)
+        self.assertEqual(variants[0].name, "contour-strong")
+        adjustment = variants[0].adjustments[0]
+        self.assertEqual(adjustment.layer_id, "contour-minor")
+        self.assertEqual(adjustment.paint["line-opacity"], 0.68)
+        self.assertEqual(adjustment.layout["line-cap"], "round")
+        self.assertEqual(adjustment.minzoom, 16.0)
+
+    def test_load_style_adjustment_variants_rejects_empty_adjustments(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variants.json"
+            path.write_text(
+                json.dumps({
+                    "variants": [
+                        {
+                            "name": "empty",
+                            "adjustments": [{"layer_id": "contour-minor"}],
+                        }
+                    ]
+                }),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                load_style_adjustment_variants(path)
+
+    def test_apply_style_adjustments_updates_layer_without_mutating_source(self):
+        adjusted, matched, missing = apply_style_adjustments(
+            STYLE,
+            adjustments=(
+                StyleAdjustment(
+                    layer_id="contour-minor",
+                    paint={"line-opacity": 0.68},
+                    minzoom=16.0,
+                ),
+                StyleAdjustment(
+                    layer_id="road-label",
+                    layout={"text-size": 11},
+                    filter=["==", ["get", "class"], "path"],
+                ),
+                StyleAdjustment(layer_id="missing", paint={"line-opacity": 0.2}),
+            ),
+        )
+
+        layers = {layer["id"]: layer for layer in adjusted["layers"]}
+        self.assertEqual(matched, ["contour-minor", "road-label"])
+        self.assertEqual(missing, ["missing"])
+        self.assertEqual(layers["contour-minor"]["paint"]["line-opacity"], 0.68)
+        self.assertEqual(layers["contour-minor"]["minzoom"], 16.0)
+        self.assertEqual(layers["road-label"]["layout"]["text-size"], 11)
+        self.assertEqual(layers["road-label"]["filter"], ["==", ["get", "class"], "path"])
+        self.assertNotIn("line-opacity", STYLE["layers"][1]["paint"])
+
+    def test_build_report_uses_existing_manifest_and_adjusts_variants(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline_dir = root / "baseline"
+            baseline_dir.mkdir()
+            browser_path = baseline_dir / "mapbox-gl-reference.png"
+            qgis_path = baseline_dir / "qgis-vector-render.png"
+            style_path = baseline_dir / "qgis-preprocessed-style.json"
+            manifest_path = baseline_dir / "manifest.json"
+            browser_path.write_bytes(b"browser")
+            qgis_path.write_bytes(b"baseline-qgis")
+            style_path.write_text(json.dumps(STYLE), encoding="utf-8")
+            manifest_path.write_text(
+                json.dumps({
+                    "camera": {
+                        "name": "unit-camera",
+                        "description": "Unit camera",
+                        "longitude": 7.0,
+                        "latitude": 46.0,
+                        "zoom": 18.0,
+                        "width": 3,
+                        "height": 1,
+                        "style_owner": "mapbox",
+                        "style_id": "outdoors-v12",
+                    },
+                    "outputs": {
+                        "browser_reference": str(browser_path),
+                        "qgis_vector_render": str(qgis_path),
+                        "qgis_preprocessed_style": str(style_path),
+                    },
+                    "metrics": {
+                        "normalized_mean_absolute_channel_delta": 0.10,
+                        "normalized_rms_channel_delta": 0.20,
+                        "changed_pixel_ratio": 0.30,
+                    },
+                }),
+                encoding="utf-8",
+            )
+
+            def fake_renderer(**kwargs):
+                output_path = kwargs["output_path"]
+                style_definition = kwargs["style_definition"]
+                layers = {layer["id"]: layer for layer in style_definition["layers"]}
+                if layers["contour-minor"]["paint"].get("line-opacity") == 0.68:
+                    output_path.write_bytes(b"adjusted")
+                else:
+                    output_path.write_bytes(b"rerender-control")
+
+            def fake_diff_builder(*, candidate_path, output_path, **_kwargs):
+                output_path.write_bytes(b"diff")
+                if candidate_path.read_bytes() == b"adjusted":
+                    return {
+                        "changed_pixel_count": 1,
+                        "changed_pixel_ratio": 0.4,
+                        "normalized_mean_absolute_channel_delta": 0.08,
+                        "normalized_rms_channel_delta": 0.18,
+                        "mean_absolute_channel_delta": 8.0,
+                        "rms_channel_delta": 18.0,
+                    }
+                return {
+                    "changed_pixel_count": 0,
+                    "changed_pixel_ratio": 0.3,
+                    "normalized_mean_absolute_channel_delta": 0.10,
+                    "normalized_rms_channel_delta": 0.20,
+                    "mean_absolute_channel_delta": 10.0,
+                    "rms_channel_delta": 20.0,
+                }
+
+            def fake_image_delta_metrics(*, candidate_path, crop_box, **_kwargs):
+                if candidate_path.read_bytes() == b"adjusted":
+                    return {
+                        "box": list(crop_box),
+                        "mean_absolute_channel_delta": 3.0,
+                        "mean_luminance_delta": -1.0,
+                        "rms_channel_delta": 4.0,
+                    }
+                return {
+                    "box": list(crop_box),
+                    "mean_absolute_channel_delta": 5.0,
+                    "mean_luminance_delta": 2.0,
+                    "rms_channel_delta": 6.0,
+                }
+
+            def fake_changed_bbox(*, candidate_path, **_kwargs):
+                if candidate_path.read_bytes() == b"adjusted":
+                    return [1, 0, 2, 1]
+                return None
+
+            with patch(
+                "qfit.validation.mapbox_outdoors_style_adjustment_probe.image_delta_metrics",
+                fake_image_delta_metrics,
+            ), patch(
+                "qfit.validation.mapbox_outdoors_style_adjustment_probe.image_changed_bbox",
+                fake_changed_bbox,
+            ):
+                report = build_style_adjustment_probe_report(
+                    StyleAdjustmentProbeConfig(
+                        baseline_manifest=manifest_path,
+                        output_root=root / "style-adjustment-probe",
+                        variants=(
+                            probe_module.StyleAdjustmentVariant(
+                                "contour-strong",
+                                (StyleAdjustment("contour-minor", paint={"line-opacity": 0.68}),),
+                            ),
+                        ),
+                        crop_boxes=((1, 0, 2, 1),),
+                        token="test-token",
+                        now=dt.datetime(2026, 5, 24, 14, 30, tzinfo=dt.timezone.utc),
+                    ),
+                    qgis_renderer=fake_renderer,
+                    diff_builder=fake_diff_builder,
+                )
+
+            control = report["variants"][0]
+            variant = report["variants"][1]
+            self.assertTrue(control["is_rerender_control"])
+            self.assertEqual(variant["matched_layer_ids"], ["contour-minor"])
+            self.assertEqual(variant["diff_bbox_vs_baseline_qgis"], [1, 0, 2, 1])
+            self.assertAlmostEqual(
+                variant["metric_delta_vs_baseline"]["normalized_mean_absolute_channel_delta"],
+                -0.02,
+            )
+            self.assertAlmostEqual(
+                variant["metric_delta_vs_rerender_control"]["normalized_rms_channel_delta"],
+                -0.02,
+            )
+            self.assertEqual(
+                variant["crop_delta_vs_rerender_control"][0]["mean_absolute_channel_delta"],
+                -2.0,
+            )
+            summary_path = (
+                root
+                / "style-adjustment-probe"
+                / "comparison-camera"
+                / "20260524T143000Z"
+                / "summary.md"
+            )
+            self.assertTrue(summary_path.exists())
+            self.assertIn("style-adjustment probe", summary_path.read_text(encoding="utf-8"))
+
+    def test_markdown_summary_lists_improving_variants(self):
+        markdown = render_markdown_summary({
+            "generated": "2026-05-24T14:30:00+00:00",
+            "camera": {"name": "unit-camera"},
+            "inputs": {"baseline_manifest": "debug/manifest.json"},
+            "baseline": {"metrics": {"normalized_mean_absolute_channel_delta": 0.1}},
+            "crop_boxes": [[0, 0, 1, 1]],
+            "rerender_control_variant": "qgis-rerender-control",
+            "variants": [
+                {
+                    "name": "contour-strong",
+                    "metrics": {"normalized_mean_absolute_channel_delta": 0.08},
+                    "metric_delta_vs_baseline": {
+                        "normalized_mean_absolute_channel_delta": -0.02,
+                        "normalized_rms_channel_delta": -0.01,
+                    },
+                    "metric_delta_vs_rerender_control": {
+                        "normalized_mean_absolute_channel_delta": -0.03,
+                        "normalized_rms_channel_delta": -0.02,
+                    },
+                    "crop_delta_vs_baseline": [{
+                        "mean_absolute_channel_delta": -1.0,
+                        "rms_channel_delta": -2.0,
+                        "mean_luminance_delta": -3.0,
+                    }],
+                    "crop_delta_vs_rerender_control": [{
+                        "mean_absolute_channel_delta": -1.5,
+                        "rms_channel_delta": -2.5,
+                    }],
+                }
+            ],
+        })
+
+        self.assertIn("Whole-image mean/RMS improving variants: `contour-strong`.", markdown)
+        self.assertIn("Control-adjusted whole-image mean/RMS improving variants: `contour-strong`.", markdown)
+
+    def test_main_builds_config_and_prints_latest_summary(self):
+        captured = {}
+
+        def fake_report_builder(config):
+            captured["config"] = config
+            return {"inputs": {"baseline_manifest": "debug/manifest.json"}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            variant_json = root / "variants.json"
+            variant_json.write_text(
+                json.dumps({
+                    "variants": [
+                        {
+                            "name": "contour-strong",
+                            "adjustments": [
+                                {"layer_id": "contour-minor", "paint": {"line-opacity": 0.68}}
+                            ],
+                        }
+                    ]
+                }),
+                encoding="utf-8",
+            )
+            output_root = root / "style-adjustment-probe"
+            run_dir = output_root / "comparison-camera" / "20260524T143000Z"
+            run_dir.mkdir(parents=True)
+            stdout = io.StringIO()
+            with patch.object(probe_module, "DEFAULT_OUTPUT_ROOT", output_root):
+                with patch.object(probe_module, "resolve_mapbox_token", return_value="resolved-token"):
+                    with patch.object(probe_module, "build_style_adjustment_probe_report", fake_report_builder):
+                        with redirect_stdout(stdout):
+                            result = probe_module.main([
+                                "--baseline-manifest",
+                                str(root / "manifest.json"),
+                                "--variant-json",
+                                str(variant_json),
+                                "--crop-box",
+                                "1,2,5,8",
+                                "--no-rerender-control",
+                            ])
+
+        config = captured["config"]
+        self.assertEqual(result, 0)
+        self.assertIsInstance(config, StyleAdjustmentProbeConfig)
+        self.assertEqual(config.baseline_manifest, root / "manifest.json")
+        self.assertEqual(config.output_root, output_root)
+        self.assertEqual(config.token, "resolved-token")
+        self.assertFalse(config.include_rerender_control)
+        self.assertEqual(config.crop_boxes, ((1, 2, 5, 8),))
+        self.assertEqual(config.variants[0].name, "contour-strong")
+        self.assertEqual(config.variants[0].adjustments[0].layer_id, "contour-minor")
+        self.assertIn("Baseline manifest: debug/manifest.json", stdout.getvalue())
+        self.assertIn("Run directory:", stdout.getvalue())
+        self.assertIn("Summary:", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -415,12 +415,12 @@ def _rerender_control_variant() -> StyleAdjustmentVariant:
 def _build_probe_context(
     *,
     config: StyleAdjustmentProbeConfig,
+    manifest_path: Path,
+    manifest: Mapping[str, object],
     paths: StyleAdjustmentProbePaths,
     qgis_renderer: Callable[..., None],
     diff_builder: Callable[..., ImageMetrics | None],
 ) -> StyleAdjustmentProbeContext:
-    manifest_path = config.baseline_manifest.expanduser().resolve()
-    manifest = load_json_object(manifest_path)
     camera = camera_from_manifest(manifest)
     browser_reference_path = _manifest_output_path(
         manifest,
@@ -479,6 +479,8 @@ def build_style_adjustment_probe_report(
     paths.run_dir.mkdir(parents=True, exist_ok=True)
     context = _build_probe_context(
         config=config,
+        manifest_path=manifest_path,
+        manifest=manifest,
         paths=paths,
         qgis_renderer=qgis_renderer,
         diff_builder=diff_builder,
@@ -514,11 +516,14 @@ def build_style_adjustment_probe_report(
                 if isinstance(variant_report.get("crop_metrics"), list)
                 else ()
             )
+        else:
+            variant_report["is_rerender_control"] = False
         variants.append(variant_report)
 
     qgis_style_path = _manifest_output_path(manifest, manifest_path=manifest_path, key="qgis_preprocessed_style")
+    generated_at = config.now or dt.datetime.now(dt.timezone.utc)
     report: dict[str, object] = {
-        "generated": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "generated": generated_at.isoformat(timespec="seconds"),
         "camera": dataclasses.asdict(camera),
         "rerender_control_variant": control_name if config.include_rerender_control else None,
         "inputs": {

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -1,0 +1,723 @@
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from .mapbox_outdoors_comparison import (
+        DEFAULT_OUTPUT_ROOT as COMPARISON_DEFAULT_OUTPUT_ROOT,
+        ImageMetrics,
+        MapboxComparisonCamera,
+        build_image_diff,
+        load_style_definition,
+        redact_sensitive_text,
+        resolve_mapbox_token,
+    )
+    from .mapbox_outdoors_rendered_layer_mask import (
+        _manifest_output_path,
+        _repo_relative,
+        camera_from_manifest,
+        image_changed_bbox,
+        image_delta_metrics,
+        load_json_object,
+        metric_delta,
+        parse_crop_box,
+        render_qgis_vector_in_subprocess,
+        safe_path_segment,
+    )
+except ImportError:  # pragma: no cover - direct script execution
+    from mapbox_outdoors_comparison import (  # type: ignore[no-redef]
+        DEFAULT_OUTPUT_ROOT as COMPARISON_DEFAULT_OUTPUT_ROOT,
+        ImageMetrics,
+        MapboxComparisonCamera,
+        build_image_diff,
+        load_style_definition,
+        redact_sensitive_text,
+        resolve_mapbox_token,
+    )
+    from mapbox_outdoors_rendered_layer_mask import (  # type: ignore[no-redef]
+        _manifest_output_path,
+        _repo_relative,
+        camera_from_manifest,
+        image_changed_bbox,
+        image_delta_metrics,
+        load_json_object,
+        metric_delta,
+        parse_crop_box,
+        render_qgis_vector_in_subprocess,
+        safe_path_segment,
+    )
+
+
+DEFAULT_OUTPUT_ROOT = COMPARISON_DEFAULT_OUTPUT_ROOT.parent / "mapbox-outdoors-style-adjustment-probe"
+REPORT_CAMERA_DIRECTORY = "comparison-camera"
+STYLE_ADJUSTMENT_OUTPUT = "qgis-adjusted-style.json"
+QGIS_RENDER_OUTPUT = "qgis-vector-render.png"
+MAPBOX_DIFF_OUTPUT = "mapbox-gl-vs-qgis-diff.png"
+QGIS_MOVEMENT_DIFF_OUTPUT = "qgis-vs-baseline-diff.png"
+CONTROL_MOVEMENT_DIFF_OUTPUT = "qgis-vs-rerender-control-diff.png"
+REPORT_JSON_OUTPUT = "style-adjustment-probe.json"
+SUMMARY_OUTPUT = "summary.md"
+METRIC_KEYS = (
+    "changed_pixel_ratio",
+    "normalized_mean_absolute_channel_delta",
+    "normalized_rms_channel_delta",
+)
+CROP_METRIC_KEYS = ("mean_absolute_channel_delta", "rms_channel_delta", "mean_luminance_delta")
+
+
+@dataclass(frozen=True)
+class StyleAdjustment:
+    layer_id: str
+    paint: Mapping[str, object] = dataclasses.field(default_factory=dict)
+    layout: Mapping[str, object] = dataclasses.field(default_factory=dict)
+    minzoom: float | None = None
+    maxzoom: float | None = None
+    filter: object | None = None
+
+
+@dataclass(frozen=True)
+class StyleAdjustmentVariant:
+    name: str
+    adjustments: tuple[StyleAdjustment, ...]
+
+
+@dataclass(frozen=True)
+class StyleAdjustmentProbeConfig:
+    baseline_manifest: Path
+    output_root: Path
+    variants: tuple[StyleAdjustmentVariant, ...]
+    token: str
+    crop_boxes: tuple[tuple[int, int, int, int], ...] = ()
+    include_rerender_control: bool = True
+    now: dt.datetime | None = None
+
+
+@dataclass(frozen=True)
+class StyleAdjustmentProbePaths:
+    run_dir: Path
+    summary_json: Path
+    summary_md: Path
+
+
+@dataclass(frozen=True)
+class StyleAdjustmentProbeContext:
+    run_dir: Path
+    camera: MapboxComparisonCamera
+    token: str
+    base_style: Mapping[str, object]
+    browser_reference_path: Path
+    baseline_qgis_path: Path
+    baseline_metrics: Mapping[str, object]
+    baseline_crop_metrics: Sequence[Mapping[str, object]]
+    crop_boxes: Sequence[tuple[int, int, int, int]]
+    qgis_renderer: Callable[..., None]
+    diff_builder: Callable[..., ImageMetrics | None]
+
+
+def _utc_timestamp(now: dt.datetime | None = None) -> str:
+    return (now or dt.datetime.now(dt.timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _require_mapping(value: object, *, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a JSON object.")
+    return value
+
+
+def _optional_mapping(value: object, *, label: str) -> Mapping[str, object]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a JSON object when provided.")
+    return value
+
+
+def _optional_zoom(value: object, *, label: str) -> float | None:
+    if value is None:
+        return None
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be numeric when provided.")
+    return float(value)
+
+
+def _style_adjustment_from_json(value: object, *, variant_name: str) -> StyleAdjustment:
+    adjustment = _require_mapping(value, label=f"variant {variant_name} adjustment")
+    layer_id = adjustment.get("layer_id")
+    if not isinstance(layer_id, str) or not layer_id:
+        raise ValueError(f"Variant {variant_name} adjustment must include layer_id.")
+    paint = _optional_mapping(adjustment.get("paint"), label=f"variant {variant_name} paint")
+    layout = _optional_mapping(adjustment.get("layout"), label=f"variant {variant_name} layout")
+    minzoom = _optional_zoom(adjustment.get("minzoom"), label=f"variant {variant_name} minzoom")
+    maxzoom = _optional_zoom(adjustment.get("maxzoom"), label=f"variant {variant_name} maxzoom")
+    filter_expression = adjustment.get("filter") if "filter" in adjustment else None
+    if not paint and not layout and minzoom is None and maxzoom is None and filter_expression is None:
+        raise ValueError(f"Variant {variant_name} adjustment for {layer_id} does not change anything.")
+    return StyleAdjustment(
+        layer_id=layer_id,
+        paint=dict(paint),
+        layout=dict(layout),
+        minzoom=minzoom,
+        maxzoom=maxzoom,
+        filter=filter_expression,
+    )
+
+
+def _style_adjustment_variant_from_json(value: object) -> StyleAdjustmentVariant:
+    variant = _require_mapping(value, label="variant")
+    name = variant.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("Each variant must include a name.")
+    safe_path_segment(name)
+    adjustments_value = variant.get("adjustments")
+    if not isinstance(adjustments_value, list) or not adjustments_value:
+        raise ValueError(f"Variant {name} must include at least one adjustment.")
+    return StyleAdjustmentVariant(
+        name=name,
+        adjustments=tuple(
+            _style_adjustment_from_json(adjustment, variant_name=name)
+            for adjustment in adjustments_value
+        ),
+    )
+
+
+def load_style_adjustment_variants(path: Path) -> tuple[StyleAdjustmentVariant, ...]:
+    payload = load_json_object(path)
+    variants_value = payload.get("variants")
+    if not isinstance(variants_value, list) or not variants_value:
+        raise ValueError("Style adjustment plan must include a non-empty variants array.")
+    variants = tuple(_style_adjustment_variant_from_json(variant) for variant in variants_value)
+    names = [variant.name for variant in variants]
+    if len(names) != len(set(names)):
+        raise ValueError("Style adjustment variant names must be unique.")
+    return variants
+
+
+def build_style_adjustment_probe_paths(
+    *,
+    output_root: Path,
+    camera_name: str,
+    now: dt.datetime | None = None,
+) -> StyleAdjustmentProbePaths:
+    run_dir = output_root / safe_path_segment(camera_name) / _utc_timestamp(now)
+    return StyleAdjustmentProbePaths(
+        run_dir=run_dir,
+        summary_json=run_dir / REPORT_JSON_OUTPUT,
+        summary_md=run_dir / SUMMARY_OUTPUT,
+    )
+
+
+def _ensure_layer_mapping(layer: object) -> dict[str, object] | None:
+    return layer if isinstance(layer, dict) else None
+
+
+def _update_mapping_property(
+    layer: dict[str, object],
+    key: str,
+    updates: Mapping[str, object],
+) -> None:
+    existing = layer.get(key)
+    target = existing if isinstance(existing, dict) else {}
+    target.update(dict(updates))
+    layer[key] = target
+
+
+def apply_style_adjustments(
+    style: Mapping[str, object],
+    *,
+    adjustments: Sequence[StyleAdjustment],
+) -> tuple[dict[str, object], list[str], list[str]]:
+    adjusted = deepcopy(dict(style))
+    layers = adjusted.get("layers")
+    if not isinstance(layers, list):
+        raise ValueError("Mapbox style JSON must include a layers array.")
+    matched_ids: list[str] = []
+    missing_ids: list[str] = []
+    for adjustment in adjustments:
+        matched = False
+        for layer_value in layers:
+            layer = _ensure_layer_mapping(layer_value)
+            if layer is None or layer.get("id") != adjustment.layer_id:
+                continue
+            matched = True
+            if adjustment.paint:
+                _update_mapping_property(layer, "paint", adjustment.paint)
+            if adjustment.layout:
+                _update_mapping_property(layer, "layout", adjustment.layout)
+            if adjustment.minzoom is not None:
+                layer["minzoom"] = adjustment.minzoom
+            if adjustment.maxzoom is not None:
+                layer["maxzoom"] = adjustment.maxzoom
+            if adjustment.filter is not None:
+                layer["filter"] = adjustment.filter
+        if matched:
+            matched_ids.append(adjustment.layer_id)
+        else:
+            missing_ids.append(adjustment.layer_id)
+    return adjusted, matched_ids, missing_ids
+
+
+def _write_variant_style(path: Path, style: Mapping[str, object], *, token: str) -> None:
+    path.write_text(redact_sensitive_text(json.dumps(style, indent=2), token) + "\n", encoding="utf-8")
+
+
+def _variant_directory(run_dir: Path, variant_name: str) -> Path:
+    return run_dir / safe_path_segment(variant_name)
+
+
+def _variant_target_layer_ids(variant: StyleAdjustmentVariant) -> list[str]:
+    return [adjustment.layer_id for adjustment in variant.adjustments]
+
+
+def _render_variant_report(
+    *,
+    variant: StyleAdjustmentVariant,
+    context: StyleAdjustmentProbeContext,
+    control_qgis_path: Path | None = None,
+    control_metrics: Mapping[str, object] | None = None,
+    control_crop_metrics: Sequence[Mapping[str, object]] = (),
+) -> dict[str, object]:
+    variant_dir = _variant_directory(context.run_dir, variant.name)
+    variant_dir.mkdir(parents=True, exist_ok=True)
+    variant_style_path = variant_dir / STYLE_ADJUSTMENT_OUTPUT
+    qgis_path = variant_dir / QGIS_RENDER_OUTPUT
+    mapbox_diff_path = variant_dir / MAPBOX_DIFF_OUTPUT
+    movement_diff_path = variant_dir / QGIS_MOVEMENT_DIFF_OUTPUT
+    control_movement_diff_path = variant_dir / CONTROL_MOVEMENT_DIFF_OUTPUT
+    variant_style, matched_ids, missing_ids = apply_style_adjustments(
+        context.base_style,
+        adjustments=variant.adjustments,
+    )
+    _write_variant_style(variant_style_path, variant_style, token=context.token)
+    context.qgis_renderer(
+        camera=context.camera,
+        token=context.token,
+        output_path=qgis_path,
+        style_definition=variant_style,
+        qgis_preprocessed_style_path=None,
+        qgis_label_styles_path=None,
+    )
+    metrics = context.diff_builder(
+        reference_path=context.browser_reference_path,
+        candidate_path=qgis_path,
+        output_path=mapbox_diff_path,
+    ) or {}
+    qgis_movement_metrics = context.diff_builder(
+        reference_path=context.baseline_qgis_path,
+        candidate_path=qgis_path,
+        output_path=movement_diff_path,
+    ) or {}
+    crop_metrics = [
+        image_delta_metrics(
+            reference_path=context.browser_reference_path,
+            candidate_path=qgis_path,
+            crop_box=crop_box,
+        )
+        for crop_box in context.crop_boxes
+    ]
+    report: dict[str, object] = {
+        "name": variant.name,
+        "target_layer_ids": _variant_target_layer_ids(variant),
+        "matched_layer_ids": matched_ids,
+        "missing_layer_ids": missing_ids,
+        "adjustments": [dataclasses.asdict(adjustment) for adjustment in variant.adjustments],
+        "directory": _repo_relative(variant_dir),
+        "style_json": _repo_relative(variant_style_path),
+        "qgis_vector_render": _repo_relative(qgis_path),
+        "mapbox_diff": _repo_relative(mapbox_diff_path),
+        "qgis_movement_diff": _repo_relative(movement_diff_path),
+        "metrics": metrics,
+        "metric_delta_vs_baseline": metric_delta(
+            metrics,
+            context.baseline_metrics,
+            keys=METRIC_KEYS,
+        ),
+        "qgis_movement_metrics": qgis_movement_metrics,
+        "diff_bbox_vs_baseline_qgis": image_changed_bbox(
+            reference_path=context.baseline_qgis_path,
+            candidate_path=qgis_path,
+        ),
+        "crop_metrics": crop_metrics,
+        "crop_delta_vs_baseline": [
+            metric_delta(crop_metrics[index], context.baseline_crop_metrics[index], keys=CROP_METRIC_KEYS)
+            for index in range(len(crop_metrics))
+        ],
+    }
+    if control_qgis_path is not None and control_metrics is not None:
+        report["metric_delta_vs_rerender_control"] = metric_delta(metrics, control_metrics, keys=METRIC_KEYS)
+        report["qgis_movement_vs_rerender_control_metrics"] = context.diff_builder(
+            reference_path=control_qgis_path,
+            candidate_path=qgis_path,
+            output_path=control_movement_diff_path,
+        ) or {}
+        report["qgis_movement_vs_rerender_control_diff"] = _repo_relative(control_movement_diff_path)
+        report["diff_bbox_vs_rerender_control_qgis"] = image_changed_bbox(
+            reference_path=control_qgis_path,
+            candidate_path=qgis_path,
+        )
+        report["crop_delta_vs_rerender_control"] = [
+            metric_delta(crop_metrics[index], control_crop_metrics[index], keys=CROP_METRIC_KEYS)
+            for index in range(len(crop_metrics))
+        ]
+    return report
+
+
+def _rerender_control_variant() -> StyleAdjustmentVariant:
+    return StyleAdjustmentVariant("qgis-rerender-control", ())
+
+
+def _build_probe_context(
+    *,
+    config: StyleAdjustmentProbeConfig,
+    paths: StyleAdjustmentProbePaths,
+    qgis_renderer: Callable[..., None],
+    diff_builder: Callable[..., ImageMetrics | None],
+) -> StyleAdjustmentProbeContext:
+    manifest_path = config.baseline_manifest.expanduser().resolve()
+    manifest = load_json_object(manifest_path)
+    camera = camera_from_manifest(manifest)
+    browser_reference_path = _manifest_output_path(
+        manifest,
+        manifest_path=manifest_path,
+        key="browser_reference",
+    )
+    baseline_qgis_path = _manifest_output_path(
+        manifest,
+        manifest_path=manifest_path,
+        key="qgis_vector_render",
+    )
+    qgis_style_path = _manifest_output_path(
+        manifest,
+        manifest_path=manifest_path,
+        key="qgis_preprocessed_style",
+    )
+    base_style = load_style_definition(qgis_style_path)
+    baseline_metrics = manifest.get("metrics") if isinstance(manifest.get("metrics"), Mapping) else {}
+    baseline_crop_metrics = [
+        image_delta_metrics(
+            reference_path=browser_reference_path,
+            candidate_path=baseline_qgis_path,
+            crop_box=crop_box,
+        )
+        for crop_box in config.crop_boxes
+    ]
+    return StyleAdjustmentProbeContext(
+        run_dir=paths.run_dir,
+        camera=camera,
+        token=config.token,
+        base_style=base_style,
+        browser_reference_path=browser_reference_path,
+        baseline_qgis_path=baseline_qgis_path,
+        baseline_metrics=baseline_metrics,
+        baseline_crop_metrics=baseline_crop_metrics,
+        crop_boxes=config.crop_boxes,
+        qgis_renderer=qgis_renderer,
+        diff_builder=diff_builder,
+    )
+
+
+def build_style_adjustment_probe_report(
+    config: StyleAdjustmentProbeConfig,
+    *,
+    qgis_renderer: Callable[..., None] = render_qgis_vector_in_subprocess,
+    diff_builder: Callable[..., ImageMetrics | None] = build_image_diff,
+) -> dict[str, object]:
+    manifest_path = config.baseline_manifest.expanduser().resolve()
+    manifest = load_json_object(manifest_path)
+    camera = camera_from_manifest(manifest)
+    paths = build_style_adjustment_probe_paths(
+        output_root=config.output_root.expanduser().resolve(),
+        camera_name=REPORT_CAMERA_DIRECTORY,
+        now=config.now,
+    )
+    paths.run_dir.mkdir(parents=True, exist_ok=True)
+    context = _build_probe_context(
+        config=config,
+        paths=paths,
+        qgis_renderer=qgis_renderer,
+        diff_builder=diff_builder,
+    )
+    variant_inputs: list[StyleAdjustmentVariant] = []
+    control_name = "qgis-rerender-control"
+    if config.include_rerender_control:
+        if any(variant.name == control_name for variant in config.variants):
+            raise ValueError(f"Variant name '{control_name}' is reserved for the rerender control.")
+        variant_inputs.append(_rerender_control_variant())
+    variant_inputs.extend(config.variants)
+
+    variants: list[dict[str, object]] = []
+    control_qgis_path: Path | None = None
+    control_metrics: Mapping[str, object] | None = None
+    control_crop_metrics: Sequence[Mapping[str, object]] = ()
+    for variant in variant_inputs:
+        variant_report = _render_variant_report(
+            variant=variant,
+            context=context,
+            control_qgis_path=control_qgis_path,
+            control_metrics=control_metrics,
+            control_crop_metrics=control_crop_metrics,
+        )
+        if variant.name == control_name:
+            variant_report["is_rerender_control"] = True
+            control_qgis_path = _variant_directory(paths.run_dir, variant.name) / QGIS_RENDER_OUTPUT
+            control_metrics = (
+                variant_report.get("metrics") if isinstance(variant_report.get("metrics"), Mapping) else {}
+            )
+            control_crop_metrics = (
+                variant_report.get("crop_metrics")
+                if isinstance(variant_report.get("crop_metrics"), list)
+                else ()
+            )
+        variants.append(variant_report)
+
+    qgis_style_path = _manifest_output_path(manifest, manifest_path=manifest_path, key="qgis_preprocessed_style")
+    report: dict[str, object] = {
+        "generated": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "camera": dataclasses.asdict(camera),
+        "rerender_control_variant": control_name if config.include_rerender_control else None,
+        "inputs": {
+            "baseline_manifest": _repo_relative(manifest_path),
+            "browser_reference": _repo_relative(context.browser_reference_path),
+            "baseline_qgis": _repo_relative(context.baseline_qgis_path),
+            "qgis_preprocessed_style": _repo_relative(qgis_style_path),
+        },
+        "baseline": {
+            "metrics": context.baseline_metrics,
+            "crop_metrics": context.baseline_crop_metrics,
+        },
+        "crop_boxes": [list(crop_box) for crop_box in config.crop_boxes],
+        "variants": variants,
+    }
+    paths.summary_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")  # NOSONAR
+    paths.summary_md.write_text(render_markdown_summary(report), encoding="utf-8")
+    return report
+
+
+def _format_number(value: object) -> str:
+    if isinstance(value, (int, float)):
+        return f"{value:.9f}"
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _mapping_value(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list_of_mappings(value: object) -> list[Mapping[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _metric_delta_improves_both(delta: Mapping[str, object]) -> bool:
+    mean_delta = delta.get("normalized_mean_absolute_channel_delta")
+    rms_delta = delta.get("normalized_rms_channel_delta")
+    return isinstance(mean_delta, (int, float)) and mean_delta < 0 and isinstance(rms_delta, (int, float)) and rms_delta < 0
+
+
+def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
+    camera = _mapping_value(report.get("camera"))
+    inputs = _mapping_value(report.get("inputs"))
+    lines = [
+        "# Mapbox Outdoors style-adjustment probe",
+        "",
+        f"Generated: `{report.get('generated')}`",
+        f"Camera: `{camera.get('name')}`",
+        "",
+        "Inputs:",
+    ]
+    lines.extend(f"- {label}: `{path}`" for label, path in inputs.items())
+    return lines
+
+
+def _whole_image_row(row: Mapping[str, object]) -> str:
+    metrics = _mapping_value(row.get("metrics"))
+    baseline_delta = _mapping_value(row.get("metric_delta_vs_baseline"))
+    control_delta = _mapping_value(row.get("metric_delta_vs_rerender_control"))
+    return (
+        f"| `{row.get('name')}` | "
+        f"{_format_number(metrics.get('normalized_mean_absolute_channel_delta'))} | "
+        f"{_format_number(metrics.get('normalized_rms_channel_delta'))} | "
+        f"{_format_number(baseline_delta.get('normalized_mean_absolute_channel_delta'))} | "
+        f"{_format_number(baseline_delta.get('normalized_rms_channel_delta'))} | "
+        f"{_format_number(control_delta.get('normalized_mean_absolute_channel_delta'))} | "
+        f"{_format_number(control_delta.get('normalized_rms_channel_delta'))} |"
+    )
+
+
+def _whole_image_lines(
+    *,
+    baseline_metrics: Mapping[str, object],
+    variant_rows: Sequence[Mapping[str, object]],
+) -> list[str]:
+    return [
+        "",
+        "## Whole-image metrics",
+        "",
+        "| Variant | Mean abs delta | RMS delta | Mean delta vs baseline | RMS delta vs baseline | Mean delta vs control | RMS delta vs control |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        (
+            "| `baseline` | "
+            f"{_format_number(baseline_metrics.get('normalized_mean_absolute_channel_delta'))} | "
+            f"{_format_number(baseline_metrics.get('normalized_rms_channel_delta'))} |  |  |  |  |"
+        ),
+        *[_whole_image_row(row) for row in variant_rows],
+    ]
+
+
+def _first_crop_delta(variant: Mapping[str, object], key: str) -> object:
+    crop_deltas = variant.get("crop_delta_vs_baseline")
+    if not isinstance(crop_deltas, list) or not crop_deltas:
+        return None
+    first = crop_deltas[0]
+    if not isinstance(first, Mapping):
+        return None
+    return first.get(key)
+
+
+def _first_control_crop_delta(row: Mapping[str, object]) -> Mapping[str, object]:
+    control_crop_delta = row.get("crop_delta_vs_rerender_control")
+    if not isinstance(control_crop_delta, list) or not control_crop_delta:
+        return {}
+    return _mapping_value(control_crop_delta[0])
+
+
+def _first_crop_row(row: Mapping[str, object]) -> str:
+    first_control_crop_delta = _first_control_crop_delta(row)
+    return (
+        f"| `{row.get('name')}` | "
+        f"{_format_number(_first_crop_delta(row, 'mean_absolute_channel_delta'))} | "
+        f"{_format_number(_first_crop_delta(row, 'rms_channel_delta'))} | "
+        f"{_format_number(_first_crop_delta(row, 'mean_luminance_delta'))} | "
+        f"{_format_number(first_control_crop_delta.get('mean_absolute_channel_delta'))} | "
+        f"{_format_number(first_control_crop_delta.get('rms_channel_delta'))} |"
+    )
+
+
+def _first_crop_lines(variant_rows: Sequence[Mapping[str, object]]) -> list[str]:
+    return [
+        "",
+        "## First crop movement",
+        "",
+        "| Variant | Mean abs delta vs baseline | RMS delta vs baseline | Luminance delta vs baseline | Mean abs delta vs control | RMS delta vs control |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+        *[_first_crop_row(row) for row in variant_rows],
+    ]
+
+
+def _read_lines(
+    *,
+    variant_rows: Sequence[Mapping[str, object]],
+    control_name: object,
+) -> list[str]:
+    baseline_improving = [
+        f"`{row.get('name')}`"
+        for row in variant_rows
+        if row.get("name") != control_name
+        and _metric_delta_improves_both(_mapping_value(row.get("metric_delta_vs_baseline")))
+    ]
+    control_improving = [
+        f"`{row.get('name')}`"
+        for row in variant_rows
+        if row.get("name") != control_name
+        and _metric_delta_improves_both(_mapping_value(row.get("metric_delta_vs_rerender_control")))
+    ]
+    return [
+        "",
+        "## Read",
+        "",
+        f"- Whole-image mean/RMS improving variants: {', '.join(baseline_improving) if baseline_improving else 'none'}.",
+        f"- Control-adjusted whole-image mean/RMS improving variants: {', '.join(control_improving) if control_improving else 'none'}.",
+        "- Negative mean/RMS deltas indicate the variant moved closer to the Mapbox GL reference.",
+        "- This is diagnostic evidence only; validate promising variants across the all-camera matrix before changing production style preprocessing.",
+        "",
+    ]
+
+
+def render_markdown_summary(report: Mapping[str, object]) -> str:
+    variant_rows = _list_of_mappings(report.get("variants"))
+    baseline_metrics = _mapping_value(_mapping_value(report.get("baseline")).get("metrics"))
+    lines = _summary_header_lines(report)
+    lines.extend(_whole_image_lines(baseline_metrics=baseline_metrics, variant_rows=variant_rows))
+    if report.get("crop_boxes"):
+        lines.extend(_first_crop_lines(variant_rows))
+    lines.extend(_read_lines(variant_rows=variant_rows, control_name=report.get("rerender_control_variant")))
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render diagnostic QGIS style-adjustment variants from an existing Mapbox Outdoors "
+            "comparison manifest and compare each variant with the baseline artifacts."
+        ),
+    )
+    parser.add_argument(
+        "--baseline-manifest",
+        required=True,
+        type=Path,
+        help="Existing comparison manifest with Mapbox reference, QGIS render, and preprocessed style paths.",
+    )
+    parser.add_argument(
+        "--variant-json",
+        required=True,
+        type=Path,
+        help="JSON plan containing variants and per-layer paint/layout/zoom/filter adjustments.",
+    )
+    parser.add_argument(
+        "--crop-box",
+        action="append",
+        type=parse_crop_box,
+        default=[],
+        help="Optional crop box as x_min,y_min,x_max,y_max. Repeat for multiple crops.",
+    )
+    parser.add_argument(
+        "--mapbox-token",
+        help="Mapbox access token. Prefer MAPBOX_ACCESS_TOKEN to avoid shell history exposure.",
+    )
+    parser.add_argument(
+        "--no-rerender-control",
+        action="store_true",
+        help="Skip the automatic same-style QGIS rerender control.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    token = resolve_mapbox_token(provided_token=args.mapbox_token)
+    report = build_style_adjustment_probe_report(
+        StyleAdjustmentProbeConfig(
+            baseline_manifest=args.baseline_manifest,
+            output_root=DEFAULT_OUTPUT_ROOT,
+            variants=load_style_adjustment_variants(args.variant_json),
+            crop_boxes=tuple(args.crop_box),
+            token=token,
+            include_rerender_control=not args.no_rerender_control,
+        )
+    )
+    inputs = report.get("inputs")
+    if isinstance(inputs, Mapping):
+        print(f"Baseline manifest: {inputs.get('baseline_manifest')}")
+    output_root = DEFAULT_OUTPUT_ROOT.expanduser().resolve()
+    newest = max(
+        (path for path in (output_root / REPORT_CAMERA_DIRECTORY).glob("*") if path.is_dir()),
+        default=None,
+    )
+    if newest is not None:
+        print(f"Run directory: {_repo_relative(newest)}")
+        print(f"Summary: {_repo_relative(newest / SUMMARY_OUTPUT)}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -14,15 +14,21 @@ try:
     from .mapbox_outdoors_comparison import (
         DEFAULT_OUTPUT_ROOT as COMPARISON_DEFAULT_OUTPUT_ROOT,
         ImageMetrics,
-        MapboxComparisonCamera,
         build_image_diff,
         load_style_definition,
         redact_sensitive_text,
         resolve_mapbox_token,
     )
     from .mapbox_outdoors_rendered_layer_mask import (
+        RenderedLayerMaskContext as StyleAdjustmentProbeContext,
+        RenderedLayerMaskPaths as StyleAdjustmentProbePaths,
+        _first_crop_lines,
+        _format_number,
+        _list_of_mappings,
         _manifest_output_path,
+        _mapping_value,
         _repo_relative,
+        _utc_timestamp,
         camera_from_manifest,
         image_changed_bbox,
         image_delta_metrics,
@@ -36,15 +42,21 @@ except ImportError:  # pragma: no cover - direct script execution
     from mapbox_outdoors_comparison import (  # type: ignore[no-redef]
         DEFAULT_OUTPUT_ROOT as COMPARISON_DEFAULT_OUTPUT_ROOT,
         ImageMetrics,
-        MapboxComparisonCamera,
         build_image_diff,
         load_style_definition,
         redact_sensitive_text,
         resolve_mapbox_token,
     )
     from mapbox_outdoors_rendered_layer_mask import (  # type: ignore[no-redef]
+        RenderedLayerMaskContext as StyleAdjustmentProbeContext,
+        RenderedLayerMaskPaths as StyleAdjustmentProbePaths,
+        _first_crop_lines,
+        _format_number,
+        _list_of_mappings,
         _manifest_output_path,
+        _mapping_value,
         _repo_relative,
+        _utc_timestamp,
         camera_from_manifest,
         image_changed_bbox,
         image_delta_metrics,
@@ -98,32 +110,6 @@ class StyleAdjustmentProbeConfig:
     crop_boxes: tuple[tuple[int, int, int, int], ...] = ()
     include_rerender_control: bool = True
     now: dt.datetime | None = None
-
-
-@dataclass(frozen=True)
-class StyleAdjustmentProbePaths:
-    run_dir: Path
-    summary_json: Path
-    summary_md: Path
-
-
-@dataclass(frozen=True)
-class StyleAdjustmentProbeContext:
-    run_dir: Path
-    camera: MapboxComparisonCamera
-    token: str
-    base_style: Mapping[str, object]
-    browser_reference_path: Path
-    baseline_qgis_path: Path
-    baseline_metrics: Mapping[str, object]
-    baseline_crop_metrics: Sequence[Mapping[str, object]]
-    crop_boxes: Sequence[tuple[int, int, int, int]]
-    qgis_renderer: Callable[..., None]
-    diff_builder: Callable[..., ImageMetrics | None]
-
-
-def _utc_timestamp(now: dt.datetime | None = None) -> str:
-    return (now or dt.datetime.now(dt.timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
 
 
 def _require_mapping(value: object, *, label: str) -> Mapping[str, object]:
@@ -284,6 +270,69 @@ def _variant_target_layer_ids(variant: StyleAdjustmentVariant) -> list[str]:
     return [adjustment.layer_id for adjustment in variant.adjustments]
 
 
+def _variant_artifact_paths(variant_dir: Path) -> dict[str, Path]:
+    return {
+        "style": variant_dir / STYLE_ADJUSTMENT_OUTPUT,
+        "qgis": variant_dir / QGIS_RENDER_OUTPUT,
+        "mapbox_diff": variant_dir / MAPBOX_DIFF_OUTPUT,
+        "movement_diff": variant_dir / QGIS_MOVEMENT_DIFF_OUTPUT,
+        "control_movement_diff": variant_dir / CONTROL_MOVEMENT_DIFF_OUTPUT,
+    }
+
+
+def _render_adjusted_style(
+    *,
+    context: StyleAdjustmentProbeContext,
+    style: Mapping[str, object],
+    style_path: Path,
+    qgis_path: Path,
+) -> None:
+    _write_variant_style(style_path, style, token=context.token)
+    context.qgis_renderer(
+        camera=context.camera,
+        token=context.token,
+        output_path=qgis_path,
+        style_definition=style,
+        qgis_preprocessed_style_path=None,
+        qgis_label_styles_path=None,
+    )
+
+
+def _variant_image_metrics(
+    *,
+    context: StyleAdjustmentProbeContext,
+    qgis_path: Path,
+    mapbox_diff_path: Path,
+    movement_diff_path: Path,
+) -> tuple[Mapping[str, object], Mapping[str, object]]:
+    mapbox_metrics = context.diff_builder(
+        reference_path=context.browser_reference_path,
+        candidate_path=qgis_path,
+        output_path=mapbox_diff_path,
+    ) or {}
+    qgis_movement_metrics = context.diff_builder(
+        reference_path=context.baseline_qgis_path,
+        candidate_path=qgis_path,
+        output_path=movement_diff_path,
+    ) or {}
+    return mapbox_metrics, qgis_movement_metrics
+
+
+def _variant_crop_metrics(
+    *,
+    context: StyleAdjustmentProbeContext,
+    qgis_path: Path,
+) -> list[Mapping[str, object]]:
+    return [
+        image_delta_metrics(
+            reference_path=context.browser_reference_path,
+            candidate_path=qgis_path,
+            crop_box=crop_box,
+        )
+        for crop_box in context.crop_boxes
+    ]
+
+
 def _render_variant_report(
     *,
     variant: StyleAdjustmentVariant,
@@ -294,42 +343,24 @@ def _render_variant_report(
 ) -> dict[str, object]:
     variant_dir = _variant_directory(context.run_dir, variant.name)
     variant_dir.mkdir(parents=True, exist_ok=True)
-    variant_style_path = variant_dir / STYLE_ADJUSTMENT_OUTPUT
-    qgis_path = variant_dir / QGIS_RENDER_OUTPUT
-    mapbox_diff_path = variant_dir / MAPBOX_DIFF_OUTPUT
-    movement_diff_path = variant_dir / QGIS_MOVEMENT_DIFF_OUTPUT
-    control_movement_diff_path = variant_dir / CONTROL_MOVEMENT_DIFF_OUTPUT
+    paths = _variant_artifact_paths(variant_dir)
     variant_style, matched_ids, missing_ids = apply_style_adjustments(
         context.base_style,
         adjustments=variant.adjustments,
     )
-    _write_variant_style(variant_style_path, variant_style, token=context.token)
-    context.qgis_renderer(
-        camera=context.camera,
-        token=context.token,
-        output_path=qgis_path,
-        style_definition=variant_style,
-        qgis_preprocessed_style_path=None,
-        qgis_label_styles_path=None,
+    _render_adjusted_style(
+        context=context,
+        style=variant_style,
+        style_path=paths["style"],
+        qgis_path=paths["qgis"],
     )
-    metrics = context.diff_builder(
-        reference_path=context.browser_reference_path,
-        candidate_path=qgis_path,
-        output_path=mapbox_diff_path,
-    ) or {}
-    qgis_movement_metrics = context.diff_builder(
-        reference_path=context.baseline_qgis_path,
-        candidate_path=qgis_path,
-        output_path=movement_diff_path,
-    ) or {}
-    crop_metrics = [
-        image_delta_metrics(
-            reference_path=context.browser_reference_path,
-            candidate_path=qgis_path,
-            crop_box=crop_box,
-        )
-        for crop_box in context.crop_boxes
-    ]
+    metrics, qgis_movement_metrics = _variant_image_metrics(
+        context=context,
+        qgis_path=paths["qgis"],
+        mapbox_diff_path=paths["mapbox_diff"],
+        movement_diff_path=paths["movement_diff"],
+    )
+    crop_metrics = _variant_crop_metrics(context=context, qgis_path=paths["qgis"])
     report: dict[str, object] = {
         "name": variant.name,
         "target_layer_ids": _variant_target_layer_ids(variant),
@@ -337,10 +368,10 @@ def _render_variant_report(
         "missing_layer_ids": missing_ids,
         "adjustments": [dataclasses.asdict(adjustment) for adjustment in variant.adjustments],
         "directory": _repo_relative(variant_dir),
-        "style_json": _repo_relative(variant_style_path),
-        "qgis_vector_render": _repo_relative(qgis_path),
-        "mapbox_diff": _repo_relative(mapbox_diff_path),
-        "qgis_movement_diff": _repo_relative(movement_diff_path),
+        "style_json": _repo_relative(paths["style"]),
+        "qgis_vector_render": _repo_relative(paths["qgis"]),
+        "mapbox_diff": _repo_relative(paths["mapbox_diff"]),
+        "qgis_movement_diff": _repo_relative(paths["movement_diff"]),
         "metrics": metrics,
         "metric_delta_vs_baseline": metric_delta(
             metrics,
@@ -350,7 +381,7 @@ def _render_variant_report(
         "qgis_movement_metrics": qgis_movement_metrics,
         "diff_bbox_vs_baseline_qgis": image_changed_bbox(
             reference_path=context.baseline_qgis_path,
-            candidate_path=qgis_path,
+            candidate_path=paths["qgis"],
         ),
         "crop_metrics": crop_metrics,
         "crop_delta_vs_baseline": [
@@ -362,13 +393,13 @@ def _render_variant_report(
         report["metric_delta_vs_rerender_control"] = metric_delta(metrics, control_metrics, keys=METRIC_KEYS)
         report["qgis_movement_vs_rerender_control_metrics"] = context.diff_builder(
             reference_path=control_qgis_path,
-            candidate_path=qgis_path,
-            output_path=control_movement_diff_path,
+            candidate_path=paths["qgis"],
+            output_path=paths["control_movement_diff"],
         ) or {}
-        report["qgis_movement_vs_rerender_control_diff"] = _repo_relative(control_movement_diff_path)
+        report["qgis_movement_vs_rerender_control_diff"] = _repo_relative(paths["control_movement_diff"])
         report["diff_bbox_vs_rerender_control_qgis"] = image_changed_bbox(
             reference_path=control_qgis_path,
-            candidate_path=qgis_path,
+            candidate_path=paths["qgis"],
         )
         report["crop_delta_vs_rerender_control"] = [
             metric_delta(crop_metrics[index], control_crop_metrics[index], keys=CROP_METRIC_KEYS)
@@ -508,24 +539,6 @@ def build_style_adjustment_probe_report(
     return report
 
 
-def _format_number(value: object) -> str:
-    if isinstance(value, (int, float)):
-        return f"{value:.9f}"
-    if value is None:
-        return ""
-    return str(value)
-
-
-def _mapping_value(value: object) -> Mapping[str, object]:
-    return value if isinstance(value, Mapping) else {}
-
-
-def _list_of_mappings(value: object) -> list[Mapping[str, object]]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, Mapping)]
-
-
 def _metric_delta_improves_both(delta: Mapping[str, object]) -> bool:
     mean_delta = delta.get("normalized_mean_absolute_channel_delta")
     rms_delta = delta.get("normalized_rms_channel_delta")
@@ -579,46 +592,6 @@ def _whole_image_lines(
             f"{_format_number(baseline_metrics.get('normalized_rms_channel_delta'))} |  |  |  |  |"
         ),
         *[_whole_image_row(row) for row in variant_rows],
-    ]
-
-
-def _first_crop_delta(variant: Mapping[str, object], key: str) -> object:
-    crop_deltas = variant.get("crop_delta_vs_baseline")
-    if not isinstance(crop_deltas, list) or not crop_deltas:
-        return None
-    first = crop_deltas[0]
-    if not isinstance(first, Mapping):
-        return None
-    return first.get(key)
-
-
-def _first_control_crop_delta(row: Mapping[str, object]) -> Mapping[str, object]:
-    control_crop_delta = row.get("crop_delta_vs_rerender_control")
-    if not isinstance(control_crop_delta, list) or not control_crop_delta:
-        return {}
-    return _mapping_value(control_crop_delta[0])
-
-
-def _first_crop_row(row: Mapping[str, object]) -> str:
-    first_control_crop_delta = _first_control_crop_delta(row)
-    return (
-        f"| `{row.get('name')}` | "
-        f"{_format_number(_first_crop_delta(row, 'mean_absolute_channel_delta'))} | "
-        f"{_format_number(_first_crop_delta(row, 'rms_channel_delta'))} | "
-        f"{_format_number(_first_crop_delta(row, 'mean_luminance_delta'))} | "
-        f"{_format_number(first_control_crop_delta.get('mean_absolute_channel_delta'))} | "
-        f"{_format_number(first_control_crop_delta.get('rms_channel_delta'))} |"
-    )
-
-
-def _first_crop_lines(variant_rows: Sequence[Mapping[str, object]]) -> list[str]:
-    return [
-        "",
-        "## First crop movement",
-        "",
-        "| Variant | Mean abs delta vs baseline | RMS delta vs baseline | Luminance delta vs baseline | Mean abs delta vs control | RMS delta vs control |",
-        "| --- | ---: | ---: | ---: | ---: | ---: |",
-        *[_first_crop_row(row) for row in variant_rows],
     ]
 
 

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -229,6 +229,27 @@ def _update_mapping_property(
     layer[key] = target
 
 
+def _apply_adjustment_to_layer(layer: dict[str, object], adjustment: StyleAdjustment) -> None:
+    if adjustment.paint:
+        _update_mapping_property(layer, "paint", adjustment.paint)
+    if adjustment.layout:
+        _update_mapping_property(layer, "layout", adjustment.layout)
+    if adjustment.minzoom is not None:
+        layer["minzoom"] = adjustment.minzoom
+    if adjustment.maxzoom is not None:
+        layer["maxzoom"] = adjustment.maxzoom
+    if adjustment.filter is not None:
+        layer["filter"] = adjustment.filter
+
+
+def _matching_layers(layers: Sequence[object], layer_id: str) -> list[dict[str, object]]:
+    return [
+        layer
+        for layer_value in layers
+        if (layer := _ensure_layer_mapping(layer_value)) is not None and layer.get("id") == layer_id
+    ]
+
+
 def apply_style_adjustments(
     style: Mapping[str, object],
     *,
@@ -241,23 +262,10 @@ def apply_style_adjustments(
     matched_ids: list[str] = []
     missing_ids: list[str] = []
     for adjustment in adjustments:
-        matched = False
-        for layer_value in layers:
-            layer = _ensure_layer_mapping(layer_value)
-            if layer is None or layer.get("id") != adjustment.layer_id:
-                continue
-            matched = True
-            if adjustment.paint:
-                _update_mapping_property(layer, "paint", adjustment.paint)
-            if adjustment.layout:
-                _update_mapping_property(layer, "layout", adjustment.layout)
-            if adjustment.minzoom is not None:
-                layer["minzoom"] = adjustment.minzoom
-            if adjustment.maxzoom is not None:
-                layer["maxzoom"] = adjustment.maxzoom
-            if adjustment.filter is not None:
-                layer["filter"] = adjustment.filter
-        if matched:
+        matches = _matching_layers(layers, adjustment.layer_id)
+        if matches:
+            for layer in matches:
+                _apply_adjustment_to_layer(layer, adjustment)
             matched_ids.append(adjustment.layer_id)
         else:
             missing_ids.append(adjustment.layer_id)


### PR DESCRIPTION
## Summary

- Add a reusable Mapbox Outdoors style-adjustment probe for diagnostic paint/layout/zoom/filter variants.
- Record baseline, rerender-control, crop, and control-adjusted metric deltas for each candidate variant.
- Document the probe workflow next to rendered-layer masks in the comparison harness guide.

## Verification

- `python3 -m pytest tests/test_mapbox_outdoors_style_adjustment_probe.py -q --tb=short`
- `python3 -m pytest tests/test_mapbox_outdoors_style_adjustment_probe.py tests/test_mapbox_outdoors_rendered_layer_mask.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- Live smoke: `python3 validation/mapbox_outdoors_style_adjustment_probe.py --baseline-manifest debug/mapbox-outdoors-comparison/zermatt-trails-z18-outdoors/20260522T124329Z/manifest.json --variant-json <temp plan> --crop-box 210,600,630,900`

## Evidence

- Live smoke artifact: `debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/20260524T144312Z/summary.md`

Refs #949.
