### PR TITLE
chore: document packaged E402 scan exceptions

### DIFF
--- a/packaging/qgis-flake8.cfg
+++ b/packaging/qgis-flake8.cfg
@@ -8,3 +8,15 @@ extend-ignore =
     # qfit uses operator-leading continuation lines throughout the plugin.
     # Treat those as style-neutral in the packaged qgis.org scan.
     W503
+per-file-ignores =
+    # These modules deliberately initialize logging, optional dependencies, or
+    # compatibility helpers before importing QGIS/plugin modules.
+    */activities/application/fetch_task.py: E402
+    */activities/infrastructure/geopackage/gpkg_writer.py: E402
+    */atlas/export_service.py: E402
+    */atlas/export_task.py: E402
+    */providers/infrastructure/strava_client.py: E402
+    qfit_dockwidget.py: E402
+    */visualization/infrastructure/background_map_service.py: E402
+    */visualization/infrastructure/layer_style_service.py: E402
+    */visualization/infrastructure/qgis_layer_gateway.py: E402

--- a/tests/test_package_plugin.py
+++ b/tests/test_package_plugin.py
@@ -21,6 +21,25 @@ _SPEC.loader.exec_module(package_plugin)
 
 
 class PackagePluginTests(unittest.TestCase):
+    def test_packaged_flake8_config_documents_qgis_import_bootstrap_ignores(self):
+        config = package_plugin.PACKAGED_FLAKE8_CONFIG.read_text(encoding="utf-8")
+
+        expected_e402_ignores = (
+            "*/activities/application/fetch_task.py: E402",
+            "*/activities/infrastructure/geopackage/gpkg_writer.py: E402",
+            "*/atlas/export_service.py: E402",
+            "*/atlas/export_task.py: E402",
+            "*/providers/infrastructure/strava_client.py: E402",
+            "qfit_dockwidget.py: E402",
+            "*/visualization/infrastructure/background_map_service.py: E402",
+            "*/visualization/infrastructure/layer_style_service.py: E402",
+            "*/visualization/infrastructure/qgis_layer_gateway.py: E402",
+        )
+
+        self.assertIn("per-file-ignores =", config)
+        for expected_ignore in expected_e402_ignores:
+            self.assertIn(expected_ignore, config)
+
     def test_should_include_excludes_packaging_noise_directories(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_package_plugin.py
+++ b/tests/test_package_plugin.py
@@ -66,7 +66,11 @@ class PackagePluginTests(unittest.TestCase):
             (root / "packaging").mkdir()
             packaged_flake8_config = root / "packaging" / "qgis-flake8.cfg"
             packaged_flake8_config.write_text(
-                "[flake8]\nextend-exclude = vendor/*\nextend-ignore = W503\n",
+                "[flake8]\n"
+                "extend-exclude = vendor/*\n"
+                "extend-ignore = W503\n"
+                "per-file-ignores =\n"
+                "    qfit_dockwidget.py: E402\n",
                 encoding="utf-8",
             )
             (root / "validation").mkdir()
@@ -95,6 +99,7 @@ class PackagePluginTests(unittest.TestCase):
             self.assertNotIn("qfit/packaging/qgis-flake8.cfg", names)
             self.assertIn("extend-exclude = vendor/*", packaged_config)
             self.assertIn("extend-ignore = W503", packaged_config)
+            self.assertIn("qfit_dockwidget.py: E402", packaged_config)
             self.assertFalse(any(name.startswith("qfit/tests/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.pytest_cache/") for name in names))
             self.assertFalse(any(name.startswith("qfit/.venv/") for name in names))


### PR DESCRIPTION
## Summary

- Add packaged Flake8 per-file ignores for QGIS/runtime import-order bootstrap modules.
- Keep the rule scoped to the current `E402` files instead of rewriting compatibility-heavy imports.
- Extend the package test so the shipped `.flake8` keeps the intentional rule.

## Verification

- `pytest tests/test_package_plugin.py`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`

Latest packaged scan state after this slice:

- Bandit: clean
- detect-secrets: clean
- Flake8: findings remain
- Remaining Flake8 categories: `E501`: 43

Refs #1408
