### PR TITLE
Support QGIS-major plugin packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,10 @@ jobs:
       - name: Install packaging dependencies
         run: python -m pip install --upgrade pypdf
 
-      - name: Build plugin ZIP
-        id: package
+      - name: Build QGIS-major plugin ZIPs
         run: |
-          python scripts/package_plugin.py
-          echo "zip=$(ls dist/*.zip)" >> "$GITHUB_OUTPUT"
+          python scripts/package_plugin.py --qgis-major 3
+          python scripts/package_plugin.py --qgis-major 4
 
       - name: Build artifact metadata
         id: artifact
@@ -46,10 +45,10 @@ jobs:
             echo "name=qfit-plugin-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload plugin ZIP
+      - name: Upload plugin ZIPs
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.name }}
-          path: ${{ steps.package.outputs.zip }}
+          path: dist/*-qgis*.zip
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/plugin-security-scan.yml
+++ b/.github/workflows/plugin-security-scan.yml
@@ -24,5 +24,16 @@ jobs:
       - name: Install scan dependencies
         run: python -m pip install --upgrade pypdf bandit detect-secrets flake8
 
-      - name: Build packaged plugin and run local-style scans
-        run: python scripts/run_plugin_security_scan.py --allow-findings
+      - name: Build QGIS 3 package and run local-style scans
+        run: >
+          python scripts/run_plugin_security_scan.py
+          --qgis-major 3
+          --reports-dir debug/plugin-security-scan/qgis3
+          --allow-findings
+
+      - name: Build QGIS 4 package and run local-style scans
+        run: >
+          python scripts/run_plugin_security_scan.py
+          --qgis-major 4
+          --reports-dir debug/plugin-security-scan/qgis4
+          --allow-findings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,16 @@ jobs:
       - name: Run unit tests
         run: python -m unittest discover -s tests -v
 
-      - name: Build plugin ZIP
-        id: package
+      - name: Build QGIS-major plugin ZIPs
         run: |
-          python scripts/package_plugin.py
-          echo "zip=$(ls dist/*.zip)" >> "$GITHUB_OUTPUT"
+          python scripts/package_plugin.py --qgis-major 3
+          python scripts/package_plugin.py --qgis-major 4
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ github.ref_name }}" \
-            "${{ steps.package.outputs.zip }}" \
+            dist/*-qgis*.zip \
             --title "${{ github.ref_name }}" \
             --generate-notes

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ qfit currently supports:
 - running analysis workflows such as frequent starting points and activity heatmaps
 - generating atlas-ready publish layers and exporting a PDF atlas from the dock
 
+### QGIS version support
+
+qfit is shipped as two QGIS-major-specific plugin ZIPs built from the same source commit:
+
+- `qfit-<version>-qgis3.zip` for QGIS 3.28 through QGIS 3.x
+- `qfit-<version>-qgis4.zip` for QGIS 4.x
+
+These are packaging targets, not separate products. New qfit feature work should land in shared domain, application, UI, and infrastructure code by default. QGIS 3 / QGIS 4 differences should stay limited to package metadata, compatibility helpers, or narrow QGIS adapter paths when the host API genuinely differs.
+
+Install the ZIP that matches your QGIS major version. Do not install both packages into the same QGIS profile at the same time because both expose the same plugin name, `qfit`.
+
 ### Main outputs
 
 qfit uses a GeoPackage as both local sync store and QGIS data source.
@@ -260,13 +271,33 @@ python -m pip install pypdf
 python3 scripts/package_plugin.py
 ```
 
-The release ZIP is written to `dist/`.
+Build the QGIS-major release archives with:
+
+```bash
+python -m pip install pypdf
+python3 scripts/package_plugin.py --qgis-major 3
+python3 scripts/package_plugin.py --qgis-major 4
+```
+
+The release ZIPs are written to `dist/`:
+
+- `qfit-<version>-qgis3.zip` has `qgisMinimumVersion=3.28` and `qgisMaximumVersion=3.99`
+- `qfit-<version>-qgis4.zip` has `qgisMinimumVersion=4.0`
+
+Check eager PyQGIS / Qt import exposure with:
+
+```bash
+python3 validation/qgis_import_compat_probe.py
+```
+
+Runtime QGIS API differences belong behind compatibility helpers or infrastructure adapters. Module-scope QGIS/Qt imports are riskier because they can fail before runtime compatibility code executes.
 
 ### CI and review expectations
 
 Before treating a change as done:
 
 - run the relevant tests
+- verify both QGIS-major packages build
 - keep SonarCloud green
 - keep CodeQL/CI green
 - address meaningful review feedback

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.52.0
+version=0.53.0
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.

--- a/scripts/package_plugin.py
+++ b/scripts/package_plugin.py
@@ -7,10 +7,13 @@ import configparser
 import importlib.util
 import pathlib
 import shutil
+import sys
 import tempfile
 import zipfile
 
+from argparse import ArgumentParser
 from importlib import metadata
+from typing import NamedTuple
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DIST_DIR = ROOT / "dist"
@@ -37,6 +40,32 @@ EXCLUDED_FILES = {
     ".gitignore",
     "sonar-project.properties",
     "symbology-style.db",
+}
+
+
+class QgisPackageProfile(NamedTuple):
+    major: int
+    archive_suffix: str
+    metadata_overrides: dict[str, str | None]
+
+
+QGIS_PACKAGE_PROFILES = {
+    3: QgisPackageProfile(
+        major=3,
+        archive_suffix="qgis3",
+        metadata_overrides={
+            "qgisMinimumVersion": "3.28",
+            "qgisMaximumVersion": "3.99",
+        },
+    ),
+    4: QgisPackageProfile(
+        major=4,
+        archive_suffix="qgis4",
+        metadata_overrides={
+            "qgisMinimumVersion": "4.0",
+            "qgisMaximumVersion": None,
+        },
+    ),
 }
 
 
@@ -120,21 +149,55 @@ def _copy_packaged_flake8_config(plugin_dir: pathlib.Path) -> None:
     shutil.copy2(PACKAGED_FLAKE8_CONFIG, plugin_dir / "setup.cfg")
 
 
-def _build_staging_tree(plugin_name: str) -> pathlib.Path:
+def _apply_metadata_profile(plugin_dir: pathlib.Path, profile: QgisPackageProfile | None) -> None:
+    if profile is None:
+        return
+
+    metadata_path = plugin_dir / "metadata.txt"
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(metadata_path)
+    if not parser.has_section("general"):
+        parser.add_section("general")
+
+    for key, value in profile.metadata_overrides.items():
+        if value is None:
+            parser.remove_option("general", key)
+        else:
+            parser.set("general", key, value)
+
+    with metadata_path.open("w", encoding="utf-8") as handle:
+        parser.write(handle)
+
+
+def _package_profile(qgis_major: int | None) -> QgisPackageProfile | None:
+    if qgis_major is None:
+        return None
+    try:
+        return QGIS_PACKAGE_PROFILES[qgis_major]
+    except KeyError as exc:
+        supported = ", ".join(str(major) for major in sorted(QGIS_PACKAGE_PROFILES))
+        raise ValueError(f"Unsupported QGIS major version {qgis_major}. Supported: {supported}") from exc
+
+
+def _build_staging_tree(plugin_name: str, profile: QgisPackageProfile | None = None) -> pathlib.Path:
     staging_root = pathlib.Path(tempfile.mkdtemp(prefix="qfit-package-"))
     plugin_dir = staging_root / plugin_name
     _copy_project_tree(plugin_dir)
     _vendor_runtime_dependencies(plugin_dir)
     _copy_packaged_flake8_config(plugin_dir)
+    _apply_metadata_profile(plugin_dir, profile)
     return staging_root
 
 
-def build_zip() -> pathlib.Path:
+def build_zip(qgis_major: int | None = None) -> pathlib.Path:
     plugin_name, version = read_metadata()
+    profile = _package_profile(qgis_major)
     DIST_DIR.mkdir(exist_ok=True)
-    archive_path = DIST_DIR / f"{plugin_name.lower()}-{version}.zip"
+    suffix = f"-{profile.archive_suffix}" if profile is not None else ""
+    archive_path = DIST_DIR / f"{plugin_name.lower()}-{version}{suffix}.zip"
 
-    staging_root = _build_staging_tree(plugin_name)
+    staging_root = _build_staging_tree(plugin_name, profile)
     try:
         with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             for path in sorted(staging_root.rglob("*")):
@@ -147,11 +210,25 @@ def build_zip() -> pathlib.Path:
     return archive_path
 
 
-def main() -> int:
-    archive_path = build_zip()
+def parse_args(argv: list[str] | None = None):
+    parser = ArgumentParser(description="Build a distributable QGIS plugin zip for qfit.")
+    parser.add_argument(
+        "--qgis-major",
+        type=int,
+        choices=sorted(QGIS_PACKAGE_PROFILES),
+        help="Build a QGIS-major-specific package with metadata version bounds.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = []
+    args = parse_args(argv)
+    archive_path = build_zip(qgis_major=args.qgis_major)
     print(f"Built {archive_path}")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/run_plugin_security_scan.py
+++ b/scripts/run_plugin_security_scan.py
@@ -50,6 +50,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=f"Directory where local scan reports are written (default: {DEFAULT_REPORTS_DIR})",
     )
     parser.add_argument(
+        "--qgis-major",
+        type=int,
+        choices=sorted(package_plugin.QGIS_PACKAGE_PROFILES),
+        help="Build and scan the QGIS-major-specific package.",
+    )
+    parser.add_argument(
         "--allow-findings",
         action="store_true",
         help="Return success even when scanners report findings, while still failing on execution errors.",
@@ -57,10 +63,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def prepare_scan_tree(reports_dir: Path) -> tuple[Path, Path]:
+def prepare_scan_tree(reports_dir: Path, qgis_major: int | None = None) -> tuple[Path, Path]:
     if reports_dir.exists():
         shutil.rmtree(reports_dir)
-    archive_path = package_plugin.build_zip()
+    archive_path = package_plugin.build_zip(qgis_major=qgis_major)
     extracted_dir = reports_dir / "extracted"
     extracted_dir.mkdir(parents=True, exist_ok=True)
 
@@ -212,7 +218,7 @@ def build_scan_commands(plugin_root: Path, reports_dir: Path) -> list[tuple[str,
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    archive_path, plugin_root = prepare_scan_tree(args.reports_dir)
+    archive_path, plugin_root = prepare_scan_tree(args.reports_dir, qgis_major=args.qgis_major)
 
     results = [
         run_scan(name, command, report_path, findings_checker=findings_checker)

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -32,6 +32,11 @@ class BuildWorkflowTests(unittest.TestCase):
     def test_runs_package_script(self):
         self.assertIn("scripts/package_plugin.py", self.text)
 
+    def test_builds_and_uploads_qgis_major_packages(self):
+        self.assertIn("scripts/package_plugin.py --qgis-major 3", self.text)
+        self.assertIn("scripts/package_plugin.py --qgis-major 4", self.text)
+        self.assertIn("dist/*-qgis*.zip", self.text)
+
 
 class ReleaseWorkflowTests(unittest.TestCase):
     def setUp(self):
@@ -70,6 +75,22 @@ class ReleaseWorkflowTests(unittest.TestCase):
 
     def test_runs_unit_tests(self):
         self.assertIn("unittest discover", self.text)
+
+    def test_releases_qgis_major_packages(self):
+        self.assertIn("scripts/package_plugin.py --qgis-major 3", self.text)
+        self.assertIn("scripts/package_plugin.py --qgis-major 4", self.text)
+        self.assertIn("dist/*-qgis*.zip", self.text)
+
+
+class PluginSecurityScanWorkflowTests(unittest.TestCase):
+    def setUp(self):
+        self.text = _read_workflow("plugin-security-scan.yml")
+
+    def test_scans_both_qgis_major_packages(self):
+        self.assertIn("--qgis-major 3", self.text)
+        self.assertIn("--qgis-major 4", self.text)
+        self.assertIn("debug/plugin-security-scan/qgis3", self.text)
+        self.assertIn("debug/plugin-security-scan/qgis4", self.text)
 
 
 class MetadataTests(unittest.TestCase):

--- a/tests/test_package_plugin.py
+++ b/tests/test_package_plugin.py
@@ -1,4 +1,5 @@
 import importlib.util
+import configparser
 import sys
 import tempfile
 import unittest
@@ -126,6 +127,92 @@ class PackagePluginTests(unittest.TestCase):
             self.assertFalse(any(name.startswith("qfit/debug/") for name in names))
             self.assertFalse(any(name.startswith("qfit/validation/") for name in names))
             self.assertFalse(any(name.startswith("qfit/validation_artifacts/") for name in names))
+
+    def test_build_zip_can_apply_qgis3_metadata_profile(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "src"
+            dist = Path(temp_dir) / "dist"
+            root.mkdir()
+            (root / "metadata.txt").write_text(
+                "[general]\nname=qfit\nversion=1.2.3\nqgisMinimumVersion=3.28\n",
+                encoding="utf-8",
+            )
+            (root / "__init__.py").write_text("# init\n", encoding="utf-8")
+            (root / "packaging").mkdir()
+            packaged_flake8_config = root / "packaging" / "qgis-flake8.cfg"
+            packaged_flake8_config.write_text("[flake8]\n", encoding="utf-8")
+
+            with (
+                patch.object(package_plugin, "ROOT", root),
+                patch.object(package_plugin, "DIST_DIR", dist),
+                patch.object(package_plugin, "PACKAGED_FLAKE8_CONFIG", packaged_flake8_config),
+                patch.object(package_plugin, "_vendor_runtime_dependencies"),
+            ):
+                archive_path = package_plugin.build_zip(qgis_major=3)
+
+            self.assertEqual(archive_path, dist / "qfit-1.2.3-qgis3.zip")
+            with zipfile.ZipFile(archive_path) as archive:
+                metadata_text = archive.read("qfit/metadata.txt").decode("utf-8")
+
+            parser = configparser.ConfigParser()
+            parser.read_string(metadata_text)
+            self.assertEqual(parser.get("general", "qgisMinimumVersion"), "3.28")
+            self.assertEqual(parser.get("general", "qgisMaximumVersion"), "3.99")
+
+    def test_build_zip_can_apply_qgis4_metadata_profile(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "src"
+            dist = Path(temp_dir) / "dist"
+            root.mkdir()
+            (root / "metadata.txt").write_text(
+                "[general]\n"
+                "name=qfit\n"
+                "version=1.2.3\n"
+                "qgisMinimumVersion=3.28\n"
+                "qgisMaximumVersion=3.99\n",
+                encoding="utf-8",
+            )
+            (root / "__init__.py").write_text("# init\n", encoding="utf-8")
+            (root / "packaging").mkdir()
+            packaged_flake8_config = root / "packaging" / "qgis-flake8.cfg"
+            packaged_flake8_config.write_text("[flake8]\n", encoding="utf-8")
+
+            with (
+                patch.object(package_plugin, "ROOT", root),
+                patch.object(package_plugin, "DIST_DIR", dist),
+                patch.object(package_plugin, "PACKAGED_FLAKE8_CONFIG", packaged_flake8_config),
+                patch.object(package_plugin, "_vendor_runtime_dependencies"),
+            ):
+                archive_path = package_plugin.build_zip(qgis_major=4)
+
+            self.assertEqual(archive_path, dist / "qfit-1.2.3-qgis4.zip")
+            with zipfile.ZipFile(archive_path) as archive:
+                metadata_text = archive.read("qfit/metadata.txt").decode("utf-8")
+
+            parser = configparser.ConfigParser()
+            parser.read_string(metadata_text)
+            self.assertEqual(parser.get("general", "qgisMinimumVersion"), "4.0")
+            self.assertFalse(parser.has_option("general", "qgisMaximumVersion"))
+
+    def test_build_zip_rejects_unknown_qgis_major_profile(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported QGIS major version 5"):
+            package_plugin.build_zip(qgis_major=5)
+
+    def test_parse_args_accepts_qgis_major(self):
+        args = package_plugin.parse_args(["--qgis-major", "4"])
+
+        self.assertEqual(args.qgis_major, 4)
+
+    def test_main_passes_qgis_major_to_build_zip(self):
+        archive_path = Path("/tmp/qfit-1.2.3-qgis4.zip")
+
+        with patch.object(package_plugin, "build_zip", return_value=archive_path) as build_zip, \
+             patch("builtins.print") as mock_print:
+            result = package_plugin.main(["--qgis-major", "4"])
+
+        self.assertEqual(result, 0)
+        build_zip.assert_called_once_with(qgis_major=4)
+        mock_print.assert_called_once_with(f"Built {archive_path}")
 
     def test_build_zip_fails_when_packaged_flake8_config_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_plugin_security_scan.py
+++ b/tests/test_plugin_security_scan.py
@@ -88,7 +88,7 @@ class PrepareScanTreeTests(unittest.TestCase):
 
             reports_dir = temp_path / "debug" / "plugin-security-scan"
             original_build_zip = plugin_security_scan.package_plugin.build_zip
-            plugin_security_scan.package_plugin.build_zip = lambda: archive_path
+            plugin_security_scan.package_plugin.build_zip = lambda qgis_major=None: archive_path
             try:
                 built_archive, plugin_root = plugin_security_scan.prepare_scan_tree(reports_dir)
             finally:
@@ -107,7 +107,8 @@ class PrepareScanTreeTests(unittest.TestCase):
             stale_report = reports_dir / "summary.txt"
             stale_report.write_text("old\n", encoding="utf-8")
 
-            def fake_build_zip():
+            def fake_build_zip(qgis_major=None):
+                self.assertIsNone(qgis_major)
                 self.assertFalse(stale_report.exists())
                 with zipfile.ZipFile(archive_path, "w") as archive:
                     archive.writestr("qfit/__init__.py", "# plugin\n")
@@ -120,6 +121,41 @@ class PrepareScanTreeTests(unittest.TestCase):
             self.assertEqual(built_archive, archive_path)
             self.assertEqual(plugin_root, reports_dir / "extracted" / "qfit")
             self.assertFalse(stale_report.exists())
+
+    def test_prepare_scan_tree_passes_qgis_major_to_packager(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            archive_path = temp_path / "qfit-1.2.3-qgis4.zip"
+            reports_dir = temp_path / "debug" / "plugin-security-scan"
+
+            def fake_build_zip(*, qgis_major=None):
+                self.assertEqual(qgis_major, 4)
+                with zipfile.ZipFile(archive_path, "w") as archive:
+                    archive.writestr("qfit/__init__.py", "# plugin\n")
+                    archive.writestr("qfit/metadata.txt", "[general]\nname=qfit\n")
+                return archive_path
+
+            with patch.object(plugin_security_scan.package_plugin, "build_zip", side_effect=fake_build_zip):
+                built_archive, plugin_root = plugin_security_scan.prepare_scan_tree(
+                    reports_dir,
+                    qgis_major=4,
+                )
+
+            self.assertEqual(built_archive, archive_path)
+            self.assertEqual(plugin_root, reports_dir / "extracted" / "qfit")
+
+
+class CliTests(unittest.TestCase):
+    def test_parse_args_accepts_qgis_major(self):
+        args = plugin_security_scan.parse_args([
+            "--qgis-major",
+            "3",
+            "--reports-dir",
+            "/tmp/qfit-scan",
+        ])
+
+        self.assertEqual(args.qgis_major, 3)
+        self.assertEqual(args.reports_dir, Path("/tmp/qfit-scan"))
 
 
 class BuildScanCommandsTests(unittest.TestCase):

--- a/tests/test_qgis_import_compat_probe.py
+++ b/tests/test_qgis_import_compat_probe.py
@@ -1,0 +1,130 @@
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tests import _path  # noqa: F401
+from qfit.validation import qgis_import_compat_probe as probe
+from qfit.validation.qgis_import_compat_probe import (
+    collect_eager_qgis_imports,
+    main,
+    parse_args,
+    render_report,
+)
+
+
+class QgisImportCompatProbeTests(unittest.TestCase):
+    def test_collects_only_module_scope_qgis_imports_from_packaged_code(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "plugin.py").write_text(
+                "from qgis.PyQt.QtCore import QDate, Qt\n"
+                "\n"
+                "def later():\n"
+                "    from qgis.core import QgsProject\n"
+                "    return QgsProject\n",
+                encoding="utf-8",
+            )
+            (root / "tests").mkdir()
+            (root / "tests" / "test_plugin.py").write_text(
+                "from qgis.core import QgsApplication\n",
+                encoding="utf-8",
+            )
+
+            refs = collect_eager_qgis_imports(root)
+
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].relative_path, "plugin.py")
+        self.assertEqual(refs[0].line, 1)
+        self.assertEqual(refs[0].module, "qgis.PyQt.QtCore")
+        self.assertEqual(refs[0].names, ("QDate", "Qt"))
+
+    def test_collects_imports_when_match_node_is_unavailable(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "plugin.py").write_text(
+                "class PluginClass:\n"
+                "    from qgis.gui import QgsFileWidget\n",
+                encoding="utf-8",
+            )
+
+            with patch.object(probe, "MATCH_NODE", None):
+                refs = collect_eager_qgis_imports(root)
+
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].module, "qgis.gui")
+        self.assertEqual(refs[0].names, ("QgsFileWidget",))
+
+    def test_collects_guarded_module_scope_qgis_imports(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "plugin.py").write_text(
+                "try:\n"
+                "    from qgis.core import QgsProject\n"
+                "except ImportError:\n"
+                "    from qgis.PyQt.QtCore import QVariant\n"
+                "if True:\n"
+                "    import qgis.gui\n"
+                "for item in []:\n"
+                "    from qgis.PyQt.QtGui import QColor\n"
+                "match 1:\n"
+                "    case 1:\n"
+                "        from qgis.PyQt.QtWidgets import QWidget\n"
+                "class PluginClass:\n"
+                "    from qgis.gui import QgsFileWidget\n",
+                encoding="utf-8",
+            )
+
+            refs = collect_eager_qgis_imports(root)
+
+        modules = {ref.module for ref in refs}
+        self.assertEqual(
+            modules,
+            {
+                "qgis.core",
+                "qgis.PyQt.QtCore",
+                "import",
+                "qgis.PyQt.QtGui",
+                "qgis.PyQt.QtWidgets",
+                "qgis.gui",
+            },
+        )
+
+    def test_report_explains_package_time_failure_mode(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "plugin.py").write_text(
+                "from qgis.core import QgsApplication\n",
+                encoding="utf-8",
+            )
+
+            report = render_report(collect_eager_qgis_imports(root))
+
+        self.assertIn("Packaged Python modules with eager qgis imports: 1", report)
+        self.assertIn("line 1: qgis.core -> QgsApplication", report)
+        self.assertIn("Runtime branching cannot protect module-scope imports", report)
+
+    def test_parse_args_accepts_custom_root(self):
+        args = parse_args(["--root", "/tmp/qfit-probe-root"])
+
+        self.assertEqual(args.root, Path("/tmp/qfit-probe-root"))
+
+    def test_main_prints_report(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "plugin.py").write_text(
+                "from qgis.core import QgsApplication\n",
+                encoding="utf-8",
+            )
+
+            with patch("builtins.print") as mock_print:
+                result = main(["--root", str(root)])
+
+        self.assertEqual(result, 0)
+        printed_report = mock_print.call_args.args[0]
+        self.assertIn("line 1: qgis.core -> QgsApplication", printed_report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/qgis_import_compat_probe.py
+++ b/validation/qgis_import_compat_probe.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Report eager qfit imports that would fail before runtime compatibility code runs."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import pathlib
+
+from dataclasses import dataclass
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+EXCLUDED_DIRS = {
+    ".git",
+    ".github",
+    ".pytest_cache",
+    ".venv",
+    "__pycache__",
+    "debug",
+    "dist",
+    "docs",
+    "scripts",
+    "tests",
+    "validation",
+    "validation_artifacts",
+}
+MATCH_NODE = getattr(ast, "Match", None)
+
+
+@dataclass(frozen=True)
+class ImportRef:
+    relative_path: str
+    line: int
+    module: str
+    names: tuple[str, ...]
+
+
+def _should_scan(path: pathlib.Path, root: pathlib.Path) -> bool:
+    if path.suffix != ".py":
+        return False
+    relative = path.relative_to(root)
+    return not any(part in EXCLUDED_DIRS for part in relative.parts)
+
+
+def _qgis_import_from_node(relative_path: str, node: ast.AST) -> ImportRef | None:
+    if isinstance(node, ast.Import):
+        names = tuple(alias.name for alias in node.names if alias.name == "qgis" or alias.name.startswith("qgis."))
+        if names:
+            return ImportRef(
+                relative_path=relative_path,
+                line=node.lineno,
+                module="import",
+                names=names,
+            )
+    if isinstance(node, ast.ImportFrom) and node.module and (
+        node.module == "qgis" or node.module.startswith("qgis.")
+    ):
+        return ImportRef(
+            relative_path=relative_path,
+            line=node.lineno,
+            module=node.module,
+            names=tuple(alias.name for alias in node.names),
+        )
+    return None
+
+
+def _nested_statement_blocks(statement: ast.stmt) -> list[list[ast.stmt]]:
+    if isinstance(statement, ast.Try):
+        return [
+            statement.body,
+            *(handler.body for handler in statement.handlers),
+            statement.orelse,
+            statement.finalbody,
+        ]
+    if isinstance(statement, ast.If):
+        return [statement.body, statement.orelse]
+    if isinstance(statement, (ast.With, ast.AsyncWith, ast.For, ast.AsyncFor, ast.While)):
+        return [statement.body, getattr(statement, "orelse", [])]
+    if MATCH_NODE is not None and isinstance(statement, MATCH_NODE):
+        return [case.body for case in statement.cases]
+    if isinstance(statement, ast.ClassDef):
+        return [statement.body]
+    return []
+
+
+def _module_scope_imports(tree: ast.Module, relative_path: str) -> list[ImportRef]:
+    refs: list[ImportRef] = []
+    pending_blocks = [tree.body]
+    while pending_blocks:
+        for statement in pending_blocks.pop():
+            ref = _qgis_import_from_node(relative_path, statement)
+            if ref is not None:
+                refs.append(ref)
+                continue
+            pending_blocks.extend(_nested_statement_blocks(statement))
+    return refs
+
+
+def collect_eager_qgis_imports(root: pathlib.Path = ROOT) -> list[ImportRef]:
+    refs: list[ImportRef] = []
+    for path in sorted(root.rglob("*.py")):
+        if not _should_scan(path, root):
+            continue
+        relative_path = path.relative_to(root).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        refs.extend(_module_scope_imports(tree, relative_path))
+    return refs
+
+
+def render_report(refs: list[ImportRef]) -> str:
+    grouped: dict[str, list[ImportRef]] = {}
+    for ref in refs:
+        grouped.setdefault(ref.relative_path, []).append(ref)
+
+    lines = [
+        "QGIS import compatibility probe",
+        f"Packaged Python modules with eager qgis imports: {len(grouped)}",
+        f"Total eager qgis import statements: {len(refs)}",
+        "",
+    ]
+    for relative_path, file_refs in grouped.items():
+        lines.append(relative_path)
+        for ref in file_refs:
+            names = ", ".join(ref.names)
+            lines.append(f"  line {ref.line}: {ref.module} -> {names}")
+    lines.extend(
+        [
+            "",
+            "Assessment:",
+            "- Runtime branching cannot protect module-scope imports if QGIS 4 removes the imported module or symbol.",
+            "- Lazy imports or a QGIS-major-specific package can protect those paths before plugin load.",
+            "- API behavior changes after import are adapter problems, not package-splitting problems.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=pathlib.Path,
+        default=ROOT,
+        help="Repository root to scan. Defaults to the qfit checkout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    refs = collect_eager_qgis_imports(args.root)
+    print(render_report(refs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What Problem This Solves

qfit needs QGIS 3 and QGIS 4 plugin packages without splitting into legacy/new codebases.

Fixes #1429.

## Why This Change Was Made

The QGIS 4 risk is at import time: module-scope PyQGIS / Qt imports can fail before runtime compatibility branches execute. This PR keeps one source tree while making QGIS-major package metadata and CI/release artifacts explicit.

## What Changed

- Added QGIS-major package profiles to `scripts/package_plugin.py`.
- Added `--qgis-major 3` and `--qgis-major 4` packaging outputs:
  - `qfit-<version>-qgis3.zip`
  - `qfit-<version>-qgis4.zip`
- Bumped plugin version to `0.53.0` and added metadata overlays:
  - QGIS 3: `qgisMinimumVersion=3.28`, `qgisMaximumVersion=3.99`
  - QGIS 4: `qgisMinimumVersion=4.0`
- Updated build, release, and plugin security scan workflows to produce/check both artifacts.
- Added an import compatibility probe for eager `qgis` imports.
- Updated README with the dual-package support model and packaging commands.

## User Impact

Users install the ZIP matching their QGIS major version. Contributors keep developing one qfit product; version-specific differences stay in package metadata, compatibility helpers, or narrow QGIS adapter paths.

## Evidence

- `.venv/bin/flake8 scripts/package_plugin.py scripts/run_plugin_security_scan.py validation/qgis_import_compat_probe.py tests/test_package_plugin.py tests/test_plugin_security_scan.py tests/test_qgis_import_compat_probe.py tests/test_ci_workflows.py`
- `.venv/bin/python -m unittest tests.test_package_plugin tests.test_plugin_security_scan tests.test_qgis_import_compat_probe tests.test_ci_workflows -v`
- `timeout 300 .venv/bin/python -m unittest discover -s tests -v`
  - `Ran 2714 tests in 6.114s`
  - `OK (skipped=201)`
- `python3 scripts/package_plugin.py --qgis-major 3`
- `python3 scripts/package_plugin.py --qgis-major 4`
- ZIP metadata check:
  - `qfit-0.53.0-qgis3.zip: min=3.28 max=3.99 pypdf=True`
  - `qfit-0.53.0-qgis4.zip: min=4.0 max= pypdf=True`
- `.venv/bin/python scripts/run_plugin_security_scan.py --qgis-major 3 --reports-dir debug/plugin-security-scan/qgis3 --allow-findings`
- `.venv/bin/python scripts/run_plugin_security_scan.py --qgis-major 4 --reports-dir debug/plugin-security-scan/qgis4 --allow-findings`
  - bandit clean
  - detect-secrets clean
  - flake8 clean
- Local changed-module coverage check after the Sonar fix:
  - `scripts/package_plugin.py`: 96%
  - `scripts/run_plugin_security_scan.py`: 64%
  - `validation/qgis_import_compat_probe.py`: 97%
  - total across those three changed modules: 85%

## Release Note

The GitHub release and QGIS Hub/plugin-repository submission should happen only after this PR is merged, required checks are green, and Codex review feedback is addressed. The release workflow now attaches both QGIS-major ZIPs when a version tag is pushed.


