### PR TITLE
Prepare QGIS 0.51.0 release

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.50.1
+version=0.51.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/scripts/package_plugin.py
+++ b/scripts/package_plugin.py
@@ -117,7 +117,7 @@ def _vendor_runtime_dependencies(plugin_dir: pathlib.Path) -> None:
 def _copy_packaged_flake8_config(plugin_dir: pathlib.Path) -> None:
     if not PACKAGED_FLAKE8_CONFIG.is_file():
         raise RuntimeError(f"Packaged Flake8 config not found: {PACKAGED_FLAKE8_CONFIG}")
-    shutil.copy2(PACKAGED_FLAKE8_CONFIG, plugin_dir / ".flake8")
+    shutil.copy2(PACKAGED_FLAKE8_CONFIG, plugin_dir / "setup.cfg")
 
 
 def _build_staging_tree(plugin_name: str) -> pathlib.Path:

--- a/scripts/run_plugin_security_scan.py
+++ b/scripts/run_plugin_security_scan.py
@@ -170,9 +170,10 @@ def _flake8_command(plugin_root: Path) -> list[str]:
         "--max-line-length=120",
         "--select=E,F,W",
     ]
-    flake8_config = plugin_root / ".flake8"
-    if flake8_config.is_file():
-        command.extend(["--config", str(flake8_config)])
+    flake8_configs = (plugin_root / ".flake8", plugin_root / "setup.cfg")
+    packaged_config = next((path for path in flake8_configs if path.is_file()), None)
+    if packaged_config is not None:
+        command.extend(["--config", str(packaged_config)])
     else:
         command.append("--isolated")
     command.append(str(plugin_root))

--- a/tests/test_package_plugin.py
+++ b/tests/test_package_plugin.py
@@ -108,13 +108,14 @@ class PackagePluginTests(unittest.TestCase):
             self.assertEqual(archive_path, dist / "qfit-1.2.3.zip")
             with zipfile.ZipFile(archive_path) as archive:
                 names = set(archive.namelist())
-                packaged_config = archive.read("qfit/.flake8").decode("utf-8")
+                packaged_config = archive.read("qfit/setup.cfg").decode("utf-8")
 
             self.assertIn("qfit/metadata.txt", names)
             self.assertIn("qfit/__init__.py", names)
             self.assertIn("qfit/core.py", names)
             self.assertIn("qfit/.bandit", names)
-            self.assertIn("qfit/.flake8", names)
+            self.assertIn("qfit/setup.cfg", names)
+            self.assertNotIn("qfit/.flake8", names)
             self.assertNotIn("qfit/packaging/qgis-flake8.cfg", names)
             self.assertIn("extend-exclude = vendor/*", packaged_config)
             self.assertIn("extend-ignore = W503", packaged_config)

--- a/tests/test_plugin_security_scan.py
+++ b/tests/test_plugin_security_scan.py
@@ -164,6 +164,23 @@ class BuildScanCommandsTests(unittest.TestCase):
             self.assertIn(str(config), flake8_entry[1])
             self.assertNotIn("--isolated", flake8_entry[1])
 
+    def test_flake8_command_uses_packaged_setup_cfg_when_present(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plugin_root = Path(temp_dir) / "qfit"
+            plugin_root.mkdir()
+            config = plugin_root / "setup.cfg"
+            config.write_text("[flake8]\n", encoding="utf-8")
+
+            commands = plugin_security_scan.build_scan_commands(
+                plugin_root,
+                Path(temp_dir) / "reports",
+            )
+
+            flake8_entry = next(command for command in commands if command[0] == "flake8")
+            self.assertIn("--config", flake8_entry[1])
+            self.assertIn(str(config), flake8_entry[1])
+            self.assertNotIn("--isolated", flake8_entry[1])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Bump the QGIS plugin metadata version to `0.51.0`.
- Package the qgis.org-shaped Flake8 configuration as `setup.cfg` instead of `.flake8` so the release keeps the intentional Flake8 exclusions without reintroducing a hidden Flake8 dotfile.
- Teach the local packaged plugin scanner to honor packaged `setup.cfg` and cover that behavior with tests.

## Validation

- `python3 -m pytest tests/test_package_plugin.py tests/test_plugin_security_scan.py -q`
- `python3 -m pytest tests/ -x -q`
- `/tmp/qfit-release-scan-venv/bin/python scripts/run_plugin_security_scan.py`
- Inspected `dist/qfit-0.51.0.zip` metadata and contents: version is `0.51.0`, `setup.cfg` is present, `.flake8` is absent, vendored `pypdf` is present, and tests/debug/cache files are absent.

Closes #1408 after manual Windows QGIS validation passes.
