### PR TITLE
[codex] Add QGIS runtime metadata to comparisons

### DIFF
--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -43,9 +43,11 @@ from qfit.validation.mapbox_outdoors_comparison import (
     _append_qgis_contour_bbox_edge_difference_source_style_label_probe,
     _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe,
     _append_qgis_contour_boundary_generator_label_probe,
+    _append_enabled_qgis_contour_label_probes,
     _append_qgis_contour_polygon_label_probe,
     _label_setting_value,
     _label_value,
+    _load_optional_qgis_runtime_snapshot,
     build_all_cameras_contact_sheet,
     build_comparison_paths,
     build_image_diff,
@@ -59,6 +61,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     is_valid_qgis_vector_tile_layer,
     list_cameras,
     load_style_definition,
+    qgis_runtime_snapshot,
     qgis_label_styles_snapshot,
     redact_sensitive_text,
     render_browser_reference,
@@ -66,6 +69,8 @@ from qfit.validation.mapbox_outdoors_comparison import (
     resolve_mapbox_token,
     run_comparison,
     write_qgis_label_styles_snapshot,
+    write_qgis_core_runtime_snapshot,
+    write_qgis_runtime_snapshot,
 )
 
 
@@ -131,7 +136,115 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(paths.metrics_json, Path("/tmp/run/metrics.json"))
         self.assertEqual(paths.qgis_preprocessed_style_json, Path("/tmp/run/qgis-preprocessed-style.json"))
         self.assertEqual(paths.qgis_label_styles_json, Path("/tmp/run/qgis-label-styles.json"))
+        self.assertEqual(paths.qgis_runtime_json, Path("/tmp/run/qgis-runtime.json"))
         self.assertEqual(paths.manifest_json, Path("/tmp/run/manifest.json"))
+
+    def test_qgis_runtime_snapshot_records_version_metadata(self):
+        fake_qgis = types.SimpleNamespace(
+            QGIS_VERSION="3.44.0-Solothurn",
+            QGIS_VERSION_INT=34400,
+            QGIS_RELEASE_NAME="Solothurn",
+        )
+
+        self.assertEqual(
+            qgis_runtime_snapshot(fake_qgis),
+            {
+                "qgis_version": "3.44.0-Solothurn",
+                "qgis_version_int": 34400,
+                "qgis_release_name": "Solothurn",
+            },
+        )
+
+    def test_write_qgis_runtime_snapshot_writes_json_and_allows_noop(self):
+        fake_qgis = types.SimpleNamespace(QGIS_VERSION="3.44.0-Solothurn")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "qgis-runtime.json"
+
+            write_qgis_runtime_snapshot(qgis_api=fake_qgis, output_path=output_path)
+            write_qgis_runtime_snapshot(qgis_api=fake_qgis, output_path=None)
+
+            runtime = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(runtime["qgis_version"], "3.44.0-Solothurn")
+        self.assertIsNone(runtime["qgis_version_int"])
+
+    def test_write_qgis_core_runtime_snapshot_uses_loaded_qgis_module(self):
+        fake_qgis = types.SimpleNamespace(
+            QGIS_VERSION="3.44.0-Solothurn",
+            QGIS_VERSION_INT=34400,
+            QGIS_RELEASE_NAME="Solothurn",
+        )
+        fake_core = types.SimpleNamespace(Qgis=fake_qgis)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "qgis-runtime.json"
+            with patch.dict(sys.modules, {"qgis.core": fake_core}):
+                write_qgis_core_runtime_snapshot(output_path=output_path)
+            runtime = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(runtime["qgis_release_name"], "Solothurn")
+
+    def test_write_qgis_core_runtime_snapshot_ignores_write_failures(self):
+        fake_qgis = types.SimpleNamespace(QGIS_VERSION="3.44.0-Solothurn")
+        fake_core = types.SimpleNamespace(Qgis=fake_qgis)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(sys.modules, {"qgis.core": fake_core}), patch("sys.stderr") as stderr_mock:
+                write_qgis_core_runtime_snapshot(output_path=Path(tmpdir))
+
+        stderr_text = "".join(call.args[0] for call in stderr_mock.write.call_args_list)
+        self.assertIn("QGIS runtime metadata was not written", stderr_text)
+
+    def test_load_optional_qgis_runtime_snapshot_ignores_invalid_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            valid_path = root / "valid.json"
+            invalid_path = root / "invalid.json"
+            non_object_path = root / "non-object.json"
+            missing_path = root / "missing.json"
+            valid_path.write_text(json.dumps({"qgis_version": "3.44.0-Solothurn"}), encoding="utf-8")
+            invalid_path.write_text("{", encoding="utf-8")
+            non_object_path.write_text("[]", encoding="utf-8")
+
+            self.assertEqual(
+                _load_optional_qgis_runtime_snapshot(valid_path),
+                {"qgis_version": "3.44.0-Solothurn"},
+            )
+            self.assertEqual(_load_optional_qgis_runtime_snapshot(invalid_path), {})
+            self.assertEqual(_load_optional_qgis_runtime_snapshot(non_object_path), {})
+            self.assertEqual(_load_optional_qgis_runtime_snapshot(missing_path), {})
+
+    def test_append_enabled_qgis_contour_label_probes_routes_flags(self):
+        layer = object()
+
+        with patch(
+            "qfit.validation.mapbox_outdoors_comparison._append_qgis_contour_polygon_label_probe"
+        ) as polygon_probe, patch(
+            "qfit.validation.mapbox_outdoors_comparison._append_qgis_contour_boundary_generator_label_probe"
+        ) as boundary_probe, patch(
+            "qfit.validation.mapbox_outdoors_comparison._append_qgis_contour_bbox_edge_difference_label_probe"
+        ) as bbox_probe, patch(
+            "qfit.validation.mapbox_outdoors_comparison."
+            "_append_qgis_contour_bbox_edge_difference_source_style_label_probe"
+        ) as source_probe, patch(
+            "qfit.validation.mapbox_outdoors_comparison."
+            "_append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe"
+        ) as high_zoom_probe:
+            _append_enabled_qgis_contour_label_probes(
+                layer,
+                qgis_contour_polygon_label_probe=True,
+                qgis_contour_boundary_generator_label_probe=False,
+                qgis_contour_bbox_edge_difference_label_probe=True,
+                qgis_contour_bbox_edge_difference_source_style_label_probe=False,
+                qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=True,
+            )
+
+        polygon_probe.assert_called_once_with(layer)
+        boundary_probe.assert_not_called()
+        bbox_probe.assert_called_once_with(layer)
+        source_probe.assert_not_called()
+        high_zoom_probe.assert_called_once_with(layer)
 
     def test_resolve_token_prefers_argument_then_environment(self):
         self.assertEqual(
@@ -1334,10 +1447,27 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         def fake_browser_renderer(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
 
-        def fake_qgis_renderer(*, output_path, qgis_preprocessed_style_path, qgis_label_styles_path, **_kwargs):
+        def fake_qgis_renderer(
+            *,
+            output_path,
+            qgis_preprocessed_style_path,
+            qgis_label_styles_path,
+            qgis_runtime_path,
+            **_kwargs,
+        ):
             output_path.write_bytes(PNG_PLACEHOLDER)
             qgis_preprocessed_style_path.write_text(json.dumps(SAMPLE_STYLE), encoding="utf-8")
             qgis_label_styles_path.write_text(json.dumps([{"style_name": "contour-label"}]), encoding="utf-8")
+            qgis_runtime_path.write_text(
+                json.dumps(
+                    {
+                        "qgis_version": "3.44.0-Solothurn",
+                        "qgis_version_int": 34400,
+                        "qgis_release_name": "Solothurn",
+                    }
+                ),
+                encoding="utf-8",
+            )
 
         def fake_diff_builder(*, output_path, **_kwargs):
             output_path.write_bytes(PNG_PLACEHOLDER)
@@ -1361,12 +1491,14 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
             metrics = json.loads(result.paths.metrics_json.read_text(encoding="utf-8"))
             preprocessed_style = json.loads(result.paths.qgis_preprocessed_style_json.read_text(encoding="utf-8"))
             label_styles = json.loads(result.paths.qgis_label_styles_json.read_text(encoding="utf-8"))
+            qgis_runtime = json.loads(result.paths.qgis_runtime_json.read_text(encoding="utf-8"))
 
         self.assertTrue(result.browser_captured)
         self.assertTrue(result.qgis_captured)
         self.assertTrue(result.diff_captured)
         self.assertTrue(result.qgis_preprocessed_style_captured)
         self.assertTrue(result.qgis_label_styles_captured)
+        self.assertTrue(result.qgis_runtime_captured)
         self.assertNotIn("test-mapbox-token", manifest_text)
         self.assertEqual(manifest["camera"]["name"], "valais-geneva-outdoors")
         self.assertEqual(manifest["style_url"], "mapbox://styles/mapbox/outdoors-v12")
@@ -1375,12 +1507,16 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(manifest["captured"]["diff"])
         self.assertTrue(manifest["captured"]["qgis_preprocessed_style"])
         self.assertTrue(manifest["captured"]["qgis_label_styles"])
+        self.assertTrue(manifest["captured"]["qgis_runtime"])
         self.assertTrue(manifest["outputs"]["qgis_preprocessed_style"].endswith("qgis-preprocessed-style.json"))
         self.assertTrue(manifest["outputs"]["qgis_label_styles"].endswith("qgis-label-styles.json"))
+        self.assertTrue(manifest["outputs"]["qgis_runtime"].endswith("qgis-runtime.json"))
         self.assertEqual(manifest["metrics"]["changed_pixel_ratio"], 0.25)
+        self.assertEqual(manifest["qgis_runtime"]["qgis_version"], "3.44.0-Solothurn")
         self.assertEqual(metrics["changed_pixel_ratio"], 0.25)
         self.assertEqual(preprocessed_style, SAMPLE_STYLE)
         self.assertEqual(label_styles, [{"style_name": "contour-label"}])
+        self.assertEqual(qgis_runtime["qgis_version_int"], 34400)
 
     def test_run_comparison_records_qgis_contour_label_probe_options(self):
         captured = {}
@@ -1664,7 +1800,12 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                                 "normalized_mean_absolute_channel_delta": 0.01 + camera_index / 100,
                                 "normalized_rms_channel_delta": 0.02 + camera_index / 100,
                                 "ssim_status": "unavailable",
-                            }
+                            },
+                            "qgis_runtime": {
+                                "qgis_version": "3.44.0-Solothurn",
+                                "qgis_version_int": 34400,
+                                "qgis_release_name": "Solothurn",
+                            },
                         }
                     ),
                     encoding="utf-8",
