### PR TITLE
chore: remove unused dockwidget storage import

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -41,7 +41,6 @@ from .activities.application.layer_summary import (
 from .activities.application.load_workflow import LoadWorkflowError
 from .activities.application.storage_selection import (
     StorageSelectionResult,
-    normalize_storage_path,
     resolve_storage_selection,
 )
 from .activities.application.sync_strategy import ActivitySyncMode, plan_activity_sync


### PR DESCRIPTION
## Summary

- remove an unused `normalize_storage_path` import from `qfit_dockwidget.py`
- keep the qgis.org-shaped packaged Flake8 scan clean after the 0.52.0 package build

Fixes follow-up scanner drift for #1408.

## Validation

- `.venv/bin/python -m unittest tests.test_qfit_dockwidget_analysis_pure tests.test_storage_selection -v`
- `.venv/bin/python scripts/run_plugin_security_scan.py --allow-findings`
