### PR TITLE
[codex] Enforce Docker QGIS runtime gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,47 @@ jobs:
           python-version: '3.12'
 
       - name: Install test dependencies
-        run: python -m pip install --upgrade pyyaml pypdf
+        run: python -m pip install --upgrade pytest pyyaml pypdf
 
       - name: Run unit tests
-        run: python -m unittest discover -s tests -v
+        run: python -m pytest tests/ -x -q --tb=short
+
+  docker-qgis3:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run tests in QGIS 3 Docker image
+        run: |
+          docker run -dt \
+            --name qfit-test-qgis3 \
+            -v "${{ github.workspace }}:/tests_directory/qfit" \
+            -e QT_QPA_PLATFORM=offscreen \
+            qgis/qgis:3.44.11
+
+          docker exec qfit-test-qgis3 bash -c "qgis_setup.sh qfit"
+          docker exec qfit-test-qgis3 bash -c "pip3 install --quiet --break-system-packages pytest pytest-cov pytest-qt pypdf 2>/dev/null || true"
+          docker exec -e QT_QPA_PLATFORM=offscreen -e QFIT_REQUIRE_QGIS=1 qfit-test-qgis3 \
+            bash -c "cd /tests_directory/qfit && python3 -m pytest tests/test_qgis_smoke.py tests/test_qt6_class_enum_probe.py -q --tb=short"
+
+  docker-qgis4:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run tests in QGIS 4 Docker image
+        run: |
+          docker run -dt \
+            --name qfit-test-qgis4 \
+            -v "${{ github.workspace }}:/tests_directory/qfit" \
+            -e QT_QPA_PLATFORM=offscreen \
+            qgis/qgis:4.2.0
+
+          docker exec qfit-test-qgis4 bash -c "qgis_setup.sh qfit"
+          docker exec qfit-test-qgis4 bash -c "pip3 install --quiet --break-system-packages pytest pytest-cov pytest-qt pypdf 2>/dev/null || true"
+          docker exec -e QT_QPA_PLATFORM=offscreen -e QFIT_REQUIRE_QGIS=1 qfit-test-qgis4 \
+            bash -c "cd /tests_directory/qfit && python3 -m pytest tests/test_qgis_smoke.py tests/test_qt6_class_enum_probe.py -q --tb=short"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,24 @@ All PRs must pass the following before merging:
 - Run tests: `python3 -m pytest tests/ -x -q`
 - Tests live in `tests/` and must not import QGIS (mock it where needed).
 
+### Docker QGIS tests (mandatory)
+
+qfit supports QGIS 3 and QGIS 4 from one source tree. Unit tests without QGIS
+**cannot** catch Qt 5 / Qt 6 import-surface differences. The Docker QGIS
+runtime suite must pass in both host versions before merge.
+
+- QGIS 3: `scripts/docker_test.sh 3`
+- QGIS 4: `scripts/docker_test.sh 4`
+- CI runs both as required checks — see `docs/testing-policy.md` for details.
+- Docker runs the real-QGIS smoke/probe suite. The full pure unit suite remains
+  covered by `python3 -m pytest tests/ -x -q`.
+- Any change touching Qt enums, class-body expressions, or `classFactory()`
+  import paths must pass Docker QGIS 4.
+- Smoke import failures inside Docker are **hard errors**, not silent skips.
+
 ### Tests must pass
 - `python3 -m pytest tests/ -x -q` must be green before opening a PR.
+- `scripts/docker_test.sh 3` and `scripts/docker_test.sh 4` must be green before merging.
 
 ### Rendering-proof checklist (mandatory for export-sensitive PRs)
 For changes that affect rendered/exported output — especially atlas PDFs, cover pages, table-of-contents pages, profiles, charts, or packaging/runtime-dependent export behaviour — green CI alone is **not** enough.

