### PR TITLE
Show detailed-route coverage in sync page

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -150,6 +150,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self._atlas_export_completed = False
         self._atlas_export_output_path = None
         self._atlas_export_task_output_path = None
+        self._detailed_route_count = None
         self._dependencies = dependencies or build_dockwidget_dependencies(iface)
         self._bind_dependencies(self._dependencies)
         self.setupUi(self)
@@ -181,6 +182,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         """Keep live local-load actions in sync with the selected GeoPackage path."""
 
         self._runtime_store().select_output_path((value or "").strip() or None)
+        self._refresh_detailed_route_coverage_from_storage()
         self._refresh_live_dock_navigation_from_runtime()
 
     def _build_local_first_dock_from_runtime(self, *, parent=None):
@@ -824,6 +826,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             stored_activity_count=result.total_stored,
         )
         self._mark_atlas_export_stale()
+        self._refresh_detailed_route_coverage_from_storage()
         self._update_stored_activities_summary(result.total_stored)
         self._set_status(result.status)
 
@@ -980,6 +983,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._populate_activity_types_from_layer()
             visual_status = self._apply_visual_configuration(apply_subset_filters=False)
 
+            self._refresh_detailed_route_coverage_from_storage()
             self._update_loaded_activities_summary(result.total_stored)
             status = result.status
             if visual_status:
@@ -1297,6 +1301,32 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             )
         )
         self._refresh_summary_status()