@@ -1712,6 +1853,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(summary["counts"], {"passed": len(CAMERAS), "failed": 0, "timeout": 0})
         self.assertEqual([entry["camera"] for entry in summary["cameras"]], list(CAMERAS))
         self.assertEqual(summary["cameras"][0]["artifact_status"], "metrics_available")
+        self.assertEqual(summary["cameras"][0]["qgis_runtime"]["qgis_version"], "3.44.0-Solothurn")
         self.assertEqual(summary["cameras"][0]["metrics"]["changed_pixel_ratio"], 0.1)
         self.assertTrue(summary["cameras"][0]["outputs"]["browser_reference"].endswith("mapbox-gl-reference.png"))
         self.assertTrue(summary["cameras"][0]["outputs"]["qgis_vector_render"].endswith("qgis-vector-render.png"))
@@ -1719,7 +1861,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertTrue(summary["contact_sheet"].endswith("contact-sheet.jpg"))
         self.assertIn("test-mapbox-token", contact_sheet_calls[0][0]["outputs"]["browser_reference"])
         self.assertIn(
-            "| `switzerland-alps-z5-outdoors` | passed | `metrics_available` | 5.35 | 0.1000 |",
+            "| `switzerland-alps-z5-outdoors` | passed | `metrics_available` | 3.44.0-Solothurn | 5.35 | 0.1000 |",
             summary_text,
         )
         self.assertIn("## Image artifacts", summary_text)
