### PR TITLE
Budget route backfill stream requests

### DIFF
--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -102,6 +102,9 @@ class StravaClient:
     MIN_ACTIVITY_PAGE_SIZE = 5
     FULL_SYNC_MIN_SHORT_REMAINING = 3
     FULL_SYNC_MIN_LONG_REMAINING = 15
+    STREAM_ENRICHMENT_SHORT_WINDOW_FRACTION = 0.75
+    STREAM_ENRICHMENT_MIN_SHORT_REMAINING = 5
+    STREAM_ENRICHMENT_MIN_LONG_REMAINING = 25
     PAGE_REQUEST_DELAY_SECONDS = 0.2
     RETRYABLE_ERRNOS = {104}
     RETRYABLE_WINERRORS = {10054}
@@ -487,7 +490,7 @@ class StravaClient:
             candidates.append(activity)
 
         stats["missing_before"] = len(candidates)
-        limit = self._stream_request_limit(candidates, max_activities)
+        limit = self._stream_request_limit(candidates, max_activities, apply_rate_limit_budget=True)
         stats["requested"] = limit
 
         for activity in candidates[:limit]:
@@ -499,11 +502,35 @@ class StravaClient:
         self.last_stream_enrichment_stats = stats
         return activities
 
-    @staticmethod
-    def _stream_request_limit(activities, max_activities):
+    def _stream_request_limit(self, activities, max_activities, *, apply_rate_limit_budget=False):
         if max_activities is None or max_activities <= 0:
-            return len(activities)
-        return min(int(max_activities), len(activities))
+            limit = len(activities)
+        else:
+            limit = min(int(max_activities), len(activities))
+        if not apply_rate_limit_budget:
+            return limit
+        rate_limit_budget = self._stream_enrichment_rate_limit_budget()
+        if rate_limit_budget is None:
+            return limit
+        return min(limit, rate_limit_budget)
+
+    def _stream_enrichment_rate_limit_budget(self):
+        if not self.last_rate_limit:
+            return None
+        budgets = []
+        short_remaining = self.last_rate_limit.get("short_remaining")
+        if short_remaining is not None:
+            short_remaining = int(short_remaining)
+            short_budget = int(short_remaining * self.STREAM_ENRICHMENT_SHORT_WINDOW_FRACTION)
+            short_headroom = max(0, short_remaining - self.STREAM_ENRICHMENT_MIN_SHORT_REMAINING)
+            budgets.append(min(short_budget, short_headroom))
+        long_remaining = self.last_rate_limit.get("long_remaining")
+        if long_remaining is not None:
+            long_remaining = int(long_remaining)
+            budgets.append(max(0, long_remaining - self.STREAM_ENRICHMENT_MIN_LONG_REMAINING))
+        if not budgets:
+            return None
+        return min(budgets)
 
     def _enrich_single_activity_with_streams(self, activity, stats):
         if self._approaching_rate_limit():
@@ -724,9 +751,9 @@ class StravaClient:
             return False
         short_remaining = self.last_rate_limit.get("short_remaining")
         long_remaining = self.last_rate_limit.get("long_remaining")
-        if short_remaining is not None and short_remaining <= 5:
+        if short_remaining is not None and short_remaining <= self.STREAM_ENRICHMENT_MIN_SHORT_REMAINING:
             return True
-        if long_remaining is not None and long_remaining <= 25:
+        if long_remaining is not None and long_remaining <= self.STREAM_ENRICHMENT_MIN_LONG_REMAINING:
             return True
         return False
 

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -193,6 +193,67 @@ class StravaClientTests(unittest.TestCase):
         self.assertEqual(client.last_stream_enrichment_stats["downloaded"], 1)
         self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 1)
 
+    def test_missing_route_enrichment_uses_short_window_budget(self):
+        client = StravaClient()
+        client.last_rate_limit = {"short_remaining": 20, "long_remaining": 1000}
+        activities = [client.normalize_activity({"id": i, "name": f"Missing {i}"}) for i in range(20)]
+
+        with (
+            patch.object(client, "_load_cached_stream_bundle", return_value=None),
+            patch.object(
+                client,
+                "fetch_activity_stream_bundle",
+                return_value={"latlng": [[46.0, 6.0], [46.1, 6.1]]},
+            ) as fetch_mock,
+            patch.object(client, "_save_cached_stream_bundle"),
+        ):
+            client.enrich_activities_with_streams(activities, max_activities=25)
+
+        self.assertEqual(fetch_mock.call_count, 15)
+        self.assertEqual(client.last_stream_enrichment_stats["requested"], 15)
+        self.assertEqual(client.last_stream_enrichment_stats["downloaded"], 15)
+        self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 5)
+
+    def test_missing_route_enrichment_keeps_ui_cap_below_rate_budget(self):
+        client = StravaClient()
+        client.last_rate_limit = {"short_remaining": 100, "long_remaining": 1000}
+        activities = [client.normalize_activity({"id": i, "name": f"Missing {i}"}) for i in range(50)]
+
+        with (
+            patch.object(client, "_load_cached_stream_bundle", return_value=None),
+            patch.object(
+                client,
+                "fetch_activity_stream_bundle",
+                return_value={"latlng": [[46.0, 6.0], [46.1, 6.1]]},
+            ) as fetch_mock,
+            patch.object(client, "_save_cached_stream_bundle"),
+        ):
+            client.enrich_activities_with_streams(activities, max_activities=25)
+
+        self.assertEqual(fetch_mock.call_count, 25)
+        self.assertEqual(client.last_stream_enrichment_stats["requested"], 25)
+        self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 25)
+
+    def test_missing_route_enrichment_uses_ui_cap_without_rate_limit_headers(self):
+        client = StravaClient()
+        client.last_rate_limit = None
+        activities = [client.normalize_activity({"id": i, "name": f"Missing {i}"}) for i in range(10)]
+
+        with (
+            patch.object(client, "_load_cached_stream_bundle", return_value=None),
+            patch.object(
+                client,
+                "fetch_activity_stream_bundle",
+                return_value={"latlng": [[46.0, 6.0], [46.1, 6.1]]},
+            ) as fetch_mock,
+            patch.object(client, "_save_cached_stream_bundle"),
+        ):
+            client.enrich_activities_with_streams(activities, max_activities=3)
+
+        self.assertEqual(fetch_mock.call_count, 3)
+        self.assertEqual(client.last_stream_enrichment_stats["requested"], 3)
+        self.assertEqual(client.last_stream_enrichment_stats["remaining_missing"], 7)
+
     def test_recent_fetch_strategy_keeps_old_first_n_behavior(self):
         client = StravaClient()
         cached = client.normalize_activity({"id": 1, "name": "Cached"})


### PR DESCRIPTION
## Summary
- apply a 75% short-window budget to missing-route stream backfill
- keep the existing 25 detailed-route UI cap as an upper bound
- reuse named stream rate-limit thresholds for the old near-limit guard

## Tests
- `python3 -m pytest tests/test_strava_client.py -q`
- `python3 -m pytest tests/test_dock_activity_workflow.py tests/test_qgis_smoke.py::QgisSmokeTests::test_backfill_missing_detailed_routes_uses_internal_cap -q`
- `python3 -m pytest -q`

---
*Generated by OpenClaw 2026.6.8 · model=openai/gpt-5.5-codex · reasoning=on (high)*
