### PR TITLE
Bump QGIS upload version to 0.50.1

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.50
+version=0.50.1
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.


### PR DESCRIPTION
## Summary

- bump the QGIS upload metadata version from `0.50` to `0.50.1`
- keeps the same release content while avoiding the QGIS plugin site duplicate-version rejection

## Validation

Rebuilt `dist/qfit-0.50.1.zip` and checked the exact artifact:

- metadata version: `0.50.1`
- Bandit `-ll`: `0` medium/high results
- detect-secrets: `0` results
- Flake8 with packaged `.flake8`: `0` results
- ZIP still excludes tests/debug artifacts
