### PR TITLE
Render selected activity routes on atlas cover

### DIFF
--- a/atlas/export_front_matter.py
+++ b/atlas/export_front_matter.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from typing import Callable
 
+ACTIVITY_LAYER_NAME = "qfit activities"
+POINTS_LAYER_NAME = "qfit activity points"
+STARTS_LAYER_NAME = "qfit activity starts"
+
 
 def export_cover_page(
     atlas_layer,
@@ -117,6 +121,7 @@ def _build_cover_map_layers(
     if not visible_layers:
         return None
 
+    activities_layer = None
     points_layer = None
     starts_layer = None
     background_layers: list = []
@@ -125,51 +130,149 @@ def _build_cover_map_layers(
             name = layer.name()
         except (RuntimeError, AttributeError):
             continue
-        if name == "qfit activity points":
+        if name == ACTIVITY_LAYER_NAME:
+            activities_layer = layer
+        elif name == POINTS_LAYER_NAME:
             points_layer = layer
-        elif name == "qfit activity starts":
+        elif name == STARTS_LAYER_NAME:
             starts_layer = layer
-        elif name == "qfit activities":
-            pass
         else:
             background_layers.append(layer)
+
+    activity_ids = cover_data.get("_atlas_activity_ids", [])
+    if activities_layer is not None and _layer_has_field(activities_layer, "source_activity_id"):
+        _save_layer_state(saved_state, activities_layer)
+        _filter_layer_to_activity_ids(activities_layer, activity_ids)
+        _apply_activity_route_render_order(activities_layer)
+        return [activities_layer] + background_layers
 
     heatmap_target = points_layer or starts_layer
     if heatmap_target is None:
         return None
 
-    try:
-        old_renderer = heatmap_target.renderer().clone()
-    except (RuntimeError, AttributeError):
-        old_renderer = None
-    saved_state.append({
-        "layer": heatmap_target,
-        "renderer": old_renderer,
-        "opacity": heatmap_target.opacity(),
-        "subset": heatmap_target.subsetString(),
-    })
+    _save_layer_state(saved_state, heatmap_target)
 
     apply_cover_heatmap_renderer(heatmap_target)
 
-    activity_ids = cover_data.get("_atlas_activity_ids", [])
-    if activity_ids:
-        safe_ids = ", ".join(
-            "'" + str(activity_id).replace("'", "''") + "'"
-            for activity_id in activity_ids
-        )
-        heatmap_target.setSubsetString(f'"source_activity_id" IN ({safe_ids})')
+    _filter_layer_to_activity_ids(heatmap_target, activity_ids)
 
     if heatmap_target is points_layer and starts_layer is not None:
-        saved_state.append({
-            "layer": starts_layer,
-            "renderer": None,
-            "opacity": starts_layer.opacity(),
-            "subset": starts_layer.subsetString(),
-        })
+        _save_layer_state(saved_state, starts_layer, save_renderer=False)
         starts_layer.setOpacity(0.0)
 
     return [heatmap_target] + background_layers
 
+
+
+def _save_layer_state(saved_state: list[dict], layer, *, save_renderer: bool = True) -> None:
+    old_renderer = None
+    renderer = None
+    renderer_order_by = None
+    renderer_order_by_enabled = None
+    if save_renderer:
+        try:
+            renderer = layer.renderer()
+            old_renderer = renderer.clone()
+        except (RuntimeError, AttributeError):
+            old_renderer = None
+        if renderer is not None:
+            try:
+                renderer_order_by = renderer.orderBy()
+            except (RuntimeError, AttributeError):
+                renderer_order_by = None
+            try:
+                renderer_order_by_enabled = renderer.orderByEnabled()
+            except (RuntimeError, AttributeError):
+                renderer_order_by_enabled = None
+    saved_state.append({
+        "layer": layer,
+        "renderer": old_renderer,
+        "renderer_ref": renderer,
+        "renderer_order_by": renderer_order_by,
+        "renderer_order_by_enabled": renderer_order_by_enabled,
+        "opacity": layer.opacity(),
+        "subset": layer.subsetString(),
+    })
+
+
+def _filter_layer_to_activity_ids(layer, activity_ids: list[str]) -> None:
+    if not activity_ids or not _layer_has_field(layer, "source_activity_id"):
+        return
+    safe_ids = ", ".join(
+        "'" + str(activity_id).replace("'", "''") + "'"
+        for activity_id in activity_ids
+    )
+    layer.setSubsetString(f'"source_activity_id" IN ({safe_ids})')
+
+
+def _layer_has_field(layer, field_name: str) -> bool:
+    try:
+        return layer.fields().indexOf(field_name) >= 0
+    except (RuntimeError, AttributeError):
+        return False
+
+
+def _apply_activity_route_render_order(layer) -> None:
+    """Draw older cover routes first so newer selected routes remain visible."""
+    if not (
+        _layer_has_field(layer, "start_date_local")
+        or _layer_has_field(layer, "start_date")
+        or _layer_has_field(layer, "source_activity_id")
+    ):
+        return
+
+    try:
+        from qgis.core import QgsFeatureRequest  # noqa: PLC0415
+    except ImportError:
+        return
+
+    try:
+        renderer = layer.renderer()
+    except (RuntimeError, AttributeError):
+        return
+    if renderer is None:
+        return
+
+    clauses = []
+    if _layer_has_field(layer, "start_date_local") and _layer_has_field(layer, "start_date"):
+        clauses.append(
+            QgsFeatureRequest.OrderByClause(
+                'coalesce(nullif("start_date_local", \'\'), nullif("start_date", \'\'), \'\')',
+                True,
+            )
+        )
+    elif _layer_has_field(layer, "start_date_local"):
+        clauses.append(
+            QgsFeatureRequest.OrderByClause(
+                'coalesce(nullif("start_date_local", \'\'), \'\')',
+                True,
+            )
+        )
+    elif _layer_has_field(layer, "start_date"):
+        clauses.append(
+            QgsFeatureRequest.OrderByClause(
+                'coalesce(nullif("start_date", \'\'), \'\')',
+                True,
+            )
+        )
+
+    if _layer_has_field(layer, "source_activity_id"):
+        clauses.append(QgsFeatureRequest.OrderByClause('"source_activity_id"', True))
+
+    if not clauses:
+        return
+
+    set_order_by = getattr(renderer, "setOrderBy", None)
+    set_order_by_enabled = getattr(renderer, "setOrderByEnabled", None)
+    if not callable(set_order_by):
+        return
+
+    try:
+        set_order_by(QgsFeatureRequest.OrderBy(clauses))
+        if callable(set_order_by_enabled):
+            set_order_by_enabled(True)
+    except (RuntimeError, AttributeError, TypeError):
+        return
 
 
 def _restore_layer_state(saved_state: list[dict]) -> None:
@@ -178,6 +281,12 @@ def _restore_layer_state(saved_state: list[dict]) -> None:
             layer = state["layer"]
             if state.get("renderer") is not None:
                 layer.setRenderer(state["renderer"])
+            elif state.get("renderer_ref") is not None:
+                renderer = state["renderer_ref"]
+                if state.get("renderer_order_by") is not None:
+                    renderer.setOrderBy(state["renderer_order_by"])
+                if state.get("renderer_order_by_enabled") is not None:
+                    renderer.setOrderByEnabled(state["renderer_order_by_enabled"])
             layer.setOpacity(state["opacity"])
             layer.setSubsetString(state["subset"])
         except (RuntimeError, AttributeError):

--- a/atlas/export_front_matter.py
+++ b/atlas/export_front_matter.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from typing import Callable
 
+try:  # pragma: no cover - availability depends on QGIS/test stubs
+    from qgis.core import QgsFeatureRequest as _QgsFeatureRequest
+except ImportError:  # pragma: no cover - exercised outside QGIS
+    _QgsFeatureRequest = None
+
 ACTIVITY_LAYER_NAME = "qfit activities"
 POINTS_LAYER_NAME = "qfit activity points"
 STARTS_LAYER_NAME = "qfit activity starts"
@@ -221,9 +226,14 @@ def _apply_activity_route_render_order(layer) -> None:
     ):
         return
 
-    try:
-        from qgis.core import QgsFeatureRequest  # noqa: PLC0415
-    except ImportError:
+    feature_request_cls = _QgsFeatureRequest
+    if feature_request_cls is None:
+        try:
+            from qgis.core import QgsFeatureRequest as feature_request_cls  # noqa: PLC0415
+        except ImportError:
+            return
+
+    if feature_request_cls is None:
         return
 
     try:
@@ -236,28 +246,28 @@ def _apply_activity_route_render_order(layer) -> None:
     clauses = []
     if _layer_has_field(layer, "start_date_local") and _layer_has_field(layer, "start_date"):
         clauses.append(
-            QgsFeatureRequest.OrderByClause(
+            feature_request_cls.OrderByClause(
                 'coalesce(nullif("start_date_local", \'\'), nullif("start_date", \'\'), \'\')',
                 True,
             )
         )
     elif _layer_has_field(layer, "start_date_local"):
         clauses.append(
-            QgsFeatureRequest.OrderByClause(
+            feature_request_cls.OrderByClause(
                 'coalesce(nullif("start_date_local", \'\'), \'\')',
                 True,
             )
         )
     elif _layer_has_field(layer, "start_date"):
         clauses.append(
-            QgsFeatureRequest.OrderByClause(
+            feature_request_cls.OrderByClause(
                 'coalesce(nullif("start_date", \'\'), \'\')',
                 True,
             )
         )
 
     if _layer_has_field(layer, "source_activity_id"):
-        clauses.append(QgsFeatureRequest.OrderByClause('"source_activity_id"', True))
+        clauses.append(feature_request_cls.OrderByClause('"source_activity_id"', True))
 
     if not clauses:
         return
@@ -268,7 +278,7 @@ def _apply_activity_route_render_order(layer) -> None:
         return
 
     try:
-        set_order_by(QgsFeatureRequest.OrderBy(clauses))
+        set_order_by(feature_request_cls.OrderBy(clauses))
         if callable(set_order_by_enabled):
             set_order_by_enabled(True)
     except (RuntimeError, AttributeError, TypeError):

--- a/atlas/export_front_matter.py
+++ b/atlas/export_front_matter.py
@@ -213,7 +213,7 @@ def _layer_has_field(layer, field_name: str) -> bool:
 
 
 def _apply_activity_route_render_order(layer) -> None:
-    """Draw older cover routes first so newer selected routes remain visible."""
+    """Prefer chronological cover-route drawing, with activity ID as fallback."""
     feature_request_cls = _qgs_feature_request_cls()
     if feature_request_cls is None:
         return
@@ -279,6 +279,7 @@ def _restore_layer_state(saved_state: list[dict]) -> None:
             if state.get("renderer") is not None:
                 layer.setRenderer(state["renderer"])
             elif state.get("renderer_ref") is not None:
+                # Best-effort restoration for in-place renderer order changes.
                 renderer = state["renderer_ref"]
                 if state.get("renderer_order_by") is not None:
                     renderer.setOrderBy(state["renderer_order_by"])

--- a/atlas/export_front_matter.py
+++ b/atlas/export_front_matter.py
@@ -2,11 +2,6 @@ from __future__ import annotations
 
 from typing import Callable
 
-try:  # pragma: no cover - availability depends on QGIS/test stubs
-    from qgis.core import QgsFeatureRequest as _QgsFeatureRequest
-except ImportError:  # pragma: no cover - exercised outside QGIS
-    _QgsFeatureRequest = None
-
 ACTIVITY_LAYER_NAME = "qfit activities"
 POINTS_LAYER_NAME = "qfit activity points"
 STARTS_LAYER_NAME = "qfit activity starts"
@@ -219,20 +214,7 @@ def _layer_has_field(layer, field_name: str) -> bool:
 
 def _apply_activity_route_render_order(layer) -> None:
     """Draw older cover routes first so newer selected routes remain visible."""
-    if not (
-        _layer_has_field(layer, "start_date_local")
-        or _layer_has_field(layer, "start_date")
-        or _layer_has_field(layer, "source_activity_id")
-    ):
-        return
-
-    feature_request_cls = _QgsFeatureRequest
-    if feature_request_cls is None:
-        try:
-            from qgis.core import QgsFeatureRequest as feature_request_cls  # noqa: PLC0415
-        except ImportError:
-            return
-
+    feature_request_cls = _qgs_feature_request_cls()
     if feature_request_cls is None:
         return
 
@@ -243,32 +225,7 @@ def _apply_activity_route_render_order(layer) -> None:
     if renderer is None:
         return
 
-    clauses = []
-    if _layer_has_field(layer, "start_date_local") and _layer_has_field(layer, "start_date"):
-        clauses.append(
-            feature_request_cls.OrderByClause(
-                'coalesce(nullif("start_date_local", \'\'), nullif("start_date", \'\'), \'\')',
-                True,
-            )
-        )
-    elif _layer_has_field(layer, "start_date_local"):
-        clauses.append(
-            feature_request_cls.OrderByClause(
-                'coalesce(nullif("start_date_local", \'\'), \'\')',
-                True,
-            )
-        )
-    elif _layer_has_field(layer, "start_date"):
-        clauses.append(
-            feature_request_cls.OrderByClause(
-                'coalesce(nullif("start_date", \'\'), \'\')',
-                True,
-            )
-        )
-
-    if _layer_has_field(layer, "source_activity_id"):
-        clauses.append(feature_request_cls.OrderByClause('"source_activity_id"', True))
-
+    clauses = _activity_route_order_by_clauses(layer, feature_request_cls)
     if not clauses:
         return
 
@@ -283,6 +240,36 @@ def _apply_activity_route_render_order(layer) -> None:
             set_order_by_enabled(True)
     except (RuntimeError, AttributeError, TypeError):
         return
+
+
+def _qgs_feature_request_cls():
+    try:
+        from qgis.core import QgsFeatureRequest  # noqa: PLC0415
+    except ImportError:
+        return None
+    return QgsFeatureRequest
+
+
+def _activity_route_order_by_clauses(layer, feature_request_cls) -> list:
+    clauses = []
+    date_expression = _activity_route_date_order_expression(layer)
+    if date_expression is not None:
+        clauses.append(feature_request_cls.OrderByClause(date_expression, True))
+    if _layer_has_field(layer, "source_activity_id"):
+        clauses.append(feature_request_cls.OrderByClause('"source_activity_id"', True))
+    return clauses
+
+
+def _activity_route_date_order_expression(layer) -> str | None:
+    has_local_date = _layer_has_field(layer, "start_date_local")
+    has_utc_date = _layer_has_field(layer, "start_date")
+    if has_local_date and has_utc_date:
+        return 'coalesce(nullif("start_date_local", \'\'), nullif("start_date", \'\'), \'\')'
+    if has_local_date:
+        return 'coalesce(nullif("start_date_local", \'\'), \'\')'
+    if has_utc_date:
+        return 'coalesce(nullif("start_date", \'\'), \'\')'
+    return None
 
 
 def _restore_layer_state(saved_state: list[dict]) -> None:

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -4530,6 +4530,48 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
         self.assertTrue(order_clauses[0][1])
         self.assertEqual(order_clauses[1], ('"source_activity_id"', True))
 
+    def test_activity_route_date_order_expression_uses_available_timestamp_fields(self):
+        """Route order expression handles local-only, UTC-only, and missing dates."""
+        from qfit.atlas import export_front_matter
+
+        layer = self._make_points_layer(name="qfit activities")
+        fields = MagicMock()
+        field_names = {"source_activity_id", "start_date_local"}
+        fields.indexOf = lambda n: 0 if n in field_names else -1
+        layer.fields.return_value = fields
+        self.assertEqual(
+            export_front_matter._activity_route_date_order_expression(layer),
+            'coalesce(nullif("start_date_local", \'\'), \'\')',
+        )
+
+        field_names = {"source_activity_id", "start_date"}
+        self.assertEqual(
+            export_front_matter._activity_route_date_order_expression(layer),
+            'coalesce(nullif("start_date", \'\'), \'\')',
+        )
+
+        field_names = {"source_activity_id"}
+        self.assertIsNone(export_front_matter._activity_route_date_order_expression(layer))
+
+    def test_activity_route_order_by_clauses_can_use_activity_id_only(self):
+        """Routes without timestamps still get deterministic activity-id ordering."""
+        from qfit.atlas import export_front_matter
+
+        layer = self._make_points_layer(name="qfit activities")
+        fields = MagicMock()
+        fields.indexOf = lambda n: 0 if n == "source_activity_id" else -1
+        layer.fields.return_value = fields
+        feature_request = MagicMock()
+        feature_request.OrderByClause.side_effect = lambda expression, ascending=True: (
+            expression,
+            ascending,
+        )
+
+        self.assertEqual(
+            export_front_matter._activity_route_order_by_clauses(layer, feature_request),
+            [('"source_activity_id"', True)],
+        )
+
     def test_activity_route_layer_without_activity_id_falls_back_to_heatmap(self):
         """An unfilterable route layer is not used for the selected-activity cover."""
         atlas_layer = _make_cover_atlas_layer_with_extents()
@@ -4599,10 +4641,10 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
              patch.object(sys.modules["qgis.core"], "QgsFeatureRequest", feature_request, create=True):
             AtlasExportTask._export_cover_page(
                 atlas_layer, "/tmp/atlas.pdf", project=project,
-            )
+        )
 
         self.assertEqual(renderer.setOrderBy.call_args_list[-1][0][0], original_order)
-        self.assertEqual(renderer.setOrderByEnabled.call_args_list[-1][0][0], False)
+        self.assertFalse(renderer.setOrderByEnabled.call_args_list[-1][0][0])
 
     def test_layer_state_restored_after_export(self):
         """Original renderer, opacity, and subset are restored after export."""

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -4487,6 +4487,12 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
         """Older selected activities are configured to render below newer ones."""
         atlas_layer = _make_cover_atlas_layer_with_extents()
         activities = self._make_points_layer(name="qfit activities")
+        feature_request = MagicMock()
+        feature_request.OrderByClause.side_effect = lambda expression, ascending=True: (
+            expression,
+            ascending,
+        )
+        feature_request.OrderBy.side_effect = lambda clauses: list(clauses)
         fields = MagicMock()
         fields.indexOf = lambda n: {
             "source_activity_id": 0,
@@ -4508,7 +4514,8 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_cover_layout", return_value=cover_layout), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls), \
-             patch("qfit.atlas.export_task._apply_cover_heatmap_renderer"):
+             patch("qfit.atlas.export_task._apply_cover_heatmap_renderer"), \
+             patch.object(sys.modules["qgis.core"], "QgsFeatureRequest", feature_request, create=True):
             AtlasExportTask._export_cover_page(
                 atlas_layer, "/tmp/atlas.pdf", project=project,
             )
@@ -4558,6 +4565,12 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
         """Render ordering is restored even if the renderer itself cannot be cloned."""
         atlas_layer = _make_cover_atlas_layer_with_extents()
         activities = self._make_points_layer(name="qfit activities")
+        feature_request = MagicMock()
+        feature_request.OrderByClause.side_effect = lambda expression, ascending=True: (
+            expression,
+            ascending,
+        )
+        feature_request.OrderBy.side_effect = lambda clauses: list(clauses)
         fields = MagicMock()
         fields.indexOf = lambda n: {
             "source_activity_id": 0,
@@ -4582,7 +4595,8 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
 
         with patch("qfit.atlas.export_task.build_cover_layout", return_value=cover_layout), \
              patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls), \
-             patch("qfit.atlas.export_task._apply_cover_heatmap_renderer"):
+             patch("qfit.atlas.export_task._apply_cover_heatmap_renderer"), \
+             patch.object(sys.modules["qgis.core"], "QgsFeatureRequest", feature_request, create=True):
             AtlasExportTask._export_cover_page(
                 atlas_layer, "/tmp/atlas.pdf", project=project,
             )

--- a/tests/test_atlas_export_task.py
+++ b/tests/test_atlas_export_task.py
@@ -66,6 +66,12 @@ def _make_qgis_stub():
     qgis_core.QgsHeatmapRenderer = MagicMock()
     qgis_core.QgsStyle = MagicMock()
     qgis_core.QgsGradientColorRamp = MagicMock()
+    qgis_core.QgsFeatureRequest = MagicMock()
+    qgis_core.QgsFeatureRequest.OrderByClause.side_effect = lambda expression, ascending=True: (
+        expression,
+        ascending,
+    )
+    qgis_core.QgsFeatureRequest.OrderBy.side_effect = lambda clauses: list(clauses)
 
     qgis_pyt = ModuleType("qgis.PyQt")
     qgis_pyt_core = ModuleType("qgis.PyQt.QtCore")
@@ -4387,12 +4393,12 @@ class TestBuildCoverLayoutWithMap(unittest.TestCase):
 class TestExportCoverPageHeatmap(unittest.TestCase):
     """Tests for heatmap layer discovery and state restoration in _export_cover_page."""
 
-    def _make_project_with_layers(self, points_layer=None, starts_layer=None,
-                                   background_layer=None):
+    def _make_project_with_layers(self, activities_layer=None, points_layer=None,
+                                   starts_layer=None, background_layer=None):
         """Build a mock project whose layer tree contains the given layers."""
         project = MagicMock()
         nodes = []
-        for lyr in [points_layer, starts_layer, background_layer]:
+        for lyr in [activities_layer, points_layer, starts_layer, background_layer]:
             if lyr is not None:
                 node = MagicMock()
                 node.isVisible.return_value = True
@@ -4415,11 +4421,12 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
         layer.fields.return_value = fields
         return layer
 
-    def test_heatmap_renderer_applied_to_points_layer(self):
-        """When a points layer exists, _export_cover_page applies heatmap renderer."""
+    def test_activity_route_layer_is_preferred_for_cover_map(self):
+        """Cover map uses selected activity routes with their existing renderer."""
         atlas_layer = _make_cover_atlas_layer_with_extents()
+        activities = self._make_points_layer(name="qfit activities")
         pts = self._make_points_layer()
-        project = self._make_project_with_layers(points_layer=pts)
+        project = self._make_project_with_layers(activities_layer=activities, points_layer=pts)
 
         cover_layout = MagicMock()
         exporter_instance = MagicMock()
@@ -4438,17 +4445,18 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
             )
 
         self.assertIsNotNone(result)
-        heatmap_mock.assert_called_once_with(pts)
-        # build_cover_layout should have received map_layers containing the points layer
+        heatmap_mock.assert_not_called()
+        # build_cover_layout should have received map_layers containing the route layer.
         _, kwargs = build_mock.call_args
         self.assertIsNotNone(kwargs.get("map_layers"))
-        self.assertIn(pts, kwargs["map_layers"])
+        self.assertIn(activities, kwargs["map_layers"])
+        self.assertNotIn(pts, kwargs["map_layers"])
 
     def test_subset_filter_applied_for_atlas_activity_ids(self):
-        """Points layer gets filtered to the atlas subset's activity IDs."""
+        """Activity route layer gets filtered to the atlas subset's activity IDs."""
         atlas_layer = _make_cover_atlas_layer_with_extents()
-        pts = self._make_points_layer()
-        project = self._make_project_with_layers(points_layer=pts)
+        activities = self._make_points_layer(name="qfit activities")
+        project = self._make_project_with_layers(activities_layer=activities)
 
         cover_layout = MagicMock()
         exporter_instance = MagicMock()
@@ -4468,12 +4476,119 @@ class TestExportCoverPageHeatmap(unittest.TestCase):
 
         # The subset string should reference the activity IDs.
         # call_args_list[0] is the filter, call_args_list[-1] is the restore.
-        subset_calls = pts.setSubsetString.call_args_list
+        subset_calls = activities.setSubsetString.call_args_list
         self.assertGreaterEqual(len(subset_calls), 2)
         filter_str = subset_calls[0][0][0]
         self.assertIn("act_1", filter_str)
         self.assertIn("act_2", filter_str)
         self.assertIn("source_activity_id", filter_str)
+
+    def test_activity_route_layer_render_order_is_time_ascending(self):
+        """Older selected activities are configured to render below newer ones."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        activities = self._make_points_layer(name="qfit activities")
+        fields = MagicMock()
+        fields.indexOf = lambda n: {
+            "source_activity_id": 0,
+            "start_date": 1,
+            "start_date_local": 2,
+        }.get(n, -1)
+        activities.fields.return_value = fields
+        renderer = activities.renderer.return_value
+        project = self._make_project_with_layers(activities_layer=activities)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas.export_task.build_cover_layout", return_value=cover_layout), \
+             patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas.export_task._apply_cover_heatmap_renderer"):
+            AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        renderer.setOrderBy.assert_called_once()
+        renderer.setOrderByEnabled.assert_called_once_with(True)
+        order_clauses = renderer.setOrderBy.call_args[0][0]
+        self.assertEqual(
+            order_clauses[0][0],
+            'coalesce(nullif("start_date_local", \'\'), nullif("start_date", \'\'), \'\')',
+        )
+        self.assertTrue(order_clauses[0][1])
+        self.assertEqual(order_clauses[1], ('"source_activity_id"', True))
+
+    def test_activity_route_layer_without_activity_id_falls_back_to_heatmap(self):
+        """An unfilterable route layer is not used for the selected-activity cover."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        activities = self._make_points_layer(name="qfit activities")
+        fields = MagicMock()
+        fields.indexOf.return_value = -1
+        activities.fields.return_value = fields
+        pts = self._make_points_layer()
+        project = self._make_project_with_layers(activities_layer=activities, points_layer=pts)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas.export_task.build_cover_layout", return_value=cover_layout) as build_mock, \
+             patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas.export_task._apply_cover_heatmap_renderer") as heatmap_mock:
+            AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        heatmap_mock.assert_called_once_with(pts)
+        _, kwargs = build_mock.call_args
+        self.assertIn(pts, kwargs["map_layers"])
+        self.assertNotIn(activities, kwargs["map_layers"])
+
+    def test_activity_route_renderer_order_restored_when_renderer_cannot_be_cloned(self):
+        """Render ordering is restored even if the renderer itself cannot be cloned."""
+        atlas_layer = _make_cover_atlas_layer_with_extents()
+        activities = self._make_points_layer(name="qfit activities")
+        fields = MagicMock()
+        fields.indexOf = lambda n: {
+            "source_activity_id": 0,
+            "start_date": 1,
+        }.get(n, -1)
+        activities.fields.return_value = fields
+        renderer = activities.renderer.return_value
+        original_order = MagicMock(name="original_order")
+        renderer.clone.side_effect = RuntimeError("clone unavailable")
+        renderer.orderBy.return_value = original_order
+        renderer.orderByEnabled.return_value = False
+        project = self._make_project_with_layers(activities_layer=activities)
+
+        cover_layout = MagicMock()
+        exporter_instance = MagicMock()
+        exporter_instance.exportToPdf.return_value = 0
+
+        exporter_cls = MagicMock()
+        exporter_cls.return_value = exporter_instance
+        exporter_cls.Success = 0
+        exporter_cls.PdfExportSettings = MagicMock(return_value=MagicMock())
+
+        with patch("qfit.atlas.export_task.build_cover_layout", return_value=cover_layout), \
+             patch("qfit.atlas.export_task.QgsLayoutExporter", exporter_cls), \
+             patch("qfit.atlas.export_task._apply_cover_heatmap_renderer"):
+            AtlasExportTask._export_cover_page(
+                atlas_layer, "/tmp/atlas.pdf", project=project,
+            )
+
+        self.assertEqual(renderer.setOrderBy.call_args_list[-1][0][0], original_order)
+        self.assertEqual(renderer.setOrderByEnabled.call_args_list[-1][0][0], False)
 
     def test_layer_state_restored_after_export(self):
         """Original renderer, opacity, and subset are restored after export."""


### PR DESCRIPTION
## What Problem This Solves

Fixes ebelo/qfit#1380.

The generated atlas cover map used the point/start heatmap overview, so selected activity routes were not visible with the normal activity styling.

## Why This Change Was Made

The cover should show the selected activity route geometries when the loaded `qfit activities` layer is available. The route layer already carries qfit activity styling, so the cover can preserve that renderer and apply only temporary subset/render-order state for export.

## User Impact

- Atlas cover maps now prefer selected activity routes over the point/start heatmap fallback.
- Routes are filtered to the atlas-selected `source_activity_id` values.
- Existing activity styling is preserved.
- Older activities render below newer activities using `start_date_local`/`start_date`, then `source_activity_id` as a deterministic tie-breaker.
- Layer subset, opacity, renderer, and renderer order state are restored after cover export.
- Existing point/start heatmap behavior remains as fallback when no usable route layer is available.

## Evidence

- `python3 -m pytest tests/test_atlas_export_task.py -k "ExportCoverPageHeatmap" -q` -> 12 passed
- `python3 -m pytest tests/ -x -q` -> 2518 passed, 174 skipped, 179 subtests passed
- SonarCloud Code Analysis -> passed, 86.1% coverage on new code, 0 new issues
- GitHub checks -> build, unit-tests, CodeQL, plugin-security-scan, and sonarcloud passed
