### PR TITLE
Preserve CRS after loading stored layers

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 from qgis.core import QgsApplication, QgsProject
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QDate, Qt
+from qgis.PyQt.QtCore import QDate, Qt, QTimer
 from qgis.PyQt.QtWidgets import (
     QFileDialog,
     QDockWidget,
@@ -943,46 +943,50 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def on_load_layers_clicked(self):
         """Load an existing GeoPackage into QGIS without fetching from Strava."""
-        self._save_settings()
-        workflow = self._dataset_load_workflow_service()
+        project_crs = self._current_project_crs()
         try:
-            request = workflow.build_load_existing_request(
-                self.outputPathLineEdit.text().strip(),
+            self._save_settings()
+            workflow = self._dataset_load_workflow_service()
+            try:
+                request = workflow.build_load_existing_request(
+                    self.outputPathLineEdit.text().strip(),
+                )
+                result = workflow.load_existing_request(request)
+            except LoadWorkflowError as exc:
+                self._show_error("GeoPackage not found", str(exc))
+                return
+            except (RuntimeError, OSError) as exc:
+                _msg = "Load stored map layers failed"
+                logger.exception(_msg)
+                self._show_error(_msg, str(exc))
+                self._set_status(_msg)
+                return
+
+            self._runtime_store().load_dataset(
+                output_path=result.output_path,
+                stored_activity_count=result.total_stored,
+                activities_layer=result.activities_layer,
+                starts_layer=result.starts_layer,
+                points_layer=result.points_layer,
+                atlas_layer=result.atlas_layer,
             )
-            result = workflow.load_existing_request(request)
-        except LoadWorkflowError as exc:
-            self._show_error("GeoPackage not found", str(exc))
-            return
-        except (RuntimeError, OSError) as exc:
-            _msg = "Load stored map layers failed"
-            logger.exception(_msg)
-            self._show_error(_msg, str(exc))
-            self._set_status(_msg)
-            return
+            self._runtime_store().set_route_layers(
+                route_tracks_layer=getattr(result, "route_tracks_layer", None),
+                route_points_layer=getattr(result, "route_points_layer", None),
+                route_profile_samples_layer=getattr(result, "route_profile_samples_layer", None),
+            )
+            self._mark_atlas_export_stale()
 
-        self._runtime_store().load_dataset(
-            output_path=result.output_path,
-            stored_activity_count=result.total_stored,
-            activities_layer=result.activities_layer,
-            starts_layer=result.starts_layer,
-            points_layer=result.points_layer,
-            atlas_layer=result.atlas_layer,
-        )
-        self._runtime_store().set_route_layers(
-            route_tracks_layer=getattr(result, "route_tracks_layer", None),
-            route_points_layer=getattr(result, "route_points_layer", None),
-            route_profile_samples_layer=getattr(result, "route_profile_samples_layer", None),
-        )
-        self._mark_atlas_export_stale()
+            self._populate_activity_types_from_layer()
+            visual_status = self._apply_visual_configuration(apply_subset_filters=False)
 
-        self._populate_activity_types_from_layer()
-        visual_status = self._apply_visual_configuration(apply_subset_filters=False)
-
-        self._update_loaded_activities_summary(result.total_stored)
-        status = result.status
-        if visual_status:
-            status = "{status} {visual_status}".format(status=status, visual_status=visual_status)
-        self._set_status(status)
+            self._update_loaded_activities_summary(result.total_stored)
+            status = result.status
+            if visual_status:
+                status = "{status} {visual_status}".format(status=status, visual_status=visual_status)
+            self._set_status(status)
+        finally:
+            self._restore_project_crs(project_crs, schedule_delayed=True)
 
     def on_clear_database_clicked(self):
         """Delete the GeoPackage, clear loaded layers, and reset status."""
@@ -1190,6 +1194,56 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._mark_atlas_export_stale()
             self._refresh_map_canvas()
         return analysis_removed
+
+    def _current_project_crs(self):
+        try:
+            crs = QgsProject.instance().crs()
+        except RuntimeError:
+            logger.debug("Failed to read current project CRS", exc_info=True)
+            return None
+        if crs is None:
+            return None
+        try:
+            if not crs.isValid():
+                return None
+        except (AttributeError, RuntimeError):
+            return None
+        return crs
+
+    def _restore_project_crs(self, crs, *, schedule_delayed=False):
+        if crs is None:
+            return
+        try:
+            if not crs.isValid():
+                return
+        except (AttributeError, RuntimeError):
+            return
+
+        try:
+            QgsProject.instance().setCrs(crs)
+        except RuntimeError:
+            logger.debug("Failed to restore project CRS after loading layers", exc_info=True)
+            # Project is already gone; a delayed retry would hit the same deleted object.
+            return
+
+        iface = getattr(self, "iface", None)
+        canvas_getter = getattr(iface, "mapCanvas", None)
+        canvas = canvas_getter() if callable(canvas_getter) else None
+        if canvas is None:
+            return
+        set_destination_crs = getattr(canvas, "setDestinationCrs", None)
+        if not callable(set_destination_crs):
+            return
+        try:
+            set_destination_crs(crs)
+        except RuntimeError:
+            logger.debug("Failed to restore canvas CRS after loading layers", exc_info=True)
+
+        if schedule_delayed:
+            try:
+                QTimer.singleShot(0, lambda: self._restore_project_crs(crs))
+            except (AttributeError, RuntimeError, TypeError):
+                logger.debug("Failed to schedule delayed CRS restore", exc_info=True)
 
     def _refresh_map_canvas(self) -> None:
         """Force QGIS to repaint the map canvas after direct layer mutations."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2903,6 +2903,51 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._update_loaded_activities_summary.assert_called_once_with(12)
         dock._set_status.assert_called_once_with("Loaded 12 activities Styled layers")
 
+    def test_on_load_layers_clicked_restores_user_crs_after_visual_configuration(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._save_settings = MagicMock()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock._populate_activity_types_from_layer = MagicMock()
+        events = []
+        dock._apply_visual_configuration = MagicMock(
+            side_effect=lambda apply_subset_filters: events.append("visual") or "Styled layers"
+        )
+        dock._update_loaded_activities_summary = MagicMock()
+        dock._set_status = MagicMock()
+        dock._atlas_export_completed = True
+        workflow = MagicMock()
+        workflow.build_load_existing_request.return_value = "load-request"
+        result = SimpleNamespace(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer="activities-layer",
+            starts_layer="starts-layer",
+            points_layer="points-layer",
+            atlas_layer="atlas-layer",
+            total_stored=12,
+            status="Loaded 12 activities",
+        )
+        workflow.load_existing_request.return_value = result
+        dock.dataset_load_workflow = workflow
+        canvas = MagicMock()
+        dock.iface = SimpleNamespace(mapCanvas=lambda: canvas)
+        project = MagicMock()
+        user_crs = MagicMock(name="user_crs")
+        user_crs.isValid.return_value = True
+        project.crs.return_value = user_crs
+        project.setCrs.side_effect = lambda crs: events.append(("restore", crs))
+        self.module.QTimer.singleShot.reset_mock()
+
+        with patch.object(self.module.QgsProject, "instance", return_value=project):
+            self.module.QfitDockWidget.on_load_layers_clicked(dock)
+
+        self.assertEqual(events, ["visual", ("restore", user_crs)])
+        project.setCrs.assert_called_once_with(user_crs)
+        canvas.setDestinationCrs.assert_called_once_with(user_crs)
+        self.module.QTimer.singleShot.assert_called_once()
+        delay, callback = self.module.QTimer.singleShot.call_args.args
+        self.assertEqual(delay, 0)
+        self.assertTrue(callable(callback))
+
     def test_on_generate_atlas_pdf_clicked_cancels_existing_export_task(self):
         dock = object.__new__(self.module.QfitDockWidget)
         running_task = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #1367.

This preserves the user's selected QGIS project/canvas CRS when `Load stored map layers` loads qfit layers from an existing GeoPackage.

## Root Cause

The previous CRS guard restored the project CRS inside the lower-level layer gateway. The UI action continues doing work after that, including route layer loading and visual configuration. QGIS can still switch the project CRS to the loaded layer CRS during those later side effects.

## Changes

- Capture the current project CRS at the start of `QfitDockWidget.on_load_layers_clicked()`.
- Restore both `QgsProject` CRS and map canvas destination CRS after the whole button action completes.
- Schedule a zero-delay Qt restore as a second pass in case QGIS applies a deferred CRS update after the handler returns.
- Add a regression test proving CRS restore happens after visual configuration.

## Validation

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -q`
- `python3 -m pytest tests/test_layer_gateway.py tests/test_load_workflow.py tests/test_project_layer_loader.py -q`
- `python3 -m pytest`
- `python3 scripts/package_plugin.py`
- Windows QGIS local package deploy from `dist/qfit-0.50.zip`; Emman confirmed the EPSG:3857 load flow now works.
