### PR TITLE
Remove stale dock footer status bar

### DIFF
--- a/tests/test_local_first_shell.py
+++ b/tests/test_local_first_shell.py
@@ -89,11 +89,11 @@ class LocalFirstDockShellTests(unittest.TestCase):
             )
         )
 
-    def test_outer_layout_keeps_navigation_content_and_footer_separate(self):
+    def test_outer_layout_keeps_navigation_content_only(self):
         shell = self.shell_module.LocalFirstDockShell()
 
         self.assertEqual(shell.outer_layout().object_name, "qfitLocalFirstDockOuterLayout")
-        self.assertEqual(shell.outer_layout().widgets, [shell.main_container, shell.footer_bar])
+        self.assertEqual(shell.outer_layout().widgets, [shell.main_container])
         self.assertEqual(
             shell.main_layout().widgets,
             [shell.navigation_container, shell.separator, shell.pages_stack],

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -83,6 +83,9 @@ class _FakeWidget:
     def setVisible(self, value):  # noqa: N802
         self._visible = value
 
+    def hide(self):
+        self.setVisible(False)
+
     def isVisible(self):  # noqa: N802
         return self._visible
 
@@ -484,7 +487,7 @@ class WizardShellTest(unittest.TestCase):
         self.assertEqual(layout.spacing, 0)
         self.assertEqual(
             layout.widgets,
-            [shell.stepper_bar, shell.separator, shell.content_scroll, shell.footer_bar],
+            [shell.stepper_bar, shell.separator, shell.content_scroll],
         )
 
     def test_delegates_stepper_state_and_page_selection(self):

--- a/ui/dockwidget/local_first_shell.py
+++ b/ui/dockwidget/local_first_shell.py
@@ -166,6 +166,7 @@ class LocalFirstDockShell(QWidget):
         self.pages_stack = self._build_pages_stack()
         self.main_container = self._build_main_container()
         self.footer_bar = self._build_footer_bar(footer_text)
+        self.footer_bar.hide()
         self._outer_layout = self._build_outer_layout()
         self._install_navigation_items(self._navigation_state.pages)
         self.set_navigation_state(self._navigation_state)
@@ -306,7 +307,6 @@ class LocalFirstDockShell(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self.main_container)
-        layout.addWidget(self.footer_bar)
         return layout
 
     def _build_pages_stack(self):

--- a/ui/dockwidget/workflow_shell.py
+++ b/ui/dockwidget/workflow_shell.py
@@ -30,9 +30,9 @@ class WorkflowShell(QWidget):
     """Reusable dock shell for the local-first workflow structure.
 
     The shell intentionally owns only the structural chrome: stepper, separator,
-    scrollable stacked pages, and compact footer. Page content remains external
-    so workflow pages can migrate one page at a time. Stable ``qfitWizard*``
-    object names are preserved for QSS and compatibility.
+    and scrollable stacked pages. Page content remains external so workflow
+    pages can migrate one page at a time. Stable ``qfitWizard*`` object names
+    are preserved for QSS and compatibility.
     """
 
     def __init__(self, parent=None, *, footer_text: str = "") -> None:
@@ -43,6 +43,7 @@ class WorkflowShell(QWidget):
         self.content_scroll = self._build_content_scroll()
         self.pages_stack = self._build_pages_stack()
         self.footer_bar = self._build_footer_bar(footer_text)
+        self.footer_bar.hide()
         self.content_scroll.setWidget(self.pages_stack)
         self._outer_layout = self._build_layout()
         self._responsive_mode = "wide"
@@ -129,7 +130,6 @@ class WorkflowShell(QWidget):
         layout.addWidget(self.stepper_bar)
         layout.addWidget(self.separator)
         layout.addWidget(self.content_scroll)
-        layout.addWidget(self.footer_bar)
         return layout
 
     def _build_separator(self):


### PR DESCRIPTION
## What Problem This Solves

Fixes ebelo/qfit#1381.

The dock footer/status bar showed stale global state such as `0 layers`, which made the GUI look wrong even when QGIS had loaded qfit layers correctly.

## Why This Change Was Made

The footer duplicated better page-level status surfaces in Data, Map, Analysis, Atlas, Settings, and QGIS task notifications. Removing it is clearer than trying to maintain another global summary.

## User Impact

- Removes the visible dock footer/status bar from both shell variants.
- Keeps existing page-level statuses and task messages intact.
- Leaves the internal footer object available for compatibility during the ongoing UI migration.

## Evidence

- `python3 -m pytest tests/test_wizard_shell.py tests/test_local_first_shell.py tests/test_workflow_shell_composition.py tests/test_wizard_shell_composition.py tests/test_wizard_footer_status.py` -> 127 passed
