### PR TITLE
release: 0.53.1 bugfix release (QGIS 4 Qt enum compat)

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.53.0
+version=0.53.1
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.


### PR DESCRIPTION
## Summary

Bugfix release 0.53.1 — fixes QGIS 4 / Qt 6 enum compatibility for the dual QGIS 3 + QGIS 4 plugin package support introduced in #1430.

## What Changed

- Bumps version from 0.53.0 to 0.53.1

This is the release tag for the bugfix that landed in #1431 (Qt enum compatibility resolver for QGIS 4 / Qt 6) on top of the QGIS-major plugin package support from #1430.

## Validation

- QGIS 3 Docker (`qgis/qgis:3.44.11`): 2568 passed, 175 skipped
- QGIS 4 Docker (`qgis/qgis:4.2.0`): 2568 passed, 175 skipped
- Packaging verified for both `--qgis-major 3` and `--qgis-major 4`
- QGIS 3 zip metadata: `qgisMinimumVersion=3.28`, `qgisMaximumVersion=3.99`
- QGIS 4 zip metadata: `qgisMinimumVersion=4.0`, no maximum version cap

## Closes

Closes #1429