### PR TITLE
[codex] Expand Docker real-QGIS test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,23 @@ on:
 permissions:
   contents: read
 
+env:
+  REAL_QGIS_TESTS: >-
+    tests/test_qgis_smoke.py
+    tests/test_qt6_class_enum_probe.py
+    tests/test_background_map_service.py
+    tests/test_gpkg_io.py
+    tests/test_gpkg_layer_builders.py
+    tests/test_gpkg_point_layer_builder.py
+    tests/test_gpkg_route_layer_builders.py
+    tests/test_gpkg_route_writer.py
+    tests/test_gpkg_schema.py
+    tests/test_gpkg_write_orchestration.py
+    tests/test_gpkg_writer.py
+    tests/test_layer_style_service.py
+    tests/test_map_canvas_service.py
+    tests/test_project_layer_loader.py
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -45,7 +62,7 @@ jobs:
           docker exec qfit-test-qgis3 bash -c "qgis_setup.sh qfit"
           docker exec qfit-test-qgis3 bash -c "pip3 install --quiet --break-system-packages pytest pytest-cov pytest-qt pypdf 2>/dev/null || true"
           docker exec -e QT_QPA_PLATFORM=offscreen -e QFIT_REQUIRE_QGIS=1 qfit-test-qgis3 \
-            bash -c "cd /tests_directory/qfit && python3 -m pytest tests/test_qgis_smoke.py tests/test_qt6_class_enum_probe.py -q --tb=short"
+            bash -c "cd /tests_directory/qfit && python3 -m pytest ${REAL_QGIS_TESTS} -q --tb=short"
 
   docker-qgis4:
     runs-on: ubuntu-latest
@@ -65,4 +82,4 @@ jobs:
           docker exec qfit-test-qgis4 bash -c "qgis_setup.sh qfit"
           docker exec qfit-test-qgis4 bash -c "pip3 install --quiet --break-system-packages pytest pytest-cov pytest-qt pypdf 2>/dev/null || true"
           docker exec -e QT_QPA_PLATFORM=offscreen -e QFIT_REQUIRE_QGIS=1 qfit-test-qgis4 \
-            bash -c "cd /tests_directory/qfit && python3 -m pytest tests/test_qgis_smoke.py tests/test_qt6_class_enum_probe.py -q --tb=short"
+            bash -c "cd /tests_directory/qfit && python3 -m pytest ${REAL_QGIS_TESTS} -q --tb=short"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,8 @@ runtime suite must pass in both host versions before merge.
 - QGIS 3: `scripts/docker_test.sh 3`
 - QGIS 4: `scripts/docker_test.sh 4`
 - CI runs both as required checks — see `docs/testing-policy.md` for details.
-- Docker runs the real-QGIS smoke/probe suite. The full pure unit suite remains
-  covered by `python3 -m pytest tests/ -x -q`.
+- Docker runs the real-QGIS suite. The full pure unit suite remains covered by
+  `python3 -m pytest tests/ -x -q`.
 - Any change touching Qt enums, class-body expressions, or `classFactory()`
   import paths must pass Docker QGIS 4.
 - Smoke import failures inside Docker are **hard errors**, not silent skips.

--- a/docs/testing-policy.md
+++ b/docs/testing-policy.md
@@ -25,18 +25,18 @@ All three must pass before merge.
 The `tests.yml` workflow runs three jobs:
 
 1. `unit-tests` — no QGIS (fast, catches logic/architecture)
-2. `docker-qgis3` — runtime smoke/probe tests inside `qgis/qgis:3.44.11`
-3. `docker-qgis4` — runtime smoke/probe tests inside `qgis/qgis:4.2.0`
+2. `docker-qgis3` — real-QGIS tests inside `qgis/qgis:3.44.11`
+3. `docker-qgis4` — real-QGIS tests inside `qgis/qgis:4.2.0`
 
 The Docker jobs are **required** checks. A PR cannot merge if any of the
 three fail.
 
-The Docker jobs intentionally run the QGIS runtime suite, not every pure
-unit test. Many pure unit tests install fake `qgis` modules or Qt 5-shaped
-stubs so they can run in the no-QGIS job; those tests are covered by
-`unit-tests`. The Docker jobs focus on what no-QGIS tests cannot prove:
-real plugin imports, QGIS-backed smoke workflows, and Qt/PyQGIS enum
-compatibility.
+The Docker jobs intentionally run the real-QGIS suite, not every pure unit
+test. Many pure unit tests install fake `qgis` modules or Qt 5-shaped stubs
+so they can run in the no-QGIS job; those tests are covered by `unit-tests`.
+The Docker jobs cover what no-QGIS tests cannot prove: real plugin imports,
+QGIS-backed smoke workflows, GeoPackage/layer/service behavior against real
+PyQGIS bindings, and Qt/PyQGIS enum compatibility.
 
 ## Smoke import failures are hard errors
 
@@ -62,8 +62,8 @@ fails.
 ## Running Docker tests locally
 
 ```bash
-scripts/docker_test.sh 3            # runtime smoke/probe suite on QGIS 3
-scripts/docker_test.sh 4            # runtime smoke/probe suite on QGIS 4
+scripts/docker_test.sh 3            # real-QGIS suite on QGIS 3
+scripts/docker_test.sh 4            # real-QGIS suite on QGIS 4
 scripts/docker_test.sh 3 -x -q      # custom pytest args on QGIS 3
 scripts/docker_test.sh 4 tests/test_qgis_smoke.py  # specific file
 ```

