### PR TITLE
Remove Data panel clear database action

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -223,7 +223,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
                 sync_activities=self.on_refresh_clicked,
                 store_activities=self.on_load_clicked,
                 sync_saved_routes=self.on_sync_routes_clicked,
-                clear_database=self.on_clear_database_clicked,
                 load_activity_layers=self.on_load_layers_clicked,
                 apply_map_filters=self.on_apply_filters_clicked,
                 run_analysis=self.on_run_analysis_clicked,
@@ -994,6 +993,16 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def on_clear_database_clicked(self):
         """Delete the GeoPackage, clear loaded layers, and reset status."""
+        if (
+            self._fetch_task is not None
+            or self._store_task is not None
+            or self._route_sync_task is not None
+        ):
+            self._set_status(
+                "Wait for the current synchronization to finish before clearing the database."
+            )
+            return
+
         output_path = self.outputPathLineEdit.text().strip()
         if not output_path:
             self._show_error(*build_missing_output_path_error())

--- a/tests/test_local_first_composition.py
+++ b/tests/test_local_first_composition.py
@@ -128,7 +128,6 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
             sync_activities=lambda: calls.append("sync"),
             store_activities=lambda: calls.append("store"),
             sync_saved_routes=lambda: calls.append("routes"),
-            clear_database=lambda: calls.append("clear"),
             load_activity_layers=lambda: calls.append("layers"),
             apply_map_filters=lambda: calls.append("apply"),
             run_analysis=lambda: calls.append("analysis"),
@@ -145,7 +144,6 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
         composition.sync_content.syncRequested.emit()
         composition.sync_content.storeRequested.emit()
         composition.sync_content.syncRoutesRequested.emit()
-        composition.sync_content.clearDatabaseRequested.emit()
         composition.sync_content.loadActivitiesRequested.emit()
         composition.map_content.loadLayersRequested.emit()
         composition.map_content.applyFiltersRequested.emit()
@@ -163,7 +161,6 @@ class LocalFirstDockCompositionTests(unittest.TestCase):
                 "sync",
                 "store",
                 "routes",
-                "clear",
                 "layers",
                 "layers",
                 "apply",

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -839,7 +839,6 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "sync_activities": "on_refresh_clicked",
             "store_activities": "on_load_clicked",
             "sync_saved_routes": "on_sync_routes_clicked",
-            "clear_database": "on_clear_database_clicked",
             "load_activity_layers": "on_load_layers_clicked",
             "apply_map_filters": "on_apply_filters_clicked",
             "run_analysis": "on_run_analysis_clicked",
@@ -3302,6 +3301,22 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._show_error.assert_called_once_with(
             "No database path",
             "Set a GeoPackage output path first.",
+        )
+
+    def test_on_clear_database_clicked_blocks_while_sync_task_is_active(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock._store_task = object()
+        dock._set_status = MagicMock()
+        dock._show_error = MagicMock()
+
+        with patch.object(self.module.QMessageBox, "question", create=True) as question:
+            self.module.QfitDockWidget.on_clear_database_clicked(dock)
+
+        question.assert_not_called()
+        dock._show_error.assert_not_called()
+        dock._set_status.assert_called_once_with(
+            "Wait for the current synchronization to finish before clearing the database."
         )
 
     def test_on_clear_database_clicked_uses_confirmation_helpers(self):

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -246,10 +246,6 @@ class QgisSmokeTests(unittest.TestCase):
             )
             self.assertEqual(dock._local_first_live_shell.page_count(), 5)
             self.assertEqual(dock._local_first_live_shell.current_key(), "data")