+
+    def _refresh_detailed_route_coverage_from_storage(self):
+        output_path = self._widget_text("outputPathLineEdit").strip()
+        if not output_path:
+            self._detailed_route_count = None
+            self._runtime_store().set_detailed_route_coverage(
+                detailed_count=None,
+                total_count=None,
+            )
+            return None
+        try:
+            coverage = SyncRepository(output_path).load_detailed_route_coverage(provider="strava")
+        except (OSError, RuntimeError, sqlite3.Error):
+            logger.warning("Could not read detailed-route coverage from GeoPackage", exc_info=True)
+            self._detailed_route_count = None
+            self._runtime_store().set_detailed_route_coverage(
+                detailed_count=None,
+                total_count=None,
+            )
+            return None
+        self._detailed_route_count = coverage.detailed_count
+        self._runtime_store().set_detailed_route_coverage(
+            detailed_count=coverage.detailed_count,
+            total_count=coverage.total_count,
+        )
+        return coverage
 
     def _strava_credentials(self):
         return _StravaCredentials(

--- a/sync_repository.py
+++ b/sync_repository.py
@@ -35,6 +35,14 @@ class ActivitySyncState:
         return self.last_success_status == "ok" and self.updated_at is not None
 
 
+@dataclass(frozen=True)
+class DetailedRouteCoverage:
+    """Stored detailed-route coverage for activity stream backfill status."""
+
+    detailed_count: int = 0
+    total_count: int = 0
+
+
 SYNC_STATE_COLUMNS = [
     "provider",
     "last_incremental_sync_at",
@@ -359,6 +367,38 @@ class SyncRepository:
             **dict(zip(SYNC_STATE_COLUMNS, state_row)),
             stored_activity_count=int(activity_row["stored_activity_count"]),
             latest_activity_start_date=activity_row["latest_activity_start_date"],
+        )
+
+    def load_detailed_route_coverage(self, provider="strava") -> DetailedRouteCoverage:
+        """Return stored detailed activity-route coverage for *provider*."""
+
+        if not self._database_exists():
+            return DetailedRouteCoverage()
+        try:
+            with self._connect() as connection:
+                row = connection.execute(
+                    """
+                    SELECT
+                        COUNT(*) AS total_count,
+                        SUM(
+                            CASE
+                                WHEN geometry_source = 'stream' THEN 1
+                                ELSE 0
+                            END
+                        ) AS detailed_count
+                    FROM activity_registry
+                    WHERE source = ?
+                    """,
+                    (provider,),
+                ).fetchone()
+        except sqlite3.OperationalError as exc:
+            if _is_missing_sync_schema_error(exc):
+                return DetailedRouteCoverage()
+            raise
+
+        return DetailedRouteCoverage(
+            detailed_count=int(row["detailed_count"] or 0),
+            total_count=int(row["total_count"] or 0),
         )
 
     def has_completed_activity_sync(self, provider="strava") -> bool:

--- a/tests/test_local_first_progress_facts.py
+++ b/tests/test_local_first_progress_facts.py
@@ -12,6 +12,7 @@ from qfit.ui.application.local_first_progress_facts import (
     current_local_first_atlas_output_path,
     current_local_first_background_facts,
     current_local_first_connection_configured,
+    current_local_first_detailed_route_count,
     current_local_first_last_sync_date,
     current_local_first_visual_temporal_mode,
     runtime_state_with_local_first_output_path,
@@ -69,7 +70,11 @@ class _FakeRuntimeState:
 class TestLocalFirstProgressFacts(unittest.TestCase):
     def test_current_progress_facts_assemble_live_local_first_state(self):
         dock = SimpleNamespace(
-            runtime_state=DockRuntimeState(output_path="stored.gpkg"),
+            runtime_state=DockRuntimeState(
+                output_path="stored.gpkg",
+                detailed_route_count=4,
+                detailed_route_total_count=12,
+            ),
             outputPathLineEdit=_FakeLineEdit(" selected.gpkg "),
             atlasPdfPathLineEdit=_FakeLineEdit("draft.pdf"),
             backgroundMapCheckBox=_FakeCheckBox(False),
@@ -97,6 +102,8 @@ class TestLocalFirstProgressFacts(unittest.TestCase):
         self.assertEqual(facts.activity_style_preset, "Simple lines")
         self.assertIsInstance(facts, LocalFirstProgressFacts)
         self.assertEqual(facts.last_sync_date, "2026-05-09")
+        self.assertEqual(facts.detailed_route_count, 4)
+        self.assertEqual(facts.detailed_route_total_count, 12)
 
     def test_connection_configured_requires_persisted_credential_text(self):
         configured_dock = SimpleNamespace(
@@ -242,6 +249,17 @@ class TestLocalFirstProgressFacts(unittest.TestCase):
         self.assertIsNone(current_local_first_last_sync_date(object()))
         self.assertIsNone(current_local_first_last_sync_date({"last_sync_date": None}))
         self.assertIsNone(current_local_first_last_sync_date({"last_sync_date": "   "}))
+
+    def test_detailed_route_count_reads_cached_count(self):
+        self.assertEqual(
+            current_local_first_detailed_route_count(SimpleNamespace(_detailed_route_count="4")),
+            4,
+        )
+        self.assertEqual(
+            current_local_first_detailed_route_count(SimpleNamespace(_detailed_route_count=-2)),
+            0,
+        )
+        self.assertIsNone(current_local_first_detailed_route_count(SimpleNamespace()))
 
     def test_runtime_state_with_output_path_preserves_matching_or_blank_path(self):
         runtime_state = _FakeRuntimeState(output_path="stored.gpkg")

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2209,6 +2209,24 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "12 activities stored in database (last sync: 2026-04-12)",
         )
 
+    def test_refresh_detailed_route_coverage_reads_storage_summary(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        coverage = SimpleNamespace(detailed_count=4, total_count=12)
+        repository = MagicMock()
+        repository.load_detailed_route_coverage.return_value = coverage
+
+        with patch.object(self.module, "SyncRepository", return_value=repository) as repo_cls:
+            result = self.module.QfitDockWidget._refresh_detailed_route_coverage_from_storage(dock)
+
+        repo_cls.assert_called_once_with("/tmp/qfit.gpkg")
+        repository.load_detailed_route_coverage.assert_called_once_with(provider="strava")
+        self.assertEqual(result, coverage)
+        self.assertEqual(dock._detailed_route_count, 4)
+        self.assertEqual(dock.runtime_state.detailed_route_count, 4)
+        self.assertEqual(dock.runtime_state.detailed_route_total_count, 12)
+
     def test_apply_analysis_configuration_delegates_current_mode_and_layer(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock.analysisModeComboBox = _FakeComboBox(current_text="Most frequent starting points")

--- a/tests/test_sync_repository.py
+++ b/tests/test_sync_repository.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from tests import _path  # noqa: F401
 from qfit.activities.domain.models import Activity
-from qfit.sync_repository import ActivitySyncState, SyncRepository
+from qfit.sync_repository import ActivitySyncState, DetailedRouteCoverage, SyncRepository
 
 
 class SyncRepositoryTests(unittest.TestCase):
@@ -320,6 +320,33 @@ class SyncUnchangedBehaviorTests(unittest.TestCase):
 
             self.assertEqual(result.updated, 1)
             self.assertEqual(result.unchanged, 0)
+
+    def test_load_detailed_route_coverage_counts_stream_geometry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = SyncRepository(str(Path(tmpdir) / "qfit.sqlite"))
+            repo.ensure_schema()
+
+            repo.upsert_activities([
+                self._activity(source_activity_id="stream", geometry_source="stream"),
+                self._activity(source_activity_id="summary", geometry_source="summary_polyline"),
+                self._activity(source_activity_id="empty", geometry_source="summary_polyline", details_json={
+                    "detailed_route_status": "empty",
+                }),
+            ])
+
+            self.assertEqual(
+                repo.load_detailed_route_coverage(provider="strava"),
+                DetailedRouteCoverage(detailed_count=1, total_count=3),
+            )
+
+    def test_load_detailed_route_coverage_returns_zero_for_missing_database(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = SyncRepository(str(Path(tmpdir) / "missing.sqlite"))
+
+            self.assertEqual(
+                repo.load_detailed_route_coverage(provider="strava"),
+                DetailedRouteCoverage(),
+            )
 
     def test_non_volatile_detail_change_triggers_update(self):
         """Changing a non-volatile detail key triggers an update."""

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -775,6 +775,40 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.shell.footer_bar.sync_pill.text(), "sync 2026-04-16")
         self.assertEqual(assembled.shell.footer_bar.path_label.text(), "qfit.gpkg")
 
+    def test_sync_page_summary_reports_detailed_route_coverage(self):
+        facts = WorkflowProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_count=200,
+            detailed_route_count=4,
+            detailed_route_total_count=200,
+            output_name="qfit.gpkg",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "200 activities stored in qfit.gpkg · Detailed routes: 4 / 200",
+        )
+
+    def test_sync_page_summary_uses_detailed_route_total_for_coverage(self):
+        facts = WorkflowProgressFacts(
+            connection_configured=True,
+            activities_stored=True,
+            activity_count=150,
+            detailed_route_count=120,
+            detailed_route_total_count=200,
+            output_name="qfit.gpkg",
+        )
+
+        assembled = self.composition.build_placeholder_wizard_shell(progress_facts=facts)
+
+        self.assertEqual(
+            assembled.sync_content.activity_summary_label.text(),
+            "150 activities stored in qfit.gpkg · Detailed routes: 120 / 200",
+        )
+
     def test_sync_page_summary_uses_singular_activity_count(self):
         facts = WorkflowProgressFacts(
             connection_configured=True,

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -110,6 +110,7 @@ from .local_first_filter_summary import build_local_first_filter_description
 
 from .local_first_progress_facts import (
     LocalFirstProgressFacts,
+    current_local_first_detailed_route_count,
     current_local_first_last_sync_date,
     runtime_state_with_local_first_output_path,
 )
@@ -332,6 +333,7 @@ __all__ = [
     "build_stepper_items",
     "build_stepper_states",
     "build_startup_workflow_progress_facts",
+    "current_local_first_detailed_route_count",
     "current_local_first_last_sync_date",
     "build_workflow_footer_facts_from_progress_facts",
     "build_workflow_footer_status",

--- a/ui/application/dock_runtime_state.py
+++ b/ui/application/dock_runtime_state.py
@@ -109,6 +109,8 @@ class DockRuntimeState:
     activities: tuple[object, ...] = field(default_factory=tuple)
     output_path: str | None = None
     stored_activity_count: int | None = None
+    detailed_route_count: int | None = None
+    detailed_route_total_count: int | None = None
     last_fetch_context: dict[str, Any] = field(default_factory=dict)
     layers: DockRuntimeLayers = field(default_factory=DockRuntimeLayers)
     tasks: DockRuntimeTasks = field(default_factory=DockRuntimeTasks)
@@ -198,11 +200,30 @@ class DockRuntimeStore:
         return self._replace_state(
             output_path=selected_path,
             stored_activity_count=None,
+            detailed_route_count=None,
+            detailed_route_total_count=None,
             layers=self._state.layers.clear_dataset().clear_routes(),
         )
 
     def set_last_fetch_context(self, last_fetch_context: dict[str, Any] | None) -> DockRuntimeState:
         return self._replace_state(last_fetch_context=dict(last_fetch_context or {}))
+
+    def set_detailed_route_coverage(
+        self,
+        *,
+        detailed_count: int | None,
+        total_count: int | None,
+    ) -> DockRuntimeState:
+        detailed_route_count = None if detailed_count is None else max(int(detailed_count), 0)
+        detailed_route_total_count = None if total_count is None else max(int(total_count), 0)
+        return self._replace_state(
+            detailed_route_count=detailed_route_count,
+            detailed_route_total_count=detailed_route_total_count,
+        )
+
+    def set_detailed_route_count(self, count: int | None) -> DockRuntimeState:
+        detailed_route_count = None if count is None else max(int(count), 0)
+        return self._replace_state(detailed_route_count=detailed_route_count)
 
     def set_dataset_layers(
         self,
@@ -364,6 +385,8 @@ class DockRuntimeStore:
             activities=(),
             output_path=None,
             stored_activity_count=None,
+            detailed_route_count=None,
+            detailed_route_total_count=None,
             last_fetch_context={},
             layers=self._state.layers.clear_dataset().clear_routes(),
         )

--- a/ui/application/local_first_progress_facts.py
+++ b/ui/application/local_first_progress_facts.py
@@ -101,6 +101,18 @@ def current_local_first_activity_style_preset(dock) -> str | None:
     return stripped or None
 
 
+def current_local_first_detailed_route_count(dock) -> int | None:
+    """Return the last stored detailed-route coverage count for summaries."""
+
+    value = getattr(dock, "_detailed_route_count", None)
+    if value is None:
+        return None
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return None
+
+
 def current_local_first_visual_temporal_mode(dock) -> str:
     """Return qfit's internal non-dynamic temporal mode for visual actions."""
 
@@ -279,6 +291,7 @@ __all__ = [
     "current_local_first_atlas_output_path",
     "current_local_first_background_facts",
     "current_local_first_connection_configured",
+    "current_local_first_detailed_route_count",
     "current_local_first_filter_facts",
     "current_local_first_last_sync_date",
     "current_local_first_visual_temporal_mode",

--- a/ui/application/workflow_progress_facts.py
+++ b/ui/application/workflow_progress_facts.py
@@ -28,6 +28,8 @@ class WorkflowProgressFacts:
     preferred_current_key: str | None = None
     fetched_activity_count: int | None = None
     activity_count: int | None = None
+    detailed_route_count: int | None = None
+    detailed_route_total_count: int | None = None
     output_name: str | None = None
     analysis_output_name: str | None = None
     atlas_output_name: str | None = None
@@ -76,6 +78,8 @@ def build_workflow_progress_facts_from_runtime_state(
         preferred_current_key=preferred_current_key,
         fetched_activity_count=len(state.activities) if state.activities else None,
         activity_count=_stored_activity_count(state),
+        detailed_route_count=_optional_count(state.detailed_route_count),
+        detailed_route_total_count=_optional_count(state.detailed_route_total_count),
         output_name=output_name,
         analysis_output_name=analysis_output_name,
         atlas_output_name=atlas_output_name,
@@ -115,6 +119,12 @@ def _has_sync_task(state: DockRuntimeState) -> bool:
 
 def _stored_activity_count(state: DockRuntimeState) -> int | None:
     count = state.stored_activity_count
+    if count is None:
+        return None
+    return max(int(count), 0)
+
+
+def _optional_count(count: int | None) -> int | None:
     if count is None:
         return None
     return max(int(count), 0)

--- a/ui/dockwidget/workflow_page_state.py
+++ b/ui/dockwidget/workflow_page_state.py
@@ -92,6 +92,8 @@ def completed_prefix_facts(facts: WorkflowProgressFacts) -> WorkflowProgressFact
         preferred_current_key=facts.preferred_current_key,
         fetched_activity_count=facts.fetched_activity_count,
         activity_count=facts.activity_count,
+        detailed_route_count=facts.detailed_route_count,
+        detailed_route_total_count=facts.detailed_route_total_count,
         output_name=facts.output_name,
         analysis_output_name=facts.analysis_output_name,
         atlas_output_name=facts.atlas_output_name,
@@ -265,7 +267,22 @@ def _stored_activity_summary(facts: WorkflowProgressFacts) -> str:
         noun = "activity" if facts.activity_count == 1 else "activities"
         activity_summary = f"{max(facts.activity_count, 0)} {noun}"
     output_summary = facts.output_name or "GeoPackage"
-    return f"{activity_summary} stored in {output_summary}"
+    summary = f"{activity_summary} stored in {output_summary}"
+    detailed_summary = _detailed_route_summary(facts)
+    if detailed_summary:
+        return f"{summary} · {detailed_summary}"
+    return summary
+
+
+def _detailed_route_summary(facts: WorkflowProgressFacts) -> str | None:
+    if (
+        facts.detailed_route_count is None
+        or facts.detailed_route_total_count is None
+    ):
+        return None
+    detailed_count = max(int(facts.detailed_route_count), 0)
+    total_count = max(int(facts.detailed_route_total_count), 0)
+    return f"Detailed routes: {min(detailed_count, total_count)} / {total_count}"
 
 
 def _fetched_activity_summary(facts: WorkflowProgressFacts) -> str:


### PR DESCRIPTION
## Summary

- show detailed-route coverage in the Sync page stored activity summary
- count coverage from the GeoPackage activity registry using stream geometry records
- refresh the count after output path changes, store/backfill completion, and loading stored layers

Fixes #1371

## Validation

- `python3 -m pytest tests/test_sync_repository.py tests/test_local_first_progress_facts.py tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py`
- `python3 -m pytest tests/test_plugin.py tests/test_sync_repository.py tests/test_local_first_progress_facts.py tests/test_wizard_shell_composition.py tests/test_qfit_dockwidget_analysis_pure.py`
- `python3 scripts/package_plugin.py`
- Deployed `dist/qfit-0.50.zip` to the local Windows QGIS plugin profile and ran `python3 -m compileall -q` on the installed plugin tree.
