### PR TITLE
chore: wrap activity route E501 lines

### DIFF
--- a/activities/domain/activity_query.py
+++ b/activities/domain/activity_query.py
@@ -121,7 +121,14 @@ def filter_activities(activities: Iterable[object], query: ActivityQuery) -> lis
 
 
 def sort_activities(activities: Sequence[object]) -> list[object]:
-    return sorted(activities, key=lambda activity: (_sort_datetime(activity) or datetime.min, (getattr(activity, "name", None) or "").casefold()), reverse=True)
+    return sorted(
+        activities,
+        key=lambda activity: (
+            _sort_datetime(activity) or datetime.min,
+            (getattr(activity, "name", None) or "").casefold(),
+        ),
+        reverse=True,
+    )
 
 
 def summarize_activities(activities: Sequence[object]) -> ActivitySummary:
@@ -162,7 +169,11 @@ def summarize_activities(activities: Sequence[object]) -> ActivitySummary:
 def build_preview_lines(activities: Sequence[object], limit: int = 8) -> list[str]:
     lines = []
     for activity in list(activities)[: max(limit, 0)]:
-        date_label = _activity_date(activity).isoformat() if _activity_date(activity) is not None else "unknown date"
+        date_label = (
+            _activity_date(activity).isoformat()
+            if _activity_date(activity) is not None
+            else "unknown date"
+        )
         activity_type = canonical_activity_label(
             getattr(activity, "activity_type", None),
             getattr(activity, "sport_type", None),
@@ -172,7 +183,10 @@ def build_preview_lines(activities: Sequence[object], limit: int = 8) -> list[st
         moving_time_label = format_duration(getattr(activity, "moving_time_s", None))
         detail_label = "detailed" if getattr(activity, "geometry_source", None) == "stream" else "summary"
         name = getattr(activity, "name", None) or "Untitled activity"
-        lines.append(f"{date_label} — {name} · {activity_type} · {distance_label} · {moving_time_label} · {detail_label}")
+        lines.append(
+            f"{date_label} — {name} · {activity_type} · "
+            f"{distance_label} · {moving_time_label} · {detail_label}"
+        )
     return lines
 
 
@@ -195,7 +209,10 @@ def build_subset_string(query: ActivityQuery) -> str:
         clauses.append(f'"distance_m" <= {query.max_distance_km * 1000.0}')
     if query.search_text:
         search_text = _escape_sql_literal(query.search_text.lower())
-        search_clauses = [f"lower(coalesce(\"{field_name}\", '')) LIKE '%{search_text}%'" for field_name in ("name", *reversed(ACTIVITY_LABEL_FIELDS))]
+        search_clauses = [
+            f"lower(coalesce(\"{field_name}\", '')) LIKE '%{search_text}%'"
+            for field_name in ("name", *reversed(ACTIVITY_LABEL_FIELDS))
+        ]
         clauses.append(f"({' OR '.join(search_clauses)})")
     if query.detailed_route_filter == DETAILED_ROUTE_FILTER_PRESENT:
         clauses.append("LOWER(COALESCE(\"geometry_source\", '')) = 'stream'")

--- a/activities/infrastructure/geopackage/route_storage.py
+++ b/activities/infrastructure/geopackage/route_storage.py
@@ -185,7 +185,10 @@ class GeoPackageRouteStore:
                     summary_polyline=record.get("summary_polyline"),
                     geometry_source=record.get("geometry_source"),
                     geometry_points=record.get("geometry_points") or [],
-                    profile_points=[self._profile_point_from_mapping(point) for point in record.get("profile_points") or []],
+                    profile_points=[
+                        self._profile_point_from_mapping(point)
+                        for point in record.get("profile_points") or []
+                    ],
                     details_json=record.get("details_json") or {},
                 )
             )
@@ -231,7 +234,10 @@ class GeoPackageRouteStore:
         }
 
         if incoming_ids:
-            cursor.execute("CREATE TEMP TABLE IF NOT EXISTS incoming_route_sync_ids (source_route_id TEXT PRIMARY KEY)")
+            cursor.execute(
+                "CREATE TEMP TABLE IF NOT EXISTS incoming_route_sync_ids "
+                "(source_route_id TEXT PRIMARY KEY)"
+            )
             cursor.execute("DELETE FROM incoming_route_sync_ids")
             cursor.executemany(
                 "INSERT INTO incoming_route_sync_ids (source_route_id) VALUES (?)",
@@ -287,7 +293,10 @@ class GeoPackageRouteStore:
             "summary_polyline": record.get("summary_polyline"),
             "geometry_source": record.get("geometry_source"),
             "geometry_points_json": json.dumps(record.get("geometry_points") or [], sort_keys=True),
-            "profile_points_json": json.dumps(self._profile_points_as_mappings(record.get("profile_points") or []), sort_keys=True),
+            "profile_points_json": json.dumps(
+                self._profile_points_as_mappings(record.get("profile_points") or []),
+                sort_keys=True,
+            ),
             "details_json": json.dumps(record.get("details_json") or {}, sort_keys=True),
             "summary_hash": summary_hash,
             "first_seen_at": first_seen_at,
@@ -339,7 +348,11 @@ class GeoPackageRouteStore:
                     "lon": round(float(mapping.get("lon")), 7),
                     "distance_m": round(float(mapping.get("distance_m") or 0.0), 3),
                     "segment_index": int(mapping.get("segment_index") or 0),
-                    "altitude_m": None if mapping.get("altitude_m") is None else round(float(mapping.get("altitude_m")), 3),
+                    "altitude_m": (
+                        None
+                        if mapping.get("altitude_m") is None
+                        else round(float(mapping.get("altitude_m")), 3)
+                    ),
                 }
             )
         return stable


### PR DESCRIPTION
## Summary

Wrap the remaining packaged `E501` findings in the first-party activity query and route storage modules.

This is a mechanical cleanup slice for #1408. It keeps the existing expressions and SQL text intact while splitting long comprehensions, f-strings, calls, and ternaries so the qgis.org-shaped packaged Flake8 scan no longer reports these files.

## Validation

- `python3 -m pytest tests/test_activity_query.py tests/test_route_storage.py`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`

The local venv does not currently have pytest installed, so the focused tests were run with the system Python test environment.
