### PR TITLE
Guard atlas PDF exports against incomplete layers

### DIFF
--- a/atlas/export_coordinator.py
+++ b/atlas/export_coordinator.py
@@ -7,6 +7,29 @@ from typing import Callable
 from .infrastructure.pdf_assembly import AtlasPdfAssemblyCancelled
 
 
+_REQUIRED_ATLAS_FIELDS = (
+    "page_number",
+    "page_sort_key",
+    "page_title",
+    "page_stats_summary",
+    "page_date",
+    "page_toc_label",
+    "page_distance_label",
+    "page_duration_label",
+    "page_elevation_gain_label",
+    "page_profile_summary",
+    "activity_type",
+    "distance_m",
+    "moving_time_s",
+    "total_elevation_gain_m",
+    "source_activity_id",
+    "center_x_3857",
+    "center_y_3857",
+    "extent_width_m",
+    "extent_height_m",
+)
+
+
 @dataclass(frozen=True)
 class AtlasExportExecutionResult:
     success: bool
@@ -74,9 +97,33 @@ class AtlasExportCoordinator:
             except OSError:
                 pass
 
-    def execute(self) -> AtlasExportExecutionResult:
+    @staticmethod
+    def _resolve_feature_count(atlas_layer) -> int:
+        feature_count = atlas_layer.featureCount() if atlas_layer else 0
+        if feature_count >= 0:
+            return feature_count
+        return sum(1 for _ in atlas_layer.getFeatures())
+
+    @staticmethod
+    def _validate_atlas_layer_schema(atlas_layer) -> str | None:
+        fields = atlas_layer.fields()
+        missing_fields = [
+            field_name
+            for field_name in _REQUIRED_ATLAS_FIELDS
+            if fields.indexOf(field_name) < 0
+        ]
+        if not missing_fields:
+            return None
+
+        return (
+            "Atlas layer is incomplete for PDF export. "
+            "Store and reload the activity map layers, then export again. "
+            f"Missing fields: {', '.join(missing_fields)}."
+        )
+
+    def _inspect_ready_atlas_layer(self) -> int | AtlasExportExecutionResult:
         try:
-            feature_count = self.atlas_layer.featureCount() if self.atlas_layer else 0
+            feature_count = self._resolve_feature_count(self.atlas_layer)
         except (RuntimeError, OSError) as exc:
             return self._stage_failure(
                 "atlas layer inspection",
@@ -90,6 +137,89 @@ class AtlasExportCoordinator:
                 error="No atlas pages found. Store and load activity layers first.",
             )
 
+        try:
+            schema_error = self._validate_atlas_layer_schema(self.atlas_layer)
+        except (RuntimeError, OSError) as exc:
+            return self._stage_failure(
+                "atlas layer inspection",
+                exc,
+                user_label="Atlas layer inspection",
+            )
+        if schema_error is not None:
+            return AtlasExportExecutionResult(
+                success=False,
+                page_count=feature_count,
+                error=schema_error,
+            )
+
+        return feature_count
+
+    def _export_front_matter_and_assemble(
+        self,
+        page_paths: list[str],
+        *,
+        page_count: int,
+    ) -> AtlasExportExecutionResult | None:
+        cover_path = None
+        toc_path = None
+        try:
+            cover_path = self.export_cover_page(
+                self.atlas_layer,
+                self.output_path,
+                project=self.project,
+            )
+            if cover_path is None:
+                self._discard_pdf_parts(page_paths)
+                return AtlasExportExecutionResult(
+                    success=False,
+                    page_count=page_count,
+                    error=(
+                        "Cover page export failed. Store and reload the activity "
+                        "map layers, then export again."
+                    ),
+                )
+            if self.is_canceled():
+                self._discard_pdf_parts(page_paths, cover_path)
+                return AtlasExportExecutionResult(success=False, page_count=page_count)
+
+            toc_path = self.export_toc_page(
+                self.atlas_layer,
+                self.output_path,
+                project=self.project,
+            )
+            if toc_path is None:
+                self._discard_pdf_parts(page_paths, cover_path)
+                return AtlasExportExecutionResult(
+                    success=False,
+                    page_count=page_count,
+                    error=(
+                        "Contents page export failed. Store and reload the activity "
+                        "map layers, then export again."
+                    ),
+                )
+            if self.is_canceled():
+                self._discard_pdf_parts(page_paths, cover_path, toc_path)
+                return AtlasExportExecutionResult(success=False, page_count=page_count)
+
+            self.assemble_output_pdf(page_paths, cover_path=cover_path, toc_path=toc_path)
+            return None
+        except AtlasPdfAssemblyCancelled:
+            self._discard_pdf_parts(page_paths, cover_path, toc_path)
+            return AtlasExportExecutionResult(success=False, page_count=page_count)
+        except (RuntimeError, OSError) as exc:
+            return self._stage_failure(
+                "final PDF assembly",
+                exc,
+                page_count=page_count,
+                user_label="Final PDF assembly",
+            )
+
+    def execute(self) -> AtlasExportExecutionResult:
+        inspection = self._inspect_ready_atlas_layer()
+        if isinstance(inspection, AtlasExportExecutionResult):
+            return inspection
+
+        feature_count = inspection
         if self.is_canceled():
             return AtlasExportExecutionResult(success=False, page_count=feature_count)
 
