### PR TITLE
chore: clean packaged flake8 blank lines

### DIFF
--- a/activities/domain/activity_query.py
+++ b/activities/domain/activity_query.py
@@ -21,6 +21,7 @@ class ActivitySummary:
     by_type: dict[str, int]
     latest_date: str | None
 
+
 DETAILED_ROUTE_FILTER_ANY = "any"
 DETAILED_ROUTE_FILTER_PRESENT = "present"
 DETAILED_ROUTE_FILTER_MISSING = "missing"

--- a/analysis/infrastructure/slope_grade_layer.py
+++ b/analysis/infrastructure/slope_grade_layer.py
@@ -83,6 +83,7 @@ def _build_memory_layer(source_layer):
         "memory",
     )
 
+
 def _layer_crs(layer):
     crs = getattr(layer, "crs", None)
     return crs() if callable(crs) else None

--- a/atlas/export_front_matter.py
+++ b/atlas/export_front_matter.py
@@ -59,7 +59,6 @@ def export_cover_page(
         _restore_layer_state(saved_state)
 
 
-
 def export_toc_page(
     atlas_layer,
     output_path: str,
@@ -85,7 +84,6 @@ def export_toc_page(
     except (RuntimeError, OSError):
         logger.exception("TOC page export failed")
         return None
-
 
 
 def _build_cover_map_layers(
@@ -161,7 +159,6 @@ def _build_cover_map_layers(
         starts_layer.setOpacity(0.0)
 
     return [heatmap_target] + background_layers
-
 
 
 def _save_layer_state(saved_state: list[dict], layer, *, save_renderer: bool = True) -> None:
@@ -289,7 +286,6 @@ def _restore_layer_state(saved_state: list[dict]) -> None:
             layer.setSubsetString(state["subset"])
         except (RuntimeError, AttributeError):
             pass
-
 
 
 def _build_pdf_export_settings(layout_exporter_cls):

--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -42,6 +42,7 @@ def _format_unexpected_export_error(exc: Exception) -> str:
         return f"Unexpected atlas export failure ({exc.__class__.__name__}): {detail}"
     return f"Unexpected atlas export failure ({exc.__class__.__name__})"
 
+
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsLayoutExporter,
@@ -124,6 +125,7 @@ class PageProfilePayload:
             None,
         )
 
+
 # ---------------------------------------------------------------------------
 # Page geometry (mm, A4 portrait with square map)
 # ---------------------------------------------------------------------------
@@ -175,6 +177,7 @@ _DETAIL_ITEM_FIELDS = [
     ("page_average_pace_label", "Pace"),
     ("page_elevation_gain_label", "Climbing"),
 ]
+
 
 def _render_page_profile_svg(page_points, *, output_path: str) -> str | None:
     return AtlasPageProfileWorkflow(

--- a/atlas/profile_payload_resolver.py
+++ b/atlas/profile_payload_resolver.py
@@ -91,7 +91,6 @@ def feature_attribute(feature, field_name: str):
         return None
 
 
-
 def load_profile_points_from_feature(feature) -> list[tuple[float, float]] | None:
     raw_value = feature_attribute(feature, "details_json")
     if isinstance(raw_value, str):

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -278,7 +278,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             if widget is not None and hasattr(widget, "hide"):
                 widget.hide()
 
-
     def _refresh_local_first_dock_from_runtime(self):
         """Refresh an optional #748 local-first dock composition from runtime facts."""
 
@@ -595,7 +594,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _save_settings(self):
         save_bindings(build_dock_settings_bindings(self), self.settings)
-
 
     def _set_default_dates(self):
         today = QDate.currentDate()
@@ -1441,7 +1439,6 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         if result is None:
             return
         self._apply_activity_type_options(result)
-
 
     def _update_connection_status(self):
         credentials = self._strava_credentials()

--- a/ui/dockwidget/workflow_dock.py
+++ b/ui/dockwidget/workflow_dock.py
@@ -25,12 +25,10 @@ WORKFLOW_DOCK_FEATURES = (
 )
 
 
-
 class WorkflowShellCompositionLike(Protocol):
     """Small structural protocol for dock-hostable workflow compositions."""
 
     shell: QWidget
-
 
 
 class WorkflowDockWidget(QDockWidget):
@@ -64,7 +62,6 @@ class WorkflowDockWidget(QDockWidget):
         self.composition = composition
 
 
-
 def build_workflow_dock_widget(
     composition: WorkflowShellCompositionLike,
     *,
@@ -74,7 +71,6 @@ def build_workflow_dock_widget(
     """Build the dock-level container for a reusable workflow composition."""
 
     return WorkflowDockWidget(composition, parent=parent, title=title)
-
 
 
 def _composition_shell(composition: WorkflowShellCompositionLike):


### PR DESCRIPTION
## Summary

- Removes the remaining packaged Flake8 blank-line findings (`E302`, `E303`, `E305`).
- Keeps the change mechanical and behavior-preserving across activity, atlas, dock, and workflow modules.

Closes part of #1408.

## Verification

- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
- `.venv/bin/python -m unittest tests.test_activity_query tests.test_slope_grade_layer tests.test_workflow_dock tests.test_atlas_export_task tests.test_qfit_dockwidget_analysis_pure -v`

Latest packaged Flake8 categories after this change:

- `E402`: 61
- `F401`: 58
- `E501`: 58
