### PR TITLE
Add Mapbox visual crop report readout

### DIFF
--- a/tests/test_mapbox_outdoors_visual_crops.py
+++ b/tests/test_mapbox_outdoors_visual_crops.py
@@ -2242,6 +2242,117 @@ class MapboxOutdoorsVisualCropsTest(unittest.TestCase):
             markdown,
         )
 
+    def test_build_summary_markdown_adds_report_read(self):
+        markdown = build_summary_markdown(
+            {
+                "generated": "2026-05-20T20:00:00+00:00",
+                "comparison_summary_json": "debug/comparison/summary.json",
+                "comparison_summary_run": {
+                    "path": "debug/comparison/summary.json",
+                    "qgis_runtimes": ["3.34.4-Prizren"],
+                },
+                "crop_size": {"width": 4, "height": 4},
+                "crops_per_camera": 1,
+                "camera_count": 2,
+                "crop_count": 3,
+                "crop_color_movement_groups": [
+                    {
+                        "movement": "lighter + blue higher",
+                        "crop_count": 3,
+                        "cameras": {
+                            "geneva-airport-motorway-z14-outdoors": 1,
+                            "zermatt-trails-z18-outdoors": 2,
+                        },
+                        "representative_crop": {
+                            "camera": "zermatt-trails-z18-outdoors",
+                            "crop": 1,
+                            "qgis_minus_mapbox_rgb": [2.0, 0.0, 16.0],
+                            "qgis_minus_mapbox_luminance": 8.0,
+                        },
+                    }
+                ],
+                "style_audit_area_fill_focus": [
+                    {
+                        "label": "Terrain/landcover",
+                        "candidate_count": 9,
+                        "by_source_layer": [
+                            {"source_layer": "landuse_overlay", "count": 4},
+                            {"source_layer": "landuse", "count": 2},
+                            {"source_layer": "contour", "count": 1},
+                        ],
+                        "qgis_dependent_by_property": [
+                            {"property": "filter", "count": 9},
+                            {"property": "paint.fill-pattern", "count": 1},
+                        ],
+                    },
+                    {
+                        "label": "Airport/special landuse",
+                        "candidate_count": 7,
+                        "by_source_layer": [
+                            {"source_layer": "landuse", "count": 4},
+                            {"source_layer": "aeroway", "count": 2},
+                        ],
+                        "qgis_dependent_by_property": [
+                            {"property": "filter", "count": 7},
+                        ],
+                    },
+                ],
+                "style_audit_area_fill_camera_focus": [
+                    {
+                        "camera": "geneva-airport-motorway-z14-outdoors",
+                        "areas": [
+                            {
+                                "label": "Terrain/landcover",
+                                "active_candidate_count": 5,
+                            },
+                            {
+                                "label": "Airport/special landuse",
+                                "active_candidate_count": 3,
+                            },
+                        ],
+                    },
+                    {
+                        "camera": "zermatt-trails-z18-outdoors",
+                        "areas": [
+                            {
+                                "label": "Terrain/landcover",
+                                "active_candidate_count": 4,
+                            }
+                        ],
+                    },
+                ],
+                "cameras": [],
+            }
+        )
+
+        report_read = markdown.split("## Report read", 1)[1].split(
+            "Crops are selected",
+            1,
+        )[0]
+        self.assertIn("| QGIS runtimes | 3.34.4-Prizren |", report_read)
+        self.assertIn(
+            (
+                "| Top crop color movements | lighter + blue higher=3 "
+                "(rep 2.0, 0.0, 16.0 / +8.0) |"
+            ),
+            report_read,
+        )
+        self.assertIn(
+            (
+                "Terrain/landcover (9 candidates; sources landuse_overlay=4, "
+                "landuse=2, contour=1; QGIS-dependent filter=9, "
+                "paint.fill-pattern=1)"
+            ),
+            report_read,
+        )
+        self.assertIn(
+            (
+                "Airport/special landuse=3 active candidates across 1 camera row, "
+                "Terrain/landcover=9 active candidates across 2 camera rows"
+            ),
+            report_read,
+        )
+
     def test_build_summary_markdown_handles_malformed_color_delta_values(self):
         markdown = build_summary_markdown(
             {

--- a/validation/mapbox_outdoors_visual_crops.py
+++ b/validation/mapbox_outdoors_visual_crops.py
@@ -2142,6 +2142,128 @@ def _comparison_summary_run_markdown(value: object) -> str:
     return f"`{path_value}`{suffix}"
 
 
+def _summary_read_qgis_runtime_label(report: Mapping[str, object]) -> str:
+    comparison_summary_run = report.get("comparison_summary_run")
+    if not isinstance(comparison_summary_run, Mapping):
+        return ""
+    qgis_runtimes = comparison_summary_run.get("qgis_runtimes")
+    if not isinstance(qgis_runtimes, list):
+        return ""
+    labels = [str(runtime) for runtime in qgis_runtimes if runtime not in (None, "")]
+    return " | ".join(labels)
+
+
+def _mapping_rows(value: object) -> list[Mapping[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [row for row in value if isinstance(row, Mapping)]
+
+
+def _summary_read_area_fill_detail_parts(row: Mapping[str, object]) -> list[str]:
+    parts = []
+    candidate_count = row.get("candidate_count")
+    if isinstance(candidate_count, int) and not isinstance(candidate_count, bool):
+        parts.append(f"{candidate_count} candidates")
+    source_layers = _count_summary_labels(row.get("by_source_layer"), "source_layer")[:3]
+    if source_layers:
+        parts.append(f"sources {_joined_summary_labels(source_layers)}")
+    qgis_dependent = _count_summary_labels(
+        row.get("qgis_dependent_by_property"),
+        "property",
+    )[:3]
+    if qgis_dependent:
+        parts.append(f"QGIS-dependent {_joined_summary_labels(qgis_dependent)}")
+    return parts
+
+
+def _summary_read_area_fill_label(row: Mapping[str, object]) -> str:
+    area_label = row.get("label")
+    if not isinstance(area_label, str) or not area_label:
+        return ""
+    detail_parts = _summary_read_area_fill_detail_parts(row)
+    if not detail_parts:
+        return area_label
+    return f"{area_label} ({'; '.join(detail_parts)})"
+
+
+def _summary_read_area_fill_labels(report: Mapping[str, object]) -> list[str]:
+    return [
+        label
+        for row in _mapping_rows(report.get("style_audit_area_fill_focus"))
+        if (label := _summary_read_area_fill_label(row))
+    ]
+
+
+def _add_summary_read_active_area_fill_count(
+    area_counts: dict[str, dict[str, int]],
+    area: Mapping[str, object],
+) -> None:
+    label = area.get("label")
+    if not isinstance(label, str) or not label:
+        return
+    counts = area_counts.setdefault(label, {"camera_rows": 0, "active_candidates": 0})
+    counts["camera_rows"] += 1
+    active_candidate_count = area.get("active_candidate_count")
+    if isinstance(active_candidate_count, int) and not isinstance(
+        active_candidate_count,
+        bool,
+    ):
+        counts["active_candidates"] += active_candidate_count
+
+
+def _summary_read_active_area_fill_labels(report: Mapping[str, object]) -> list[str]:
+    area_counts: dict[str, dict[str, int]] = {}
+    camera_focus_rows = _mapping_rows(report.get("style_audit_area_fill_camera_focus"))
+    for camera_focus in camera_focus_rows:
+        for area in _mapping_rows(camera_focus.get("areas")):
+            _add_summary_read_active_area_fill_count(area_counts, area)
+    return [
+        (
+            f"{label}={counts['active_candidates']} active candidates "
+            f"across {counts['camera_rows']} camera "
+            f"{'row' if counts['camera_rows'] == 1 else 'rows'}"
+        )
+        for label, counts in sorted(area_counts.items())
+    ]
+
+
+def _summary_read_lines(report: Mapping[str, object]) -> list[str]:
+    rows = []
+    qgis_runtime_label = _summary_read_qgis_runtime_label(report)
+    if qgis_runtime_label:
+        rows.append(["QGIS runtimes", qgis_runtime_label])
+    movement_labels = _area_fill_crop_movement_labels(report)[:3]
+    if movement_labels:
+        rows.append(["Top crop color movements", _joined_summary_labels(movement_labels)])
+    area_fill_labels = _summary_read_area_fill_labels(report)
+    if area_fill_labels:
+        rows.append(["Style audit area-fill candidates", _joined_summary_labels(area_fill_labels)])
+    active_area_fill_labels = _summary_read_active_area_fill_labels(report)
+    if active_area_fill_labels:
+        rows.append(
+            [
+                "Active area-fill candidates at crop zooms",
+                _joined_summary_labels(active_area_fill_labels),
+            ]
+        )
+    if not rows:
+        return []
+    lines = [
+        "",
+        "## Report read",
+        "",
+        (
+            "Condenses the runtime, repeated crop tint families, and style-audit area-fill "
+            "cues that are most useful before choosing a follow-up Mapbox Outdoors style slice."
+        ),
+        "",
+        "| Signal | Read |",
+        "| --- | --- |",
+    ]
+    lines.extend(_markdown_table_row(row) for row in rows)
+    return lines
+
+
 def _include_comparison_delta_columns(report: Mapping[str, object]) -> bool:
     return any(
         isinstance(camera, Mapping) and isinstance(camera.get("comparison_delta"), Mapping)
@@ -3355,6 +3477,7 @@ def _style_audit_area_fill_candidate_detail_lines(report: Mapping[str, object]) 
 def build_summary_markdown(report: Mapping[str, object]) -> str:
     lines = _summary_header_lines(report)
     include_comparison_delta = _include_comparison_delta_columns(report)
+    lines.extend(_summary_read_lines(report))
     lines.extend(_summary_table_intro_lines(report))
     for camera in report.get("cameras", []):
         if not isinstance(camera, Mapping):


### PR DESCRIPTION
Refs #949.

## Summary

- Add a `Report read` section to the Mapbox Outdoors visual crop Markdown report.
- Condense QGIS runtime labels, top crop color movement families, global style-audit area-fill candidates, and active area-fill candidate counts at crop zooms.
- Cover the new readout with a focused Markdown unit test.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_visual_crops.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- Regenerated a style-audit annotated crop report from the latest #949 all-camera artifacts: `debug/mapbox-outdoors-visual-crops/20260525T114723Z/summary.md`
