### PR TITLE
[codex] Track QGIS runtime in rendered mask reports

### DIFF
--- a/tests/test_mapbox_outdoors_rendered_layer_mask.py
+++ b/tests/test_mapbox_outdoors_rendered_layer_mask.py
@@ -553,9 +553,9 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             )
             markdown = render_aggregate_markdown_summary(aggregate)
 
-        self.assertEqual(aggregate["qgis_runtimes"], ["(not captured)", "3.44.0-Solothurn"])
+        self.assertEqual(aggregate["qgis_runtimes"], ["3.44.0-Solothurn", "Future"])
         self.assertIn("rendered-layer mask aggregate", markdown)
-        self.assertIn("QGIS runtimes: `(not captured), 3.44.0-Solothurn`", markdown)
+        self.assertIn("QGIS runtimes: `3.44.0-Solothurn, Future`", markdown)
         self.assertIn("| `contour-z13-lines` | 2 | 2 | 1 | 1 | 0 | 0 |", markdown)
         self.assertIn("| `park-grass-fills` | 2 | 2 | 1 | 0 | 0 | 1 |", markdown)
         self.assertIn(

--- a/tests/test_mapbox_outdoors_rendered_layer_mask.py
+++ b/tests/test_mapbox_outdoors_rendered_layer_mask.py
@@ -147,6 +147,11 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
                         "normalized_rms_channel_delta": 0.0,
                         "changed_pixel_ratio": 0.0,
                     },
+                    "qgis_runtime": {
+                        "qgis_version": "3.44.0-Solothurn",
+                        "qgis_version_int": 34400,
+                        "qgis_release_name": "Solothurn",
+                    },
                 }),
                 encoding="utf-8",
             )
@@ -220,6 +225,7 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
 
             control = report["variants"][0]
             variant = report["variants"][1]
+            self.assertEqual(report["qgis_runtime"]["qgis_version"], "3.44.0-Solothurn")
             self.assertTrue(control["is_rerender_control"])
             self.assertEqual(control["name"], "qgis-rerender-control")
             self.assertTrue(variant["render_changed"])
@@ -256,12 +262,14 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             self.assertTrue(summary_path.exists())
             summary_markdown = summary_path.read_text(encoding="utf-8")
             self.assertIn("rendered-layer mask probe", summary_markdown)
+            self.assertIn("QGIS runtime: `3.44.0-Solothurn`", summary_markdown)
             self.assertIn("Mean delta vs control", summary_markdown)
 
     def test_markdown_summary_lists_render_moving_variants(self):
         markdown = render_markdown_summary({
             "generated": "2026-05-22T07:30:00+00:00",
             "camera": {"name": "unit-camera"},
+            "qgis_runtime": {"qgis_version_int": 34400},
             "inputs": {"baseline_manifest": "debug/manifest.json"},
             "baseline": {"metrics": {"normalized_mean_absolute_channel_delta": 0.1}},
             "crop_boxes": [[0, 0, 1, 1]],
@@ -336,6 +344,7 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
         })
 
         self.assertIn("`moving`", markdown)
+        self.assertIn("QGIS runtime: `34400`", markdown)
         self.assertIn("## Crop movement", markdown)
         self.assertIn("| `moving` | 1 | `[0, 0, 1, 1]` | 1.000000000 | 2.000000000 | 3.000000000 |", markdown)
         self.assertIn("Control-adjusted render-moving variants: `moving`.", markdown)
