### PR TITLE
Show all crop movements in Mapbox probes

### DIFF
--- a/tests/test_mapbox_outdoors_rendered_layer_mask.py
+++ b/tests/test_mapbox_outdoors_rendered_layer_mask.py
@@ -272,6 +272,8 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
         })
 
         self.assertIn("`moving`", markdown)
+        self.assertIn("## Crop movement", markdown)
+        self.assertIn("| `moving` | 1 | `[0, 0, 1, 1]` | 1.000000000 | 2.000000000 | 3.000000000 |", markdown)
         self.assertIn("Control-adjusted render-moving variants: `moving`.", markdown)
 
     def test_qgis_child_script_keeps_token_out_of_source(self):

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -264,7 +264,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
             "camera": {"name": "unit-camera"},
             "inputs": {"baseline_manifest": "debug/manifest.json"},
             "baseline": {"metrics": {"normalized_mean_absolute_channel_delta": 0.1}},
-            "crop_boxes": [[0, 0, 1, 1]],
+            "crop_boxes": [[0, 0, 1, 1], [1, 1, 2, 2]],
             "rerender_control_variant": "qgis-rerender-control",
             "variants": [
                 {
@@ -278,19 +278,38 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                         "normalized_mean_absolute_channel_delta": -0.03,
                         "normalized_rms_channel_delta": -0.02,
                     },
-                    "crop_delta_vs_baseline": [{
-                        "mean_absolute_channel_delta": -1.0,
-                        "rms_channel_delta": -2.0,
-                        "mean_luminance_delta": -3.0,
-                    }],
-                    "crop_delta_vs_rerender_control": [{
-                        "mean_absolute_channel_delta": -1.5,
-                        "rms_channel_delta": -2.5,
-                    }],
+                    "crop_delta_vs_baseline": [
+                        {
+                            "mean_absolute_channel_delta": -1.0,
+                            "rms_channel_delta": -2.0,
+                            "mean_luminance_delta": -3.0,
+                        },
+                        {
+                            "mean_absolute_channel_delta": 4.0,
+                            "rms_channel_delta": 5.0,
+                            "mean_luminance_delta": 6.0,
+                        },
+                    ],
+                    "crop_delta_vs_rerender_control": [
+                        {
+                            "mean_absolute_channel_delta": -1.5,
+                            "rms_channel_delta": -2.5,
+                        },
+                        {
+                            "mean_absolute_channel_delta": 4.5,
+                            "rms_channel_delta": 5.5,
+                        },
+                    ],
                 }
             ],
         })
 
+        self.assertIn("## Crop movement", markdown)
+        self.assertIn(
+            "| `contour-strong` | 2 | `[1, 1, 2, 2]` | 4.000000000 | 5.000000000 | "
+            "6.000000000 | 4.500000000 | 5.500000000 |",
+            markdown,
+        )
         self.assertIn("Whole-image mean/RMS improving variants: `contour-strong`.", markdown)
         self.assertIn("Control-adjusted whole-image mean/RMS improving variants: `contour-strong`.", markdown)
 

--- a/validation/mapbox_outdoors_rendered_layer_mask.py
+++ b/validation/mapbox_outdoors_rendered_layer_mask.py
@@ -638,14 +638,14 @@ def _format_number(value: object) -> str:
     return str(value)
 
 
-def _first_crop_delta(variant: Mapping[str, object], key: str) -> object:
+def _crop_delta(variant: Mapping[str, object], *, crop_index: int, key: str) -> object:
     crop_deltas = variant.get("crop_delta_vs_baseline")
-    if not isinstance(crop_deltas, list) or not crop_deltas:
+    if not isinstance(crop_deltas, list) or crop_index >= len(crop_deltas):
         return None
-    first = crop_deltas[0]
-    if not isinstance(first, Mapping):
+    crop_delta = crop_deltas[crop_index]
+    if not isinstance(crop_delta, Mapping):
         return None
