### PR TITLE
fix: split high-zoom park and grass landuse

### DIFF
--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -1347,6 +1347,7 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ("scrub", ["match", ["get", "class"], "scrub", True, False], _LANDUSE_SCRUB_FILL_COLOR),
     ("agriculture", ["match", ["get", "class"], "agriculture", True, False], _LANDUSE_AGRICULTURE_FILL_COLOR),
     ("grass", ["match", ["get", "class"], "grass", True, False], _LANDUSE_AGRICULTURE_FILL_COLOR),
+    ("grass-high-zoom", ["match", ["get", "class"], "grass", True, False], _LANDUSE_AGRICULTURE_FILL_COLOR),
     ("glacier", ["match", ["get", "class"], "glacier", True, False], _LANDUSE_GLACIER_FILL_COLOR),
     ("sand", ["match", ["get", "class"], "sand", True, False], _LANDUSE_SAND_FILL_COLOR),
     ("rock-low-zoom", ["match", ["get", "class"], "rock", True, False], _LANDUSE_ROCK_FILL_COLOR),
@@ -1362,6 +1363,15 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
     ),
     (
         "park",
+        [
+            "all",
+            ["match", ["get", "class"], "park", True, False],
+            ["match", ["get", "type"], ["garden", "playground", "zoo"], False, True],
+        ],
+        _LANDUSE_PARK_FILL_COLOR,
+    ),
+    (
+        "park-high-zoom",
         [
             "all",
             ["match", ["get", "class"], "park", True, False],
@@ -1430,8 +1440,12 @@ _LANDUSE_CLASS_FILL_COLOR_VARIANTS: tuple[tuple[str, object, str], ...] = (
 )
 _LANDUSE_CLASS_FILL_COLOR_VARIANT_ZOOM_BOUNDS = {
     # Match the live Outdoors z16 rock-color stop without recoloring lower zooms.
+    "grass": (None, 16.0),
+    "grass-high-zoom": (16.0, None),
     "rock-low-zoom": (None, 16.0),
     "rock-high-zoom": (16.0, None),
+    "park": (None, 16.0),
+    "park-high-zoom": (16.0, None),
     "airport": (None, 14.0),
     "airport-muted-z14-to-z15": (14.0, 15.0),
     "airport-z15-plus": (15.0, None),

--- a/tests/test_mapbox_config.py
+++ b/tests/test_mapbox_config.py
@@ -3557,7 +3557,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config._LANDUSE_CLASS_FILL_COLOR_SPLIT_LAYER_IDS,
             {"landuse-other-z8-to-z10", "landuse-other-z10-plus"},
         )
-        self.assertEqual(len(result["layers"]), 42)
+        self.assertEqual(len(result["layers"]), 44)
         self.assertIn("landuse-other-below-z8", by_id)
         self.assertNotIn("landuse-other-below-z8-park", by_id)
         stable_class_variants = {
@@ -3580,11 +3580,13 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         rock_mid = by_id["landuse-other-z8-to-z10-rock-low-zoom"]
         rock_high_low = by_id["landuse-other-z10-plus-rock-low-zoom"]
         rock_high = by_id["landuse-other-z10-plus-rock-high-zoom"]
+        grass_high = by_id["landuse-other-z10-plus-grass-high-zoom"]
         commercial_mid = by_id["landuse-other-z8-to-z10-commercial-area-low-zoom"]
         commercial_high_low = by_id["landuse-other-z10-plus-commercial-area-low-zoom"]
         commercial_high = by_id["landuse-other-z10-plus-commercial-area-high-zoom"]
         park_special_high = by_id["landuse-other-z10-plus-park-special"]
         park_high = by_id["landuse-other-z10-plus-park"]
+        park_high_zoom = by_id["landuse-other-z10-plus-park-high-zoom"]
         airport_high_low = by_id["landuse-other-z10-plus-airport"]
         airport_high_muted = by_id["landuse-other-z10-plus-airport-muted-z14-to-z15"]
         airport_high = by_id["landuse-other-z10-plus-airport-z15-plus"]
@@ -3598,9 +3600,16 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                     ["match", ["get", "class"], class_filter, True, False],
                 )
         self.assertNotIn("landuse-other-z8-to-z10-rock-high-zoom", by_id)
+        self.assertNotIn("landuse-other-z8-to-z10-grass-high-zoom", by_id)
+        self.assertNotIn("landuse-other-z8-to-z10-park-high-zoom", by_id)
         self.assertNotIn("landuse-other-z8-to-z10-airport-muted-z14-to-z15", by_id)
         self.assertNotIn("landuse-other-z8-to-z10-airport-z15-plus", by_id)
         self.assertNotIn("landuse-other-z8-to-z10-commercial-area-high-zoom", by_id)
+        self.assertEqual(grass_high["paint"]["fill-color"], mapbox_config._LANDUSE_AGRICULTURE_FILL_COLOR)
+        self.assertEqual(
+            grass_high["filter"][-1],
+            ["match", ["get", "class"], "grass", True, False],
+        )
         self.assertEqual(rock_mid["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_FILL_COLOR)
         self.assertEqual(rock_high_low["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_FILL_COLOR)
         self.assertEqual(rock_high["paint"]["fill-color"], mapbox_config._LANDUSE_ROCK_HIGH_ZOOM_FILL_COLOR)
@@ -3629,6 +3638,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertEqual(remaining_mid["paint"]["fill-color"], mapbox_config._LANDUSE_FALLBACK_FILL_COLOR)
         self.assertEqual(park_special_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_SPECIAL_FILL_COLOR)
         self.assertEqual(park_high["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
+        self.assertEqual(park_high_zoom["paint"]["fill-color"], mapbox_config._LANDUSE_PARK_FILL_COLOR)
         self.assertEqual(airport_high_low["paint"]["fill-color"], mapbox_config._LANDUSE_AIRPORT_FILL_COLOR)
         self.assertEqual(
             airport_high_muted["paint"]["fill-color"],
@@ -3652,6 +3662,12 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
         self.assertAlmostEqual(remaining_high["paint"]["fill-opacity"], 1.0)
         self.assertEqual(park_mid["minzoom"], 8.0)
         self.assertEqual(park_mid["maxzoom"], 10.0)
+        self.assertEqual(grass_high["minzoom"], 16.0)
+        self.assertNotIn("maxzoom", grass_high)
+        self.assertEqual(park_high["minzoom"], 10.0)
+        self.assertEqual(park_high["maxzoom"], 16.0)
+        self.assertEqual(park_high_zoom["minzoom"], 16.0)
+        self.assertNotIn("maxzoom", park_high_zoom)
         self.assertEqual(airport_high_low["minzoom"], 10.0)
         self.assertEqual(airport_high_low["maxzoom"], 14.0)
         self.assertEqual(airport_high_muted["minzoom"], 14.0)
@@ -3691,6 +3707,7 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 ["match", ["get", "type"], ["garden", "playground", "zoo"], True, False],
             ],
         )
+        self.assertEqual(park_high_zoom["filter"][-1], park_high["filter"][-1])
         self.assertEqual(
             airport_mid["filter"][-1],
             ["match", ["get", "class"], "airport", True, False],
@@ -3746,6 +3763,54 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
             mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-rock-high-zoom"),
             "landuse",
         )
+        self.assertEqual(
+            mapbox_config.base_mapbox_style_layer_id_for_qfit("landuse-other-z10-plus-park-high-zoom"),
+            "landuse",
+        )
+
+    def test_landuse_high_zoom_park_and_grass_variants_sample_high_zoom_filter(self):
+        landuse_filter = [
+            "all",
+            [">=", ["to-number", ["get", "sizerank"]], 0],
+            [
+                "match",
+                ["get", "class"],
+                ["agriculture", "wood", "grass", "scrub", "glacier", "pitch", "sand"],
+                True,
+                "residential",
+                False,
+                ["park", "airport"],
+                ["step", ["zoom"], False, 8, ["==", ["get", "sizerank"], 1], 10, True],
+                False,
+            ],
+            [
+                "<=",
+                [
+                    "-",
+                    ["to-number", ["get", "sizerank"]],
+                    ["interpolate", ["exponential", 1.5], ["zoom"], 12, 0, 18, 14],
+                ],
+                14,
+            ],
+        ]
+        layer = self._landuse_layer(filter_value=landuse_filter)
+        layer["paint"]["fill-color"] = copy.deepcopy(mapbox_config._LANDUSE_FILL_COLOR_EXPRESSION)
+
+        result = simplify_mapbox_style_expressions({"layers": [layer]})
+
+        by_id = {layer["id"]: layer for layer in result["layers"]}
+        grass_low = by_id["landuse-other-z10-plus-grass"]
+        grass_high = by_id["landuse-other-z10-plus-grass-high-zoom"]
+        park_low = by_id["landuse-other-z10-plus-park"]
+        park_high = by_id["landuse-other-z10-plus-park-high-zoom"]
+        self.assertEqual(grass_low["maxzoom"], 16.0)
+        self.assertEqual(park_low["maxzoom"], 16.0)
+        self.assertEqual(grass_high["minzoom"], 16.0)
+        self.assertEqual(park_high["minzoom"], 16.0)
+        self.assertAlmostEqual(grass_low["filter"][3][2], 14.0)
+        self.assertAlmostEqual(park_low["filter"][3][2], 14.0)
+        self.assertAlmostEqual(grass_high["filter"][3][2], 19.473684210526315)
+        self.assertAlmostEqual(park_high["filter"][3][2], 19.473684210526315)
 
     def test_landuse_fill_opacity_uses_effective_zoom_band_midpoints(self):
         layer = self._landuse_layer()
@@ -3823,12 +3888,14 @@ class SimplifyMapboxStyleTests(unittest.TestCase):
                 "landuse-other-z10-plus-scrub",
                 "landuse-other-z10-plus-agriculture",
                 "landuse-other-z10-plus-grass",
+                "landuse-other-z10-plus-grass-high-zoom",
                 "landuse-other-z10-plus-glacier",
                 "landuse-other-z10-plus-sand",
                 "landuse-other-z10-plus-rock-low-zoom",
                 "landuse-other-z10-plus-rock-high-zoom",
                 "landuse-other-z10-plus-park-special",
                 "landuse-other-z10-plus-park",
+                "landuse-other-z10-plus-park-high-zoom",
                 "landuse-other-z10-plus-airport",
                 "landuse-other-z10-plus-airport-muted-z14-to-z15",
                 "landuse-other-z10-plus-airport-z15-plus",


### PR DESCRIPTION
## Summary

- Split the Mapbox Outdoors park and grass landuse fill variants at z16 so the z16+ QGIS layers sample the high-zoom source filter threshold.
- Keep the lower-zoom park/grass layers capped below z16 to avoid changing the broader z10-z15 cameras.
- Add regression coverage for the generated layer IDs, zoom bounds, base-layer mapping, and high-zoom filter sampling.

Refs #949

## Validation

- `python3 -m pytest tests/test_mapbox_config.py -q --tb=short`
  - `219 passed in 0.19s`
- `python3 -m pytest tests/ -x -q --tb=short`
  - `2437 passed, 180 skipped, 177 subtests passed in 6.99s`
- `MAPBOX_ACCESS_TOKEN=*** python3 validation/mapbox_outdoors_comparison.py --all-cameras`
  - `7 passed, 0 failed, 0 timeout`
  - Report: `debug/mapbox-outdoors-comparison/all-cameras/20260524T153821Z/summary.md`
  - Compared with the previous all-camera baseline at `debug/mapbox-outdoors-comparison/all-cameras/20260522T124334Z/summary.json`, the z18 Zermatt trails camera improved from mean Δ `0.029157` to `0.025098` and RMS Δ `0.085310` to `0.079091`; lower-zoom camera metrics were unchanged within rounding.