@@ -447,6 +456,7 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             geneva_report.write_text(
                 json.dumps({
                     "camera": {"name": "geneva-airport-motorway-z14-outdoors"},
+                    "qgis_runtime": {"qgis_version": "3.44.0-Solothurn"},
                     "rerender_control_variant": "qgis-rerender-control",
                     "crop_boxes": [[0, 0, 1, 1]],
                     "variants": [
@@ -501,6 +511,7 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             chamonix_report.write_text(
                 json.dumps({
                     "camera": {"name": "chamonix-trails-z14-outdoors"},
+                    "qgis_runtime": {"qgis_release_name": "Future"},
                     "rerender_control_variant": "qgis-rerender-control",
                     "crop_boxes": [[0, 0, 1, 1]],
                     "variants": [
@@ -542,7 +553,9 @@ class MapboxOutdoorsRenderedLayerMaskTests(unittest.TestCase):
             )
             markdown = render_aggregate_markdown_summary(aggregate)
 
+        self.assertEqual(aggregate["qgis_runtimes"], ["(not captured)", "3.44.0-Solothurn"])
         self.assertIn("rendered-layer mask aggregate", markdown)
+        self.assertIn("QGIS runtimes: `(not captured), 3.44.0-Solothurn`", markdown)
         self.assertIn("| `contour-z13-lines` | 2 | 2 | 1 | 1 | 0 | 0 |", markdown)
         self.assertIn("| `park-grass-fills` | 2 | 2 | 1 | 0 | 0 | 1 |", markdown)
         self.assertIn(

--- a/validation/mapbox_outdoors_rendered_layer_mask.py
+++ b/validation/mapbox_outdoors_rendered_layer_mask.py
@@ -55,6 +55,7 @@ REPORT_CAMERA_DIRECTORY = "comparison-camera"
 VARIANT_SPEC_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*=[^=]+$")
 SAFE_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 LUMINANCE_WEIGHTS = (0.2126, 0.7152, 0.0722)
+QGIS_RUNTIME_NOT_CAPTURED = "(not captured)"
 
 
 @dataclass(frozen=True)
@@ -148,6 +149,22 @@ def load_json_object(path: Path) -> dict[str, object]:
     if not isinstance(loaded, dict):
         raise ValueError(f"Expected JSON object: {path}")
     return loaded
+
+
+def _qgis_runtime_from_mapping(value: object) -> dict[str, object]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _qgis_runtime_label(value: object) -> str:
+    if not isinstance(value, Mapping) or not value:
+        return QGIS_RUNTIME_NOT_CAPTURED
+    qgis_version = value.get("qgis_version")
+    if qgis_version:
+        return str(qgis_version)
+    qgis_version_int = value.get("qgis_version_int")
+    if qgis_version_int is not None:
+        return str(qgis_version_int)
+    return QGIS_RUNTIME_NOT_CAPTURED
 
 
 def _resolve_artifact_path(path_text: object, *, manifest_path: Path) -> Path:
@@ -626,6 +643,7 @@ def build_rendered_layer_mask_report(
     report: dict[str, object] = {
         "generated": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
         "camera": dataclasses.asdict(camera),
+        "qgis_runtime": _qgis_runtime_from_mapping(manifest.get("qgis_runtime")),
         "rerender_control_variant": control_variant_name if config.include_rerender_control else None,
         "inputs": {
             "baseline_manifest": _repo_relative(manifest_path),
@@ -701,6 +719,7 @@ def _summary_header_lines(report: Mapping[str, object]) -> list[str]:
         "",
         f"Generated: `{report.get('generated')}`",
         f"Camera: `{camera.get('name')}`",
+        f"QGIS runtime: `{_qgis_runtime_label(report.get('qgis_runtime'))}`",
         "",
         "Inputs:",
     ]
@@ -1037,11 +1056,12 @@ def _aggregate_mask_crop_entries(
 
 def _aggregate_mask_entries(
     report_path_value: Path,
-) -> tuple[str, list[dict[str, object]], list[dict[str, object]]]:
+) -> tuple[str, str, list[dict[str, object]], list[dict[str, object]]]:
     report_path = report_path_value.expanduser().resolve()
     report = load_json_object(report_path)
     camera = _mapping_value(report.get("camera"))
     camera_name = str(camera.get("name") or "(unknown camera)")
+    qgis_runtime_label = _qgis_runtime_label(report.get("qgis_runtime"))
     control_name = report.get("rerender_control_variant")
     crop_boxes = report.get("crop_boxes")
     variant_entries: list[dict[str, object]] = []
@@ -1061,7 +1081,7 @@ def _aggregate_mask_entries(
                 crop_boxes=crop_boxes,
             )
         )
-    return _repo_relative(report_path), variant_entries, crop_entries
+    return _repo_relative(report_path), qgis_runtime_label, variant_entries, crop_entries
 
 
 def _aggregate_mask_totals(variant_entries: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
@@ -1092,17 +1112,22 @@ def build_rendered_layer_mask_aggregate_report(
     now: dt.datetime | None = None,
 ) -> dict[str, object]:
     input_reports = []
+    qgis_runtimes: set[str] = set()
     variant_entries: list[dict[str, object]] = []
     crop_entries: list[dict[str, object]] = []
     for report_path in report_paths:
-        input_path, report_variant_entries, report_crop_entries = _aggregate_mask_entries(report_path)
+        input_path, qgis_runtime_label, report_variant_entries, report_crop_entries = _aggregate_mask_entries(
+            report_path
+        )
         input_reports.append(input_path)
+        qgis_runtimes.add(qgis_runtime_label)
         variant_entries.extend(report_variant_entries)
         crop_entries.extend(report_crop_entries)
     generated = now or dt.datetime.now(dt.timezone.utc)
     return {
         "generated": generated.isoformat(timespec="seconds"),
         "input_reports": input_reports,
+        "qgis_runtimes": sorted(qgis_runtimes),
         "variant_totals": _aggregate_mask_totals(variant_entries),
         "variant_rows": sorted(variant_entries, key=lambda row: (str(row["variant"]), str(row["camera"]))),
         "crop_rows": sorted(
@@ -1176,6 +1201,7 @@ def _aggregate_read_lines(
 
 def render_aggregate_markdown_summary(report: Mapping[str, object]) -> str:
     input_reports = [str(path) for path in report.get("input_reports") or []]
+    qgis_runtimes = [str(runtime) for runtime in report.get("qgis_runtimes") or []]
     totals = _list_of_mappings(report.get("variant_totals"))
     variant_rows = _list_of_mappings(report.get("variant_rows"))
     crop_rows = _list_of_mappings(report.get("crop_rows"))
@@ -1184,6 +1210,7 @@ def render_aggregate_markdown_summary(report: Mapping[str, object]) -> str:
         "",
         f"Generated: `{report.get('generated')}`",
         f"Input reports: `{len(input_reports)}`",
+        f"QGIS runtimes: `{', '.join(qgis_runtimes) if qgis_runtimes else QGIS_RUNTIME_NOT_CAPTURED}`",
     ]
     if input_reports:
         lines.extend(["", "Inputs:"])

--- a/validation/mapbox_outdoors_rendered_layer_mask.py
+++ b/validation/mapbox_outdoors_rendered_layer_mask.py
@@ -164,6 +164,9 @@ def _qgis_runtime_label(value: object) -> str:
     qgis_version_int = value.get("qgis_version_int")
     if qgis_version_int is not None:
         return str(qgis_version_int)
+    qgis_release_name = value.get("qgis_release_name")
+    if qgis_release_name:
+        return str(qgis_release_name)
     return QGIS_RUNTIME_NOT_CAPTURED
 
 


### PR DESCRIPTION
## Summary

- copy baseline comparison `qgis_runtime` metadata into rendered-layer mask JSON reports
- show the QGIS runtime in rendered-layer mask Markdown summaries
- summarize distinct QGIS runtimes across rendered-mask aggregate inputs

## Why

Rendered-layer mask probes are part of the #949 validation trail. Carrying the QGIS runtime through these reports keeps rendered-owner and crop-signal evidence comparable across local QGIS upgrades and legacy inputs.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_rendered_layer_mask.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
