### PR TITLE
Expose full Settings helper text

### DIFF
--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -346,6 +346,9 @@ class ContextualHelpTests(unittest.TestCase):
         self.assertEqual(helper.minimumWidth(), 0)
         self.assertEqual(helper.size_policy, (3, 4))
         self.assertEqual(helper.interaction_flags, _FakeQt.TextSelectableByMouse)
+        self.assertEqual(helper.tooltip, "Inline helper copy")
+        self.assertEqual(helper.whats_this, "Inline helper copy")
+        self.assertEqual(helper.status_tip, "Inline helper copy")
         self.assertIn("palette(mid)", helper.style_sheet)
 
         wrapper = anchor.parentWidget()
@@ -388,6 +391,8 @@ class ContextualHelpTests(unittest.TestCase):
         )
 
         self.assertEqual(root.distanceSpinBoxContextHelpLabel.text(), "New helper")
+        self.assertEqual(root.distanceSpinBoxContextHelpLabel.tooltip, "New helper")
+        self.assertEqual(root.distanceSpinBoxContextHelpLabel.whats_this, "New helper")
         self.assertTrue(root.distanceSpinBoxContextHelpLabel.isVisible())
         self.assertIs(anchor.parentWidget(), wrapper)
 

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -393,6 +393,7 @@ class ContextualHelpTests(unittest.TestCase):
         self.assertEqual(root.distanceSpinBoxContextHelpLabel.text(), "New helper")
         self.assertEqual(root.distanceSpinBoxContextHelpLabel.tooltip, "New helper")
         self.assertEqual(root.distanceSpinBoxContextHelpLabel.whats_this, "New helper")
+        self.assertEqual(root.distanceSpinBoxContextHelpLabel.status_tip, "New helper")
         self.assertTrue(root.distanceSpinBoxContextHelpLabel.isVisible())
         self.assertIs(anchor.parentWidget(), wrapper)
 

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -229,6 +229,7 @@ class ContextualHelpBinder:
         existing = getattr(self.root, helper_name, None)
         if existing is not None:
             existing.setText(text)
+            self._apply_tooltip(existing, text)
             existing.show()
             return
 
@@ -245,6 +246,7 @@ class ContextualHelpBinder:
                 qtwidgets.QSizePolicy.Preferred,
             )
         helper.setTextInteractionFlags(self._qtcore().Qt.TextSelectableByMouse)
+        self._apply_tooltip(helper, text)
         helper.setStyleSheet("color: palette(mid); margin-top: 2px; margin-bottom: 4px;")
         self._insert_after_anchor(anchor, helper)
         setattr(self.root, helper_name, helper)


### PR DESCRIPTION
## What Problem This Solves

Fixes ebelo/qfit#1383.

Claude Desktop testing through the QGIS/qfit GUI found that some Settings tab helper labels could be clipped mid-sentence in a narrow dock, with no obvious way to read the rest of the text.

## What Changed

- Apply tooltip, What’s This, and status-tip text to generated inline helper labels.
- Keep reused helper labels updated with the same full helper text.
- Preserve the existing wrapping and flexible sizing behavior.

## Evidence

- `python3 -m pytest tests/test_contextual_help.py` -> 8 passed
