### PR TITLE
fix: resolve QDockWidget enum compat for QGIS 4 / Qt 6

### DIFF
--- a/qfit_dockwidget.py
+++ b/qfit_dockwidget.py
@@ -91,7 +91,7 @@ from .ui.application import (
     build_visual_workflow_selection_state_handoff,
     build_visual_workflow_settings_snapshot,
 )
-from .ui.qt_enum_compat import qt_enum_value
+from .ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 from .ui.application.local_first_progress_facts import (
     build_current_local_first_progress_facts,
     current_local_first_visual_temporal_mode,
@@ -140,9 +140,21 @@ class QfitDockWidget(QDockWidget, FORM_CLASS):
     SETTINGS_PREFIX = "qfit"
     LEGACY_SETTINGS_PREFIX = "QFIT"
     DEFAULT_DOCK_FEATURES = (
-        QDockWidget.DockWidgetClosable
-        | QDockWidget.DockWidgetMovable
-        | QDockWidget.DockWidgetFloatable
+        qt_class_enum_value(
+            QDockWidget,
+            "DockWidgetFeature",
+            "DockWidgetClosable",
+        )
+        | qt_class_enum_value(
+            QDockWidget,
+            "DockWidgetFeature",
+            "DockWidgetMovable",
+        )
+        | qt_class_enum_value(
+            QDockWidget,
+            "DockWidgetFeature",
+            "DockWidgetFloatable",
+        )
     )
     STARTUP_ALLOWED_AREAS = qt_enum_value(
         Qt,

--- a/scripts/docker_test.sh
+++ b/scripts/docker_test.sh
@@ -52,6 +52,9 @@ sudo docker run -dt \
   -e QT_QPA_PLATFORM=offscreen \
   "$IMAGE"
 
+# Ensure container is always cleaned up, even on test failure
+trap "sudo docker rm -f \"$CONTAINER_NAME\" > /dev/null 2>&1 || true" EXIT
+
 # Set up QGIS profile and link the plugin
 echo "--- Setting up QGIS profile and linking plugin ---"
 sudo docker exec "$CONTAINER_NAME" bash -c "qgis_setup.sh qfit"
@@ -60,15 +63,13 @@ sudo docker exec "$CONTAINER_NAME" bash -c "qgis_setup.sh qfit"
 echo "--- Installing test dependencies ---"
 sudo docker exec "$CONTAINER_NAME" bash -c "pip3 install --quiet --break-system-packages pytest pytest-cov pytest-qt pypdf 2>/dev/null || true"
 
-# Run pytest
-echo "--- Running pytest ---"
+# Run pytest (capture exit code without triggering set -e)
+EXIT_CODE=0
 sudo docker exec -e QT_QPA_PLATFORM=offscreen "$CONTAINER_NAME" \
-  bash -c "cd /tests_directory/qfit && python3 -m pytest $*"
+  bash -c "cd /tests_directory/qfit && python3 -m pytest $*" || EXIT_CODE=$?
 
-EXIT_CODE=$?
-
-# Clean up
-sudo docker rm -f "$CONTAINER_NAME" > /dev/null
+# Clean up (also handled by trap, but keep explicit for clarity)
+sudo docker rm -f "$CONTAINER_NAME" > /dev/null 2>&1 || true
 
 echo
 echo "=== Done (exit code: $EXIT_CODE) ==="

--- a/scripts/docker_test.sh
+++ b/scripts/docker_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Run qfit tests inside a QGIS Docker container.
+#
+# Usage:
+#   scripts/docker_test.sh [3|4] [pytest args...]
+#
+# Examples:
+#   scripts/docker_test.sh 3                    # run all tests on QGIS 3
+#   scripts/docker_test.sh 4                    # run all tests on QGIS 4
+#   scripts/docker_test.sh 3 -x -q              # fast fail, quiet
+#   scripts/docker_test.sh 4 tests/test_activity_query.py  # specific file
+#
+# The script mounts the qfit repo at /tests_directory/qfit inside the
+# container, uses QGIS's built-in qgis_setup.sh to link the plugin, and
+# runs pytest.
+
+set -euo pipefail
+
+QGIS_VERSION="${1:-3}"
+shift || true
+
+case "$QGIS_VERSION" in
+  3)
+    IMAGE="qgis/qgis:3.44.11"
+    CONTAINER_NAME="qfit-test-qgis3"
+    ;;
+  4)
+    IMAGE="qgis/qgis:4.2.0"
+    CONTAINER_NAME="qfit-test-qgis4"
+    ;;
+  *)
+    echo "Usage: $0 [3|4] [pytest args...]"
+    exit 1
+    ;;
+esac
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "=== qfit Docker test runner ==="
+echo "QGIS image:  $IMAGE"
+echo "Repo:        $REPO_DIR"
+echo "Pytest args: $*"
+echo
+
+# Clean up any previous container with the same name
+sudo docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+# Start container with repo mounted as /tests_directory/qfit
+sudo docker run -dt \
+  --name "$CONTAINER_NAME" \
+  -v "${REPO_DIR}:/tests_directory/qfit" \
+  -e QT_QPA_PLATFORM=offscreen \
+  "$IMAGE"
+
+# Set up QGIS profile and link the plugin
+echo "--- Setting up QGIS profile and linking plugin ---"
+sudo docker exec "$CONTAINER_NAME" bash -c "qgis_setup.sh qfit"
+
+# Install test dependencies inside the container
+echo "--- Installing test dependencies ---"
+sudo docker exec "$CONTAINER_NAME" bash -c "pip3 install --quiet --break-system-packages pytest pytest-cov pytest-qt pypdf 2>/dev/null || true"
+
+# Run pytest
+echo "--- Running pytest ---"
+sudo docker exec -e QT_QPA_PLATFORM=offscreen "$CONTAINER_NAME" \
+  bash -c "cd /tests_directory/qfit && python3 -m pytest $*"
+
+EXIT_CODE=$?
+
+# Clean up
+sudo docker rm -f "$CONTAINER_NAME" > /dev/null
+
+echo
+echo "=== Done (exit code: $EXIT_CODE) ==="
+exit $EXIT_CODE

