### PR TITLE
[codex] Fix direct Mapbox validation script imports

### DIFF
--- a/tests/test_mapbox_validation_script_imports.py
+++ b/tests/test_mapbox_validation_script_imports.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+import sys
+import unittest
+
+from tests import _path  # noqa: F401
+
+
+class MapboxValidationScriptImportTests(unittest.TestCase):
+    def test_runtime_helper_imports_support_direct_script_execution(self):
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+
+        for script_path in (
+            "validation/mapbox_outdoors_comparison.py",
+            "validation/mapbox_outdoors_label_settings.py",
+        ):
+            with self.subTest(script_path=script_path):
+                result = subprocess.run(
+                    [sys.executable, script_path, "--help"],
+                    check=False,
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)

--- a/tests/test_mapbox_validation_script_imports.py
+++ b/tests/test_mapbox_validation_script_imports.py
@@ -2,8 +2,11 @@ import os
 import subprocess
 import sys
 import unittest
+from pathlib import Path
 
 from tests import _path  # noqa: F401
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class MapboxValidationScriptImportTests(unittest.TestCase):
@@ -19,6 +22,7 @@ class MapboxValidationScriptImportTests(unittest.TestCase):
                 result = subprocess.run(
                     [sys.executable, script_path, "--help"],
                     check=False,
+                    cwd=REPO_ROOT,
                     env=env,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,

--- a/validation/mapbox_outdoors_comparison.py
+++ b/validation/mapbox_outdoors_comparison.py
@@ -16,8 +16,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, TypeAlias
 
-from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
-from qfit.validation.mapbox_outdoors_runtime import qgis_runtime_snapshot as _runtime_snapshot
+try:
+    from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
+    from qfit.validation.mapbox_outdoors_runtime import qgis_runtime_snapshot as _runtime_snapshot
+except ImportError:  # pragma: no cover - direct script execution
+    from mapbox_outdoors_runtime import format_qgis_runtime_label  # type: ignore[no-redef]
+    from mapbox_outdoors_runtime import qgis_runtime_snapshot as _runtime_snapshot  # type: ignore[no-redef]
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PARENT = REPO_ROOT.parent

--- a/validation/mapbox_outdoors_label_settings.py
+++ b/validation/mapbox_outdoors_label_settings.py
@@ -11,8 +11,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable
 
-from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
-from qfit.validation.mapbox_outdoors_runtime import qgis_runtime_snapshot
+try:
+    from qfit.validation.mapbox_outdoors_runtime import format_qgis_runtime_label
+    from qfit.validation.mapbox_outdoors_runtime import qgis_runtime_snapshot
+except ImportError:  # pragma: no cover - direct script execution
+    from mapbox_outdoors_runtime import format_qgis_runtime_label  # type: ignore[no-redef]
+    from mapbox_outdoors_runtime import qgis_runtime_snapshot  # type: ignore[no-redef]
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PARENT = REPO_ROOT.parent


### PR DESCRIPTION
## Summary

- restore direct `python3 validation/...` execution for Mapbox comparison and label-settings scripts after the shared runtime helper extraction
- add a regression test that runs both scripts through `--help` without `PYTHONPATH`

## Evidence

A fresh #949 all-camera validation attempt from clean `main` failed before rendering because `validation/mapbox_outdoors_comparison.py` could not import `qfit.validation.mapbox_outdoors_runtime` when executed as a script. These validation scripts are documented and used directly from the checkout.

## Validation

- `python3 -m pytest tests/test_mapbox_validation_script_imports.py tests/test_mapbox_outdoors_comparison.py tests/test_mapbox_outdoors_label_settings.py -q --tb=short`
- `git diff --check`
- `python3 -m pytest tests/ -x -q --tb=short`

Refs #949.