### PR TITLE
[codex] Surface QGIS release labels in comparison summaries

### DIFF
--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -45,6 +45,7 @@ from qfit.validation.mapbox_outdoors_comparison import (
     _append_qgis_contour_boundary_generator_label_probe,
     _append_enabled_qgis_contour_label_probes,
     _append_qgis_contour_polygon_label_probe,
+    _format_qgis_runtime,
     _label_setting_value,
     _label_value,
     _load_optional_qgis_runtime_snapshot,
@@ -195,6 +196,12 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
         stderr_text = "".join(call.args[0] for call in stderr_mock.write.call_args_list)
         self.assertIn("QGIS runtime metadata was not written", stderr_text)
+
+    def test_format_qgis_runtime_keeps_zero_version_int(self):
+        self.assertEqual(_format_qgis_runtime({"qgis_version_int": 0}), "0")
+
+    def test_format_qgis_runtime_falls_back_to_release_name(self):
+        self.assertEqual(_format_qgis_runtime({"qgis_release_name": "Future"}), "Future")
 
     def test_load_optional_qgis_runtime_snapshot_ignores_invalid_metadata(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -1552,7 +1552,12 @@ def _format_qgis_runtime(value: object) -> str:
     if qgis_version:
         return str(qgis_version)
     qgis_version_int = value.get("qgis_version_int")
-    return str(qgis_version_int) if qgis_version_int else "—"
+    if qgis_version_int is not None:
+        return str(qgis_version_int)
+    qgis_release_name = value.get("qgis_release_name")
+    if qgis_release_name:
+        return str(qgis_release_name)
+    return "—"
 
 
 def _artifact_markdown_path(path_text: object, *, base_dir: Path | None) -> str:


### PR DESCRIPTION
## Summary

- preserve `qgis_version_int: 0` in comparison summary runtime labels
- use `qgis_release_name` as a fallback comparison summary runtime label when version fields are absent
- add regression coverage for both fallback cases

## Why

The base all-camera comparison summary is the source artifact that later #949 reports consume. Keeping release-name-only and zero-version runtime metadata visible there makes QGIS runtime traceability consistent across comparison, style-adjustment, rendered-mask, and delta reports.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_comparison.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
