### PR TITLE
[codex] clarify activity storage selection

### DIFF
--- a/activities/application/load_workflow.py
+++ b/activities/application/load_workflow.py
@@ -4,6 +4,7 @@ import sqlite3
 from dataclasses import dataclass, field
 from typing import Callable
 
+from .storage_selection import default_has_qfit_schema
 from ...atlas.publish_atlas import (
     DEFAULT_ATLAS_MARGIN_PERCENT,
     DEFAULT_ATLAS_TARGET_ASPECT_RATIO,
@@ -278,10 +279,12 @@ class LoadDatasetWorkflow:
         layer_gateway: LayerGateway,
         path_exists: Callable[[str], bool] | None = None,
         stored_activity_count_loader: Callable[[str], int] | None = None,
+        qfit_schema_exists: Callable[[str], bool] | None = None,
     ):
         self.layer_gateway = layer_gateway
         self._path_exists = path_exists
         self._stored_activity_count_loader = stored_activity_count_loader
+        self._qfit_schema_exists = qfit_schema_exists
 
     @staticmethod
     def build_load_existing_request(output_path) -> LoadDatasetRequest:
@@ -291,6 +294,11 @@ class LoadDatasetWorkflow:
         if self._path_exists is not None:
             return self._path_exists(output_path)
         return os.path.exists(output_path)