--- a/docs/testing-policy.md
+++ b/docs/testing-policy.md
@@ -1,0 +1,81 @@
+# qfit Testing Policy
+
+## Principle
+
+qfit supports QGIS 3 and QGIS 4 from one source tree. The plugin runtime
+surface must be tested against real QGIS environments before any PR is
+merged.
+
+Unit tests without QGIS (the default CI job) catch logic errors, but they
+**cannot** catch Qt/PyQGIS import-surface differences between Qt 5 and Qt 6.
+That gap has shipped real crashes. Docker QGIS images close it.
+
+## Mandatory test environments
+
+| Environment | Image | Qt version | What it catches |
+|---|---|---|---|
+| No-QGIS unit tests | `ubuntu-latest` + Python 3.12 | n/a | Full unit suite: logic, architecture, packaging |
+| QGIS 3 Docker | `qgis/qgis:3.44.11` | Qt 5 / PyQt5 | QGIS 3 plugin import + runtime smoke + enum probe |
+| QGIS 4 Docker | `qgis/qgis:4.2.0` | Qt 6 / PyQt6 | QGIS 4 plugin import + runtime smoke + Qt 6 enum probe |
+
+All three must pass before merge.
+
+## CI enforcement
+
+The `tests.yml` workflow runs three jobs:
+
+1. `unit-tests` — no QGIS (fast, catches logic/architecture)
+2. `docker-qgis3` — runtime smoke/probe tests inside `qgis/qgis:3.44.11`
+3. `docker-qgis4` — runtime smoke/probe tests inside `qgis/qgis:4.2.0`
+
+The Docker jobs are **required** checks. A PR cannot merge if any of the
+three fail.
+
+The Docker jobs intentionally run the QGIS runtime suite, not every pure
+unit test. Many pure unit tests install fake `qgis` modules or Qt 5-shaped
+stubs so they can run in the no-QGIS job; those tests are covered by
+`unit-tests`. The Docker jobs focus on what no-QGIS tests cannot prove:
+real plugin imports, QGIS-backed smoke workflows, and Qt/PyQGIS enum
+compatibility.
+
+## Smoke import failures are hard errors
+
+`tests/test_qgis_smoke.py` guards the top-level qfit import chain. If the
+import of `qfit.qfit_dockwidget` or any other qfit module fails inside a
+Docker QGIS environment, the test suite **must fail**, not skip.
+
+The smoke test may still skip when QGIS is genuinely unavailable (e.g. in
+the no-QGIS `unit-tests` job), but inside Docker QGIS jobs the skip guard
+is removed and import failures propagate as test errors.
+
+## Qt class-scope enum probe
+
+`tests/test_qt6_class_enum_probe.py` resolves every class-scope Qt enum
+used at class-body level in qfit source against the real binding. This
+catches `QDockWidget.DockWidgetClosable`-style failures that a broad
+try/except import can silently swallow.
+
+The probe runs in all environments. On Qt 5 it resolves flat members; on
+Qt 6 it resolves nested members. If neither shape is available, the probe
+fails.
+
+## Running Docker tests locally
+
+```bash
+scripts/docker_test.sh 3            # runtime smoke/probe suite on QGIS 3
+scripts/docker_test.sh 4            # runtime smoke/probe suite on QGIS 4
+scripts/docker_test.sh 3 -x -q      # custom pytest args on QGIS 3
+scripts/docker_test.sh 4 tests/test_qgis_smoke.py  # specific file
+```
+
+The script handles container lifecycle, plugin linking, and cleanup. It
+requires Docker on the host.
+
+## When to add a Docker test
+
+- Any change that touches Qt enum references, class-body expressions using
+  Qt/PyQt classes, or `classFactory()` import paths must pass Docker QGIS 4.
+- Any change to packaging or plugin metadata must produce both zip artifacts
+  and pass Docker tests on both QGIS versions.
+- Rendering/export-sensitive changes still need the rendering-proof checklist
+  from `CONTRIBUTING.md` in addition to Docker tests.

--- a/qfit_config_dialog.py
+++ b/qfit_config_dialog.py
@@ -42,13 +42,23 @@ from .configuration.application.ui_settings_binding import (
 )
 from .providers.domain.provider import ProviderError
 from .providers.infrastructure.strava_client import StravaClient
-from .ui.qt_enum_compat import qt_enum_value
+from .ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 from .ui.widgets import make_password_line_edit
 
 logger = logging.getLogger(__name__)
 
+QT_BUTTON_SAVE = qt_class_enum_value(
+    QDialogButtonBox, "StandardButton", "Save"
+)
+QT_BUTTON_CLOSE = qt_class_enum_value(
+    QDialogButtonBox, "StandardButton", "Close"
+)
+
 _NOT_TESTED_LABEL = "Not tested"
 _OAUTH_NOT_STARTED_LABEL = "Not started"
+QT_FORM_WRAP_LONG_ROWS = qt_class_enum_value(
+    QFormLayout, "RowWrapPolicy", "WrapLongRows"
+)
 QT_TEXT_SELECTABLE_BY_MOUSE = qt_enum_value(
     Qt,
     "TextInteractionFlag",
@@ -100,16 +110,16 @@ class QfitConfigDialog(QDialog):
         layout.addWidget(self._build_mapbox_group())
 
         self._button_box = QDialogButtonBox(
-            QDialogButtonBox.Save | QDialogButtonBox.Close,
+            QT_BUTTON_SAVE | QT_BUTTON_CLOSE,
         )
-        self._button_box.button(QDialogButtonBox.Save).clicked.connect(self._save)
+        self._button_box.button(QT_BUTTON_SAVE).clicked.connect(self._save)
         self._button_box.rejected.connect(self.close)
         layout.addWidget(self._button_box)
 
     def _build_strava_group(self) -> QGroupBox:
         group = QGroupBox("Strava connection")
         form = QFormLayout(group)
-        form.setRowWrapPolicy(QFormLayout.WrapLongRows)
+        form.setRowWrapPolicy(QT_FORM_WRAP_LONG_ROWS)
 
         self._strava_status_label = QLabel()
         self._strava_status_label.setObjectName("stravaStatusLabel")
@@ -190,7 +200,7 @@ class QfitConfigDialog(QDialog):
     def _build_mapbox_group(self) -> QGroupBox:
         group = QGroupBox("Mapbox connection")
         form = QFormLayout(group)
-        form.setRowWrapPolicy(QFormLayout.WrapLongRows)
+        form.setRowWrapPolicy(QT_FORM_WRAP_LONG_ROWS)
 
         self._mapbox_status_label = QLabel()
         self._mapbox_status_label.setObjectName("mapboxStatusLabel")

--- a/scripts/docker_test.sh
+++ b/scripts/docker_test.sh
@@ -5,8 +5,8 @@
 #   scripts/docker_test.sh [3|4] [pytest args...]
 #
 # Examples:
-#   scripts/docker_test.sh 3                    # run all tests on QGIS 3
-#   scripts/docker_test.sh 4                    # run all tests on QGIS 4
+#   scripts/docker_test.sh 3                    # run QGIS runtime tests on QGIS 3
+#   scripts/docker_test.sh 4                    # run QGIS runtime tests on QGIS 4
 #   scripts/docker_test.sh 3 -x -q              # fast fail, quiet
 #   scripts/docker_test.sh 4 tests/test_activity_query.py  # specific file
 #
@@ -18,6 +18,10 @@ set -euo pipefail
 
 QGIS_VERSION="${1:-3}"
 shift || true
+
+if [[ "$#" -eq 0 ]]; then
+  set -- tests/test_qgis_smoke.py tests/test_qt6_class_enum_probe.py -q --tb=short
+fi
 
 case "$QGIS_VERSION" in
   3)