@@ -1794,6 +1936,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
                         "outputs": {"diff": str(diff_path), "browser_reference": str(tmp_path / "missing.png")},
                         "captured": {"diff": True, "browser_reference": False},
                         "metrics": {},
+                        "qgis_runtime": {"qgis_version": "3.44.0-Solothurn"},
                     }
                 ),
                 encoding="utf-8",
@@ -1815,6 +1958,7 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
         self.assertEqual(metricless_status, "metrics_unavailable")
         self.assertEqual(metricless_metrics, {})
         self.assertEqual(metricless_full[2], {"diff": str(diff_path)})
+        self.assertEqual(metricless_full[3], {"qgis_version": "3.44.0-Solothurn"})
 
     def test_main_rejects_single_camera_with_all_cameras(self):
         from qfit.validation import mapbox_outdoors_comparison

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -216,6 +216,7 @@ class ComparisonPaths:
     metrics_json: Path
     qgis_preprocessed_style_json: Path
     qgis_label_styles_json: Path
+    qgis_runtime_json: Path
     manifest_json: Path
 
 
@@ -245,12 +246,14 @@ class ComparisonResult:
     diff_captured: bool
     qgis_preprocessed_style_captured: bool = False
     qgis_label_styles_captured: bool = False
+    qgis_runtime_captured: bool = False
     qgis_contour_polygon_label_probe: bool = False
     qgis_contour_boundary_generator_label_probe: bool = False
     qgis_contour_bbox_edge_difference_label_probe: bool = False
     qgis_contour_bbox_edge_difference_source_style_label_probe: bool = False
     qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe: bool = False
     image_metrics: dict[str, object] = dataclasses.field(default_factory=dict)
