### PR TITLE
Request Strava read_all for route sync

### DIFF
--- a/docs/strava-setup.md
+++ b/docs/strava-setup.md
@@ -56,10 +56,11 @@ Routes are intentionally kept separate from completed activities so planning
 data does not get mixed into activity history.
 
 Saved routes use Strava's route-list, route-detail, and GPX export endpoints
-through the same OAuth refresh-token flow as activity imports. Private routes
-may require Strava's `read_all` scope. If you authorized qfit before route
-catalog support and Strava later denies route access, re-authorize qfit with a
-token that includes the additional route visibility you need.
+through the same OAuth refresh-token flow as activity imports. Strava filters
+private routes from the route-list endpoint unless the token has the `read_all`
+scope, and private-route GPX export has the same requirement. qfit's OAuth
+helper requests `read_all`; if you authorized qfit before that scope was added,
+re-authorize qfit from Settings before syncing private saved routes.
 
 When route records are written to a qfit GeoPackage, they use dedicated route
 objects:

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -118,7 +118,7 @@ class StravaClient:
         "temp",
         "grade_smooth",
     ]
-    DEFAULT_SCOPE = "read,activity:read_all"
+    DEFAULT_SCOPE = "read,read_all,activity:read_all"
     DEFAULT_REDIRECT_URI = "http://localhost/exchange_token"
 
     def __init__(

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -16,7 +16,7 @@ class StravaClientTests(unittest.TestCase):
         self.assertIn("client_id=123", url)
         self.assertIn("response_type=code", url)
         self.assertIn("approval_prompt=force", url)
-        self.assertIn("scope=read%2Cactivity%3Aread_all", url)
+        self.assertIn("scope=read%2Cread_all%2Cactivity%3Aread_all", url)
 
     def test_normalize_activity_maps_core_fields(self):
         client = StravaClient()


### PR DESCRIPTION
## Summary

- request Strava `read_all` in qfit OAuth authorization URLs
- document that private saved routes require reauthorizing with `read_all`
- update the authorize URL test for the expanded scope

## Root Cause

The route pagination fix is deployed, but the live Strava route list still returns 90 routes. The deployed code now continues until Strava returns an empty page, so a persistent 90-route result points at Strava filtering the API response rather than qfit stopping early.

Strava documents `GET /athletes/{id}/routes` as returning routes created by the authenticated athlete and filtering private routes unless the token has `read_all`. qfit was only requesting `read,activity:read_all`, so existing/new private routes can be visible in the Strava web UI but absent from qfit route sync.

Important: existing refresh tokens do not gain the new scope automatically. Users must reauthorize qfit from Settings after this change.

## Validation

- `python3 -m pytest tests/test_strava_client.py tests/test_config_connection_service.py`
- `python3 -m pytest`

---
*Generated by OpenClaw 2026.6.8 · model=openai/gpt-5.5-codex · reasoning=on (high)*
