### PR TITLE
chore: clean singleton flake8 findings

### DIFF
--- a/activities/application/activity_selection_state.py
+++ b/activities/application/activity_selection_state.py
@@ -24,4 +24,3 @@ class ActivitySelectionState:
             query=normalized_query,
             filtered_count=len(filter_activities(activities, normalized_query)),
         )
-

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -393,7 +393,6 @@ def resolve_background_style(
     style_owner: str = "",
     style_id: str = "",
 ) -> tuple[str, str]:
-    preset = get_background_preset(preset_name)
     if not preset_requires_custom_style(preset_name):
         return preset_defaults(preset_name)
 

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -249,7 +249,8 @@ def _button_stylesheet(state: str, *, compact: bool = False) -> str:
         f"font-weight: {font_weight}; "
         f"font-size: {'9pt' if compact else '9.5pt'}; "
         "} "
-        f"QToolButton:hover:enabled {{ background: {COLOR_HOVER}; color: {COLOR_TEXT}; }}"    )
+        f"QToolButton:hover:enabled {{ background: {COLOR_HOVER}; color: {COLOR_TEXT}; }}"
+    )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- Remove the trailing blank line from `ActivitySelectionState`.
- Drop an unused local in `resolve_background_style`.
- Fix the StepperBar stylesheet closing parenthesis spacing.

This removes the current packaged qgis.org Flake8 singleton findings for `W391`, `F841`, and `E202`.

## Verification

- `python3 -m unittest tests.test_activity_preview tests.test_stepper_bar tests.test_mapbox_config -v`
- `python3 -m pytest tests/test_activity_preview.py tests/test_stepper_bar.py tests/test_mapbox_config.py -q`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`

Part of #1408.
