### PR TITLE
[codex] Surface QGIS release runtime labels

### DIFF
--- a/tests/test_mapbox_outdoors_comparison_delta.py
+++ b/tests/test_mapbox_outdoors_comparison_delta.py
@@ -140,7 +140,7 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
         )
         self.assertAlmostEqual(report["largest_metric_movements"][0]["mean_delta"], -0.005)
 
-    def test_build_comparison_delta_report_skips_unrecognized_runtime_shapes(self):
+    def test_build_comparison_delta_report_labels_release_name_runtime(self):
         baseline = {
             "cameras": [
                 _camera_row("zero-runtime", mean=0.04, rms=0.08, qgis_runtime={"qgis_version_int": 0}),
@@ -156,7 +156,7 @@ class MapboxOutdoorsComparisonDeltaTests(unittest.TestCase):
 
         report = build_comparison_delta_report(baseline, candidate)
 
-        self.assertEqual(report["qgis_runtimes"]["baseline"], ["(not captured)", "0"])
+        self.assertEqual(report["qgis_runtimes"]["baseline"], ["0", "Future"])
         self.assertEqual(report["qgis_runtimes"]["candidate"], ["(not captured)"])
 
     def test_build_comparison_delta_report_preserves_missing_camera_rows(self):

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -74,6 +74,9 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
     def test_format_qgis_runtime_keeps_zero_version_int(self):
         self.assertEqual(probe_module._format_qgis_runtime({"qgis_version_int": 0}), "0")
 
+    def test_format_qgis_runtime_falls_back_to_release_name(self):
+        self.assertEqual(probe_module._format_qgis_runtime({"qgis_release_name": "Future"}), "Future")
+
     def test_load_style_adjustment_variants_rejects_empty_adjustments(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "variants.json"
@@ -444,7 +447,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
         }
         valais_row = rows[("landcover-opacity-70", "valais-geneva-outdoors", "rerender_control")]
         self.assertEqual(aggregate["generated"], "2026-05-24T15:00:00+00:00")
-        self.assertEqual(aggregate["qgis_runtimes"], ["(not captured)", "3.44.0-Solothurn", "33404"])
+        self.assertEqual(aggregate["qgis_runtimes"], ["(not captured)", "3.44.0-Solothurn", "33404", "Future"])
         self.assertEqual(valais_row["runs"], 2)
         self.assertEqual(valais_row["improving_runs"], 1)
         self.assertEqual(valais_row["worsening_runs"], 1)

--- a/tests/test_mapbox_outdoors_style_adjustment_probe.py
+++ b/tests/test_mapbox_outdoors_style_adjustment_probe.py
@@ -336,7 +336,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
             second_report = root / "second-style-adjustment-probe.json"
             third_report = root / "third-style-adjustment-probe.json"
             legacy_report = root / "legacy-style-adjustment-probe.json"
-            unrecognized_runtime_report = root / "unrecognized-runtime-style-adjustment-probe.json"
+            release_name_runtime_report = root / "release-name-runtime-style-adjustment-probe.json"
             first_report.write_text(
                 json.dumps({
                     "camera": {"name": "valais-geneva-outdoors"},
@@ -421,7 +421,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                 }),
                 encoding="utf-8",
             )
-            unrecognized_runtime_report.write_text(
+            release_name_runtime_report.write_text(
                 json.dumps({
                     "camera": {"name": "future-camera"},
                     "qgis_runtime": {"qgis_release_name": "Future"},
@@ -436,7 +436,7 @@ class MapboxOutdoorsStyleAdjustmentProbeTests(unittest.TestCase):
                     second_report,
                     third_report,
                     legacy_report,
-                    unrecognized_runtime_report,
+                    release_name_runtime_report,
                 ),
                 now=dt.datetime(2026, 5, 24, 15, 0, tzinfo=dt.timezone.utc),
             )

--- a/validation/mapbox_outdoors_comparison_delta.py
+++ b/validation/mapbox_outdoors_comparison_delta.py
@@ -122,6 +122,9 @@ def _qgis_runtime_label(value: object) -> str:
     qgis_version_int = value.get("qgis_version_int")
     if qgis_version_int is not None:
         return str(qgis_version_int)
+    qgis_release_name = value.get("qgis_release_name")
+    if qgis_release_name:
+        return str(qgis_release_name)
     return QGIS_RUNTIME_NOT_CAPTURED
 
 

--- a/validation/mapbox_outdoors_style_adjustment_probe.py
+++ b/validation/mapbox_outdoors_style_adjustment_probe.py
@@ -147,7 +147,10 @@ def _qgis_runtime_version_label(value: object) -> str | None:
     if qgis_version:
         return str(qgis_version)
     qgis_version_int = runtime.get("qgis_version_int")
-    return str(qgis_version_int) if qgis_version_int is not None else None
+    if qgis_version_int is not None:
+        return str(qgis_version_int)
+    qgis_release_name = runtime.get("qgis_release_name")
+    return str(qgis_release_name) if qgis_release_name else None
 
 
 def _format_qgis_runtime(value: object) -> str:


### PR DESCRIPTION
## Summary

- use `qgis_release_name` as the fallback QGIS runtime label in style-adjustment reports
- use `qgis_release_name` as the fallback QGIS runtime label in comparison-delta reports
- add regression coverage for release-name-only runtime metadata

## Why

Rendered-layer mask reports now preserve release-name-only runtime metadata. This keeps the other #949 validation reports consistent so captured QGIS runtime context does not collapse to `(not captured)` when version fields are absent.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_style_adjustment_probe.py tests/test_mapbox_outdoors_comparison_delta.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