-            self.assertEqual(
-                dock._local_first_dock_composition.sync_content.clear_button.text(),
-                "Clear local database…",
-            )
             self.assertTrue(dock.scrollArea.isHidden())
             self.assertTrue(dock.summaryStatusLabel.isHidden())
             self.assertGreaterEqual(
@@ -621,8 +617,8 @@ class QgisSmokeTests(unittest.TestCase):
         try:
             fake_task = MagicMock(name="store_task")
             dock._save_settings = MagicMock()
-            dock.activities = [{"id": 1}]
-            dock.load_workflow.build_write_request = MagicMock(return_value="store-request")
+            dock._runtime_store().set_activities([{"id": 1}])
+            dock.store_workflow.build_write_request = MagicMock(return_value="store-request")
 
             with (
                 patch("qfit.qfit_dockwidget.build_store_task", return_value=fake_task) as build_store_task,
@@ -631,9 +627,9 @@ class QgisSmokeTests(unittest.TestCase):
                 task_manager.return_value.addTask = MagicMock()
                 dock.on_load_clicked()
 
-            dock.load_workflow.build_write_request.assert_called_once()
+            dock.store_workflow.build_write_request.assert_called_once()
             build_store_task.assert_called_once()
-            self.assertEqual(build_store_task.call_args.args[:2], (dock.load_workflow, "store-request"))
+            self.assertEqual(build_store_task.call_args.args[:2], (dock.store_workflow, "store-request"))
             self.assertIs(build_store_task.call_args.kwargs["on_finished"].__self__, dock)
             task_manager.return_value.addTask.assert_called_once_with(fake_task)
             self.assertIs(dock._store_task, fake_task)

--- a/tests/test_sync_page.py
+++ b/tests/test_sync_page.py
@@ -93,33 +93,8 @@ class SyncPageContentTest(unittest.TestCase):
         )
         self.assertTrue(content.routes_button.isEnabled())
         self.assertEqual(content.routes_button.toolTip(), "")
-        self.assertEqual(
-            content.clear_button.objectName(),
-            "qfitWizardSyncClearDatabaseButton",
-        )
-        self.assertEqual(content.clear_button.text(), "Clear local database…")
-        self.assertEqual(
-            content.clear_button.property("destructiveAction"),
-            "clear_database",
-        )
-        self.assertEqual(
-            content.clear_button.property("wizardActionRole"),
-            "destructive",
-        )
-        self.assertNotEqual(
-            content.clear_button.styleSheet(),
-            content.sync_button.styleSheet(),
-        )
-        self.assertNotIn("#589632", content.clear_button.styleSheet())
-        self.assertFalse(content.clear_button.isEnabled())
-        self.assertEqual(
-            content.clear_button.property("wizardActionAvailability"),
-            "blocked",
-        )
-        self.assertEqual(
-            content.clear_button.toolTip(),
-            "Select a GeoPackage before clearing local data.",
-        )
+        self.assertFalse(hasattr(content, "clear_button"))
+        self.assertFalse(hasattr(content, "clear_action_row"))
         self.assertEqual(content.action_row.objectName(), "qfitWizardSyncActionRow")
         self.assertEqual(
             content.action_row.outer_layout().widgets,
@@ -130,21 +105,12 @@ class SyncPageContentTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            content.clear_action_row.objectName(),
-            "qfitWizardSyncDestructiveActionRow",
-        )
-        self.assertEqual(
-            content.clear_action_row.outer_layout().widgets,
-            [content.clear_button],
-        )
-        self.assertEqual(
             content.outer_layout().widgets,
             [
                 content.status_label,
                 content.detail_label,
                 content.action_row,
                 content.activity_summary_label,
-                content.clear_action_row,
             ],
         )
 
@@ -157,7 +123,6 @@ class SyncPageContentTest(unittest.TestCase):
             activity_summary_text="42 activities stored · 40 detailed routes",
             primary_action_label="Fetch latest activities",
             local_action_enabled=True,
-            clear_action_enabled=True,
         )
 
         content.set_state(state)
