### PR TITLE
Fix clipped Settings helper copy

### DIFF
--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -349,9 +349,18 @@ class ContextualHelpTests(unittest.TestCase):
             entries["writeActivityPointsCheckBox"].target_text,
             "Write sampled activity points from detailed tracks",
         )
-        self.assertIn("activity_points layer", entries["writeActivityPointsCheckBox"].helper_text)
+        self.assertEqual(
+            entries["writeActivityPointsCheckBox"].helper_text,
+            "Writes sampled track points to activity_points when detailed Strava streams are available.",
+        )
+        self.assertLessEqual(len(entries["writeActivityPointsCheckBox"].helper_text), 90)
         self.assertEqual(entries["pointSamplingStrideSpinBox"].label_text, "Keep every Nth point")
         self.assertEqual(entries["backgroundPresetComboBox"].label_text, "Basemap preset")
+        self.assertEqual(
+            entries["backgroundPresetComboBox"].helper_text,
+            "Pick a built-in style, or use Winter/Custom for a Mapbox Studio style.",
+        )
+        self.assertLessEqual(len(entries["backgroundPresetComboBox"].helper_text), 80)
         self.assertEqual(entries["atlasTitleLineEdit"].label_text, "Atlas title")
         self.assertEqual(entries["atlasSubtitleLineEdit"].label_text, "Atlas subtitle")
         self.assertEqual(entries["refreshButton"].target_text, "Fetch activities")

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -41,8 +41,7 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
             "default Mapbox owner/style fields; Winter and Custom expect your own Mapbox Studio style."
         ),
         helper_text=(
-            "Built-in presets are the quickest path. Use Winter or Custom when you want your own Mapbox Studio "
-            "style instead of qfit's default examples."
+            "Pick a built-in style, or use Winter/Custom for a Mapbox Studio style."
         ),
         help_button=True,
     ),
@@ -80,9 +79,7 @@ DOCK_HELP_ENTRIES: tuple[HelpEntry, ...] = (
             "sampled stream data in QGIS."
         ),
         helper_text=(
-            "Best when detailed tracks are enabled. qfit writes this data to the activity_points layer, which can "
-            "include sampled distance, time, elevation, speed, heart rate, cadence, power, temperature, and "
-            "moving-state values when Strava provides them."
+            "Writes sampled track points to activity_points when detailed Strava streams are available."
         ),
     ),
     HelpEntry(


### PR DESCRIPTION
## What Problem This Solves

Fixes ebelo/qfit#1396.

The Settings tab could still show long generated helper labels clipped in a narrow QGIS dock, even though the full text was available through help surfaces.

## What Changed

- Shorten the always-visible helper text for the Basemap preset setting.
- Shorten the always-visible helper text for sampled activity points.
- Keep the longer context in the existing tooltips/help affordances.
- Add tests that pin the concise visible helper copy.

## Evidence

- `python3 -m pytest tests/test_contextual_help.py` -> 8 passed
- `python3 -m pytest tests/test_contextual_help.py tests/test_local_first_shell.py tests/test_wizard_shell.py tests/test_package_plugin.py tests/test_plugin.py` -> 44 passed
- `python3 scripts/package_plugin.py` -> built `dist/qfit-0.50.zip`
