### PR TITLE
chore: wrap remaining packaged flake8 lines

### DIFF
--- a/activities/application/sync_controller.py
+++ b/activities/application/sync_controller.py
@@ -358,7 +358,8 @@ class SyncController:
             )
         return (
             "Fetched {activity_count} activities from {source}, detailed tracks: {detailed_count}, "
-            "cached streams: {cached}, downloaded streams: {downloaded}, rate-limit skips: {skipped}{progress}.{rate_note}{fetch_notice}"
+            "cached streams: {cached}, downloaded streams: {downloaded}, rate-limit skips: "
+            "{skipped}{progress}.{rate_note}{fetch_notice}"
         ).format(
             activity_count=activity_count,
             source=provider.source_name,

--- a/atlas/qgis_export_runtime.py
+++ b/atlas/qgis_export_runtime.py
@@ -13,7 +13,8 @@ class QgisAtlasExportRuntime(AtlasExportRuntime):
         except ImportError:
             return (
                 "Atlas PDF export requires the bundled 'pypdf' runtime for qfit's current PDF assembly pipeline. "
-                "Install qfit with scripts/install_plugin.py --mode copy or use the packaged plugin zip so runtime dependencies are vendored."
+                "Install qfit with scripts/install_plugin.py --mode copy or use the packaged plugin zip so "
+                "runtime dependencies are vendored."
             )
         return None
 

--- a/configuration/application/dock_settings_bindings.py
+++ b/configuration/application/dock_settings_bindings.py
@@ -17,7 +17,12 @@ def build_dock_settings_bindings(dock) -> list[UIFieldBinding]:
     """
 
     return [
-        UIFieldBinding("output_path", dock._default_output_path(), lambda: dock.outputPathLineEdit.text().strip(), dock.outputPathLineEdit.setText),
+        UIFieldBinding(
+            "output_path",
+            dock._default_output_path(),
+            lambda: dock.outputPathLineEdit.text().strip(),
+            dock.outputPathLineEdit.setText,
+        ),
         UIFieldBinding(
             "write_activity_points",
             True,

--- a/mapbox_config.py
+++ b/mapbox_config.py
@@ -616,7 +616,11 @@ _ROAD_CLASS_LINE_COLOR_VARIANTS_BY_LAYER_ID = {
 }
 _ROAD_CLASS_LINE_COLOR_SUFFIXES = tuple(
     sorted(
-        {suffix for variants in _ROAD_CLASS_LINE_COLOR_VARIANTS_BY_LAYER_ID.values() for _class_value, suffix in variants},
+        {
+            suffix
+            for variants in _ROAD_CLASS_LINE_COLOR_VARIANTS_BY_LAYER_ID.values()
+            for _class_value, suffix in variants
+        },
         key=len,
         reverse=True,
     )
@@ -768,7 +772,8 @@ _ROAD_LABEL_FILTER_ZOOM_BANDS: tuple[tuple[str, float | None, float | None, obje
     (_ROAD_LABEL_HIGH_ZOOM_SUFFIX, 15.0, None, _ROAD_LABEL_HIGH_ZOOM_CLASS_FILTER),
 )
 _ROAD_LABEL_FILTER_ZOOM_VARIANT_IDS = {
-    f"{_ROAD_LABEL_LAYER_ID}-{suffix}" for suffix, _band_minzoom, _band_maxzoom, _class_filter in _ROAD_LABEL_FILTER_ZOOM_BANDS
+    f"{_ROAD_LABEL_LAYER_ID}-{suffix}"
+    for suffix, _band_minzoom, _band_maxzoom, _class_filter in _ROAD_LABEL_FILTER_ZOOM_BANDS
 }
 _ROAD_LABEL_HIGH_ZOOM_SYMBOL_SPACING = 400.0
 _ROAD_LABEL_HIGH_ZOOM_TEXT_COLOR = "hsl(0, 0%, 38%)"
@@ -972,7 +977,13 @@ _SETTLEMENT_DOT_ICON_IMAGE_EXPRESSION = [
     _SETTLEMENT_DOT_ICON_SPLIT_ZOOM,
     "",
 ]
-_SETTLEMENT_DOT_TEXT_ANCHOR_EXPRESSION = ["step", ["zoom"], ["get", "text_anchor"], _SETTLEMENT_DOT_ICON_SPLIT_ZOOM, "center"]
+_SETTLEMENT_DOT_TEXT_ANCHOR_EXPRESSION = [
+    "step",
+    ["zoom"],
+    ["get", "text_anchor"],
+    _SETTLEMENT_DOT_ICON_SPLIT_ZOOM,
+    "center",
+]
 _SETTLEMENT_DOT_TEXT_RADIAL_OFFSET_EXPRESSION = [
     "step",
     ["zoom"],
@@ -2853,12 +2864,16 @@ def _is_country_label_layer_id(layer_id: object) -> bool:
 
 def _is_settlement_major_label_layer_id(layer_id: object) -> bool:
     normalized = str(layer_id or "")
-    return normalized == _SETTLEMENT_MAJOR_LABEL_LAYER_ID or normalized.startswith(f"{_SETTLEMENT_MAJOR_LABEL_LAYER_ID}-")
+    return normalized == _SETTLEMENT_MAJOR_LABEL_LAYER_ID or normalized.startswith(
+        f"{_SETTLEMENT_MAJOR_LABEL_LAYER_ID}-"
+    )
 
 
 def _is_settlement_minor_label_layer_id(layer_id: object) -> bool:
     normalized = str(layer_id or "")
-    return normalized == _SETTLEMENT_MINOR_LABEL_LAYER_ID or normalized.startswith(f"{_SETTLEMENT_MINOR_LABEL_LAYER_ID}-")
+    return normalized == _SETTLEMENT_MINOR_LABEL_LAYER_ID or normalized.startswith(
+        f"{_SETTLEMENT_MINOR_LABEL_LAYER_ID}-"
+    )
 
 
 def _landcover_fill_opacity_base_layer_id(layer_id: object) -> str | None:
@@ -6936,7 +6951,11 @@ def build_mapbox_vector_tiles_url(
     token, owner, resolved_style_id = _validated_mapbox_style_parts(access_token, style_owner, style_id)
 
     if tileset_ids:
-        joined_tilesets = ",".join(quote(tileset_id.strip(), safe=".,-_") for tileset_id in tileset_ids if tileset_id.strip())
+        joined_tilesets = ",".join(
+            quote(tileset_id.strip(), safe=".,-_")
+            for tileset_id in tileset_ids
+            if tileset_id.strip()
+        )
     else:
         joined_tilesets = "{owner}.{style_id}".format(
             owner=quote(owner, safe=""),

--- a/providers/infrastructure/strava_client.py
+++ b/providers/infrastructure/strava_client.py
@@ -1019,7 +1019,8 @@ class StravaClient:
         long_remaining = rate_limit.get("long_remaining")
         guidance = self._rate_limit_retry_guidance(rate_limit)
         return (
-            "Stopped early to avoid hitting the Strava rate limit. Remaining read quota: short={short}, long={long}. {guidance}"
+            "Stopped early to avoid hitting the Strava rate limit. Remaining read quota: "
+            "short={short}, long={long}. {guidance}"
         ).format(
             short=short_remaining if short_remaining is not None else "?",
             long=long_remaining if long_remaining is not None else "?",
@@ -1035,7 +1036,9 @@ class StravaClient:
         short_remaining = rate_limit.get("short_remaining")
         long_remaining = rate_limit.get("long_remaining")
         return (
-            "{operation} hit the Strava rate limit (read limit {short_limit}/15 min, {long_limit}/day; remaining short={short_remaining}, long={long_remaining}). {guidance}"
+            "{operation} hit the Strava rate limit (read limit {short_limit}/15 min, "
+            "{long_limit}/day; remaining short={short_remaining}, long={long_remaining}). "
+            "{guidance}"
         ).format(
             operation=operation,
             short_limit=short_limit if short_limit is not None else "?",

--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -126,7 +126,8 @@ class QfitConfigDialog(QDialog):
         form.addRow("Redirect URI:", self._redirect_uri_edit)
 
         self._oauth_help_label = QLabel(
-            "Use qfit's OAuth helper below to generate the refresh token. Do not paste the token shown on the Strava API application page."
+            "Use qfit's OAuth helper below to generate the refresh token. Do not paste the token shown on "
+            "the Strava API application page."
         )
         self._oauth_help_label.setObjectName("stravaOAuthHelpLabel")
         self._oauth_help_label.setWordWrap(True)
@@ -280,7 +281,10 @@ class QfitConfigDialog(QDialog):
                     clipboard.setText(url)
                 self._show_info(
                     "Open Strava authorize page manually",
-                    "qfit could not open the browser automatically. The authorization URL was copied to your clipboard.\n\nOpen this URL in a browser and continue the flow there:\n\n{url}".format(
+                    (
+                        "qfit could not open the browser automatically. The authorization URL was copied "
+                        "to your clipboard.\n\nOpen this URL in a browser and continue the flow there:\n\n{url}"
+                    ).format(
                         url=url
                     ),
                 )
@@ -289,7 +293,8 @@ class QfitConfigDialog(QDialog):
                 )
                 return
             self._strava_oauth_status_label.setText(
-                "Strava authorization opened in your browser. Approve access, copy the returned code, then paste it here and click Exchange code."
+                "Strava authorization opened in your browser. Approve access, copy the returned code, "
+                "then paste it here and click Exchange code."
             )
         except ProviderError as exc:
             self._show_error("Strava authorization failed", str(exc))

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -1428,7 +1428,10 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             return
         current_value = self.activityTypeComboBox.currentText() or "All"
         try:
-            field_names = [self.activities_layer.fields().at(i).name() for i in range(self.activities_layer.fields().count())]
+            field_names = [
+                self.activities_layer.fields().at(i).name()
+                for i in range(self.activities_layer.fields().count())
+            ]
             result = build_activity_type_options_from_records(
                 self.activities_layer.getFeatures(),
                 field_names,


### PR DESCRIPTION
## Summary

- Wrap the remaining packaged `E501` findings across first-party qfit modules.
- Keep the changes mechanical: split long string literals, comprehensions, and calls without changing behavior.
- Leave vendored `pypdf` untouched and avoid new scanner ignores.

Closes part of #1408.

## Verification

- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
- `.venv/bin/python -m compileall -q activities/application/sync_controller.py atlas/qgis_export_runtime.py configuration/application/dock_settings_bindings.py mapbox_config.py providers/infrastructure/strava_client.py qfit_config_dialog.py qfit_dockwidget.py`
- `.venv/bin/python -m unittest tests.test_qgis_atlas_export_runtime tests.test_dock_settings_bindings tests.test_mapbox_config tests.test_strava_client tests.test_config_dialog tests.test_activity_type_options -v`
- `.venv/bin/python - <<'PY' ... tests.test_sync_controller with a minimal qgis.core.QgsTask stub ... PY`

Note: local `.venv/bin/python -m pytest ...` is unavailable because this venv does not have `pytest` installed.