+
+    def _has_qfit_schema(self, output_path: str) -> bool:
+        if self._qfit_schema_exists is not None:
+            return self._qfit_schema_exists(output_path)
+        return default_has_qfit_schema(output_path)
 
     def load_existing(self, request: LoadDatasetRequest | str) -> LoadDatasetResult:
         """Load layers from an existing GeoPackage without writing.
@@ -307,6 +315,11 @@ class LoadDatasetWorkflow:
             raise LoadWorkflowError(
                 "No database found at:\n  {path}\n\n"
                 "Store activities first to create it.".format(path=request.output_path)
+            )
+        if not self._has_qfit_schema(request.output_path):
+            raise LoadWorkflowError(
+                "The selected GeoPackage does not contain qfit's activity "
+                "schema. Choose a qfit database or a new file path."
             )
 
         activities_layer, starts_layer, points_layer, atlas_layer = (

--- a/activities/application/storage_selection.py
+++ b/activities/application/storage_selection.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from dataclasses import dataclass
+from typing import Callable
+
+
+StorageIntent = str
+
+STORAGE_INTENT_NEW = "new"
+STORAGE_INTENT_EXISTING = "existing"
+STORAGE_INTENT_INVALID = "invalid"
+
+NEW_DATABASE_STATUS = "New database will be created"
+EXISTING_QFIT_DATABASE_STATUS = "Existing qfit database selected"
+NON_QFIT_GEOPACKAGE_STATUS = "Existing GeoPackage selected; qfit schema not found"
+ROUTE_ONLY_QFIT_DATABASE_STATUS = (
+    "Existing qfit database selected; store activities to add map layers"
+)
+PATH_CHANGED_STATUS = "Path changed; load stored layers to refresh the map"
+INVALID_DATABASE_PATH_STATUS = "Invalid database path"
+
+QFIT_ACTIVITY_SCHEMA_TABLE = "activity_registry"
+QFIT_ROUTE_SCHEMA_TABLE = "route_registry"
+
+
+@dataclass(frozen=True)
+class StorageSelectionResult:
+    """Validated GeoPackage storage selection rendered by the dock UI."""
+
+    normalized_path: str
+    intent: StorageIntent
+    can_load: bool
+    can_store: bool
+    status_text: str
+    validation_reason: str = ""
+
+    @property
+    def is_valid(self) -> bool:
+        return self.intent != STORAGE_INTENT_INVALID
+
+
+@dataclass(frozen=True)
+class StoragePathProbe:
+    """Filesystem and schema probes for storage-selection resolution."""
+
+    path_exists: Callable[[str], bool] = os.path.exists
+    is_file: Callable[[str], bool] = os.path.isfile
+    is_dir: Callable[[str], bool] = os.path.isdir
+    is_readable: Callable[[str], bool] = lambda path: os.access(path, os.R_OK)
+    has_qfit_schema: Callable[[str], bool] | None = None
+    has_qfit_store_schema: Callable[[str], bool] | None = None
+
+
+def normalize_storage_path(raw_path: str) -> str:
+    """Normalize committed storage text without mutating mid-edit input."""
+
+    value = (raw_path or "").strip()
+    if not value:
+        return ""
+    expanded = os.path.expanduser(value)
+    _root, extension = os.path.splitext(expanded)
+    if not extension:
+        expanded = "{path}.gpkg".format(path=expanded)
+    return os.path.normpath(expanded)
+
+
+def default_has_qfit_schema(path: str) -> bool:
+    """Return whether an existing GeoPackage has qfit's activity schema."""
+
+    return _has_any_table(path, (QFIT_ACTIVITY_SCHEMA_TABLE,))
+
+
+def default_has_qfit_store_schema(path: str) -> bool:
+    """Return whether an existing GeoPackage can be updated by qfit."""
+
+    return _has_any_table(
+        path,
+        (QFIT_ACTIVITY_SCHEMA_TABLE, QFIT_ROUTE_SCHEMA_TABLE),
+    )
+
+
+def _has_any_table(path: str, table_names: tuple[str, ...]) -> bool:
+    placeholders = ", ".join("?" for _table_name in table_names)
+
+    try:
+        with sqlite3.connect(path) as connection:
+            row = connection.execute(
+                f"""
+                SELECT 1
+                FROM sqlite_master
+                WHERE type = 'table' AND name IN ({placeholders})
+                LIMIT 1
+                """,
+                table_names,
+            ).fetchone()
+    except (OSError, sqlite3.DatabaseError):
+        return False
+    return row is not None
+
+
+def resolve_storage_selection(
+    raw_path: str,
+    *,
+    probe: StoragePathProbe | None = None,
+    loaded_dataset_path: str | None = None,
+) -> StorageSelectionResult:
+    """Classify a committed GeoPackage path for create/load/switch workflows."""
+
+    probe = probe or StoragePathProbe()
+    normalized_path = normalize_storage_path(raw_path)
+
+    initial_result = _resolve_initial_path_state(normalized_path, probe)
+    if initial_result is not None:
+        return initial_result
+
+    existing_path_error = _existing_path_error(normalized_path, probe)
+    if existing_path_error is not None:
+        return existing_path_error
+
+    return _resolve_existing_schema_state(
+        normalized_path,
+        probe,
+        loaded_dataset_path=loaded_dataset_path,
+    )
+
+
+def _resolve_initial_path_state(
+    normalized_path: str,
+    probe: StoragePathProbe,
+) -> StorageSelectionResult | None:
+    if not normalized_path:
+        return _invalid_result("", "Choose a GeoPackage path first.")
+
+    if os.path.splitext(normalized_path)[1].lower() != ".gpkg":
+        return _invalid_result(normalized_path, "Use a .gpkg GeoPackage file.")
+
+    parent_directory = os.path.dirname(normalized_path) or "."
+    if not probe.path_exists(parent_directory) or not probe.is_dir(parent_directory):
+        return _invalid_result(
+            normalized_path,
+            "The parent directory does not exist: {path}".format(
+                path=parent_directory,
+            ),
+        )
+
+    if probe.path_exists(normalized_path):
+        return None
+
+    return StorageSelectionResult(
+        normalized_path=normalized_path,
+        intent=STORAGE_INTENT_NEW,
+        can_load=False,
+        can_store=True,
+        status_text=NEW_DATABASE_STATUS,
+    )
+
+
+def _existing_path_error(
+    normalized_path: str,
+    probe: StoragePathProbe,
+) -> StorageSelectionResult | None:
+    if not probe.is_file(normalized_path):
+        return _invalid_result(normalized_path, "The selected path is not a file.")
+
+    if probe.is_readable(normalized_path):
+        return None
+
+    return _invalid_result(
+        normalized_path,
+        "The selected GeoPackage is not readable.",
+    )
+
+
+def _resolve_existing_schema_state(
+    normalized_path: str,
+    probe: StoragePathProbe,
+    *,
+    loaded_dataset_path: str | None,
+) -> StorageSelectionResult:
+
+    has_qfit_schema = probe.has_qfit_schema or default_has_qfit_schema
+    has_qfit_store_schema = (
+        probe.has_qfit_store_schema or default_has_qfit_store_schema
+    )
+    if not has_qfit_schema(normalized_path):
+        if has_qfit_store_schema(normalized_path):
+            return StorageSelectionResult(
+                normalized_path=normalized_path,
+                intent=STORAGE_INTENT_EXISTING,
+                can_load=False,
+                can_store=True,
+                status_text=ROUTE_ONLY_QFIT_DATABASE_STATUS,
+                validation_reason=(
+                    "The selected qfit database does not contain stored "
+                    "activity layers yet. Store activities first."
+                ),
+            )
+        return StorageSelectionResult(
+            normalized_path=normalized_path,
+            intent=STORAGE_INTENT_EXISTING,
+            can_load=False,
+            can_store=False,
+            status_text=NON_QFIT_GEOPACKAGE_STATUS,
+            validation_reason=(
+                "The selected GeoPackage does not contain qfit's activity "
+                "schema. Choose a qfit database or a new file path."
+            ),
+        )
+
+    loaded_dataset_path = normalize_storage_path(loaded_dataset_path or "")
+    status = EXISTING_QFIT_DATABASE_STATUS
+    if loaded_dataset_path and loaded_dataset_path != normalized_path:
+        status = PATH_CHANGED_STATUS
+
+    return StorageSelectionResult(
+        normalized_path=normalized_path,
+        intent=STORAGE_INTENT_EXISTING,
+        can_load=True,
+        can_store=True,
+        status_text=status,
+    )
+
+
+def _invalid_result(path: str, reason: str) -> StorageSelectionResult:
+    return StorageSelectionResult(
+        normalized_path=path,
+        intent=STORAGE_INTENT_INVALID,
+        can_load=False,
+        can_store=False,
+        status_text=INVALID_DATABASE_PATH_STATUS,
+        validation_reason=reason,
+    )

