### PR TITLE
release: 0.53.2 bugfix (QDockWidget enum compat for QGIS 4)

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.53.1
+version=0.53.2
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.


### PR DESCRIPTION
## Summary

Bugfix release 0.53.2 — fixes the `QDockWidget.DockWidgetClosable` AttributeError that crashed qfit on QGIS 4 / Qt 6 during `classFactory()`.

## What Changed

- Bumps version from 0.53.1 to 0.53.2

This is the release tag for the QDockWidget enum compatibility fix from #1433, which addresses the real QGIS 4.0.3 crash reported by Emman.

## Validation

- QGIS 3 Docker (`qgis/qgis:3.44.11`): 2571 passed, 175 skipped
- QGIS 4 Docker (`qgis/qgis:4.2.0`): 2571 passed, 175 skipped
- SonarCloud: Quality Gate passed
- CodeQL: passed
- Greptile: passed (both findings addressed)