### PR TITLE
Address automated review feedback

### DIFF
--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -132,7 +132,7 @@ def ensure_route_spatial_indexes(output_path):
     _ensure_spatial_indexes(output_path, {"route_tracks": None, "route_points": None})
 
 
-def _quote_gpkg_identifier(value):
+def _quote_sql_string_literal(value):
     return "'" + str(value).replace("'", "''") + "'"
 
 
@@ -157,6 +157,12 @@ def _geometry_column_name(connection, layer_name):
 
 
 def _has_spatial_index(connection, layer_name, geometry_column):
+    extensions_table = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'gpkg_extensions'"
+    ).fetchone()
+    if extensions_table is None:
+        return False
+
     extension_row = connection.execute(
         """
         SELECT 1
@@ -188,8 +194,8 @@ def _create_spatial_index_with_ogr(output_path, layer_name, geometry_column):
     try:
         result = data_source.ExecuteSQL(
             "SELECT CreateSpatialIndex("
-            f"{_quote_gpkg_identifier(layer_name)}, "
-            f"{_quote_gpkg_identifier(geometry_column)})"
+            f"{_quote_sql_string_literal(layer_name)}, "
+            f"{_quote_sql_string_literal(geometry_column)})"
         )
     finally:
         if result is not None:
@@ -214,8 +220,17 @@ def _create_spatial_index_with_qgis(output_path, layer_name):
 def _create_spatial_index(output_path, layer_name, geometry_column):
     try:
         _create_spatial_index_with_ogr(output_path, layer_name, geometry_column)
-    except RuntimeError:
-        _create_spatial_index_with_qgis(output_path, layer_name)
+    except RuntimeError as ogr_error:
+        try:
+            _create_spatial_index_with_qgis(output_path, layer_name)
+        except RuntimeError as qgis_error:
+            combined_error = RuntimeError(
+                "Failed to create spatial index with OGR "
+                f"({ogr_error}) and QGIS fallback ({qgis_error})"
+            )
+            if hasattr(combined_error, "add_note"):
+                combined_error.add_note(f"OGR error: {ogr_error!r}")
+            raise combined_error from qgis_error
 
 
 def _ensure_spatial_indexes(output_path, index_groups):

--- a/tests/test_gpkg_geopackage_unit.py
+++ b/tests/test_gpkg_geopackage_unit.py
@@ -448,6 +448,36 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
             if os.path.exists(path):
                 os.unlink(path)
 
+    def test_ensure_spatial_indexes_treats_missing_extensions_table_as_unindexed(self):
+        moved = self._import_gpkg_write_orchestration_with_stubs()
+        fd, path = tempfile.mkstemp(suffix=".gpkg")
+        os.close(fd)
+        try:
+            with sqlite3.connect(path) as connection:
+                connection.execute(
+                    "CREATE TABLE gpkg_geometry_columns (table_name TEXT, column_name TEXT)"
+                )
+                connection.execute(
+                    "INSERT INTO gpkg_geometry_columns (table_name, column_name) VALUES (?, ?)",
+                    ("activity_tracks", "geom"),
+                )
+                connection.commit()
+
+            def create_spatial_index(output_path, layer_name, geometry_column):
+                self.assertEqual(output_path, path)
+                self.assertEqual(layer_name, "activity_tracks")
+                self.assertEqual(geometry_column, "geom")
+                with sqlite3.connect(output_path) as connection:
+                    self._create_minimal_spatial_index_metadata(connection, layer_name, geometry_column)
+
+            with patch.object(moved, "_create_spatial_index", side_effect=create_spatial_index) as create:
+                moved._ensure_spatial_indexes(path, {"activity_tracks": None})
+
+            create.assert_called_once_with(path, "activity_tracks", "geom")
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
     def test_ensure_spatial_indexes_requires_geometry_metadata(self):
         moved = self._import_gpkg_write_orchestration_with_stubs()
         fd, path = tempfile.mkstemp(suffix=".gpkg")
@@ -468,7 +498,7 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
     def test_spatial_index_helpers_quote_and_name_gpkg_objects(self):
         moved = self._import_gpkg_write_orchestration_with_stubs()
 
-        self.assertEqual(moved._quote_gpkg_identifier("activity's"), "'activity''s'")
+        self.assertEqual(moved._quote_sql_string_literal("activity's"), "'activity''s'")
         self.assertEqual(
             moved._spatial_index_table_names("activity_tracks", "geom"),
             {
@@ -529,6 +559,29 @@ class GeoPackagePackageUnitTests(unittest.TestCase):
 
         ogr_create.assert_called_once_with("/tmp/full.gpkg", "activity_tracks", "geom")
         qgis_create.assert_called_once_with("/tmp/full.gpkg", "activity_tracks")
+
+    def test_create_spatial_index_reports_ogr_and_qgis_failures(self):
+        moved = self._import_gpkg_write_orchestration_with_stubs()
+
+        with patch.object(
+            moved,
+            "_create_spatial_index_with_ogr",
+            side_effect=RuntimeError("ogr failed"),
+        ), patch.object(
+            moved,
+            "_create_spatial_index_with_qgis",
+            side_effect=RuntimeError("qgis failed"),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "OGR \\(ogr failed\\).*QGIS fallback \\(qgis failed\\)",
+            ) as cm:
+                moved._create_spatial_index("/tmp/full.gpkg", "activity_tracks", "geom")
+            if hasattr(RuntimeError(), "add_note"):
+                self.assertEqual(
+                    getattr(cm.exception, "__notes__", []),
+                    ["OGR error: RuntimeError('ogr failed')"],
+                )
 
     def test_create_spatial_index_with_qgis_keeps_provider_fallback(self):
         moved = self._import_gpkg_write_orchestration_with_stubs()

--- a/tests/test_layer_gateway.py
+++ b/tests/test_layer_gateway.py
@@ -113,6 +113,31 @@ class LayerGatewayBoundaryTests(unittest.TestCase):
         canvas.zoom_to_layers.assert_called_once_with(gateway.iface, result)
         gateway._move_background_layers_to_bottom.assert_called_once_with()
 
+    def test_qgis_gateway_canvas_service_lazy_init_uses_zoom_contract(self):
+        modules = self._qgis_gateway_modules()
+
+        with patch.dict(sys.modules, modules, clear=False):
+            self._reset_qgis_gateway_imports()
+            adapter_module = importlib.import_module(
+                "qfit.visualization.infrastructure.qgis_layer_gateway"
+            )
+
+            gateway = adapter_module.QgisLayerGateway(MagicMock(name="iface"))
+            stale_placeholder = MagicMock(name="stale_canvas_placeholder")
+            del stale_placeholder.zoom_to_layers
+            gateway._canvas_service = stale_placeholder
+            gateway._background_service = MagicMock(name="background_service")
+            replacement = MagicMock(name="canvas_service")
+
+            with patch.object(
+                adapter_module,
+                "_build_map_canvas_service",
+                return_value=replacement,
+            ) as build:
+                self.assertIs(gateway._get_canvas_service(), replacement)
+
+        build.assert_called_once()
+
     def test_qgis_gateway_restores_project_crs_when_layer_loading_fails(self):
         modules = self._qgis_gateway_modules()
 

--- a/tests/test_map_canvas_service.py
+++ b/tests/test_map_canvas_service.py
@@ -368,6 +368,55 @@ class MapCanvasServiceMockTests(unittest.TestCase):
         canvas.setExtent.assert_called_once()
         canvas.refresh.assert_called_once()
 
+    def test_zoom_to_layers_transforms_layer_extent_to_canvas_crs(self):
+        iface, canvas = _make_iface()
+        layer, extent = _make_layer((0, 0, 1, 1))
+        source_crs = MagicMock(name="source_crs")
+        source_crs.isValid.return_value = True
+        destination_crs = MagicMock(name="destination_crs")
+        destination_crs.isValid.return_value = True
+        layer.crs.return_value = source_crs
+        canvas.mapSettings.return_value.destinationCrs.return_value = destination_crs
+        self._bg.snap_extent_to_background_tile_zoom.side_effect = lambda e, c: e
+
+        transformed = MagicMock(name="transformed_extent")
+        transformed.isEmpty.return_value = False
+        transform = MagicMock(name="transform")
+        transform.transformBoundingBox.return_value = transformed
+        _def_service_module.QgsCoordinateTransform.reset_mock()
+        _def_service_module.QgsCoordinateTransform.return_value = transform
+
+        self.service.zoom_to_layers(iface, [layer])
+
+        _def_service_module.QgsCoordinateTransform.assert_called_once_with(
+            source_crs,
+            destination_crs,
+            _def_service_module.QgsProject.instance.return_value,
+        )
+        transform.transformBoundingBox.assert_called_once_with(extent)
+        canvas.setExtent.assert_called_once_with(transformed)
+
+    def test_zoom_to_layers_falls_back_when_extent_transform_raises_qgs_exception(self):
+        iface, canvas = _make_iface()
+        layer, extent = _make_layer((0, 0, 1, 1))
+        source_crs = MagicMock(name="source_crs")
+        source_crs.isValid.return_value = True
+        destination_crs = MagicMock(name="destination_crs")
+        destination_crs.isValid.return_value = True
+        layer.crs.return_value = source_crs
+        canvas.mapSettings.return_value.destinationCrs.return_value = destination_crs
+        self._bg.snap_extent_to_background_tile_zoom.side_effect = lambda e, c: e
+
+        transform = MagicMock(name="transform")
+        transform.transformBoundingBox.side_effect = _def_service_module.QgsCsException("boom")
+        _def_service_module.QgsCoordinateTransform.reset_mock()
+        _def_service_module.QgsCoordinateTransform.return_value = transform
+
+        self.service.zoom_to_layers(iface, [layer])
+
+        transform.transformBoundingBox.assert_called_once_with(extent)
+        canvas.setExtent.assert_called_once_with(extent)
+
     def test_zoom_to_layers_noop_when_all_extents_empty(self):
         iface, canvas = _make_iface()
         layer, _ = _make_layer()

--- a/visualization/infrastructure/map_canvas_service.py
+++ b/visualization/infrastructure/map_canvas_service.py
@@ -3,11 +3,18 @@ import logging
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
+    QgsCsException,
     QgsProject,
     QgsRectangle,
 )
 
 logger = logging.getLogger(__name__)
+
+try:
+    if not issubclass(QgsCsException, Exception):
+        QgsCsException = Exception
+except TypeError:
+    QgsCsException = Exception
 
 WORKING_CRS = "EPSG:3857"
 
@@ -58,11 +65,16 @@ class MapCanvasService:
 
     def zoom_to_layers(self, iface, layers):
         """Combine layer extents, snap to tile zoom, and set canvas extent."""
+        canvas = iface.mapCanvas() if iface is not None else None
+        if canvas is None:
+            return
+
+        destination_crs = self._canvas_destination_crs(canvas)
         extents = None
         for layer in layers:
             if layer is None or not layer.isValid():
                 continue
-            layer_extent = layer.extent()
+            layer_extent = self._layer_extent_in_canvas_crs(layer, destination_crs)
             if layer_extent.isEmpty():
                 continue
             if extents is None:
@@ -73,10 +85,48 @@ class MapCanvasService:
         if extents is None or extents.isEmpty():
             return
 
-        canvas = iface.mapCanvas() if iface is not None else None
-        if canvas is None:
-            return
-
         extents = self._background_service.snap_extent_to_background_tile_zoom(extents, canvas)
         canvas.setExtent(extents)
         canvas.refresh()
+
+    def _canvas_destination_crs(self, canvas):
+        try:
+            return canvas.mapSettings().destinationCrs()
+        except (AttributeError, RuntimeError):
+            try:
+                return QgsProject.instance().crs()
+            except RuntimeError:
+                logger.debug("Failed to read canvas destination CRS", exc_info=True)
+                return None
+
+    def _layer_extent_in_canvas_crs(self, layer, destination_crs):
+        layer_extent = layer.extent()
+        if layer_extent.isEmpty():
+            return layer_extent
+
+        try:
+            source_crs = layer.crs()
+            if (
+                source_crs is None
+                or destination_crs is None
+                or not self._is_coordinate_reference_system(source_crs)
+                or not self._is_coordinate_reference_system(destination_crs)
+                or not source_crs.isValid()
+                or not destination_crs.isValid()
+                or source_crs == destination_crs
+            ):
+                return QgsRectangle(layer_extent)
+            transform = QgsCoordinateTransform(source_crs, destination_crs, QgsProject.instance())
+            transformed = transform.transformBoundingBox(layer_extent)
+            if not transformed.isEmpty():
+                return transformed
+        except (AttributeError, RuntimeError, TypeError, QgsCsException):
+            logger.debug("Layer extent transform failed", exc_info=True)
+
+        return QgsRectangle(layer_extent)
+
+    def _is_coordinate_reference_system(self, crs):
+        try:
+            return isinstance(crs, QgsCoordinateReferenceSystem)
+        except TypeError:
+            return hasattr(crs, "isValid")

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -47,8 +47,6 @@ def _build_layer_style_service():
 class QgisLayerGateway:
     """QGIS-backed adapter for loading, filtering, styling, and map wiring."""
 
-    WORKING_CRS = "EPSG:3857"
-
     def __init__(self, iface):
         self.iface = iface
         self._style_service = SimpleNamespace()
@@ -64,7 +62,7 @@ class QgisLayerGateway:
         return self._background_service
 
     def _get_canvas_service(self):
-        if not hasattr(self._canvas_service, "ensure_working_crs"):
+        if not hasattr(self._canvas_service, "zoom_to_layers"):
             self._canvas_service = _build_map_canvas_service(self._get_background_service())
         return self._canvas_service
 


### PR DESCRIPTION
## Summary

Closes #1365.

Addresses automated review feedback that appeared after #1362 and #1364 were marked ready and merged:

- treat a missing `gpkg_extensions` table as “no spatial index” so valid unindexed GeoPackages can create indexes
- rename the GeoPackage SQL quoting helper to describe string-literal quoting accurately
- preserve both OGR and QGIS fallback diagnostics when spatial-index creation fails through both paths
- remove stale CRS gateway code after switching to preserve-user-CRS behavior
- transform layer extents into the canvas CRS before zooming, so restored non-Web-Mercator projects do not zoom to raw Web-Mercator atlas extents

## Validation

```bash
python3 -m pytest
```

Result: `2483 passed, 180 skipped`.

## Review process note

This PR is intentionally opened ready for review, not as a draft, so Codex and Greptile can analyze it before merge.
