### PR TITLE
[codex] Fix QGIS 4 Qt enum compatibility

### DIFF
--- a/atlas/export_task.py
+++ b/atlas/export_task.py
@@ -60,6 +60,8 @@ from qgis.core import (
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QFont
 
+from qfit.ui.qt_enum_compat import qt_enum_value
+
 from .layout_metrics import BUILTIN_ATLAS_MAP_TARGET_ASPECT_RATIO
 from .profile_item import (
     NativeProfileItemConfig,
@@ -84,6 +86,10 @@ _COVER_SUMMARY_ROW_FIELDS = (
     "extent_height_m",
     "source_activity_id",
 )
+QT_ALIGN_LEFT = qt_enum_value(Qt, "AlignmentFlag", "AlignLeft")
+QT_ALIGN_RIGHT = qt_enum_value(Qt, "AlignmentFlag", "AlignRight")
+QT_ALIGN_TOP = qt_enum_value(Qt, "AlignmentFlag", "AlignTop")
+QT_ALIGN_VCENTER = qt_enum_value(Qt, "AlignmentFlag", "AlignVCenter")
 from .export_coordinator import AtlasExportCoordinator
 from .export_front_matter import export_cover_page, export_toc_page
 from .export_page_runtime_builder import AtlasPageRuntimeBuilder
@@ -438,9 +444,9 @@ def _add_label(
     label.setFont(font)
     if color is not None:
         label.setFontColor(color)
-    h_align = Qt.AlignRight if align_right else Qt.AlignLeft
+    h_align = QT_ALIGN_RIGHT if align_right else QT_ALIGN_LEFT
     label.setHAlign(h_align)
-    label.setVAlign(Qt.AlignTop if v_align_top else Qt.AlignVCenter)
+    label.setVAlign(QT_ALIGN_TOP if v_align_top else QT_ALIGN_VCENTER)
     label.attemptMove(QgsLayoutPoint(x, y, QgsUnitTypes.LayoutMillimeters))
     label.attemptResize(QgsLayoutSize(w, h, QgsUnitTypes.LayoutMillimeters))
     layout.addLayoutItem(label)

--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -42,19 +42,25 @@ from .configuration.application.ui_settings_binding import (
 )
 from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_client import StravaClient
+from .ui.qt_enum_compat import qt_enum_value
 from .ui.widgets import make_password_line_edit
 
 logger = logging.getLogger(__name__)
 
 _NOT_TESTED_LABEL = "Not tested"
 _OAUTH_NOT_STARTED_LABEL = "Not started"
+QT_TEXT_SELECTABLE_BY_MOUSE = qt_enum_value(
+    Qt,
+    "TextInteractionFlag",
+    "TextSelectableByMouse",
+)
 
 
 def _configure_wrapping_status_label(label: QLabel) -> QLabel:
     """Keep long connection/test messages inside the dialog content width."""
 
     label.setWordWrap(True)
-    label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+    label.setTextInteractionFlags(QT_TEXT_SELECTABLE_BY_MOUSE)
     return label
 
 
@@ -131,7 +137,7 @@ class QfitConfigDialog(QDialog):
         )
         self._oauth_help_label.setObjectName("stravaOAuthHelpLabel")
         self._oauth_help_label.setWordWrap(True)
-        self._oauth_help_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._oauth_help_label.setTextInteractionFlags(QT_TEXT_SELECTABLE_BY_MOUSE)
         form.addRow(self._oauth_help_label)
 
         self._authorization_code_edit = QLineEdit()

--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -91,6 +91,7 @@ from .ui.application import (
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
 )
+from .ui.qt_enum_compat import qt_enum_value
 from .ui.application.local_first_progress_facts import (
     build_current_local_first_progress_facts,
     current_local_first_visual_temporal_mode,
@@ -143,7 +144,15 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
         | QDockWidget.DockWidgetMovable
         | QDockWidget.DockWidgetFloatable
     )
-    STARTUP_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
+    STARTUP_ALLOWED_AREAS = qt_enum_value(
+        Qt,
+        "DockWidgetArea",
+        "LeftDockWidgetArea",
+    ) | qt_enum_value(
+        Qt,
+        "DockWidgetArea",
+        "RightDockWidgetArea",
+    )
 
     def __init__(
         self,

--- a/qfit_plugin.py
+++ b/qfit_plugin.py
@@ -7,8 +7,10 @@ from qgis.PyQt.QtWidgets import QAction
 from .qfit_config_dialog import QfitConfigDialog
 from .qfit_dockwidget import QfitDockWidget
 from .ui.about_dock import QfitAboutDock
+from .ui.qt_enum_compat import optional_qt_enum_value, qt_enum_value
 
 MENU_NAME = "&qfit"
+QT_RIGHT_DOCK_WIDGET_AREA = qt_enum_value(Qt, "DockWidgetArea", "RightDockWidgetArea")
 
 
 class QfitPlugin:
@@ -74,7 +76,7 @@ class QfitPlugin:
                 parent=self.iface.mainWindow(),
                 open_configuration=self.show_config,
             )
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dockwidget)
+            self.iface.addDockWidget(QT_RIGHT_DOCK_WIDGET_AREA, self.dockwidget)
         self.dockwidget.show()
         self.dockwidget.raise_()
 
@@ -97,8 +99,8 @@ class QfitPlugin:
     def _restore_dialog_window_state(self, dialog) -> None:
         window_state = getattr(dialog, "windowState", None)
         set_window_state = getattr(dialog, "setWindowState", None)
-        minimized = getattr(Qt, "WindowMinimized", None)
-        active = getattr(Qt, "WindowActive", None)
+        minimized = optional_qt_enum_value(Qt, "WindowState", "WindowMinimized")
+        active = optional_qt_enum_value(Qt, "WindowState", "WindowActive")
         if (
             not callable(window_state)
             or not callable(set_window_state)
@@ -114,7 +116,7 @@ class QfitPlugin:
     def show_about(self):
         if self._about_dock is None:
             self._about_dock = QfitAboutDock(parent=self.iface.mainWindow())
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, self._about_dock)
+            self.iface.addDockWidget(QT_RIGHT_DOCK_WIDGET_AREA, self._about_dock)
             self._about_dock.setFloating(True)
         self._about_dock.show()
         self._about_dock.raise_()

--- a/tests/test_qt_enum_compat.py
+++ b/tests/test_qt_enum_compat.py
@@ -1,0 +1,29 @@
+import unittest
+
+from tests import _path  # noqa: F401
+
+from qfit.ui.qt_enum_compat import optional_qt_enum_value, qt_enum_value
+
+
+class _FlatQt:
+    Horizontal = 1
+
+
+class _NestedQt:
+    class Orientation:
+        Horizontal = 2
+
+
+class QtEnumCompatTest(unittest.TestCase):
+    def test_resolves_qt5_flat_enum_member(self):
+        self.assertEqual(qt_enum_value(_FlatQt, "Orientation", "Horizontal"), 1)
+
+    def test_resolves_qt6_nested_enum_member(self):
+        self.assertEqual(qt_enum_value(_NestedQt, "Orientation", "Horizontal"), 2)
+
+    def test_optional_resolver_returns_none_for_missing_member(self):
+        self.assertIsNone(optional_qt_enum_value(_NestedQt, "FocusPolicy", "NoFocus"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_widget_compat.py
+++ b/tests/test_ui_widget_compat.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 import types
 import unittest
@@ -333,6 +334,22 @@ class _FakeListWidgetItem:
         return self._data[role]
 
 
+class _FakeNestedQt:
+    class CheckState:
+        Checked = 2
+        Unchecked = 0
+
+    class ItemDataRole:
+        UserRole = 256
+
+    class ItemFlag:
+        ItemIsUserCheckable = 16
+
+    class Orientation:
+        Horizontal = 1
+        Vertical = 2
+
+
 def _fake_qgis_gui(
     *,
     collapsible_group_box=None,
@@ -371,6 +388,31 @@ def _fake_qt_widgets():
 
 
 class UiWidgetCompatTests(unittest.TestCase):
+    def test_imports_with_qgis4_nested_qt_enums(self):
+        module_name = "qfit.ui.widgets.compat"
+        original_module = sys.modules.pop(module_name, None)
+        widgets_package = sys.modules.get("qfit.ui.widgets")
+        original_package_attr = (
+            getattr(widgets_package, "compat", None) if widgets_package is not None else None
+        )
+        if widgets_package is not None and hasattr(widgets_package, "compat"):
+            delattr(widgets_package, "compat")
+
+        fake_qtcore = types.ModuleType("qgis.PyQt.QtCore")
+        fake_qtcore.Qt = _FakeNestedQt
+        try:
+            with patch.dict(sys.modules, {"qgis.PyQt.QtCore": fake_qtcore}):
+                reimported = importlib.import_module(module_name)
+        finally:
+            sys.modules.pop(module_name, None)
+            if original_module is not None:
+                sys.modules[module_name] = original_module
+            if widgets_package is not None and original_package_attr is not None:
+                widgets_package.compat = original_package_attr
+
+        self.assertEqual(reimported.QT_HORIZONTAL, _FakeNestedQt.Orientation.Horizontal)
+        self.assertEqual(reimported.QT_USER_ROLE, _FakeNestedQt.ItemDataRole.UserRole)
+
     def test_uses_native_collapsible_group_box_when_qgis_provides_it(self):
         parent = object()
         with patch.dict(

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -49,8 +49,10 @@ class _FakeCursor:
 class _FakeQt:
     AlignTop = 8
     AlignCenter = 9
+    Checked = 21
     ForbiddenCursor = 10
     Horizontal = 13
+    ItemIsUserCheckable = 22
     Key_Enter = 16
     Key_Return = 17
     Key_Space = 18
@@ -60,6 +62,8 @@ class _FakeQt:
     StrongFocus = 20
     ToolButtonTextBesideIcon = 12
     ToolButtonTextOnly = 15
+    Unchecked = 23
+    UserRole = 24
     Vertical = 14
 
 

--- a/ui/about_dock.py
+++ b/ui/about_dock.py
@@ -4,6 +4,18 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QLabel, QDockWidget, QVBoxLayout, QWidget
 
 from .about_info import AboutInfo, build_about_html, read_about_info
+from .qt_enum_compat import qt_enum_value
+
+QT_TEXT_BROWSER_INTERACTION = qt_enum_value(
+    Qt,
+    "TextInteractionFlag",
+    "TextBrowserInteraction",
+)
+QT_TEXT_SELECTABLE_BY_MOUSE = qt_enum_value(
+    Qt,
+    "TextInteractionFlag",
+    "TextSelectableByMouse",
+)
 
 
 class QfitAboutDock(QDockWidget):
@@ -33,7 +45,7 @@ class QfitAboutDock(QDockWidget):
         self._content_label.setWordWrap(True)
         self._content_label.setOpenExternalLinks(True)
         self._content_label.setTextInteractionFlags(
-            Qt.TextBrowserInteraction | Qt.TextSelectableByMouse
+            QT_TEXT_BROWSER_INTERACTION | QT_TEXT_SELECTABLE_BY_MOUSE
         )
         layout.addWidget(self._content_label)
         layout.addStretch(1)

--- a/ui/application/local_first_backing_controls.py
+++ b/ui/application/local_first_backing_controls.py
@@ -140,6 +140,8 @@ def _move_clear_database_to_actions_menu(dock) -> None:
     from qgis.PyQt.QtCore import Qt
     from qgis.PyQt.QtWidgets import QMenu, QToolButton
 
+    from qfit.ui.qt_enum_compat import qt_enum_value
+
     menu = QMenu(getattr(dock, "outputGroupBox", None))
     if hasattr(menu, "setObjectName"):
         menu.setObjectName("databaseActionsMenu")
@@ -155,7 +157,7 @@ def _move_clear_database_to_actions_menu(dock) -> None:
     menu_button.setToolTip(
         "Less common database operations; destructive actions ask for confirmation."
     )
-    menu_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+    menu_button.setToolButtonStyle(qt_enum_value(Qt, "ToolButtonStyle", "ToolButtonTextBesideIcon"))
     menu_button.setPopupMode(QToolButton.InstantPopup)
     menu_button.setMenu(menu)
 

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterable
 
+from qfit.ui.qt_enum_compat import qt_enum_value
+
 
 @dataclass(frozen=True)
 class HelpEntry:
@@ -243,7 +245,13 @@ class ContextualHelpBinder:
                 qtwidgets.QSizePolicy.Ignored,
                 qtwidgets.QSizePolicy.Preferred,
             )
-        helper.setTextInteractionFlags(self._qtcore().Qt.TextSelectableByMouse)
+        helper.setTextInteractionFlags(
+            qt_enum_value(
+                self._qtcore().Qt,
+                "TextInteractionFlag",
+                "TextSelectableByMouse",
+            )
+        )
         self._apply_tooltip(helper, text)
         helper.setStyleSheet("color: palette(mid); margin-top: 2px; margin-bottom: 4px;")
         self._insert_after_anchor(anchor, helper)
@@ -278,8 +286,8 @@ class ContextualHelpBinder:
             button.setAccessibleName("Show help")
         if hasattr(button, "setAccessibleDescription"):
             button.setAccessibleDescription(text)
-        button.setCursor(self._qtcore().Qt.WhatsThisCursor)
-        button.setFocusPolicy(self._qtcore().Qt.NoFocus)
+        button.setCursor(qt_enum_value(self._qtcore().Qt, "CursorShape", "WhatsThisCursor"))
+        button.setFocusPolicy(qt_enum_value(self._qtcore().Qt, "FocusPolicy", "NoFocus"))
         button.setStyleSheet("font-weight: bold; padding: 0 4px;")
         self._connect_help_button(button, text)
         layout.addWidget(button)

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -10,6 +10,7 @@ from qfit.ui.tokens import (
     COLOR_SEPARATOR,
     pill_tone_palette,
 )
+from qfit.ui.qt_enum_compat import qt_enum_value
 
 from ._qt_compat import import_qt_module
 
@@ -33,6 +34,12 @@ WORKFLOW_ACTION_ROLE_PROPERTY = "workflowActionRole"
 WIZARD_ACTION_ROLE_PROPERTY = "wizardActionRole"
 WORKFLOW_ACTION_AVAILABILITY_PROPERTY = "workflowActionAvailability"
 WIZARD_ACTION_AVAILABILITY_PROPERTY = "wizardActionAvailability"
+QT_POINTING_HAND_CURSOR = qt_enum_value(Qt, "CursorShape", "PointingHandCursor")
+QT_TOOL_BUTTON_TEXT_BESIDE_ICON = qt_enum_value(
+    Qt,
+    "ToolButtonStyle",
+    "ToolButtonTextBesideIcon",
+)
 
 
 class WorkflowActionRow(QWidget):
@@ -212,10 +219,10 @@ def _allow_button_shrink(button: QToolButton) -> None:
 
 def _apply_button_chrome(button: QToolButton, *, role: str = "primary") -> None:
     if hasattr(button, "setToolButtonStyle"):
-        button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        button.setToolButtonStyle(QT_TOOL_BUTTON_TEXT_BESIDE_ICON)
     _allow_button_shrink(button)
     if hasattr(button, "setCursor"):
-        button.setCursor(Qt.PointingHandCursor)
+        button.setCursor(QT_POINTING_HAND_CURSOR)
     if hasattr(button, "setStyleSheet"):
         button.setStyleSheet(_button_stylesheet(role=role))
 

--- a/ui/dockwidget/local_first_shell.py
+++ b/ui/dockwidget/local_first_shell.py
@@ -15,6 +15,7 @@ from qfit.ui.tokens import (
 
 from ._qt_compat import import_qt_module
 from .footer_status_bar import FooterStatusBar
+from qfit.ui.qt_enum_compat import optional_qt_enum_value, qt_enum_value
 
 _qtcore = import_qt_module(
     "qgis.PyQt.QtCore",
@@ -44,6 +45,18 @@ QSizePolicy = _qtwidgets.QSizePolicy
 QStackedWidget = _qtwidgets.QStackedWidget
 QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
+QT_FORBIDDEN_CURSOR = qt_enum_value(Qt, "CursorShape", "ForbiddenCursor")
+QT_KEY_ENTER = qt_enum_value(Qt, "Key", "Key_Enter")
+QT_KEY_RETURN = qt_enum_value(Qt, "Key", "Key_Return")
+QT_KEY_SPACE = qt_enum_value(Qt, "Key", "Key_Space")
+QT_LEFT_BUTTON = qt_enum_value(Qt, "MouseButton", "LeftButton")
+QT_POINTING_HAND_CURSOR = qt_enum_value(Qt, "CursorShape", "PointingHandCursor")
+QT_STRONG_FOCUS = qt_enum_value(Qt, "FocusPolicy", "StrongFocus")
+QT_STYLED_BACKGROUND = optional_qt_enum_value(
+    Qt,
+    "WidgetAttribute",
+    "WA_StyledBackground",
+)
 
 
 class LocalFirstNavigationItem(QWidget):
@@ -65,10 +78,10 @@ class LocalFirstNavigationItem(QWidget):
         self._layout.addWidget(self._label)
         if hasattr(self, "setSizePolicy"):
             self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        if hasattr(self, "setAttribute") and hasattr(Qt, "WA_StyledBackground"):
-            self.setAttribute(Qt.WA_StyledBackground, True)
+        if hasattr(self, "setAttribute") and QT_STYLED_BACKGROUND is not None:
+            self.setAttribute(QT_STYLED_BACKGROUND, True)
         if hasattr(self, "setFocusPolicy"):
-            self.setFocusPolicy(Qt.StrongFocus)
+            self.setFocusPolicy(QT_STRONG_FOCUS)
 
     def setText(self, value: str) -> None:  # noqa: N802
         self._label.setText(value)
@@ -122,7 +135,7 @@ class LocalFirstNavigationItem(QWidget):
     def mousePressEvent(self, event) -> None:  # noqa: N802
         self._pressed_inside = (
             self.isEnabled()
-            and _event_button(event) == Qt.LeftButton
+            and _event_button(event) == QT_LEFT_BUTTON
             and _event_position_inside_widget(event, self)
         )
         parent_press = getattr(super(), "mousePressEvent", None)
@@ -133,7 +146,7 @@ class LocalFirstNavigationItem(QWidget):
         should_activate = (
             self.isEnabled()
             and self._pressed_inside
-            and _event_button(event) == Qt.LeftButton
+            and _event_button(event) == QT_LEFT_BUTTON
             and _event_position_inside_widget(event, self)
         )
         self._pressed_inside = False
@@ -272,7 +285,7 @@ class LocalFirstDockShell(QWidget):
         item.setProperty("navTone", tone)
         item.setProperty("qfitNavItem", True)
         item.setToolTip(f"{page_state.title}: {page_state.status_text}")
-        item.setCursor(Qt.PointingHandCursor if page_state.enabled else Qt.ForbiddenCursor)
+        item.setCursor(QT_POINTING_HAND_CURSOR if page_state.enabled else QT_FORBIDDEN_CURSOR)
         if hasattr(item, "setStyleSheet"):
             item.setStyleSheet(_navigation_item_stylesheet(tone, item.objectName()))
         _refresh_dynamic_qss(item)
@@ -386,7 +399,7 @@ def _event_position_inside_widget(event, widget) -> bool:
 
 
 def _is_activation_key(key) -> bool:
-    return key in (Qt.Key_Return, Qt.Key_Enter, Qt.Key_Space)
+    return key in (QT_KEY_RETURN, QT_KEY_ENTER, QT_KEY_SPACE)
 
 
 def _nav_tone(page_state: LocalFirstDockPageState) -> str:

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -25,6 +25,7 @@ from qfit.ui.widgets.tokens import (
     COLOR_PANEL,
     COLOR_TEXT,
 )
+from qfit.ui.qt_enum_compat import qt_enum_value
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt", "pyqtSignal"))
 _qtwidgets = import_qt_module(
@@ -52,6 +53,13 @@ QVBoxLayout = _qtwidgets.QVBoxLayout
 QWidget = _qtwidgets.QWidget
 
 STEP_PAGE_NARROW_WIDTH = 360
+QT_ALIGN_CENTER = qt_enum_value(Qt, "AlignmentFlag", "AlignCenter")
+QT_POINTING_HAND_CURSOR = qt_enum_value(Qt, "CursorShape", "PointingHandCursor")
+QT_TOOL_BUTTON_TEXT_BESIDE_ICON = qt_enum_value(
+    Qt,
+    "ToolButtonStyle",
+    "ToolButtonTextBesideIcon",
+)
 
 
 class StepPage(QWidget):
@@ -240,7 +248,7 @@ class StepPage(QWidget):
     def _build_status_pill(self):
         label = QLabel("", self)
         label.setObjectName("qfitWizardStepStatusPill")
-        label.setAlignment(Qt.AlignCenter)
+        label.setAlignment(QT_ALIGN_CENTER)
         label.setMinimumHeight(18)
         _allow_horizontal_shrink(label)
         return label
@@ -481,7 +489,7 @@ def _allow_label_wrap(label) -> None:
 
 def _configure_responsive_button(button) -> None:
     if hasattr(button, "setToolButtonStyle"):
-        button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        button.setToolButtonStyle(QT_TOOL_BUTTON_TEXT_BESIDE_ICON)
     if hasattr(button, "setMinimumWidth"):
         button.setMinimumWidth(0)
     if hasattr(button, "setSizePolicy"):
@@ -490,7 +498,7 @@ def _configure_responsive_button(button) -> None:
 
 def _apply_workflow_navigation_cursor(button) -> None:
     if hasattr(button, "setCursor"):
-        button.setCursor(Qt.PointingHandCursor)
+        button.setCursor(QT_POINTING_HAND_CURSOR)
 
 
 def _button_text(label: str, icon: str) -> str:

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -12,6 +12,7 @@ from qfit.ui.application.stepper_presenter import (
     step_key_for_index,
 )
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
+from qfit.ui.qt_enum_compat import qt_enum_value
 
 from ._qt_compat import import_qt_module
 
@@ -46,6 +47,13 @@ STEPPER_WIDE_HEIGHT = 36
 STEPPER_COMPACT_HEIGHT = 32
 WORKFLOW_STEPPER_STATE_PROPERTY = "workflowState"
 WIZARD_STEPPER_STATE_PROPERTY = "wizardState"
+QT_FORBIDDEN_CURSOR = qt_enum_value(Qt, "CursorShape", "ForbiddenCursor")
+QT_POINTING_HAND_CURSOR = qt_enum_value(Qt, "CursorShape", "PointingHandCursor")
+QT_TOOL_BUTTON_TEXT_BESIDE_ICON = qt_enum_value(
+    Qt,
+    "ToolButtonStyle",
+    "ToolButtonTextBesideIcon",
+)
 
 
 class StepperBar(QWidget):
@@ -130,7 +138,7 @@ class StepperBar(QWidget):
         for index, _label in enumerate(STEPPER_LABELS):
             button = QToolButton(self)
             button.setObjectName(f"qfitStepperStep{index + 1}")
-            button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+            button.setToolButtonStyle(QT_TOOL_BUTTON_TEXT_BESIDE_ICON)
             button.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
             if hasattr(button, "setMinimumWidth"):
                 button.setMinimumWidth(0)
@@ -157,7 +165,7 @@ class StepperBar(QWidget):
         button.setProperty("responsiveMode", "compact" if self._compact else "wide")
         button.setEnabled(state != "locked")
         button.setCursor(
-            Qt.ForbiddenCursor if state == "locked" else Qt.PointingHandCursor
+            QT_FORBIDDEN_CURSOR if state == "locked" else QT_POINTING_HAND_CURSOR
         )
         button.setToolTip(_button_tooltip(index, state))
         button.setStyleSheet(_button_stylesheet(state, compact=self._compact))

--- a/ui/dockwidget/workflow_dock.py
+++ b/ui/dockwidget/workflow_dock.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from ._qt_compat import import_qt_module
+from qfit.ui.qt_enum_compat import qt_enum_value
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt",))
 _qtwidgets = import_qt_module(
@@ -17,7 +18,15 @@ QWidget = _qtwidgets.QWidget
 
 WORKFLOW_DOCK_OBJECT_NAME = "qfitWizardDockWidget"
 WORKFLOW_DOCK_TITLE = "qfit"
-WORKFLOW_DOCK_ALLOWED_AREAS = Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
+WORKFLOW_DOCK_ALLOWED_AREAS = qt_enum_value(
+    Qt,
+    "DockWidgetArea",
+    "LeftDockWidgetArea",
+) | qt_enum_value(
+    Qt,
+    "DockWidgetArea",
+    "RightDockWidgetArea",
+)
 WORKFLOW_DOCK_FEATURES = (
     QDockWidget.DockWidgetClosable
     | QDockWidget.DockWidgetMovable

--- a/ui/qt_enum_compat.py
+++ b/ui/qt_enum_compat.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+
+def qt_enum_value(qt, enum_name: str, member_name: str):
+    """Return a Qt enum value across Qt 5 flat and Qt 6 nested enum APIs."""
+
+    direct_value = getattr(qt, member_name, None)
+    if direct_value is not None:
+        return direct_value
+
+    enum_type = getattr(qt, enum_name, None)
+    enum_value = getattr(enum_type, member_name, None) if enum_type is not None else None
+    if enum_value is not None:
+        return enum_value
+
+    msg = f"Qt has neither {member_name!r} nor {enum_name}.{member_name!r}"
+    raise AttributeError(msg)
+
+
+def optional_qt_enum_value(qt, enum_name: str, member_name: str):
+    try:
+        return qt_enum_value(qt, enum_name, member_name)
+    except AttributeError:
+        return None
+
+
+__all__ = ["optional_qt_enum_value", "qt_enum_value"]

--- a/ui/widgets/compat.py
+++ b/ui/widgets/compat.py
@@ -7,7 +7,15 @@ from importlib import import_module
 
 from qgis.PyQt.QtCore import Qt
 
+from qfit.ui.qt_enum_compat import qt_enum_value
+
 CheckableListOption = str | tuple[str, str]
+
+QT_CHECKED = qt_enum_value(Qt, "CheckState", "Checked")
+QT_HORIZONTAL = qt_enum_value(Qt, "Orientation", "Horizontal")
+QT_ITEM_IS_USER_CHECKABLE = qt_enum_value(Qt, "ItemFlag", "ItemIsUserCheckable")
+QT_UNCHECKED = qt_enum_value(Qt, "CheckState", "Unchecked")
+QT_USER_ROLE = qt_enum_value(Qt, "ItemDataRole", "UserRole")
 
 
 @dataclass
@@ -104,9 +112,9 @@ def make_checkable_list(
     for option in options:
         value, label = _normalise_checkable_list_option(option)
         item = widgets.QListWidgetItem(label)
-        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
-        item.setData(Qt.UserRole, value)
-        item.setCheckState(Qt.Checked if value in checked else Qt.Unchecked)
+        item.setFlags(item.flags() | QT_ITEM_IS_USER_CHECKABLE)
+        item.setData(QT_USER_ROLE, value)
+        item.setCheckState(QT_CHECKED if value in checked else QT_UNCHECKED)
         list_widget.addItem(item)
 
     return list_widget
@@ -118,8 +126,8 @@ def checked_list_values(list_widget) -> list[str]:
     values = []
     for index in range(list_widget.count()):
         item = list_widget.item(index)
-        if item.checkState() == Qt.Checked:
-            values.append(item.data(Qt.UserRole))
+        if item.checkState() == QT_CHECKED:
+            values.append(item.data(QT_USER_ROLE))
     return values
 
 
@@ -420,7 +428,7 @@ def make_range_slider(
     lower: float | None = None,
     upper: float | None = None,
     decimals: int = 1,
-    orientation: Qt.Orientation = Qt.Horizontal,
+    orientation=QT_HORIZONTAL,
     parent=None,
 ):
     """Create a double range slider with a QGIS-version-safe fallback.
@@ -491,7 +499,7 @@ def _bind_base_signal(signal_owner, signal_name: str, instance):
 @lru_cache(maxsize=None)
 def _build_scaled_range_slider(range_slider_class):
     class ScaledRangeSlider(range_slider_class):
-        def __init__(self, orientation=Qt.Horizontal, parent=None, *, decimals: int = 1):
+        def __init__(self, orientation=QT_HORIZONTAL, parent=None, *, decimals: int = 1):
             self._scale = 10 ** decimals
             try:
                 super().__init__(orientation, parent)

--- a/ui/widgets/pill.py
+++ b/ui/widgets/pill.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from importlib import import_module
 
+from qfit.ui.qt_enum_compat import qt_enum_value
+
 from .tokens import pill_tone_palette
 
 DEFAULT_PILL_OBJECT_NAME = "qfitPill"
@@ -39,7 +41,7 @@ def configure_pill(
 
     qtcore = _import_qtcore()
     widget.setObjectName(object_name)
-    widget.setAlignment(qtcore.Qt.AlignCenter)
+    widget.setAlignment(qt_enum_value(qtcore.Qt, "AlignmentFlag", "AlignCenter"))
     widget.setMinimumHeight(18)
     set_pill_tone(widget, tone, object_name=object_name)
 

--- a/visualization/infrastructure/layer_style_service.py
+++ b/visualization/infrastructure/layer_style_service.py
@@ -20,6 +20,7 @@ from qgis.core import (
 )
 
 from ...mapbox_config import BACKGROUND_LAYER_PREFIX
+from qfit.ui.qt_enum_compat import qt_enum_value
 from ..application.render_plan import (
     DEFAULT_RENDER_PRESET,
     RENDERER_ATLAS_PAGE,
@@ -44,6 +45,9 @@ HEATMAP_VISUALIZE_RADIUS_M = 1000
 HEATMAP_VISUALIZE_MAXIMUM = 25
 ROUTE_LINE_HEX = "#8e44ad"
 ROUTE_POINT_RGB = "142,68,173"
+QT_DASH_LINE = qt_enum_value(Qt, "PenStyle", "DashLine")
+QT_ROUND_CAP = qt_enum_value(Qt, "PenCapStyle", "RoundCap")
+QT_ROUND_JOIN = qt_enum_value(Qt, "PenJoinStyle", "RoundJoin")
 
 
 def build_qfit_heatmap_renderer(*, maximum_value=None):
@@ -262,15 +266,15 @@ class LayerStyleService:
             outline_layer = QgsSimpleLineSymbolLayer()
             outline_layer.setColor(QColor(line_style.outline_color))
             outline_layer.setWidth(line_style.line_width + (line_style.outline_width * 2.0))
-            outline_layer.setPenCapStyle(Qt.RoundCap)
-            outline_layer.setPenJoinStyle(Qt.RoundJoin)
+            outline_layer.setPenCapStyle(QT_ROUND_CAP)
+            outline_layer.setPenJoinStyle(QT_ROUND_JOIN)
             symbol.appendSymbolLayer(outline_layer)
 
         line_layer = QgsSimpleLineSymbolLayer()
         line_layer.setColor(QColor(color_hex))
         line_layer.setWidth(line_style.line_width)
-        line_layer.setPenCapStyle(Qt.RoundCap)
-        line_layer.setPenJoinStyle(Qt.RoundJoin)
+        line_layer.setPenCapStyle(QT_ROUND_CAP)
+        line_layer.setPenJoinStyle(QT_ROUND_JOIN)
         symbol.appendSymbolLayer(line_layer)
         return symbol
 
@@ -319,9 +323,9 @@ class LayerStyleService:
         line_layer = QgsSimpleLineSymbolLayer()
         line_layer.setColor(QColor(ROUTE_LINE_HEX))
         line_layer.setWidth(0.65)
-        line_layer.setPenCapStyle(Qt.RoundCap)
-        line_layer.setPenJoinStyle(Qt.RoundJoin)
-        line_layer.setPenStyle(Qt.DashLine)
+        line_layer.setPenCapStyle(QT_ROUND_CAP)
+        line_layer.setPenJoinStyle(QT_ROUND_JOIN)
+        line_layer.setPenStyle(QT_DASH_LINE)
         symbol.appendSymbolLayer(line_layer)
 
         layer.setRenderer(QgsSingleSymbolRenderer(symbol))


### PR DESCRIPTION
## Summary

Fixes #1429.

QGIS 4 / Qt 6 no longer exposes several Qt enum members through the flat Qt 5-style names such as `Qt.Horizontal`. qfit evaluated one of those flat names while importing `ui.widgets.compat`, so the plugin could fail during `classFactory()` before any runtime compatibility branch could run.

This PR adds a small Qt enum resolver that supports both Qt 5 flat members and Qt 6 nested enum members, then applies it across the plugin startup and core UI paths for orientations, dock areas, item roles, check states, alignment, cursors, tool-button styles, text-interaction flags, window states, and line-symbol pen styles.

## Validation

- `python3 -m pytest` -> 2568 passed, 175 skipped
- `python3 scripts/package_plugin.py --qgis-major 4`
- verified packaged `metadata.txt` has `qgisMinimumVersion = 4.0` and no `qgisMaximumVersion`
- packaged QGIS 4 scan via temporary venv: Bandit clean, detect-secrets clean, Flake8 clean
- simulated QGIS 4 nested Qt enum import regression in `tests/test_ui_widget_compat.py`

I could not run a real local QGIS 4 desktop load in this WSL workspace because only QGIS 3 installs are visible locally; the QGIS 4 failure reported in the issue appears to come from a different Windows environment.