@@ -177,8 +142,6 @@ class SyncPageContentTest(unittest.TestCase):
         self.assertEqual(content.sync_button.text(), "Fetch latest activities")
         self.assertTrue(content.load_button.isEnabled())
         self.assertEqual(content.load_button.toolTip(), "")
-        self.assertTrue(content.clear_button.isEnabled())
-        self.assertEqual(content.clear_button.toolTip(), "")
 
     def test_presentation_copy_wraps_without_forcing_panel_width(self):
         content = self.sync_page.SyncPageContent()
@@ -271,17 +234,6 @@ class SyncPageContentTest(unittest.TestCase):
         content.routes_button.clicked.emit()
 
         self.assertEqual(calls, ["routes"])
-
-    def test_clear_database_button_emits_reusable_page_signal(self):
-        content = self.sync_page.SyncPageContent(
-            self.sync_page.SyncPageState(clear_action_enabled=True)
-        )
-        calls = []
-        content.clearDatabaseRequested.connect(lambda: calls.append("clear"))
-
-        content.clear_button.clicked.emit()
-
-        self.assertEqual(calls, ["clear"])
 
     def test_installs_only_on_sync_wizard_page_body(self):
         sync_spec = next(

--- a/tests/test_wizard_shell_composition.py
+++ b/tests/test_wizard_shell_composition.py
@@ -503,7 +503,6 @@ class WizardShellCompositionTest(unittest.TestCase):
             sync_activities=lambda: calls.append("sync"),
             store_activities=lambda: calls.append("store"),
             sync_saved_routes=lambda: calls.append("routes"),
-            clear_database=lambda: calls.append("clear"),
             load_activity_layers=lambda: calls.append("load"),
             apply_map_filters=lambda: calls.append("filter"),
             run_analysis=lambda: calls.append("analysis"),
@@ -523,7 +522,6 @@ class WizardShellCompositionTest(unittest.TestCase):
         assembled.connection_content.configure_button.clicked.emit()
         assembled.sync_content.sync_button.clicked.emit()
         assembled.sync_content.routes_button.clicked.emit()
-        assembled.sync_content.clear_button.clicked.emit()
         assembled.sync_content.load_button.clicked.emit()
         assembled.map_content.load_layers_button.clicked.emit()
         assembled.map_content.apply_filters_button.clicked.emit()
@@ -540,7 +538,6 @@ class WizardShellCompositionTest(unittest.TestCase):
                 "configure",
                 "sync",
                 "routes",
-                "clear",
                 "load",
                 "load",
                 "filter",
@@ -695,7 +692,6 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(assembled.sync_content.status_label.text(), "Activities stored")
         self.assertFalse(assembled.sync_content.sync_button.isEnabled())
         self.assertTrue(assembled.sync_content.load_button.isEnabled())
-        self.assertTrue(assembled.sync_content.clear_button.isEnabled())
         self.assertEqual(
             assembled.map_content.status_label.text(),
             "Stored map layers ready to load",
@@ -836,30 +832,6 @@ class WizardShellCompositionTest(unittest.TestCase):
         self.assertEqual(
             assembled.sync_content.activity_summary_label.text(),
             "Activities stored in qfit.gpkg",
-        )
-
-    def test_sync_page_enables_clear_database_when_output_path_is_selected(self):
-        assembled = self.composition.build_placeholder_wizard_shell(
-            progress_facts=WorkflowProgressFacts(
-                output_name="qfit.gpkg",
-            ),
-        )
-
-        self.assertTrue(assembled.sync_content.clear_button.isEnabled())
-        self.assertEqual(assembled.sync_content.clear_button.toolTip(), "")
-
-    def test_sync_page_blocks_clear_database_while_route_sync_is_running(self):
-        assembled = self.composition.build_placeholder_wizard_shell(
-            progress_facts=WorkflowProgressFacts(
-                output_name="qfit.gpkg",
-                route_sync_in_progress=True,
-            ),
-        )
-
-        self.assertFalse(assembled.sync_content.clear_button.isEnabled())
-        self.assertEqual(
-            assembled.sync_content.clear_button.toolTip(),
-            "Wait for the current synchronization to finish.",
         )
 
     def test_sync_page_shows_fetched_activities_ready_to_finish_sync(self):

--- a/ui/application/local_first_parity_audit.py
+++ b/ui/application/local_first_parity_audit.py
@@ -55,7 +55,6 @@ _ACTION_SURFACES = (
             "syncRequested",
             "storeRequested",
             "syncRoutesRequested",
-            "clearDatabaseRequested",
             "loadActivitiesRequested",
         ),
     ),

--- a/ui/dockwidget/local_first_composition.py
+++ b/ui/dockwidget/local_first_composition.py
@@ -150,11 +150,6 @@ def connect_local_first_action_callbacks(
         callbacks.load_activity_layers,
     )
     connect_optional_signal(
-        composition.sync_content,
-        "clearDatabaseRequested",
-        callbacks.clear_database,
-    )
-    connect_optional_signal(
         composition.map_content,
         "loadLayersRequested",
         callbacks.load_activity_layers,

--- a/ui/dockwidget/sync_page.py
+++ b/ui/dockwidget/sync_page.py
@@ -6,7 +6,6 @@ from ._qt_compat import import_qt_module
 from .action_row import (
     build_workflow_action_row,
     set_workflow_action_availability,
-    style_destructive_action_button,
     style_primary_action_button,
     style_secondary_action_button,
 )
@@ -57,9 +56,6 @@ class SyncPageState:
     routes_action_blocked_tooltip: str = (
         "Configure the Strava connection before syncing saved routes."
     )
-    clear_action_label: str = "Clear local database…"
-    clear_action_enabled: bool = False
-    clear_action_blocked_tooltip: str = "Select a GeoPackage before clearing local data."
 
 
 class SyncPageContent(QWidget):
@@ -69,7 +65,6 @@ class SyncPageContent(QWidget):
     storeRequested = pyqtSignal()
     loadActivitiesRequested = pyqtSignal()
     syncRoutesRequested = pyqtSignal()
-    clearDatabaseRequested = pyqtSignal()
 
     def __init__(self, state: SyncPageState | None = None, parent=None) -> None:
         super().__init__(parent)
@@ -106,24 +101,12 @@ class SyncPageContent(QWidget):
             action_name="sync_saved_routes",
         )
         self.routes_button.clicked.connect(self.syncRoutesRequested.emit)
-        self.clear_button = QToolButton(self)
-        self.clear_button.setObjectName("qfitWizardSyncClearDatabaseButton")
-        style_destructive_action_button(
-            self.clear_button,
-            action_name="clear_database",
-        )
-        self.clear_button.clicked.connect(self.clearDatabaseRequested.emit)
         self.action_row = build_workflow_action_row(
             self.load_button,
             self.routes_button,
             self.sync_button,
             parent=self,
             object_name="qfitWizardSyncActionRow",
-        )
-        self.clear_action_row = build_workflow_action_row(
-            self.clear_button,
-            parent=self,
-            object_name="qfitWizardSyncDestructiveActionRow",
         )
         self._layout = self._build_layout()
         self.set_state(state or SyncPageState())
@@ -157,12 +140,6 @@ class SyncPageContent(QWidget):
             enabled=state.routes_action_enabled,
             tooltip=state.routes_action_blocked_tooltip,
         )
