### PR TITLE
Preserve fetched preview when loading layers

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -946,6 +946,7 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def on_load_layers_clicked(self):
         """Load an existing GeoPackage into QGIS without fetching from Strava."""
         project_crs = self._current_project_crs()
+        preview_snapshot = self._activity_preview_snapshot()
         try:
             self._save_settings()
             workflow = self._dataset_load_workflow_service()
@@ -984,12 +985,42 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
             self._refresh_detailed_route_coverage_from_storage()
             self._update_loaded_activities_summary(result.total_stored)
+            self._restore_activity_preview_snapshot(preview_snapshot)
             status = result.status
             if visual_status:
                 status = "{status} {visual_status}".format(status=status, visual_status=visual_status)
             self._set_status(status)
         finally:
             self._restore_project_crs(project_crs, schedule_delayed=True)
+
+    def _activity_preview_snapshot(self):
+        preview_widget = getattr(self, "activityPreviewPlainTextEdit", None)
+        to_plain_text = getattr(preview_widget, "toPlainText", None)
+        if not callable(to_plain_text):
+            return None
+
+        preview_text = to_plain_text()
+        if not preview_text:
+            return None
+
+        return {
+            "preview_text": preview_text,
+            "query_summary": self._label_text("querySummaryLabel"),
+        }
+
+    def _restore_activity_preview_snapshot(self, snapshot) -> None:
+        if not snapshot:
+            return
+
+        preview_widget = getattr(self, "activityPreviewPlainTextEdit", None)
+        set_plain_text = getattr(preview_widget, "setPlainText", None)
+        if callable(set_plain_text):
+            set_plain_text(snapshot["preview_text"])
+
+        query_label = getattr(self, "querySummaryLabel", None)
+        set_query_text = getattr(query_label, "setText", None)
+        if callable(set_query_text):
+            set_query_text(snapshot["query_summary"])
 
     def on_clear_database_clicked(self):
         """Delete the GeoPackage, clear loaded layers, and reset status."""

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -111,6 +111,18 @@ class _FakeLabel(_FakeWidget):
         self._text = text
 
 
+class _FakePlainTextEdit(_FakeWidget):
+    def __init__(self, text="", parent=None):
+        super().__init__(parent)
+        self._text = text
+
+    def toPlainText(self):  # noqa: N802
+        return self._text
+
+    def setPlainText(self, text):  # noqa: N802
+        self._text = text
+
+
 class _FakeComboBox(_FakeWidget):
     def __init__(self, parent=None, current_text=None):
         super().__init__(parent)
@@ -2918,6 +2930,46 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._populate_activity_types_from_layer.assert_called_once_with()
         dock._apply_visual_configuration.assert_called_once_with(apply_subset_filters=False)
         dock._update_loaded_activities_summary.assert_called_once_with(12)
+        dock._set_status.assert_called_once_with("Loaded 12 activities Styled layers")
+
+    def test_on_load_layers_clicked_preserves_fetched_activity_preview(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._save_settings = MagicMock()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/qfit.gpkg")
+        dock.querySummaryLabel = _FakeLabel("6 recent activities")
+        dock.activityPreviewPlainTextEdit = _FakePlainTextEdit("Morning Run\nEvening Ride")
+        dock._populate_activity_types_from_layer = MagicMock()
+        dock._update_loaded_activities_summary = MagicMock()
+        dock._set_status = MagicMock()
+        dock._atlas_export_completed = True
+
+        def clear_preview(*_args, **_kwargs):
+            dock.querySummaryLabel.setText("Fetch activities to preview")
+            dock.activityPreviewPlainTextEdit.setPlainText("")
+            return "Styled layers"
+
+        dock._apply_visual_configuration = MagicMock(side_effect=clear_preview)
+        workflow = MagicMock()
+        workflow.build_load_existing_request.return_value = "load-request"
+        result = SimpleNamespace(
+            output_path="/tmp/qfit.gpkg",
+            activities_layer="activities-layer",
+            starts_layer="starts-layer",
+            points_layer="points-layer",
+            atlas_layer="atlas-layer",
+            total_stored=12,
+            status="Loaded 12 activities",
+        )
+        workflow.load_existing_request.return_value = result
+        dock.dataset_load_workflow = workflow
+
+        self.module.QfitDockWidget.on_load_layers_clicked(dock)
+
+        self.assertEqual(dock.querySummaryLabel.text(), "6 recent activities")
+        self.assertEqual(
+            dock.activityPreviewPlainTextEdit.toPlainText(),
+            "Morning Run\nEvening Ride",
+        )
         dock._set_status.assert_called_once_with("Loaded 12 activities Styled layers")
 
     def test_on_load_layers_clicked_restores_user_crs_after_visual_configuration(self):


### PR DESCRIPTION
## What Problem This Solves

Fixes ebelo/qfit#1386.

Claude Desktop testing through the QGIS/qfit GUI found that the Data tab fetched activity preview disappeared after clicking **Load stored map layers**.

## What Changed

- Snapshot existing fetched-preview text before loading stored layers.
- Restore that preview text and query summary after the layer load refreshes visual state.
- Only restore when there was real preview text, so an empty placeholder state stays empty.
- Add a regression test where layer loading clears the preview and the dock restores it.

## Evidence

- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py -k "on_load_layers_clicked"` -> 3 passed, 108 deselected
- `python3 -m pytest tests/test_qfit_dockwidget_analysis_pure.py` -> 111 passed
