### PR TITLE
chore: clean activity classification spacing

### DIFF
--- a/activities/domain/activity_classification.py
+++ b/activities/domain/activity_classification.py
@@ -13,14 +13,14 @@ ACTIVITY_LABEL_FIELDS: tuple[str, ...] = ("sport_type", "activity_type")
 
 # Resolution order matters: first matching family wins.
 _FAMILY_TOKENS: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("machine",  ("virtual", "trainer", "commute", "ebike", "machine")),
-    ("winter",   ("ski", "snow", "sled")),
-    ("water",    ("swim", "surf", "paddle", "row", "kayak", "canoe", "sup")),
+    ("machine", ("virtual", "trainer", "commute", "ebike", "machine")),
+    ("winter", ("ski", "snow", "sled")),
+    ("water", ("swim", "surf", "paddle", "row", "kayak", "canoe", "sup")),
     ("mountain", ("iceclimb", "climb", "mountain", "boulder", "alpinism")),
-    ("running",  ("run", "jog")),
-    ("walking",  ("walk", "hike", "trek", "backpack")),
-    ("fitness",  ("crossfit", "workout", "yoga", "weight", "gym", "pilates")),
-    ("cycling",  ("ride", "bike", "cycle")),
+    ("running", ("run", "jog")),
+    ("walking", ("walk", "hike", "trek", "backpack")),
+    ("fitness", ("crossfit", "workout", "yoga", "weight", "gym", "pilates")),
+    ("cycling", ("ride", "bike", "cycle")),
 )
 
 


### PR DESCRIPTION
## Summary

- remove extra tuple-alignment spaces from the activity family token table
- clear the current packaged Flake8 `E241` findings without changing classification order or behavior

## Validation

- `.venv/bin/python -m unittest tests.test_activity_classification tests.test_activity_domain_compatibility tests.test_activity_query`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`

Package scan impact:

- Bandit: clean
- detect-secrets: clean
- Flake8: findings remain, with `E241` removed from the current package scan output

Issue: #1408
