### PR TITLE
chore: wrap visualization E501 lines

### DIFF
--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -213,7 +213,12 @@ class LayerStyleService:
             categories.append(QgsRendererCategory(value, symbol, value or "Unknown"))
 
         renderer = QgsCategorizedSymbolRenderer(field_name, categories)
-        renderer.setSourceSymbol(self._build_line_symbol(resolve_activity_color(OTHER_ACTIVITY_LABEL, basemap_preset_name), line_style))
+        renderer.setSourceSymbol(
+            self._build_line_symbol(
+                resolve_activity_color(OTHER_ACTIVITY_LABEL, basemap_preset_name),
+                line_style,
+            )
+        )
         layer.setRenderer(renderer)
         layer.setOpacity(line_style.opacity)
         layer.triggerRepaint()

--- a/visualization/infrastructure/map_canvas_service.py
+++ b/visualization/infrastructure/map_canvas_service.py
@@ -53,7 +53,12 @@ class MapCanvasService:
         project.setCrs(working_crs)
         if canvas is not None:
             canvas.setDestinationCrs(working_crs)
-            if preserve_extent and current_extent is not None and current_crs.isValid() and not current_extent.isEmpty():
+            if (
+                preserve_extent
+                and current_extent is not None
+                and current_crs.isValid()
+                and not current_extent.isEmpty()
+            ):
                 transform = QgsCoordinateTransform(current_crs, working_crs, project)
                 try:
                     transformed = transform.transformBoundingBox(current_extent)

--- a/visualization/infrastructure/qgis_layer_gateway.py
+++ b/visualization/infrastructure/qgis_layer_gateway.py
@@ -139,7 +139,15 @@ class QgisLayerGateway:
         except (AttributeError, RuntimeError, TypeError):
             return False
 
-    def ensure_background_layer(self, enabled, preset_name, access_token, style_owner="", style_id="", tile_mode=TILE_MODE_RASTER):
+    def ensure_background_layer(
+        self,
+        enabled,
+        preset_name,
+        access_token,
+        style_owner="",
+        style_id="",
+        tile_mode=TILE_MODE_RASTER,
+    ):
         return self._get_background_service().ensure_background_layer(
             enabled=enabled,
             preset_name=preset_name,
@@ -149,7 +157,18 @@ class QgisLayerGateway:
             tile_mode=tile_mode,
         )
 
-    def apply_filters(self, layer, activity_type=None, date_from=None, date_to=None, min_distance_km=None, max_distance_km=None, search_text=None, detailed_only=False, detailed_route_filter=None):
+    def apply_filters(
+        self,
+        layer,
+        activity_type=None,
+        date_from=None,
+        date_to=None,
+        min_distance_km=None,
+        max_distance_km=None,
+        search_text=None,
+        detailed_only=False,
+        detailed_route_filter=None,
+    ):
         self._get_filter_service().apply_filters(
             layer,
             activity_type=activity_type,


### PR DESCRIPTION
## Summary

Wrap the remaining packaged `E501` findings in visualization infrastructure modules.

This is a mechanical cleanup slice for #1408. It only splits long method signatures, a renderer symbol call, and a canvas extent condition; behavior is unchanged.

## Validation

- `python3 -m pytest tests/test_layer_gateway.py tests/test_layer_style_service.py tests/test_map_canvas_service.py`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