-    return first.get(key)
+    return crop_delta.get(key)
 
 
 def _has_control_adjusted_movement(variant: Mapping[str, object]) -> bool:
@@ -720,34 +720,73 @@ def _whole_image_lines(
     ]
 
 
-def _first_control_crop_delta(row: Mapping[str, object]) -> Mapping[str, object]:
+def _control_crop_delta(row: Mapping[str, object], *, crop_index: int) -> Mapping[str, object]:
     control_crop_delta = row.get("crop_delta_vs_rerender_control")
-    if not isinstance(control_crop_delta, list) or not control_crop_delta:
+    if not isinstance(control_crop_delta, list) or crop_index >= len(control_crop_delta):
         return {}
-    return _mapping_value(control_crop_delta[0])
+    return _mapping_value(control_crop_delta[crop_index])
 
 
-def _first_crop_row(row: Mapping[str, object]) -> str:
-    first_control_crop_delta = _first_control_crop_delta(row)
+def _crop_box_label(crop_boxes: Sequence[object], *, crop_index: int) -> str:
+    if crop_index >= len(crop_boxes):
+        return ""
+    crop_box = crop_boxes[crop_index]
+    return f"`{crop_box}`"
+
+
+def _crop_movement_row(row: Mapping[str, object], *, crop_index: int, crop_boxes: Sequence[object]) -> str:
+    control_crop_delta = _control_crop_delta(row, crop_index=crop_index)
     return (
-        f"| `{row.get('name')}` | "
-        f"{_format_number(_first_crop_delta(row, 'mean_absolute_channel_delta'))} | "
-        f"{_format_number(_first_crop_delta(row, 'rms_channel_delta'))} | "
-        f"{_format_number(_first_crop_delta(row, 'mean_luminance_delta'))} | "
-        f"{_format_number(first_control_crop_delta.get('mean_absolute_channel_delta'))} | "
-        f"{_format_number(first_control_crop_delta.get('rms_channel_delta'))} |"
+        f"| `{row.get('name')}` | {crop_index + 1} | {_crop_box_label(crop_boxes, crop_index=crop_index)} | "
+        f"{_format_number(_crop_delta(row, crop_index=crop_index, key='mean_absolute_channel_delta'))} | "
+        f"{_format_number(_crop_delta(row, crop_index=crop_index, key='rms_channel_delta'))} | "
+        f"{_format_number(_crop_delta(row, crop_index=crop_index, key='mean_luminance_delta'))} | "
+        f"{_format_number(control_crop_delta.get('mean_absolute_channel_delta'))} | "
+        f"{_format_number(control_crop_delta.get('rms_channel_delta'))} |"
     )
 
 
-def _first_crop_lines(variant_rows: Sequence[Mapping[str, object]]) -> list[str]:
+def _crop_count(variant_rows: Sequence[Mapping[str, object]], crop_boxes: Sequence[object]) -> int:
+    counts = [len(crop_boxes)]
+    for row in variant_rows:
+        crop_deltas = row.get("crop_delta_vs_baseline")
+        if isinstance(crop_deltas, list):
+            counts.append(len(crop_deltas))
+        control_crop_deltas = row.get("crop_delta_vs_rerender_control")
+        if isinstance(control_crop_deltas, list):
+            counts.append(len(control_crop_deltas))
+    return max(counts)
+
+
+def _crop_movement_lines(
+    variant_rows: Sequence[Mapping[str, object]],
+    crop_boxes: Sequence[object] = (),
+) -> list[str]:
+    crop_count = _crop_count(variant_rows, crop_boxes)
+    rows = [
+        _crop_movement_row(row, crop_index=crop_index, crop_boxes=crop_boxes)
+        for crop_index in range(crop_count)
+        for row in variant_rows
+    ]
     return [
         "",
-        "## First crop movement",
+        "## Crop movement",
         "",
-        "| Variant | Mean abs delta vs baseline | RMS delta vs baseline | Luminance delta vs baseline | Mean abs delta vs control | RMS delta vs control |",
-        "| --- | ---: | ---: | ---: | ---: | ---: |",
-        *[_first_crop_row(row) for row in variant_rows],
+        "| Variant | Crop | Box | Mean abs delta vs baseline | RMS delta vs baseline | Luminance delta vs baseline | Mean abs delta vs control | RMS delta vs control |",
+        "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |",
+        *rows,
     ]
