### PR TITLE
chore: package qgis flake8 config

### DIFF
--- a/packaging/qgis-flake8.cfg
+++ b/packaging/qgis-flake8.cfg
@@ -1,0 +1,6 @@
+[flake8]
+# qgis.org scans the packaged plugin tree. Vendored pypdf is third-party code
+# copied into the package for offline QGIS runtime use, so keep style findings
+# focused on qfit-owned files.
+extend-exclude =
+    vendor/*

--- a/scripts/package_plugin.py
+++ b/scripts/package_plugin.py
@@ -14,6 +14,7 @@ from importlib import metadata
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DIST_DIR = ROOT / "dist"
+PACKAGED_FLAKE8_CONFIG = ROOT / "packaging" / "qgis-flake8.cfg"
 EXCLUDED_DIRS = {
     ".git",
     ".github",
@@ -23,6 +24,7 @@ EXCLUDED_DIRS = {
     "debug",
     "dist",
     "docs",
+    "packaging",
     "scripts",
     "tests",
     "validation",
@@ -112,11 +114,18 @@ def _vendor_runtime_dependencies(plugin_dir: pathlib.Path) -> None:
         shutil.copy2(license_path, licenses_dir / "pypdf_LICENSE.txt")
 
 
+def _copy_packaged_flake8_config(plugin_dir: pathlib.Path) -> None:
+    if not PACKAGED_FLAKE8_CONFIG.is_file():
+        raise RuntimeError(f"Packaged Flake8 config not found: {PACKAGED_FLAKE8_CONFIG}")
+    shutil.copy2(PACKAGED_FLAKE8_CONFIG, plugin_dir / ".flake8")
+
+
 def _build_staging_tree(plugin_name: str) -> pathlib.Path:
     staging_root = pathlib.Path(tempfile.mkdtemp(prefix="qfit-package-"))
     plugin_dir = staging_root / plugin_name
     _copy_project_tree(plugin_dir)
     _vendor_runtime_dependencies(plugin_dir)
+    _copy_packaged_flake8_config(plugin_dir)
     return staging_root
 
 

--- a/tests/test_package_plugin.py
+++ b/tests/test_package_plugin.py
@@ -30,6 +30,7 @@ class PackagePluginTests(unittest.TestCase):
                 root / ".pytest_cache" / "v" / "cache" / "nodeids",
                 root / ".venv" / "lib" / "python3.12" / "site-packages" / "sample.py",
                 root / "debug" / "plugin-security-scan" / "summary.txt",
+                root / "packaging" / "qgis-flake8.cfg",
                 root / "validation" / "sample.txt",
                 root / "validation_artifacts" / "artifact.txt",
             ]
@@ -62,6 +63,9 @@ class PackagePluginTests(unittest.TestCase):
             (root / ".venv" / "lib" / "python3.12" / "site-packages" / "sample.py").write_text("# venv\n", encoding="utf-8")
             (root / "debug" / "plugin-security-scan").mkdir(parents=True)
             (root / "debug" / "plugin-security-scan" / "summary.txt").write_text("summary\n", encoding="utf-8")
+            (root / "packaging").mkdir()
+            packaged_flake8_config = root / "packaging" / "qgis-flake8.cfg"
+            packaged_flake8_config.write_text("[flake8]\nextend-exclude = vendor/*\n", encoding="utf-8")
             (root / "validation").mkdir()
             (root / "validation" / "sample.txt").write_text("validation\n", encoding="utf-8")
             (root / "validation_artifacts").mkdir()
@@ -70,6 +74,7 @@ class PackagePluginTests(unittest.TestCase):
             with (
                 patch.object(package_plugin, "ROOT", root),
                 patch.object(package_plugin, "DIST_DIR", dist),
+                patch.object(package_plugin, "PACKAGED_FLAKE8_CONFIG", packaged_flake8_config),
                 patch.object(package_plugin, "_vendor_runtime_dependencies"),
             ):
                 archive_path = package_plugin.build_zip()
@@ -77,18 +82,38 @@ class PackagePluginTests(unittest.TestCase):
             self.assertEqual(archive_path, dist / "qfit-1.2.3.zip")
             with zipfile.ZipFile(archive_path) as archive:
                 names = set(archive.namelist())
+                packaged_config = archive.read("qfit/.flake8").decode("utf-8")
 
             self.assertIn("qfit/metadata.txt", names)
             self.assertIn("qfit/__init__.py", names)
             self.assertIn("qfit/core.py", names)
             self.assertIn("qfit/.bandit", names)
-            self.assertNotIn("qfit/.flake8", names)
+            self.assertIn("qfit/.flake8", names)
+            self.assertNotIn("qfit/packaging/qgis-flake8.cfg", names)
+            self.assertIn("extend-exclude = vendor/*", packaged_config)
             self.assertFalse(any(name.startswith("qfit/tests/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.pytest_cache/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.venv/") for name in names))
             self.assertFalse(any(name.startswith("qfit/debug/") for name in names))
             self.assertFalse(any(name.startswith("qfit/validation/") for name in names))
             self.assertFalse(any(name.startswith("qfit/validation_artifacts/") for name in names))
+
+    def test_build_zip_fails_when_packaged_flake8_config_is_missing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "src"
+            dist = Path(temp_dir) / "dist"
+            root.mkdir()
+            (root / "metadata.txt").write_text("[general]\nname=qfit\nversion=1.2.3\n", encoding="utf-8")
+            (root / "__init__.py").write_text("# init\n", encoding="utf-8")
+
+            with (
+                patch.object(package_plugin, "ROOT", root),
+                patch.object(package_plugin, "DIST_DIR", dist),
+                patch.object(package_plugin, "PACKAGED_FLAKE8_CONFIG", root / "missing-flake8.cfg"),
+                patch.object(package_plugin, "_vendor_runtime_dependencies"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "Packaged Flake8 config not found"):
+                    package_plugin.build_zip()
 
 
 if __name__ == "__main__":

--- a/tests/test_plugin_security_scan.py
+++ b/tests/test_plugin_security_scan.py
@@ -124,25 +124,28 @@ class PrepareScanTreeTests(unittest.TestCase):
 
 class BuildScanCommandsTests(unittest.TestCase):
     def test_bandit_command_matches_qgis_medium_high_filter(self):
-        commands = plugin_security_scan.build_scan_commands(
-            Path("/tmp/plugin-root"),
-            Path("/tmp/reports"),
-        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            commands = plugin_security_scan.build_scan_commands(
+                temp_path / "plugin-root",
+                temp_path / "reports",
+            )
 
         bandit_entry = next(command for command in commands if command[0] == "bandit")
         self.assertIn("-ll", bandit_entry[1])
 
     def test_flake8_command_scans_packaged_tree_without_repo_config(self):
-        commands = plugin_security_scan.build_scan_commands(
-            Path("/tmp/plugin-root"),
-            Path("/tmp/reports"),
-        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            commands = plugin_security_scan.build_scan_commands(
+                temp_path / "plugin-root",
+                temp_path / "reports",
+            )
 
         flake8_entry = next(command for command in commands if command[0] == "flake8")
         self.assertIn("--isolated", flake8_entry[1])
         self.assertIn("--max-line-length=120", flake8_entry[1])
         self.assertIn("--select=E,F,W", flake8_entry[1])
-        self.assertNotIn("--extend-exclude=vendor/", flake8_entry[1])
 
     def test_flake8_command_uses_packaged_config_when_present(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -153,13 +156,13 @@ class BuildScanCommandsTests(unittest.TestCase):
 
             commands = plugin_security_scan.build_scan_commands(
                 plugin_root,
-                Path("/tmp/reports"),
+                Path(temp_dir) / "reports",
             )
 
-        flake8_entry = next(command for command in commands if command[0] == "flake8")
-        self.assertIn("--config", flake8_entry[1])
-        self.assertIn(str(config), flake8_entry[1])
-        self.assertNotIn("--isolated", flake8_entry[1])
+            flake8_entry = next(command for command in commands if command[0] == "flake8")
+            self.assertIn("--config", flake8_entry[1])
+            self.assertIn(str(config), flake8_entry[1])
+            self.assertNotIn("--isolated", flake8_entry[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a packaged qgis.org Flake8 config that excludes vendored `vendor/` code from the package scan
- keep the repo-local `.flake8` excluded from the ZIP while copying the packaged config into the staged plugin as `qfit/.flake8`
- cover the packaging behavior and clean up scanner command tests from the prior review comment

## Validation

- `.venv/bin/python -m unittest tests.test_package_plugin tests.test_plugin_security_scan`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`

Issue: #1408