@@ -65,8 +69,8 @@ sudo docker exec "$CONTAINER_NAME" bash -c "pip3 install --quiet --break-system-
 
 # Run pytest (capture exit code without triggering set -e)
 EXIT_CODE=0
-sudo docker exec -e QT_QPA_PLATFORM=offscreen "$CONTAINER_NAME" \
-  bash -c "cd /tests_directory/qfit && python3 -m pytest $*" || EXIT_CODE=$?
+sudo docker exec -e QT_QPA_PLATFORM=offscreen -e QFIT_REQUIRE_QGIS=1 "$CONTAINER_NAME" \
+  bash -c 'cd /tests_directory/qfit && python3 -m pytest "$@"' bash "$@" || EXIT_CODE=$?
 
 # Clean up (also handled by trap, but keep explicit for clarity)
 sudo docker rm -f "$CONTAINER_NAME" > /dev/null 2>&1 || true

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -82,6 +82,21 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("dist/*-qgis*.zip", self.text)
 
 
+class TestsWorkflowTests(unittest.TestCase):
+    def setUp(self):
+        self.text = _read_workflow("tests.yml")
+
+    def test_unit_job_uses_pytest(self):
+        self.assertIn("python -m pip install --upgrade pytest", self.text)
+        self.assertIn("python -m pytest tests/ -x -q --tb=short", self.text)
+
+    def test_docker_jobs_run_qgis_runtime_suite(self):
+        self.assertIn("qgis/qgis:3.44.11", self.text)
+        self.assertIn("qgis/qgis:4.2.0", self.text)
+        self.assertIn("QFIT_REQUIRE_QGIS=1", self.text)
+        self.assertIn("tests/test_qgis_smoke.py tests/test_qt6_class_enum_probe.py", self.text)
+
+
 class PluginSecurityScanWorkflowTests(unittest.TestCase):
     def setUp(self):
         self.text = _read_workflow("plugin-security-scan.yml")

--- a/tests/test_contextual_help.py
+++ b/tests/test_contextual_help.py
@@ -303,6 +303,10 @@ class _FakeQtWidgetsModule:
         Ignored = 3
         Preferred = 4
 
+        class Policy:
+            Ignored = 3
+            Preferred = 4
+
     QWhatsThis = _FakeQWhatsThis
     QWidget = _FakeWidget
     QLabel = _FakeLabel

