### PR TITLE
chore: clean packaged F401 findings

### DIFF
--- a/activities/domain/__init__.py
+++ b/activities/domain/__init__.py
@@ -21,3 +21,23 @@ from .activity_query import (
     summarize_activities,
 )
 from .models import Activity
+
+__all__ = [
+    "ACTIVITY_LABEL_FIELDS",
+    "Activity",
+    "ActivityQuery",
+    "ActivitySummary",
+    "activity_prefers_pace",
+    "build_preview_lines",
+    "build_subset_string",
+    "canonical_activity_label",
+    "filter_activities",
+    "format_duration",
+    "format_summary_text",
+    "normalize_activity_type",
+    "ordered_canonical_activity_labels",
+    "preferred_activity_field",
+    "resolve_activity_family",
+    "sort_activities",
+    "summarize_activities",
+]

--- a/analysis/application/analysis_controller.py
+++ b/analysis/application/analysis_controller.py
@@ -46,3 +46,12 @@ class AnalysisController:
 
     def run_request(self, request: RunAnalysisRequest) -> RunAnalysisResult:
         return self.run(request=request)
+
+
+__all__ = [
+    "AnalysisController",
+    "FREQUENT_STARTING_POINTS_MODE",
+    "HEATMAP_MODE",
+    "POWER_OUTPUT_MODE",
+    "SLOPE_GRADE_MODE",
+]

