### PR TITLE
[codex] Track QGIS runtime in style-adjustment probes

### DIFF
--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -71,6 +71,9 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         self.assertEqual(adjustment.layout["line-cap"], "round")
         self.assertEqual(adjustment.minzoom, 16.0)
 
+    def test_format_qgis_runtime_keeps_zero_version_int(self):
+        self.assertEqual(probe_module._format_qgis_runtime({"qgis_version_int": 0}), "0")
+
     def test_load_style_adjustment_variants_rejects_empty_adjustments(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "variants.json"
@@ -150,6 +153,11 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                         "normalized_mean_absolute_channel_delta": 0.10,
                         "normalized_rms_channel_delta": 0.20,
                         "changed_pixel_ratio": 0.30,
+                    },
+                    "qgis_runtime": {
+                        "qgis_version": "3.44.0-Solothurn",
+                        "qgis_version_int": 34400,
+                        "qgis_release_name": "Solothurn",
                     },
                 }),
                 encoding="utf-8",
@@ -232,6 +240,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
             control = report["variants"][0]
             variant = report["variants"][1]
             self.assertEqual(report["generated"], "2026-05-24T14:30:00+00:00")
+            self.assertEqual(report["qgis_runtime"]["qgis_version"], "3.44.0-Solothurn")
             self.assertTrue(control["is_rerender_control"])
             self.assertFalse(variant["is_rerender_control"])
             self.assertEqual(variant["matched_layer_ids"], ["contour-minor"])
@@ -256,12 +265,15 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                 / "summary.md"
             )
             self.assertTrue(summary_path.exists())
-            self.assertIn("style-adjustment probe", summary_path.read_text(encoding="utf-8"))
+            summary_text = summary_path.read_text(encoding="utf-8")
+            self.assertIn("style-adjustment probe", summary_text)
+            self.assertIn("QGIS runtime: `3.44.0-Solothurn`", summary_text)
 
     def test_markdown_summary_lists_improving_variants(self):
         markdown = render_markdown_summary({
             "generated": "2026-05-24T14:30:00+00:00",
             "camera": {"name": "unit-camera"},
+            "qgis_runtime": {"qgis_version": "3.44.0-Solothurn"},
             "inputs": {"baseline_manifest": "debug/manifest.json"},
             "baseline": {"metrics": {"normalized_mean_absolute_channel_delta": 0.1}},
             "crop_boxes": [[0, 0, 1, 1], [1, 1, 2, 2]],
@@ -305,6 +317,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         })
 
         self.assertIn("## Crop movement", markdown)