--- a/tests/test_qgis_smoke.py
+++ b/tests/test_qgis_smoke.py
@@ -14,6 +14,20 @@ from tests.qgis_app import get_shared_qgis_app
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+# When Docker QGIS tests run, they set QFIT_REQUIRE_QGIS=1 so that import
+# failures are hard errors instead of silent skips.  This prevents Qt 6
+# enum-migration crashes from hiding behind a broad try/except guard.
+_REQUIRE_QGIS = os.environ.get("QFIT_REQUIRE_QGIS") == "1"
+
+if _REQUIRE_QGIS:
+    # Several pure unit tests install fake qgis modules during collection so
+    # they can import QGIS-facing code without a real QGIS runtime. Docker
+    # smoke tests must not inherit those fakes; reset QGIS modules before
+    # importing the real plugin stack.
+    for module_name in list(sys.modules):
+        if module_name == "qgis" or module_name.startswith("qgis."):
+            sys.modules.pop(module_name, None)
+
 try:
     from qgis.core import (
         QgsApplication,
@@ -30,6 +44,8 @@ try:
     from qgis.PyQt.QtCore import QDate, Qt
     from qgis.PyQt.QtGui import QImage
     from qgis.PyQt.QtWidgets import QFormLayout
+
+    from qfit.ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 
     from qfit.activities.domain.activity_query import ActivityQuery, build_subset_string
     from qfit.analysis.infrastructure.frequent_start_points_layer import (
@@ -70,7 +86,12 @@ try:
 
     QGIS_AVAILABLE = True
     QGIS_IMPORT_ERROR = None
-except Exception as exc:  # pragma: no cover - exercised only when QGIS is unavailable
+except Exception as exc:
+    if _REQUIRE_QGIS:
+        # Inside Docker QGIS tests, import failures must crash, not skip.
+        # This is what catches Qt 6 enum-migration issues that a broad
+        # try/except would otherwise swallow into a silent skip.
+        raise
     QgsApplication = None
     QgsCoordinateReferenceSystem = None
     QgsFeature = None
@@ -282,8 +303,22 @@ class QgisSmokeTests(unittest.TestCase):
             ):
                 with self.subTest(removed_attr=removed_attr):
                     self.assertFalse(hasattr(dock, removed_attr))
-            self.assertTrue(bool(dock.features() & dock.DockWidgetMovable))
-            self.assertTrue(bool(dock.features() & dock.DockWidgetFloatable))
+            self.assertTrue(
+                bool(
+                    dock.features()
+                    & qt_class_enum_value(
+                        type(dock), "DockWidgetFeature", "DockWidgetMovable"
+                    )
+                )
+            )
+            self.assertTrue(
+                bool(
+                    dock.features()
+                    & qt_class_enum_value(
+                        type(dock), "DockWidgetFeature", "DockWidgetFloatable"
+                    )
+                )
+            )
             self.assertEqual(dock.activitiesGroupBox.title(), "")
             self.assertFalse(hasattr(dock, "activitiesSectionToggleButton"))
             self.assertFalse(hasattr(dock, "activitiesSectionContentWidget"))
@@ -809,8 +844,14 @@ class QgisSmokeTests(unittest.TestCase):
 
             form = dialog._oauth_help_label.parentWidget().layout()
             _row, role = form.getWidgetPosition(dialog._oauth_help_label)
-            self.assertEqual(role, QFormLayout.SpanningRole)
-            self.assertEqual(form.rowWrapPolicy(), QFormLayout.WrapLongRows)
+            self.assertEqual(
+                role,
+                qt_class_enum_value(QFormLayout, "ItemRole", "SpanningRole"),
+            )
+            self.assertEqual(
+                form.rowWrapPolicy(),
+                qt_class_enum_value(QFormLayout, "RowWrapPolicy", "WrapLongRows"),
+            )
         finally:
             dialog.close()
             dialog.deleteLater()
@@ -1548,7 +1589,6 @@ class QgisSmokeTests(unittest.TestCase):
             from pathlib import Path
 
             os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-            sys.path.insert(0, "/home/ebelo/.openclaw/workspace")
 
             from qgis.core import QgsApplication, QgsLayoutExporter, QgsProject, QgsRectangle
             from qgis.PyQt.QtGui import QImage
@@ -1764,12 +1804,26 @@ class QgisSmokeTests(unittest.TestCase):
             """
         )
 
+        import qgis as _qgis_mod
+        _qgis_python_path = os.path.dirname(list(_qgis_mod.__path__)[0])
+        _qfit_parent_path = str(REPO_ROOT.parent)
+        _pythonpath_parts = [
+            _qfit_parent_path,
+            _qgis_python_path,
+            os.environ.get("PYTHONPATH", ""),
+        ]
+        _pythonpath_parts = [p for p in _pythonpath_parts if p]
+
         result = subprocess.run(
             [sys.executable, "-c", script],
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
-            env={**os.environ, "QT_QPA_PLATFORM": "offscreen"},
+            env={
+                **os.environ,
+                "QT_QPA_PLATFORM": "offscreen",
+                "PYTHONPATH": os.pathsep.join(_pythonpath_parts),
+            },
             timeout=180,
         )
 
@@ -1905,8 +1959,14 @@ class QgisSmokeTests(unittest.TestCase):
     def _render_layers_to_image(self, layers, extent, width=800, height=800):
         settings = QgsMapSettings()
         settings.setLayers(layers)
-        settings.setOutputSize(QImage(width, height, QImage.Format_ARGB32).size())
-        settings.setBackgroundColor(Qt.white)
+        settings.setOutputSize(
+            QImage(
+                width,
+                height,
+                qt_class_enum_value(QImage, "Format", "Format_ARGB32"),
+            ).size()
+        )
+        settings.setBackgroundColor(qt_enum_value(Qt, "GlobalColor", "white"))
 
         destination_crs = QgsProject.instance().crs()
         if destination_crs.isValid():

--- a/tests/test_qt6_class_enum_probe.py
+++ b/tests/test_qt6_class_enum_probe.py
@@ -1,0 +1,179 @@
+"""Probe test: resolve class-scope and module-scope Qt enums against the real binding.
+
+This test exists because qfit uses Qt enum members (``Qt.Horizontal``,
+``QDockWidget.DockWidgetClosable``, etc.) at class-body and module scope.
+In Qt 5 these are flat attributes; in Qt 6 they moved under nested enum
+classes.  A broad ``try/except`` import guard in other test modules can
+silently swallow the resulting ``AttributeError`` into a skip, hiding real
+crashes from the test suite.
+
+This probe runs unconditionally (no skip guard) so that import-surface
+Qt enum failures are caught immediately on both Qt 5 and Qt 6.
+"""
+
+import unittest
+
+from tests import _path  # noqa: F401
+
+
+def _import_qt():
+    """Import the Qt binding qfit actually uses, or skip if unavailable."""
+    try:
+        from qgis.PyQt.QtCore import Qt, QStandardPaths
+        from qgis.PyQt.QtGui import QImage
+        from qgis.PyQt.QtWidgets import (
+            QDockWidget,
+            QFormLayout,
+            QFrame,
+            QSizePolicy,
+            QToolButton,
+            QDialogButtonBox,
+        )
+    except Exception:
+        try:
+            from PyQt5.QtCore import Qt, QStandardPaths
+            from PyQt5.QtGui import QImage
+            from PyQt5.QtWidgets import (
+                QDockWidget,
+                QFormLayout,
+                QFrame,
+                QSizePolicy,
+                QToolButton,
+                QDialogButtonBox,
+            )
+        except Exception:
+            try:
+                from PyQt6.QtCore import Qt, QStandardPaths
+                from PyQt6.QtGui import QImage
+                from PyQt6.QtWidgets import (
+                    QDockWidget,
+                    QFormLayout,
+                    QFrame,
+                    QSizePolicy,
+                    QToolButton,
+                    QDialogButtonBox,
+                )
+            except Exception:
+                raise unittest.SkipTest("No Qt binding available")
+    return (
+        Qt,
+        QStandardPaths,
+        QDockWidget,
+        QFormLayout,
+        QFrame,
+        QImage,
+        QSizePolicy,
+        QToolButton,
+        QDialogButtonBox,
+    )
+
+
+(
+    Qt,
+    QStandardPaths,
+    QDockWidget,
+    QFormLayout,
+    QFrame,
+    QImage,
+    QSizePolicy,
+    QToolButton,
+    QDialogButtonBox,
+) = _import_qt()
+
+# Every class-scope Qt enum used at class-body or function-call level in qfit source.
+# Each entry: (class, enum_name, member_name)
+# Update this list when adding new class-scope Qt enum references.
+CLASS_SCOPE_ENUMS = [
+    (QDockWidget, "DockWidgetFeature", "DockWidgetClosable"),
+    (QDockWidget, "DockWidgetFeature", "DockWidgetMovable"),
+    (QDockWidget, "DockWidgetFeature", "DockWidgetFloatable"),
+    (QStandardPaths, "StandardLocation", "AppDataLocation"),
+    (QFormLayout, "RowWrapPolicy", "WrapLongRows"),
+    (QFrame, "Shape", "HLine"),
+    (QFrame, "Shape", "VLine"),
+    (QFrame, "Shape", "NoFrame"),
+    (QFrame, "Shadow", "Plain"),
+    (QImage, "Format", "Format_ARGB32"),
+    (QSizePolicy, "Policy", "Expanding"),
+    (QSizePolicy, "Policy", "Fixed"),
+    (QSizePolicy, "Policy", "Ignored"),
+    (QSizePolicy, "Policy", "Preferred"),
+    (QToolButton, "ToolButtonPopupMode", "InstantPopup"),
+    (QDialogButtonBox, "StandardButton", "Save"),
+    (QDialogButtonBox, "StandardButton", "Close"),
+]
+
+# Every module-scope Qt enum used at module/class-body level via qt_enum_value.
+# Each entry: (qt_module, enum_name, member_name)
+MODULE_SCOPE_ENUMS = [
+    ("AlignmentFlag", "AlignLeft"),
+    ("AlignmentFlag", "AlignRight"),
+    ("AlignmentFlag", "AlignTop"),
+    ("AlignmentFlag", "AlignVCenter"),
+    ("AlignmentFlag", "AlignCenter"),
+    ("CheckState", "Checked"),
+    ("GlobalColor", "white"),
+    ("CheckState", "Unchecked"),
+    ("CursorShape", "ForbiddenCursor"),
+    ("CursorShape", "PointingHandCursor"),
+    ("CursorShape", "WhatsThisCursor"),
+    ("DockWidgetArea", "LeftDockWidgetArea"),
+    ("DockWidgetArea", "RightDockWidgetArea"),
+    ("FocusPolicy", "StrongFocus"),
+    ("FocusPolicy", "NoFocus"),
+    ("ItemDataRole", "UserRole"),
+    ("ItemFlag", "ItemIsUserCheckable"),
+    ("Key", "Key_Enter"),
+    ("Key", "Key_Return"),
+    ("Key", "Key_Space"),
+    ("MouseButton", "LeftButton"),
+    ("Orientation", "Horizontal"),
+    ("PenStyle", "DashLine"),
+    ("PenCapStyle", "RoundCap"),
+    ("PenJoinStyle", "RoundJoin"),
+    ("TextInteractionFlag", "TextBrowserInteraction"),
+    ("TextInteractionFlag", "TextSelectableByMouse"),
+    ("ToolButtonStyle", "ToolButtonTextBesideIcon"),
+]
+
+
+class QtClassEnumProbeTest(unittest.TestCase):
+    """Verify class-scope Qt enums resolve on the real binding."""
+
+    def test_class_scope_enums_resolve(self):
+        for cls, enum_name, member_name in CLASS_SCOPE_ENUMS:
+            with self.subTest(cls=cls.__name__, member=member_name):
+                # Try flat (Qt 5) then nested (Qt 6)
+                direct = getattr(cls, member_name, None)
+                if direct is not None:
+                    continue
+                enum_type = getattr(cls, enum_name, None)
+                nested = getattr(enum_type, member_name, None) if enum_type else None
+                self.assertIsNotNone(
+                    nested,
+                    f"{cls.__name__}.{member_name} not found as flat or "
+                    f"{cls.__name__}.{enum_name}.{member_name}",
+                )
+
+
+class QtModuleEnumProbeTest(unittest.TestCase):
+    """Verify module-scope Qt enums resolve on the real binding."""
+
+    def test_module_scope_enums_resolve(self):
+        for enum_name, member_name in MODULE_SCOPE_ENUMS:
+            with self.subTest(enum=enum_name, member=member_name):
+                # Try flat (Qt 5) then nested (Qt 6)
+                direct = getattr(Qt, member_name, None)
+                if direct is not None:
+                    continue
+                enum_type = getattr(Qt, enum_name, None)
+                nested = getattr(enum_type, member_name, None) if enum_type else None
+                self.assertIsNotNone(
+                    nested,
+                    f"Qt.{member_name} not found as flat or "
+                    f"Qt.{enum_name}.{member_name}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stepper_bar.py
+++ b/tests/test_stepper_bar.py
@@ -142,7 +142,17 @@ class _FakeToolButton(_FakeWidget):
 
 class _FakeFrame(_FakeWidget):
     HLine = 1
+    VLine = 1
     Plain = 2
+    NoFrame = 0
+
+    class Shape:
+        HLine = 1
+        VLine = 1
+        NoFrame = 0
+
+    class Shadow:
+        Plain = 2
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -182,6 +192,12 @@ class _FakeSizePolicy:
     Fixed = 2
     Ignored = 3
     Preferred = 4
+
+    class Policy:
+        Expanding = 1
+        Fixed = 2
+        Ignored = 3
+        Preferred = 4
 
 
 def _fake_qt_modules():

--- a/tests/test_wizard_shell.py
+++ b/tests/test_wizard_shell.py
@@ -229,8 +229,17 @@ class _FakeComboBox(_FakeWidget):
 
 class _FakeFrame(_FakeWidget):
     HLine = 1
+    VLine = 1
     Plain = 2
     NoFrame = 3
+
+    class Shape:
+        HLine = 1
+        VLine = 1
+        NoFrame = 3
+
+    class Shadow:
+        Plain = 2
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -374,6 +383,12 @@ class _FakeSizePolicy:
     Fixed = 2
     Ignored = 3
     Preferred = 4
+
+    class Policy:
+        Expanding = 1
+        Fixed = 2
+        Ignored = 3
+        Preferred = 4
 
 
 def _fake_qt_modules():

--- a/ui/application/local_first_backing_controls.py
+++ b/ui/application/local_first_backing_controls.py
@@ -140,7 +140,7 @@ def _move_clear_database_to_actions_menu(dock) -> None:
     from qgis.PyQt.QtCore import Qt
     from qgis.PyQt.QtWidgets import QMenu, QToolButton
 
-    from qfit.ui.qt_enum_compat import qt_enum_value
+    from qfit.ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 
     menu = QMenu(getattr(dock, "outputGroupBox", None))
     if hasattr(menu, "setObjectName"):
@@ -157,8 +157,12 @@ def _move_clear_database_to_actions_menu(dock) -> None:
     menu_button.setToolTip(
         "Less common database operations; destructive actions ask for confirmation."
     )
-    menu_button.setToolButtonStyle(qt_enum_value(Qt, "ToolButtonStyle", "ToolButtonTextBesideIcon"))
-    menu_button.setPopupMode(QToolButton.InstantPopup)
+    menu_button.setToolButtonStyle(
+        qt_enum_value(Qt, "ToolButtonStyle", "ToolButtonTextBesideIcon")
+    )
+    menu_button.setPopupMode(
+        qt_class_enum_value(QToolButton, "ToolButtonPopupMode", "InstantPopup")
+    )
     menu_button.setMenu(menu)
 
     output_layout.removeWidget(clear_button)

--- a/ui/contextual_help.py
+++ b/ui/contextual_help.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterable
 
-from qfit.ui.qt_enum_compat import qt_enum_value
+from qfit.ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 
 
 @dataclass(frozen=True)
@@ -242,8 +242,12 @@ class ContextualHelpBinder:
             helper.setMinimumWidth(0)
         if hasattr(helper, "setSizePolicy"):
             helper.setSizePolicy(
-                qtwidgets.QSizePolicy.Ignored,
-                qtwidgets.QSizePolicy.Preferred,
+                qt_class_enum_value(
+                    qtwidgets.QSizePolicy, "Policy", "Ignored"
+                ),
+                qt_class_enum_value(
+                    qtwidgets.QSizePolicy, "Policy", "Preferred"
+                ),
             )
         helper.setTextInteractionFlags(
             qt_enum_value(

--- a/ui/dockwidget/action_row.py
+++ b/ui/dockwidget/action_row.py
@@ -10,7 +10,7 @@ from qfit.ui.tokens import (
     COLOR_SEPARATOR,
     pill_tone_palette,
 )
-from qfit.ui.qt_enum_compat import qt_enum_value
+from qfit.ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 
 from ._qt_compat import import_qt_module
 
@@ -40,6 +40,10 @@ QT_TOOL_BUTTON_TEXT_BESIDE_ICON = qt_enum_value(
     "ToolButtonStyle",
     "ToolButtonTextBesideIcon",
 )
+QT_SIZE_POLICY_IGNORED = qt_class_enum_value(
+    QSizePolicy, "Policy", "Ignored"
+)
+QT_SIZE_POLICY_FIXED = qt_class_enum_value(QSizePolicy, "Policy", "Fixed")
 
 
 class WorkflowActionRow(QWidget):
@@ -214,7 +218,7 @@ def _allow_button_shrink(button: QToolButton) -> None:
     if hasattr(button, "setMinimumWidth"):
         button.setMinimumWidth(0)
     if hasattr(button, "setSizePolicy"):
-        button.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
+        button.setSizePolicy(QT_SIZE_POLICY_IGNORED, QT_SIZE_POLICY_FIXED)
 
 
 def _apply_button_chrome(button: QToolButton, *, role: str = "primary") -> None:

--- a/ui/dockwidget/local_first_shell.py
+++ b/ui/dockwidget/local_first_shell.py
@@ -15,7 +15,7 @@ from qfit.ui.tokens import (
 
 from ._qt_compat import import_qt_module
 from .footer_status_bar import FooterStatusBar
-from qfit.ui.qt_enum_compat import optional_qt_enum_value, qt_enum_value
+from qfit.ui.qt_enum_compat import optional_qt_enum_value, qt_class_enum_value, qt_enum_value
 
 _qtcore = import_qt_module(
     "qgis.PyQt.QtCore",
@@ -57,6 +57,13 @@ QT_STYLED_BACKGROUND = optional_qt_enum_value(
     "WidgetAttribute",
     "WA_StyledBackground",
 )
+QT_SIZE_POLICY_EXPANDING = qt_class_enum_value(
+    QSizePolicy, "Policy", "Expanding"
+)
+QT_SIZE_POLICY_FIXED = qt_class_enum_value(QSizePolicy, "Policy", "Fixed")
+QT_FRAME_VLINE = qt_class_enum_value(QFrame, "Shape", "VLine")
+QT_FRAME_HLINE = qt_class_enum_value(QFrame, "Shape", "HLine")
+QT_FRAME_PLAIN = qt_class_enum_value(QFrame, "Shadow", "Plain")
 
 
 class LocalFirstNavigationItem(QWidget):
@@ -77,7 +84,7 @@ class LocalFirstNavigationItem(QWidget):
             self._layout.setSpacing(0)
         self._layout.addWidget(self._label)
         if hasattr(self, "setSizePolicy"):
-            self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+            self.setSizePolicy(QT_SIZE_POLICY_EXPANDING, QT_SIZE_POLICY_FIXED)
         if hasattr(self, "setAttribute") and QT_STYLED_BACKGROUND is not None:
             self.setAttribute(QT_STYLED_BACKGROUND, True)
         if hasattr(self, "setFocusPolicy"):
@@ -330,8 +337,8 @@ class LocalFirstDockShell(QWidget):
     def _build_separator(self):
         separator = QFrame(self)
         separator.setObjectName("qfitLocalFirstDockSeparator")
-        separator.setFrameShape(getattr(QFrame, "VLine", QFrame.HLine))
-        separator.setFrameShadow(QFrame.Plain)
+        separator.setFrameShape(QT_FRAME_VLINE)
+        separator.setFrameShadow(QT_FRAME_PLAIN)
         separator.setFixedWidth(1)
         return separator
 

--- a/ui/dockwidget/page_content_style.py
+++ b/ui/dockwidget/page_content_style.py
@@ -10,6 +10,7 @@ from qfit.ui.tokens import (
 )
 
 from ._qt_compat import import_qt_module
+from qfit.ui.qt_enum_compat import qt_class_enum_value
 
 _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
@@ -23,6 +24,12 @@ _qtcore = import_qt_module(
 )
 
 QSizePolicy = _qtwidgets.QSizePolicy
+QT_SIZE_POLICY_IGNORED = qt_class_enum_value(
+    QSizePolicy, "Policy", "Ignored"
+)
+QT_SIZE_POLICY_PREFERRED = qt_class_enum_value(
+    QSizePolicy, "Policy", "Preferred"
+)
 Qt = _qtcore.Qt
 
 PAGE_CONTENT_MARGINS = (0, 0, 0, 0)
@@ -83,7 +90,7 @@ def configure_fluid_text_label(label) -> None:
     if hasattr(label, "setMinimumWidth"):
         label.setMinimumWidth(0)
     if hasattr(label, "setSizePolicy"):
-        label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+        label.setSizePolicy(QT_SIZE_POLICY_IGNORED, QT_SIZE_POLICY_PREFERRED)
 
 
 def configure_top_aligned_panel_layout(

--- a/ui/dockwidget/step_page.py
+++ b/ui/dockwidget/step_page.py
@@ -25,7 +25,7 @@ from qfit.ui.widgets.tokens import (
     COLOR_PANEL,
     COLOR_TEXT,
 )
-from qfit.ui.qt_enum_compat import qt_enum_value
+from qfit.ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 
 _qtcore = import_qt_module("qgis.PyQt.QtCore", "PyQt5.QtCore", ("Qt", "pyqtSignal"))
 _qtwidgets = import_qt_module(
@@ -60,6 +60,13 @@ QT_TOOL_BUTTON_TEXT_BESIDE_ICON = qt_enum_value(
     "ToolButtonStyle",
     "ToolButtonTextBesideIcon",
 )
+QT_SIZE_POLICY_IGNORED = qt_class_enum_value(
+    QSizePolicy, "Policy", "Ignored"
+)
+QT_SIZE_POLICY_PREFERRED = qt_class_enum_value(
+    QSizePolicy, "Policy", "Preferred"
+)
+QT_SIZE_POLICY_FIXED = qt_class_enum_value(QSizePolicy, "Policy", "Fixed")
 
 
 class StepPage(QWidget):
@@ -478,7 +485,7 @@ def _allow_horizontal_shrink(widget) -> None:
     if hasattr(widget, "setMinimumWidth"):
         widget.setMinimumWidth(0)
     if hasattr(widget, "setSizePolicy"):
-        widget.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+        widget.setSizePolicy(QT_SIZE_POLICY_IGNORED, QT_SIZE_POLICY_PREFERRED)
 
 
 def _allow_label_wrap(label) -> None:
@@ -493,7 +500,7 @@ def _configure_responsive_button(button) -> None:
     if hasattr(button, "setMinimumWidth"):
         button.setMinimumWidth(0)
     if hasattr(button, "setSizePolicy"):
-        button.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
+        button.setSizePolicy(QT_SIZE_POLICY_IGNORED, QT_SIZE_POLICY_FIXED)
 
 
 def _apply_workflow_navigation_cursor(button) -> None:

--- a/ui/dockwidget/stepper_bar.py
+++ b/ui/dockwidget/stepper_bar.py
@@ -12,7 +12,7 @@ from qfit.ui.application.stepper_presenter import (
     step_key_for_index,
 )
 from qfit.ui.tokens import COLOR_ACCENT, COLOR_HOVER, COLOR_MUTED, COLOR_SEPARATOR, COLOR_TEXT
-from qfit.ui.qt_enum_compat import qt_enum_value
+from qfit.ui.qt_enum_compat import qt_class_enum_value, qt_enum_value
 
 from ._qt_compat import import_qt_module
 
@@ -54,6 +54,12 @@ QT_TOOL_BUTTON_TEXT_BESIDE_ICON = qt_enum_value(
     "ToolButtonStyle",
     "ToolButtonTextBesideIcon",
 )
+QT_SIZE_POLICY_IGNORED = qt_class_enum_value(
+    QSizePolicy, "Policy", "Ignored"
+)
+QT_SIZE_POLICY_FIXED = qt_class_enum_value(QSizePolicy, "Policy", "Fixed")
+QT_FRAME_HLINE = qt_class_enum_value(QFrame, "Shape", "HLine")
+QT_FRAME_PLAIN = qt_class_enum_value(QFrame, "Shadow", "Plain")
 
 
 class StepperBar(QWidget):
@@ -139,7 +145,7 @@ class StepperBar(QWidget):
             button = QToolButton(self)
             button.setObjectName(f"qfitStepperStep{index + 1}")
             button.setToolButtonStyle(QT_TOOL_BUTTON_TEXT_BESIDE_ICON)
-            button.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
+            button.setSizePolicy(QT_SIZE_POLICY_IGNORED, QT_SIZE_POLICY_FIXED)
             if hasattr(button, "setMinimumWidth"):
                 button.setMinimumWidth(0)
             button.clicked.connect(
@@ -150,8 +156,8 @@ class StepperBar(QWidget):
             if index < len(STEPPER_LABELS) - 1:
                 connector = QFrame(self)
                 connector.setObjectName(f"qfitStepperConnector{index + 1}")
-                connector.setFrameShape(QFrame.HLine)
-                connector.setFrameShadow(QFrame.Plain)
+                connector.setFrameShape(QT_FRAME_HLINE)
+                connector.setFrameShadow(QT_FRAME_PLAIN)
                 connector.setFixedWidth(8)
                 connector.setFixedHeight(1)
                 self._connectors.append(connector)

--- a/ui/dockwidget/workflow_shell.py
+++ b/ui/dockwidget/workflow_shell.py
@@ -6,6 +6,7 @@ from ._qt_compat import import_qt_module
 from .footer_status_bar import FooterStatusBar
 from .step_page import STEP_PAGE_NARROW_WIDTH
 from .stepper_bar import STEPPER_COMPACT_WIDTH, STEPPER_LABELS, StepperBar
+from qfit.ui.qt_enum_compat import qt_class_enum_value
 
 _qtwidgets = import_qt_module(
     "qgis.PyQt.QtWidgets",
@@ -20,6 +21,9 @@ _qtwidgets = import_qt_module(
 )
 
 QFrame = _qtwidgets.QFrame
+QT_FRAME_HLINE = qt_class_enum_value(QFrame, "Shape", "HLine")
+QT_FRAME_PLAIN = qt_class_enum_value(QFrame, "Shadow", "Plain")
+QT_FRAME_NO_FRAME = qt_class_enum_value(QFrame, "Shape", "NoFrame")
 QScrollArea = _qtwidgets.QScrollArea
 QStackedWidget = _qtwidgets.QStackedWidget
 QVBoxLayout = _qtwidgets.QVBoxLayout
@@ -135,8 +139,8 @@ class WorkflowShell(QWidget):
     def _build_separator(self):
         separator = QFrame(self)
         separator.setObjectName("qfitWizardShellSeparator")
-        separator.setFrameShape(QFrame.HLine)
-        separator.setFrameShadow(QFrame.Plain)
+        separator.setFrameShape(QT_FRAME_HLINE)
+        separator.setFrameShadow(QT_FRAME_PLAIN)
         separator.setFixedHeight(1)
         return separator
 
@@ -144,7 +148,7 @@ class WorkflowShell(QWidget):
         scroll = QScrollArea(self)
         scroll.setObjectName("qfitWizardContentScroll")
         scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QFrame.NoFrame)
+        scroll.setFrameShape(QT_FRAME_NO_FRAME)
         return scroll
 
     def _build_pages_stack(self):

--- a/ui/dockwidget_dependencies.py
+++ b/ui/dockwidget_dependencies.py
@@ -116,7 +116,11 @@ def _build_project_hygiene_service() -> ProjectHygienePort:
 def _writable_app_data_location() -> str:
     from qgis.PyQt.QtCore import QStandardPaths
 
-    return QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)
+    from qfit.ui.qt_enum_compat import qt_class_enum_value
+
+    return QStandardPaths.writableLocation(
+        qt_class_enum_value(QStandardPaths, "StandardLocation", "AppDataLocation")
+    )
 
 
 def _build_cache() -> QfitCache:


### PR DESCRIPTION
## What Problem This Solves

QGIS 4 / Qt 6 compatibility bugs were able to ship because the existing CI only ran the no-QGIS unit suite. Real QGIS import failures in `test_qgis_smoke.py` could be swallowed into skips, and Docker validation was not enforced as a PR gate.

This PR turns the release lesson from #1429 into a concrete test policy and CI gate.

## What Changed

- Added Docker QGIS 3 and QGIS 4 runtime jobs to `tests.yml`.
- Switched the no-QGIS unit job to the documented pytest command.
- Added `docs/testing-policy.md` and updated `CONTRIBUTING.md` with the support model.
- Updated `scripts/docker_test.sh` so the default Docker run executes the real-QGIS runtime suite.
- Made QGIS smoke import failures hard errors when `QFIT_REQUIRE_QGIS=1`.
- Added `tests/test_qt6_class_enum_probe.py` to probe Qt 5 flat and Qt 6 nested enum surfaces against the real binding.
- Fixed additional Qt 6 enum references found once the smoke tests actually ran under QGIS 4 / PyQt6.

## Validation

- `python3 -m pytest tests/ -x -q --tb=short` -> 2575 passed, 175 skipped
- `python3 -m pytest tests/test_ci_workflows.py tests/test_qt6_class_enum_probe.py tests/test_qt_enum_compat.py -q --tb=short` -> 31 passed
- `scripts/docker_test.sh 3` -> 44 passed
- `scripts/docker_test.sh 4` -> 44 passed
- workflow YAML parse -> OK
- `python3 scripts/package_plugin.py --qgis-major 3`
- `python3 scripts/package_plugin.py --qgis-major 4`

## Notes

I intentionally kept Docker focused on the real-QGIS runtime smoke/probe suite rather than every pure unit test. The full unit suite remains covered by the no-QGIS pytest job; many pure tests intentionally install fake QGIS modules or Qt 5-shaped stubs and are not a clean signal inside QGIS Docker.
