### PR TITLE
Flag control-only rendered mask crop improvements

### DIFF
--- a/tests/test_mapbox_outdoors_rendered_layer_mask.py
+++ b/tests/test_mapbox_outdoors_rendered_layer_mask.py
@@ -305,6 +305,20 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
                         "mean_absolute_channel_delta": -0.5,
                         "rms_channel_delta": 0.25,
                     }],
+                },
+                {
+                    "name": "control-only",
+                    "target_layer_ids": ["label-layer"],
+                    "render_changed": False,
+                    "metrics": {},
+                    "crop_delta_vs_baseline": [{
+                        "mean_absolute_channel_delta": 0.0,
+                        "rms_channel_delta": 0.0,
+                    }],
+                    "crop_delta_vs_rerender_control": [{
+                        "mean_absolute_channel_delta": -0.75,
+                        "rms_channel_delta": -0.5,
+                    }],
                 }
             ],
         })
@@ -315,7 +329,13 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
         self.assertIn("Control-adjusted render-moving variants: `moving`.", markdown)
         self.assertIn(
             "Control-adjusted crop-improving variants: `moving` crop 1 "
-            "(mean/RMS -1.000000000/-2.000000000).",
+            "(mean/RMS -1.000000000/-2.000000000), `control-only` crop 1 "
+            "(mean/RMS -0.750000000/-0.500000000).",
+            markdown,
+        )
+        self.assertIn(
+            "Control-only crop-improving variants: `control-only` crop 1 "
+            "(mean/RMS -0.750000000/-0.500000000).",
             markdown,
         )
         self.assertIn(

--- a/validation/mapbox_outdoors_rendered_layer_mask.py
+++ b/validation/mapbox_outdoors_rendered_layer_mask.py
@@ -810,6 +810,12 @@ def _crop_delta_signal(delta: Mapping[str, object]) -> str | None:
     return None
 
 
+def _crop_delta_is_zero(delta: Mapping[str, object]) -> bool:
+    mean_delta = _numeric_metric_value(delta, "mean_absolute_channel_delta")
+    rms_delta = _numeric_metric_value(delta, "rms_channel_delta")
+    return mean_delta == 0 and rms_delta == 0
+
+
 def _crop_signal_label(
     row: Mapping[str, object],
     *,
@@ -843,6 +849,29 @@ def _control_adjusted_crop_signal_labels(
     return labels
 
 
+def _control_only_crop_improvement_labels(
+    variant_rows: Sequence[Mapping[str, object]],
+    *,
+    control_name: object,
+) -> list[str]:
+    labels = []
+    for row in variant_rows:
+        if row.get("name") == control_name:
+            continue
+        baseline_crop_deltas = row.get("crop_delta_vs_baseline")
+        control_crop_deltas = row.get("crop_delta_vs_rerender_control")
+        if not isinstance(baseline_crop_deltas, list) or not isinstance(control_crop_deltas, list):
+            continue
+        for crop_index, delta_value in enumerate(control_crop_deltas):
+            if crop_index >= len(baseline_crop_deltas):
+                continue
+            delta = _mapping_value(delta_value)
+            baseline_delta = _mapping_value(baseline_crop_deltas[crop_index])
+            if _crop_delta_signal(delta) == "improving" and _crop_delta_is_zero(baseline_delta):
+                labels.append(_crop_signal_label(row, crop_index=crop_index, delta=delta))
+    return labels
+
+
 def _format_limited(labels: Sequence[str], *, limit: int = 5) -> str:
     if not labels:
         return "none"
@@ -867,6 +896,10 @@ def _read_lines(
         control_name=control_name,
         signal="improving",
     )
+    control_only_crop_improving = _control_only_crop_improvement_labels(
+        variant_rows,
+        control_name=control_name,
+    )
     crop_worsening = _control_adjusted_crop_signal_labels(
         variant_rows,
         control_name=control_name,
@@ -883,6 +916,7 @@ def _read_lines(
         "",
         f"- Control-adjusted render-moving variants: {', '.join(moving) if moving else 'none'}.",
         f"- Control-adjusted crop-improving variants: {_format_limited(crop_improving)}.",
+        f"- Control-only crop-improving variants: {_format_limited(control_only_crop_improving)}.",
         f"- Control-adjusted crop-worsening variants: {_format_limited(crop_worsening)}.",
         f"- Control-adjusted crop-mixed variants: {_format_limited(crop_mixed)}.",
         "- Use the rerender-control columns to separate style-mask movement from QGIS rerender noise.",


### PR DESCRIPTION
## Summary
- add a `Control-only crop-improving variants` line to rendered-layer mask `Read` sections
- flag apparent crop improvements where the variant stayed at baseline and only the rerender control moved
- cover the false-positive case with a markdown regression fixture

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_rendered_layer_mask.py -q`
- `python3 -m pytest tests/ -x -q --tb=short`
- generated `debug/mapbox-outdoors-rendered-layer-mask/comparison-camera/20260524T205945Z/summary.md` using the local QGIS profile Mapbox token; the new bucket is present and reports `none` for a stable-control Geneva rerun

Refs #949
