### PR TITLE
[codex] Release 0.53.3

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=qfit
 qgisMinimumVersion=3.28
 description=Explore fitness data spatially in QGIS
-version=0.53.2
+version=0.53.3
 author=Emmanuel Belo
 email=emmanuel.nicolas.belo@gmail.com
 about=qfit imports and visualizes fitness activity data in QGIS, starting with Strava and expanding toward broader FIT/GPX workflows.


### PR DESCRIPTION
## What Changed

Bump qfit plugin metadata from `0.53.2` to `0.53.3` for the bugfix release containing the QGIS 4 / Qt 6 enum compatibility follow-up and the new Docker QGIS runtime gates from #1435.

## Validation

- `python3 -m pytest tests/test_ci_workflows.py -q --tb=short` -> 23 passed
- `python3 scripts/package_plugin.py --qgis-major 3`
- `python3 scripts/package_plugin.py --qgis-major 4`
- ZIP metadata check:
  - `qfit-0.53.3-qgis3.zip`: `qgisMinimumVersion = 3.28`, `qgisMaximumVersion = 3.99`, `version = 0.53.3`
  - `qfit-0.53.3-qgis4.zip`: `qgisMinimumVersion = 4.0`, `version = 0.53.3`