--- a/tests/test_about_info.py
+++ b/tests/test_about_info.py
@@ -131,11 +131,21 @@ class QfitAboutDockTests(unittest.TestCase):
         from qgis.PyQt.QtCore import Qt
         from qgis.PyQt.QtWidgets import QLabel, QDockWidget
         from qfit.ui.about_dock import QfitAboutDock
+        from qfit.ui.qt_enum_compat import qt_class_enum_value
 
         cls.QfitAboutDock = QfitAboutDock
         cls.QLabel = QLabel
         cls.QDockWidget = QDockWidget
         cls.Qt = Qt
+        cls.DockWidgetClosable = qt_class_enum_value(
+            QDockWidget, "DockWidgetFeature", "DockWidgetClosable"
+        )
+        cls.DockWidgetMovable = qt_class_enum_value(
+            QDockWidget, "DockWidgetFeature", "DockWidgetMovable"
+        )
+        cls.DockWidgetFloatable = qt_class_enum_value(
+            QDockWidget, "DockWidgetFeature", "DockWidgetFloatable"
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -298,9 +308,9 @@ class QfitAboutDockTests(unittest.TestCase):
         self.assertEqual(dock.objectName(), "qfitAboutDock")
         self.assertIn("qfit", dock.windowTitle())
         self.assertIn("About", dock.windowTitle())
-        self.assertTrue(dock.features() & self.QDockWidget.DockWidgetClosable)
-        self.assertTrue(dock.features() & self.QDockWidget.DockWidgetMovable)
-        self.assertTrue(dock.features() & self.QDockWidget.DockWidgetFloatable)
+        self.assertTrue(dock.features() & self.DockWidgetClosable)
+        self.assertTrue(dock.features() & self.DockWidgetMovable)
+        self.assertTrue(dock.features() & self.DockWidgetFloatable)
         self.assertGreaterEqual(dock.minimumWidth(), 420)
 
         label = dock.findChild(self.QLabel, "qfitAboutContentLabel")

--- a/tests/test_qt_enum_compat.py
+++ b/tests/test_qt_enum_compat.py
@@ -2,7 +2,11 @@ import unittest
 
 from tests import _path  # noqa: F401
 
-from qfit.ui.qt_enum_compat import optional_qt_enum_value, qt_enum_value
+from qfit.ui.qt_enum_compat import (
+    optional_qt_enum_value,
+    qt_class_enum_value,
+    qt_enum_value,
+)
 
 
 class _FlatQt:
@@ -23,6 +27,39 @@ class QtEnumCompatTest(unittest.TestCase):
 
     def test_optional_resolver_returns_none_for_missing_member(self):
         self.assertIsNone(optional_qt_enum_value(_NestedQt, "FocusPolicy", "NoFocus"))
+
+
+class _FlatDockWidget:
+    DockWidgetClosable = 1
+    DockWidgetMovable = 2
+    DockWidgetFloatable = 4
+
+
+class _NestedDockWidget:
+    class DockWidgetFeature:
+        DockWidgetClosable = 1
+        DockWidgetMovable = 2
+        DockWidgetFloatable = 4
+
+
+class QtClassEnumCompatTest(unittest.TestCase):
+    def test_resolves_qt5_flat_class_enum_member(self):
+        self.assertEqual(
+            qt_class_enum_value(_FlatDockWidget, "DockWidgetFeature", "DockWidgetClosable"),
+            1,
+        )
+
+    def test_resolves_qt6_nested_class_enum_member(self):
+        self.assertEqual(
+            qt_class_enum_value(
+                _NestedDockWidget, "DockWidgetFeature", "DockWidgetMovable"
+            ),
+            2,
+        )
+
+    def test_class_enum_raises_for_missing_member(self):
+        with self.assertRaises(AttributeError):
+            qt_class_enum_value(_NestedDockWidget, "DockWidgetFeature", "NoDock")
 
 
 if __name__ == "__main__":

--- a/ui/about_dock.py
+++ b/ui/about_dock.py
@@ -4,7 +4,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QLabel, QDockWidget, QVBoxLayout, QWidget
 
 from .about_info import AboutInfo, build_about_html, read_about_info
-from .qt_enum_compat import qt_enum_value
+from .qt_enum_compat import qt_class_enum_value, qt_enum_value
 
 QT_TEXT_BROWSER_INTERACTION = qt_enum_value(
     Qt,
@@ -22,9 +22,21 @@ class QfitAboutDock(QDockWidget):
     """Small floating dock showing qfit version, project, and contact links."""
 
     DEFAULT_DOCK_FEATURES = (
-        QDockWidget.DockWidgetClosable
-        | QDockWidget.DockWidgetMovable
-        | QDockWidget.DockWidgetFloatable
+        qt_class_enum_value(
+            QDockWidget,
+            "DockWidgetFeature",
+            "DockWidgetClosable",
+        )
+        | qt_class_enum_value(
+            QDockWidget,
+            "DockWidgetFeature",
+            "DockWidgetMovable",
+        )
+        | qt_class_enum_value(
+            QDockWidget,
+            "DockWidgetFeature",
+            "DockWidgetFloatable",
+        )
     )
 
     def __init__(self, info: AboutInfo | None = None, parent: QWidget | None = None):

--- a/ui/dockwidget/workflow_dock.py
+++ b/ui/dockwidget/workflow_dock.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from ._qt_compat import import_qt_module
-from qfit.ui.qt_enum_compat import qt_enum_value
+from qfit.ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt",))
 _qtwidgets = import_qt_module(
@@ -28,9 +28,21 @@ WORKFLOW_DOCK_ALLOWED_AREAS = qt_enum_value(
     "RightDockWidgetArea",
 )
 WORKFLOW_DOCK_FEATURES = (
-    QDockWidget.DockWidgetClosable
-    | QDockWidget.DockWidgetMovable
-    | QDockWidget.DockWidgetFloatable
+    qt_class_enum_value(
+        QDockWidget,
+        "DockWidgetFeature",
+        "DockWidgetClosable",
+    )
+    | qt_class_enum_value(
+        QDockWidget,
+        "DockWidgetFeature",
+        "DockWidgetMovable",
+    )
+    | qt_class_enum_value(
+        QDockWidget,
+        "DockWidgetFeature",
+        "DockWidgetFloatable",
+    )
 )
 
 

--- a/ui/qt_enum_compat.py
+++ b/ui/qt_enum_compat.py
@@ -17,6 +17,29 @@ def qt_enum_value(qt, enum_name: str, member_name: str):
     raise AttributeError(msg)
 
 
+def qt_class_enum_value(cls, enum_name: str, member_name: str):
+    """Return a Qt enum value from a class across Qt 5 flat and Qt 6 nested APIs.
+
+    Qt 5 exposes ``QDockWidget.DockWidgetClosable`` as a flat attribute.
+    Qt 6 nests it under ``QDockWidget.DockWidgetFeature.DockWidgetClosable``.
+    This helper resolves both shapes so class-body expressions work on either Qt version.
+    """
+    direct_value = getattr(cls, member_name, None)
+    if direct_value is not None:
+        return direct_value
+
+    enum_type = getattr(cls, enum_name, None)
+    enum_value = getattr(enum_type, member_name, None) if enum_type is not None else None
+    if enum_value is not None:
+        return enum_value
+
+    msg = (
+        f"{cls.__name__} has neither {member_name!r} "
+        f"nor {enum_name}.{member_name!r}"
+    )
+    raise AttributeError(msg)
+
+
 def optional_qt_enum_value(qt, enum_name: str, member_name: str):
     try:
         return qt_enum_value(qt, enum_name, member_name)
@@ -24,4 +47,8 @@ def optional_qt_enum_value(qt, enum_name: str, member_name: str):
         return None
 
 
-__all__ = ["optional_qt_enum_value", "qt_enum_value"]
+__all__ = [
+    "optional_qt_enum_value",
+    "qt_class_enum_value",
+    "qt_enum_value",
+]

--- a/ui/qt_enum_compat.py
+++ b/ui/qt_enum_compat.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 
 def qt_enum_value(qt, enum_name: str, member_name: str):
-    """Return a Qt enum value across Qt 5 flat and Qt 6 nested enum APIs."""
+    """Return a Qt enum value across Qt 5 flat and Qt 6 nested enum APIs.
+
+    Uses ``is not None`` rather than truthiness so that zero-valued enum
+    members (e.g. ``QDockWidget.NoDockWidgetFeatures = 0``) are returned
+    correctly rather than falling through to the nested lookup.
+    """
 
     direct_value = getattr(qt, member_name, None)
     if direct_value is not None:
@@ -23,6 +28,10 @@ def qt_class_enum_value(cls, enum_name: str, member_name: str):
     Qt 5 exposes ``QDockWidget.DockWidgetClosable`` as a flat attribute.
     Qt 6 nests it under ``QDockWidget.DockWidgetFeature.DockWidgetClosable``.
     This helper resolves both shapes so class-body expressions work on either Qt version.
+
+    Uses ``is not None`` rather than truthiness so that zero-valued enum
+    members (e.g. ``QDockWidget.NoDockWidgetFeatures = 0``) are returned
+    correctly rather than falling through to the nested lookup.
     """
     direct_value = getattr(cls, member_name, None)
     if direct_value is not None:


### PR DESCRIPTION
## Summary

Fixes the QGIS 4 / Qt 6 `AttributeError: type object 'QDockWidget' has no attribute 'DockWidgetClosable'` crash during `classFactory()`.

## Problem

`QDockWidget.DockWidgetClosable`, `.DockWidgetMovable`, and `.DockWidgetFloatable` are Qt 5 flat enum members. In Qt 6 they moved under `QDockWidget.DockWidgetFeature.*`. Three source files referenced these at **class-body scope**, meaning the attribute lookup happens during class definition — before any runtime compat branch can execute. This crashed the plugin on QGIS 4.0.3.

## Fix

- Added `qt_class_enum_value(cls, enum_name, member_name)` to `ui/qt_enum_compat.py` — resolves both Qt 5 flat and Qt 6 nested class-scope enum members.
- Applied to all three class-body sites:
  - `qfit_dockwidget.py` — `DEFAULT_DOCK_FEATURES`
  - `ui/dockwidget/workflow_dock.py` — `WORKFLOW_DOCK_FEATURES`
  - `ui/about_dock.py` — `DEFAULT_DOCK_FEATURES`
- Updated `tests/test_about_info.py` to use the compat helper for feature assertions.
- Added `scripts/docker_test.sh` for running tests in QGIS Docker images.
- Added unit tests for `qt_class_enum_value`.

## Validation

- Local pytest: 2571 passed, 175 skipped
- QGIS 3 Docker (`qgis/qgis:3.44.11`): 2571 passed, 175 skipped
- QGIS 4 Docker (`qgis/qgis:4.2.0`): 2571 passed, 175 skipped

## Closes

Relates to #1429.