### PR TITLE
Raise Configuration dialog from Review settings

### DIFF
--- a/qfit_plugin.py
+++ b/qfit_plugin.py
@@ -82,9 +82,32 @@ class QfitPlugin:
         if self._config_dialog is None:
             self._config_dialog = QfitConfigDialog(parent=self.iface.mainWindow())
             self._config_dialog.settingsSaved.connect(self._refresh_dock_configuration)
-        self._config_dialog.show()
-        self._config_dialog.raise_()
-        self._config_dialog.activateWindow()
+        self._present_config_dialog()
+
+    def _present_config_dialog(self) -> None:
+        dialog = self._config_dialog
+        if dialog is None:
+            return
+
+        self._restore_dialog_window_state(dialog)
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+
+    def _restore_dialog_window_state(self, dialog) -> None:
+        window_state = getattr(dialog, "windowState", None)
+        set_window_state = getattr(dialog, "setWindowState", None)
+        minimized = getattr(Qt, "WindowMinimized", None)
+        active = getattr(Qt, "WindowActive", None)
+        if (
+            not callable(window_state)
+            or not callable(set_window_state)
+            or minimized is None
+            or active is None
+        ):
+            return
+
+        set_window_state((window_state() & ~minimized) | active)
 
     def show_about(self):
         if self._about_dock is None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -293,6 +293,42 @@ class TestQfitPluginMenuStructure(unittest.TestCase):
 
         plugin.dockwidget.refresh_configuration_from_settings.assert_called_once_with()
 
+    def test_show_config_restores_and_raises_existing_dialog(self):
+        plugin, _iface = self._make_plugin()
+        plugin_module = sys.modules["qfit.qfit_plugin"]
+        plugin_module.Qt.WindowMinimized = 0x01
+        plugin_module.Qt.WindowActive = 0x02
+
+        class FakeSignal:
+            def connect(self, _slot):
+                pass
+
+        class FakeConfigDialog:
+            created = []
+
+            def __init__(self, parent=None):
+                self.parent = parent
+                self.settingsSaved = FakeSignal()
+                self.show = MagicMock()
+                self.raise_ = MagicMock()
+                self.activateWindow = MagicMock()
+                self.windowState = MagicMock(
+                    return_value=plugin_module.Qt.WindowMinimized
+                )
+                self.setWindowState = MagicMock()
+                FakeConfigDialog.created.append(self)
+
+        with patch("qfit.qfit_plugin.QfitConfigDialog", FakeConfigDialog):
+            plugin.show_config()
+            plugin.show_config()
+
+        dialog = FakeConfigDialog.created[-1]
+        self.assertEqual(len(FakeConfigDialog.created), 1)
+        dialog.setWindowState.assert_called_with(plugin_module.Qt.WindowActive)
+        self.assertEqual(dialog.show.call_count, 2)
+        self.assertEqual(dialog.raise_.call_count, 2)
+        self.assertEqual(dialog.activateWindow.call_count, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What Problem This Solves

Fixes ebelo/qfit#1385.

The Settings tab Review settings action could appear to do nothing on the first click if the existing Configuration dialog was hidden or minimized behind QGIS.

## Why This Change Was Made

- Reuse the existing Configuration dialog instead of creating duplicates.
- Restore the dialog from minimized state before presenting it.
- Show, raise, and activate the dialog every time Review settings is clicked.

## User Impact

A single click on Review settings should bring the Configuration dialog to the front with visible focus feedback.

## Evidence

- `python3 -m pytest tests/test_plugin.py` -> 10 passed
- `python3 -m pytest tests/test_contextual_help.py` -> 8 passed
