### PR TITLE
[codex] Track QGIS runtimes in comparison deltas

### DIFF
--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -22,8 +22,8 @@ from qfit.validation.mapbox_outdoors_comparison_delta import (
 )
 
 
-def _camera_row(camera, *, mean, rms, changed=0.5, status="passed", zoom=14.25):
-    return {
+def _camera_row(camera, *, mean, rms, changed=0.5, status="passed", zoom=14.25, qgis_runtime=None):
+    row = {
         "camera": camera,
         "zoom": zoom,
         "status": status,
@@ -34,6 +34,9 @@ def _camera_row(camera, *, mean, rms, changed=0.5, status="passed", zoom=14.25):
             "normalized_rms_channel_delta": rms,
         },
     }
+    if qgis_runtime is not None:
+        row["qgis_runtime"] = qgis_runtime
+    return row
 
 
 class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
@@ -61,14 +64,38 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
     def test_build_comparison_delta_report_pairs_cameras_and_counts_directions(self):
         baseline = {
             "cameras": [
-                _camera_row("chamonix-trails-z14-outdoors", mean=0.04, rms=0.08, changed=0.95),
-                _camera_row("zermatt-trails-z18-outdoors", mean=0.03, rms=0.09, changed=0.99),
+                _camera_row(
+                    "chamonix-trails-z14-outdoors",
+                    mean=0.04,
+                    rms=0.08,
+                    changed=0.95,
+                    qgis_runtime={"qgis_version": "3.44.0-Solothurn"},
+                ),
+                _camera_row(
+                    "zermatt-trails-z18-outdoors",
+                    mean=0.03,
+                    rms=0.09,
+                    changed=0.99,
+                    qgis_runtime={"qgis_version_int": 33404},
+                ),
             ]
         }
         candidate = {
             "cameras": [
-                _camera_row("chamonix-trails-z14-outdoors", mean=0.035, rms=0.081, changed=0.94),
-                _camera_row("zermatt-trails-z18-outdoors", mean=0.031, rms=0.088, changed=0.99),
+                _camera_row(
+                    "chamonix-trails-z14-outdoors",
+                    mean=0.035,
+                    rms=0.081,
+                    changed=0.94,
+                    qgis_runtime={"qgis_version": "3.44.0-Solothurn"},
+                ),
+                _camera_row(
+                    "zermatt-trails-z18-outdoors",
+                    mean=0.031,
+                    rms=0.088,
+                    changed=0.99,
+                    qgis_runtime={"build_date": "2024-01-01"},
+                ),
             ]
         }
 
@@ -83,6 +110,8 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
         self.assertEqual(report["generated_at"], "20260520T185100Z")
         self.assertEqual(report["baseline_label"], "post-label-cleanups")
         self.assertEqual(report["candidate_label"], "probe")
+        self.assertEqual(report["qgis_runtimes"]["baseline"], ["3.44.0-Solothurn", "33404"])
+        self.assertEqual(report["qgis_runtimes"]["candidate"], ["(not captured)", "3.44.0-Solothurn"])
         self.assertEqual(report["camera_count"], 2)
         self.assertEqual(
             report["summary"],
@@ -110,6 +139,25 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
             ["chamonix-trails-z14-outdoors", "zermatt-trails-z18-outdoors"],
         )
         self.assertAlmostEqual(report["largest_metric_movements"][0]["mean_delta"], -0.005)