--- a/configuration/application/dock_settings_bindings.py
+++ b/configuration/application/dock_settings_bindings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .ui_settings_binding import UIFieldBinding
+from ...activities.application.storage_selection import normalize_storage_path
 from ...activities.domain.activity_query import DETAILED_ROUTE_FILTER_ANY
 from ...mapbox_config import DEFAULT_BACKGROUND_PRESET, TILE_MODE_RASTER
 
@@ -20,7 +21,7 @@ def build_dock_settings_bindings(dock) -> list[UIFieldBinding]:
         UIFieldBinding(
             "output_path",
             dock._default_output_path(),
-            lambda: dock.outputPathLineEdit.text().strip(),
+            lambda: normalize_storage_path(dock.outputPathLineEdit.text()),
             dock.outputPathLineEdit.setText,
         ),
         UIFieldBinding(

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.51.0
+version=0.52.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -39,6 +39,11 @@ from .activities.application.layer_summary import (
     build_stored_activities_summary,
 )
 from .activities.application.load_workflow import LoadWorkflowError
+from .activities.application.storage_selection import (
+    StorageSelectionResult,
+    normalize_storage_path,
+    resolve_storage_selection,
+)
 from .activities.application.sync_strategy import ActivitySyncMode, plan_activity_sync
 from .activities.application.store_task import build_store_task
 from .analysis.infrastructure.activity_heatmap_layer import (
@@ -125,6 +130,12 @@ def _fetch_status_for_sync_plan(status_text, sync_plan):
     return "Fetching recent activities from Strava with GeoPackage sync overlap…"
 
 
+def _storage_selection_message(result: StorageSelectionResult) -> str:
+    if result.validation_reason:
+        return result.validation_reason
+    return result.status_text
+
+
 class QfitDockWidget(QDockWidget, FORM_CLASS):
     SETTINGS_PREFIX = "qfit"
     LEGACY_SETTINGS_PREFIX = "QFIT"
@@ -183,8 +194,48 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         """Keep live local-load actions in sync with the selected GeoPackage path."""
 
         self._runtime_store().select_output_path((value or "").strip() or None)
-        self._refresh_detailed_route_coverage_from_storage()
         self._refresh_live_dock_navigation_from_runtime()
+
+    def _on_output_path_editing_finished(self) -> None:
+        """Commit typed storage-path edits once the user leaves the field."""
+
+        self._commit_output_path_selection(self.outputPathLineEdit.text())
+
+    def _commit_output_path_selection(
+        self,
+        raw_path: str,
+        *,
+        show_error: bool = False,
+    ) -> StorageSelectionResult:
+        loaded_dataset_path = None
+        if self.activities_layer is not None:
+            loaded_dataset_path = self.output_path
+        result = resolve_storage_selection(
+            raw_path,
+            loaded_dataset_path=loaded_dataset_path,
+        )
+        self._apply_storage_selection_result(result)
+        if show_error and not result.can_store:
+            self._show_error("Invalid database path", _storage_selection_message(result))
+        return result
+
+    def _apply_storage_selection_result(
+        self,
+        result: StorageSelectionResult,
+    ) -> None:
+        current_path = self.outputPathLineEdit.text().strip()
+        if result.normalized_path and result.normalized_path != current_path:
+            self.outputPathLineEdit.setText(result.normalized_path)
+        self._runtime_store().select_output_path(result.normalized_path or None)
+        if result.can_load:
+            self._refresh_detailed_route_coverage_from_storage()
+        self._set_storage_status(result.status_text)
+        self._refresh_live_dock_navigation_from_runtime()
+
+    def _set_storage_status(self, text: str) -> None:
+        label = getattr(self, "outputStatusLabel", None)
+        if label is not None:
+            label.setText(text)
 
     def _build_local_first_dock_from_runtime(self, *, parent=None):
         """Build the #748 local-first dock composition from live runtime facts.
@@ -460,6 +511,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
 
     def _wire_events(self):
         self.browseButton.clicked.connect(self.on_browse_clicked)
+        open_existing_button = getattr(self, "openExistingButton", None)
+        if open_existing_button is not None:
+            open_existing_button.clicked.connect(self.on_open_existing_clicked)
         self.refreshButton.clicked.connect(self.on_refresh_clicked)
         self.backfillMissingDetailedRoutesButton.clicked.connect(self.on_backfill_missing_detailed_routes_clicked)
         self.loadButton.clicked.connect(self.on_load_clicked)
@@ -477,6 +531,9 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         self.atlasPdfPathLineEdit.textChanged.connect(self._on_atlas_pdf_path_changed)
         self.generateAtlasPdfButton.clicked.connect(self.on_generate_atlas_pdf_clicked)
         self.outputPathLineEdit.textChanged.connect(self._on_output_path_changed)
+        editing_finished = getattr(self.outputPathLineEdit, "editingFinished", None)
+        if editing_finished is not None:
+            editing_finished.connect(self._on_output_path_editing_finished)
 
         preview_inputs = [
             self.activityTypeComboBox.currentTextChanged,
@@ -624,14 +681,22 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     def on_browse_clicked(self):
         path, _selected = QFileDialog.getSaveFileName(
             self,
-            "Choose GeoPackage output",
+            "Choose new GeoPackage",
             self.outputPathLineEdit.text(),
             "GeoPackage (*.gpkg)",
         )
         if path:
-            if not path.lower().endswith(".gpkg"):
-                path = "{path}.gpkg".format(path=path)
-            self.outputPathLineEdit.setText(path)
+            self._commit_output_path_selection(path)
+
+    def on_open_existing_clicked(self):
+        path, _selected = QFileDialog.getOpenFileName(
+            self,
+            "Open existing GeoPackage",
+            self.outputPathLineEdit.text(),
+            "GeoPackage (*.gpkg)",
+        )
+        if path:
+            self._commit_output_path_selection(path)
 
     def on_refresh_clicked(self):
         # If a fetch is already running, cancel it.
@@ -769,12 +834,19 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
             self._set_status("Store already in progress...")
             return None
 
+        storage_result = self._commit_output_path_selection(
+            self.outputPathLineEdit.text(),
+            show_error=True,
+        )
+        if not storage_result.can_store:
+            return False
+
         self._save_settings()
         workflow = self._store_activities_workflow()
         try:
             request = workflow.build_write_request(
                 activities=self.runtime_state.activities,
-                output_path=self.outputPathLineEdit.text().strip(),
+                output_path=storage_result.normalized_path,
                 write_activity_points=self.writeActivityPointsCheckBox.isChecked(),
                 point_stride=self.pointSamplingStrideSpinBox.value(),
                 sync_metadata=self.last_fetch_context,
@@ -948,11 +1020,20 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         preview_snapshot = self._activity_preview_snapshot()
         loaded_activities_layer = None
         try:
+            storage_result = self._commit_output_path_selection(
+                self.outputPathLineEdit.text(),
+            )
+            if not storage_result.can_load:
+                self._show_error(
+                    "GeoPackage cannot be loaded",
+                    _storage_selection_message(storage_result),
+                )
+                return
             self._save_settings()
             workflow = self._dataset_load_workflow_service()
             try:
                 request = workflow.build_load_existing_request(
-                    self.outputPathLineEdit.text().strip(),
+                    storage_result.normalized_path,
                 )
                 result = workflow.load_existing_request(request)
             except LoadWorkflowError as exc:

--- a/qfit_dockwidget_base.ui
+++ b/qfit_dockwidget_base.ui
@@ -145,11 +145,28 @@
              <item>
               <widget class="QPushButton" name="browseButton">
                <property name="text">
-                <string>Browse…</string>
+                <string>New GeoPackage…</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="openExistingButton">
+               <property name="text">
+                <string>Open existing…</string>
                </property>
               </widget>
              </item>
             </layout>
+           </item>
+           <item>
+            <widget class="QLabel" name="outputStatusLabel">
+             <property name="text">
+              <string>New database will be created</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
            </item>
            <item>
             <layout class="QFormLayout" name="analysisLayout">

--- a/tests/test_dock_settings_bindings.py
+++ b/tests/test_dock_settings_bindings.py
@@ -250,6 +250,15 @@ class DockSettingsBindingsTests(unittest.TestCase):
         self.assertEqual(settings.get("analysis_mode"), "Most frequent starting points")
         self.assertEqual(settings.get("style_preset"), "By activity type")
 
+    def test_save_normalizes_bare_output_path_to_geopackage(self):
+        dock = FakeDock()
+        dock.outputPathLineEdit.setText("qfit_test")
+        settings = _settings()
+
+        save_bindings(build_dock_settings_bindings(dock), settings)
+
+        self.assertEqual(settings.get("output_path"), "qfit_test.gpkg")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_load_workflow.py
+++ b/tests/test_load_workflow.py
@@ -91,7 +91,11 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
             MagicMock(name="atlas"),
         )
         layer_gateway.load_route_layers.return_value = route_layers
-        workflow = LoadDatasetWorkflow(layer_gateway, path_exists=lambda _path: True)
+        workflow = LoadDatasetWorkflow(
+            layer_gateway,
+            path_exists=lambda _path: True,
+            qfit_schema_exists=lambda _path: True,
+        )
 
         result = workflow.load_existing_request(
             workflow.build_load_existing_request("/tmp/existing.gpkg")
@@ -124,6 +128,7 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
             layer_gateway,
             path_exists=lambda _path: True,
             stored_activity_count_loader=lambda _path: 2889,
+            qfit_schema_exists=lambda _path: True,
         )
 
         result = workflow.load_existing_request(
@@ -148,6 +153,7 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
             layer_gateway,
             path_exists=lambda _path: True,
             stored_activity_count_loader=lambda _path: 0,
+            qfit_schema_exists=lambda _path: True,
         )
 
         result = workflow.load_existing_request(
@@ -173,6 +179,7 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
             stored_activity_count_loader=MagicMock(
                 side_effect=sqlite3.OperationalError("database is locked")
             ),
+            qfit_schema_exists=lambda _path: True,
         )
 
         result = workflow.load_existing_request(
@@ -201,7 +208,11 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
             "qfit.activities.application.load_workflow.SyncRepository",
             return_value=repository,
         ):
-            workflow = LoadDatasetWorkflow(layer_gateway, path_exists=lambda _path: True)
+            workflow = LoadDatasetWorkflow(
+                layer_gateway,
+                path_exists=lambda _path: True,
+                qfit_schema_exists=lambda _path: True,
+            )
             result = workflow.load_existing_request(
                 workflow.build_load_existing_request("/tmp/existing.gpkg")
             )
@@ -219,7 +230,11 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
             MagicMock(name="atlas"),
         )
         layer_gateway.load_route_layers.return_value = (None, None, None)
-        workflow = LoadDatasetWorkflow(layer_gateway, path_exists=lambda _path: True)
+        workflow = LoadDatasetWorkflow(
+            layer_gateway,
+            path_exists=lambda _path: True,
+            qfit_schema_exists=lambda _path: True,
+        )
 
         result = workflow.load_existing_request(
             workflow.build_load_existing_request("/tmp/existing.gpkg")
@@ -247,7 +262,11 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
             BrokenFeatureCountLayer(),
             None,
         )
-        workflow = LoadDatasetWorkflow(layer_gateway, path_exists=lambda _path: True)
+        workflow = LoadDatasetWorkflow(
+            layer_gateway,
+            path_exists=lambda _path: True,
+            qfit_schema_exists=lambda _path: True,
+        )
 
         result = workflow.load_existing_request(
             workflow.build_load_existing_request("/tmp/existing.gpkg")
@@ -255,6 +274,21 @@ class LoadDatasetWorkflowTests(unittest.TestCase):
 
         self.assertIn("Loaded saved route layers: 0 route tracks", result.status)
         self.assertIn("0 route points", result.status)
+
+    def test_load_existing_rejects_non_qfit_geopackage_before_layer_loading(self):
+        layer_gateway = MagicMock()
+        workflow = LoadDatasetWorkflow(
+            layer_gateway,
+            path_exists=lambda _path: True,
+            qfit_schema_exists=lambda _path: False,
+        )
+
+        with self.assertRaisesRegex(LoadWorkflowError, "qfit's activity schema"):
+            workflow.load_existing_request(
+                workflow.build_load_existing_request("/tmp/other.gpkg")
+            )
+
+        layer_gateway.load_output_layers.assert_not_called()
 
 
 class ClearDatabaseWorkflowTests(unittest.TestCase):
@@ -549,7 +583,13 @@ class LoadExistingValidationTests(unittest.TestCase):
 class LoadExistingSuccessTests(unittest.TestCase):
     def setUp(self):
         self.layer_manager = MagicMock()
-        self.service = LoadWorkflowService(self.layer_manager)
+        self.service = LoadWorkflowService(
+            self.layer_manager,
+            dataset_load_workflow=LoadDatasetWorkflow(
+                self.layer_manager,
+                qfit_schema_exists=lambda _path: True,
+            ),
+        )
 
     @patch("qfit.activities.application.load_workflow.os.path.exists", return_value=True)
     def test_returns_load_result(self, mock_exists):
@@ -718,7 +758,13 @@ class LoadRequestContractTests(unittest.TestCase):
         layer_manager = MagicMock()
         layer_manager.load_output_layers.return_value = (None, None, None, None)
         layer_manager.load_route_layers.return_value = (None, None, None)
-        service = LoadWorkflowService(layer_manager)
+        service = LoadWorkflowService(
+            layer_manager,
+            dataset_load_workflow=LoadDatasetWorkflow(
+                layer_manager,
+                qfit_schema_exists=lambda _path: True,
+            ),
+        )
 
         request = service.build_load_existing_request("/tmp/existing.gpkg")
         via_request = service.load_existing_request(request)

--- a/tests/test_local_first_control_moves.py
+++ b/tests/test_local_first_control_moves.py
@@ -90,6 +90,8 @@ class LocalFirstControlMoveTests(unittest.TestCase):
                 "storage": (
                     "outputPathLineEdit",
                     "browseButton",
+                    "openExistingButton",
+                    "outputStatusLabel",
                     "writeActivityPointsCheckBox",
                     "pointSamplingStrideSpinBox",
                 ),

--- a/tests/test_local_first_parity_audit.py
+++ b/tests/test_local_first_parity_audit.py
@@ -73,6 +73,8 @@ class LocalFirstParityAuditTests(unittest.TestCase):
             storage.required_widget_attrs,
         )
         self.assertIn("browseButton", surfaces["storage"].required_widget_attrs)
+        self.assertIn("openExistingButton", surfaces["storage"].required_widget_attrs)
+        self.assertIn("outputStatusLabel", surfaces["storage"].required_widget_attrs)
 
     def test_audit_includes_loose_widget_and_local_first_action_surfaces(self):
         surfaces = {

--- a/tests/test_qfit_dockwidget_analysis_pure.py
+++ b/tests/test_qfit_dockwidget_analysis_pure.py
@@ -264,6 +264,8 @@ class _FakeSubsetLayer:
 class _FakeLineEdit:
     def __init__(self, text=""):
         self._text = text
+        self.textChanged = _FakeSignal()
+        self.editingFinished = _FakeSignal()
 
     def text(self):
         return self._text
@@ -327,6 +329,21 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         move = local_first_control_move_for_key(key)
         for attr in move.required_widget_attrs:
             setattr(dock, attr, MagicMock(name=attr))
+
+    def _storage_selection_result(
+        self,
+        path="/tmp/qfit.gpkg",
+        *,
+        can_load=True,
+        can_store=True,
+    ):
+        return self.module.StorageSelectionResult(
+            normalized_path=path,
+            intent="existing",
+            can_load=can_load,
+            can_store=can_store,
+            status_text="Existing qfit database selected",
+        )
 
     @staticmethod
     def _import_module_with_stubs():
@@ -732,6 +749,36 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertEqual(dock.runtime_state.output_path, "/tmp/local-qfit.gpkg")
         dock._refresh_live_dock_navigation_from_runtime.assert_called_once_with()
 
+    def test_output_path_text_change_does_not_read_storage_coverage(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock._refresh_live_dock_navigation_from_runtime = MagicMock()
+        dock._refresh_detailed_route_coverage_from_storage = MagicMock()
+
+        self.module.QfitDockWidget._on_output_path_changed(
+            dock,
+            "/tmp/local-qfit.gpkg",
+        )
+
+        dock._refresh_detailed_route_coverage_from_storage.assert_not_called()
+
+    def test_output_path_commit_refreshes_existing_storage_coverage(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/local-qfit.gpkg")
+        dock.outputStatusLabel = _FakeLabel("")
+        dock._refresh_live_dock_navigation_from_runtime = MagicMock()
+        dock._refresh_detailed_route_coverage_from_storage = MagicMock()
+
+        with patch.object(
+            self.module,
+            "resolve_storage_selection",
+            return_value=self._storage_selection_result("/tmp/local-qfit.gpkg"),
+        ):
+            self.module.QfitDockWidget._on_output_path_editing_finished(dock)
+
+        dock._refresh_detailed_route_coverage_from_storage.assert_called_once_with()
+
     def test_output_path_change_clears_stale_loaded_dataset_state(self):
         dock = object.__new__(self.module.QfitDockWidget)
         dock._runtime_state_store = self.module.DockRuntimeStore()
@@ -751,6 +798,65 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         self.assertIsNone(dock.runtime_state.stored_activity_count)
         self.assertIsNone(dock.runtime_state.activities_layer)
         dock._refresh_live_dock_navigation_from_runtime.assert_called_once_with()
+
+    def test_on_browse_clicked_uses_save_dialog_for_new_geopackage(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/old.gpkg")
+        dock.outputStatusLabel = _FakeLabel("")
+        dock._refresh_live_dock_navigation_from_runtime = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            selected_path = "{directory}/qfit_test".format(directory=tmpdir)
+            with patch.object(
+                self.module.QFileDialog,
+                "getSaveFileName",
+                return_value=(selected_path, "GeoPackage (*.gpkg)"),
+                create=True,
+            ) as save_dialog, patch.object(
+                self.module.QFileDialog,
+                "getOpenFileName",
+                create=True,
+            ) as open_dialog:
+                self.module.QfitDockWidget.on_browse_clicked(dock)
+
+        save_dialog.assert_called_once()
+        self.assertEqual(save_dialog.call_args.args[1], "Choose new GeoPackage")
+        open_dialog.assert_not_called()
+        self.assertTrue(dock.outputPathLineEdit.text().endswith("qfit_test.gpkg"))
+        self.assertEqual(dock.outputStatusLabel.text(), "New database will be created")
+
+    def test_on_open_existing_clicked_uses_open_dialog_for_qfit_geopackage(self):
+        dock = object.__new__(self.module.QfitDockWidget)
+        dock._runtime_state_store = self.module.DockRuntimeStore()
+        dock.outputPathLineEdit = _FakeLineEdit("/tmp/old.gpkg")
+        dock.outputStatusLabel = _FakeLabel("")
+        dock._refresh_live_dock_navigation_from_runtime = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            selected_path = "{directory}/existing.gpkg".format(directory=tmpdir)
+            with sqlite3.connect(selected_path) as connection:
+                connection.execute("CREATE TABLE activity_registry (id TEXT)")
+            with patch.object(
+                self.module.QFileDialog,
+                "getOpenFileName",
+                return_value=(selected_path, "GeoPackage (*.gpkg)"),
+                create=True,
+            ) as open_dialog, patch.object(
+                self.module.QFileDialog,
+                "getSaveFileName",
+                create=True,
+            ) as save_dialog:
+                self.module.QfitDockWidget.on_open_existing_clicked(dock)
+
+        open_dialog.assert_called_once()
+        self.assertEqual(open_dialog.call_args.args[1], "Open existing GeoPackage")
+        save_dialog.assert_not_called()
+        self.assertEqual(dock.outputPathLineEdit.text(), selected_path)
+        self.assertEqual(
+            dock.outputStatusLabel.text(),
+            "Existing qfit database selected",
+        )
 
     def test_local_first_progress_facts_reflect_existing_visible_geopackage_path(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -1022,6 +1128,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.syncRoutesButton = SimpleNamespace(clicked=_FakeSignal())
         dock.loadLayersButton = SimpleNamespace(clicked=_FakeSignal())
         dock.clearDatabaseButton = SimpleNamespace(clicked=_FakeSignal())
+        dock.openExistingButton = SimpleNamespace(clicked=_FakeSignal())
         dock.applyFiltersButton = SimpleNamespace(clicked=_FakeSignal())
         dock.runAnalysisButton = SimpleNamespace(clicked=_FakeSignal())
         dock.loadBackgroundButton = SimpleNamespace(clicked=_FakeSignal())
@@ -1033,7 +1140,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.atlasPdfBrowseButton = SimpleNamespace(clicked=_FakeSignal())
         dock.atlasPdfPathLineEdit = SimpleNamespace(textChanged=_FakeSignal())
         dock.generateAtlasPdfButton = SimpleNamespace(clicked=_FakeSignal())
-        dock.outputPathLineEdit = SimpleNamespace(textChanged=_FakeSignal())
+        dock.outputPathLineEdit = SimpleNamespace(
+            textChanged=_FakeSignal(),
+            editingFinished=_FakeSignal(),
+        )
         dock.activityTypeComboBox = SimpleNamespace(currentTextChanged=_FakeSignal())
         dock.activitySearchLineEdit = SimpleNamespace(textChanged=_FakeSignal())
         dock.dateFromEdit = SimpleNamespace(dateChanged=_FakeSignal())
@@ -1045,6 +1155,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         )
         for name in (
             "on_browse_clicked",
+            "on_open_existing_clicked",
             "on_refresh_clicked",
             "on_backfill_missing_detailed_routes_clicked",
             "on_load_clicked",
@@ -1060,6 +1171,7 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
             "on_generate_atlas_pdf_clicked",
             "_update_connection_status",
             "_on_output_path_changed",
+            "_on_output_path_editing_finished",
             "_refresh_activity_preview",
         ):
             setattr(dock, name, MagicMock(name=name))
@@ -2868,9 +2980,10 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         self.assertFalse(started)
         dock._show_error.assert_called_once_with(
-            "Missing input",
-            "Choose a GeoPackage output path first.",
+            "Invalid database path",
+            "Choose a GeoPackage path first.",
         )
+        dock.load_workflow.build_write_request.assert_not_called()
 
     def test_start_store_activities_returns_false_for_write_request_error(self):
         dock = object.__new__(self.module.QfitDockWidget)
@@ -2921,7 +3034,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.dataset_load_workflow = workflow
         self.module.QTimer.singleShot.reset_mock()
 
-        self.module.QfitDockWidget.on_load_layers_clicked(dock)
+        with patch.object(
+            self.module,
+            "resolve_storage_selection",
+            return_value=self._storage_selection_result(),
+        ):
+            self.module.QfitDockWidget.on_load_layers_clicked(dock)
 
         self.assertEqual(dock.output_path, "/tmp/qfit.gpkg")
         self.assertEqual(dock.activities_layer, "activities-layer")
@@ -2974,7 +3092,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         workflow.load_existing_request.return_value = result
         dock.dataset_load_workflow = workflow
 
-        self.module.QfitDockWidget.on_load_layers_clicked(dock)
+        with patch.object(
+            self.module,
+            "resolve_storage_selection",
+            return_value=self._storage_selection_result(),
+        ):
+            self.module.QfitDockWidget.on_load_layers_clicked(dock)
 
         self.assertEqual(dock.querySummaryLabel.text(), "6 recent activities")
         self.assertEqual(
@@ -3008,7 +3131,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
         dock.dataset_load_workflow = workflow
         self.module.QTimer.singleShot.reset_mock()
 
-        self.module.QfitDockWidget.on_load_layers_clicked(dock)
+        with patch.object(
+            self.module,
+            "resolve_storage_selection",
+            return_value=self._storage_selection_result(),
+        ):
+            self.module.QfitDockWidget.on_load_layers_clicked(dock)
 
         dock.layer_gateway.zoom_to_layers.assert_not_called()
         self.module.QTimer.singleShot.assert_called_once()
@@ -3065,7 +3193,12 @@ class TestQfitDockWidgetAnalysisPure(unittest.TestCase):
 
         try:
             with patch.object(self.module.QgsProject, "instance", return_value=project):
-                self.module.QfitDockWidget.on_load_layers_clicked(dock)
+                with patch.object(
+                    self.module,
+                    "resolve_storage_selection",
+                    return_value=self._storage_selection_result(),
+                ):
+                    self.module.QfitDockWidget.on_load_layers_clicked(dock)
 
                 self.assertEqual(events, ["visual", ("restore", user_crs)])
                 project.setCrs.assert_called_once_with(user_crs)

--- a/tests/test_storage_selection.py
+++ b/tests/test_storage_selection.py
@@ -1,0 +1,130 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.activities.application.storage_selection import (
+    EXISTING_QFIT_DATABASE_STATUS,
+    NON_QFIT_GEOPACKAGE_STATUS,
+    PATH_CHANGED_STATUS,
+    ROUTE_ONLY_QFIT_DATABASE_STATUS,
+    STORAGE_INTENT_EXISTING,
+    STORAGE_INTENT_INVALID,
+    STORAGE_INTENT_NEW,
+    StoragePathProbe,
+    normalize_storage_path,
+    resolve_storage_selection,
+)
+
+
+class StorageSelectionTests(unittest.TestCase):
+    def test_empty_path_is_invalid(self):
+        result = resolve_storage_selection("")
+
+        self.assertEqual(result.intent, STORAGE_INTENT_INVALID)
+        self.assertFalse(result.can_load)
+        self.assertFalse(result.can_store)
+        self.assertIn("Choose a GeoPackage path", result.validation_reason)
+
+    def test_bare_basename_gets_gpkg_extension(self):
+        result = resolve_storage_selection(
+            "qfit_test",
+            probe=StoragePathProbe(
+                path_exists=lambda path: path == ".",
+                is_dir=lambda path: path == ".",
+            ),
+        )
+
+        self.assertEqual(result.intent, STORAGE_INTENT_NEW)
+        self.assertEqual(result.normalized_path, "qfit_test.gpkg")
+        self.assertFalse(result.can_load)
+        self.assertTrue(result.can_store)
+
+    def test_explicit_gpkg_path_is_preserved(self):
+        self.assertEqual(
+            normalize_storage_path("/tmp/qfit_test.gpkg"),
+            "/tmp/qfit_test.gpkg",
+        )
+
+    def test_existing_qfit_geopackage_can_load_and_store(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "existing.gpkg")
+            with sqlite3.connect(path) as connection:
+                connection.execute("CREATE TABLE activity_registry (id TEXT)")
+
+            result = resolve_storage_selection(path)
+
+        self.assertEqual(result.intent, STORAGE_INTENT_EXISTING)
+        self.assertTrue(result.can_load)
+        self.assertTrue(result.can_store)
+        self.assertEqual(result.status_text, EXISTING_QFIT_DATABASE_STATUS)
+
+    def test_existing_qfit_geopackage_path_allows_uri_metacharacters(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "existing?test#1.gpkg")
+            with sqlite3.connect(path) as connection:
+                connection.execute("CREATE TABLE activity_registry (id TEXT)")
+
+            result = resolve_storage_selection(path)
+
+        self.assertEqual(result.intent, STORAGE_INTENT_EXISTING)
+        self.assertTrue(result.can_load)
+        self.assertTrue(result.can_store)
+
+    def test_existing_non_qfit_geopackage_is_specific_validation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "other.gpkg")
+            with sqlite3.connect(path) as connection:
+                connection.execute("CREATE TABLE gpkg_contents (id TEXT)")
+
+            result = resolve_storage_selection(path)
+
+        self.assertEqual(result.intent, STORAGE_INTENT_EXISTING)
+        self.assertFalse(result.can_load)
+        self.assertFalse(result.can_store)
+        self.assertEqual(result.status_text, NON_QFIT_GEOPACKAGE_STATUS)
+        self.assertIn("qfit's activity schema", result.validation_reason)
+
+    def test_existing_route_only_qfit_geopackage_can_store_activities(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "routes.gpkg")
+            with sqlite3.connect(path) as connection:
+                connection.execute("CREATE TABLE route_registry (id TEXT)")
+
+            result = resolve_storage_selection(path)
+
+        self.assertEqual(result.intent, STORAGE_INTENT_EXISTING)
+        self.assertFalse(result.can_load)
+        self.assertTrue(result.can_store)
+        self.assertEqual(result.status_text, ROUTE_ONLY_QFIT_DATABASE_STATUS)
+
+    def test_missing_parent_directory_is_invalid(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "missing", "qfit.gpkg")
+
+            result = resolve_storage_selection(path)
+
+        self.assertEqual(result.intent, STORAGE_INTENT_INVALID)
+        self.assertIn("parent directory", result.validation_reason)
+
+    def test_switching_from_loaded_database_marks_layers_stale(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_path = os.path.join(tmpdir, "old.gpkg")
+            new_path = os.path.join(tmpdir, "new.gpkg")
+            for path in (old_path, new_path):
+                with sqlite3.connect(path) as connection:
+                    connection.execute("CREATE TABLE activity_registry (id TEXT)")
+
+            result = resolve_storage_selection(
+                new_path,
+                loaded_dataset_path=old_path,
+            )
+
+        self.assertTrue(result.can_load)
+        self.assertEqual(result.status_text, PATH_CHANGED_STATUS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/application/local_first_control_moves.py
+++ b/ui/application/local_first_control_moves.py
@@ -142,6 +142,8 @@ LOCAL_FIRST_CONTROL_MOVES: tuple[LocalFirstControlMove, ...] = (
         required_widget_attrs=(
             "outputPathLineEdit",
             "browseButton",
+            "openExistingButton",
+            "outputStatusLabel",
             "writeActivityPointsCheckBox",
             "pointSamplingStrideSpinBox",
         ),


### PR DESCRIPTION
## Summary

- Adds an activities application storage-selection resolver that classifies committed paths as new, existing qfit, existing non-qfit, or invalid.
- Splits Data storage actions into save-style New GeoPackage and open-style Open existing flows, with compact storage status rendering.
- Moves expensive storage coverage reads off `textChanged` and validates typed paths on commit.
- Bumps plugin metadata to `0.52.0` for the 0.52 release.

Closes #1425.

## Validation

- `python3 -m pytest tests/ -x -q`
- `python3 -m pytest tests/test_storage_selection.py tests/test_qfit_dockwidget_analysis_pure.py tests/test_load_workflow.py -q`
- `python3 scripts/package_plugin.py`

## Rendering Proof

Not rendering-sensitive. This changes storage selection, validation, and release metadata, not atlas or map rendering output.