+    qgis_runtime: dict[str, object] = dataclasses.field(default_factory=dict)
     style_json_path: str | None = None
 
 
@@ -276,6 +279,7 @@ def build_comparison_paths(*, run_dir: Path) -> ComparisonPaths:
         metrics_json=run_dir / "metrics.json",
         qgis_preprocessed_style_json=run_dir / "qgis-preprocessed-style.json",
         qgis_label_styles_json=run_dir / "qgis-label-styles.json",
+        qgis_runtime_json=run_dir / "qgis-runtime.json",
         manifest_json=run_dir / "manifest.json",
     )
 
@@ -352,6 +356,7 @@ def _redacted_manifest(
             "metrics": str(result.paths.metrics_json),
             "qgis_preprocessed_style": str(result.paths.qgis_preprocessed_style_json),
             "qgis_label_styles": str(result.paths.qgis_label_styles_json),
+            "qgis_runtime": str(result.paths.qgis_runtime_json),
         },
         "style_json_path": result.style_json_path,
         "qgis_contour_polygon_label_probe": result.qgis_contour_polygon_label_probe,
@@ -373,11 +378,14 @@ def _redacted_manifest(
             "diff": result.diff_captured,
             "qgis_preprocessed_style": result.qgis_preprocessed_style_captured,
             "qgis_label_styles": result.qgis_label_styles_captured,
+            "qgis_runtime": result.qgis_runtime_captured,
         },
         "metrics": result.image_metrics,
+        "qgis_runtime": result.qgis_runtime,
         "notes": [
             "Mapbox tokens are intentionally excluded from this manifest.",
             "This is a manual visual QA aid, not a CI gate.",
+            "QGIS runtime metadata helps compare version-sensitive Mapbox GL style conversion output.",
         ],
     }
 
