### PR TITLE
Keep stored activity count after loading layers

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -8,7 +8,7 @@ from ...atlas.publish_atlas import (
     DEFAULT_ATLAS_TARGET_ASPECT_RATIO,
     DEFAULT_MIN_EXTENT_DEGREES,
 )
-from ...sync_repository import SyncStats
+from ...sync_repository import SyncRepository, SyncStats
 from ...visualization.application.layer_gateway import LayerGateway
 
 logger = logging.getLogger(__name__)
@@ -276,9 +276,11 @@ class LoadDatasetWorkflow:
         self,
         layer_gateway: LayerGateway,
         path_exists: Callable[[str], bool] | None = None,
+        stored_activity_count_loader: Callable[[str], int] | None = None,
     ):
         self.layer_gateway = layer_gateway
         self._path_exists = path_exists
+        self._stored_activity_count_loader = stored_activity_count_loader
 
     @staticmethod
     def build_load_existing_request(output_path) -> LoadDatasetRequest:
@@ -312,7 +314,7 @@ class LoadDatasetWorkflow:
         route_tracks_layer, route_points_layer, route_profile_samples_layer = (
             self.layer_gateway.load_route_layers(request.output_path)
         )
-        total = activities_layer.featureCount() if activities_layer else 0
+        total = self._stored_activity_count(request.output_path, activities_layer)
 
         return LoadDatasetResult(
             output_path=request.output_path,
@@ -335,6 +337,15 @@ class LoadDatasetWorkflow:
 
     def load_existing_request(self, request: LoadDatasetRequest) -> LoadDatasetResult:
         return self.load_existing(request)
+
+    def _stored_activity_count(self, output_path: str, activities_layer) -> int:
+        if self._stored_activity_count_loader is not None:
+            total = self._stored_activity_count_loader(output_path)
+        else:
+            total = SyncRepository(output_path).load_detailed_route_coverage().total_count
+        if total > 0:
+            return total
+        return _safe_feature_count(activities_layer)
 
 
 class ClearDatabaseWorkflow:

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -108,6 +108,53 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("profile samples", result.status)
 
+    def test_load_existing_uses_stored_registry_count_not_loaded_layer_count(self):
+        layer_gateway = MagicMock()
+        activities_layer = MagicMock()
+        activities_layer.featureCount.return_value = 1732
+        layer_gateway.load_output_layers.return_value = (
+            activities_layer,
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+        layer_gateway.load_route_layers.return_value = (None, None, None)
+        workflow = LoadDatasetWorkflow(
+            layer_gateway,
+            path_exists=lambda _path: True,
+            stored_activity_count_loader=lambda _path: 2889,
+        )
+
+        result = workflow.load_existing_request(
+            workflow.build_load_existing_request("/tmp/existing.gpkg")
+        )
+
+        self.assertEqual(result.total_stored, 2889)
+        activities_layer.featureCount.assert_not_called()
+
+    def test_load_existing_falls_back_to_layer_count_without_stored_registry_count(self):
+        layer_gateway = MagicMock()
+        activities_layer = MagicMock()
+        activities_layer.featureCount.return_value = 42
+        layer_gateway.load_output_layers.return_value = (
+            activities_layer,
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+        layer_gateway.load_route_layers.return_value = (None, None, None)
+        workflow = LoadDatasetWorkflow(
+            layer_gateway,
+            path_exists=lambda _path: True,
+            stored_activity_count_loader=lambda _path: 0,
+        )
+
+        result = workflow.load_existing_request(
+            workflow.build_load_existing_request("/tmp/existing.gpkg")
+        )
+
+        self.assertEqual(result.total_stored, 42)
+
     def test_load_existing_status_explains_when_route_layers_are_missing(self):
         layer_gateway = MagicMock()
         activities_layer = MagicMock()


### PR DESCRIPTION
## What Problem This Solves

Fixes ebelo/qfit#1382.

After loading stored map layers, the Data tab could replace the stored activity count with the loaded activity layer feature count. That made datasets with stored activities lacking loaded route geometries appear to lose activities while detailed-route coverage still used the full stored denominator.

## Why This Change Was Made

The load-existing workflow should report stored records using the GeoPackage activity registry, matching detailed-route coverage semantics. The loaded layer feature count is still kept as a fallback for older or malformed datasets where no registry total is available.

## User Impact

- Data tab stored activity counts remain stable after loading stored map layers.
- Detailed route counts and stored activity summaries use the same stored-record denominator.
- Existing load behavior still works when registry count metadata is unavailable.

## Evidence

- `python3 -m pytest tests/test_load_workflow.py -q` -> 32 passed
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -k "on_load_layers_clicked_updates_runtime_state_from_result or detailed_route_coverage" -q` -> 2 passed
- `python3 -m pytest tests/ -x -q` -> 2520 passed, 174 skipped, 179 subtests passed