+        self.assertIn("QGIS runtime: `3.44.0-Solothurn`", markdown)
         self.assertIn(
             "| `contour-strong` | 2 | `[1, 1, 2, 2]` | 4.000000000 | 5.000000000 | "
             "6.000000000 | 4.500000000 | 5.500000000 |",
@@ -319,9 +332,12 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
             first_report = root / "first-style-adjustment-probe.json"
             second_report = root / "second-style-adjustment-probe.json"
             third_report = root / "third-style-adjustment-probe.json"
+            legacy_report = root / "legacy-style-adjustment-probe.json"
+            unrecognized_runtime_report = root / "unrecognized-runtime-style-adjustment-probe.json"
             first_report.write_text(
                 json.dumps({
                     "camera": {"name": "valais-geneva-outdoors"},
+                    "qgis_runtime": {"qgis_version": "3.44.0-Solothurn"},
                     "rerender_control_variant": "qgis-rerender-control",
                     "crop_boxes": [[0, 0, 1, 1], [1, 1, 2, 2]],
                     "variants": [
@@ -353,6 +369,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
             second_report.write_text(
                 json.dumps({
                     "camera": {"name": "valais-geneva-outdoors"},
+                    "qgis_runtime": {"qgis_version": "3.44.0-Solothurn"},
                     "rerender_control_variant": "qgis-rerender-control",
                     "crop_boxes": [[0, 0, 1, 1], [1, 1, 2, 2]],
                     "variants": [
@@ -378,6 +395,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
             third_report.write_text(
                 json.dumps({
                     "camera": {"name": "geneva-airport-motorway-z14-outdoors"},
+                    "qgis_runtime": {"qgis_version_int": 33404},
                     "variants": [
                         {
                             "name": "landcover-opacity-70",
@@ -393,9 +411,30 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                 }),
                 encoding="utf-8",
             )
+            legacy_report.write_text(
+                json.dumps({
+                    "camera": {"name": "legacy-camera"},
+                    "variants": [],
+                }),
+                encoding="utf-8",
+            )
+            unrecognized_runtime_report.write_text(
+                json.dumps({
+                    "camera": {"name": "future-camera"},
+                    "qgis_runtime": {"qgis_release_name": "Future"},
+                    "variants": [],
+                }),
+                encoding="utf-8",
+            )
 
             aggregate = build_style_adjustment_aggregate_report(
-                (first_report, second_report, third_report),
+                (
+                    first_report,
+                    second_report,
+                    third_report,
+                    legacy_report,
+                    unrecognized_runtime_report,
+                ),
                 now=dt.datetime(2026, 5, 24, 15, 0, tzinfo=dt.timezone.utc),
             )
 
@@ -405,6 +444,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         }
         valais_row = rows[("landcover-opacity-70", "valais-geneva-outdoors", "rerender_control")]
         self.assertEqual(aggregate["generated"], "2026-05-24T15:00:00+00:00")
+        self.assertEqual(aggregate["qgis_runtimes"], ["(not captured)", "3.44.0-Solothurn", "33404"])
         self.assertEqual(valais_row["runs"], 2)
         self.assertEqual(valais_row["improving_runs"], 1)
         self.assertEqual(valais_row["worsening_runs"], 1)
@@ -474,6 +514,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         markdown = render_aggregate_markdown_summary({
             "generated": "2026-05-24T15:00:00+00:00",
             "input_reports": ["debug/first.json", "debug/second.json"],
+            "qgis_runtimes": ["3.44.0-Solothurn"],
             "variant_totals": [
                 {
                     "variant": "landcover-opacity-70",
@@ -541,6 +582,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         })
 
         self.assertIn("style-adjustment aggregate", markdown)
+        self.assertIn("QGIS runtimes: `3.44.0-Solothurn`", markdown)
         self.assertIn("`landcover-opacity-70`", markdown)
         self.assertIn("| `landcover-opacity-70` | `valais-geneva-outdoors` |", markdown)
         self.assertIn("## Aggregated crop movement", markdown)

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -137,6 +137,30 @@ def _optional_zoom(value: object, *, label: str) -> float | None:
     return float(value)
 
 
+def _qgis_runtime_from_mapping(value: object) -> dict[str, object]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _qgis_runtime_version_label(value: object) -> str | None:
+    runtime = _qgis_runtime_from_mapping(value)
+    qgis_version = runtime.get("qgis_version")
+    if qgis_version:
+        return str(qgis_version)
+    qgis_version_int = runtime.get("qgis_version_int")
+    return str(qgis_version_int) if qgis_version_int is not None else None
+
+
+def _format_qgis_runtime(value: object) -> str:
+    return _qgis_runtime_version_label(value) or "(not captured)"
+
+
+def _aggregate_qgis_runtime_label(value: object) -> str | None:
+    runtime = _qgis_runtime_from_mapping(value)
+    if not runtime:
+        return "(not captured)"
+    return _qgis_runtime_version_label(runtime)
+
+
 def _style_adjustment_from_json(value: object, *, variant_name: str) -> StyleAdjustment:
     adjustment = _require_mapping(value, label=f"variant {variant_name} adjustment")
     layer_id = adjustment.get("layer_id")
@@ -528,6 +552,7 @@ def build_style_adjustment_probe_report(
     report: dict[str, object] = {
         "generated": generated_at.isoformat(timespec="seconds"),
         "camera": dataclasses.asdict(camera),
+        "qgis_runtime": _qgis_runtime_from_mapping(manifest.get("qgis_runtime")),
         "rerender_control_variant": control_name if config.include_rerender_control else None,
         "inputs": {
             "baseline_manifest": _repo_relative(manifest_path),
@@ -717,6 +742,7 @@ def _aggregate_delta_entries(
     report_path_value: Path,
 ) -> tuple[
     str,
+    str,
     list[tuple[str, str, str, Mapping[str, object]]],
     list[tuple[str, str, str, int, str, Mapping[str, object]]],
 ]:
@@ -724,6 +750,7 @@ def _aggregate_delta_entries(
     report = load_json_object(report_path)
     camera = _mapping_value(report.get("camera"))
     camera_name = str(camera.get("name") or "(unknown camera)")
+    qgis_runtime_label = _aggregate_qgis_runtime_label(report.get("qgis_runtime"))
     control_variant_name = report.get("rerender_control_variant")
     crop_boxes = report.get("crop_boxes")
     entries: list[tuple[str, str, str, Mapping[str, object]]] = []
@@ -747,7 +774,7 @@ def _aggregate_delta_entries(
                 variant=variant,
             )
         )
-    return _repo_relative(report_path), entries, crop_entries
+    return _repo_relative(report_path), qgis_runtime_label, entries, crop_entries
 
 
 def _aggregate_camera_rows(
@@ -808,9 +835,12 @@ def build_style_adjustment_aggregate_report(
     grouped_crop_rows: dict[tuple[str, str, str, int, str], list[Mapping[str, object]]] = {}
     total_cameras: dict[tuple[str, str], set[str]] = {}
     input_paths: list[str] = []
+    qgis_runtimes: set[str] = set()
     for report_path_value in report_paths:
-        input_path, entries, crop_entries = _aggregate_delta_entries(report_path_value)
+        input_path, qgis_runtime_label, entries, crop_entries = _aggregate_delta_entries(report_path_value)
         input_paths.append(input_path)
+        if qgis_runtime_label is not None:
+            qgis_runtimes.add(qgis_runtime_label)
         for variant_name, camera_name, delta_source, delta in entries:
             grouped_rows.setdefault((variant_name, camera_name, delta_source), []).append(delta)
             total_key = (variant_name, delta_source)
@@ -826,6 +856,7 @@ def build_style_adjustment_aggregate_report(
     return {
         "generated": generated_at.isoformat(timespec="seconds"),
         "input_reports": input_paths,
+        "qgis_runtimes": sorted(qgis_runtimes),
         "rows": _aggregate_camera_rows(grouped_rows),
         "variant_totals": _aggregate_variant_totals(grouped_totals, total_cameras),
         "crop_rows": _aggregate_crop_rows(grouped_crop_rows),
@@ -834,11 +865,13 @@ def build_style_adjustment_aggregate_report(
 
 def _aggregate_summary_header_lines(report: Mapping[str, object]) -> list[str]:
     input_reports = [str(path) for path in report.get("input_reports") or []]
+    qgis_runtimes = [str(runtime) for runtime in report.get("qgis_runtimes") or []]
     lines = [
         "# Mapbox Outdoors style-adjustment aggregate",
         "",
         f"Generated: `{report.get('generated')}`",
         f"Input reports: `{len(input_reports)}`",
+        f"QGIS runtimes: `{', '.join(qgis_runtimes) if qgis_runtimes else '(not captured)'}`",
     ]
     if input_reports:
         lines.append("")
@@ -1082,6 +1115,7 @@ def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
         "",
         f"Generated: `{report.get('generated')}`",
         f"Camera: `{camera.get('name')}`",
+        f"QGIS runtime: `{_format_qgis_runtime(report.get('qgis_runtime'))}`",
         "",
         "Inputs:",
     ]


### PR DESCRIPTION
## Summary

- copy baseline comparison `qgis_runtime` metadata into style-adjustment probe JSON reports
- show the QGIS runtime in per-camera style-adjustment Markdown summaries
- summarize distinct QGIS runtimes across style-adjustment aggregate inputs

## Why

PR #1340 made comparison manifests record the QGIS runtime. Style-adjustment probes are downstream #949 validation artifacts, so preserving that runtime keeps repeated-render and cross-machine evidence traceable without changing rendering behavior.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_style_adjustment_probe.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