+
+    def test_build_comparison_delta_report_skips_unrecognized_runtime_shapes(self):
+        baseline = {
+            "cameras": [
+                _camera_row("zero-runtime", mean=0.04, rms=0.08, qgis_runtime={"qgis_version_int": 0}),
+                _camera_row(
+                    "future-runtime",
+                    mean=0.04,
+                    rms=0.08,
+                    qgis_runtime={"qgis_release_name": "Future"},
+                ),
+            ]
+        }
+        candidate = {"cameras": [_camera_row("zero-runtime", mean=0.03, rms=0.07)]}
+
+        report = build_comparison_delta_report(baseline, candidate)
+
+        self.assertEqual(report["qgis_runtimes"]["baseline"], ["(not captured)", "0"])
+        self.assertEqual(report["qgis_runtimes"]["candidate"], ["(not captured)"])
 
     def test_build_comparison_delta_report_preserves_missing_camera_rows(self):
         report = build_comparison_delta_report(
@@ -211,6 +259,8 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
 
         self.assertIn("# Mapbox Outdoors comparison delta", markdown)
         self.assertIn("Baseline: `baseline`", markdown)
+        self.assertIn("Baseline QGIS runtimes: `(not captured)`", markdown)
+        self.assertIn("Candidate QGIS runtimes: `(not captured)`", markdown)
         self.assertIn("## Largest Metric Movements", markdown)
         self.assertIn(
             "| `camera-a` | 18.00 | -0.010000000 | +0.010000000 | +0.010000000 | "

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -31,6 +31,7 @@ DELTA_METRIC_KEYS = (
 DIRECTION_BUCKETS = ("improved", "worsened", "unchanged", "unknown")
 TOP_MOVEMENT_LIMIT = 5
 DEFAULT_MOVEMENT_THRESHOLD = 0.0
+QGIS_RUNTIME_NOT_CAPTURED = "(not captured)"
 
 
 class ComparisonDeltaPaths(NamedTuple):
@@ -108,6 +109,25 @@ def _row_zoom(row: Mapping[str, object] | None) -> float | None:
     if isinstance(zoom, bool) or not isinstance(zoom, (int, float)):
         return None
     return float(zoom)
+
+
+def _qgis_runtime_label(value: object) -> str:
+    if not isinstance(value, Mapping):
+        return QGIS_RUNTIME_NOT_CAPTURED
+    if not value:
+        return QGIS_RUNTIME_NOT_CAPTURED
+    qgis_version = value.get("qgis_version")
+    if qgis_version:
+        return str(qgis_version)
+    qgis_version_int = value.get("qgis_version_int")
+    if qgis_version_int is not None:
+        return str(qgis_version_int)
+    return QGIS_RUNTIME_NOT_CAPTURED
+
+
+def _qgis_runtime_labels(rows: list[Mapping[str, object]]) -> list[str]:
+    labels = {_qgis_runtime_label(row.get("qgis_runtime")) for row in rows}
+    return sorted(labels)
 
 
 def _ordered_camera_names(
@@ -303,6 +323,10 @@ def build_comparison_delta_report(
         "candidate_label": candidate_label,
         "camera_count": len(rows),
         "movement_threshold": movement_threshold,
+        "qgis_runtimes": {
+            "baseline": _qgis_runtime_labels(baseline_rows),
+            "candidate": _qgis_runtime_labels(candidate_rows),
+        },
         "summary": _direction_counts("mean", mean_directions)
         | _direction_counts("rms", rms_directions),
         "cameras": rows,
@@ -426,8 +450,17 @@ def _append_largest_metric_movements_section(lines: list[str], report: Mapping[s
     lines.append("")
 
 
+def _qgis_runtime_line(label: str, runtimes: object) -> str:
+    if not isinstance(runtimes, list):
+        return f"{label} QGIS runtimes: `{QGIS_RUNTIME_NOT_CAPTURED}`"
+    runtime_values = [str(runtime) for runtime in runtimes]
+    runtime_text = ", ".join(runtime_values) if runtime_values else QGIS_RUNTIME_NOT_CAPTURED
+    return f"{label} QGIS runtimes: `{runtime_text}`"
+
+
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    qgis_runtimes = report.get("qgis_runtimes") if isinstance(report.get("qgis_runtimes"), Mapping) else {}
     lines = [
         "# Mapbox Outdoors comparison delta",
         "",
@@ -435,6 +468,8 @@ def build_summary_markdown(report: Mapping[str, object]) -> str:
         "",
         f"Baseline: `{report.get('baseline_label', 'baseline')}`",
         f"Candidate: `{report.get('candidate_label', 'candidate')}`",
+        _qgis_runtime_line("Baseline", qgis_runtimes.get("baseline")),
+        _qgis_runtime_line("Candidate", qgis_runtimes.get("candidate")),
         "",
     ]
     _append_input_artifacts_section(lines, report)


### PR DESCRIPTION
## Summary

- record distinct baseline and candidate QGIS runtimes in comparison-delta JSON reports
- show those runtimes in comparison-delta Markdown summaries
- cover mixed captured, missing, and integer runtime labels in delta tests

## Why

Comparison-delta reports are the before/after readout for #949 style probes. Now that all-camera comparison summaries carry QGIS runtime metadata, the delta report should preserve that context so before/after evidence stays traceable across local QGIS upgrades and legacy summaries.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison_delta.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
