### PR TITLE
[codex] Track QGIS runtime in label diagnostics

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -378,7 +378,7 @@ python3 validation/mapbox_outdoors_label_settings.py \
 
 Add `--qgis-contour-bbox-edge-difference-source-style-label-probe` or `--qgis-contour-bbox-edge-difference-source-style-high-zoom-label-probe` to include source-style variants in the same report.
 
-The report keeps the probe separate from source Mapbox layers, so the summary can distinguish converted production labels from diagnostic-only QGIS rules.
+The report keeps the probe separate from source Mapbox layers, so the summary can distinguish converted production labels from diagnostic-only QGIS rules. It also records token-free QGIS runtime metadata so label-conversion evidence can be compared safely across QGIS upgrades.
 
 ## Road feature diagnostic
 

--- a/tests/test_mapbox_outdoors_comparison.py
+++ b/tests/test_mapbox_outdoors_comparison.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 from tests import _path  # noqa: F401
 
+from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
 from qfit.validation.mapbox_outdoors_comparison import (
     CAMERAS,
     CONTACT_SHEET_COLUMN_GAP,
@@ -202,6 +203,9 @@ class MapboxOutdoorsComparisonTests(unittest.TestCase):
 
     def test_format_qgis_runtime_falls_back_to_release_name(self):
         self.assertEqual(_format_qgis_runtime({"qgis_release_name": "Future"}), "Future")
+
+    def test_format_qgis_runtime_label_uses_configured_missing_label(self):
+        self.assertEqual(format_qgis_runtime_label({}, missing_label="missing"), "missing")
 
     def test_load_optional_qgis_runtime_snapshot_ignores_invalid_metadata(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -20,6 +20,7 @@ from qfit.validation.mapbox_outdoors_label_settings import (
     _data_defined_expression_issue_rows,
     _ensure_qgis_application,
     _fetch_sprite_resources,
+    _format_qgis_runtime,
     _geometry_generator_markdown_value,
     _label_settings_report,
     _label_style_summary_rows,
@@ -378,7 +379,12 @@ def _fake_qgis_modules():
     core_module.QgsPalLayerSettings = FakeQgsPalLayerSettings
     core_module.QgsProperty = FakeQgsProperty
     core_module.QgsTextBackgroundSettings = FakeQgsTextBackgroundSettings
-    core_module.Qgis = SimpleNamespace(RenderUnit=SimpleNamespace(Millimeters="millimeters"))
+    core_module.Qgis = SimpleNamespace(
+        RenderUnit=SimpleNamespace(Millimeters="millimeters"),
+        QGIS_VERSION="3.44.0-Solothurn",
+        QGIS_VERSION_INT=34400,
+        QGIS_RELEASE_NAME="Solothurn",
+    )
     qgis_module.core = core_module
     return {"qgis": qgis_module, "qgis.core": core_module}
 
@@ -555,6 +561,10 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertTrue(controls["remove_duplicate_labels"])
         self.assertTrue(controls["remove_duplicate_label_distance"])
         self.assertFalse(controls["label_margin_distance"])
+
+    def test_format_qgis_runtime_uses_release_name_fallback(self):
+        self.assertEqual(_format_qgis_runtime({"qgis_release_name": "Future"}), "Future")
+        self.assertEqual(_format_qgis_runtime({"qgis_version_int": 0}), "0")
 
     def test_qgis_pal_layer_property_names_by_value_reports_enum_names(self):
         names = _qgis_pal_layer_property_names_by_value(FakeQgsPalLayerSettings)
@@ -2032,6 +2042,14 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         append_source_style_probe.assert_called_once()
         append_source_style_high_zoom_probe.assert_called_once()
         self.assertEqual(report["qgis_converter_result"], "success")
+        self.assertEqual(
+            report["qgis_runtime"],
+            {
+                "qgis_version": "3.44.0-Solothurn",
+                "qgis_version_int": 34400,
+                "qgis_release_name": "Solothurn",
+            },
+        )
         self.assertEqual(report["sprite_definition_count"], 1)
         self.assertFalse(report["sprite_context_loaded"])
         self.assertTrue(report["qgis_contour_bbox_edge_difference_label_probe"])
@@ -2073,6 +2091,11 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "style_owner": "mapbox",
             "style_id": "outdoors-v12",
             "generated": "2026-05-18T08:22:00+00:00",
+            "qgis_runtime": {
+                "qgis_version": "3.34.4-Prizren",
+                "qgis_version_int": 33404,
+                "qgis_release_name": "Prizren",
+            },
             "sprite_context_loaded": True,
             "sprite_definition_count": 440,
             "qgis_duplicate_label_controls": {
@@ -2324,6 +2347,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         markdown = build_summary_markdown(report)
 
         self.assertIn("# Mapbox Outdoors QGIS label settings — mapbox/outdoors-v12", markdown)
+        self.assertIn("QGIS runtime: `3.34.4-Prizren`", markdown)
         self.assertIn("Converted label styles: 1", markdown)
         self.assertIn("Sprite context loaded: yes", markdown)
         self.assertIn(

--- a/tests/test_mapbox_outdoors_label_settings.py
+++ b/tests/test_mapbox_outdoors_label_settings.py
@@ -547,17 +547,13 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertTrue(app.initialized)
         self.assertIs(FakeQgsApplication.instance(), app)
 
-    def test_qgis_duplicate_label_controls_report_runtime_support(self):
-        class FakeQgis:
-            QGIS_VERSION = "3.44.0"
-
+    def test_qgis_duplicate_label_controls_report_available_controls(self):
         class FakePalLayerSettings:
             RemoveDuplicateLabels = 1
             RemoveDuplicateLabelDistance = 2
 
-        controls = _qgis_duplicate_label_controls(FakePalLayerSettings, FakeQgis)
+        controls = _qgis_duplicate_label_controls(FakePalLayerSettings)
 
-        self.assertEqual(controls["qgis_version"], "3.44.0")
         self.assertTrue(controls["remove_duplicate_labels"])
         self.assertTrue(controls["remove_duplicate_label_distance"])
         self.assertFalse(controls["label_margin_distance"])
@@ -2099,7 +2095,6 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
             "sprite_context_loaded": True,
             "sprite_definition_count": 440,
             "qgis_duplicate_label_controls": {
-                "qgis_version": "3.34.4-Prizren",
                 "remove_duplicate_labels": False,
                 "remove_duplicate_label_distance": False,
                 "label_margin_distance": False,
@@ -2351,7 +2346,7 @@ class MapboxOutdoorsLabelSettingsTests(unittest.TestCase):
         self.assertIn("Converted label styles: 1", markdown)
         self.assertIn("Sprite context loaded: yes", markdown)
         self.assertIn(
-            "QGIS duplicate-label controls: QGIS 3.34.4-Prizren; remove_duplicate_labels=no; remove_duplicate_label_distance=no; label_margin_distance=no",
+            "QGIS duplicate-label controls: remove_duplicate_labels=no; remove_duplicate_label_distance=no; label_margin_distance=no",
             markdown,
         )
         self.assertIn("Bbox-edge contour label probe: yes", markdown)

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, TypeAlias
 
 from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
+from qfit.validation.mapbox_outdoors_runtime import qgis_runtime_snapshot as _runtime_snapshot
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PARENT = REPO_ROOT.parent
@@ -716,12 +717,7 @@ def write_qgis_label_styles_snapshot(*, layer: object, output_path: Path, token:
 
 def qgis_runtime_snapshot(qgis_api: object) -> dict[str, object]:
     """Return token-free QGIS runtime metadata for version-sensitive render probes."""
-
-    return {
-        "qgis_version": getattr(qgis_api, "QGIS_VERSION", None),
-        "qgis_version_int": getattr(qgis_api, "QGIS_VERSION_INT", None),
-        "qgis_release_name": getattr(qgis_api, "QGIS_RELEASE_NAME", None),
-    }
+    return _runtime_snapshot(qgis_api)
 
 
 def write_qgis_runtime_snapshot(*, qgis_api: object, output_path: Path | None) -> None:

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, TypeAlias
 
+from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PARENT = REPO_ROOT.parent
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-comparison"
@@ -1546,18 +1548,7 @@ def _format_summary_metric(metrics: dict[str, object], key: str) -> str:
 
 
 def _format_qgis_runtime(value: object) -> str:
-    if not isinstance(value, dict):
-        return "—"
-    qgis_version = value.get("qgis_version")
-    if qgis_version:
-        return str(qgis_version)
-    qgis_version_int = value.get("qgis_version_int")
-    if qgis_version_int is not None:
-        return str(qgis_version_int)
-    qgis_release_name = value.get("qgis_release_name")
-    if qgis_release_name:
-        return str(qgis_release_name)
-    return "—"
+    return format_qgis_runtime_label(value, missing_label="—")
 
 
 def _artifact_markdown_path(path_text: object, *, base_dir: Path | None) -> str:

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable
 
+from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PARENT = REPO_ROOT.parent
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-label-settings"
@@ -626,9 +628,8 @@ def _ensure_qgis_application(qgs_application):
     return app, created_app
 
 
-def _qgis_duplicate_label_controls(qgs_pal_layer_settings, qgis_api) -> dict[str, object]:
+def _qgis_duplicate_label_controls(qgs_pal_layer_settings) -> dict[str, object]:
     return {
-        "qgis_version": getattr(qgis_api, "QGIS_VERSION", None),
         **{
             key: hasattr(qgs_pal_layer_settings, property_name)
             for key, property_name in _QGIS_DUPLICATE_LABEL_CONTROL_PROPERTIES
@@ -2011,7 +2012,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             sprite_count=sprite_count,
             records=records,
             source_label_layers=source_label_layers,
-            qgis_duplicate_label_controls=_qgis_duplicate_label_controls(QgsPalLayerSettings, Qgis),
+            qgis_duplicate_label_controls=_qgis_duplicate_label_controls(QgsPalLayerSettings),
             qgis_runtime=_qgis_runtime_snapshot(Qgis),
         )
     finally:
@@ -2141,18 +2142,7 @@ def _qgis_duplicate_label_controls_markdown_value(value: object) -> str:
 
 
 def _format_qgis_runtime(value: object) -> str:
-    if not isinstance(value, dict):
-        return "(not captured)"
-    qgis_version = value.get("qgis_version")
-    if qgis_version:
-        return str(qgis_version)
-    qgis_version_int = value.get("qgis_version_int")
-    if qgis_version_int is not None:
-        return str(qgis_version_int)
-    qgis_release_name = value.get("qgis_release_name")
-    if qgis_release_name:
-        return str(qgis_release_name)
-    return "(not captured)"
+    return format_qgis_runtime_label(value, missing_label="(not captured)")
 
 
 def _zoom_range_markdown_value(minzoom: object, maxzoom: object) -> str:

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -636,6 +636,14 @@ def _qgis_duplicate_label_controls(qgs_pal_layer_settings, qgis_api) -> dict[str
     }
 
 
+def _qgis_runtime_snapshot(qgis_api: object) -> dict[str, object]:
+    return {
+        "qgis_version": getattr(qgis_api, "QGIS_VERSION", None),
+        "qgis_version_int": getattr(qgis_api, "QGIS_VERSION_INT", None),
+        "qgis_release_name": getattr(qgis_api, "QGIS_RELEASE_NAME", None),
+    }
+
+
 def _load_original_style(config: LabelSettingsConfig, fetch_mapbox_style_definition) -> dict[str, object]:
     if config.style_json_path is not None:
         return load_style_definition(config.style_json_path)
@@ -1908,12 +1916,14 @@ def _label_settings_report(
     records: list[dict[str, object]],
     source_label_layers: list[dict[str, object]] | None = None,
     qgis_duplicate_label_controls: dict[str, object] | None = None,
+    qgis_runtime: dict[str, object] | None = None,
 ) -> dict[str, object]:
     source_label_layer_rows = source_label_layers or []
     return {
         "style_owner": config.style_owner,
         "style_id": config.style_id,
         "generated": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "qgis_runtime": qgis_runtime or {},
         "qgis_converter_result": result,
         "sprite_context_requested": config.include_sprite_context,
         "sprite_context_loaded": sprite_loaded,
@@ -2002,6 +2012,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             records=records,
             source_label_layers=source_label_layers,
             qgis_duplicate_label_controls=_qgis_duplicate_label_controls(QgsPalLayerSettings, Qgis),
+            qgis_runtime=_qgis_runtime_snapshot(Qgis),
         )
     finally:
         if created_app:
@@ -2127,6 +2138,21 @@ def _qgis_duplicate_label_controls_markdown_value(value: object) -> str:
     if qgis_version:
         controls.insert(0, f"QGIS {_markdown_value(qgis_version)}")
     return "; ".join(controls)
+
+
+def _format_qgis_runtime(value: object) -> str:
+    if not isinstance(value, dict):
+        return "(not captured)"
+    qgis_version = value.get("qgis_version")
+    if qgis_version:
+        return str(qgis_version)
+    qgis_version_int = value.get("qgis_version_int")
+    if qgis_version_int is not None:
+        return str(qgis_version_int)
+    qgis_release_name = value.get("qgis_release_name")
+    if qgis_release_name:
+        return str(qgis_release_name)
+    return "(not captured)"
 
 
 def _zoom_range_markdown_value(minzoom: object, maxzoom: object) -> str:
@@ -2590,6 +2616,7 @@ def build_summary_markdown(report: dict[str, object]) -> str:
         f"# Mapbox Outdoors QGIS label settings — {report.get('style_owner')}/{report.get('style_id')}",
         "",
         f"Generated: {report.get('generated')}",
+        f"QGIS runtime: `{_format_qgis_runtime(report.get('qgis_runtime'))}`",
         f"Converted label styles: {report.get('label_count', len(rows))}",
         f"Sprite context loaded: {_markdown_value(report.get('sprite_context_loaded'))}",
         f"Sprite definitions: {_markdown_value(report.get('sprite_definition_count'))}",

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Callable, Iterable
 
 from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
+from qfit.validation.mapbox_outdoors_runtime import qgis_runtime_snapshot
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PARENT = REPO_ROOT.parent
@@ -634,14 +635,6 @@ def _qgis_duplicate_label_controls(qgs_pal_layer_settings) -> dict[str, object]:
             key: hasattr(qgs_pal_layer_settings, property_name)
             for key, property_name in _QGIS_DUPLICATE_LABEL_CONTROL_PROPERTIES
         },
-    }
-
-
-def _qgis_runtime_snapshot(qgis_api: object) -> dict[str, object]:
-    return {
-        "qgis_version": getattr(qgis_api, "QGIS_VERSION", None),
-        "qgis_version_int": getattr(qgis_api, "QGIS_VERSION_INT", None),
-        "qgis_release_name": getattr(qgis_api, "QGIS_RELEASE_NAME", None),
     }
 
 
@@ -2013,7 +2006,7 @@ def collect_label_settings(config: LabelSettingsConfig) -> dict[str, object]:
             records=records,
             source_label_layers=source_label_layers,
             qgis_duplicate_label_controls=_qgis_duplicate_label_controls(QgsPalLayerSettings),
-            qgis_runtime=_qgis_runtime_snapshot(Qgis),
+            qgis_runtime=qgis_runtime_snapshot(Qgis),
         )
     finally:
         if created_app:

--- a/validation/mapbox_outdoors_runtime.py
+++ b/validation/mapbox_outdoors_runtime.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+def format_qgis_runtime_label(value: object, *, missing_label: str) -> str:
+    if not isinstance(value, dict):
+        return missing_label
+    qgis_version = value.get("qgis_version")
+    if qgis_version:
+        return str(qgis_version)
+    qgis_version_int = value.get("qgis_version_int")
+    if qgis_version_int is not None:
+        return str(qgis_version_int)
+    qgis_release_name = value.get("qgis_release_name")
+    if qgis_release_name:
+        return str(qgis_release_name)
+    return missing_label

--- a/validation/mapbox_outdoors_runtime.py
+++ b/validation/mapbox_outdoors_runtime.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
 
+def qgis_runtime_snapshot(qgis_api: object) -> dict[str, object]:
+    return {
+        "qgis_version": getattr(qgis_api, "QGIS_VERSION", None),
+        "qgis_version_int": getattr(qgis_api, "QGIS_VERSION_INT", None),
+        "qgis_release_name": getattr(qgis_api, "QGIS_RELEASE_NAME", None),
+    }
+
+
 def format_qgis_runtime_label(value: object, *, missing_label: str) -> str:
     if not isinstance(value, dict):
         return missing_label


### PR DESCRIPTION
## Summary

- add structured QGIS runtime metadata to the Mapbox Outdoors label-settings diagnostic report
- show the runtime label in the generated Markdown summary
- document that label-conversion reports preserve token-free runtime context across QGIS upgrades

## Evidence

Official QGIS documentation describes Mapbox GL JSON styles as vector-tile style inputs, and the PyQGIS API exposes runtime version/release metadata. This keeps #949 label-conversion evidence comparable with the runtime traceability now present in comparison, style-adjustment, rendered-mask, and comparison-delta reports.

## Validation

- python3 -m pytest tests/test_mapbox_outdoors_label_settings.py -q --tb=short
- git diff --check
- python3 -m pytest tests/ -x -q --tb=short

Refs #949.