### PR TITLE
Fix capped Strava route pagination

### DIFF
--- a/activities/infrastructure/geopackage/route_storage.py
+++ b/activities/infrastructure/geopackage/route_storage.py
@@ -215,6 +215,8 @@ class GeoPackageRouteStore:
     def _prune_missing_routes(self, cursor, routes, sync_metadata):
         if not sync_metadata.get("is_full_sync"):
             return
+        if sync_metadata.get("fetch_notice"):
+            return
 
         provider = sync_metadata.get("provider") or self._infer_single_provider(routes)
         if provider is None:

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -282,7 +282,7 @@ class StravaClient:
                 )
 
             routes.extend(self.normalize_route(item) for item in payload)
-            if len(payload) < current_per_page:
+            if not payload:
                 break
             if max_pages == 0 and self._should_pause_full_sync_for_rate_limit():
                 self.last_fetch_notice = self._rate_limit_pause_notice()

--- a/tests/test_route_storage.py
+++ b/tests/test_route_storage.py
@@ -96,6 +96,31 @@ class RouteStorageTests(unittest.TestCase):
             {("strava", "keep"), ("komoot", "other")},
         )
 
+    def test_full_sync_with_fetch_notice_does_not_prune_missing_routes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = GeoPackageRouteStore(os.path.join(tmpdir, "routes.gpkg"))
+            store.ensure_schema()
+            store.upsert_routes([
+                SavedRoute(source="strava", source_route_id="keep", name="Keep"),
+                SavedRoute(source="strava", source_route_id="preserve", name="Preserve"),
+            ])
+
+            stats = store.upsert_routes(
+                [SavedRoute(source="strava", source_route_id="keep", name="Keep")],
+                sync_metadata={
+                    "is_full_sync": True,
+                    "provider": "strava",
+                    "fetch_notice": "Stopped early while fetching Strava routes.",
+                },
+            )
+            records = store.load_all_route_records()
+
+        self.assertEqual(stats.total_count, 2)
+        self.assertEqual(
+            {record["source_route_id"] for record in records},
+            {"keep", "preserve"},
+        )
+
     def test_empty_full_sync_without_provider_does_not_prune_any_provider(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             store = GeoPackageRouteStore(os.path.join(tmpdir, "routes.gpkg"))

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -349,7 +349,9 @@ class StravaClientTests(unittest.TestCase):
                 return {"id": 999}
             if idx == 2:
                 return [{"id": 1, "name": "Route 1"}, {"id": 2, "name": "Route 2"}]
-            return [{"id": 3, "name": "Route 3"}]
+            if idx == 3:
+                return [{"id": 3, "name": "Route 3"}]
+            return []
 
         client._request_json = fake_request_json
 
@@ -360,6 +362,42 @@ class StravaClientTests(unittest.TestCase):
         self.assertIn("/athlete", seen_urls[0])
         self.assertIn("/athletes/999/routes?page=1&per_page=2", seen_urls[1])
         self.assertIn("/athletes/999/routes?page=2&per_page=2", seen_urls[2])
+        self.assertIn("/athletes/999/routes?page=3&per_page=2", seen_urls[3])
+
+    def test_fetch_routes_continues_until_empty_when_strava_returns_short_pages(self):
+        client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")
+        seen_urls = []
+        page_one = [{"id": route_id, "name": "Route {0}".format(route_id)} for route_id in range(1, 91)]
+        page_two = [{"id": route_id, "name": "Route {0}".format(route_id)} for route_id in range(91, 180)]
+        page_three = [{"id": 180, "name": "Route 180"}, {"id": 181, "name": "Route 181"}]
+        call_count = [0]
+
+        def fake_request_json(request, operation=None, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return {"access_token": "fake_token"}
+            seen_urls.append(request)
+            if idx == 1:
+                return {"id": 999}
+            if idx == 2:
+                return page_one
+            if idx == 3:
+                return page_two
+            if idx == 4:
+                return page_three
+            return []
+
+        client._request_json = fake_request_json
+
+        with patch("qfit.providers.infrastructure.strava_client.time.sleep"):
+            routes = client.fetch_routes(per_page=200, max_pages=0)
+
+        self.assertEqual([route.source_route_id for route in routes], [str(route_id) for route_id in range(1, 182)])
+        self.assertIn("/athletes/999/routes?page=1&per_page=200", seen_urls[1])
+        self.assertIn("/athletes/999/routes?page=2&per_page=200", seen_urls[2])
+        self.assertIn("/athletes/999/routes?page=3&per_page=200", seen_urls[3])
+        self.assertIn("/athletes/999/routes?page=4&per_page=200", seen_urls[4])
 
     def test_fetch_routes_accepts_known_athlete_id(self):
         client = StravaClient(client_id="123", client_secret="abc", refresh_token="tok")


### PR DESCRIPTION
## Summary

- keep Strava route pagination going until the API returns an empty page instead of treating any short page as terminal
- keep route registry pruning disabled whenever route sync metadata carries a fetch notice
- cover uneven short-page route pagination and incomplete-fetch prune guard

Fixes #1375

## Root Cause

QFit requested `per_page=200` and treated any route page shorter than 200 as the final page. Strava pagination can return pages with fewer items before the result set is exhausted, so qfit could stop early and miss later routes.

The route registry prune path also trusted `is_full_sync` alone, so inconsistent or future partial-fetch metadata could still delete routes that were absent from an incomplete API response.

## Validation

- `python3 -m pytest tests/test_strava_client.py::StravaClientTests::test_fetch_routes_continues_until_empty_when_strava_returns_short_pages tests/test_strava_client.py::StravaClientTests::test_fetch_routes_resolves_athlete_and_paginates_until_last_page`
- `python3 -m pytest tests/test_route_storage.py`
- `python3 -m pytest tests/test_strava_client.py tests/test_route_storage.py tests/test_route_sync_task.py tests/test_strava_provider.py`
- `python3 -m pytest`

---
*Generated by OpenClaw 2026.6.8 · model=openai/gpt-5.5-codex · reasoning=on (high)*