### PR TITLE
Show per-camera source overlap class coverage

### DIFF
--- a/docs/mapbox-outdoors-comparison-harness.md
+++ b/docs/mapbox-outdoors-comparison-harness.md
@@ -209,7 +209,7 @@ python3 validation/mapbox_outdoors_source_crop_overlap.py \
   --aggregate-output /tmp/source-crop-overlap-aggregate.md
 ```
 
-The aggregate Markdown summarizes source-layer coverage sums, top class coverage within each source layer, QGIS style-layer coverage sums, distinct QGIS runtimes, and per-camera rows from the input reports. Use it to choose the next owner-mask or missing-class probe across the camera matrix; it remains bbox attribution, not rendered-pixel ownership or a production style-change recommendation.
+The aggregate Markdown summarizes source-layer coverage sums, top class coverage within each source layer, QGIS style-layer coverage sums, distinct QGIS runtimes, and per-camera rows with class counts and class coverage from the input reports. Use it to choose the next owner-mask or missing-class probe across the camera matrix; it remains bbox attribution, not rendered-pixel ownership or a production style-change recommendation.
 
 When source/crop overlap points at a possible rendered owner, run QGIS-only transparent layer masks against an existing comparison manifest before changing production paint:
 

--- a/tests/test_mapbox_outdoors_source_crop_overlap.py
+++ b/tests/test_mapbox_outdoors_source_crop_overlap.py
@@ -713,7 +713,7 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
         self.assertIn("| `landuse` | `landuse-green` | `fill` | 2 | 2 | 7 | 2.250 | 1.500 |", markdown)
         self.assertIn(
             "| `geneva-airport-motorway-z14-outdoors` | 14 | `landuse` | 7 | 2.500 | "
-            "park=3, grass=2 | landuse-green=1.500, landuse-other=0.250 |",
+            "park=3, grass=2 | park=1.400, grass=1.100 | landuse-green=1.500, landuse-other=0.250 |",
             markdown,
         )
         self.assertIn("Top source-layer bbox coverage sums: landuse=3.750", markdown)
@@ -752,7 +752,7 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertIn("Aggregate summary:", stdout.getvalue())
         self.assertIn("source/crop overlap aggregate", output_markdown)
-        self.assertIn("| `unit-camera` | 10 | `landuse` | 1 | 0.500 | park=1 | - |", output_markdown)
+        self.assertIn("| `unit-camera` | 10 | `landuse` | 1 | 0.500 | park=1 | - | - |", output_markdown)
 
     def test_aggregate_class_readout_handles_non_numeric_coverage_values(self):
         markdown = render_aggregate_markdown_summary({
@@ -778,6 +778,33 @@ class MapboxOutdoorsSourceCropOverlapTests(unittest.TestCase):
 
         self.assertIn("Top source-layer class coverage sums: landuse: park=0.750, bad=-.", markdown)
         self.assertIn("| `landuse` | 1 | 1 | 2 | 1.000 | 1.000 | 0 | park=0.750, bad=- |", markdown)
+
+    def test_aggregate_camera_class_coverage_handles_non_numeric_values(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report_path = _write_aggregate_source_overlap_report(
+                root / "source-crop-overlap.json",
+                camera="unit-camera",
+                camera_zoom=10.0,
+                qgis_runtimes=["3.34.4-Prizren"],
+                source_layers=[
+                    _aggregate_source_layer(
+                        "landuse",
+                        overlap_feature_count=2,
+                        coverage=1.0,
+                        classes={"park": 1, "bad": 1},
+                        class_coverage={"park": 0.75, "bad": "not-a-number"},
+                    )
+                ],
+            )
+
+            aggregate = build_source_crop_overlap_aggregate_report((report_path,))
+            markdown = render_aggregate_markdown_summary(aggregate)
+
+        self.assertIn(
+            "| `unit-camera` | 10 | `landuse` | 2 | 1.000 | park=1, bad=1 | park=0.750, bad=- | - |",
+            markdown,
+        )
 
     def test_collect_report_requires_crop_boxes_for_camera(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/validation/mapbox_outdoors_source_crop_overlap.py
+++ b/validation/mapbox_outdoors_source_crop_overlap.py
@@ -1701,7 +1701,7 @@ def _format_property_coverage(record: Mapping[str, object], key: str) -> str:
     if not isinstance(value_areas, dict) or not value_areas:
         return "-"
     return ", ".join(
-        f"{value}={float(area_record.get('crop_coverage_ratio', 0.0)):.3f}"
+        f"{value}={_format_coverage(area_record.get('crop_coverage_ratio', 0.0))}"
         for value, area_record in value_areas.items()
         if isinstance(area_record, dict)
     )
@@ -2208,6 +2208,7 @@ def _camera_source_row(
         "overlap_feature_count": _int_value(record.get("overlap_feature_count")),
         "bbox_crop_coverage_ratio": _float_value(record.get("bbox_crop_coverage_ratio")),
         "classes": _format_property_counts(record, "class"),
+        "class_coverage": _format_property_coverage(record, "class"),
         "qgis_style_layer_coverage": _format_style_layer_matches(record),
     }
 
@@ -2413,6 +2414,7 @@ def _aggregate_camera_source_row(row: Mapping[str, object]) -> str:
             row.get("overlap_feature_count"),
             _format_coverage(row.get("bbox_crop_coverage_ratio")),
             row.get("classes") or "-",
+            row.get("class_coverage") or "-",
             row.get("qgis_style_layer_coverage") or "-",
         ]
     )
@@ -2522,10 +2524,10 @@ def render_aggregate_markdown_summary(report: Mapping[str, object]) -> str:
         "",
         "## Per-camera source overlap",
         "",
-        "| Camera | Zoom | Source layer | Overlap features | Bbox crop coverage | Classes | QGIS style-layer coverage |",
-        "| --- | ---: | --- | ---: | ---: | --- | --- |",
+        "| Camera | Zoom | Source layer | Overlap features | Bbox crop coverage | Classes | Class coverage | QGIS style-layer coverage |",
+        "| --- | ---: | --- | ---: | ---: | --- | --- | --- |",
     ])
-    lines.extend(_aggregate_camera_source_row(row) for row in camera_rows) if camera_rows else lines.append("| _none_ | | | 0 | 0 | | |")
+    lines.extend(_aggregate_camera_source_row(row) for row in camera_rows) if camera_rows else lines.append("| _none_ | | | 0 | 0 | | | |")
     lines.append("")
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary

- add per-camera class coverage to the source/crop overlap aggregate rows
- document that aggregate per-camera rows now include class counts and class coverage
- keep the change diagnostic-only for #949 so the next owner-mask/style probe can target concrete camera/class pairs

## Evidence

- Regenerated aggregate: `debug/mapbox-outdoors-source-crop-overlap/aggregate/20260525T1302-all-camera-source-overlap-camera-class-aggregate.md`
- The regenerated read shows per-camera coverage such as Geneva landuse park/grass, Lausanne landuse agriculture/wood, Switzerland low-zoom landuse agriculture/wood/scrub, and high-zoom Zermatt rock/grass.
- This is bbox attribution only, not rendered-pixel ownership or a production style-change recommendation.

## Validation

- `python3 -m pytest tests/test_mapbox_outdoors_source_crop_overlap.py -q --tb=short`
- `python3 -m pytest tests/ -x -q --tb=short && git diff --check`

Refs #949