+
+
+def _extend_crop_movement_lines(
+    lines: list[str],
+    *,
+    report: Mapping[str, object],
+    variant_rows: Sequence[Mapping[str, object]],
+) -> None:
+    crop_boxes = report.get("crop_boxes")
+    if isinstance(crop_boxes, list) and crop_boxes:
+        lines.extend(_crop_movement_lines(variant_rows, crop_boxes))
 
 
 def _read_lines(
@@ -777,8 +816,7 @@ def render_markdown_summary(report: Mapping[str, object]) -> str:
     baseline_metrics = _mapping_value(_mapping_value(report.get("baseline")).get("metrics"))
     lines = _summary_header_lines(report)
     lines.extend(_whole_image_lines(baseline_metrics=baseline_metrics, variant_rows=variant_rows))
-    if report.get("crop_boxes"):
-        lines.extend(_first_crop_lines(variant_rows))
+    _extend_crop_movement_lines(lines, report=report, variant_rows=variant_rows)
     lines.extend(_read_lines(variant_rows=variant_rows, control_name=report.get("rerender_control_variant")))
     return "\n".join(lines)
 

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -21,7 +21,7 @@ try:
     from .mapbox_outdoors_rendered_layer_mask import (
         RenderedLayerMaskContext as StyleAdjustmentProbeContext,
         RenderedLayerMaskPaths as StyleAdjustmentProbePaths,
-        _first_crop_lines,
+        _extend_crop_movement_lines,
         _format_number,
         _list_of_mappings,
         _manifest_output_path,
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover - direct script execution
     from mapbox_outdoors_rendered_layer_mask import (  # type: ignore[no-redef]
         RenderedLayerMaskContext as StyleAdjustmentProbeContext,
         RenderedLayerMaskPaths as StyleAdjustmentProbePaths,
-        _first_crop_lines,
+        _extend_crop_movement_lines,
         _format_number,
         _list_of_mappings,
         _manifest_output_path,
@@ -860,8 +860,7 @@ def render_markdown_summary(report: Mapping[str, object]) -> str:
     baseline_metrics = _mapping_value(_mapping_value(report.get("baseline")).get("metrics"))
     lines = _summary_header_lines(report)
     lines.extend(_whole_image_lines(baseline_metrics=baseline_metrics, variant_rows=variant_rows))
-    if report.get("crop_boxes"):
-        lines.extend(_first_crop_lines(variant_rows))
+    _extend_crop_movement_lines(lines, report=report, variant_rows=variant_rows)
     lines.extend(_read_lines(variant_rows=variant_rows, control_name=report.get("rerender_control_variant")))
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- replace the probe Markdown "First crop movement" table with a "Crop movement" table that lists every crop box
- include crop index and crop box in both rendered-layer-mask and style-adjustment probe summaries
- add coverage for multi-crop Markdown output in both probe test suites

## Why
The latest #949 Geneva/Switzerland diagnostics use two crop boxes per camera, and the strongest remaining crop is often crop 2. The report JSON already stored all crop deltas, but the Markdown summary only showed crop 1, forcing manual JSON inspection for the target crop.

Self-validation against existing debug artifacts confirmed the new rendered Markdown surfaces crop 2 rows for:
- `debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/20260524T190231Z/style-adjustment-probe.json`
- `debug/mapbox-outdoors-rendered-layer-mask/comparison-camera/20260524T191141Z/summary.json`

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_adjustment_probe.py tests/test_mapbox_outdoors_rendered_layer_mask.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