--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -60,7 +60,6 @@ from qgis.core import (
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QFont
 
-from ..activities.domain.activity_classification import ordered_canonical_activity_labels
 from .layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .profile_item import (
     NativeProfileItemConfig,

--- a/atlas/export_use_case.py
+++ b/atlas/export_use_case.py
@@ -9,7 +9,6 @@ from .export_service import (
     AtlasExportPlan,
     AtlasExportResult,
     AtlasExportService,
-    GenerateAtlasPdfRequest,
 )
 
 

--- a/atlas/profile_export_workflow.py
+++ b/atlas/profile_export_workflow.py
@@ -9,7 +9,6 @@ from qgis.core import QgsCoordinateReferenceSystem, QgsProfileRequest
 
 from .profile_backend_policy import DEFAULT_PROFILE_BACKEND_POLICY
 from .profile_item import (
-    build_native_profile_curve,
     build_native_profile_curve_from_feature,
     configure_native_profile_plot_range,
 )

--- a/providers/infrastructure/__init__.py
+++ b/providers/infrastructure/__init__.py
@@ -2,3 +2,9 @@
 
 from .strava_client import StravaClient, StravaClientError
 from .strava_provider import StravaProvider
+
+__all__ = [
+    "StravaClient",
+    "StravaClientError",
+    "StravaProvider",
+]

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -16,8 +16,9 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox,
 )
 
-from .activities.application import (
-    ActivitySelectionState,
+# Keep selected imported names available as legacy direct dockwidget aliases.
+from .activities.application import (  # noqa: F401
+    ActivitySelectionState as ActivitySelectionState,
     ActivityTypeOptionsResult,
     build_activity_preview_selection_state,
     build_activity_type_options_from_activities,
@@ -51,9 +52,9 @@ from .analysis.infrastructure.frequent_start_points_layer import (
 )
 from .analysis.infrastructure.power_output_layer import POWER_OUTPUT_LAYER_NAME
 from .analysis.infrastructure.slope_grade_layer import SLOPE_GRADE_LAYER_NAME
-from .atlas.export_service import (
-    AtlasExportResult,
-    AtlasExportService,
+from .atlas.export_service import (  # noqa: F401
+    AtlasExportResult as AtlasExportResult,
+    AtlasExportService as AtlasExportService,
 )
 from .atlas.profile_style import build_native_profile_plot_style_from_settings
 from .ui.application import (
@@ -93,8 +94,8 @@ from .ui.application.local_first_progress_facts import (
 from .ui.contextual_help import ContextualHelpBinder, build_dock_help_entries
 from .detailed_route_strategy import DEFAULT_DETAILED_ROUTE_STRATEGY, DETAILED_ROUTE_STRATEGY_MISSING
 from .mapbox_config import MapboxConfigError
-from .visualization.application import (
-    LayerRefs,
+from .visualization.application import (  # noqa: F401
+    LayerRefs as LayerRefs,
     build_background_map_failure_status,
     build_background_map_failure_title,
 )

--- a/ui/application/__init__.py
+++ b/ui/application/__init__.py
@@ -371,6 +371,7 @@ __all__ = [
     "local_first_widget_move_keys",
     "preferred_current_key_from_workflow_settings",
     "missing_issue805_local_first_areas",
+    "RefreshVisualizationStyleAction",
     "refresh_local_first_conditional_control_visibility",
     "refresh_local_first_control_visibility",
     "remove_widget_from_current_layout",

--- a/ui/dockwidget/wizard_composition.py
+++ b/ui/dockwidget/wizard_composition.py
@@ -33,24 +33,25 @@ from .workflow_composition import (
     connect_wizard_action_callbacks,
     refresh_wizard_shell_composition,
 )
-from .workflow_composition import (
-    DockWorkflowActionCallbacks,
-    DockWorkflowPageSpec,
-    DockWorkflowProgress,
-    WorkflowCompositionPage,
-    WorkflowPage,
-    WorkflowPageStateSnapshots,
-    WorkflowSettingsSnapshot,
-    WorkflowShell,
-    WorkflowShellComposition,
-    WorkflowShellPresenter,
-    WorkflowProgressFacts,
-    WorkflowStepPage,
-    build_default_workflow_page_specs,
-    build_placeholder_workflow_shell,
-    build_workflow_page_states_from_facts,
-    connect_workflow_action_callbacks,
-    refresh_workflow_shell_composition,
+# Workflow names remain direct aliases but are intentionally excluded from star exports.
+from .workflow_composition import (  # noqa: F401
+    DockWorkflowActionCallbacks as DockWorkflowActionCallbacks,
+    DockWorkflowPageSpec as DockWorkflowPageSpec,
+    DockWorkflowProgress as DockWorkflowProgress,
+    WorkflowCompositionPage as WorkflowCompositionPage,
+    WorkflowPage as WorkflowPage,
+    WorkflowPageStateSnapshots as WorkflowPageStateSnapshots,
+    WorkflowSettingsSnapshot as WorkflowSettingsSnapshot,
+    WorkflowShell as WorkflowShell,
+    WorkflowShellComposition as WorkflowShellComposition,
+    WorkflowShellPresenter as WorkflowShellPresenter,
+    WorkflowProgressFacts as WorkflowProgressFacts,
+    WorkflowStepPage as WorkflowStepPage,
+    build_default_workflow_page_specs as build_default_workflow_page_specs,
+    build_placeholder_workflow_shell as build_placeholder_workflow_shell,
+    build_workflow_page_states_from_facts as build_workflow_page_states_from_facts,
+    connect_workflow_action_callbacks as connect_workflow_action_callbacks,
+    refresh_workflow_shell_composition as refresh_workflow_shell_composition,
 )
 
 __all__ = [

--- a/ui/dockwidget/wizard_shell.py
+++ b/ui/dockwidget/wizard_shell.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from .workflow_shell import FooterStatusBar, STEPPER_LABELS, WorkflowShell
+from .workflow_shell import FooterStatusBar as FooterStatusBar  # noqa: F401
+from .workflow_shell import STEPPER_LABELS as STEPPER_LABELS  # noqa: F401
+from .workflow_shell import WorkflowShell
 
 WizardShell = WorkflowShell
 """Compatibility alias for pre-#805 wizard shell imports."""

--- a/ui/dockwidget/wizard_step_page.py
+++ b/ui/dockwidget/wizard_step_page.py
@@ -2,20 +2,21 @@
 
 from __future__ import annotations
 
-from .step_page import (
-    DockWorkflowPageSpec,
+# Workflow names remain direct aliases but are intentionally excluded from star exports.
+from .step_page import (  # noqa: F401
+    DockWorkflowPageSpec as DockWorkflowPageSpec,
     DockWizardPageSpec,
-    StepPage,
-    WorkflowStepPage,
+    StepPage as StepPage,
+    WorkflowStepPage as WorkflowStepPage,
     WizardStepPage,
     apply_wizard_step_page_statuses,
-    apply_workflow_step_page_statuses,
+    apply_workflow_step_page_statuses as apply_workflow_step_page_statuses,
     build_default_wizard_page_specs,
-    build_default_workflow_page_specs,
+    build_default_workflow_page_specs as build_default_workflow_page_specs,
     build_wizard_step_pages,
-    build_workflow_step_pages,
+    build_workflow_step_pages as build_workflow_step_pages,
     install_wizard_step_pages,
-    install_workflow_step_pages,
+    install_workflow_step_pages as install_workflow_step_pages,
 )
 
 __all__ = [


### PR DESCRIPTION
## Summary
- declare intentional compatibility/facade re-exports with `__all__`
- remove genuinely unused first-party imports from implementation modules
- suppress only compatibility direct-alias imports that intentionally remain outside `__all__`
- eliminate the packaged qgis.org-shaped `F401` scanner findings for #1408

Fixes part of #1408.

## Validation
- `python3 -m pytest tests/test_analysis_controller.py tests/test_strava_provider.py tests/test_activity_domain_compatibility.py tests/test_dock_atlas_workflow.py tests/test_atlas_export_use_case.py tests/test_atlas_export_task.py -q`
- `python3 -m unittest tests.test_qfit_dockwidget_analysis_pure tests.test_step_page tests.test_wizard_shell tests.test_wizard_shell_composition -v`
- `.venv/bin/python -m flake8 --max-line-length=120 --select=F activities/domain/__init__.py providers/infrastructure/__init__.py analysis/application/analysis_controller.py atlas/export_task.py atlas/export_use_case.py atlas/profile_export_workflow.py qfit_dockwidget.py ui/application/__init__.py ui/dockwidget/wizard_composition.py ui/dockwidget/wizard_shell.py ui/dockwidget/wizard_step_page.py`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`

## Packaged scan state
- Bandit: clean
- detect-secrets: clean
- Flake8: findings remain
- Remaining categories after this slice: `E402` 60, `E501` 54
- `F401`: 0

## Rendering proof
Not rendering-sensitive; this only declares public re-export surfaces, preserves compatibility aliases, and removes unused imports.
