### PR TITLE
Preserve user CRS when loading stored layers

### DIFF
--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -67,8 +67,12 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         self.assertIsInstance(gateway, LayerGateway)
         canvas = gateway._canvas_service
         loader = gateway._project_layer_loader
-        canvas.ensure_working_crs.assert_called_once_with(gateway.iface, preserve_extent=False)
+        project = modules["qgis.core"].QgsProject.instance.return_value
+        project_crs = project.crs.return_value
+        canvas.ensure_working_crs.assert_not_called()
         loader.load_output_layers.assert_called_once_with("/tmp/out.gpkg")
+        project.setCrs.assert_called_once_with(project_crs)
+        gateway.iface.mapCanvas.return_value.setDestinationCrs.assert_called_once_with(project_crs)
         canvas.zoom_to_layers.assert_called_once_with(
             gateway.iface,
             [result[0], result[1], result[2], result[3]],
@@ -99,8 +103,12 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         self.assertIsInstance(gateway, LayerGateway)
         canvas = gateway._canvas_service
         loader = gateway._project_layer_loader
-        canvas.ensure_working_crs.assert_called_once_with(gateway.iface, preserve_extent=False)
+        project = modules["qgis.core"].QgsProject.instance.return_value
+        project_crs = project.crs.return_value
+        canvas.ensure_working_crs.assert_not_called()
         loader.load_route_layers.assert_called_once_with("/tmp/out.gpkg")
+        project.setCrs.assert_called_once_with(project_crs)
+        gateway.iface.mapCanvas.return_value.setDestinationCrs.assert_called_once_with(project_crs)
         gateway._style_service.apply_route_style.assert_called_once_with(*result)
         canvas.zoom_to_layers.assert_called_once_with(gateway.iface, result)
         gateway._move_background_layers_to_bottom.assert_called_once_with()
@@ -251,8 +259,12 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         modules["qfit.visualization.infrastructure.background_map_service"].BackgroundMapService.assert_not_called()
         modules["qfit.visualization.infrastructure.map_canvas_service"].MapCanvasService.assert_not_called()
         modules["qfit.visualization.infrastructure.project_layer_loader"].ProjectLayerLoader.assert_not_called()
-        gateway._canvas_service.ensure_working_crs.assert_called_once_with(gateway.iface, preserve_extent=False)
+        project = modules["qgis.core"].QgsProject.instance.return_value
+        project_crs = project.crs.return_value
+        gateway._canvas_service.ensure_working_crs.assert_not_called()
         gateway._project_layer_loader.load_output_layers.assert_called_once_with("/tmp/override.gpkg")
+        project.setCrs.assert_called_once_with(project_crs)
+        gateway.iface.mapCanvas.return_value.setDestinationCrs.assert_called_once_with(project_crs)
         gateway._background_service.ensure_background_layer.assert_called_once()
 
     @staticmethod

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -172,6 +172,88 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
 
         project.setCrs.assert_called_once_with(project_crs)
 
+    def test_qgis_gateway_current_project_crs_handles_unavailable_project(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            modules["qgis.core"].QgsProject.instance.return_value.crs.side_effect = RuntimeError("closed")
+
+            self.assertIsNone(gateway._current_project_crs())
+
+    def test_qgis_gateway_current_project_crs_handles_missing_or_broken_crs(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            project = modules["qgis.core"].QgsProject.instance.return_value
+
+            project.crs.return_value = None
+            self.assertIsNone(gateway._current_project_crs())
+
+            broken_crs = MagicMock(name="broken_crs")
+            broken_crs.isValid.side_effect = RuntimeError("invalid")
+            project.crs.return_value = broken_crs
+            self.assertIsNone(gateway._current_project_crs())
+
+    def test_qgis_gateway_restore_project_crs_handles_invalid_and_broken_crs(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            project = modules["qgis.core"].QgsProject.instance.return_value
+
+            gateway._restore_project_crs(None)
+
+            invalid_crs = MagicMock(name="invalid_crs")
+            invalid_crs.isValid.return_value = False
+            gateway._restore_project_crs(invalid_crs)
+
+            broken_crs = MagicMock(name="broken_crs")
+            broken_crs.isValid.side_effect = AttributeError("missing")
+            gateway._restore_project_crs(broken_crs)
+
+        project.setCrs.assert_not_called()
+
+    def test_qgis_gateway_restore_project_crs_handles_restore_failures(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            project = modules["qgis.core"].QgsProject.instance.return_value
+            project_crs = project.crs.return_value
+
+            project.setCrs.side_effect = RuntimeError("project closed")
+            gateway._restore_project_crs(project_crs)
+            gateway.iface.mapCanvas.return_value.setDestinationCrs.assert_not_called()
+
+            project.setCrs.side_effect = None
+            gateway.iface.mapCanvas.return_value.setDestinationCrs.side_effect = RuntimeError("canvas closed")
+            gateway._restore_project_crs(project_crs)
+
+        self.assertEqual(project.setCrs.call_count, 2)
+        gateway.iface.mapCanvas.return_value.setDestinationCrs.assert_called_once_with(project_crs)
+
     def test_qgis_gateway_remove_layers_delegates_to_qgsproject(self):
         modules = self._qgis_gateway_modules()
 

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -113,6 +113,65 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         canvas.zoom_to_layers.assert_called_once_with(gateway.iface, result)
         gateway._move_background_layers_to_bottom.assert_called_once_with()
 
+    def test_qgis_gateway_restores_project_crs_when_layer_loading_fails(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            gateway._canvas_service = MagicMock(name="canvas_service")
+            gateway._project_layer_loader = MagicMock(name="project_layer_loader")
+            gateway._project_layer_loader.load_output_layers.side_effect = RuntimeError("load failed")
+
+            with self.assertRaisesRegex(RuntimeError, "load failed"):
+                gateway.load_output_layers("/tmp/out.gpkg")
+
+        project = modules["qgis.core"].QgsProject.instance.return_value
+        project_crs = project.crs.return_value
+        project.setCrs.assert_called_once_with(project_crs)
+        gateway.iface.mapCanvas.return_value.setDestinationCrs.assert_called_once_with(project_crs)
+        gateway._canvas_service.zoom_to_layers.assert_not_called()
+
+    def test_qgis_gateway_ignores_invalid_project_crs_snapshot(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            project = modules["qgis.core"].QgsProject.instance.return_value
+            project.crs.return_value.isValid.return_value = False
+
+            self.assertIsNone(gateway._current_project_crs())
+            gateway._restore_project_crs(project.crs.return_value)
+
+        project.setCrs.assert_not_called()
+        gateway.iface.mapCanvas.return_value.setDestinationCrs.assert_not_called()
+
+    def test_qgis_gateway_can_restore_project_crs_without_canvas(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(None)
+            project = modules["qgis.core"].QgsProject.instance.return_value
+            project_crs = project.crs.return_value
+
+            gateway._restore_project_crs(project_crs)
+
+        project.setCrs.assert_called_once_with(project_crs)
+
     def test_qgis_gateway_remove_layers_delegates_to_qgsproject(self):
         modules = self._qgis_gateway_modules()
 

--- a/tests/test_layer_manager.py
+++ b/tests/test_layer_manager.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 
@@ -13,7 +13,7 @@ except ImportError as exc:  # pragma: no cover - depends on QGIS bindings in CI
 
 @unittest.skipIf(LayerManager is None, f"LayerManager unavailable: {_LAYER_MANAGER_IMPORT_ERROR}")
 class LayerManagerTests(unittest.TestCase):
-    def test_load_output_layers_switches_crs_without_preserving_old_extent(self):
+    def test_load_output_layers_preserves_user_project_crs(self):
         iface = MagicMock()
         manager = LayerManager(iface)
 
@@ -28,18 +28,67 @@ class LayerManagerTests(unittest.TestCase):
         manager._canvas_service.zoom_to_layers = MagicMock()
         manager._move_background_layers_to_bottom = MagicMock()
 
-        result = manager.load_output_layers("/tmp/test.gpkg")
+        project = MagicMock()
+        project_crs = MagicMock()
+        project_crs.isValid.return_value = True
+        project.crs.return_value = project_crs
+        canvas = iface.mapCanvas.return_value
 
-        manager._canvas_service.ensure_working_crs.assert_called_once_with(
-            iface, preserve_extent=False
-        )
+        with patch("qfit.visualization.infrastructure.qgis_layer_gateway.QgsProject") as qgs_project:
+            qgs_project.instance.return_value = project
+            result = manager.load_output_layers("/tmp/test.gpkg")
+
+        manager._canvas_service.ensure_working_crs.assert_not_called()
         manager._project_layer_loader.load_output_layers.assert_called_once_with(
             "/tmp/test.gpkg"
         )
+        project.setCrs.assert_called_once_with(project_crs)
+        canvas.setDestinationCrs.assert_called_once_with(project_crs)
         manager._canvas_service.zoom_to_layers.assert_called_once_with(
             iface, [activities, starts, points, atlas]
         )
         self.assertEqual(result, (activities, starts, points, atlas))
+
+    def test_load_route_layers_preserves_user_project_crs(self):
+        iface = MagicMock()
+        manager = LayerManager(iface)
+
+        routes = MagicMock()
+        points = MagicMock()
+        samples = MagicMock()
+        manager._project_layer_loader.load_output_layers = MagicMock()
+        manager._project_layer_loader.load_route_layers = MagicMock(
+            return_value=(routes, points, samples)
+        )
+        manager._style_service.apply_style = MagicMock()
+        manager._style_service.apply_route_style = MagicMock()
+        manager._canvas_service.ensure_working_crs = MagicMock()
+        manager._canvas_service.zoom_to_layers = MagicMock()
+        manager._move_background_layers_to_bottom = MagicMock()
+
+        project = MagicMock()
+        project_crs = MagicMock()
+        project_crs.isValid.return_value = True
+        project.crs.return_value = project_crs
+        canvas = iface.mapCanvas.return_value
+
+        with patch("qfit.visualization.infrastructure.qgis_layer_gateway.QgsProject") as qgs_project:
+            qgs_project.instance.return_value = project
+            result = manager.load_route_layers("/tmp/test.gpkg")
+
+        manager._canvas_service.ensure_working_crs.assert_not_called()
+        manager._project_layer_loader.load_route_layers.assert_called_once_with(
+            "/tmp/test.gpkg"
+        )
+        project.setCrs.assert_called_once_with(project_crs)
+        canvas.setDestinationCrs.assert_called_once_with(project_crs)
+        manager._style_service.apply_route_style.assert_called_once_with(
+            routes, points, samples
+        )
+        manager._canvas_service.zoom_to_layers.assert_called_once_with(
+            iface, (routes, points, samples)
+        )
+        self.assertEqual(result, (routes, points, samples))
 
 
 if __name__ == "__main__":

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -17,6 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 try:
     from qgis.core import (
         QgsApplication,
+        QgsCoordinateReferenceSystem,
         QgsCoordinateTransform,
         QgsFeature,
         QgsLayoutExporter,
@@ -71,6 +72,7 @@ try:
     QGIS_IMPORT_ERROR = None
 except Exception as exc:  # pragma: no cover - exercised only when QGIS is unavailable
     QgsApplication = None
+    QgsCoordinateReferenceSystem = None
     QgsFeature = None
     QgsLayoutExporter = None
     QgsProject = None
@@ -1069,6 +1071,10 @@ class QgisSmokeTests(unittest.TestCase):
             background = self.layer_manager.ensure_background_layer(True, "Outdoor", "test-token")
             background_name = background.name()
             self.assertTrue(background.isValid())
+
+            user_selected_crs = QgsCoordinateReferenceSystem("EPSG:3857")
+            QgsProject.instance().setCrs(user_selected_crs)
+            self.iface.mapCanvas().setDestinationCrs(user_selected_crs)
 
             activities_layer, starts_layer, points_layer, atlas_layer = self.layer_manager.load_output_layers(output_path)
             self.layer_manager.apply_style(

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -91,10 +91,13 @@ class QgisLayerGateway:
     def load_output_layers(self, gpkg_path):
         canvas_service = self._get_canvas_service()
         project_layer_loader = self._get_project_layer_loader()
-        canvas_service.ensure_working_crs(self.iface, preserve_extent=False)
-        activities_layer, starts_layer, points_layer, atlas_layer = (
-            project_layer_loader.load_output_layers(gpkg_path)
-        )
+        project_crs = self._current_project_crs()
+        try:
+            activities_layer, starts_layer, points_layer, atlas_layer = (
+                project_layer_loader.load_output_layers(gpkg_path)
+            )
+        finally:
+            self._restore_project_crs(project_crs)
         self._move_background_layers_to_bottom()
         canvas_service.zoom_to_layers(
             self.iface, [activities_layer, starts_layer, points_layer, atlas_layer]
@@ -104,8 +107,11 @@ class QgisLayerGateway:
     def load_route_layers(self, gpkg_path):
         canvas_service = self._get_canvas_service()
         project_layer_loader = self._get_project_layer_loader()
-        canvas_service.ensure_working_crs(self.iface, preserve_extent=False)
-        route_layers = project_layer_loader.load_route_layers(gpkg_path)
+        project_crs = self._current_project_crs()
+        try:
+            route_layers = project_layer_loader.load_route_layers(gpkg_path)
+        finally:
+            self._restore_project_crs(project_crs)
         self._get_style_service().apply_route_style(*route_layers)
         self._move_background_layers_to_bottom()
         canvas_service.zoom_to_layers(self.iface, route_layers)
@@ -178,3 +184,41 @@ class QgisLayerGateway:
 
     def _move_background_layers_to_bottom(self):
         self._get_background_service().move_background_layers_to_bottom()
+
+    def _current_project_crs(self):
+        try:
+            crs = QgsProject.instance().crs()
+        except RuntimeError:
+            logger.debug("Failed to read current project CRS", exc_info=True)
+            return None
+        if crs is None:
+            return None
+        try:
+            if not crs.isValid():
+                return None
+        except (AttributeError, RuntimeError):
+            return None
+        return crs
+
+    def _restore_project_crs(self, crs):
+        if crs is None:
+            return
+        try:
+            if not crs.isValid():
+                return
+        except (AttributeError, RuntimeError):
+            return
+
+        try:
+            QgsProject.instance().setCrs(crs)
+        except RuntimeError:
+            logger.debug("Failed to restore project CRS after loading layers", exc_info=True)
+            return
+
+        canvas = self.iface.mapCanvas() if self.iface is not None else None
+        if canvas is None:
+            return
+        try:
+            canvas.setDestinationCrs(crs)
+        except RuntimeError:
+            logger.debug("Failed to restore canvas CRS after loading layers", exc_info=True)


### PR DESCRIPTION
## Summary

Fixes #1363.

This changes stored activity and route layer loading so qfit preserves the CRS currently selected by the user in QGIS. Loading qfit layers no longer forces Web Mercator and now restores the project/canvas CRS after QGIS adds the layers, preventing first-layer CRS auto-selection from flipping the project to `EPSG:4326`.

Layer CRS assignment is unchanged: qfit still assigns fallback CRS metadata to layers when the layer itself is missing CRS metadata.

## Validation

```bash
python3 -m pytest tests/test_layer_gateway.py tests/test_layer_manager.py tests/test_project_layer_loader.py tests/test_map_canvas_service.py tests/test_qgis_smoke.py::QgisSmokeTests::test_headless_qgis_smoke_covers_write_load_crs_temporal_and_background_order
coverage run --source=qfit.visualization.infrastructure.qgis_layer_gateway -m unittest tests.test_layer_gateway && coverage report -m visualization/infrastructure/qgis_layer_gateway.py
```

Results: `33 passed, 12 skipped`; local gateway coverage `88%`.

## Local testing note

I did not redeploy this branch to the Windows QGIS profile yet because it is based on `origin/main` and would overwrite the currently deployed spatial-index crash fix from PR #1362. Once #1362 is merged or stacked locally, this can be deployed safely for manual CRS testing.