@@ -704,6 +712,42 @@ def write_qgis_label_styles_snapshot(*, layer: object, output_path: Path, token:
     output_path.write_text(redact_sensitive_text(snapshot_text, token) + "\n", encoding="utf-8")
 
 
+def qgis_runtime_snapshot(qgis_api: object) -> dict[str, object]:
+    """Return token-free QGIS runtime metadata for version-sensitive render probes."""
+
+    return {
+        "qgis_version": getattr(qgis_api, "QGIS_VERSION", None),
+        "qgis_version_int": getattr(qgis_api, "QGIS_VERSION_INT", None),
+        "qgis_release_name": getattr(qgis_api, "QGIS_RELEASE_NAME", None),
+    }
+
+
+def write_qgis_runtime_snapshot(*, qgis_api: object, output_path: Path | None) -> None:
+    if output_path is None:
+        return
+    output_path.write_text(
+        json.dumps(qgis_runtime_snapshot(qgis_api), indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_qgis_core_runtime_snapshot(*, output_path: Path | None) -> None:
+    qgis_core_module = sys.modules.get("qgis.core")
+    qgis_api = getattr(qgis_core_module, "Qgis", qgis_core_module)
+    try:
+        write_qgis_runtime_snapshot(qgis_api=qgis_api, output_path=output_path)
+    except OSError as exc:
+        print(f"warning: QGIS runtime metadata was not written: {exc}", file=sys.stderr)
+
+
+def _load_optional_qgis_runtime_snapshot(path: Path) -> dict[str, object]:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
 def _append_qgis_contour_polygon_label_probe(layer: object) -> None:
     from qgis.core import (  # type: ignore[import-not-found] # noqa: PLC0415
         QgsPalLayerSettings,
@@ -841,6 +885,27 @@ def _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
     )
 
 
+def _append_enabled_qgis_contour_label_probes(
+    layer: object,
+    *,
+    qgis_contour_polygon_label_probe: bool,
+    qgis_contour_boundary_generator_label_probe: bool,
+    qgis_contour_bbox_edge_difference_label_probe: bool,
+    qgis_contour_bbox_edge_difference_source_style_label_probe: bool,
+    qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe: bool,
+) -> None:
+    if qgis_contour_polygon_label_probe:
+        _append_qgis_contour_polygon_label_probe(layer)
+    if qgis_contour_boundary_generator_label_probe:
+        _append_qgis_contour_boundary_generator_label_probe(layer)
+    if qgis_contour_bbox_edge_difference_label_probe:
+        _append_qgis_contour_bbox_edge_difference_label_probe(layer)
+    if qgis_contour_bbox_edge_difference_source_style_label_probe:
+        _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
+    if qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe:
+        _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe(layer)
+
+
 def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     *,
     camera: MapboxComparisonCamera,
@@ -849,6 +914,7 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
     style_definition: dict[str, object] | None = None,
     qgis_preprocessed_style_path: Path | None = None,
     qgis_label_styles_path: Path | None = None,
+    qgis_runtime_path: Path | None = None,
     qgis_contour_polygon_label_probe: bool = False,
     qgis_contour_boundary_generator_label_probe: bool = False,
     qgis_contour_bbox_edge_difference_label_probe: bool = False,
@@ -891,6 +957,8 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
         app.initQgis()
 
     try:
+        write_qgis_core_runtime_snapshot(output_path=qgis_runtime_path)
+
         resolved_style_definition = (
             style_definition
             if style_definition is not None
@@ -924,16 +992,18 @@ def render_qgis_vector(  # pragma: no cover - depends on optional PyQGIS runtime
         if not is_valid_qgis_vector_tile_layer(layer=layer, vector_tile_layer_type=QgsVectorTileLayer):
             raise RuntimeError("QGIS did not create a valid Mapbox vector tile layer.")
         BackgroundMapService()._apply_mapbox_gl_style(layer, simplified_style, sprite_resources=sprite_resources)
-        if qgis_contour_polygon_label_probe:
-            _append_qgis_contour_polygon_label_probe(layer)
-        if qgis_contour_boundary_generator_label_probe:
-            _append_qgis_contour_boundary_generator_label_probe(layer)
-        if qgis_contour_bbox_edge_difference_label_probe:
-            _append_qgis_contour_bbox_edge_difference_label_probe(layer)
-        if qgis_contour_bbox_edge_difference_source_style_label_probe:
-            _append_qgis_contour_bbox_edge_difference_source_style_label_probe(layer)
-        if qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe:
-            _append_qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe(layer)
+        _append_enabled_qgis_contour_label_probes(
+            layer,
+            qgis_contour_polygon_label_probe=qgis_contour_polygon_label_probe,
+            qgis_contour_boundary_generator_label_probe=qgis_contour_boundary_generator_label_probe,
+            qgis_contour_bbox_edge_difference_label_probe=qgis_contour_bbox_edge_difference_label_probe,
+            qgis_contour_bbox_edge_difference_source_style_label_probe=(
+                qgis_contour_bbox_edge_difference_source_style_label_probe
+            ),
+            qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe=(
+                qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
+            ),
+        )
         if qgis_label_styles_path is not None:
             write_qgis_label_styles_snapshot(layer=layer, output_path=qgis_label_styles_path, token=token)
 
@@ -1032,7 +1102,9 @@ def run_comparison(
     diff_captured = False
     qgis_preprocessed_style_captured = False
     qgis_label_styles_captured = False
+    qgis_runtime_captured = False
     image_metrics: ImageMetrics = {}
+    qgis_runtime: dict[str, object] = {}
     style_definition = (
         load_style_definition(config.style_json_path)
         if config.style_json_path is not None
@@ -1057,6 +1129,7 @@ def run_comparison(
             style_definition=style_definition,
             qgis_preprocessed_style_path=paths.qgis_preprocessed_style_json,
             qgis_label_styles_path=paths.qgis_label_styles_json,
+            qgis_runtime_path=paths.qgis_runtime_json,
             qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
             qgis_contour_boundary_generator_label_probe=(
                 config.qgis_contour_boundary_generator_label_probe
@@ -1074,6 +1147,9 @@ def run_comparison(
         qgis_captured = True
         qgis_preprocessed_style_captured = paths.qgis_preprocessed_style_json.exists()
         qgis_label_styles_captured = paths.qgis_label_styles_json.exists()
+        qgis_runtime_captured = paths.qgis_runtime_json.exists()
+        if qgis_runtime_captured:
+            qgis_runtime = _load_optional_qgis_runtime_snapshot(paths.qgis_runtime_json)
 
     if config.diff and browser_captured and qgis_captured:
         image_metrics = diff_builder(
@@ -1091,6 +1167,7 @@ def run_comparison(
         diff_captured=diff_captured,
         qgis_preprocessed_style_captured=qgis_preprocessed_style_captured,
         qgis_label_styles_captured=qgis_label_styles_captured,
+        qgis_runtime_captured=qgis_runtime_captured,
         qgis_contour_polygon_label_probe=config.qgis_contour_polygon_label_probe,
         qgis_contour_boundary_generator_label_probe=(
             config.qgis_contour_boundary_generator_label_probe
@@ -1105,6 +1182,7 @@ def run_comparison(
             config.qgis_contour_bbox_edge_difference_source_style_high_zoom_label_probe
         ),
         image_metrics=image_metrics,
+        qgis_runtime=qgis_runtime,
         style_json_path=str(config.style_json_path) if config.style_json_path is not None else None,
     )
     write_manifest(camera=config.camera, result=result)
@@ -1386,29 +1464,31 @@ def _manifest_artifact_status_metrics_and_outputs(
     *,
     token: str,
     redact_outputs: bool = True,
-) -> tuple[str, dict[str, object], dict[str, str]]:
+) -> tuple[str, dict[str, object], dict[str, str], dict[str, object]]:
     if manifest_path is None:
-        return MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING, {}, {}
+        return MANIFEST_ARTIFACT_STATUS_MANIFEST_MISSING, {}, {}, {}
     try:
         loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE, {}, {}
+        return MANIFEST_ARTIFACT_STATUS_MANIFEST_UNREADABLE, {}, {}, {}
     metrics = loaded.get("metrics") if isinstance(loaded, dict) else None
     outputs = (
         _manifest_visual_outputs(loaded, token=token, redact_outputs=redact_outputs)
         if isinstance(loaded, dict)
         else {}
     )
+    runtime = loaded.get("qgis_runtime") if isinstance(loaded, dict) else None
+    qgis_runtime = runtime if isinstance(runtime, dict) else {}
     if not isinstance(metrics, dict):
-        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}, outputs
+        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}, outputs, qgis_runtime
     metric_summary = {key: metrics[key] for key in MATRIX_SUMMARY_METRIC_KEYS if key in metrics}
     if not metric_summary:
-        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}, outputs
-    return MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE, metric_summary, outputs
+        return MANIFEST_ARTIFACT_STATUS_METRICS_UNAVAILABLE, {}, outputs, qgis_runtime
+    return MANIFEST_ARTIFACT_STATUS_METRICS_AVAILABLE, metric_summary, outputs, qgis_runtime
 
 
 def _manifest_artifact_status_and_metrics(manifest_path: Path | None) -> tuple[str, dict[str, object]]:
-    status, metrics, _outputs = _manifest_artifact_status_metrics_and_outputs(manifest_path, token="")
+    status, metrics, _outputs, _qgis_runtime = _manifest_artifact_status_metrics_and_outputs(manifest_path, token="")
     return status, metrics
 
 
@@ -1421,7 +1501,10 @@ def _all_camera_summary_entry(
     manifest_path: Path | None,
     token: str,
 ) -> dict[str, object]:
-    artifact_status, metrics, outputs = _manifest_artifact_status_metrics_and_outputs(manifest_path, token=token)
+    artifact_status, metrics, outputs, qgis_runtime = _manifest_artifact_status_metrics_and_outputs(
+        manifest_path,
+        token=token,
+    )
     return {
         "camera": camera.name,
         "description": camera.description,
@@ -1433,6 +1516,7 @@ def _all_camera_summary_entry(
         "manifest": redact_sensitive_text(str(manifest_path), token) if manifest_path is not None else None,
         "metrics": metrics,
         "outputs": outputs,
+        "qgis_runtime": qgis_runtime,
     }
 
 
@@ -1441,7 +1525,7 @@ def _all_camera_contact_sheet_entry(
     camera: MapboxComparisonCamera,
     manifest_path: Path | None,
 ) -> dict[str, object]:
-    _artifact_status, _metrics, outputs = _manifest_artifact_status_metrics_and_outputs(
+    _artifact_status, _metrics, outputs, _qgis_runtime = _manifest_artifact_status_metrics_and_outputs(
         manifest_path,
         token="",
         redact_outputs=False,
@@ -1459,6 +1543,16 @@ def _format_summary_metric(metrics: dict[str, object], key: str) -> str:
     if isinstance(value, float):
         return f"{value:.4f}"
     return str(value)
+
+
+def _format_qgis_runtime(value: object) -> str:
+    if not isinstance(value, dict):
+        return "—"
+    qgis_version = value.get("qgis_version")
+    if qgis_version:
+        return str(qgis_version)
+    qgis_version_int = value.get("qgis_version_int")
+    return str(qgis_version_int) if qgis_version_int else "—"
 
 
 def _artifact_markdown_path(path_text: object, *, base_dir: Path | None) -> str:
@@ -1665,8 +1759,8 @@ def _all_cameras_summary_markdown(summary: dict[str, object]) -> str:
         "",
         f"Generated: `{summary['generated_at']}`",
         "",
-        "| Camera | Status | Artifacts | z | Changed ratio | Mean Δ | RMS Δ | SSIM | Manifest |",
-        "| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |",
+        "| Camera | Status | Artifacts | QGIS | z | Changed ratio | Mean Δ | RMS Δ | SSIM | Manifest |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |",
     ]
     for entry in summary["cameras"]:
         metrics = entry["metrics"] if isinstance(entry.get("metrics"), dict) else {}
@@ -1677,6 +1771,7 @@ def _all_cameras_summary_markdown(summary: dict[str, object]) -> str:
             f"`{entry['camera']}` | "
             f"{entry['status']} | "
             f"`{artifact_status}` | "
+            f"{_format_qgis_runtime(entry.get('qgis_runtime'))} | "
             f"{entry['zoom']:g} | "
             f"{_format_summary_metric(metrics, 'changed_pixel_ratio')} | "
             f"{_format_summary_metric(metrics, 'normalized_mean_absolute_channel_delta')} | "


### PR DESCRIPTION
## Summary

- add a `qgis-runtime.json` artifact to Mapbox Outdoors comparison runs
- include QGIS version metadata in comparison manifests and all-camera summaries
- keep the change diagnostic-only so rendered output and style preprocessing behavior are unchanged

## Why

Issue #949 parity work depends on QGIS' Mapbox GL style conversion behavior, and that behavior is version-sensitive. Recording the local QGIS runtime with each comparison makes visual evidence easier to compare across machines and future QGIS upgrades.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short`
- `git diff --check origin/main...HEAD`
- `python3 -m pytest tests/ -x -q --tb=short`
- live QGIS-only capture using the local QGIS profile Mapbox token source without printing it: `python3 validation/mapbox_outdoors_comparison.py chamonix-trails-z14-outdoors --skip-browser --skip-diff`
  - artifact: `debug/mapbox-outdoors-comparison/chamonix-trails-z14-outdoors/20260525T090618Z/manifest.json`
  - verified `qgis_runtime` metadata was captured with QGIS version keys