### PR TITLE
Guard Configuration dialog window-state restore

### DIFF
--- a/qfit_plugin.py
+++ b/qfit_plugin.py
@@ -107,7 +107,9 @@ class QfitPlugin:
         ):
             return
 
-        set_window_state((window_state() & ~minimized) | active)
+        state = window_state()
+        if state & minimized:
+            set_window_state((state & ~minimized) | active)
 
     def show_about(self):
         if self._about_dock is None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -313,7 +313,10 @@ class TestQfitPluginMenuStructure(unittest.TestCase):
                 self.raise_ = MagicMock()
                 self.activateWindow = MagicMock()
                 self.windowState = MagicMock(
-                    return_value=plugin_module.Qt.WindowMinimized
+                    side_effect=[
+                        plugin_module.Qt.WindowMinimized,
+                        plugin_module.Qt.WindowActive,
+                    ]
                 )
                 self.setWindowState = MagicMock()
                 FakeConfigDialog.created.append(self)
@@ -324,7 +327,7 @@ class TestQfitPluginMenuStructure(unittest.TestCase):
 
         dialog = FakeConfigDialog.created[-1]
         self.assertEqual(len(FakeConfigDialog.created), 1)
-        dialog.setWindowState.assert_called_with(plugin_module.Qt.WindowActive)
+        dialog.setWindowState.assert_called_once_with(plugin_module.Qt.WindowActive)
         self.assertEqual(dialog.show.call_count, 2)
         self.assertEqual(dialog.raise_.call_count, 2)
         self.assertEqual(dialog.activateWindow.call_count, 2)


### PR DESCRIPTION
## What Problem This Solves

Follow-up for ebelo/qfit#1385 after the automatic review on #1393 noted that the Configuration dialog window state was restored unconditionally.

## Why This Change Was Made

- Only call `setWindowState` when the dialog is actually minimized.
- Keep `show()`, `raise_()`, and `activateWindow()` on every Review settings click.
- Strengthen the regression test so the second click does not rewrite an already-active window state.

## Evidence

- `python3 -m pytest tests/test_plugin.py` -> 10 passed
