### PR TITLE
Defer stored layer activity zoom until canvas settles

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -995,7 +995,17 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         finally:
             self._restore_project_crs(project_crs, schedule_delayed=True)
             if loaded_activities_layer is not None:
-                self._zoom_to_loaded_activity_extent(loaded_activities_layer)
+                self._schedule_zoom_to_loaded_activity_extent(loaded_activities_layer)
+
+    def _schedule_zoom_to_loaded_activity_extent(self, activities_layer) -> None:
+        try:
+            QTimer.singleShot(
+                0,
+                lambda layer=activities_layer: self._zoom_to_loaded_activity_extent(layer),
+            )
+        except (AttributeError, RuntimeError, TypeError):
+            logger.debug("Failed to schedule loaded activity extent zoom", exc_info=True)
+            self._zoom_to_loaded_activity_extent(activities_layer)
 
     def _zoom_to_loaded_activity_extent(self, activities_layer) -> None:
         zoom_to_layers = getattr(getattr(self, "layer_gateway", None), "zoom_to_layers", None)

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -2919,6 +2919,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         workflow.load_existing_request.return_value = result
         dock.dataset_load_workflow = workflow
+        self.module.QTimer.singleShot.reset_mock()
 
         self.module.QfitDockWidget.on_load_layers_clicked(dock)
 
@@ -2931,6 +2932,11 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock._populate_activity_types_from_layer.assert_called_once_with()
         dock._apply_visual_configuration.assert_called_once_with(apply_subset_filters=False)
         dock._update_loaded_activities_summary.assert_called_once_with(12)
+        dock.layer_gateway.zoom_to_layers.assert_not_called()
+        self.module.QTimer.singleShot.assert_called_once()
+        delay, callback = self.module.QTimer.singleShot.call_args.args
+        self.assertEqual(delay, 0)
+        callback()
         dock.layer_gateway.zoom_to_layers.assert_called_once_with(
             ["activities-layer"],
             snap_to_background=False,
@@ -3000,9 +3006,15 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             status="Loaded 12 activities",
         )
         dock.dataset_load_workflow = workflow
+        self.module.QTimer.singleShot.reset_mock()
 
         self.module.QfitDockWidget.on_load_layers_clicked(dock)
 
+        dock.layer_gateway.zoom_to_layers.assert_not_called()
+        self.module.QTimer.singleShot.assert_called_once()
+        delay, callback = self.module.QTimer.singleShot.call_args.args
+        self.assertEqual(delay, 0)
+        callback()
         dock.layer_gateway.zoom_to_layers.assert_called_once_with(
             ["activities-layer"],
             snap_to_background=False,
@@ -3045,25 +3057,43 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         user_crs.isValid.return_value = True
         project.crs.return_value = user_crs
         project.setCrs.side_effect = lambda crs: events.append(("restore", crs))
+        scheduled_callbacks = []
         self.module.QTimer.singleShot.reset_mock()
-
-        with patch.object(self.module.QgsProject, "instance", return_value=project):
-            self.module.QfitDockWidget.on_load_layers_clicked(dock)
-
-        self.assertEqual(
-            events,
-            [
-                "visual",
-                ("restore", user_crs),
-                ("zoom", ["activities-layer"], {"snap_to_background": False}),
-            ],
+        self.module.QTimer.singleShot.side_effect = (
+            lambda _delay, callback: scheduled_callbacks.append(callback)
         )
-        project.setCrs.assert_called_once_with(user_crs)
-        canvas.setDestinationCrs.assert_called_once_with(user_crs)
-        self.module.QTimer.singleShot.assert_called_once()
-        delay, callback = self.module.QTimer.singleShot.call_args.args
-        self.assertEqual(delay, 0)
-        self.assertTrue(callable(callback))
+
+        try:
+            with patch.object(self.module.QgsProject, "instance", return_value=project):
+                self.module.QfitDockWidget.on_load_layers_clicked(dock)
+
+                self.assertEqual(events, ["visual", ("restore", user_crs)])
+                project.setCrs.assert_called_once_with(user_crs)
+                canvas.setDestinationCrs.assert_called_once_with(user_crs)
+                self.assertEqual(self.module.QTimer.singleShot.call_count, 2)
+                self.assertEqual(
+                    [
+                        call_args.args[0]
+                        for call_args in self.module.QTimer.singleShot.call_args_list
+                    ],
+                    [0, 0],
+                )
+                self.assertEqual(len(scheduled_callbacks), 2)
+
+                scheduled_callbacks[0]()
+                scheduled_callbacks[1]()
+
+                self.assertEqual(
+                    events,
+                    [
+                        "visual",
+                        ("restore", user_crs),
+                        ("restore", user_crs),
+                        ("zoom", ["activities-layer"], {"snap_to_background": False}),
+                    ],
+                )
+        finally:
+            self.module.QTimer.singleShot.side_effect = None
 
     def test_on_generate_atlas_pdf_clicked_cancels_existing_export_task(self):
         dock = object.__new__(self.module.QfitDockWidget)


### PR DESCRIPTION
## Summary

- defer the final `Load stored map layers` activity zoom onto the Qt event loop
- queue that zoom after the delayed CRS restore so first-click canvas work settles before fitting activities
- update dock-widget tests to prove the final zoom is scheduled and still uses the raw activity extent without background snapping

Fixes #1402

## Validation

- `python3 -m pytest tests/test_map_canvas_service.py tests/test_layer_gateway.py tests/test_load_workflow.py tests/test_qfit_dockwidget_analysis_pure.py`
- `git diff --check`