-        self.clear_button.setText(state.clear_action_label)
-        set_workflow_action_availability(
-            self.clear_button,
-            enabled=state.clear_action_enabled,
-            tooltip=state.clear_action_blocked_tooltip,
-        )
 
     def outer_layout(self):
         """Expose the layout for adapter wiring and pure tests."""
@@ -184,7 +161,6 @@ class SyncPageContent(QWidget):
         layout.addWidget(self.detail_label)
         layout.addWidget(self.action_row)
         layout.addWidget(self.activity_summary_label)
-        layout.addWidget(self.clear_action_row)
         return layout
 
 

--- a/ui/dockwidget/workflow_composition.py
+++ b/ui/dockwidget/workflow_composition.py
@@ -429,11 +429,6 @@ def _connect_action_callbacks(
         callbacks.load_activity_layers,
     )
     _connect_optional_signal(
-        sync_content,
-        "clearDatabaseRequested",
-        callbacks.clear_database,
-    )
-    _connect_optional_signal(
         map_content,
         "loadLayersRequested",
         callbacks.load_activity_layers,

--- a/ui/dockwidget/workflow_page_state.py
+++ b/ui/dockwidget/workflow_page_state.py
@@ -29,7 +29,6 @@ class DockWorkflowActionCallbacks:
     sync_activities: Callable[[], None] | None = None
     store_activities: Callable[[], None] | None = None
     sync_saved_routes: Callable[[], None] | None = None
-    clear_database: Callable[[], None] | None = None
     load_activity_layers: Callable[[], None] | None = None
     apply_map_filters: Callable[[], None] | None = None
     run_analysis: Callable[[], None] | None = None
@@ -191,12 +190,6 @@ def _sync_state_from_facts(facts: WorkflowProgressFacts) -> SyncPageState:
             or (facts.connection_configured and not facts.sync_in_progress)
         ),
         routes_action_blocked_tooltip=_sync_routes_action_blocked_tooltip(facts, default),