@@ -137,33 +267,11 @@ class AtlasExportCoordinator:
                 error="No pages were exported.",
             )
 
-        try:
-            cover_path = self.export_cover_page(
-                self.atlas_layer,
-                self.output_path,
-                project=self.project,
-            )
-            if self.is_canceled():
-                self._discard_pdf_parts(page_paths, cover_path)
-                return AtlasExportExecutionResult(success=False, page_count=page_count)
-            toc_path = self.export_toc_page(
-                self.atlas_layer,
-                self.output_path,
-                project=self.project,
-            )
-            if self.is_canceled():
-                self._discard_pdf_parts(page_paths, cover_path, toc_path)
-                return AtlasExportExecutionResult(success=False, page_count=page_count)
-            self.assemble_output_pdf(page_paths, cover_path=cover_path, toc_path=toc_path)
-        except AtlasPdfAssemblyCancelled:
-            self._discard_pdf_parts(page_paths, cover_path, toc_path)
-            return AtlasExportExecutionResult(success=False, page_count=page_count)
-        except (RuntimeError, OSError) as exc:
-            return self._stage_failure(
-                "final PDF assembly",
-                exc,
-                page_count=page_count,
-                user_label="Final PDF assembly",
-            )
+        front_matter_result = self._export_front_matter_and_assemble(
+            page_paths,
+            page_count=page_count,
+        )
+        if front_matter_result is not None:
+            return front_matter_result
 
         return AtlasExportExecutionResult(success=not self.is_canceled(), page_count=page_count)

--- a/tests/test_atlas_export_coordinator.py
+++ b/tests/test_atlas_export_coordinator.py
@@ -3,7 +3,11 @@ from unittest.mock import MagicMock, patch
 
 from tests import _path  # noqa: F401
 
-from qfit.atlas.export_coordinator import AtlasExportCoordinator, AtlasExportExecutionResult
+from qfit.atlas.export_coordinator import (
+    _REQUIRED_ATLAS_FIELDS,
+    AtlasExportCoordinator,
+    AtlasExportExecutionResult,
+)
 from qfit.atlas.infrastructure import AtlasPdfAssemblyCancelled
 
 
@@ -11,6 +15,13 @@ class AtlasExportCoordinatorTests(unittest.TestCase):
     def _make_coordinator(self, *, feature_count=2, canceled=False):
         atlas_layer = MagicMock(name="atlas_layer")
         atlas_layer.featureCount.return_value = feature_count
+        fields = MagicMock(name="fields")
+        fields.indexOf.side_effect = (
+            lambda name: _REQUIRED_ATLAS_FIELDS.index(name)
+            if name in _REQUIRED_ATLAS_FIELDS
+            else -1
+        )
+        atlas_layer.fields.return_value = fields
 
         layout = object()
         exporter_instance = object()
@@ -57,6 +68,28 @@ class AtlasExportCoordinatorTests(unittest.TestCase):
             "assemble_output_pdf": assemble_output_pdf,
             "logger": logger,
         }
+
+    def test_execute_resolves_unknown_filtered_feature_count(self):
+        parts = self._make_coordinator(feature_count=-1)
+        parts["atlas_layer"].getFeatures.return_value = iter([object(), object(), object()])
+
+        result = parts["coordinator"].execute()
+
+        self.assertEqual(result, AtlasExportExecutionResult(success=True, page_count=3, error=None))
+
+    def test_execute_rejects_incomplete_legacy_atlas_layer(self):
+        parts = self._make_coordinator()
+        parts["atlas_layer"].fields.return_value.indexOf.side_effect = (
+            lambda name: 0 if name in {"page_number", "page_sort_key"} else -1
+        )
+
+        result = parts["coordinator"].execute()
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.page_count, 2)
+        self.assertIn("Atlas layer is incomplete for PDF export", result.error)
+        self.assertIn("page_title", result.error)
+        parts["build_layout"].assert_not_called()
 
     def test_execute_returns_empty_layer_error(self):
         parts = self._make_coordinator(feature_count=0)
