### PR TITLE
Harden stored activity count fallback

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sqlite3
 from dataclasses import dataclass, field
 from typing import Callable
 
@@ -339,10 +340,14 @@ class LoadDatasetWorkflow:
         return self.load_existing(request)
 
     def _stored_activity_count(self, output_path: str, activities_layer) -> int:
-        if self._stored_activity_count_loader is not None:
-            total = self._stored_activity_count_loader(output_path)
-        else:
-            total = SyncRepository(output_path).load_detailed_route_coverage().total_count
+        try:
+            if self._stored_activity_count_loader is not None:
+                total = self._stored_activity_count_loader(output_path)
+            else:
+                total = SyncRepository(output_path).load_detailed_route_coverage().total_count
+        except (sqlite3.DatabaseError, RuntimeError, OSError, TypeError, ValueError):
+            logger.debug("Failed to read stored activity count", exc_info=True)
+            total = 0
         if total > 0:
             return total
         return _safe_feature_count(activities_layer)

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import sqlite3
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -152,6 +153,58 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
         result = workflow.load_existing_request(
             workflow.build_load_existing_request("/tmp/existing.gpkg")
         )
+
+        self.assertEqual(result.total_stored, 42)
+
+    def test_load_existing_falls_back_to_layer_count_when_count_loader_fails(self):
+        layer_gateway = MagicMock()
+        activities_layer = MagicMock()
+        activities_layer.featureCount.return_value = 42
+        layer_gateway.load_output_layers.return_value = (
+            activities_layer,
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+        layer_gateway.load_route_layers.return_value = (None, None, None)
+        workflow = LoadDatasetWorkflow(
+            layer_gateway,
+            path_exists=lambda _path: True,
+            stored_activity_count_loader=MagicMock(
+                side_effect=sqlite3.OperationalError("database is locked")
+            ),
+        )
+
+        result = workflow.load_existing_request(
+            workflow.build_load_existing_request("/tmp/existing.gpkg")
+        )
+
+        self.assertEqual(result.total_stored, 42)
+
+    def test_load_existing_falls_back_when_repository_count_read_fails(self):
+        layer_gateway = MagicMock()
+        activities_layer = MagicMock()
+        activities_layer.featureCount.return_value = 42
+        layer_gateway.load_output_layers.return_value = (
+            activities_layer,
+            MagicMock(name="starts"),
+            MagicMock(name="points"),
+            MagicMock(name="atlas"),
+        )
+        layer_gateway.load_route_layers.return_value = (None, None, None)
+        repository = MagicMock()
+        repository.load_detailed_route_coverage.side_effect = sqlite3.DatabaseError(
+            "file is not a database"
+        )
+
+        with patch(
+            "qfit.activities.application.load_workflow.SyncRepository",
+            return_value=repository,
+        ):
+            workflow = LoadDatasetWorkflow(layer_gateway, path_exists=lambda _path: True)
+            result = workflow.load_existing_request(
+                workflow.build_load_existing_request("/tmp/existing.gpkg")
+            )
 
         self.assertEqual(result.total_stored, 42)
 


### PR DESCRIPTION
## What Problem This Solves

Follow-up to ebelo/qfit#1382 and PR #1389 review feedback.

The stored activity count fix now prefers the GeoPackage registry total, but the metadata read can fail for older, partial, locked, or corrupt GeoPackages. In those cases, the load workflow should still fall back to the already-loaded activity layer count instead of failing the whole load action.

## What Changed

- Catch stored-count metadata read failures in `LoadDatasetWorkflow`.
- Log the failure at debug level and use the activity layer feature count fallback.
- Add regression coverage for locked/corrupt count reads.

## Evidence

- `python3 -m pytest tests/test_load_workflow.py` -> 34 passed
