### PR TITLE
chore: align plugin scanner with qgis checks

### DIFF
--- a/scripts/run_plugin_security_scan.py
+++ b/scripts/run_plugin_security_scan.py
@@ -162,11 +162,28 @@ def write_summary(
     summary_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 
 
+def _flake8_command(plugin_root: Path) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "flake8",
+        "--max-line-length=120",
+        "--select=E,F,W",
+    ]
+    flake8_config = plugin_root / ".flake8"
+    if flake8_config.is_file():
+        command.extend(["--config", str(flake8_config)])
+    else:
+        command.append("--isolated")
+    command.append(str(plugin_root))
+    return command
+
+
 def build_scan_commands(plugin_root: Path, reports_dir: Path) -> list[tuple[str, list[str], Path, object | None]]:
     return [
         (
             "bandit",
-            [sys.executable, "-m", "bandit", "-r", str(plugin_root), "-f", "json", "-q"],
+            [sys.executable, "-m", "bandit", "-r", str(plugin_root), "-f", "json", "-q", "-ll"],
             reports_dir / "bandit.json",
             exit_code_one_is_findings,
         ),
@@ -185,13 +202,7 @@ def build_scan_commands(plugin_root: Path, reports_dir: Path) -> list[tuple[str,
         ),
         (
             "flake8",
-            [
-                sys.executable,
-                "-m",
-                "flake8",
-                "--extend-exclude=vendor/",
-                str(plugin_root),
-            ],
+            _flake8_command(plugin_root),
             reports_dir / "flake8.txt",
             exit_code_one_is_findings,
         ),

--- a/tests/test_plugin_security_scan.py
+++ b/tests/test_plugin_security_scan.py
@@ -123,14 +123,43 @@ class PrepareScanTreeTests(unittest.TestCase):
 
 
 class BuildScanCommandsTests(unittest.TestCase):
-    def test_flake8_command_excludes_vendor_tree(self):
+    def test_bandit_command_matches_qgis_medium_high_filter(self):
+        commands = plugin_security_scan.build_scan_commands(
+            Path("/tmp/plugin-root"),
+            Path("/tmp/reports"),
+        )
+
+        bandit_entry = next(command for command in commands if command[0] == "bandit")
+        self.assertIn("-ll", bandit_entry[1])
+
+    def test_flake8_command_scans_packaged_tree_without_repo_config(self):
         commands = plugin_security_scan.build_scan_commands(
             Path("/tmp/plugin-root"),
             Path("/tmp/reports"),
         )
 
         flake8_entry = next(command for command in commands if command[0] == "flake8")
-        self.assertIn("--extend-exclude=vendor/", flake8_entry[1])
+        self.assertIn("--isolated", flake8_entry[1])
+        self.assertIn("--max-line-length=120", flake8_entry[1])
+        self.assertIn("--select=E,F,W", flake8_entry[1])
+        self.assertNotIn("--extend-exclude=vendor/", flake8_entry[1])
+
+    def test_flake8_command_uses_packaged_config_when_present(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plugin_root = Path(temp_dir) / "qfit"
+            plugin_root.mkdir()
+            config = plugin_root / ".flake8"
+            config.write_text("[flake8]\n", encoding="utf-8")
+
+            commands = plugin_security_scan.build_scan_commands(
+                plugin_root,
+                Path("/tmp/reports"),
+            )
+
+        flake8_entry = next(command for command in commands if command[0] == "flake8")
+        self.assertIn("--config", flake8_entry[1])
+        self.assertIn(str(config), flake8_entry[1])
+        self.assertNotIn("--isolated", flake8_entry[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- align the packaged plugin security scan more closely with qgis.org scanner behavior
- run Bandit with the qgis.org medium/high filter
- run Flake8 against the extracted package without accidentally reading the repo `.flake8`, while still honoring a packaged `.flake8` if one is intentionally shipped later

## Validation
- python3 -m pytest tests/test_plugin_security_scan.py
- .venv/bin/python scripts/run_plugin_security_scan.py --allow-findings

The aligned local scan now reports Bandit/secrets clean and Flake8 findings, which matches the qgis.org feedback direction instead of hiding it behind repo-local config.
