### PR TITLE
Show Mapbox source overlap aggregate classes

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -209,7 +209,7 @@ python3 validation/mapbox_outdoors_source_crop_overlap.py \
   --aggregate-output /tmp/source-crop-overlap-aggregate.md
 ```
 
-The aggregate Markdown summarizes source-layer coverage sums, QGIS style-layer coverage sums, distinct QGIS runtimes, and per-camera rows from the input reports. Use it to choose the next owner-mask or missing-class probe across the camera matrix; it remains bbox attribution, not rendered-pixel ownership or a production style-change recommendation.
+The aggregate Markdown summarizes source-layer coverage sums, top class coverage within each source layer, QGIS style-layer coverage sums, distinct QGIS runtimes, and per-camera rows from the input reports. Use it to choose the next owner-mask or missing-class probe across the camera matrix; it remains bbox attribution, not rendered-pixel ownership or a production style-change recommendation.
 
 When source/crop overlap points at a possible rendered owner, run QGIS-only transparent layer masks against an existing comparison manifest before changing production paint:
 

--- a/tests/test_mapbox_outdoors_source_crop_overlap.py
+++ b/tests/test_mapbox_outdoors_source_crop_overlap.py
@@ -645,6 +645,7 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
                         overlap_feature_count=7,
                         coverage=2.5,
                         classes={"park": 3, "grass": 2},
+                        class_coverage={"park": 1.4, "grass": 1.1},
                         style_matches={
                             "landuse-green": {"type": "fill", "feature_count": 5, "crop_coverage_ratio": 1.5},
                             "landuse-other": {"type": "fill", "feature_count": 2, "crop_coverage_ratio": 0.25},
@@ -664,6 +665,7 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
                         overlap_feature_count=4,
                         coverage=1.25,
                         classes={"residential": 4},
+                        class_coverage={"residential": 1.25},
                         style_matches={
                             "landuse-green": {"type": "fill", "feature_count": 2, "crop_coverage_ratio": 0.75}
                         },
@@ -673,6 +675,7 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
                         overlap_feature_count=1,
                         coverage=0.5,
                         classes={"national_park": 1},
+                        class_coverage={"national_park": 0.5},
                     ),
                 ],
             )
@@ -694,12 +697,19 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
         self.assertEqual(source_rows["landuse"]["camera_count"], 2)
         self.assertEqual(source_rows["landuse"]["overlap_feature_count"], 11)
         self.assertEqual(source_rows["landuse"]["coverage_sum"], 3.75)
+        self.assertEqual(
+            source_rows["landuse"]["class_coverage"],
+            {"park": 1.4, "residential": 1.25, "grass": 1.1},
+        )
         self.assertEqual(source_rows["aeroway"]["zero_overlap_reports"], 1)
         self.assertEqual(style_rows[("landuse", "landuse-green")]["feature_count"], 7)
         self.assertEqual(style_rows[("landuse", "landuse-green")]["coverage_sum"], 2.25)
         self.assertIn("# Mapbox Outdoors source/crop overlap aggregate", markdown)
         self.assertIn("QGIS runtimes: `3.34.4-Prizren, Future`", markdown)
-        self.assertIn("| `landuse` | 2 | 2 | 11 | 3.750 | 2.500 | 0 |", markdown)
+        self.assertIn(
+            "| `landuse` | 2 | 2 | 11 | 3.750 | 2.500 | 0 | park=1.400, residential=1.250, grass=1.100 |",
+            markdown,
+        )
         self.assertIn("| `landuse` | `landuse-green` | `fill` | 2 | 2 | 7 | 2.250 | 1.500 |", markdown)
         self.assertIn(
             "| `geneva-airport-motorway-z14-outdoors` | 14 | `landuse` | 7 | 2.500 | "
@@ -707,6 +717,7 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
             markdown,
         )
         self.assertIn("Top source-layer bbox coverage sums: landuse=3.750", markdown)
+        self.assertIn("Top source-layer class coverage sums: landuse: park=1.400", markdown)
         self.assertIn("Source layers with zero overlap wherever requested: aeroway.", markdown)
         self.assertIn("Treat aggregate coverage as bbox attribution across reports", markdown)
 
@@ -742,6 +753,31 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
         self.assertIn("Aggregate summary:", stdout.getvalue())
         self.assertIn("source/crop overlap aggregate", output_markdown)
         self.assertIn("| `unit-camera` | 10 | `landuse` | 1 | 0.500 | park=1 | - |", output_markdown)
+
+    def test_aggregate_class_readout_handles_non_numeric_coverage_values(self):
+        markdown = render_aggregate_markdown_summary({
+            "generated": "2026-05-25T12:30:00+00:00",
+            "input_reports": ["debug/source-crop-overlap.json"],
+            "qgis_runtimes": ["3.34.4-Prizren"],
+            "source_layer_rows": [
+                {
+                    "source_layer": "landuse",
+                    "report_count": 1,
+                    "camera_count": 1,
+                    "overlap_feature_count": 2,
+                    "coverage_sum": 1.0,
+                    "max_bbox_crop_coverage_ratio": 1.0,
+                    "zero_overlap_reports": 0,
+                    "class_coverage": {"park": 0.75, "bad": "not-a-number"},
+                    "cameras": ["unit-camera"],
+                }
+            ],
+            "style_layer_rows": [],
+            "camera_source_rows": [],
+        })
+
+        self.assertIn("Top source-layer class coverage sums: landuse: park=0.750, bad=-.", markdown)
+        self.assertIn("| `landuse` | 1 | 1 | 2 | 1.000 | 1.000 | 0 | park=0.750, bad=- |", markdown)
 
     def test_collect_report_requires_crop_boxes_for_camera(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -793,6 +829,7 @@ def _aggregate_source_layer(
     overlap_feature_count,
     coverage,
     classes=None,
+    class_coverage=None,
     style_matches=None,
 ):
     return {
@@ -800,6 +837,12 @@ def _aggregate_source_layer(
         "overlap_feature_count": overlap_feature_count,
         "bbox_crop_coverage_ratio": coverage,
         "property_counts": {"class": classes or {}},
+        "property_overlap_areas": {
+            "class": {
+                class_name: {"crop_coverage_ratio": coverage}
+                for class_name, coverage in (class_coverage or {}).items()
+            }
+        },
         "qgis_style_layer_matches": style_matches or {},
     }
 

--- a/validation/mapbox_outdoors_source_crop_overlap.py
+++ b/validation/mapbox_outdoors_source_crop_overlap.py
@@ -81,6 +81,7 @@ class _AggregateSourceLayerTotal:
     source_layer: str
     reports: set[str] = field(default_factory=set)
     cameras: set[str] = field(default_factory=set)
+    class_coverage: Counter[str] = field(default_factory=Counter)
     overlap_feature_count: int = 0
     coverage_sum: float = 0.0
     max_coverage: float = 0.0
@@ -2120,6 +2121,28 @@ def _report_qgis_runtimes(report: Mapping[str, object]) -> list[str]:
     return [str(runtime) for runtime in runtimes if runtime not in (None, "")]
 
 
+def _update_class_coverage(counter: Counter[str], record: Mapping[str, object]) -> None:
+    property_areas = record.get("property_overlap_areas")
+    if not isinstance(property_areas, Mapping):
+        return
+    class_areas = property_areas.get("class")
+    if not isinstance(class_areas, Mapping):
+        return
+    for class_name, area_record in class_areas.items():
+        if not isinstance(area_record, Mapping):
+            continue
+        coverage = _float_value(area_record.get("crop_coverage_ratio"))
+        if coverage > 0.0:
+            counter.update({str(class_name): coverage})
+
+
+def _class_coverage_row(counter: Counter[str]) -> dict[str, float]:
+    return {
+        class_name: _rounded_float(coverage)
+        for class_name, coverage in counter.most_common(MAX_COUNT_VALUES)
+    }
+
+
 def _update_source_layer_total(
     total: _AggregateSourceLayerTotal,
     *,
@@ -2131,6 +2154,7 @@ def _update_source_layer_total(
     overlap_feature_count = _int_value(record.get("overlap_feature_count"))
     total.reports.add(input_report)
     total.cameras.add(camera_name)
+    _update_class_coverage(total.class_coverage, record)
     total.overlap_feature_count += overlap_feature_count
     total.coverage_sum += coverage
     total.max_coverage = max(total.max_coverage, coverage)
@@ -2197,6 +2221,7 @@ def _source_layer_total_row(total: _AggregateSourceLayerTotal) -> dict[str, obje
         "coverage_sum": _rounded_float(total.coverage_sum),
         "max_bbox_crop_coverage_ratio": _rounded_float(total.max_coverage),
         "zero_overlap_reports": total.zero_overlap_reports,
+        "class_coverage": _class_coverage_row(total.class_coverage),
         "cameras": sorted(total.cameras),
     }
 
@@ -2337,6 +2362,12 @@ def _camera_list_label(value: object) -> str:
     return ", ".join(f"`{camera}`" for camera in value)
 
 
+def _format_class_coverage(value: object) -> str:
+    if not isinstance(value, Mapping) or not value:
+        return "-"
+    return ", ".join(f"{class_name}={_format_coverage(coverage)}" for class_name, coverage in value.items())
+
+
 def _aggregate_source_layer_row(row: Mapping[str, object]) -> str:
     return _markdown_table_row(
         [
@@ -2347,6 +2378,7 @@ def _aggregate_source_layer_row(row: Mapping[str, object]) -> str:
             _format_coverage(row.get("coverage_sum")),
             _format_coverage(row.get("max_bbox_crop_coverage_ratio")),
             row.get("zero_overlap_reports"),
+            _format_class_coverage(row.get("class_coverage")),
             _camera_list_label(row.get("cameras")),
         ]
     )
@@ -2408,6 +2440,20 @@ def _aggregate_style_read_labels(rows: Sequence[Mapping[str, object]]) -> list[s
     ][:5]
 
 
+def _aggregate_class_read_labels(rows: Sequence[Mapping[str, object]]) -> list[str]:
+    labels = []
+    for row in rows:
+        class_coverage = row.get("class_coverage")
+        if not isinstance(class_coverage, Mapping) or not class_coverage:
+            continue
+        class_labels = ", ".join(
+            f"{class_name}={_format_coverage(coverage)}"
+            for class_name, coverage in list(class_coverage.items())[:3]
+        )
+        labels.append(f"{row.get('source_layer') or MISSING_VALUE}: {class_labels}")
+    return labels[:5]
+
+
 def _aggregate_zero_overlap_labels(rows: Sequence[Mapping[str, object]]) -> list[str]:
     return [
         str(row.get("source_layer") or MISSING_VALUE)
@@ -2428,6 +2474,7 @@ def _aggregate_read_lines(
         "",
         f"- Top source-layer bbox coverage sums: {_joined_read_labels(_aggregate_source_read_labels(source_rows))}.",
         f"- Top QGIS style-layer bbox coverage sums: {_joined_read_labels(_aggregate_style_read_labels(style_rows))}.",
+        f"- Top source-layer class coverage sums: {_joined_read_labels(_aggregate_class_read_labels(source_rows))}.",
         (
             "- Source layers with zero overlap wherever requested: "
             f"{_joined_read_labels(_aggregate_zero_overlap_labels(source_rows))}."
@@ -2459,10 +2506,10 @@ def render_aggregate_markdown_summary(report: Mapping[str, object]) -> str:
         "",
         "## Source layer totals",
         "",
-        "| Source layer | Reports | Cameras | Overlap features | Coverage sum | Max coverage | Zero-overlap reports | Cameras |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        "| Source layer | Reports | Cameras | Overlap features | Coverage sum | Max coverage | Zero-overlap reports | Top class coverage | Cameras |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
     ])
-    lines.extend(_aggregate_source_layer_row(row) for row in source_rows) if source_rows else lines.append("| _none_ | 0 | 0 | 0 | 0 | 0 | 0 | |")
+    lines.extend(_aggregate_source_layer_row(row) for row in source_rows) if source_rows else lines.append("| _none_ | 0 | 0 | 0 | 0 | 0 | 0 | | |")
     lines.extend([
         "",
         "## QGIS style-layer coverage totals",


### PR DESCRIPTION
## Summary
- add top class coverage to source/crop overlap aggregate source-layer rows
- surface class coverage in the aggregate readout so low-zoom landuse/landcover candidates are visible without a one-off script
- update harness docs to mention aggregate class coverage

Refs #949

## Validation
- `python3 -m pytest tests/test_mapbox_outdoors_source_crop_overlap.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short`
- `git diff --check`
- Generated class-aware aggregate from current seven-camera #949 source/crop evidence: `debug/mapbox-outdoors-source-crop-overlap/aggregate/20260525T1248-all-camera-source-overlap-class-aggregate.md`

## Read
- The class-aware aggregate keeps QGIS runtime `3.34.4-Prizren` visible.
- Top source-layer class coverage now makes the main landuse contributors visible directly in the report readout: `grass=11.062`, `wood=9.155`, `rock=6.964`, `agriculture=6.040`, `park=5.543`, and `residential=3.174`.
- It also names the repeated landcover contributors: `scrub=4.935`, `grass=4.838`, `crop=4.810`, and `wood=4.391`.
- This remains bbox attribution only; no production style change is promoted.