-        clear_action_enabled=(
-            bool(facts.output_name)
-            and not facts.sync_in_progress
-            and not facts.route_sync_in_progress
-        ),
-        clear_action_blocked_tooltip=_sync_clear_action_blocked_tooltip(facts, default),
     )
 
 
@@ -221,17 +214,6 @@ def _sync_routes_action_blocked_tooltip(
         return _SYNC_IN_PROGRESS_TOOLTIP
     if not facts.connection_configured:
         return default.routes_action_blocked_tooltip
-    return ""
-
-
-def _sync_clear_action_blocked_tooltip(
-    facts: WorkflowProgressFacts,
-    default: SyncPageState,
-) -> str:
-    if facts.sync_in_progress or facts.route_sync_in_progress:
-        return _SYNC_IN_PROGRESS_TOOLTIP
-    if not facts.output_name:
-        return default.clear_action_blocked_tooltip
     return ""
 
 


### PR DESCRIPTION
## Summary

- remove the destructive `Clear local database…` action from the Data panel
- drop the obsolete Sync page signal/state/wiring for that action
- keep the Settings panel `Database actions` -> `Clear database…` path intact

Fixes #1373

## Validation

- `python3 -m pytest tests/test_sync_page.py tests/test_wizard_shell_composition.py tests/test_local_first_composition.py tests/test_local_first_parity_audit.py tests/test_dockwidget_dependencies.py tests/test_contextual_help.py tests/test_qgis_smoke.py::QgisSmokeTests::test_dock_widget_updates_local_first_visibility_rules tests/test_qgis_smoke.py::QgisSmokeTests::test_load_clicked_builds_background_store_task`
- `python3 -m pytest tests/test_plugin.py tests/test_sync_page.py tests/test_wizard_shell_composition.py tests/test_local_first_composition.py tests/test_local_first_parity_audit.py tests/test_dockwidget_dependencies.py tests/test_contextual_help.py`
- `python3 scripts/package_plugin.py`
- Deployed `dist/qfit-0.50.zip` to the local Windows QGIS plugin profile and ran `python3 -m compileall -q` on the installed plugin tree.

Note: full `tests/test_qgis_smoke.py` currently stalls after the already-passing leading smoke tests in this environment, so I validated the two smoke cases touched by this change individually.

---
*Generated by OpenClaw 2026.6.8 · model=openai/gpt-5.5-codex · reasoning=on (high)*