@@ -127,6 +160,52 @@ class AtlasExportCoordinatorTests(unittest.TestCase):
         self.assertEqual(result, AtlasExportExecutionResult(success=False, page_count=2))
         parts["export_cover_page"].assert_called_once()
         parts["export_toc_page"].assert_not_called()
+        parts["assemble_output_pdf"].assert_not_called()
+        self.assertEqual(
+            [call.args[0] for call in remove.call_args_list],
+            ["/tmp/cover.pdf", "/tmp/page-0.pdf"],
+        )
+
+    def test_execute_fails_when_cover_page_is_missing(self):
+        parts = self._make_coordinator()
+        parts["export_cover_page"].return_value = None
+
+        with patch("qfit.atlas.export_coordinator.os.remove") as remove:
+            result = parts["coordinator"].execute()
+
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(
+                success=False,
+                page_count=2,
+                error=(
+                    "Cover page export failed. Store and reload the activity "
+                    "map layers, then export again."
+                ),
+            ),
+        )
+        parts["export_toc_page"].assert_not_called()
+        parts["assemble_output_pdf"].assert_not_called()
+        remove.assert_called_once_with("/tmp/page-0.pdf")
+
+    def test_execute_fails_when_contents_page_is_missing(self):
+        parts = self._make_coordinator()
+        parts["export_toc_page"].return_value = None
+
+        with patch("qfit.atlas.export_coordinator.os.remove") as remove:
+            result = parts["coordinator"].execute()
+
+        self.assertEqual(
+            result,
+            AtlasExportExecutionResult(
+                success=False,
+                page_count=2,
+                error=(
+                    "Contents page export failed. Store and reload the activity "
+                    "map layers, then export again."
+                ),
+            ),
+        )
         parts["assemble_output_pdf"].assert_not_called()
         self.assertEqual(
             [call.args[0] for call in remove.call_args_list],

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -92,6 +92,7 @@ _qgis_core = _make_qgis_stub()
 
 import qfit.atlas.export_task as atlas_export_task  # noqa: E402
 import qfit.atlas.profile_item as profile_item  # noqa: E402
+from qfit.atlas.export_coordinator import _REQUIRED_ATLAS_FIELDS  # noqa: E402
 from qfit.atlas.profile_item import (  # noqa: E402
     DEFAULT_NATIVE_PROFILE_PLOT_STYLE,
     build_native_profile_inputs,
@@ -141,6 +142,11 @@ def _make_atlas_layer(feature_count=3):
     fields.indexOf = lambda name: 0  # all stored-extent fields exist
     layer.fields.return_value = fields
     return layer
+
+
+def _modern_field_index(field_names):
+    all_field_names = list(dict.fromkeys([*field_names, *_REQUIRED_ATLAS_FIELDS]))
+    return lambda name: all_field_names.index(name) if name in all_field_names else -1
 
 
 def _make_atlas_mock(feature_count=3):
@@ -2276,7 +2282,7 @@ class TestPerPageLabelTextSetting(unittest.TestCase):
             "center_x_3857", "center_y_3857", "extent_width_m", "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
 
         # Feature attributes: return realistic values per field index.
@@ -2299,8 +2305,9 @@ class TestPerPageLabelTextSetting(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -2340,7 +2347,7 @@ class TestPerPageLabelTextSetting(unittest.TestCase):
             "center_x_3857", "center_y_3857", "extent_width_m", "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
 
         # All label attributes are None (e.g. activity with no profile data).
@@ -2356,8 +2363,9 @@ class TestPerPageLabelTextSetting(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -2402,7 +2410,7 @@ class TestProfileChartRendering(unittest.TestCase):
             "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
 
         attr_values = {
@@ -2428,8 +2436,8 @@ class TestProfileChartRendering(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("qfit.atlas.profile_payload_resolver.PageProfilePayloadResolver._resolve_page_profile_source", return_value=("track-geometry", track_feature, "EPSG:3857")), \
              patch("qfit.atlas.export_task.build_native_profile_curve_from_feature", return_value="curve") as build_native_curve, \
              patch("os.replace"), \
@@ -2466,7 +2474,7 @@ class TestProfileChartRendering(unittest.TestCase):
             "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
 
         feature_one = MagicMock(name="feature_one")
@@ -2502,8 +2510,8 @@ class TestProfileChartRendering(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch(
                  "qfit.atlas.export_task.build_native_profile_curve_from_feature",
                  side_effect=["curve-1", "curve-2"],
@@ -2534,7 +2542,7 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
             "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
         atlas_layer.source.return_value = "/tmp/fake.gpkg|layername=activity_atlas_pages"
 
@@ -2564,8 +2572,8 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
@@ -2583,7 +2591,7 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
             "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
         atlas_layer.source.return_value = "/tmp/fake.gpkg|layername=activity_atlas_pages"
 
@@ -2612,8 +2620,8 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
@@ -2631,7 +2639,7 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
             "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
         atlas_layer.source.return_value = "/tmp/fake.gpkg|layername=activity_atlas_pages"
 
@@ -2661,8 +2669,8 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("qfit.atlas.export_task.build_native_profile_curve_from_feature", return_value="curve") as build_native_curve, \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
@@ -2686,8 +2694,8 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             result = task.run()
@@ -2704,8 +2712,9 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
         layout_mock, atlas_mock, exporter_cls_mock = _make_atlas_mock(feature_count=1)
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -2726,8 +2735,8 @@ class TestAtlasExportTaskSuccess(unittest.TestCase):
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("os.remove"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -2843,8 +2852,9 @@ class TestAtlasExportTaskNoCallback(unittest.TestCase):
         layout_mock, atlas_mock, exporter_cls_mock = _make_atlas_mock(feature_count=1)
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             task.run()
@@ -2870,8 +2880,9 @@ class TestAtlasExportTaskLayerSubsetHandling(unittest.TestCase):
         layout_mock, atlas_mock, exporter_cls_mock = _make_atlas_mock(feature_count=1)
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -2925,8 +2936,9 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -2974,7 +2986,7 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
             "source_activity_id": 4,
             "page_profile_summary": 5,
         }
-        atlas_layer.fields.return_value.indexOf = lambda name: field_positions.get(name, -1)
+        atlas_layer.fields.return_value.indexOf = lambda name: field_positions.get(name, _modern_field_index(field_positions.keys())(name))
 
         layout_mock, atlas_mock, exporter_cls_mock = _make_atlas_mock(feature_count=1)
         map_item = MagicMock()
@@ -3004,8 +3016,9 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
              patch("qfit.atlas.export_task.QgsRectangle", _Rect), \
              patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -3031,8 +3044,8 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler", return_value=assembler), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("os.remove", side_effect=lambda p: remove_calls.append(p)), \
              patch("os.makedirs"):
             _run_task(task)
@@ -3054,12 +3067,17 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
         assembler = MagicMock()
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler", return_value=assembler), \
              patch("os.makedirs"):
             _run_task(task)
-        assembler.assemble.assert_called_once_with(["/tmp/qfit_test_replace.pdf.page_0.pdf"], "/tmp/qfit_test_replace.pdf", cover_path=None, toc_path=None)
+        assembler.assemble.assert_called_once_with(
+            ["/tmp/qfit_test_replace.pdf.page_0.pdf"],
+            "/tmp/qfit_test_replace.pdf",
+            cover_path="/tmp/cover.pdf",
+            toc_path="/tmp/toc.pdf",
+        )
 
     def test_profile_chart_clears_picture_when_svg_render_returns_none(self):
         """If chart rendering yields no SVG, the profile picture is cleared and refreshed."""
@@ -3080,7 +3098,7 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
             "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
         atlas_layer.source.return_value = "/tmp/fake.gpkg|layername=activity_atlas_pages"
 
@@ -3102,8 +3120,8 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -3129,7 +3147,7 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
             "extent_height_m",
         ]
         atlas_layer.fields.return_value.indexOf = (
-            lambda name: field_names.index(name) if name in field_names else -1
+            _modern_field_index(field_names)
         )
         atlas_layer.source.return_value = "/tmp/fake.gpkg|layername=activity_atlas_pages"
 
@@ -3151,8 +3169,8 @@ class TestAtlasExportTaskPerPageFilter(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value=None), \
-             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value=None), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page", return_value="/tmp/cover.pdf"), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page", return_value="/tmp/toc.pdf"), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.makedirs"):
             _run_task(task)
@@ -3578,6 +3596,8 @@ class TestCoverPage(unittest.TestCase):
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page",
                    return_value=cover_path), \
+             patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page",
+                   return_value="/tmp/qfit_cover_test.pdf.toc.pdf"), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler",
                    return_value=MagicMock(assemble=lambda pages, out, **kwargs: merge_calls.append((pages, out, kwargs)))), \
              patch("os.remove"), \
@@ -3588,11 +3608,11 @@ class TestCoverPage(unittest.TestCase):
         self.assertEqual(len(page_paths), 2)
         self.assertEqual(output_path, "/tmp/qfit_cover_test.pdf")
         self.assertEqual(kwargs["cover_path"], cover_path)
-        self.assertIsNone(kwargs["toc_path"])
+        self.assertEqual(kwargs["toc_path"], "/tmp/qfit_cover_test.pdf.toc.pdf")
         self.assertIsNotNone(received.get("output_path"))
 
-    def test_cover_page_skipped_on_failure(self):
-        """Export succeeds even when _export_cover_page raises or returns None."""
+    def test_cover_page_failure_fails_export(self):
+        """Export fails instead of producing an atlas without required front matter."""
         layer = _make_atlas_layer(feature_count=1)
         received = {}
         task = AtlasExportTask(
@@ -3609,9 +3629,11 @@ class TestCoverPage(unittest.TestCase):
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
-        # Export should still succeed without a cover page.
-        self.assertIsNotNone(received.get("output_path"))
-        self.assertIsNone(received.get("error"))
+        self.assertIsNone(received.get("output_path"))
+        self.assertEqual(
+            received.get("error"),
+            "Cover page export failed. Store and reload the activity map layers, then export again.",
+        )
 
     def test_build_cover_layout_returns_none_for_empty_layer(self):
         """build_cover_layout returns None when the atlas layer has no features."""
@@ -4023,8 +4045,8 @@ class TestTocPageInExport(unittest.TestCase):
         self.assertEqual(kwargs["cover_path"], cover_path)
         self.assertEqual(kwargs["toc_path"], toc_path)
 
-    def test_toc_page_skipped_on_failure(self):
-        """Export succeeds even when _export_toc_page returns None."""
+    def test_toc_page_failure_fails_export(self):
+        """Export fails instead of producing an atlas without required contents."""
         layer = _make_atlas_layer(feature_count=1)
         received = {}
         task = AtlasExportTask(
@@ -4036,15 +4058,18 @@ class TestTocPageInExport(unittest.TestCase):
         with patch("qfit.atlas.export_task.build_atlas_layout", return_value=layout_mock), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls_mock), \
              patch("qfit.atlas.export_task.AtlasExportTask._export_cover_page",
-                   return_value=None), \
+                   return_value="/tmp/qfit_toc_fail.pdf.cover.pdf"), \
              patch("qfit.atlas.export_task.AtlasExportTask._export_toc_page",
                    return_value=None), \
              patch("qfit.atlas.export_task.AtlasExportTask._build_pdf_assembler"), \
              patch("os.replace"), \
              patch("os.makedirs"):
             _run_task(task)
-        self.assertIsNotNone(received.get("output_path"))
-        self.assertIsNone(received.get("error"))
+        self.assertIsNone(received.get("output_path"))
+        self.assertEqual(
+            received.get("error"),
+            "Contents page export failed. Store and reload the activity map layers, then export again.",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -4078,7 +4103,7 @@ def _make_cover_atlas_layer_with_extents(feature_count=2):
     layer.featureCount.return_value = feature_count
 
     fields = MagicMock()
-    fields.indexOf = lambda name: field_names.index(name) if name in field_names else -1
+    fields.indexOf = _modern_field_index(field_names)
     fields.__iter__.return_value = iter([type("Field", (), {"name": (lambda self, _n=name: _n)})() for name in field_names])
     layer.fields.return_value = fields
 


### PR DESCRIPTION
Fixes #1369.

## Summary

- reject atlas PDF exports when the loaded `activity_atlas_pages` layer is missing the modern atlas fields needed for cover, contents, detail, and profile output
- fail the export when required cover or contents pages cannot be generated, instead of silently assembling a partial PDF
- resolve filtered GeoPackage atlas page counts when QGIS reports `featureCount() == -1`

## Validation

- `python3 -m pytest tests/test_atlas_export_coordinator.py tests/test_atlas_export_task.py tests/test_atlas_export_page_runner.py tests/test_publish_atlas.py tests/test_gpkg_writer.py`
- Built `dist/qfit-0.50.zip`
- Deployed the packaged plugin zip to the Windows QGIS profile
- Generated and visually inspected `C:\Users\emman\qfit_atlas_2026_rides_deployed_validation.pdf`
  - 9 filtered 2026 Ride atlas pages
  - 11 PDF pages total: cover, contents, and 9 ride pages
  - cover summary, contents, route map, per-page detail block, and elevation profile render correctly
