### PR TITLE
chore: ignore W503 in packaged flake8 scan

### DIFF
--- a/packaging/qgis-flake8.cfg
+++ b/packaging/qgis-flake8.cfg
@@ -4,3 +4,7 @@
 # focused on qfit-owned files.
 extend-exclude =
     vendor/*
+extend-ignore =
+    # qfit uses operator-leading continuation lines throughout the plugin.
+    # Treat those as style-neutral in the packaged qgis.org scan.
+    W503

--- a/tests/test_package_plugin.py
+++ b/tests/test_package_plugin.py
@@ -65,7 +65,10 @@ class PackagePluginTests(unittest.TestCase):
             (root / "debug" / "plugin-security-scan" / "summary.txt").write_text("summary\n", encoding="utf-8")
             (root / "packaging").mkdir()
             packaged_flake8_config = root / "packaging" / "qgis-flake8.cfg"
-            packaged_flake8_config.write_text("[flake8]\nextend-exclude = vendor/*\n", encoding="utf-8")
+            packaged_flake8_config.write_text(
+                "[flake8]\nextend-exclude = vendor/*\nextend-ignore = W503\n",
+                encoding="utf-8",
+            )
             (root / "validation").mkdir()
             (root / "validation" / "sample.txt").write_text("validation\n", encoding="utf-8")
             (root / "validation_artifacts").mkdir()
@@ -91,6 +94,7 @@ class PackagePluginTests(unittest.TestCase):
             self.assertIn("qfit/.flake8", names)
             self.assertNotIn("qfit/packaging/qgis-flake8.cfg", names)
             self.assertIn("extend-exclude = vendor/*", packaged_config)
+            self.assertIn("extend-ignore = W503", packaged_config)
             self.assertFalse(any(name.startswith("qfit/tests/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.pytest_cache/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.venv/") for name in names))


### PR DESCRIPTION
## Summary

- add a packaged Flake8 `W503` ignore for qfit's existing operator-leading continuation style
- keep the vendor exclusion from the prior cleanup slice intact
- assert that the packaged Flake8 config contents are preserved in the plugin ZIP

## Validation

- `.venv/bin/python -m unittest tests.test_package_plugin tests.test_plugin_security_scan`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`

Package scan impact:

- Bandit: clean
- detect-secrets: clean
- Flake8: findings remain, with `W503` removed from the current package scan output

Issue: #1408
