### PR TITLE
[codex] Add Mapbox style probe aggregate report

### DIFF
--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -493,7 +493,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                             ])
 
         config = captured["config"]
-        self.assertEqual(result, 0)
+        self.assertIsNone(result)
         self.assertIsInstance(config, StyleAdjustmentProbeConfig)
         self.assertEqual(config.baseline_manifest, root / "manifest.json")
         self.assertEqual(config.output_root, output_root)
@@ -537,7 +537,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                 ])
             output_markdown = output_path.read_text(encoding="utf-8")
 
-        self.assertEqual(result, 0)
+        self.assertIsNone(result)
         self.assertIn("Aggregate summary:", stdout.getvalue())
         self.assertIn("landcover-opacity-70", output_markdown)
 

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -382,6 +382,34 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         self.assertEqual(valais_total["camera_count"], 1)
         self.assertAlmostEqual(valais_total["mean_delta_range"], 0.00015)
 
+    def test_aggregate_report_ignores_boolean_metric_values(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            report_path = root / "style-adjustment-probe.json"
+            report_path.write_text(
+                json.dumps({
+                    "camera": {"name": "unit-camera"},
+                    "variants": [
+                        {
+                            "name": "boolean-noise",
+                            "metric_delta_vs_baseline": {
+                                "normalized_mean_absolute_channel_delta": False,
+                                "normalized_rms_channel_delta": True,
+                            },
+                        }
+                    ],
+                }),
+                encoding="utf-8",
+            )
+
+            aggregate = build_style_adjustment_aggregate_report((report_path,))
+
+        row = aggregate["rows"][0]
+        self.assertIsNone(row["mean_delta_average"])
+        self.assertIsNone(row["rms_delta_average"])
+        self.assertEqual(row["improving_runs"], 0)
+        self.assertEqual(row["worsening_runs"], 0)
+
     def test_aggregate_markdown_summary_surfaces_mixed_signal(self):
         markdown = render_aggregate_markdown_summary({
             "generated": "2026-05-24T15:00:00+00:00",

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -341,6 +341,9 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                     "variants": [
                         {
                             "name": "landcover-opacity-70",
+                            "metric_delta_vs_rerender_control": {
+                                "normalized_mean_absolute_channel_delta": -0.0002,
+                            },
                             "metric_delta_vs_baseline": {
                                 "normalized_mean_absolute_channel_delta": -0.0003,
                                 "normalized_rms_channel_delta": -0.0004,

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -14,8 +14,10 @@ from qfit.validation.mapbox_outdoors_style_adjustment_probe import (
     StyleAdjustment,
     StyleAdjustmentProbeConfig,
     apply_style_adjustments,
+    build_style_adjustment_aggregate_report,
     build_style_adjustment_probe_report,
     load_style_adjustment_variants,
+    render_aggregate_markdown_summary,
     render_markdown_summary,
 )
 
@@ -292,6 +294,135 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         self.assertIn("Whole-image mean/RMS improving variants: `contour-strong`.", markdown)
         self.assertIn("Control-adjusted whole-image mean/RMS improving variants: `contour-strong`.", markdown)
 
+    def test_aggregate_report_groups_repeated_variant_camera_deltas(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            first_report = root / "first-style-adjustment-probe.json"
+            second_report = root / "second-style-adjustment-probe.json"
+            third_report = root / "third-style-adjustment-probe.json"
+            first_report.write_text(
+                json.dumps({
+                    "camera": {"name": "valais-geneva-outdoors"},
+                    "rerender_control_variant": "qgis-rerender-control",
+                    "variants": [
+                        {"name": "qgis-rerender-control", "is_rerender_control": True},
+                        {
+                            "name": "landcover-opacity-70",
+                            "is_rerender_control": False,
+                            "metric_delta_vs_rerender_control": {
+                                "normalized_mean_absolute_channel_delta": -0.0001,
+                                "normalized_rms_channel_delta": -0.0002,
+                            },
+                        },
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            second_report.write_text(
+                json.dumps({
+                    "camera": {"name": "valais-geneva-outdoors"},
+                    "rerender_control_variant": "qgis-rerender-control",
+                    "variants": [
+                        {
+                            "name": "landcover-opacity-70",
+                            "is_rerender_control": False,
+                            "metric_delta_vs_rerender_control": {
+                                "normalized_mean_absolute_channel_delta": 0.00005,
+                                "normalized_rms_channel_delta": 0.0001,
+                            },
+                        },
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            third_report.write_text(
+                json.dumps({
+                    "camera": {"name": "geneva-airport-motorway-z14-outdoors"},
+                    "variants": [
+                        {
+                            "name": "landcover-opacity-70",
+                            "metric_delta_vs_baseline": {
+                                "normalized_mean_absolute_channel_delta": -0.0003,
+                                "normalized_rms_channel_delta": -0.0004,
+                            },
+                        },
+                    ],
+                }),
+                encoding="utf-8",
+            )
+
+            aggregate = build_style_adjustment_aggregate_report(
+                (first_report, second_report, third_report),
+                now=dt.datetime(2026, 5, 24, 15, 0, tzinfo=dt.timezone.utc),
+            )
+
+        rows = {
+            (row["variant"], row["camera"], row["delta_source"]): row
+            for row in aggregate["rows"]
+        }
+        valais_row = rows[("landcover-opacity-70", "valais-geneva-outdoors", "rerender_control")]
+        self.assertEqual(aggregate["generated"], "2026-05-24T15:00:00+00:00")
+        self.assertEqual(valais_row["runs"], 2)
+        self.assertEqual(valais_row["improving_runs"], 1)
+        self.assertEqual(valais_row["worsening_runs"], 1)
+        self.assertAlmostEqual(valais_row["mean_delta_average"], -0.000025)
+        self.assertAlmostEqual(valais_row["rms_delta_range"], 0.0003)
+        self.assertEqual(
+            rows[("landcover-opacity-70", "geneva-airport-motorway-z14-outdoors", "baseline")][
+                "improving_runs"
+            ],
+            1,
+        )
+        total_rows = {
+            (row["variant"], row["delta_source"]): row
+            for row in aggregate["variant_totals"]
+        }
+        valais_total = total_rows[("landcover-opacity-70", "rerender_control")]
+        self.assertEqual(valais_total["runs"], 2)
+        self.assertEqual(valais_total["camera_count"], 1)
+        self.assertAlmostEqual(valais_total["mean_delta_range"], 0.00015)
+
+    def test_aggregate_markdown_summary_surfaces_mixed_signal(self):
+        markdown = render_aggregate_markdown_summary({
+            "generated": "2026-05-24T15:00:00+00:00",
+            "input_reports": ["debug/first.json", "debug/second.json"],
+            "variant_totals": [
+                {
+                    "variant": "landcover-opacity-70",
+                    "delta_source": "rerender_control",
+                    "runs": 2,
+                    "camera_count": 1,
+                    "mean_delta_average": -0.000025,
+                    "rms_delta_average": -0.00005,
+                    "mean_delta_range": 0.00015,
+                    "rms_delta_range": 0.0003,
+                    "improving_runs": 1,
+                    "worsening_runs": 1,
+                    "other_runs": 0,
+                }
+            ],
+            "rows": [
+                {
+                    "variant": "landcover-opacity-70",
+                    "camera": "valais-geneva-outdoors",
+                    "delta_source": "rerender_control",
+                    "runs": 2,
+                    "mean_delta_average": -0.000025,
+                    "rms_delta_average": -0.00005,
+                    "mean_delta_range": 0.00015,
+                    "rms_delta_range": 0.0003,
+                    "improving_runs": 1,
+                    "worsening_runs": 1,
+                    "other_runs": 0,
+                }
+            ],
+        })
+
+        self.assertIn("style-adjustment aggregate", markdown)
+        self.assertIn("`landcover-opacity-70`", markdown)
+        self.assertIn("| `landcover-opacity-70` | `valais-geneva-outdoors` |", markdown)
+        self.assertIn("0.000300000", markdown)
+
     def test_main_builds_config_and_prints_latest_summary(self):
         captured = {}
 
@@ -346,6 +477,41 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         self.assertIn("Baseline manifest: debug/manifest.json", stdout.getvalue())
         self.assertIn("Run directory:", stdout.getvalue())
         self.assertIn("Summary:", stdout.getvalue())
+
+    def test_main_aggregate_mode_writes_markdown_summary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            report_path = root / "style-adjustment-probe.json"
+            output_path = root / "aggregate.md"
+            report_path.write_text(
+                json.dumps({
+                    "camera": {"name": "valais-geneva-outdoors"},
+                    "rerender_control_variant": "qgis-rerender-control",
+                    "variants": [
+                        {
+                            "name": "landcover-opacity-70",
+                            "metric_delta_vs_rerender_control": {
+                                "normalized_mean_absolute_channel_delta": -0.0001,
+                                "normalized_rms_channel_delta": -0.0002,
+                            },
+                        }
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                result = probe_module.main([
+                    "--aggregate-report",
+                    str(report_path),
+                    "--aggregate-output",
+                    str(output_path),
+                ])
+            output_markdown = output_path.read_text(encoding="utf-8")
+
+        self.assertEqual(result, 0)
+        self.assertIn("Aggregate summary:", stdout.getvalue())
+        self.assertIn("landcover-opacity-70", output_markdown)
 
 
 if __name__ == "__main__":

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -404,11 +404,8 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
 
             aggregate = build_style_adjustment_aggregate_report((report_path,))
 
-        row = aggregate["rows"][0]
-        self.assertIsNone(row["mean_delta_average"])
-        self.assertIsNone(row["rms_delta_average"])
-        self.assertEqual(row["improving_runs"], 0)
-        self.assertEqual(row["worsening_runs"], 0)
+        self.assertEqual(aggregate["rows"], [])
+        self.assertEqual(aggregate["variant_totals"], [])
 
     def test_aggregate_markdown_summary_surfaces_mixed_signal(self):
         markdown = render_aggregate_markdown_summary({
@@ -450,6 +447,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         self.assertIn("`landcover-opacity-70`", markdown)
         self.assertIn("| `landcover-opacity-70` | `valais-geneva-outdoors` |", markdown)
         self.assertIn("0.000300000", markdown)
+        self.assertIn("## Key", markdown)
 
     def test_main_builds_config_and_prints_latest_summary(self):
         captured = {}

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -77,6 +77,10 @@ QGIS_MOVEMENT_DIFF_OUTPUT = "qgis-vs-baseline-diff.png"
 CONTROL_MOVEMENT_DIFF_OUTPUT = "qgis-vs-rerender-control-diff.png"
 REPORT_JSON_OUTPUT = "style-adjustment-probe.json"
 SUMMARY_OUTPUT = "summary.md"
+AGGREGATE_METRIC_KEYS = (
+    "normalized_mean_absolute_channel_delta",
+    "normalized_rms_channel_delta",
+)
 METRIC_KEYS = (
     "changed_pixel_ratio",
     "normalized_mean_absolute_channel_delta",
@@ -550,6 +554,194 @@ def _metric_delta_improves_both(delta: Mapping[str, object]) -> bool:
     return isinstance(mean_delta, (int, float)) and mean_delta < 0 and isinstance(rms_delta, (int, float)) and rms_delta < 0
 
 
+def _metric_delta_worsens_both(delta: Mapping[str, object]) -> bool:
+    mean_delta = delta.get("normalized_mean_absolute_channel_delta")
+    rms_delta = delta.get("normalized_rms_channel_delta")
+    return isinstance(mean_delta, (int, float)) and mean_delta > 0 and isinstance(rms_delta, (int, float)) and rms_delta > 0
+
+
+def _preferred_aggregate_delta(row: Mapping[str, object]) -> tuple[str, Mapping[str, object]]:
+    control_delta = _mapping_value(row.get("metric_delta_vs_rerender_control"))
+    if any(key in control_delta for key in AGGREGATE_METRIC_KEYS):
+        return "rerender_control", control_delta
+    return "baseline", _mapping_value(row.get("metric_delta_vs_baseline"))
+
+
+def _numeric_metric_values(rows: Sequence[Mapping[str, object]], key: str) -> list[float]:
+    values: list[float] = []
+    for row in rows:
+        value = row.get(key)
+        if isinstance(value, (int, float)):
+            values.append(float(value))
+    return values
+
+
+def _mean_value(values: Sequence[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _metric_range(values: Sequence[float]) -> float | None:
+    return max(values) - min(values) if values else None
+
+
+def _aggregate_metric_rows(rows: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    mean_delta_values = _numeric_metric_values(rows, "normalized_mean_absolute_channel_delta")
+    rms_delta_values = _numeric_metric_values(rows, "normalized_rms_channel_delta")
+    return {
+        "runs": len(rows),
+        "mean_delta_average": _mean_value(mean_delta_values),
+        "mean_delta_min": min(mean_delta_values) if mean_delta_values else None,
+        "mean_delta_max": max(mean_delta_values) if mean_delta_values else None,
+        "mean_delta_range": _metric_range(mean_delta_values),
+        "rms_delta_average": _mean_value(rms_delta_values),
+        "rms_delta_min": min(rms_delta_values) if rms_delta_values else None,
+        "rms_delta_max": max(rms_delta_values) if rms_delta_values else None,
+        "rms_delta_range": _metric_range(rms_delta_values),
+        "improving_runs": sum(1 for row in rows if _metric_delta_improves_both(row)),
+        "worsening_runs": sum(1 for row in rows if _metric_delta_worsens_both(row)),
+    }
+
+
+def build_style_adjustment_aggregate_report(
+    report_paths: Sequence[Path],
+    *,
+    now: dt.datetime | None = None,
+) -> dict[str, object]:
+    grouped_rows: dict[tuple[str, str, str], list[Mapping[str, object]]] = {}
+    grouped_totals: dict[tuple[str, str], list[Mapping[str, object]]] = {}
+    total_cameras: dict[tuple[str, str], set[str]] = {}
+    input_paths: list[str] = []
+    for report_path_value in report_paths:
+        report_path = report_path_value.expanduser().resolve()
+        report = load_json_object(report_path)
+        input_paths.append(_repo_relative(report_path))
+        camera = _mapping_value(report.get("camera"))
+        camera_name = str(camera.get("name") or "(unknown camera)")
+        control_variant_name = report.get("rerender_control_variant")
+        for variant in _list_of_mappings(report.get("variants")):
+            variant_name = variant.get("name")
+            if not isinstance(variant_name, str) or not variant_name:
+                continue
+            if variant.get("is_rerender_control") is True or variant_name == control_variant_name:
+                continue
+            delta_source, delta = _preferred_aggregate_delta(variant)
+            if not any(key in delta for key in AGGREGATE_METRIC_KEYS):
+                continue
+            grouped_rows.setdefault((variant_name, camera_name, delta_source), []).append(delta)
+            total_key = (variant_name, delta_source)
+            grouped_totals.setdefault(total_key, []).append(delta)
+            total_cameras.setdefault(total_key, set()).add(camera_name)
+
+    generated_at = now or dt.datetime.now(dt.timezone.utc)
+    rows = []
+    for variant_name, camera_name, delta_source in sorted(grouped_rows):
+        deltas = grouped_rows[(variant_name, camera_name, delta_source)]
+        aggregate = _aggregate_metric_rows(deltas)
+        aggregate["variant"] = variant_name
+        aggregate["camera"] = camera_name
+        aggregate["delta_source"] = delta_source
+        aggregate["other_runs"] = (
+            aggregate["runs"] - aggregate["improving_runs"] - aggregate["worsening_runs"]
+        )
+        rows.append(aggregate)
+    totals = []
+    for variant_name, delta_source in sorted(grouped_totals):
+        deltas = grouped_totals[(variant_name, delta_source)]
+        aggregate = _aggregate_metric_rows(deltas)
+        aggregate["variant"] = variant_name
+        aggregate["delta_source"] = delta_source
+        aggregate["camera_count"] = len(total_cameras[(variant_name, delta_source)])
+        aggregate["other_runs"] = (
+            aggregate["runs"] - aggregate["improving_runs"] - aggregate["worsening_runs"]
+        )
+        totals.append(aggregate)
+    return {
+        "generated": generated_at.isoformat(timespec="seconds"),
+        "input_reports": input_paths,
+        "rows": rows,
+        "variant_totals": totals,
+    }
+
+
+def _aggregate_summary_header_lines(report: Mapping[str, object]) -> list[str]:
+    input_reports = [str(path) for path in report.get("input_reports") or []]
+    lines = [
+        "# Mapbox Outdoors style-adjustment aggregate",
+        "",
+        f"Generated: `{report.get('generated')}`",
+        f"Input reports: `{len(input_reports)}`",
+    ]
+    if input_reports:
+        lines.append("")
+        lines.append("Inputs:")
+        lines.extend(f"- `{path}`" for path in input_reports[:20])
+        if len(input_reports) > 20:
+            lines.append(f"- ... {len(input_reports) - 20} more")
+    return lines
+
+
+def _aggregate_row(row: Mapping[str, object]) -> str:
+    return (
+        f"| `{row.get('variant')}` | `{row.get('camera')}` | `{row.get('delta_source')}` | "
+        f"{row.get('runs')} | "
+        f"{_format_number(row.get('mean_delta_average'))} | "
+        f"{_format_number(row.get('rms_delta_average'))} | "
+        f"{_format_number(row.get('mean_delta_range'))} | "
+        f"{_format_number(row.get('rms_delta_range'))} | "
+        f"{row.get('improving_runs')} | {row.get('worsening_runs')} | {row.get('other_runs')} |"
+    )
+
+
+def _aggregate_total_row(row: Mapping[str, object]) -> str:
+    return (
+        f"| `{row.get('variant')}` | `{row.get('delta_source')}` | "
+        f"{row.get('runs')} | {row.get('camera_count')} | "
+        f"{_format_number(row.get('mean_delta_average'))} | "
+        f"{_format_number(row.get('rms_delta_average'))} | "
+        f"{_format_number(row.get('mean_delta_range'))} | "
+        f"{_format_number(row.get('rms_delta_range'))} | "
+        f"{row.get('improving_runs')} | {row.get('worsening_runs')} | {row.get('other_runs')} |"
+    )
+
+
+def render_aggregate_markdown_summary(report: Mapping[str, object]) -> str:
+    totals = _list_of_mappings(report.get("variant_totals"))
+    rows = _list_of_mappings(report.get("rows"))
+    lines = _aggregate_summary_header_lines(report)
+    lines.extend([
+        "",
+        "## Variant totals",
+        "",
+        "| Variant | Delta source | Runs | Cameras | Mean delta avg | RMS delta avg | Mean delta range | RMS delta range | Improving | Worsening | Other |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ])
+    if totals:
+        lines.extend(_aggregate_total_row(row) for row in totals)
+    else:
+        lines.append("| _none_ |  | 0 | 0 |  |  |  |  | 0 | 0 | 0 |")
+    lines.extend([
+        "",
+        "## Aggregated variant movement",
+        "",
+        "| Variant | Camera | Delta source | Runs | Mean delta avg | RMS delta avg | Mean delta range | RMS delta range | Improving | Worsening | Other |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ])
+    if rows:
+        lines.extend(_aggregate_row(row) for row in rows)
+    else:
+        lines.append("| _none_ |  |  | 0 |  |  |  |  | 0 | 0 | 0 |")
+    lines.extend([
+        "",
+        "## Read",
+        "",
+        "- Deltas are grouped by variant and camera, preferring rerender-control deltas when present.",
+        "- Negative mean/RMS averages indicate the variant moved closer to the Mapbox GL reference on average.",
+        "- Non-zero ranges or mixed improving/worsening counts indicate repeated-render or camera-matrix instability.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
 def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
     camera = _mapping_value(report.get("camera"))
     inputs = _mapping_value(report.get("inputs"))
@@ -649,15 +841,25 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--baseline-manifest",
-        required=True,
         type=Path,
         help="Existing comparison manifest with Mapbox reference, QGIS render, and preprocessed style paths.",
     )
     parser.add_argument(
         "--variant-json",
-        required=True,
         type=Path,
         help="JSON plan containing variants and per-layer paint/layout/zoom/filter adjustments.",
+    )
+    parser.add_argument(
+        "--aggregate-report",
+        action="append",
+        type=Path,
+        default=[],
+        help="Existing style-adjustment-probe.json report to aggregate. Repeat for multiple reports.",
+    )
+    parser.add_argument(
+        "--aggregate-output",
+        type=Path,
+        help="Optional Markdown output path for --aggregate-report mode. Defaults to stdout.",
     )
     parser.add_argument(
         "--crop-box",
@@ -679,7 +881,21 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.aggregate_report:
+        aggregate_report = build_style_adjustment_aggregate_report(tuple(args.aggregate_report))
+        markdown_summary = render_aggregate_markdown_summary(aggregate_report)
+        if args.aggregate_output is not None:
+            output_path = args.aggregate_output.expanduser().resolve()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(markdown_summary, encoding="utf-8")
+            print(f"Aggregate summary: {_repo_relative(output_path)}")
+        else:
+            print(markdown_summary)
+        return 0
+    if args.baseline_manifest is None or args.variant_json is None:
+        parser.error("--baseline-manifest and --variant-json are required unless --aggregate-report is provided.")
     token = resolve_mapbox_token(provided_token=args.mapbox_token)
     report = build_style_adjustment_probe_report(
         StyleAdjustmentProbeConfig(

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -571,7 +571,7 @@ def _numeric_metric_values(rows: Sequence[Mapping[str, object]], key: str) -> li
     values: list[float] = []
     for row in rows:
         value = row.get(key)
-        if isinstance(value, (int, float)):
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
             values.append(float(value))
     return values
 

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -4,7 +4,6 @@ import argparse
 import dataclasses
 import datetime as dt
 import json
-import sys
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
@@ -956,4 +955,4 @@ def main(argv: Sequence[str] | None = None) -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
-    sys.exit(main())
+    main()

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -570,10 +570,21 @@ def _preferred_aggregate_delta(row: Mapping[str, object]) -> tuple[str, Mapping[
 def _numeric_metric_values(rows: Sequence[Mapping[str, object]], key: str) -> list[float]:
     values: list[float] = []
     for row in rows:
-        value = row.get(key)
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            values.append(float(value))
+        value = _numeric_metric_value(row, key)
+        if value is not None:
+            values.append(value)
     return values
+
+
+def _numeric_metric_value(row: Mapping[str, object], key: str) -> float | None:
+    value = row.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _has_aggregate_metric_pair(delta: Mapping[str, object]) -> bool:
+    return all(_numeric_metric_value(delta, key) is not None for key in AGGREGATE_METRIC_KEYS)
 
 
 def _mean_value(values: Sequence[float]) -> float | None:
@@ -622,7 +633,7 @@ def _aggregate_delta_entries(
         if variant.get("is_rerender_control") is True or variant_name == control_variant_name:
             continue
         delta_source, delta = _preferred_aggregate_delta(variant)
-        if any(key in delta for key in AGGREGATE_METRIC_KEYS):
+        if _has_aggregate_metric_pair(delta):
             entries.append((variant_name, camera_name, delta_source, delta))
     return _repo_relative(report_path), entries
 
@@ -753,7 +764,7 @@ def render_aggregate_markdown_summary(report: Mapping[str, object]) -> str:
         lines.append("| _none_ |  |  | 0 |  |  |  |  | 0 | 0 | 0 |")
     lines.extend([
         "",
-        "## Read",
+        "## Key",
         "",
         "- Deltas are grouped by variant and camera, preferring rerender-control deltas when present.",
         "- Negative mean/RMS averages indicate the variant moved closer to the Mapbox GL reference on average.",

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -549,22 +549,25 @@ def build_style_adjustment_probe_report(
 
 
 def _metric_delta_improves_both(delta: Mapping[str, object]) -> bool:
-    mean_delta = delta.get("normalized_mean_absolute_channel_delta")
-    rms_delta = delta.get("normalized_rms_channel_delta")
-    return isinstance(mean_delta, (int, float)) and mean_delta < 0 and isinstance(rms_delta, (int, float)) and rms_delta < 0
+    mean_delta = _numeric_metric_value(delta, "normalized_mean_absolute_channel_delta")
+    rms_delta = _numeric_metric_value(delta, "normalized_rms_channel_delta")
+    return mean_delta is not None and mean_delta < 0 and rms_delta is not None and rms_delta < 0
 
 
 def _metric_delta_worsens_both(delta: Mapping[str, object]) -> bool:
-    mean_delta = delta.get("normalized_mean_absolute_channel_delta")
-    rms_delta = delta.get("normalized_rms_channel_delta")
-    return isinstance(mean_delta, (int, float)) and mean_delta > 0 and isinstance(rms_delta, (int, float)) and rms_delta > 0
+    mean_delta = _numeric_metric_value(delta, "normalized_mean_absolute_channel_delta")
+    rms_delta = _numeric_metric_value(delta, "normalized_rms_channel_delta")
+    return mean_delta is not None and mean_delta > 0 and rms_delta is not None and rms_delta > 0
 
 
-def _preferred_aggregate_delta(row: Mapping[str, object]) -> tuple[str, Mapping[str, object]]:
+def _preferred_aggregate_delta(row: Mapping[str, object]) -> tuple[str | None, Mapping[str, object]]:
     control_delta = _mapping_value(row.get("metric_delta_vs_rerender_control"))
-    if any(key in control_delta for key in AGGREGATE_METRIC_KEYS):
+    if _has_aggregate_metric_pair(control_delta):
         return "rerender_control", control_delta
-    return "baseline", _mapping_value(row.get("metric_delta_vs_baseline"))
+    baseline_delta = _mapping_value(row.get("metric_delta_vs_baseline"))
+    if _has_aggregate_metric_pair(baseline_delta):
+        return "baseline", baseline_delta
+    return None, {}
 
 
 def _numeric_metric_values(rows: Sequence[Mapping[str, object]], key: str) -> list[float]:
@@ -633,7 +636,7 @@ def _aggregate_delta_entries(
         if variant.get("is_rerender_control") is True or variant_name == control_variant_name:
             continue
         delta_source, delta = _preferred_aggregate_delta(variant)
-        if _has_aggregate_metric_pair(delta):
+        if delta_source is not None:
             entries.append((variant_name, camera_name, delta_source, delta))
     return _repo_relative(report_path), entries
 

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -602,6 +602,61 @@ def _aggregate_metric_rows(rows: Sequence[Mapping[str, object]]) -> dict[str, ob
     }
 
 
+def _aggregate_other_runs(aggregate: Mapping[str, object]) -> int:
+    return int(aggregate["runs"]) - int(aggregate["improving_runs"]) - int(aggregate["worsening_runs"])
+
+
+def _aggregate_delta_entries(
+    report_path_value: Path,
+) -> tuple[str, list[tuple[str, str, str, Mapping[str, object]]]]:
+    report_path = report_path_value.expanduser().resolve()
+    report = load_json_object(report_path)
+    camera = _mapping_value(report.get("camera"))
+    camera_name = str(camera.get("name") or "(unknown camera)")
+    control_variant_name = report.get("rerender_control_variant")
+    entries: list[tuple[str, str, str, Mapping[str, object]]] = []
+    for variant in _list_of_mappings(report.get("variants")):
+        variant_name = variant.get("name")
+        if not isinstance(variant_name, str) or not variant_name:
+            continue
+        if variant.get("is_rerender_control") is True or variant_name == control_variant_name:
+            continue
+        delta_source, delta = _preferred_aggregate_delta(variant)
+        if any(key in delta for key in AGGREGATE_METRIC_KEYS):
+            entries.append((variant_name, camera_name, delta_source, delta))
+    return _repo_relative(report_path), entries
+
+
+def _aggregate_camera_rows(
+    grouped_rows: Mapping[tuple[str, str, str], Sequence[Mapping[str, object]]],
+) -> list[dict[str, object]]:
+    rows = []
+    for variant_name, camera_name, delta_source in sorted(grouped_rows):
+        aggregate = _aggregate_metric_rows(grouped_rows[(variant_name, camera_name, delta_source)])
+        aggregate["variant"] = variant_name
+        aggregate["camera"] = camera_name
+        aggregate["delta_source"] = delta_source
+        aggregate["other_runs"] = _aggregate_other_runs(aggregate)
+        rows.append(aggregate)
+    return rows
+
+
+def _aggregate_variant_totals(
+    grouped_totals: Mapping[tuple[str, str], Sequence[Mapping[str, object]]],
+    total_cameras: Mapping[tuple[str, str], set[str]],
+) -> list[dict[str, object]]:
+    totals = []
+    for variant_name, delta_source in sorted(grouped_totals):
+        total_key = (variant_name, delta_source)
+        aggregate = _aggregate_metric_rows(grouped_totals[total_key])
+        aggregate["variant"] = variant_name
+        aggregate["delta_source"] = delta_source
+        aggregate["camera_count"] = len(total_cameras[total_key])
+        aggregate["other_runs"] = _aggregate_other_runs(aggregate)
+        totals.append(aggregate)
+    return totals
+
+
 def build_style_adjustment_aggregate_report(
     report_paths: Sequence[Path],
     *,
@@ -612,54 +667,20 @@ def build_style_adjustment_aggregate_report(
     total_cameras: dict[tuple[str, str], set[str]] = {}
     input_paths: list[str] = []
     for report_path_value in report_paths:
-        report_path = report_path_value.expanduser().resolve()
-        report = load_json_object(report_path)
-        input_paths.append(_repo_relative(report_path))
-        camera = _mapping_value(report.get("camera"))
-        camera_name = str(camera.get("name") or "(unknown camera)")
-        control_variant_name = report.get("rerender_control_variant")
-        for variant in _list_of_mappings(report.get("variants")):
-            variant_name = variant.get("name")
-            if not isinstance(variant_name, str) or not variant_name:
-                continue
-            if variant.get("is_rerender_control") is True or variant_name == control_variant_name:
-                continue
-            delta_source, delta = _preferred_aggregate_delta(variant)
-            if not any(key in delta for key in AGGREGATE_METRIC_KEYS):
-                continue
+        input_path, entries = _aggregate_delta_entries(report_path_value)
+        input_paths.append(input_path)
+        for variant_name, camera_name, delta_source, delta in entries:
             grouped_rows.setdefault((variant_name, camera_name, delta_source), []).append(delta)
             total_key = (variant_name, delta_source)
             grouped_totals.setdefault(total_key, []).append(delta)
             total_cameras.setdefault(total_key, set()).add(camera_name)
 
     generated_at = now or dt.datetime.now(dt.timezone.utc)
-    rows = []
-    for variant_name, camera_name, delta_source in sorted(grouped_rows):
-        deltas = grouped_rows[(variant_name, camera_name, delta_source)]
-        aggregate = _aggregate_metric_rows(deltas)
-        aggregate["variant"] = variant_name
-        aggregate["camera"] = camera_name
-        aggregate["delta_source"] = delta_source
-        aggregate["other_runs"] = (
-            aggregate["runs"] - aggregate["improving_runs"] - aggregate["worsening_runs"]
-        )
-        rows.append(aggregate)
-    totals = []
-    for variant_name, delta_source in sorted(grouped_totals):
-        deltas = grouped_totals[(variant_name, delta_source)]
-        aggregate = _aggregate_metric_rows(deltas)
-        aggregate["variant"] = variant_name
-        aggregate["delta_source"] = delta_source
-        aggregate["camera_count"] = len(total_cameras[(variant_name, delta_source)])
-        aggregate["other_runs"] = (
-            aggregate["runs"] - aggregate["improving_runs"] - aggregate["worsening_runs"]
-        )
-        totals.append(aggregate)
     return {
         "generated": generated_at.isoformat(timespec="seconds"),
         "input_reports": input_paths,
-        "rows": rows,
-        "variant_totals": totals,
+        "rows": _aggregate_camera_rows(grouped_rows),
+        "variant_totals": _aggregate_variant_totals(grouped_totals, total_cameras),
     }
 
 
@@ -880,7 +901,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Sequence[str] | None = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
     if args.aggregate_report:
@@ -893,7 +914,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"Aggregate summary: {_repo_relative(output_path)}")
         else:
             print(markdown_summary)
-        return 0
+        return
     if args.baseline_manifest is None or args.variant_json is None:
         parser.error("--baseline-manifest and --variant-json are required unless --aggregate-report is provided.")
     token = resolve_mapbox_token(provided_token=args.mapbox_token)
@@ -918,7 +939,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     if newest is not None:
         print(f"Run directory: {_repo_relative(newest)}")
         print(f"Summary: {_repo_relative(newest / SUMMARY_OUTPUT)}")
-    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary

- add an aggregate mode to the Mapbox Outdoors style-adjustment probe
- group repeated probe reports by variant/camera and produce variant-level totals across the camera matrix
- keep the output token-free and Markdown-oriented for issue evidence on #949

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_style_adjustment_probe.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Self-validated against existing #949 probe artifacts with `--aggregate-report`, producing `debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/20260524T171136Z/aggregate-summary.md`

Refs #949
