### PR TITLE
[codex] Surface style probe render instability

### DIFF
--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -556,9 +556,21 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
             markdown,
         )
         self.assertIn(
+            "Repeated-render unstable whole-image rows: "
+            "`landcover-opacity-70` on `valais-geneva-outdoors` "
+            "(`rerender_control`, 2 runs, mean/RMS range 0.000150000/0.000300000).",
+            markdown,
+        )
+        self.assertIn(
             "Crop rows all-improving: "
             "`water-deeper` on `switzerland-alps-z5-outdoors` crop 1 "
             "(`rerender_control`, 2/2 improving, 0/2 worsening).",
+            markdown,
+        )
+        self.assertIn(
+            "Repeated-render unstable crop rows: "
+            "`water-deeper` on `switzerland-alps-z5-outdoors` crop 1 "
+            "(`rerender_control`, 2 runs, mean/RMS range 0.200000000/0.300000000).",
             markdown,
         )
         self.assertIn("0.000300000", markdown)

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -930,6 +930,30 @@ def _crop_signal_label(row: Mapping[str, object]) -> str:
     )
 
 
+def _has_repeated_render_range(row: Mapping[str, object]) -> bool:
+    if _runs_count(row) < 2:
+        return False
+    mean_range = _numeric_metric_value(row, "mean_delta_range") or 0.0
+    rms_range = _numeric_metric_value(row, "rms_delta_range") or 0.0
+    return mean_range > 0.0 or rms_range > 0.0
+
+
+def _repeat_range_label(row: Mapping[str, object]) -> str:
+    return (
+        f"`{row.get('variant')}` on `{row.get('camera')}` "
+        f"(`{row.get('delta_source')}`, {_runs_count(row)} runs, mean/RMS range "
+        f"{_format_number(row.get('mean_delta_range'))}/{_format_number(row.get('rms_delta_range'))})"
+    )
+
+
+def _crop_repeat_range_label(row: Mapping[str, object]) -> str:
+    return (
+        f"`{row.get('variant')}` on `{row.get('camera')}` crop {row.get('crop')} "
+        f"(`{row.get('delta_source')}`, {_runs_count(row)} runs, mean/RMS range "
+        f"{_format_number(row.get('mean_delta_range'))}/{_format_number(row.get('rms_delta_range'))})"
+    )
+
+
 def _metric_sort_value(row: Mapping[str, object]) -> float:
     mean_delta = _numeric_metric_value(row, "mean_delta_average") or 0.0
     rms_delta = _numeric_metric_value(row, "rms_delta_average") or 0.0
@@ -948,10 +972,22 @@ def _format_limited(labels: Sequence[str], *, limit: int = 5) -> str:
 def _aggregate_read_lines(
     *,
     totals: Sequence[Mapping[str, object]],
+    rows: Sequence[Mapping[str, object]],
     crop_rows: Sequence[Mapping[str, object]],
 ) -> list[str]:
     all_improving_totals = [_variant_signal_label(row) for row in totals if _is_all_improving(row)]
     mixed_totals = [_variant_signal_label(row) for row in totals if _is_mixed_signal(row)]
+    unstable_rows = [
+        _repeat_range_label(row)
+        for row in sorted(
+            (row for row in rows if _has_repeated_render_range(row)),
+            key=lambda row: (
+                str(row.get("variant")),
+                str(row.get("camera")),
+                str(row.get("delta_source")),
+            ),
+        )
+    ]
     all_improving_crops = [
         _crop_signal_label(row)
         for row in sorted(
@@ -960,14 +996,28 @@ def _aggregate_read_lines(
         )
     ]
     mixed_crops = [_crop_signal_label(row) for row in crop_rows if _is_mixed_signal(row)]
+    unstable_crops = [
+        _crop_repeat_range_label(row)
+        for row in sorted(
+            (row for row in crop_rows if _has_repeated_render_range(row)),
+            key=lambda row: (
+                str(row.get("variant")),
+                str(row.get("camera")),
+                _count_value(row, "crop"),
+                str(row.get("delta_source")),
+            ),
+        )
+    ]
     return [
         "",
         "## Read",
         "",
         f"- Whole-image all-improving variants: {_format_limited(all_improving_totals)}.",
         f"- Whole-image mixed-signal variants: {_format_limited(mixed_totals)}.",
+        f"- Repeated-render unstable whole-image rows: {_format_limited(unstable_rows)}.",
         f"- Crop rows all-improving: {_format_limited(all_improving_crops)}.",
         f"- Crop rows mixed-signal: {_format_limited(mixed_crops)}.",
+        f"- Repeated-render unstable crop rows: {_format_limited(unstable_crops)}.",
         "- Treat crop-only wins as diagnostic leads; promote a style change only after camera-matrix validation avoids regressions.",
     ]
 
@@ -1010,7 +1060,7 @@ def render_aggregate_markdown_summary(report: Mapping[str, object]) -> str:
         lines.extend(_aggregate_crop_row(row) for row in crop_rows)
     else:
         lines.append("| _none_ |  |  | 0 |  | 0 |  |  |  |  |  | 0 | 0 | 0 |")
-    lines.extend(_aggregate_read_lines(totals=totals, crop_rows=crop_rows))
+    lines.extend(_aggregate_read_lines(totals=totals, rows=rows, crop_rows=crop_rows))
     lines.extend([
         "",
         "## Key",


### PR DESCRIPTION
## Summary
- add repeated-render unstable whole-image rows to style-adjustment aggregate readouts
- add repeated-render unstable crop rows to the same read section
- cover both new readout bullets in the aggregate Markdown fixture

## Why
For #949, the latest aeroway opacity probe had to be rejected because repeated runs moved enough to undermine the first pairwise signal. The aggregate tables already carried mean/RMS ranges, but the `## Read` section did not call out repeated-render instability directly.

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_style_adjustment_probe.py -q --tb=short`
- `python3 validation/mapbox_outdoors_style_adjustment_probe.py --aggregate-report debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/20260525T082654Z/style-adjustment-probe.json --aggregate-report debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/20260525T082714Z/style-adjustment-probe.json --aggregate-report debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/20260525T082852Z/style-adjustment-probe.json --aggregate-report debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/20260525T082858Z/style-adjustment-probe.json --aggregate-output debug/mapbox-outdoors-style-adjustment-probe/comparison-camera/aeroway-polygon-opacity-50-geneva-chamonix-reruns-20260525T0830-aggregate-with-instability.md`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`