### PR TITLE
chore: wrap GeoPackage index SQL strings

### DIFF
--- a/activities/infrastructure/geopackage/gpkg_write_orchestration.py
+++ b/activities/infrastructure/geopackage/gpkg_write_orchestration.py
@@ -51,35 +51,42 @@ ROUTE_LAYER_ATTRIBUTE_INDEXES = {
         "CREATE INDEX IF NOT EXISTS idx_route_points_distance_m ON route_points(distance_m)",
     ),
     "route_profile_samples": (
-        "CREATE INDEX IF NOT EXISTS idx_route_profile_samples_source_route_id ON route_profile_samples(source, source_route_id)",
-        "CREATE INDEX IF NOT EXISTS idx_route_profile_samples_point_index ON route_profile_samples(source, source_route_id, point_index)",
+        "CREATE INDEX IF NOT EXISTS idx_route_profile_samples_source_route_id "
+        "ON route_profile_samples(source, source_route_id)",
+        "CREATE INDEX IF NOT EXISTS idx_route_profile_samples_point_index "
+        "ON route_profile_samples(source, source_route_id, point_index)",
         "CREATE INDEX IF NOT EXISTS idx_route_profile_samples_distance_m ON route_profile_samples(distance_m)",
     ),
 }
 
 DERIVED_LAYER_ATTRIBUTE_INDEXES = {
     "activity_tracks": (
-        "CREATE INDEX IF NOT EXISTS idx_activity_tracks_source_activity_id ON activity_tracks(source, source_activity_id)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_tracks_source_activity_id "
+        "ON activity_tracks(source, source_activity_id)",
         "CREATE INDEX IF NOT EXISTS idx_activity_tracks_activity_type ON activity_tracks(activity_type)",
         "CREATE INDEX IF NOT EXISTS idx_activity_tracks_start_date ON activity_tracks(start_date)",
         "CREATE INDEX IF NOT EXISTS idx_activity_tracks_sport_type ON activity_tracks(sport_type)",
     ),
     "activity_starts": (
-        "CREATE INDEX IF NOT EXISTS idx_activity_starts_source_activity_id ON activity_starts(source, source_activity_id)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_starts_source_activity_id "
+        "ON activity_starts(source, source_activity_id)",
         "CREATE INDEX IF NOT EXISTS idx_activity_starts_activity_type ON activity_starts(activity_type)",
         "CREATE INDEX IF NOT EXISTS idx_activity_starts_start_date ON activity_starts(start_date)",
     ),
     "activity_points": (
-        "CREATE INDEX IF NOT EXISTS idx_activity_points_source_activity_id ON activity_points(source, source_activity_id)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_points_source_activity_id "
+        "ON activity_points(source, source_activity_id)",
         "CREATE INDEX IF NOT EXISTS idx_activity_points_activity_type ON activity_points(activity_type)",
         "CREATE INDEX IF NOT EXISTS idx_activity_points_start_date ON activity_points(start_date)",
-        "CREATE INDEX IF NOT EXISTS idx_activity_points_point_timestamp_local ON activity_points(point_timestamp_local)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_points_point_timestamp_local "
+        "ON activity_points(point_timestamp_local)",
         "CREATE INDEX IF NOT EXISTS idx_activity_points_point_timestamp_utc ON activity_points(point_timestamp_utc)",
     ),
     "activity_atlas_pages": (
         "CREATE INDEX IF NOT EXISTS idx_activity_atlas_pages_page_number ON activity_atlas_pages(page_number)",
         "CREATE INDEX IF NOT EXISTS idx_activity_atlas_pages_page_sort_key ON activity_atlas_pages(page_sort_key)",
-        "CREATE INDEX IF NOT EXISTS idx_activity_atlas_pages_source_activity_id ON activity_atlas_pages(source, source_activity_id)",
+        "CREATE INDEX IF NOT EXISTS idx_activity_atlas_pages_source_activity_id "
+        "ON activity_atlas_pages(source, source_activity_id)",
     ),
 }
 


### PR DESCRIPTION
## Summary
- wrap long GeoPackage attribute-index SQL constants with adjacent string literals
- keep the generated SQL text unchanged while removing seven packaged `E501` findings
- continue the qgis.org-shaped Flake8 cleanup for #1408

Fixes part of #1408.

## Validation
- `.venv/bin/python -m flake8 --max-line-length=120 --select=E,F,W activities/infrastructure/geopackage/gpkg_write_orchestration.py`
- `python3 -m pytest tests/test_gpkg_geopackage_unit.py tests/test_gpkg_write_orchestration.py -q`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`

## Packaged scan state
- Bandit: clean
- detect-secrets: clean
- Flake8: findings remain
- Remaining categories after this slice: `E402` 60, `E501` 47

## Rendering proof
Not rendering-sensitive; this only wraps Python string literals for existing GeoPackage index SQL constants.