--- a/scripts/docker_test.sh
+++ b/scripts/docker_test.sh
@@ -20,7 +20,22 @@ QGIS_VERSION="${1:-3}"
 shift || true
 
 if [[ "$#" -eq 0 ]]; then
-  set -- tests/test_qgis_smoke.py tests/test_qt6_class_enum_probe.py -q --tb=short
+  set -- \
+    tests/test_qgis_smoke.py \
+    tests/test_qt6_class_enum_probe.py \
+    tests/test_background_map_service.py \
+    tests/test_gpkg_io.py \
+    tests/test_gpkg_layer_builders.py \
+    tests/test_gpkg_point_layer_builder.py \
+    tests/test_gpkg_route_layer_builders.py \
+    tests/test_gpkg_route_writer.py \
+    tests/test_gpkg_schema.py \
+    tests/test_gpkg_write_orchestration.py \
+    tests/test_gpkg_writer.py \
+    tests/test_layer_style_service.py \
+    tests/test_map_canvas_service.py \
+    tests/test_project_layer_loader.py \
+    -q --tb=short
 fi
 
 case "$QGIS_VERSION" in

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -94,7 +94,11 @@ class TestsWorkflowTests(unittest.TestCase):
         self.assertIn("qgis/qgis:3.44.11", self.text)
         self.assertIn("qgis/qgis:4.2.0", self.text)
         self.assertIn("QFIT_REQUIRE_QGIS=1", self.text)
-        self.assertIn("tests/test_qgis_smoke.py tests/test_qt6_class_enum_probe.py", self.text)
+        self.assertIn("REAL_QGIS_TESTS", self.text)
+        self.assertIn("tests/test_qgis_smoke.py", self.text)
+        self.assertIn("tests/test_qt6_class_enum_probe.py", self.text)
+        self.assertIn("tests/test_gpkg_schema.py", self.text)
+        self.assertIn("tests/test_layer_style_service.py", self.text)
 
 
 class PluginSecurityScanWorkflowTests(unittest.TestCase):

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -95,6 +95,7 @@ class TestsWorkflowTests(unittest.TestCase):
         self.assertIn("qgis/qgis:4.2.0", self.text)
         self.assertIn("QFIT_REQUIRE_QGIS=1", self.text)
         self.assertIn("REAL_QGIS_TESTS", self.text)
+        self.assertEqual(self.text.count("${REAL_QGIS_TESTS}"), 2)
         self.assertIn("tests/test_qgis_smoke.py", self.text)
         self.assertIn("tests/test_qt6_class_enum_probe.py", self.text)
         self.assertIn("tests/test_gpkg_schema.py", self.text)

--- a/tests/test_gpkg_schema.py
+++ b/tests/test_gpkg_schema.py
@@ -12,7 +12,6 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover
     QgsApplication = None
 
 if QgsApplication is not None:
-    from qfit import gpkg_schema as legacy_gpkg_schema
     from qfit.activities.infrastructure.geopackage.gpkg_schema import (
         ATLAS_FIELDS,
         COVER_HIGHLIGHT_FIELDS,
@@ -26,6 +25,7 @@ if QgsApplication is not None:
         TRACK_FIELDS,
         make_qgs_fields,
     )
+    from qfit.activities.infrastructure.geopackage import gpkg_schema as gpkg_schema_module
     from qfit.sync_repository import REGISTRY_TABLE, SYNC_STATE_TABLE
 else:  # pragma: no cover
     ATLAS_FIELDS = None
@@ -48,8 +48,8 @@ def _ensure_qgis_app():
 
 @unittest.skipIf(QgsApplication is None, "QGIS Python bindings are not available")
 class GpkgSchemaFieldsTests(unittest.TestCase):
-    def test_legacy_gpkg_schema_shim_exports_same_constant(self):
-        self.assertEqual(legacy_gpkg_schema.TRACK_FIELDS, TRACK_FIELDS)
+    def test_geopackage_schema_module_exports_same_constant(self):
+        self.assertEqual(gpkg_schema_module.TRACK_FIELDS, TRACK_FIELDS)
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Summary

Expand the Docker QGIS test jobs so they cover the broader real-QGIS test set, not only the startup smoke/probe pair.

This answers the gap between the no-QGIS unit job reporting 175 QGIS-related skips and the Docker jobs previously running only 44 real-QGIS tests.

## What Changed

- Added the broader real-QGIS test list to `.github/workflows/tests.yml` via `REAL_QGIS_TESTS`.
- Updated `scripts/docker_test.sh` default arguments to run the same expanded suite locally.
- Updated testing policy docs from “smoke/probe suite” to “real-QGIS suite”.
- Updated workflow self-tests to assert the expanded Docker suite is wired in.
- Fixed `tests/test_gpkg_schema.py` so it no longer checks a removed root-level `qfit.gpkg_schema` shim that was hidden by no-QGIS skips.

## Validation

- `python3 -m pytest tests/test_gpkg_schema.py tests/test_ci_workflows.py -q --tb=short` -> 42 passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 2575 passed, 175 skipped
- `scripts/docker_test.sh 4` -> 200 passed, 80 skipped
- `scripts/docker_test.sh 3` -> 200 passed, 80 skipped

The remaining Docker skips are the mock/fallback halves of paired tests that intentionally skip when real QGIS is present.
