### PR TITLE
[codex] Surface QGIS runtime in visual crops

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -139,6 +139,7 @@ python3 validation/mapbox_outdoors_visual_crops.py \
 ```
 
 Manual boxes are recorded in `visual-crops.json`, echoed in the Markdown report header, and marked as `manual` in the crop table's selection column.
+When the comparison summary includes token-free QGIS runtime metadata, visual crop JSON and Markdown reports list the distinct runtime labels in the comparison run header so crop evidence remains comparable after local QGIS upgrades.
 
 When path/pedestrian styling is under review, pass the matching focus report so each crop row is annotated with the strongest per-camera stroke-width, source-capped stroke, pedestrian core/case cap, and dash cues:
 

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -13,6 +13,7 @@ from tests import _path  # noqa: F401
 from qfit.validation.mapbox_outdoors_visual_crops import (
     VisualCropAnnotationInputs,
     _candidate_source_type_label,
+    _comparison_summary_run_metadata,
     _computed_crop_color_movement_group_records,
     _crop_color_metric,
     _path_pedestrian_focus_coverage_rows,
@@ -185,6 +186,11 @@ def _write_visual_triplet(
                     "browser_reference": str(browser_path),
                     "qgis_vector_render": str(qgis_path),
                     "diff": str(diff_path),
+                },
+                "qgis_runtime": {
+                    "qgis_version": "3.44.0-Solothurn",
+                    "qgis_version_int": 34400,
+                    "qgis_release_name": "Solothurn",
                 },
             }
         ],
@@ -505,6 +511,27 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertEqual(paths.json_path, run_dir / "visual-crops.json")
         self.assertEqual(paths.summary_path, run_dir / "summary.md")
         self.assertEqual(paths.contact_sheet_path, run_dir / "crop-sheet.jpg")
+
+    def test_comparison_summary_run_metadata_records_qgis_runtime_labels(self):
+        metadata = _comparison_summary_run_metadata(
+            {
+                "generated_at": "2026-05-20T20:00:00+00:00",
+                "style_url": "mapbox://styles/mapbox/outdoors-v12",
+                "cameras": [
+                    {"qgis_runtime": {"qgis_version": "3.44.0-Solothurn"}},
+                    {"qgis_runtime": {"qgis_version_int": 0}},
+                    {"qgis_runtime": {"qgis_release_name": "Future"}},
+                    {"qgis_runtime": {}},
+                    {"status": "failed"},
+                ],
+            },
+            Path("debug/comparison/summary.json"),
+        )
+
+        self.assertEqual(
+            metadata["qgis_runtimes"],
+            ["(not captured)", "0", "3.44.0-Solothurn", "Future"],
+        )
 
     def test_parse_crop_size_requires_positive_width_and_height(self):
         self.assertEqual(parse_crop_size("320x240"), (320, 240))
@@ -1854,6 +1881,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     "path": "debug/comparison/summary.json",
                     "generated_at": "2026-05-20T20:00:00+00:00",
                     "style_url": "mapbox://styles/mapbox/outdoors-v12",
+                    "qgis_runtimes": ["3.44.0-Solothurn", "3.44.1-Solothurn"],
                 },
                 "crop_size": {"width": 4, "height": 4},
                 "crops_per_camera": 1,
@@ -1892,7 +1920,8 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
         self.assertIn(
             "Comparison summary run: `debug/comparison/summary.json` "
             "(generated_at=2026-05-20T20:00:00+00:00, "
-            "style_url=mapbox://styles/mapbox/outdoors-v12)",
+            "style_url=mapbox://styles/mapbox/outdoors-v12, "
+            "qgis_runtimes=3.44.0-Solothurn, 3.44.1-Solothurn)",
             markdown,
         )
         self.assertIn("zermatt-trails-z18-outdoors", markdown)
@@ -2670,6 +2699,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
                     "path": str(summary_path),
                     "generated_at": "2026-05-20T20:00:00+00:00",
                     "style_url": "mapbox://styles/mapbox/outdoors-v12",
+                    "qgis_runtimes": ["3.44.0-Solothurn"],
                 },
             )
             self.assertEqual(

--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -1921,7 +1921,7 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             "Comparison summary run: `debug/comparison/summary.json` "
             "(generated_at=2026-05-20T20:00:00+00:00, "
             "style_url=mapbox://styles/mapbox/outdoors-v12, "
-            "qgis_runtimes=3.44.0-Solothurn, 3.44.1-Solothurn)",
+            "qgis_runtimes=3.44.0-Solothurn | 3.44.1-Solothurn)",
             markdown,
         )
         self.assertIn("zermatt-trails-z18-outdoors", markdown)

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -2137,7 +2137,7 @@ def _comparison_summary_run_markdown(value: object) -> str:
     if isinstance(qgis_runtimes, list):
         runtime_labels = [str(runtime) for runtime in qgis_runtimes if runtime is not None]
         if runtime_labels:
-            details.append(f"qgis_runtimes={', '.join(runtime_labels)}")
+            details.append(f"qgis_runtimes={' | '.join(runtime_labels)}")
     suffix = f" ({', '.join(details)})" if details else ""
     return f"`{path_value}`{suffix}"
 

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -23,6 +23,7 @@ try:
         comparison_visual_artifacts_from_summary,
         load_json_object,
     )
+    from .mapbox_outdoors_runtime import format_qgis_runtime_label
 except ImportError:  # pragma: no cover - direct script execution
     from mapbox_outdoors_comparison import build_all_cameras_contact_sheet  # type: ignore[no-redef]
     from mapbox_outdoors_path_pedestrian_focus import (  # type: ignore[no-redef]
@@ -37,6 +38,7 @@ except ImportError:  # pragma: no cover - direct script execution
         comparison_visual_artifacts_from_summary,
         load_json_object,
     )
+    from mapbox_outdoors_runtime import format_qgis_runtime_label  # type: ignore[no-redef]
 
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "debug" / "mapbox-outdoors-visual-crops"
 DEFAULT_CROP_SIZE = (320, 240)
@@ -52,6 +54,7 @@ DEFAULT_FOCUS_COVERAGE_SAMPLE_LIMIT = 3
 MAX_STYLE_AUDIT_SIMPLIFICATION_VALUE_LENGTH = 96
 MIN_SCORE_FOR_CROP = 1.0
 MAX_OVERLAP_RATIO = 0.35
+QGIS_RUNTIME_NOT_CAPTURED = "(not captured)"
 CROP_IMAGE_COLUMNS = (
     ("browser_reference", "Mapbox GL"),
     ("qgis_vector_render", "QGIS"),
@@ -1912,7 +1915,27 @@ def _comparison_summary_run_metadata(
         value = comparison_summary.get(key)
         if isinstance(value, str) and value:
             run_metadata[key] = value
+    qgis_runtimes = _comparison_summary_qgis_runtime_labels(comparison_summary)
+    if qgis_runtimes:
+        run_metadata["qgis_runtimes"] = qgis_runtimes
     return run_metadata
+
+
+def _comparison_summary_qgis_runtime_labels(
+    comparison_summary: Mapping[str, object],
+) -> list[str]:
+    cameras = comparison_summary.get("cameras")
+    if not isinstance(cameras, list):
+        return []
+    labels = {
+        format_qgis_runtime_label(
+            camera.get("qgis_runtime"),
+            missing_label=QGIS_RUNTIME_NOT_CAPTURED,
+        )
+        for camera in cameras
+        if isinstance(camera, Mapping) and "qgis_runtime" in camera
+    }
+    return sorted(labels)
 
 
 def _format_focus_number(value: object) -> str:
@@ -2110,6 +2133,11 @@ def _comparison_summary_run_markdown(value: object) -> str:
         for key in ("generated_at", "style_url")
         if isinstance((detail_value := value.get(key)), str) and detail_value
     ]
+    qgis_runtimes = value.get("qgis_runtimes")
+    if isinstance(qgis_runtimes, list):
+        runtime_labels = [str(runtime) for runtime in qgis_runtimes if runtime is not None]
+        if runtime_labels:
+            details.append(f"qgis_runtimes={', '.join(runtime_labels)}")
     suffix = f" ({', '.join(details)})" if details else ""
     return f"`{path_value}`{suffix}"
 


### PR DESCRIPTION
## Summary

- record distinct QGIS runtime labels from comparison summaries in visual crop report metadata
- show those labels in the visual crop Markdown comparison-run header
- document the provenance field for crop evidence generated after QGIS upgrades

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

Refs #949
